### PR TITLE
Fixed follow symlinks in glob

### DIFF
--- a/lib/utils/glob-pages.js
+++ b/lib/utils/glob-pages.js
@@ -15,7 +15,7 @@ let globCache
 function createCache (directory, callback) {
   const pagesData = []
 
-  glob(globQuery(directory), null, (err, pages) => {
+  glob(globQuery(directory), { follow: true }, (err, pages) => {
     if (err) { return callback(err) }
 
     pages.forEach((page) => {


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/460

This makes life easy by allowing `.md` files to be in their own directory symlinked under `./pages` . This way the 'code' is separate from the actual blog posts.