### PR TITLE
Pin eslint a11y plugin until move to eslint 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint-plugin-flow-vars": "^0.5.0",
     "eslint-plugin-flowtype": "^2.4.0",
     "eslint-plugin-import": "^1.12.0",
-    "eslint-plugin-jsx-a11y": "^1.5.5",
+    "eslint-plugin-jsx-a11y": "1.5.3",
     "eslint-plugin-react": "^5.2.2",
     "flow-bin": "^0.30.0",
     "iflow-debug": "^1.0.15",


### PR DESCRIPTION
They added a peer dependency to eslint 3 after that which breaks
installs for NPM 2 users.

Fixes #365