### PR TITLE
Fix setting gatsbyPath

### DIFF
--- a/lib/utils/babel-config.js
+++ b/lib/utils/babel-config.js
@@ -25,7 +25,7 @@ function defaultConfig () {
  *
  */
 function resolvePlugin (pluginName, directory, type) {
-  const gatsbyPath = path.resolve('..', '..')
+  const gatsbyPath = path.resolve(__dirname, '..', '..')
   const plugin = resolve(`babel-${type}-${pluginName}`, directory) ||
     resolve(`babel-${type}-${pluginName}`, gatsbyPath) ||
     resolve(pluginName, directory) ||


### PR DESCRIPTION
path.resolve defaults to using the current working directory so the path
this was creating wasn't correct. The error was masked by NPM 3 as it
puts all of Gatsby's babel plugins in the top-level node_modules
directory but in NPM 2, things don't work unless you explicitly install
the babel plugins yourself. Adding __dirname solved loading babel
plugins in NPM 2.