### PR TITLE
fix: route update hook gets current location from listener

### DIFF
--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -16,7 +16,10 @@ function loadConfig (cb) {
   return cb()
 }
 
+let currentLocation = null
+
 browserHistory.listen(location => {
+  currentLocation = location
   if (onRouteChange) {
     console.warn('onRouteChange is now deprecated and will be removed in the next major Gatsby release (0.12). Please use onRouteUpdate instead. See the PR for more info (https://github.com/gatsbyjs/gatsby/pull/321).')
     onRouteChange(location)
@@ -25,8 +28,7 @@ browserHistory.listen(location => {
 
 function onUpdate () {
   if (onRouteUpdate) {
-    const location = browserHistory.getCurrentLocation()
-    onRouteUpdate(location)
+    onRouteUpdate(currentLocation)
   }
 }
 


### PR DESCRIPTION
Fixes issue with #321 per https://github.com/gatsbyjs/gatsby/pull/321#issuecomment-230339143.