### PR TITLE
Backport file/url loader config from 1.0 branch

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -271,19 +271,39 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         'url-loader?limit=10000',
         'image-webpack-loader?{progressive:true, optimizationLevel: 7, interlaced: false, pngquant:{quality: "65-90", speed: 4}}', // eslint-disable-line
       ],
+      query: {
+        name: 'static/[name].[hash].[ext]',
+      },
     })
-    // Font loaders.
+    // "file" loader makes sure those assets end up in the `public` folder.
+    // When you `import` an asset, you get its filename.
+    config.loader('file-loader', {
+      test: /\.(ico|eot|otf|webp|ttf)(\?.*)?$/,
+      loader: 'file',
+      query: {
+        name: 'static/[name].[hash].[ext]',
+      },
+    })
+    // "url" loader works just like "file" loader but it also embeds
+    // assets smaller than specified size as data URLs to avoid requests.
+    config.loader('url-loader', {
+      test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
+      loader: 'url',
+      query: {
+        limit: 7500,
+        name: 'static/[name].[hash].[ext]',
+      },
+    })
+    // Font loader.
     config.loader('woff', {
       test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: 'url-loader?limit=10000&mimetype=application/font-woff',
-    })
-    config.loader('ttf', {
-      test: /\.(ttf)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: 'file-loader',
-    })
-    config.loader('eot', {
-      test: /\.(eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-      loader: 'file-loader',
+      loader: 'url',
+      query: {
+        limit: 15000, // Set high limit for inlining fonts as they're in the
+        // critical path for rendering.
+        name: 'static/[name].[hash].[ext]',
+        mimetype: 'application/font-woff',
+      },
     })
 
     const cssModulesConf = 'css?modules&minimize&importLoaders=1'


### PR DESCRIPTION
Adds support for more file types + hashes file names to support
long-term caching.