### PR TITLE
Change default develop host to "localhost" on windows

### DIFF
--- a/bin/develop.js
+++ b/bin/develop.js
@@ -15,9 +15,13 @@ if (require('./published')) {
   develop = require('../lib/utils/develop')
 }
 
+var defaultHost = process.platform === 'win32' 
+  ? 'localhost'
+  : '0.0.0.0';
+  
 program
   .version(packageJson.version)
-  .option('-h, --host <url>', 'Set host. Defaults to 0.0.0.0', '0.0.0.0')
+  .option('-h, --host <url>', 'Set host. Defaults to ' + defaultHost, defaultHost)
   .option('-p, --port <port>', 'Set port. Defaults to 8000', '8000')
   .parse(process.argv)
 


### PR DESCRIPTION
Windows won't resolve 0.0.0.0 as localhost/127.0.0.1 implicitly, so hot loading and links break. This just changes the default to a more (I think) helpful default for win32 users, rather then getting surprised by a default that doesn't work.

(fair warning I wrote this in the browser editor, so sorry if something is off)