### PR TITLE
Sourcemap settings for UglifyJsPlugin in build

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -113,6 +113,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
             __PREFIX_LINKS__: program.prefixLinks,
           }),
           new ExtractTextPlugin('styles.css'),
+          new webpack.optimize.UglifyJsPlugin({sourceMap: false}),
         ]
       case 'build-html':
         return [
@@ -137,7 +138,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
             __PREFIX_LINKS__: program.prefixLinks,
           }),
           new webpack.optimize.DedupePlugin(),
-          new webpack.optimize.UglifyJsPlugin(),
+          new webpack.optimize.UglifyJsPlugin({sourceMap: false}),
         ]
       default:
         throw new Error(`The state requested ${stage} doesn't exist.`)


### PR DESCRIPTION
We need {sourceMap:false} for UglifyJsPlugin to avoid local path showing up below sources and webpack in google chrome inspector. This also minify css files.
