### PR TITLE
Incorporate linkPrefix into webpack's publicPath

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -3,9 +3,11 @@ import StaticSiteGeneratorPlugin from 'static-site-generator-webpack-plugin'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import Config from 'webpack-configurator'
 const debug = require('debug')('gatsby:webpack-config')
+import fs from 'fs'
 import path from 'path'
 import _ from 'lodash'
 import invariant from 'invariant'
+import toml from 'toml'
 
 import babelConfig from './babel-config'
 
@@ -31,8 +33,28 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
   const babelStage = suppliedStage
   const stage = (suppliedStage === 'develop-html') ? 'develop' : suppliedStage
 
+  let siteConfig = {}
+
+  try {
+    siteConfig = toml.parse(fs.readFileSync(path.join(directory, 'config.toml')))
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e
+    }
+  }
+
   debug(`Loading webpack config for stage "${stage}"`)
   function output () {
+    let publicPath = '/'
+
+    if (program.prefixLinks) {
+      publicPath = siteConfig.linkPrefix
+
+      if (!publicPath.endsWith('/')) {
+        publicPath += '/'
+      }
+    }
+
     switch (stage) {
       case 'develop':
         return {
@@ -46,7 +68,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         return {
           path: `${directory}/public`,
           filename: 'bundle-for-css.js',
-          publicPath: '/',
+          publicPath,
         }
       case 'build-html':
         // A temp file required by static-site-generator-plugin. See plugins() below.
@@ -55,11 +77,13 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
           path: `${directory}/public`,
           filename: 'render-page.js',
           libraryTarget: 'umd',
+          publicPath,
         }
       case 'build-javascript':
         return {
           filename: 'bundle.js',
           path: `${directory}/public`,
+          publicPath,
         }
       default:
         throw new Error(`The state requested ${stage} doesn't exist.`)


### PR DESCRIPTION
This correctly references asset paths, e.g. FontAwesome, when static sites are targeted at sub-paths.

Prior to this, FontAwesome asset paths would point at the site root.