### PR TITLE
Exit with the right status when build fails

### DIFF
--- a/bin/build.coffee
+++ b/bin/build.coffee
@@ -16,5 +16,8 @@ directory = path.resolve(relativeDirectory)
 program.directory = directory
 program.relativeDirectory = relativeDirectory
 
-build(program)
-
+build program, (err) ->
+  if err?
+    throw err
+  else
+    console.log('Done')

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -3,7 +3,7 @@ var buildProductionBundle = require('./build-production');
 var postBuild = require('./post-build');
 var globPages = require('./glob-pages');
 
-module.exports = function(program) {
+module.exports = function(program, callback) {
   var directory = program.directory;
   try {
     var customPostBuild = require(directory + "/post-build");
@@ -14,27 +14,29 @@ module.exports = function(program) {
   return generateStaticPages(program, function(err, stats) {
     if (err) {
       console.log("failed at generating static html pages");
-      return console.log(err);
+      return callback(err);
     }
     console.log("Compiling production bundle.js");
     return buildProductionBundle(program, function(err, stats) {
       if (err) {
         console.log("failed to compile bundle.js");
-        return console.log(err);
+        return callback(err);
       }
       console.log("Copying assets");
       return postBuild(program, function(err, results) {
         if (err) {
           console.log("failed to copy assets");
-          return console.log(err);
+          return callback(err);
         }
         if ((typeof customPostBuild !== "undefined" && customPostBuild !== null)) {
           console.log("Performing custom post-build steps");
           return globPages(directory, function(err, pages) {
             return customPostBuild(pages, function(err) {
-              return console.log('Done');
+              return callback(null);
             });
           });
+        } else {
+          return callback(null);
         }
       });
     });


### PR DESCRIPTION
If the build fails, exit with the failure code (1). This is done by
throwing any errors from the build instead of just logging them to
stdout like before.

The correct exit code is important when running Gatsby in a CI build,
for example. You want the build to fail so you don't deploy the site,
if it didn't build successfully.