### PR TITLE
Add url-loader for images in components directory

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -185,14 +185,22 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
     })
     config.loader('png', {
       test: /\.png$/,
-      loader: 'null',
+      include: [/components/],
+      loader: 'url-loader?mimetype=image/png&limit=10000',
     })
     config.loader('jpg', {
       test: /\.jpg$/,
-      loader: 'null',
+      include: [/components/],
+      loader: 'url-loader?mimetype=image/jpg&limit=10000',
     })
     config.loader('gif', {
       test: /\.gif$/,
+      include: [/components/],
+      loader: 'url-loader?mimetype=image/gif&limit=10000',
+    })
+    config.loader('img', {
+      test: /\.(png|jpg|gif)$/,
+      exclude: [/components/],
       loader: 'null',
     })
     config.loader('ico', {


### PR DESCRIPTION
This PR adds support for using images in components with require/import syntax. It allows to write reusable components that doesn't have to use any file from `pages` directory.

E.g.

Component file structure:
~~~
components/
  Logo/
    logo.png
    Logo.js
~~~

Logo.js

~~~
import React from 'react'
import img from './logo.png'

export default function Logo () {
  return (
    <img src={img} alt="Our awesome logo" />
  )
}
~~~

In my opinion, im the feature all images should be passed through webpack loader, at least to rewrite names (for better caching). It would also make it possible to resize/compress those files during build stage.