### PR TITLE
fix webpack gif warning

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -177,6 +177,10 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
       test: /\.svg$/,
       loader: 'null',
     })
+    config.loader('gif', {
+      test: /\.gif$/,
+      loader: 'null',
+    })
     config.loader('ico', {
       test: /\.ico$/,
       loader: 'null',


### PR DESCRIPTION
Thanks for making this project it's really great way of making static sites!

Suppress this error in the console when using gifs:
```js
Module parse failed:***.gif Line 1: Unexpected token ILLEGAL
You may need an appropriate loader to handle this file type.
(Source code omitted for this binary file)
 @ ./pages ^\.\/.*$
```