### PR TITLE
Remove react-hmre from Dev HTML Compiler Config

### DIFF
--- a/lib/utils/babel-config.js
+++ b/lib/utils/babel-config.js
@@ -7,9 +7,11 @@ import isArray from 'lodash/isArray'
 import objectAssign from 'object-assign'
 import invariant from 'invariant'
 
-const DEFAULT_BABEL_CONFIG = {
-  presets: ['react', 'es2015', 'stage-0'],
-  plugins: ['add-module-exports', 'transform-object-assign'],
+function defaultConfig () {
+  return {
+    presets: ['react', 'es2015', 'stage-0'],
+    plugins: ['add-module-exports', 'transform-object-assign'],
+  }
 }
 
 /**
@@ -122,7 +124,7 @@ export default function babelConfig (program, stage) {
 
   const babelrc = findBabelrc(directory) ||
     findBabelPackage(directory) ||
-    DEFAULT_BABEL_CONFIG
+    defaultConfig()
 
   if (stage === 'develop') {
     babelrc.presets.unshift('react-hmre')

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -15,7 +15,6 @@ import glob from 'glob'
 
 import globPages from './glob-pages'
 import webpackConfig from './webpack.config'
-import babelConfig from './babel-config'
 const debug = require('debug')('gatsby:application')
 
 module.exports = (program) => {
@@ -33,16 +32,7 @@ module.exports = (program) => {
       HTMLPath = '../isomorphic/html'
     }
 
-    const htmlCompilerConfig = webpackConfig(program, directory, 'develop', program.port)
-    // Remove react-transform option from Babel as redbox-react doesn't work
-    // on the server.
-    htmlCompilerConfig.removeLoader('js')
-    htmlCompilerConfig.loader('js', {
-      test: /\.jsx?$/, // Accept either .js or .jsx files.
-      exclude: /(node_modules|bower_components)/,
-      loader: 'babel',
-      query: babelConfig(program),
-    })
+    const htmlCompilerConfig = webpackConfig(program, directory, 'develop-html', program.port)
 
     webpackRequire(htmlCompilerConfig.resolve(), require.resolve(HTMLPath), (error, factory) => {
       if (error) {

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -15,6 +15,7 @@ import glob from 'glob'
 
 import globPages from './glob-pages'
 import webpackConfig from './webpack.config'
+import babelConfig from './babel-config'
 const debug = require('debug')('gatsby:application')
 
 module.exports = (program) => {
@@ -33,6 +34,15 @@ module.exports = (program) => {
     }
 
     const htmlCompilerConfig = webpackConfig(program, directory, 'develop', program.port)
+    // Remove react-transform option from Babel as redbox-react doesn't work
+    // on the server.
+    htmlCompilerConfig.removeLoader('js')
+    htmlCompilerConfig.loader('js', {
+      test: /\.jsx?$/, // Accept either .js or .jsx files.
+      exclude: /(node_modules|bower_components)/,
+      loader: 'babel',
+      query: babelConfig(program),
+    })
 
     webpackRequire(htmlCompilerConfig.resolve(), require.resolve(HTMLPath), (error, factory) => {
       if (error) {

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -22,11 +22,15 @@ try {
 
 // Four stages:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
-//   2) build-css: build styles.css file
-//   3) build-html: build all HTML files
-//   4) build-javascript: Build bundle.js for Single Page App in production
+//   2) develop-html: same as develop without react-hmre in the babel config for html renderer
+//   3) build-css: build styles.css file
+//   4) build-html: build all HTML files
+//   5) build-javascript: Build bundle.js for Single Page App in production
 
-module.exports = (program, directory, stage, webpackPort = 1500, routes = []) => {
+module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes = []) => {
+  const babelStage = suppliedStage
+  const stage = (suppliedStage === 'develop-html') ? 'develop' : suppliedStage
+
   debug(`Loading webpack config for stage "${stage}"`)
   function output () {
     switch (stage) {
@@ -189,7 +193,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
       test: /\.jsx?$/, // Accept either .js or .jsx files.
       exclude: /(node_modules|bower_components)/,
       loader: 'babel',
-      query: babelConfig(program, stage),
+      query: babelConfig(program, babelStage),
     })
     config.loader('coffee', {
       test: /\.coffee$/,


### PR DESCRIPTION
Also fixes a bug where react-hmre would get added twice to the
DEFAULT_BABEL_CONFIG as there are two webpack compilers for the
development server. This was mutating the const object when it should be
creating a new default for each run. Now a new object is returned
instead.

Fixes #304