### PR TITLE
absolute css asset loading (fixes #310)

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         return {
           path: `${directory}/public`,
           filename: 'bundle-for-css.js',
+          publicPath: '/',
         }
       case 'build-html':
         // A temp file required by static-site-generator-plugin. See plugins() below.


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby/issues/310 using https://github.com/webpack/css-loader/issues/113

NPM tests passed, and it works in my project.

