### PR TITLE
Webpack config refactor; CSS now generated with HTML

### DIFF
--- a/lib/utils/build-css.js
+++ b/lib/utils/build-css.js
@@ -1,0 +1,16 @@
+import webpack from 'webpack'
+import webpackConfig from './webpack.config'
+import fs from 'fs'
+
+module.exports = (program, callback) => {
+  const { directory } = program
+
+  const compilerConfig = webpackConfig(program, directory, 'build-css')
+
+  return webpack(compilerConfig.resolve()).run((err, stats) => {
+    // We don't want any javascript produced by this step in the process.
+    fs.unlinkSync(`${directory}/public/bundle-for-css.js`)
+
+    return callback(err, stats)
+  })
+}

--- a/lib/utils/build-html.js
+++ b/lib/utils/build-html.js
@@ -3,17 +3,17 @@ import webpack from 'webpack'
 import globPages from './glob-pages'
 import webpackConfig from './webpack.config'
 import fs from 'fs'
-const debug = require('debug')('gatsby:static')
+const debug = require('debug')('gatsby:html')
 
 module.exports = (program, callback) => {
   const { directory } = program
 
   globPages(directory, (err, pages) => {
-    debug('generating static site')
+    debug('generating static HTML')
     const routes = pages.filter((page) => page.path).map((page) => page.path)
 
     // Static site generation.
-    const compilerConfig = webpackConfig(program, directory, 'build-static', null, routes)
+    const compilerConfig = webpackConfig(program, directory, 'build-html', null, routes)
 
     webpack(compilerConfig.resolve()).run((e, stats) => {
       if (e) {
@@ -24,7 +24,7 @@ module.exports = (program, callback) => {
       }
 
       // A temp file required by static-site-generator-plugin
-      fs.unlinkSync('public/render-page.js')
+      fs.unlinkSync(`${directory}/public/render-page.js`)
 
       return callback(null, stats)
     })

--- a/lib/utils/build-javascript.js
+++ b/lib/utils/build-javascript.js
@@ -4,7 +4,7 @@ import webpackConfig from './webpack.config'
 module.exports = (program, callback) => {
   const { directory } = program
 
-  const compilerConfig = webpackConfig(program, directory, 'build-spa')
+  const compilerConfig = webpackConfig(program, directory, 'build-javascript')
 
   return webpack(compilerConfig.resolve()).run((err, stats) => callback(err, stats))
 }

--- a/lib/utils/build-javascript.js
+++ b/lib/utils/build-javascript.js
@@ -6,5 +6,5 @@ module.exports = (program, callback) => {
 
   const compilerConfig = webpackConfig(program, directory, 'build-javascript')
 
-  return webpack(compilerConfig.resolve()).run((err, stats) => callback(err, stats))
+  return webpack(compilerConfig.resolve()).run(callback)
 }

--- a/lib/utils/build-spa.js
+++ b/lib/utils/build-spa.js
@@ -4,8 +4,7 @@ import webpackConfig from './webpack.config'
 module.exports = (program, callback) => {
   const { directory } = program
 
-  // Build production js.
-  const compilerConfig = webpackConfig(program, directory, 'production')
+  const compilerConfig = webpackConfig(program, directory, 'build-spa')
 
   return webpack(compilerConfig.resolve()).run((err, stats) => callback(err, stats))
 }

--- a/lib/utils/build-static.js
+++ b/lib/utils/build-static.js
@@ -2,6 +2,7 @@ require('node-cjsx').transform()
 import webpack from 'webpack'
 import globPages from './glob-pages'
 import webpackConfig from './webpack.config'
+import fs from 'fs'
 const debug = require('debug')('gatsby:static')
 
 module.exports = (program, callback) => {
@@ -12,7 +13,7 @@ module.exports = (program, callback) => {
     const routes = pages.filter((page) => page.path).map((page) => page.path)
 
     // Static site generation.
-    const compilerConfig = webpackConfig(program, directory, 'static', null, routes)
+    const compilerConfig = webpackConfig(program, directory, 'build-static', null, routes)
 
     webpack(compilerConfig.resolve()).run((e, stats) => {
       if (e) {
@@ -21,6 +22,10 @@ module.exports = (program, callback) => {
       if (stats.hasErrors()) {
         return callback(`Error: ${stats.toJson().errors}`, stats)
       }
+
+      // A temp file required by static-site-generator-plugin
+      fs.unlinkSync('public/render-page.js')
+
       return callback(null, stats)
     })
   })

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -1,4 +1,5 @@
-import buildStaticSite from './build-static'
+import buildCSS from './build-css'
+import buildHTML from './build-html'
 import buildProductionBundle from './build-javascript'
 import postBuild from './post-build'
 import globPages from './glob-pages'
@@ -73,19 +74,25 @@ function html (program, callback) {
     callback(error)
   }
 
-  buildStaticSite(program, (error) => {
-    if (error) {
-      console.log('Failed at generating static HTML/CSS')
-      return callback(error)
+  buildCSS(program, (cssError) => {
+    if (cssError) {
+      console.log('Failed at generating styles.css')
+      return callback(cssError)
     }
 
-    // If we're not generating a SPA, go directly to post build steps
-    if (config.noProductionJavascript) {
-      post(program, callback)
-    } else {
-      bundle(program, callback)
-    }
-    return true
+    return buildHTML(program, (htmlError) => {
+      if (htmlError) {
+        console.log('Failed at generating HTML')
+        return callback(htmlError)
+      }
+
+      // If we're not generating javascript, go directly to post build steps
+      if (config.noProductionJavascript) {
+        return post(program, callback)
+      } else {
+        return bundle(program, callback)
+      }
+    })
   })
 }
 

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -1,5 +1,5 @@
-import generateStaticPages from './static-generation'
-import buildProductionBundle from './build-production'
+import buildStaticSite from './build-static'
+import buildProductionBundle from './build-spa'
 import postBuild from './post-build'
 import globPages from './glob-pages'
 import toml from 'toml'
@@ -62,7 +62,7 @@ function bundle (program, callback) {
 }
 
 function html (program, callback) {
-  console.log('Generating static html pages')
+  console.log('Generating static HTML/CSS')
 
   const directory = program.directory
   let config
@@ -73,9 +73,9 @@ function html (program, callback) {
     callback(error)
   }
 
-  generateStaticPages(program, (error) => {
+  buildStaticSite(program, (error) => {
     if (error) {
-      console.log('failed at generating static html pages')
+      console.log('Failed at generating static HTML/CSS')
       return callback(error)
     }
 

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -1,5 +1,5 @@
 import buildStaticSite from './build-static'
-import buildProductionBundle from './build-spa'
+import buildProductionBundle from './build-javascript'
 import postBuild from './post-build'
 import globPages from './glob-pages'
 import toml from 'toml'

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -15,10 +15,11 @@ try {
   }
 }
 
-// Three stages:
+// Four stages:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
-//   2) build-static: build all HTML and CSS files
-//   3) build-javascript: Build bundle.js for Single Page App in production
+//   2) build-css: build styles.css file
+//   3) build-html: build all HTML files
+//   4) build-javascript: Build bundle.js for Single Page App in production
 
 module.exports = (program, directory, stage, webpackPort = 1500, routes = []) => {
   debug(`Loading webpack config for stage "${stage}"`)
@@ -30,9 +31,16 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
           filename: 'bundle.js',
           publicPath: `http://${program.host}:${webpackPort}/`,
         }
-      case 'build-static':
+      case 'build-css':
+        // Webpack will always generate a resultant javascript file.
+        // But we don't want it for this step. Deleted by build-css.js.
+        return {
+          path: `${directory}/public`,
+          filename: 'bundle-for-css.js',
+        }
+      case 'build-html':
         // A temp file required by static-site-generator-plugin. See plugins() below.
-        // Deleted by build-static.js, since it's not needed for production.
+        // Deleted by build-html.js, since it's not needed for production.
         return {
           path: `${directory}/public`,
           filename: 'render-page.js',
@@ -55,7 +63,11 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
           require.resolve('webpack-hot-middleware/client'),
           `${__dirname}/web-entry`,
         ]
-      case 'build-static':
+      case 'build-css':
+        return {
+          main: `${__dirname}/web-entry`,
+        }
+      case 'build-html':
         return {
           main: `${__dirname}/static-entry`,
         }
@@ -82,7 +94,17 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
             __PREFIX_LINKS__: program.prefixLinks,
           }),
         ]
-      case 'build-static':
+      case 'build-css':
+        return [
+          new webpack.DefinePlugin({
+            'process.env': {
+              NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'production'),
+            },
+            __PREFIX_LINKS__: program.prefixLinks,
+          }),
+          new ExtractTextPlugin('styles.css'),
+        ]
+      case 'build-html':
         return [
           new StaticSiteGeneratorPlugin('render-page.js', routes),
           new webpack.DefinePlugin({
@@ -91,7 +113,6 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
             },
             __PREFIX_LINKS__: program.prefixLinks,
           }),
-          new ExtractTextPlugin('styles.css'),
         ]
       case 'build-javascript':
         return [
@@ -142,7 +163,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
     switch (stage) {
       case 'develop':
         return 'eval'
-      case 'build-static':
+      case 'build-html':
         return false
       case 'build-javascript':
         return 'source-map'
@@ -273,7 +294,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         })
         return config
 
-      case 'build-static':
+      case 'build-css':
         config.loader('css', {
           test: /\.css$/,
           loader: ExtractTextPlugin.extract(['css', 'postcss']),
@@ -299,9 +320,27 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         })
         return config
 
+      case 'build-html':
+        // We don't deal with CSS at all when building the HTML.
+        // The 'null' loader is used to prevent 'module not found' errors.
+
+        config.loader('css', {
+          test: /\.css$/,
+          loader: 'null',
+        })
+        config.loader('less', {
+          test: /\.less/,
+          loader: 'null',
+        })
+        config.loader('sass', {
+          test: /\.(sass|scss)/,
+          loader: 'null',
+        })
+        return config
+
       case 'build-javascript':
-        // We don't deal with CSS when building the SPA, just javascript
-        // The 'null' loader is used to prevent 'module not found' errors
+        // We don't deal with CSS at all when building the javascript.
+        // The 'null' loader is used to prevent 'module not found' errors.
 
         config.loader('css', {
           test: /\.css$/,

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -18,7 +18,7 @@ try {
 // Three stages:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
 //   2) build-static: build all HTML and CSS files
-//   3) build-spa: Build bundle.js for Single Page App in production
+//   3) build-javascript: Build bundle.js for Single Page App in production
 
 module.exports = (program, directory, stage, webpackPort = 1500, routes = []) => {
   debug(`Loading webpack config for stage "${stage}"`)
@@ -38,7 +38,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
           filename: 'render-page.js',
           libraryTarget: 'umd',
         }
-      case 'build-spa':
+      case 'build-javascript':
         return {
           filename: 'bundle.js',
           path: `${directory}/public`,
@@ -59,7 +59,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         return {
           main: `${__dirname}/static-entry`,
         }
-      case 'build-spa':
+      case 'build-javascript':
         return [
           `${__dirname}/web-entry`,
         ]
@@ -93,7 +93,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
           }),
           new ExtractTextPlugin('styles.css'),
         ]
-      case 'build-spa':
+      case 'build-javascript':
         return [
           // Moment.js includes 100s of KBs of extra localization data
           // by default in Webpack that most sites don't want.
@@ -144,7 +144,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         return 'eval'
       case 'build-static':
         return false
-      case 'build-spa':
+      case 'build-javascript':
         return 'source-map'
       default:
         return false
@@ -299,7 +299,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         })
         return config
 
-      case 'build-spa':
+      case 'build-javascript':
         // We don't deal with CSS when building the SPA, just javascript
         // The 'null' loader is used to prevent 'module not found' errors
 

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -15,6 +15,11 @@ try {
   }
 }
 
+// Three stages:
+//   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
+//   2) build-static: build all HTML and CSS files
+//   3) build-spa: Build bundle.js for Single Page App in production
+
 module.exports = (program, directory, stage, webpackPort = 1500, routes = []) => {
   debug(`Loading webpack config for stage "${stage}"`)
   function output () {
@@ -25,13 +30,15 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
           filename: 'bundle.js',
           publicPath: `http://${program.host}:${webpackPort}/`,
         }
-      case 'static':
+      case 'build-static':
+        // A temp file required by static-site-generator-plugin. See plugins() below.
+        // Deleted by build-static.js, since it's not needed for production.
         return {
           path: `${directory}/public`,
-          filename: 'bundle.js',
+          filename: 'render-page.js',
           libraryTarget: 'umd',
         }
-      case 'production':
+      case 'build-spa':
         return {
           filename: 'bundle.js',
           path: `${directory}/public`,
@@ -48,13 +55,13 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
           require.resolve('webpack-hot-middleware/client'),
           `${__dirname}/web-entry`,
         ]
-      case 'production':
+      case 'build-static':
+        return {
+          main: `${__dirname}/static-entry`,
+        }
+      case 'build-spa':
         return [
           `${__dirname}/web-entry`,
-        ]
-      case 'static':
-        return [
-          `${__dirname}/static-entry`,
         ]
       default:
         throw new Error(`The state requested ${stage} doesn't exist.`)
@@ -75,7 +82,18 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
             __PREFIX_LINKS__: program.prefixLinks,
           }),
         ]
-      case 'production':
+      case 'build-static':
+        return [
+          new StaticSiteGeneratorPlugin('render-page.js', routes),
+          new webpack.DefinePlugin({
+            'process.env': {
+              NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'production'),
+            },
+            __PREFIX_LINKS__: program.prefixLinks,
+          }),
+          new ExtractTextPlugin('styles.css'),
+        ]
+      case 'build-spa':
         return [
           // Moment.js includes 100s of KBs of extra localization data
           // by default in Webpack that most sites don't want.
@@ -88,18 +106,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
             __PREFIX_LINKS__: program.prefixLinks,
           }),
           new webpack.optimize.DedupePlugin(),
-          new ExtractTextPlugin('styles.css'),
           new webpack.optimize.UglifyJsPlugin(),
-        ]
-      case 'static':
-        return [
-          new StaticSiteGeneratorPlugin('bundle.js', routes),
-          new webpack.DefinePlugin({
-            'process.env': {
-              NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'production'),
-            },
-            __PREFIX_LINKS__: program.prefixLinks,
-          }),
         ]
       default:
         throw new Error(`The state requested ${stage} doesn't exist.`)
@@ -135,9 +142,9 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
     switch (stage) {
       case 'develop':
         return 'eval'
-      case 'static':
+      case 'build-static':
         return false
-      case 'production':
+      case 'build-spa':
         return 'source-map'
       default:
         return false
@@ -266,22 +273,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         })
         return config
 
-      case 'static':
-        config.loader('css', {
-          test: /\.css$/,
-          loaders: ['css'],
-        })
-        config.loader('less', {
-          test: /\.less/,
-          loaders: ['css', 'less'],
-        })
-        config.loader('sass', {
-          test: /\.(sass|scss)/,
-          loaders: ['css', 'sass'],
-        })
-        return config
-
-      case 'production':
+      case 'build-static':
         config.loader('css', {
           test: /\.css$/,
           loader: ExtractTextPlugin.extract(['css', 'postcss']),
@@ -304,6 +296,24 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
               autoprefixer: false,
             }),
           ],
+        })
+        return config
+
+      case 'build-spa':
+        // We don't deal with CSS when building the SPA, just javascript
+        // The 'null' loader is used to prevent 'module not found' errors
+
+        config.loader('css', {
+          test: /\.css$/,
+          loader: 'null',
+        })
+        config.loader('less', {
+          test: /\.less/,
+          loader: 'null',
+        })
+        config.loader('sass', {
+          test: /\.(sass|scss)/,
+          loader: 'null',
         })
         return config
 


### PR DESCRIPTION
I realized that the `noProductionJavascript` option wasn't quite right because it still generates a weird unminified `public/bundle.js`, and you get no generated `styles.css`. This pull request changes that.

First, it makes the three stages in `util/webpack.config.js` a little easier to understand, renaming them to:

1. develop
2. build-static
3. build-spa

Second, it moves `styles.css` generation to Stage 2, the 'build-static' stage.

Third, it renames the temp webpack-generated file required by `static-site-generator-webpack-plugin` (previously `public/bundle.js`, so it was overwritten by the final webpack stage) to `public/render-page.js` and deletes it when Stage 2 is complete.