### PR TITLE
add fallback directory for resolving linked npm modules

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -163,6 +163,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         `${directory}/node_modules`,
         'node_modules',
       ],
+      fallback: `${directory}/node_modules`,
     }
   }
 
@@ -375,6 +376,7 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
       modulesDirectories: [
         'node_modules',
       ],
+      fallback: `${directory}/node_modules`,
     },
     plugins: plugins(),
     resolve: resolve(),

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -163,7 +163,10 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
         `${directory}/node_modules`,
         'node_modules',
       ],
-      fallback: `${directory}/node_modules`,
+      fallback: [
+        `${directory}/node_modules`,
+        path.resolve(__dirname, '../..', 'node_modules'),
+      ],
     }
   }
 
@@ -376,7 +379,10 @@ module.exports = (program, directory, stage, webpackPort = 1500, routes = []) =>
       modulesDirectories: [
         'node_modules',
       ],
-      fallback: `${directory}/node_modules`,
+      fallback: [
+        `${directory}/node_modules`,
+        path.resolve(__dirname, '../..', 'node_modules'),
+      ],
     },
     plugins: plugins(),
     resolve: resolve(),


### PR DESCRIPTION
Gatsby currently throws an error if you're using a module via `npm link` that uses a loader. This PR allows this by adding a `fallback` field pointing to gatsby `npm_modules`.

See: http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-doesn-t-find-their-dependencies

Tests Pass, Works in my project.