### PR TITLE
Use H for host option short flag.

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -22,7 +22,7 @@ program
 
 program.command('develop')
   .description('Start development server. Watches files and rebuilds and hot reloads if something changes') // eslint-disable-line max-len
-  .option('-h, --host <url>',
+  .option('-H, --host <url>',
           `Set host. Defaults to ${defaultHost}`,
           defaultHost
          )
@@ -56,7 +56,7 @@ program.command('build')
 
 program.command('serve-build')
   .description('Serve built site.')
-  .option('-h, --host <url>',
+  .option('-H, --host <url>',
           `Set host. Defaults to ${defaultHost}`,
           defaultHost
          )
@@ -78,6 +78,12 @@ program
     newCommand(rootPath, starter)
   })
 
+program.on('--help', () => {
+  console.log(`To show subcommand help:
+
+    gatsby [command] -h
+`)
+})
 
 // If the user types an unknown sub-command, just display the help.
 const subCmd = process.argv.slice(2, 3)[0]


### PR DESCRIPTION
Allows subcommand help to display (`-h`).
Add program help text to show subcommand help.


### Updated usage output:
```sh
$> gatsby -h

  Usage:  [command] [options]


  Commands:

    develop [options]         Start development server. Watches files and rebuilds and hot reloads if something changes
    build [options]           Build a Gatsby project.
    serve-build [options]     Serve built site.
    new [rootPath] [starter]  Create new Gatsby project.

  Options:

    -h, --help     output usage information
    -V, --version  output the version number

To show subcommand help:

    gatsby [command] -h
```

### Subcommand usage output:
```sh
$> gatsby develop -h

  Usage: develop [options]

  Start development server. Watches files and rebuilds and hot reloads if something changes

  Options:

    -h, --help         output usage information
    -H, --host <url>   Set host. Defaults to 0.0.0.0
    -p, --port <port>  Set port. Defaults to 8000

```