### PR TITLE
Fix path rewrite for pages with paths not ending with '/'

### DIFF
--- a/lib/utils/post-build.js
+++ b/lib/utils/post-build.js
@@ -41,7 +41,7 @@ module.exports = (program, cb) => {
         })
 
         if (page) {
-          newPath = parsePath(page.path).path + parsed.basename
+          newPath = path.join(parsePath(page.path).path, parsed.basename)
         } else {
           // We couldn't find a page associated with this file. Probably
           // the file is in a directory of static files. In any case,


### PR DESCRIPTION
Today I started playing with this library a little and noticed, that for pages with paths, that does not end with '/' the static files paths are rewritten in the wrong way.

E.g. for page :

~~~
---
title: Hello World
date: "2015-05-01T22:12:03.284Z"
layout: post
path: "/hello-world"
---

![Chinese Salty Egg](./salty_egg.jpg)

~~~

Path of `salty_egg.jpg` will be rewritten into `public/hello-worldsalty_egg.jpg` instead of `public/hello-world/salty_egg.jpg`. 

This simple patch fixes that issue.