### PR TITLE
Enable babelrc plugins with options array syntax

### DIFF
--- a/lib/utils/babel-config.js
+++ b/lib/utils/babel-config.js
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import json5 from 'json5'
 import startsWith from 'lodash/startsWith'
+import isArray from 'lodash/isArray'
 import invariant from 'invariant'
 
 const DEFAULT_BABEL_CONFIG = {
@@ -62,7 +63,15 @@ function normalizeConfig (config, directory) {
 
   const plugins = config.plugins || []
   plugins.forEach(plugin => {
-    normalizedConfig.plugins.push(resolvePlugin(plugin, directory, 'plugin'))
+    let normalizedPlugin
+    console.log(plugin, isArray(plugin))
+    if (isArray(plugin)) {
+      normalizedPlugin = [resolvePlugin(plugin[0], directory, 'plugin'), plugin[1]]
+    } else {
+      normalizedPlugin = resolvePlugin(plugin, directory, 'plugin')
+    }
+
+    normalizedConfig.plugins.push(normalizedPlugin)
   })
 
   return normalizedConfig

--- a/lib/utils/babel-config.js
+++ b/lib/utils/babel-config.js
@@ -64,7 +64,6 @@ function normalizeConfig (config, directory) {
   const plugins = config.plugins || []
   plugins.forEach(plugin => {
     let normalizedPlugin
-    console.log(plugin, isArray(plugin))
     if (isArray(plugin)) {
       normalizedPlugin = [resolvePlugin(plugin[0], directory, 'plugin'), plugin[1]]
     } else {


### PR DESCRIPTION
Recently I've been fiddling a lot with multiple approaches to styles. By accident I've discovered a small bug that this pull request is fixing. 

[Babel docs](https://babeljs.io/docs/plugins/) allows two type of plugin syntax: string or an array with options e.g.

~~~
{
  "plugins": [
    "add-module-exports",
    ["css-in-js", { "vendorPrefixes": true, "bundleFile": "public/bundle.css" }]
  ]
}
~~~

The second syntax caused an error, as normalization casts array to string. 