### PR TITLE
Set NODE_ENV env var to 'production' when building

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -41,6 +41,9 @@ program.command('build')
   .description('Build a Gatsby project.')
   .option('--prefix-links', 'Build site with links prefixed (set prefix in your config).')
   .action((command) => {
+    // Set NODE_ENV to 'production'
+    process.env.NODE_ENV = 'production'
+
     const build = require('../utils/build')
     const p = {
       ...command,


### PR DESCRIPTION
Fixes #337

There seems to be a few Webpack loaders that require this e.g.
sass-loader. We set NODE_ENV to production already *inside* Webpack e.g.
for React's optimizations but this PR is necessary for code *outside*
Webpack e.g. node code in Webpack loaders.