### PR TITLE
Close #367 Into 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: cpp
 sudo: false
 env:
-  - export NODE_VERSION="0.12"
   - export NODE_VERSION="4"
   - export NODE_VERSION="6"
 os:

--- a/bin/gatsby.js
+++ b/bin/gatsby.js
@@ -9,14 +9,11 @@ global.appStartTime = Date.now()
 var sysPath = require('path')
 var fs = require('fs')
 var version = process.version
-var versionDigits = version.split('.')
-  .map(function (d) { return d.match(/\d+/)[0] })
-  .slice(0, 2).join('.')
-var verDigit = Number(versionDigits)
+var verDigit = Number(version.match(/\d+/)[0])
 
-if (verDigit < 0.12) {
+if (verDigit < 4) {
   console.error(
-    'Error: Gatsby 0.9+ requires node.js v0.12 or higher (you have ' + version + ') ' +
+    'Error: Gatsby 1.0+ requires node.js v4 or higher (you have ' + version + ') ' +
     'Upgrade node to the latest stable release.'
   )
   process.exit()

--- a/lib/utils/webpack-modify-validate.js
+++ b/lib/utils/webpack-modify-validate.js
@@ -1,0 +1,47 @@
+import _ from 'lodash'
+import invariant from 'invariant'
+import path from 'path'
+import validate from 'webpack-validator'
+
+let modifyWebpackConfig
+try {
+  const gatsbyNodeConfig = path.resolve(process.cwd(), `./gatsby-node`)
+  const nodeConfig = require(gatsbyNodeConfig)
+  modifyWebpackConfig = nodeConfig.modifyWebpackConfig
+} catch (e) {
+  if (e.code !== `MODULE_NOT_FOUND` && !_.includes(e.Error, `gatsby-node`)) {
+    console.log(e)
+  }
+}
+
+export default function ValidateWebpackConfig (module, config, stage) {
+  let userWebpackConfig = module(config)
+  if (modifyWebpackConfig) {
+    userWebpackConfig = modifyWebpackConfig(userWebpackConfig, stage)
+
+    invariant(_.isObject(userWebpackConfig) && _.isFunction(userWebpackConfig.resolve),
+      `
+      You must return an webpack-configurator instance when modifying the Webpack config.
+      Returned: ${userWebpackConfig}
+      stage: ${stage}
+      `)
+  }
+
+  const validationState = validate(userWebpackConfig.resolve(), {
+    returnValidation: true,
+  })
+
+  if (!validationState.error) {
+    return userWebpackConfig
+  }
+
+  console.log(`There were errors with your webpack config:`)
+  validationState.error.details.forEach((err, index) => {
+    console.log(`[${index + 1}]`)
+    console.log(err.path)
+    console.log(err.type, `,`, err.message)
+    console.log(`\n`)
+  })
+
+  return process.exit(1)
+}

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -1,11 +1,13 @@
-import webpack from 'webpack'
-import StaticSiteGeneratorPlugin from 'static-site-generator-webpack-plugin'
-import ExtractTextPlugin from 'extract-text-webpack-plugin'
-import Config from 'webpack-configurator'
-import path from 'path'
 import _ from 'lodash'
-import invariant from 'invariant'
+import fs from 'fs'
+import path from 'path'
+import webpack from 'webpack'
+import Config from 'webpack-configurator'
+import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import StaticSiteGeneratorPlugin from 'static-site-generator-webpack-plugin'
 import { StatsWriterPlugin } from 'webpack-stats-plugin'
+
+import webpackModifyValidate from './webpack-modify-validate'
 
 const debug = require(`debug`)(`gatsby:webpack-config`)
 const WebpackMD5Hash = require(`webpack-md5-hash`)
@@ -14,17 +16,6 @@ const ChunkManifestPlugin = require(`chunk-manifest-webpack-plugin`)
 const { pagesDB, siteDB } = require(`../utils/globals`)
 const { layoutComponentChunkName } = require(`./js-chunk-names`)
 const babelConfig = require(`./babel-config`)
-
-let modifyWebpackConfig
-try {
-  const gatsbyNodeConfig = path.resolve(process.cwd(), `./gatsby-node`)
-  const nodeConfig = require(gatsbyNodeConfig)
-  modifyWebpackConfig = nodeConfig.modifyWebpackConfig
-} catch (e) {
-  if (e.code !== `MODULE_NOT_FOUND` && !_.includes(e.Error, `gatsby-node`)) {
-    console.log(e)
-  }
-}
 
 // Five stages or modes:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
@@ -379,6 +370,33 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, pages =
     }
   }
 
+  function resolveLoader () {
+    const root = [
+      path.resolve(__dirname, '..', 'loaders'),
+      path.resolve(directory, `node_modules`),
+      path.resolve(directory, `node_modules/gatsby/node_modules`),
+    ]
+
+    const userLoaderDirectoryPath = path.resolve(directory, 'loaders')
+
+    try {
+      if (fs.statSync(userLoaderDirectoryPath).isDirectory()) {
+        root.push(userLoaderDirectoryPath)
+      }
+    } catch (e) {
+      if (e && e.code !== 'ENOENT') {
+        console.log(e)
+      }
+    }
+
+    return {
+      root,
+      modulesDirectories: [
+        'node_modules',
+      ],
+    }
+  }
+
   const config = new Config()
 
   config.merge({
@@ -391,33 +409,10 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, pages =
     profile: stage === `production`,
     devtool: devtool(),
     output: output(),
-    resolveLoader: {
-      // Hierarchy of directories for Webpack to look for loaders.
-      // First is the /loaders/ directory in the site.
-      // Then in the special directory of loaders Gatsby ships with.
-      // Then the site's node_modules directory
-      // and last the Gatsby node_modules directory.
-      root: [
-        path.resolve(directory, `loaders`),
-        path.resolve(__dirname, `..`, `loaders`),
-        path.resolve(directory, `node_modules`),
-        path.resolve(directory, `node_modules/gatsby/node_modules`),
-      ],
-    },
+    resolveLoader: resolveLoader(),
     plugins: plugins(),
     resolve: resolve(),
   })
 
-  if (modifyWebpackConfig) {
-    const modifiedWebpackConfig = modifyWebpackConfig(module(config), stage)
-    invariant(_.isObject(modifiedWebpackConfig),
-              `
-              You must return an object when modifying the Webpack config.
-              Returned: ${modifiedWebpackConfig}
-              stage: ${stage}
-              `)
-    return modifiedWebpackConfig
-  } else {
-    return module(config)
-  }
+  return webpackModifyValidate(module, config, stage)
 }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "nyc": "^7.0.0"
   },
   "engines": {
-    "node": ">0.12.0"
+    "node": ">4.0.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby#readme",
   "keywords": [


### PR DESCRIPTION
This is an updated version of #381 into 1.0 which adds webpack-validator into Gatsby, notifies users of a failing configuration and closes the program. 