### PR TITLE
Show other wrapper require errors than MODULE_NOT_FOUND on console

### DIFF
--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -99,7 +99,12 @@ module.exports = (files, pagesReq) => {
       // $FlowIssue - https://github.com/facebook/flow/issues/1975
       wrappers[type] = require(`wrappers/${type}`)
     } catch (e) {
-      // Ignore error.
+      // Ignore module not found errors; show others on console
+      if (e.code !== 'MODULE_NOT_FOUND'
+          && (e.message && !e.message.match(/^Cannot find module/))
+          && typeof console !== 'undefined') {
+        console.error('Error requiring wrapper', type, ':', e)
+      }
     }
   })
 


### PR DESCRIPTION
I spent a lot of time debugging an issue caused by a wrapper JSX that tried to use `window` when server-side rendering. It was hard to identify because Gatsby quietly ignored the wrapper require errors.

So I made this patch to show require errors when they are something else than "module not found". For some reason, when running Gatsby, e.code is not set to MODULE_NOT_FOUND as it should, so I also included a regex check for the message.