### PR TITLE
Add font loader

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -197,10 +197,6 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
       test: /\.jpg$/,
       loader: 'null',
     })
-    config.loader('svg', {
-      test: /\.svg$/,
-      loader: 'null',
-    })
     config.loader('gif', {
       test: /\.gif$/,
       loader: 'null',
@@ -223,6 +219,23 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
       query: {
         directory,
       },
+    })
+    // Font loaders
+    config.loader('woff', {
+      test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+      loader: 'url-loader?limit=10000&minetype=application/font-woff',
+    })
+    config.loader('ttf', {
+      test: /\.(ttf)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+      loader: 'file-loader',
+    })
+    config.loader('eot', {
+      test: /\.(eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+      loader: 'file-loader',
+    })
+    config.loader('svg', {
+      test: /\.(svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+      loader: 'file-loader',
     })
 
     switch (stage) {


### PR DESCRIPTION
Fixes #148 
Loaders are split by extension so they can be overridden by `gatsby.config.js`