### PR TITLE
Upgrade css-loader to current 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.9.3",
     "commander": "^2.8.1",
-    "css-loader": "^0.14.4",
+    "css-loader": "^0.19.0",
     "front-matter": "^1.0.0",
     "fs-extra": "^0.19.0",
     "glob": "^5.0.7",


### PR DESCRIPTION
css-loader was failing silently when using `css?modules` in my
temporary fork (which [adds postcss/css-modules support](https://github.com/ChristopherBiscardi/gatsby/blob/9f8b9a332ad29815ba6b7249503cc67f03bfa271/lib/utils/webpack.config.coffee#L97)). Upgrading
css-loader fixed the issue.

Also potentially of note, the following were outdated as well:

```bash
> npm outdated
Package               Current  Wanted     Latest  Location
css-loader             0.14.5  0.14.5     0.19.0  css-loader
fs-extra               0.19.0  0.19.0     0.24.0  fs-extra
hapi                    8.8.1   8.8.1     10.1.0  hapi
parse-filepath          0.5.0   0.5.0      0.6.3  parse-filepath
react-document-title    1.0.4   1.0.4      2.0.1  react-document-title
react-router           0.13.3  0.13.3  1.0.0-rc1  react-router
typography              0.3.6   0.3.6      0.6.2  typography
```