### PR TITLE
Change target to be node for html-build

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -437,6 +437,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     },
     entry: entry(),
     debug: true,
+    target: stage === 'build-html' ? 'node' : 'web',
     devtool: devtool(),
     output: output(),
     resolveLoader: {


### PR DESCRIPTION
Certain npm plugins fail when being built with SSR (namely firebase); this patch changes the build target to node for packages that have separate node and browser versions