### PR TITLE
(webpack loaders) manage images links with query parameters

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -232,7 +232,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     })
     // Image loaders.
     config.loader('images', {
-      test: /\.(jpe?g|png|gif|svg)$/i,
+      test: /\.(jpe?g|png|gif|svg)(\?.*)?$/i,
       loaders: [
         'url-loader?limit=10000',
         'image-webpack-loader?{progressive:true, optimizationLevel: 7, interlaced: false, pngquant:{quality: "65-90", speed: 4}}', // eslint-disable-line


### PR DESCRIPTION
When a image link contains query parameter, webpack doesn't
handle it.

e.g. with a link to an .svg file -> .../file.svg?v=1

the file will not be handle by webpack, and the user will get
an error like below.

```
Module parse failed:
/.../node_modules/font-awesome/fonts/fontawesome-webfont.svg?v=4.6.3
Unexpected token (1:0)
You may need an appropriate loader to handle this file type.
```