### PR TITLE
Enable DEBUG=gatsby:* gatsby develop

### DIFF
--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -13,6 +13,7 @@ var webpackRequire = require('webpack-require');
 var fs = require('fs')
 var assign = require('object-assign')
 var getUserGatsbyConfig = require('./get-user-gatsby-config');
+var debug = require('debug')('gatsby:application');
 
 var globPages = require('./glob-pages');
 var webpackConfig = require('./webpack.config');
@@ -23,6 +24,7 @@ module.exports = function(program) {
 
   // Load pages for the site.
   return globPages(directory, function(err, pages) {
+
     // Generate random port for webpack to listen on.
     // Perhaps should check if port is open.
     var webpackPort = Math.round(Math.random() * 1000 + 1000);
@@ -34,9 +36,11 @@ module.exports = function(program) {
 
     var HTMLPath;
     if (fs.existsSync(directory + "/html.cjsx") || fs.existsSync(directory + "/html.jsx")) {
+      debug('using project\'s html wrapper');
       HTMLPath = directory + "/html"
     }
     else {
+      debug('using gatsby default html wrapper');
       HTMLPath = __dirname + "/../isomorphic/html"
     }
 
@@ -49,6 +53,7 @@ module.exports = function(program) {
         err.forEach(function(error) { console.log(error) })
         process.exit()
       }
+      debug('configuring server');
       var HTML = factory()
 
       var webpackDevServer = new WebpackDevServer(compiler, {
@@ -111,6 +116,7 @@ module.exports = function(program) {
 
         if (negotiator.mediaType() === "text/html") {
           request.setUrl("/html" + request.path);
+
           return reply.continue();
         } else {
           // Rewrite path to match disk path.

--- a/lib/utils/glob-pages.coffee
+++ b/lib/utils/glob-pages.coffee
@@ -5,6 +5,7 @@ fs = require 'fs'
 frontMatter = require 'front-matter'
 _ = require 'underscore'
 toml = require('toml')
+debug = require('debug')('gatsby:glob')
 
 module.exports = (directory, callback) ->
   # Read in site config.
@@ -73,4 +74,5 @@ module.exports = (directory, callback) ->
 
       pagesData.push pageData
 
+    debug('globbed', pagesData.length, 'pages');
     callback(null, pagesData)

--- a/lib/utils/post-build.js
+++ b/lib/utils/post-build.js
@@ -4,6 +4,7 @@ var fs = require('fs-extra');
 var async = require('async');
 var parsePath = require('parse-filepath');
 var _ = require('underscore');
+var debug = require('debug')('gatsby:post-build');
 
 var globPages = require('./glob-pages');
 
@@ -13,6 +14,7 @@ module.exports = function(program, cb) {
 
   return globPages(directory, function(err, pages) {
 
+    debug('copying files');
     // Async callback to copy each file.
     var copy = function(file, callback) {
       // Map file to path generated for that directory.

--- a/lib/utils/static-generation.coffee
+++ b/lib/utils/static-generation.coffee
@@ -3,11 +3,13 @@ webpack = require 'webpack'
 globPages = require './glob-pages'
 webpackConfig = require './webpack.config'
 getUserGatsbyConfig = require './get-user-gatsby-config'
+debug = require('debug')('gatsby:static')
 
 module.exports = (program, callback) ->
   {relativeDirectory, directory} = program
 
   globPages directory, (err, pages) ->
+    debug('generating static site')
     routes = pages.filter((page) -> page.path?).map((page) -> page.path)
 
     #### Static site generation.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "coffee-script": "^1.9.3",
     "commander": "^2.8.1",
     "css-loader": "^0.22.0",
+    "debug": "^2.2.0",
     "front-matter": "^1.0.0",
     "fs-extra": "^0.19.0",
     "glob": "^5.0.7",


### PR DESCRIPTION
Adds a dependency on debug so that the following yields additional
logs in development

```
> DEBUG=gatsby:* gatsby build
```

![screenshot 2015-12-06 01 48 23](https://cloud.githubusercontent.com/assets/551247/11612758/785acbe6-9bbb-11e5-9b35-0203be691b16.png)