### PR TITLE
Show errors during static page generation

### DIFF
--- a/lib/utils/static-entry.cjsx
+++ b/lib/utils/static-entry.cjsx
@@ -25,22 +25,28 @@ module.exports = (locals, callback) ->
     else
       childPages = []
 
-    body = React.renderToString(
-      <Handler
-        config={config}
-        pages={pages}
-        page={page}
-        childPages={childPages}
-        state={state}
-      />
-    )
+    body = ''
+    html = ''
+    try
+      body = React.renderToString(
+        <Handler
+          config={config}
+          pages={pages}
+          page={page}
+          childPages={childPages}
+          state={state}
+        />
+      )
 
-    html = "<!DOCTYPE html>\n" + React.renderToStaticMarkup(
-      <HTML
-        config={config}
-        page={page}
-        body={body}
-      />
-    )
+      html = "<!DOCTYPE html>\n" + React.renderToStaticMarkup(
+        <HTML
+          config={config}
+          page={page}
+          body={body}
+        />
+      )
+    catch e
+      console.error e.stack
+      return callback(e)
 
     callback null, html

--- a/lib/utils/static-generation.coffee
+++ b/lib/utils/static-generation.coffee
@@ -13,4 +13,8 @@ module.exports = (program, callback) ->
     compilerConfig = webpackConfig(program, directory, 'static', null, routes)
 
     webpack(compilerConfig).run (err, stats) ->
-      callback(err, stats)
+      if err
+        return callback(err, stats)
+      if stats.hasErrors()
+        return callback('Error: ' + stats.toJson().errors, stats)
+      callback(null, stats)


### PR DESCRIPTION
Previously when errors were thrown during static page rendering, they
were swallowed by static-site-generator-webpack-plugin and the page was
rendered with blank content.

This commit adds a check to stats.hasErrors() and returns the error
string from stats to the callback. However, the stats object does not
expose the original errors, so we also print the stack trace to make
it possible to debug errors only thrown during server rendering.