### PR TITLE
Extract the Hapi Server to expose it for testing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,3 @@
 {
-  "presets": ['react', 'es2015', 'stage-0'],
-  "plugins": [
-    'transform-object-rest-spread'
-  ]
+  "presets": ['react', 'es2015', 'stage-0']
 }

--- a/lib/utils/dev-server.js
+++ b/lib/utils/dev-server.js
@@ -1,0 +1,168 @@
+import Hapi from 'hapi'
+import Boom from 'boom'
+import React from 'react'
+import ReactDOMServer from 'react-dom/server'
+import webpack from 'webpack'
+import Negotiator from 'negotiator'
+import parsePath from 'parse-filepath'
+import find from 'lodash/find'
+import webpackRequire from 'webpack-require'
+import WebpackPlugin from 'hapi-webpack-plugin'
+import fs from 'fs'
+import glob from 'glob'
+import webpackConfig from './webpack.config'
+const debug = require('debug')('gatsby:application')
+
+module.exports = function devServer (program, pages, callback) {
+  const { directory } = program
+  const compilerConfig = webpackConfig(program, directory, 'develop', program.port)
+
+  const compiler = webpack(compilerConfig.resolve())
+
+  let HTMLPath = `${directory}/html`
+  // Check if we can't find an html component in root of site.
+  if (glob.sync(`${HTMLPath}.*`).length === 0) {
+    HTMLPath = '../isomorphic/html'
+  }
+
+  const htmlCompilerConfig = webpackConfig(program, directory, 'develop', program.port)
+  // Remove react-transform option from Babel as redbox-react doesn't work
+  // on the server.
+  htmlCompilerConfig.removeLoader('js')
+  htmlCompilerConfig.loader('js', {
+    test: /\.jsx?$/, // Accept either .js or .jsx files.
+    exclude: /(node_modules|bower_components)/,
+    loader: 'babel',
+    query: {
+      presets: ['react', 'es2015', 'stage-1'],
+      plugins: ['add-module-exports'],
+    },
+  })
+
+  webpackRequire(htmlCompilerConfig.resolve(), require.resolve(HTMLPath), (error, factory) => {
+    if (error) {
+      console.log(`Failed to require ${directory}/html.js`)
+      error.forEach((e) => {
+        console.log(e)
+      })
+      process.exit()
+    }
+    const HTML = factory()
+    debug('Configuring develop server')
+
+    // Setup and start Hapi to serve html + static files + webpack-hot-middleware.
+    const server = new Hapi.Server()
+    server.connection({
+      host: program.host,
+      port: program.port,
+    })
+
+    server.route({
+      method: 'GET',
+      path: '/html/{path*}',
+      handler: (request, reply) => {
+        if (request.path === 'favicon.ico') {
+          return reply(Boom.notFound())
+        }
+
+        try {
+          const htmlElement = React.createElement(
+            HTML, {
+              body: '',
+            }
+          )
+          let html = ReactDOMServer.renderToStaticMarkup(htmlElement)
+          html = `<!DOCTYPE html>\n${html}`
+          return reply(html)
+        } catch (e) {
+          console.log(e.stack)
+          throw e
+        }
+      },
+    })
+
+    server.route({
+      method: 'GET',
+      path: '/{path*}',
+      handler: {
+        directory: {
+          path: `${directory}/pages`,
+          listing: false,
+          index: false,
+        },
+      },
+    })
+
+    server.ext('onRequest', (request, reply) => {
+      const negotiator = new Negotiator(request.raw.req)
+
+      // Try to map the url path to match an actual path of a file on disk.
+      const parsed = parsePath(request.path)
+      const page = find(pages, (p) => p.path === (`${parsed.dirname}/`))
+
+      let absolutePath = `${directory}/pages`
+      let path
+      if (page) {
+        path = `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
+        absolutePath += `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
+      } else {
+        path = request.path
+        absolutePath += request.path
+      }
+      let isFile = false
+      try {
+        isFile = fs.lstatSync(absolutePath).isFile()
+      } catch (e) {
+        // Ignore.
+      }
+
+      // If the path matches a file, return that.
+      if (isFile) {
+        request.setUrl(path)
+        reply.continue()
+      // Let people load the bundle.js directly.
+      } else if (request.path === '/bundle.js') {
+        reply.continue()
+      } else if (negotiator.mediaType() === 'text/html') {
+        request.setUrl(`/html${request.path}`)
+        reply.continue()
+      } else {
+        reply.continue()
+      }
+    })
+
+    const assets = {
+      noInfo: true,
+      reload: true,
+      publicPath: compilerConfig._config.output.publicPath,
+    }
+    const hot = {
+      hot: true,
+      quiet: true,
+      noInfo: true,
+      host: program.host,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+      },
+      stats: {
+        colors: true,
+      },
+    }
+
+    server.register({
+      register: WebpackPlugin,
+      options: {
+        compiler,
+        assets,
+        hot,
+      },
+    }, (er) => {
+      if (er) {
+        console.log(er)
+        process.exit()
+      }
+
+      callback(server)
+    })
+  })
+}

--- a/lib/utils/dev-server.js
+++ b/lib/utils/dev-server.js
@@ -26,18 +26,6 @@ module.exports = function devServer (program, pages, callback) {
   }
 
   const htmlCompilerConfig = webpackConfig(program, directory, 'develop', program.port)
-  // Remove react-transform option from Babel as redbox-react doesn't work
-  // on the server.
-  htmlCompilerConfig.removeLoader('js')
-  htmlCompilerConfig.loader('js', {
-    test: /\.jsx?$/, // Accept either .js or .jsx files.
-    exclude: /(node_modules|bower_components)/,
-    loader: 'babel',
-    query: {
-      presets: ['react', 'es2015', 'stage-1'],
-      plugins: ['add-module-exports'],
-    },
-  })
 
   webpackRequire(htmlCompilerConfig.resolve(), require.resolve(HTMLPath), (error, factory) => {
     if (error) {

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -1,184 +1,23 @@
 require('node-cjsx').transform()
-import Hapi from 'hapi'
-import Boom from 'boom'
-import React from 'react'
-import ReactDOMServer from 'react-dom/server'
-import webpack from 'webpack'
-import Negotiator from 'negotiator'
-import parsePath from 'parse-filepath'
-import find from 'lodash/find'
-import webpackRequire from 'webpack-require'
-import WebpackPlugin from 'hapi-webpack-plugin'
 import opn from 'opn'
-import fs from 'fs'
-import glob from 'glob'
-
 import globPages from './glob-pages'
-import webpackConfig from './webpack.config'
-const debug = require('debug')('gatsby:application')
+import devServer from './dev-server'
 
 module.exports = (program) => {
   const directory = program.directory
 
   // Load pages for the site.
-  return globPages(directory, (err, pages) => {
-    const compilerConfig = webpackConfig(program, directory, 'develop', program.port)
-
-    const compiler = webpack(compilerConfig.resolve())
-
-    let HTMLPath = `${directory}/html`
-    // Check if we can't find an html component in root of site.
-    if (glob.sync(`${HTMLPath}.*`).length === 0) {
-      HTMLPath = '../isomorphic/html'
-    }
-
-    const htmlCompilerConfig = webpackConfig(program, directory, 'develop', program.port)
-    // Remove react-transform option from Babel as redbox-react doesn't work
-    // on the server.
-    htmlCompilerConfig.removeLoader('js')
-    htmlCompilerConfig.loader('js', {
-      test: /\.jsx?$/, // Accept either .js or .jsx files.
-      exclude: /(node_modules|bower_components)/,
-      loader: 'babel',
-      query: {
-        presets: ['react', 'es2015', 'stage-1'],
-        plugins: ['add-module-exports'],
-      },
-    })
-
-    webpackRequire(htmlCompilerConfig.resolve(), require.resolve(HTMLPath), (error, factory) => {
-      if (error) {
-        console.log(`Failed to require ${directory}/html.js`)
-        error.forEach((e) => {
+  return globPages(directory, (err, pages) =>
+    devServer(program, pages, server => {
+      server.start((e) => {
+        if (e) {
           console.log(e)
-        })
-        process.exit()
-      }
-      const HTML = factory()
-      debug('Configuring develop server')
-
-      // Setup and start Hapi to serve html + static files + webpack-hot-middleware.
-      const server = new Hapi.Server()
-      server.connection({
-        host: program.host,
-        port: program.port,
-      })
-
-      server.route({
-        method: 'GET',
-        path: '/html/{path*}',
-        handler: (request, reply) => {
-          if (request.path === 'favicon.ico') {
-            return reply(Boom.notFound())
-          }
-
-          try {
-            const htmlElement = React.createElement(
-              HTML, {
-                body: '',
-              }
-            )
-            let html = ReactDOMServer.renderToStaticMarkup(htmlElement)
-            html = `<!DOCTYPE html>\n${html}`
-            return reply(html)
-          } catch (e) {
-            console.log(e.stack)
-            throw e
-          }
-        },
-      })
-
-      server.route({
-        method: 'GET',
-        path: '/{path*}',
-        handler: {
-          directory: {
-            path: `${directory}/pages`,
-            listing: false,
-            index: false,
-          },
-        },
-      })
-
-      server.ext('onRequest', (request, reply) => {
-        const negotiator = new Negotiator(request.raw.req)
-
-        // Try to map the url path to match an actual path of a file on disk.
-        const parsed = parsePath(request.path)
-        const page = find(pages, (p) => p.path === (`${parsed.dirname}/`))
-
-        let absolutePath = `${directory}/pages`
-        let path
-        if (page) {
-          path = `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
-          absolutePath += `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
-        } else {
-          path = request.path
-          absolutePath += request.path
         }
-        let isFile = false
-        try {
-          isFile = fs.lstatSync(absolutePath).isFile()
-        } catch (e) {
-          // Ignore.
+        if (program.open) {
+          opn(server.info.uri)
         }
-
-        // If the path matches a file, return that.
-        if (isFile) {
-          request.setUrl(path)
-          reply.continue()
-        // Let people load the bundle.js directly.
-        } else if (request.path === '/bundle.js') {
-          reply.continue()
-        } else if (negotiator.mediaType() === 'text/html') {
-          request.setUrl(`/html${request.path}`)
-          reply.continue()
-        } else {
-          reply.continue()
-        }
-      })
-
-      const assets = {
-        noInfo: true,
-        reload: true,
-        publicPath: compilerConfig._config.output.publicPath,
-      }
-      const hot = {
-        hot: true,
-        quiet: true,
-        noInfo: true,
-        host: program.host,
-        headers: {
-          'Access-Control-Allow-Origin': '*',
-        },
-        stats: {
-          colors: true,
-        },
-      }
-
-      server.register({
-        register: WebpackPlugin,
-        options: {
-          compiler,
-          assets,
-          hot,
-        },
-      }, (er) => {
-        if (er) {
-          console.log(er)
-          process.exit()
-        }
-
-        server.start((e) => {
-          if (e) {
-            console.log(e)
-          }
-          if (program.open) {
-            opn(server.info.uri)
-          }
-          return console.log('Listening at:', server.info.uri)
-        })
+        console.log('Listening at:', server.info.uri)
       })
     })
-  })
+  )
 }

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -155,7 +155,14 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
       exclude: /(node_modules|bower_components)/,
       loader: 'babel',
       query: {
-        plugins: ['add-module-exports'],
+        presets: [
+          'babel-preset-react',
+          'babel-preset-es2015',
+          'babel-preset-stage-0',
+        ].map(require.resolve),
+        plugins: [
+          'babel-plugin-add-module-exports',
+        ].map(require.resolve),
       },
     })
     config.loader('coffee', {

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -260,10 +260,18 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
           exclude: /(node_modules|bower_components)/,
           loader: 'babel',
           query: {
-            presets: ['react-hmre', 'react', 'es2015', 'stage-1'],
-            plugins: ['add-module-exports'],
+            presets: [
+              'babel-preset-react-hmre',
+              'babel-preset-react',
+              'babel-preset-es2015',
+              'babel-preset-stage-0',
+            ].map(require.resolve),
+            plugins: [
+              'babel-plugin-add-module-exports',
+            ].map(require.resolve),
           },
         })
+
         return config
 
       case 'static':

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-core": "^6.7.6",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.1.2",
-    "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
   },
   "devDependencies": {
     "ava": "^0.14.0",
-    "ava-http": "^0.2.1",
     "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.2",
     "babel-register": "^6.7.2",

--- a/test/fixtures/override-htmljs/html.js
+++ b/test/fixtures/override-htmljs/html.js
@@ -1,0 +1,26 @@
+import React, { PropTypes } from 'react'
+import { prefixLink } from 'gatsby-helpers'
+
+function HTML (props) {
+  return (
+    <html>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0 maximum-scale=5.0"
+        />
+      </head>
+      <body>
+        <div id="react-mount" dangerouslySetInnerHTML={{ __html: props.body }} />
+        <footer>GatsbyJS Override html.js</footer>
+        <script src={prefixLink('/bundle.js')} />
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = { body: PropTypes.any }
+
+module.exports = HTML

--- a/test/fixtures/override-htmljs/pages/index.js
+++ b/test/fixtures/override-htmljs/pages/index.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function index () {
+  return <h1>Index</h1>
+}

--- a/test/helpers/develop.js
+++ b/test/helpers/develop.js
@@ -1,0 +1,44 @@
+import Promise from 'bluebird'
+import cheerio from 'cheerio'
+import devServer from '../../lib/utils/dev-server'
+import globPages from '../../lib/utils/glob-pages'
+
+function programStub (fixturePath) {
+  return {
+    directory: fixturePath,
+    port: 8000,
+    host: '0.0.0.0',
+  }
+}
+
+function createServer (server) {
+  return {
+    server,
+    get (url) {
+      const injectOptions = (typeof url === 'string') ? { url } : url
+      return new Promise(resolve => {
+        server.inject(injectOptions, response => {
+          resolve(cheerio.load(response.payload))
+        })
+      })
+    },
+    getHtml (url) {
+      return this.get({
+        url,
+        headers: { accept: 'text/html' },
+      })
+    },
+  }
+}
+
+export function develop (fixturePath) {
+  const program = programStub(fixturePath)
+
+  return new Promise(resolve => {
+    globPages(fixturePath, (error, pages) => {
+      devServer(program, pages, server => {
+        resolve(createServer(server))
+      })
+    })
+  })
+}

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -42,3 +42,5 @@ export function dom (filePath) {
   return readFile(filePath)
     .then(html => cheerio.load(html))
 }
+
+export { develop } from './develop'

--- a/test/integration/cli-returns-help.js
+++ b/test/integration/cli-returns-help.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import packageJson from '../../package.json'
-import { gatsby } from '../support'
+import { gatsby } from '../helpers'
 
 test('cli can be called and exits with 0', async t => {
   const noArgs = await gatsby()

--- a/test/integration/static-html-wrappers.js
+++ b/test/integration/static-html-wrappers.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import path from 'path'
-import { build, dom } from '../support'
+import { build, dom } from '../helpers'
 
 const fixturePath = path.resolve('..', 'fixtures', 'static-wrappers')
 

--- a/test/integration/user-overrides-htmljs.js
+++ b/test/integration/user-overrides-htmljs.js
@@ -1,0 +1,30 @@
+import test from 'ava'
+import path from 'path'
+import includes from 'lodash/includes'
+import { build, develop, dom } from '../helpers'
+
+const fixturePath = path.resolve('..', 'fixtures', 'override-htmljs')
+
+test.before('build the site', async () => {
+  await build(fixturePath)
+})
+
+test('the rendered index has the override footer', async t => {
+  const indexPath = path.resolve(fixturePath, 'public', 'index.html')
+  const $ = await dom(indexPath)
+
+  const footer = $('footer').first()
+  t.truthy(footer)
+  const footerText = footer.text()
+  t.true(includes(footerText, 'html.js'))
+})
+
+test('the server has the override footer', async t => {
+  const server = await develop(fixturePath)
+  const $ = await server.getHtml('/')
+
+  const footer = $('footer').first()
+  t.truthy(footer)
+  const footerText = footer.text()
+  t.true(includes(footerText, 'html.js'))
+})

--- a/test/integration/user-rewrites-path-not-ending-in-slash.js
+++ b/test/integration/user-rewrites-path-not-ending-in-slash.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import path from 'path'
 import Promise from 'bluebird'
-import { build } from '../support'
+import { build } from '../helpers'
 import fse from 'fs-extra'
 const fs = Promise.promisifyAll(fse)
 

--- a/test/integration/user-rewrites-path.js
+++ b/test/integration/user-rewrites-path.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import path from 'path'
 import Promise from 'bluebird'
-import { build } from '../support'
+import { build } from '../helpers'
 import fse from 'fs-extra'
 const fs = Promise.promisifyAll(fse)
 


### PR DESCRIPTION
* The Hapi Server has been extracted so that it can be
tested using the built in #inject() method.
* Test support has been moved to /helpers. This is the default location
that is ignored by `ava`.
* Added a test to ensure that the user can override the default html.js
in both the develop and build stages.

After some research I think using Hapi's inject is going to provide the best testing experience with the least amount of test setup. This way we have simpler test infrastructure that is less likely to be the cause of test failures.

The only code change was that the server is now started in `lib/utils/develop` and constructed in `lib/utils/dev-server`