### PR TITLE
Add support for HTML frontmatter

### DIFF
--- a/lib/isomorphic/wrappers/html.jsx
+++ b/lib/isomorphic/wrappers/html.jsx
@@ -3,14 +3,16 @@ import React, {PropTypes} from 'react'
 module.exports = React.createClass({
   propTypes: {
     page: PropTypes.shape({
-      data: PropTypes.string,
+      data: PropTypes.shape({
+        body: PropTypes.string.isRequired,
+      }),
     }),
   },
 
   render: function () {
-    const html = this.props.page.data
+    const html = this.props.page.data.body
     return (
-    <div dangerouslySetInnerHTML={{__html: html}} />
+      <div dangerouslySetInnerHTML={{__html: html}} />
     )
   },
 })

--- a/lib/utils/glob-pages.coffee
+++ b/lib/utils/glob-pages.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 parsePath = require 'parse-filepath'
 fs = require 'fs'
 frontMatter = require 'front-matter'
+htmlFrontMatter = require 'html-frontmatter'
 _ = require 'underscore'
 toml = require('toml')
 debug = require('debug')('gatsby:glob')
@@ -39,7 +40,9 @@ module.exports = (directory, callback) ->
         data = _.extend {}, rawData.attributes
         pageData.data = data
       else if ext is "html"
-        pageData.data = fs.readFileSync(page, 'utf-8')
+        html = fs.readFileSync(page, 'utf-8')
+        data = _.extend({}, htmlFrontMatter(html), { body: html })
+        pageData.data = data
       else
         data = {}
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "glob": "^5.0.7",
     "hapi": "^8.5.1",
     "highlight.js": "^8.6.0",
+    "html-frontmatter": "^1.5.1",
     "json-loader": "^0.5.2",
     "less": "^2.5.1",
     "less-loader": "^2.2.0",


### PR DESCRIPTION
Load metadata for HTML files from a frontmatter embedded in HTML comments.

Example:
```html
<!--
title: Hello World
order: 1
-->
<h1>Hello World</h1>
```