### PR TITLE
Copy svg and txt files to public folder

### DIFF
--- a/lib/utils/post-build.coffee
+++ b/lib/utils/post-build.coffee
@@ -41,6 +41,6 @@ module.exports = (program, cb) ->
       )
 
     # Copy static assets to public folder.
-    glob directory + '/pages/**/?(*.jpg|*.png|*.pdf|*.gif|*.ico)', null, (err, files) ->
+    glob directory + '/pages/**/?(*.jpg|*.png|*.svg|*.pdf|*.gif|*.ico|*.txt)', null, (err, files) ->
       async.map files, copy, (err, results) ->
         cb(err, results)


### PR DESCRIPTION
SVG files were added to webpack config in #34, but they were not copied to the public folder.