### PR TITLE
config.noProductionJS to turn off bundle.js build, readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,25 @@ module.exports = React.createClass({
 ```
 
 ### Structure of a Gatsby site
-* `config.toml` - Core application configuration is stored here. Available via a `require` or `import` of 'config'. Values:
-  * `spa` - set to a falsey value to prevent generation of bundle.js (containing your client-side Single Page App - SPA) during a `gatbsy build`. You'll need to update your top-level `html.js` file so that it doesn't pull in `bundle.js` in production, but you'll want to keep it for `gatsby develop` mode.
+* `config.toml` - Core application configuration is stored here. Available via a `require`
+or `import` of 'config'. Values:
+  * `noProductionJavascript` - set to a truthy value to prevent generation of bundle.js
+  (containing your client-side Single Page App) during a `gatbsy build`. You'll need
+  to update your top-level `html.js` file so that it doesn't pull in `bundle.js` in
+  production, but you'll want to keep it for `gatsby develop` mode.
 * `/pages` - All pages go here. Everything is turned into a page except
 files which start with an underscore:
-  * `_template` files under `/pages` are treated as parent templates for other pages in the same directory tree.
-  * (optional) `pages/404.js` or `pages/404.html` - automatically picked up as your 'not found' page. If you `<Link>` to an unknown URL, this page will be shown. Note: in production, you'll need to [set up your server host to show this page when it can't find the requested file](https://github.com/gatsbyjs/gatsby/pull/121#issuecomment-194715068).
-* (optional) `post-build.js` - a `function(pages, cb)` you can provide to do final processing on all generated content.
-* (optional) `app.js` - a way to hook into key application events. Provide an `onRouteChange` key of type `function(state, page)` to be notified whenever React-Router navigates.
+  * `_template` files under `/pages` are treated as parent templates for other pages in
+  the same directory tree.
+  * (optional) `pages/404.js` or `pages/404.html` - automatically picked up as your 'not
+  found' page. If you `<Link>` to an unknown URL, this page will be shown. Note: in
+  production, you'll need to [set up your server host to show this page when it can't find
+  the requested file](https://github.com/gatsbyjs/gatsby/pull/121#issuecomment-194715068).
+* (optional) `post-build.js` - a `function(pages, cb)` you can provide to do final
+processing on all generated content.
+* (optional) `app.js` - a way to hook into key application events. Provide an
+`onRouteChange` key of type `function(state, page)` to be notified whenever React-Router
+navigates.
 
 ### How to use your own webpack loaders
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ module.exports = React.createClass({
 })
 ```
 
+### Structure of a Gatsby site
+* `config.toml` - Core application configuration is stored here. Available via a `require` or `import` of 'config'. Values:
+  * `spa` - set to a falsey value to prevent generation of bundle.js (containing your client-side Single Page App - SPA) during a `gatbsy build`. You'll need to update your top-level `html.js` file so that it doesn't pull in `bundle.js` in production, but you'll want to keep it for `gatsby develop` mode.
+* `/pages` - All pages go here. Everything is turned into a page except
+files which start with an underscore:
+  * `_template` files under `/pages` are treated as parent templates for other pages in the same directory tree.
+  * (optional) `pages/404.js` or `pages/404.html` - automatically picked up as your 'not found' page. If you `<Link>` to an unknown URL, this page will be shown. Note: in production, you'll need to [set up your server host to show this page when it can't find the requested file](https://github.com/gatsbyjs/gatsby/pull/121#issuecomment-194715068).
+* (optional) `post-build.js` - a `function(pages, cb)` you can provide to do final processing on all generated content.
+* (optional) `app.js` - a way to hook into key application events. Provide an `onRouteChange` key of type `function(state, page)` to be notified whenever React-Router navigates.
+
 ### How to use your own webpack loaders
 
 Gatsby uses
@@ -289,11 +299,6 @@ It is also possible to
 
 ### How to write your own wrappers
 * Coming...
-
-### Structure of a Gatsby site
-* `/pages` — All pages go here. Everything is turned into a page except
-files which start with an underscore
-* `_template` files — coming...
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,7 @@ title: This is a title
 This is a markdown file.
 ```
 
-When loaded and required, the resulting javascript object looks like the
-following.
+When loaded and required, the resulting javascript object looks like the following:
 
 ```javascript
 {
@@ -191,9 +190,9 @@ module.exports = React.createClass({
   displayName: "MarkdownWrapper",
 
   render: function() {
-    post = @props.page.data
+    var post = this.props.route.page.data
 
-    <div className="markdown">
+    return <div className="markdown">
       <h1>{post.title}</h1>
       <div dangerouslySetInnerHTML={{__html: post.body}}/>
     </div>

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -77,10 +77,10 @@ function html (program, callback) {
     }
 
     // If we're not generating a SPA, go directly to post build steps
-    if (config.spa || typeof config.spa === 'undefined') {
-      bundle(program, callback)
-    } else {
+    if (config.noProductionJavascript) {
       post(program, callback)
+    } else {
+      bundle(program, callback)
     }
   })
 }

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -2,8 +2,11 @@ import generateStaticPages from './static-generation'
 import buildProductionBundle from './build-production'
 import postBuild from './post-build'
 import globPages from './glob-pages'
+import toml from 'toml'
+import fs from 'fs'
 
-module.exports = (program, callback) => {
+
+function customPost (program, callback) {
   const directory = program.directory
   let customPostBuild
   try {
@@ -12,37 +15,74 @@ module.exports = (program, callback) => {
     // Do nothiing.
   }
 
-  console.log('Generating static html pages')
-  return generateStaticPages(program, (err) => {
-    if (err) {
-      console.log('failed at generating static html pages')
-      return callback(err)
-    }
-    console.log('Compiling production bundle.js')
-    return buildProductionBundle(program, (e) => {
-      if (e) {
-        console.log('failed to compile bundle.js')
-        return callback(e)
-      }
-      console.log('Copying assets')
-      return postBuild(program, (error) => {
+  if (customPostBuild) {
+    console.log('Performing custom post-build steps')
+
+    globPages(directory, (globError, pages) =>
+      customPostBuild(pages, (error) => {
         if (error) {
-          console.log('failed to copy assets')
-          return callback(error)
+          console.log('customPostBuild function failed')
+          callback(error)
         }
-        if ((typeof customPostBuild !== 'undefined' && customPostBuild !== null)) {
-          console.log('Performing custom post-build steps')
-          return globPages(directory, (globError, pages) =>
-            customPostBuild(pages, (customPostBuildError) => {
-              if (customPostBuildError) {
-                console.log('customPostBuild function failed')
-                callback(customPostBuildError)
-              }
-              return callback(null)
-            })
-          )
-        }
+        return callback()
       })
-    })
+    )
+  } else {
+    callback()
+  }
+}
+
+function post (program, callback) {
+  console.log('Copying assets')
+
+  postBuild(program, (error) => {
+    if (error) {
+      console.log('failed to copy assets')
+      return callback(error)
+    }
+
+    customPost(program, callback)
   })
 }
+
+function bundle (program, callback) {
+  console.log('Compiling production bundle.js')
+
+  buildProductionBundle(program, (error) => {
+    if (error) {
+      console.log('failed to compile bundle.js')
+      return callback(error)
+    }
+
+    post(program, callback)
+  })
+}
+
+function html (program, callback) {
+  console.log('Generating static html pages')
+
+  const directory = program.directory
+  let config
+  try {
+    config = toml.parse(fs.readFileSync(`${directory}/config.toml`))
+  } catch (error) {
+    console.log("Couldn't load your site config")
+    callback(error)
+  }
+
+  generateStaticPages(program, (error) => {
+    if (error) {
+      console.log('failed at generating static html pages')
+      return callback(error)
+    }
+
+    // If we're not generating a SPA, go directly to post build steps
+    if (config.spa || typeof config.spa === 'undefined') {
+      bundle(program, callback)
+    } else {
+      post(program, callback)
+    }
+  })
+}
+
+module.exports = html

--- a/lib/utils/static-entry.js
+++ b/lib/utils/static-entry.js
@@ -18,7 +18,16 @@ module.exports = (locals, callback) => {
       console.log(error)
       callback(error)
     } else if (renderProps) {
-      const body = renderToString(<RouterContext {...renderProps}/>)
+      const component = <RouterContext {...renderProps}/>
+      let body
+
+      // if we're not generating a SPA for production, eliminate React IDs
+      if (config.spa || typeof config.spa === 'undefined') {
+        body = renderToString(component)
+      } else {
+        body = renderToStaticMarkup(component)
+      }
+
       const html = `<!DOCTYPE html>\n ${renderToStaticMarkup(
           <HTML config={config} body={body} {...renderProps} />
       )}`

--- a/lib/utils/static-entry.js
+++ b/lib/utils/static-entry.js
@@ -22,10 +22,10 @@ module.exports = (locals, callback) => {
       let body
 
       // if we're not generating a SPA for production, eliminate React IDs
-      if (config.spa || typeof config.spa === 'undefined') {
-        body = renderToString(component)
-      } else {
+      if (config.noProductionJavascript) {
         body = renderToStaticMarkup(component)
+      } else {
+        body = renderToString(component)
       }
 
       const html = `<!DOCTYPE html>\n ${renderToStaticMarkup(


### PR DESCRIPTION
A bit of a refactor to `utils/build.js` to better enable this change - each step was split out into its own, separate function.

Note that this change also ensures that Done callback is always called. Without a user-provided post-build, the callback was never called. Realized that I was never getting that 'Done' console log after my
builds.

Also some readme updates to capture what I've learned from inspecting the source. And match the latest API. :0)