### PR TITLE
Don't start develop server if port in use

### DIFF
--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -159,12 +159,27 @@ module.exports = (program) => {
 
         server.start((e) => {
           if (e) {
-            console.log(e)
+            if (e.code === 'EADDRINUSE') {
+              const finder = require('process-finder')
+              finder.find({ elevate: false, port: program.port }, (startErr, pids) => {
+                const msg =
+`We were unable to start Gatsby on port ${program.port} as there's already a process
+listening on that port (PID: ${pids[0]}). You can either use a different port
+(e.g. gatsby develop --port ${parseInt(program.port, 10) + 1}) or stop the process already listening
+on your desired port.`
+                console.log(msg)
+                process.exit()
+              })
+            } else {
+              console.log(e)
+              process.exit()
+            }
+          } else {
+            if (program.open) {
+              opn(server.info.uri)
+            }
+            console.log('Listening at:', server.info.uri)
           }
-          if (program.open) {
-            opn(server.info.uri)
-          }
-          return console.log('Listening at:', server.info.uri)
         })
       })
     })

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "postcss-import": "^8.1.2",
     "postcss-loader": "^0.9.1",
     "postcss-reporter": "^1.3.3",
+    "process-finder": "^1.0.0",
     "raw-loader": "^0.5.1",
     "react": "^15.1.0",
     "react-document-title": "^2.0.1",


### PR DESCRIPTION
Also output friendlier error message w/ PID of process
that's listening on the desired port.

Fixes #334 