### PR TITLE
Fixed link prefix for URLs without leading slash

### DIFF
--- a/lib/isomorphic/gatsby-helpers.js
+++ b/lib/isomorphic/gatsby-helpers.js
@@ -27,7 +27,10 @@ const prefixLink = (_link) => {
     if (isDataURL(_link)) {
       return _link
     } else {
-      return config.linkPrefix + _link
+      if (!_link.startsWith('/')) {
+        return `${config.linkPrefix}/${_link}`
+      }
+      return `${config.linkPrefix}${_link}`
     }
   } else {
     return _link


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/473