### PR TITLE
Show renderToStaticMarkup errors in develop mode

### DIFF
--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -76,15 +76,20 @@ module.exports = (program) => {
             return reply(Boom.notFound())
           }
 
-          const htmlElement = React.createElement(
-            HTML, {
-              pages,
-              config: siteConfig,
-            }
-          )
-          let html = ReactDOMServer.renderToStaticMarkup(htmlElement)
-          html = `<!DOCTYPE html>\n${html}`
-          return reply(html)
+          try {
+            const htmlElement = React.createElement(
+              HTML, {
+                pages,
+                config: siteConfig,
+              }
+            )
+            let html = ReactDOMServer.renderToStaticMarkup(htmlElement)
+            html = `<!DOCTYPE html>\n${html}`
+            return reply(html)
+          } catch (e) {
+            console.log(e.stack)
+            throw e
+          }
         },
       })
 


### PR DESCRIPTION
I've noticed that when I'm making changes to the top-level HTML React component, I don't have enough debugging tools. I get minimal information in `develop` mode, and I get a generic error in `build` mode.