### PR TITLE
Fix route -> parent template matching

### DIFF
--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -1,7 +1,6 @@
 import filter from 'lodash/filter'
 import sortBy from 'lodash/sortBy'
 import last from 'lodash/last'
-import includes from 'underscore.string/include'
 import { prefixLink } from './gatsby-helpers'
 
 module.exports = (files, pagesReq) => {
@@ -42,7 +41,7 @@ module.exports = (files, pagesReq) => {
   // with it.
   templatesWithoutRoot.forEach((templateFile) => {
     let parentTemplates = filter(templatesWithoutRoot, (template) =>
-      includes(templateFile.requirePath, template.file.dirname)
+      templateFile.requirePath.indexOf(template.file.dirname) === 0
     )
     // Sort parent templates by directory length. In cases
     // where a template has multiple parents
@@ -122,7 +121,7 @@ module.exports = (files, pagesReq) => {
 
     // Determine parent template for page.
     const parentTemplates = filter(templatesWithoutRoot, (templateFile) =>
-      includes(page.requirePath, templateFile.file.dirname)
+      page.requirePath.indexOf(templateFile.file.dirname) === 0
     )
 
     const sortedParentTemplates = sortBy(parentTemplates, (route) => route.file.dirname.length)
@@ -159,7 +158,7 @@ module.exports = (files, pagesReq) => {
       })
     }
 
-    if (includes(page.path, '/404')) {
+    if (page.path.indexOf('/404') !== -1) {
       notFound = {
         path: '*',
         component: handler,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "toml": "^2.2.2",
     "toml-loader": "^1.0.0",
     "typography": "^0.7.0",
-    "underscore.string": "^3.2.3",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.13",
     "webpack-configurator": "^0.3.0",


### PR DESCRIPTION
This commit also removes the need for underscore.string