### PR TITLE
Fix gatsby develop on npm3

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -48,8 +48,8 @@ module.exports = function(program, directory, stage, webpackPort, routes) {
         switch(stage) {
         case "develop":
             return [
-                `${__dirname}/../../node_modules/webpack-dev-server/client?${program.host}:${webpackPort}`,
-                `${__dirname}/../../node_modules/webpack/hot/only-dev-server`,
+                require.resolve('webpack-dev-server/client') + `?${program.host}:${webpackPort}`,
+                require.resolve('webpack/hot/only-dev-server'),
                 `${__dirname}/web-entry`
             ]
         case "production":


### PR DESCRIPTION
Because npm3 dedupes packages by default, the ../../node_modules paths
assuming those packages are installed below gatsby in the tree fail
with:

    Cannot find module ... node_modules/gatsby/lib/utils/../../
    node_modules/webpack-dev-server/client?0.0.0.0:1826

Use `require.resolve` instead of relying the packages to be found in
a certain folder.