### PR TITLE
Topics/clean starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ include yours!
 * [Simple documentation site](https://github.com/gatsbyjs/gatsby-starter-documentation) ([Demo](http://gatsbyjs.github.io/gatsby-starter-documentation/))
 * [Lumen](https://github.com/wpioneer/gatsby-starter-lumen) ([Demo](http://wpioneer.github.io/gatsby-starter-lumen/))
 * [DrunkenBlog](https://github.com/konsumer/gatsby-starter-drunkenblog) ([Demo](http://konsumer.js.org/gatsby-starter-drunkenblog/))
-* [Clean start](https://github.com/brianstone/gatsby-starter-clean)([Demo](http://gatsby-starter-clean.netlify.com/))
+* [Clean start](https://github.com/brianstone/gatsby-starter-clean) ([Demo](http://gatsby-starter-clean.netlify.com/))
 
 ### Tutorial: Building a documentation site from the Gatsby Documentation Starter
 1. Install gatsby `npm install -g gatsby`

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ include yours!
 * [Simple documentation site](https://github.com/gatsbyjs/gatsby-starter-documentation) ([Demo](http://gatsbyjs.github.io/gatsby-starter-documentation/))
 * [Lumen](https://github.com/wpioneer/gatsby-starter-lumen) ([Demo](http://wpioneer.github.io/gatsby-starter-lumen/))
 * [DrunkenBlog](https://github.com/konsumer/gatsby-starter-drunkenblog) ([Demo](http://konsumer.js.org/gatsby-starter-drunkenblog/))
+* [Clean start](https://github.com/brianstone/gatsby-starter-clean)([Demo](http://gatsby-starter-clean.netlify.com/))
 
 ### Tutorial: Building a documentation site from the Gatsby Documentation Starter
 1. Install gatsby `npm install -g gatsby`


### PR DESCRIPTION
I opened up issue #483 to come up with a way to start a gatsby project in a 'clean' state. The gatsby default starter contained more than I intended to use, so I forked the `gatsby-starter-default` and the cleaned up some of the files and updated the css a bit. It should work using `gatsby new clean gh:brianstone/gatsby-clean-starter`