### PR TITLE
Add publicPath to build-javascript and build-html

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -6,6 +6,7 @@ const debug = require('debug')('gatsby:webpack-config')
 import path from 'path'
 import _ from 'lodash'
 import invariant from 'invariant'
+import { siteConfig } from 'config'
 
 import babelConfig from './babel-config'
 
@@ -30,6 +31,10 @@ try {
 module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes = []) => {
   const babelStage = suppliedStage
   const stage = (suppliedStage === 'develop-html') ? 'develop' : suppliedStage
+  const linkPrefix = siteConfig.linkPrefix ? siteConfig.linkPrefix : '/'
+  const publicPath = linkPrefix.indexOf('/') === linkPrefix.length - 1
+    ? linkPrefix
+    : `${linkPrefix}/`
 
   debug(`Loading webpack config for stage "${stage}"`)
   function output () {
@@ -46,7 +51,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         return {
           path: `${directory}/public`,
           filename: 'bundle-for-css.js',
-          publicPath: '/',
+          publicPath,
         }
       case 'build-html':
         // A temp file required by static-site-generator-plugin. See plugins() below.
@@ -55,11 +60,13 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
           path: `${directory}/public`,
           filename: 'render-page.js',
           libraryTarget: 'umd',
+          publicPath,
         }
       case 'build-javascript':
         return {
           filename: 'bundle.js',
           path: `${directory}/public`,
+          publicPath,
         }
       default:
         throw new Error(`The state requested ${stage} doesn't exist.`)


### PR DESCRIPTION
Use linkPrefix for publicPath when set
Fixes #392 

Unfortunately, this doesn't work because I mistakenly thought gatsby was using the `config` package to pull in the `config.toml`.  Is a project's `config.toml` already available to the gatsby cli context somewhere?