### PR TITLE
Introduce jupyter notebook format (ipynb)

### DIFF
--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -81,6 +81,7 @@ module.exports = (files, pagesReq) => {
   })
 
   const staticFileTypes = [
+    'ipynb',
     'md',
     'markdown',
     'html',

--- a/lib/utils/load-context.js
+++ b/lib/utils/load-context.js
@@ -2,10 +2,10 @@
 // This file is auto-written and used by Gatsby to require
 // files from your pages directory.
 module.exports = function (callback) {
-  let context = require.context('./pages', true, /(coffee|cjsx|jsx|js|markdown|md|html|json|yaml|toml)$/) // eslint-disable-line
+  let context = require.context('./pages', true, /(coffee|cjsx|jsx|js|markdown|md|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
   if (module.hot) {
     module.hot.accept(context.id, () => {
-      context = require.context('./pages', true, /(coffee|cjsx|jsx|js|markdown|md|html|json|yaml|toml)$/) // eslint-disable-line
+      context = require.context('./pages', true, /(coffee|cjsx|jsx|js|markdown|md|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
       return callback(context)
     })
   }

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -216,6 +216,10 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
       test: /\.html$/,
       loader: 'html',
     })
+    config.loader('ipynb', {
+      test: /\.ipynb$/,
+      loaders: ['json'],
+    })
     config.loader('json', {
       test: /\.json$/,
       loaders: ['json'],


### PR DESCRIPTION
Jupyter (née IPython) Notebooks are a format used by data scientists and others to communicate their work along with a live REPL.

[Example notebook on GitHub](https://github.com/jakevdp/sklearn_pycon2015/blob/master/notebooks/02.1-Machine-Learning-Intro.ipynb)

I don't know if you actually support the idea of new file extensions here - I wasn't sure how to extend it. I see how to override current loaders (for JSON or Markdown e.g.), just not how to set other file types.