### PR TITLE
PrefixLink fixes

### DIFF
--- a/lib/isomorphic/gatsby-helpers.js
+++ b/lib/isomorphic/gatsby-helpers.js
@@ -22,7 +22,7 @@ const prefixLink = (_link) => {
     `
     invariant(isString(config.linkPrefix), invariantMessage)
 
-    return isDataURL(_link) ? _link : path.join(config.linkPrefix, _link)
+    return (!isString(_link) || isDataURL(_link)) ? _link : path.join(config.linkPrefix, _link)
   } else {
     return _link
   }

--- a/lib/isomorphic/gatsby-helpers.js
+++ b/lib/isomorphic/gatsby-helpers.js
@@ -1,6 +1,7 @@
 import { config } from 'config'
 import invariant from 'invariant'
 import isString from 'lodash/isString'
+import path from 'path'
 
 function isDataURL (s) {
   // Regex from https://gist.github.com/bgrins/6194623#gistcomment-1671744
@@ -21,7 +22,7 @@ const prefixLink = (_link) => {
     `
     invariant(isString(config.linkPrefix), invariantMessage)
 
-    return isDataURL(_link) ? _link : config.linkPrefix + _link
+    return isDataURL(_link) ? _link : path.join(config.linkPrefix, _link)
   } else {
     return _link
   }

--- a/lib/isomorphic/gatsby-helpers.js
+++ b/lib/isomorphic/gatsby-helpers.js
@@ -2,6 +2,13 @@ import { config } from 'config'
 import invariant from 'invariant'
 import isString from 'lodash/isString'
 
+function isDataURL (s) {
+  // Regex from https://gist.github.com/bgrins/6194623#gistcomment-1671744
+  // eslint-disable-next-line max-len
+  const regex = /^\s*data:([a-z]+\/[a-z0-9\-\+]+(;[a-z\-]+=[a-z0-9\-]+)?)?(;base64)?,[a-z0-9!\$&',\(\)\*\+,;=\-\._~:@\/\?%\s]*\s*$/i
+  return !!s.match(regex)
+}
+
 // Function to add prefix to links.
 const prefixLink = (_link) => {
   if (
@@ -14,7 +21,7 @@ const prefixLink = (_link) => {
     `
     invariant(isString(config.linkPrefix), invariantMessage)
 
-    return config.linkPrefix + _link
+    return isDataURL(_link) ? _link : config.linkPrefix + _link
   } else {
     return _link
   }


### PR DESCRIPTION
When `url-loader` is used with `limit` option some of images are encoded to base64 data url, this fix prevent such links from being prefixed.

It also makes link prefixing safer by using `path.join` instead of string concatenation.