### PR TITLE
Add a test case for calling --version in CLI

### DIFF
--- a/test/integration/cli-returns-help.js
+++ b/test/integration/cli-returns-help.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import packageJson from '../../package.json'
 import { gatsby } from '../support'
 
 test('cli can be called and exits with 0', async t => {
@@ -16,4 +17,16 @@ test('cli returns help when called with unknown args', async t => {
   const asdf = await gatsby(['asdf'])
   const help = await gatsby(['--help'])
   t.is(asdf.stdout, help.stdout)
+})
+
+test('cli does not return help when called with --version', async t => {
+  const version = await gatsby(['--version'])
+  const help = await gatsby(['--help'])
+  t.not(version.stdout, help.stdout)
+})
+
+test('cli returns the gatsby version when called with --version', async t => {
+  const versionCli = await gatsby(['--version'])
+  const versionPackage = packageJson.version
+  t.true(versionCli.stdout.indexOf(versionPackage) > -1)
 })

--- a/test/support.js
+++ b/test/support.js
@@ -27,14 +27,14 @@ export function spawn (command, args = [], options = {}) {
 }
 
 export function gatsby (args = [], options = {}) {
-  const spawnArguments = concat([gatsbyCli], args)
+  const spawnArguments = concat(['--', gatsbyCli], args)
   return spawn(babel, spawnArguments, options)
 }
 
 export function build (fixturePath) {
   const buildPath = path.resolve(fixturePath, 'public')
   return remove(buildPath)
-    .then(() => spawn(babel, [gatsbyCli, 'build'], { cwd: fixturePath }))
+    .then(() => gatsby(['build'], { cwd: fixturePath }))
 }
 
 export function dom (filePath) {


### PR DESCRIPTION
For #249 

---

I should have had the support use -- for `getopt` from the beginning.