### PR TITLE
Add history as top-level dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hapi": "^8.5.1",
     "hapi-webpack-plugin": "^1.3.0",
     "highlight.js": "^9.1.0",
+    "history": "^2.0.0",
     "html-frontmatter": "^1.5.1",
     "json-loader": "^0.5.2",
     "less": "^2.6.0",


### PR DESCRIPTION
`history` is being half-installed by npm 2.14.12 due to `scroll-behavior` peerDependency, which caused the webpack build to fail when it couldn't find history's dependency 'warning.' This does not happen in npm 3.x because all  dependencies are installed at top level.

This was the webpack error:

```
ERROR in /usr/local/lib/~/gatsby/~/history/lib/DOMStateStorage.js
Module not found: Error: Cannot resolve module 'warning' in /usr/local/lib/node_modules/gatsby/node_modules/history/lib
 @ /usr/local/lib/~/gatsby/~/history/lib/DOMStateStorage.js 10:15-33
```

Note that `history` was also installed under `react-router`, where it had all required dependencies.

Also removes this warning:

```
npm WARN peerDependencies The peer dependency history@^1.12.1 || ^2.0.0 included from scroll-behavior will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```