### PR TITLE
Performance Changes 🚀

### DIFF
--- a/lib/utils/babel-config.js
+++ b/lib/utils/babel-config.js
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import json5 from 'json5'
 import startsWith from 'lodash/startsWith'
+import objectAssign from 'object-assign'
 import invariant from 'invariant'
 
 const DEFAULT_BABEL_CONFIG = {
@@ -65,7 +66,7 @@ function normalizeConfig (config, directory) {
     normalizedConfig.plugins.push(resolvePlugin(plugin, directory, 'plugin'))
   })
 
-  return normalizedConfig
+  return objectAssign({}, config, normalizedConfig)
 }
 
 /**
@@ -116,6 +117,10 @@ export default function babelConfig (program, stage) {
 
   if (stage === 'develop') {
     babelrc.presets.unshift('react-hmre')
+  }
+
+  if (!babelrc.hasOwnProperty('cacheDirectory')) {
+    babelrc.cacheDirectory = true
   }
 
   return normalizeConfig(babelrc, directory)

--- a/lib/utils/glob-pages.js
+++ b/lib/utils/glob-pages.js
@@ -2,9 +2,7 @@ import glob from 'glob'
 import buildPage from './build-page'
 const debug = require('debug')('gatsby:glob')
 
-module.exports = (directory, callback) => {
-  const pagesData = []
-
+function globQuery (directory) {
   // Make this list easy to modify through the config?
   // Or just keep adding extensions...?
   const fileTypesToGlob = [
@@ -20,8 +18,14 @@ module.exports = (directory, callback) => {
   ]
   const fileGlobQuery = fileTypesToGlob.map((type) => `*.${type}`)
   const joinedFileQuery = fileGlobQuery.join('|')
-  const globQuery = `${directory}/pages/**/?(${joinedFileQuery})`
-  glob(globQuery, null, (err, pages) => {
+  return `${directory}/pages/**/?(${joinedFileQuery})`
+}
+
+let globCache
+function createCache (directory, callback) {
+  const pagesData = []
+
+  glob(globQuery(directory), null, (err, pages) => {
     if (err) { return callback(err) }
 
     pages.forEach((page) => {
@@ -29,6 +33,15 @@ module.exports = (directory, callback) => {
     })
 
     debug(`globbed ${pagesData.length} pages`)
+    globCache = pagesData
     return callback(null, pagesData)
   })
+}
+
+module.exports = function globPages (directory, callback) {
+  if (typeof globCache === 'undefined') {
+    createCache(directory, callback)
+  } else {
+    callback(null, globCache)
+  }
 }

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -154,11 +154,9 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         '.toml',
         '.yaml',
       ],
-      modulesDirectories: [
+      root: [
         directory,
-        `${__dirname}/../isomorphic`,
-        `${directory}/node_modules`,
-        'node_modules',
+        path.resolve(__dirname, '..', 'isomorphic'),
       ],
     }
   }

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -363,11 +363,12 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
     devtool: devtool(),
     output: output(),
     resolveLoader: {
+      root: [
+        path.resolve(directory, 'loaders'),
+        path.resolve(__dirname, '..', 'loaders'),
+      ],
       modulesDirectories: [
-        `${directory}/node_modules`,
-        `${directory}/loaders`,
-        `${__dirname}/../../node_modules`,
-        `${__dirname}/../loaders`,
+        'node_modules',
       ],
     },
     plugins: plugins(),


### PR DESCRIPTION
If you want to see incremental progress I put the `time` output on each commit. Here is the overall result:

```
# gatsbyjs/gatsby-starter-blog BEFORE
Command being timed: "gatsby build"
User time (seconds): 31.49
System time (seconds): 2.56
Percent of CPU this job got: 107%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:31.72

# gatsbyjs/gatsby-starter-blog AFTER
Command being timed: "gatsby build"
User time (seconds): 23.78
System time (seconds): 2.80
Percent of CPU this job got: 110%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:24.05
```

```
# kyleamathews/blog BEFORE
Command being timed: "gatsby build"
User time (seconds): 38.03
System time (seconds): 3.02
Percent of CPU this job got: 106%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:38.47

# kyleamathews/blog AFTER
Command being timed: "gatsby build"
User time (seconds): 26.70
System time (seconds): 2.79
Percent of CPU this job got: 112%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.30
```