### PR TITLE
provide config and pages props to HTML react component

### DIFF
--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -19,7 +19,7 @@ module.exports = (program) => {
   const directory = program.directory
 
   // Load pages for the site.
-  return globPages(directory, (err, pages) => {
+  return globPages(directory, (err, pages, siteConfig) => {
     // Generate random port for webpack to listen on.
     // Perhaps should check if port is open.
     const webpackPort = Math.round(Math.random() * 1000 + 1000)
@@ -93,7 +93,10 @@ module.exports = (program) => {
             return reply(Boom.notFound())
           }
 
-          let html = ReactDOMServer.renderToStaticMarkup(React.createElement(HTML))
+          let html = ReactDOMServer.renderToStaticMarkup(React.createElement(HTML, {
+            pages,
+            config: siteConfig,
+          }))
           html = '<!DOCTYPE html>\n' + html
           return reply(html)
         },

--- a/lib/utils/glob-pages.coffee
+++ b/lib/utils/glob-pages.coffee
@@ -75,4 +75,4 @@ module.exports = (directory, callback) ->
       pagesData.push pageData
 
     debug('globbed', pagesData.length, 'pages');
-    callback(null, pagesData)
+    callback(null, pagesData, siteConfig)


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/119

The top-level HTML react component gets the site config (`config`) and complete set of pages (`pages`) as props during static file generation, so let's provide them during develop mode.

_Note: they are loaded only on process startup, so the `gatsby develop` command will need to be restarted to pick up config/page changes._

This seems reasonable for now, since we shouldn't be doing much with `pages` in this component, and config changes relatively infrequently. Not to mention that webpack doesn't pick up new files. Still, let me know if you'd like another `globPages()` call or just straight config load inside the '/html/{path*}' `hapi` handler to keep the values fresh.