### PR TITLE
lib/utils/build.js now requires postBuild function in gatsby-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ Gatsby uses [webpack-configurator](https://github.com/lewie9021/webpack-configur
 to make changing the webpack loaders easy. The default set of loaders is organized by [key](lib/utils/webpack.config.js#L125).
 
 Gatsby uses `gatsby-node.js` to pass control to the user before
-resolving the final webpack configuration. `gatsby-node.js` should
-live in the root of your project and export a function which accepts a
+resolving the final build configuration. `gatsby-node.js` should
+live in the root of your project can export a function which accepts a
 webpack-configurator config object and an environment string. The
 environment string will be one of `develop`, `static` or
 `production`.
@@ -339,6 +339,18 @@ which you can use to enhance Gatsby.
 It is also possible to
 [write your own plugins](https://webpack.github.io/docs/how-to-write-a-plugin.html).
 
+### Perform additional post build step
+
+Gatsby also uses `gatsby-node.js` to pass control of the final build step over
+to the user when running `gatsby build`. The post build function takes two arguments, the pages and the callback for completing the build:
+
+```javascript
+export.postBuild = function(pages, callback) {
+  // perform actions on pages here
+
+  callback();
+}
+```
 
 ### How to write your own wrappers
 * Coming...

--- a/README.md
+++ b/README.md
@@ -235,8 +235,6 @@ files which start with an underscore:
   found' page. If you `<Link>` to an unknown URL, this page will be shown. Note: in
   production, you'll need to [set up your server host to show this page when it can't find
   the requested file](https://github.com/gatsbyjs/gatsby/pull/121#issuecomment-194715068).
-* (optional) `post-build.js` - a `function(pages, cb)` you can provide to do final
-processing on all generated content.
 * (optional) `gatsby-browser.js` - a way to hook into key application events. Export
 `onRouteChange` of type `function(location)` to be notified whenever React-Router
 navigates.

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -10,7 +10,8 @@ function customPost (program, callback) {
   const directory = program.directory
   let customPostBuild
   try {
-    customPostBuild = require(`${directory}/post-build`)
+    const gatsbyNodeConfig = require(`${directory}/gatsby-node`)
+    customPostBuild = gatsbyNodeConfig.postBuild
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {
       console.log('Failed to load custom post build script. It will be skipped.')
@@ -21,7 +22,7 @@ function customPost (program, callback) {
   if (customPostBuild) {
     console.log('Performing custom post-build steps')
 
-    globPages(directory, (globError, pages) =>
+    return globPages(directory, (globError, pages) =>
       customPostBuild(pages, (error) => {
         if (error) {
           console.log('customPostBuild function failed')
@@ -30,9 +31,9 @@ function customPost (program, callback) {
         return callback()
       })
     )
-  } else {
-    callback()
   }
+
+  return callback()
 }
 
 function post (program, callback) {

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -14,7 +14,7 @@ function customPost (program, callback) {
     customPostBuild = gatsbyNodeConfig.postBuild
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {
-      console.log("Failed to load gatsby-node.js", e)
+      console.log("Failed to load gatsby-node.js, skipping custom post build script", e)
     }
   }
 

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -14,7 +14,7 @@ function customPost (program, callback) {
     customPostBuild = gatsbyNodeConfig.postBuild
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {
-      console.log("Failed to load gatsby-node.js, skipping custom post build script", e)
+      console.log('Failed to load gatsby-node.js, skipping custom post build script', e)
     }
   }
 

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -14,8 +14,7 @@ function customPost (program, callback) {
     customPostBuild = gatsbyNodeConfig.postBuild
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {
-      console.log('Failed to load custom post build script. It will be skipped.')
-      console.log(e)
+      console.log("Failed to load gatsby-node.js", e)
     }
   }
 


### PR DESCRIPTION
Removes requirement for a post-build.js file in the root of the project for a custom post build step in gatsby build. Instead it requires for a postBuild export in the gatsby-node file in the root of the domain, where the webpack custom configuration is also stored.

Closes #239 