### PR TITLE
Don't show help when calling --version

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -83,7 +83,8 @@ program
 
 // If the user types an unknown sub-command, just display the help.
 const subCmd = process.argv.slice(2, 3)[0]
-const cmds = _.map(program.commands, '_name')
+let cmds = _.map(program.commands, '_name')
+cmds = cmds.concat(['--version', '-V'])
 
 if (!_.includes(cmds, subCmd)) {
   program.help()


### PR DESCRIPTION
Our little helper to show help when someone put in an unknown command wasn't accounting for the built-in command from commander `--version` and `-V`.