### PR TITLE
Added numenta.com to Sites built with Gatsby README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ it'll be converted to `/docs/index.html`.
 * [ZBT MIT Website](http://zbt.mit.edu) ([source](https://github.com/Slava/zbt-website))
 * [ethereumclassic.org](http://ethereumclassic.org/) ([source](https://github.com/ethereumclassic/ethereumclassic.github.io/tree/source))
 * [Husam Machlovi, Portfolio & Blog](http://husammachlovi.com)
+* [numenta.com](http://numenta.com)
 * [Edit this file to add yours!](https://github.com/gatsbyjs/gatsby/blob/master/README.md)
 
 *Note, for the sites that have made their source available, you can


### PR DESCRIPTION
Added numenta.com to the list of sites built with Gatsby.

I also suggest moving that list to the wiki if possible:

https://github.com/gatsbyjs/gatsby/wiki

Then, link to the new wiki page from the README.