### PR TITLE
Verifying that path strings are prepended a forward slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All templates, css, and content are *hot reloadable*.
 * [nordnet.se/brand](https://www.nordnet.se/brand/)
 * [likescoffee.com](http://likescoffee.com/) ([source](https://github.com/pamo/pamo.github.io/tree/development))
 * [vii.campjs.com](http://vii.campjs.com/) ([source](https://github.com/campjs/campjs-vii))
+* [michaeljdeeb.com](http://michaeljdeeb.com) ([source](https://github.com/michaeljdeeb/michaeljdeeb-gatsby-blog))
 * [Edit this file to add yours!](https://github.com/gatsbyjs/gatsby/blob/master/README.md)
 
 ### Why use Gatsby instead of other Static Site Generators

--- a/lib/utils/glob-pages.js
+++ b/lib/utils/glob-pages.js
@@ -6,6 +6,7 @@ import fs from 'fs'
 import frontMatter from 'front-matter'
 import htmlFrontMatter from 'html-frontmatter'
 import objectAssign from 'object-assign'
+import invariant from 'invariant'
 const debug = require('debug')('gatsby:glob')
 let rewritePath
 try {
@@ -76,6 +77,11 @@ module.exports = (directory, callback) => {
       if (!(parsed.name.slice(0, 1) === '_')) {
         if (data.path) {
           // Path was hardcoded.
+          const pathInvariantMessage = `
+          You're setting path to ${data.path} for ${parsed.dirname},
+          but it should be /${data.path}
+          `
+          invariant((data.path.charAt(0) === '/'), pathInvariantMessage)
           pageData.path = data.path
         } else if (rewritePath) {
           pageData.path = rewritePath(parsed, pageData)


### PR DESCRIPTION
Some funny things can occur if the path variable is improperly set in the front matter of a page.

This will check that all path strings are prepended with a forward slash.

Some interesting things to note, possibly for documentation or to improve upon the check.
- No additional testing was added, but this fix passes `npm test`
- This checking mechanism only works for `gatsby build` or the initial launch of `gatsby develop` (not thrown during hot reloading)
- If your pages are structured similarly to the [starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog/tree/master/pages), not having a forward slash at the end of your path string will cause files that aren't index to appear outside the folder with the folder name appended to them.
  - Ex. `/pages/2015-05-01-hello-world/salty_egg.jpg` would become `/hello-worldsalty_egg.jpg` if path were set to `/hello-world`
  - Opted not to check for this as someone may want a page such as `404.md` to have the path `/404.html` for GitHub Pages.