### PR TITLE
Allow /404 file to act as wildcard route

### DIFF
--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -20,6 +20,7 @@ module.exports = (files, pagesReq) => {
     pages,
     templates,
   }
+  let notFound = null
   const templatesHash = {}
   templatesHash.root = routes
   templatesHash['/'] = routes
@@ -159,7 +160,22 @@ module.exports = (files, pagesReq) => {
         parentTemplateFile,
       })
     }
+
+    if (includes(page.path, '/404')) {
+      notFound = {
+        path: '*',
+        component: handler,
+        page,
+        pages,
+        templates,
+        parentTemplateFile,
+      }
+    }
   })
+
+  if (notFound) {
+    routes.childRoutes.push(notFound)
+  }
 
   return routes
 }


### PR DESCRIPTION
Didn't see a way to put a 'not found' page in place, thought I'd add one.

_Scenario:_ I've created a 404 page for nginx, but when it loads fully I get an empty screen because `react-router` doesn't know about the random URL the user attempted to load. This change allows me to put a `404.jsx` somewhere in the project, and that is automatically registered as the wildcard handler.