### PR TITLE
Enable hot reloading of imported stylesheets

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -290,12 +290,14 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         })
 
         config.merge({
-          postcss: [
-            require('postcss-import')(),
-            require('postcss-cssnext')({ browsers: 'last 2 versions' }),
-            require('postcss-browser-reporter'),
-            require('postcss-reporter'),
-          ],
+          postcss (wp) {
+            return [
+              require('postcss-import')({ addDependencyTo: wp }),
+              require('postcss-cssnext')({ browsers: 'last 2 versions' }),
+              require('postcss-browser-reporter'),
+              require('postcss-reporter'),
+            ]
+          },
         })
         return config
 


### PR DESCRIPTION
Initializes postcss as a function with the wp argument
passed in. This allows to use the 'addDependencyTo' option
of postcss-import plugin so that hot reloading will work
properly with imported stylesheets.