### PR TITLE
Parse the port to a number if needed, further fixing #524

### DIFF
--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -208,7 +208,7 @@ module.exports = (program) => {
 
       return rlInterface.question(question, (answer) => {
         if (answer.length === 0 || answer.match(/^yes|y$/i)) {
-          port = _port // eslint-disable-line no-param-reassign
+          program.port = _port // eslint-disable-line no-param-reassign
         }
 
         return startServer(program)

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -192,19 +192,23 @@ function startServer (program) {
 }
 
 module.exports = (program) => {
-  detect(program.port, (err, _port) => {
+  const port = typeof program.port === 'string'
+    ? parseInt(program.port, 10)
+    : program.port
+
+  detect(port, (err, _port) => {
     if (err) {
       console.error(err)
       process.exit()
     }
 
-    if (program.port !== _port) {
+    if (port !== _port) {
       // eslint-disable-next-line max-len
-      const question = `Something is already running at port ${program.port} \nWould you like to run the app at another port instead? [Y/n] `
+      const question = `Something is already running at port ${port} \nWould you like to run the app at another port instead? [Y/n] `
 
       return rlInterface.question(question, (answer) => {
         if (answer.length === 0 || answer.match(/^yes|y$/i)) {
-          program.port = _port // eslint-disable-line no-param-reassign
+          port = _port // eslint-disable-line no-param-reassign
         }
 
         return startServer(program)


### PR DESCRIPTION
Solves the "wrong type of arguments with: 8000" error message introduced in `v0.12.3`.