### PR TITLE
Redirect from non-slash to slash page, fixes #452.

### DIFF
--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -127,6 +127,10 @@ function startServer (program) {
         } else if (request.path === '/bundle.js') {
           reply.continue()
         } else if (negotiator.mediaType() === 'text/html') {
+          // If the path does not end with a slash, add it.
+          if (request.path[request.path.length - 1] != '/') {
+            request.path += '/';
+          }
           request.setUrl(`/html${request.path}`)
           reply.continue()
         } else {


### PR DESCRIPTION
If the path does not end with a slash, add it.