### PR TITLE
Add typescript loading support (.ts, .tsx)

### DIFF
--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -2,6 +2,20 @@
 import _ from 'lodash'
 import { prefixLink } from './gatsby-helpers'
 
+function requireComponent (moduleReq) {
+  // Minor differences in `require` behavior across languages
+  // are handled by this wrapper.
+  //
+  // If `moduleReq` is a typescript module (versus javascript/coffeescript)
+  // an object with a `default` property is returned rather than the
+  // default export.
+  let module = moduleReq
+  if (module.default) {
+    module = module.default
+  }
+  return module
+}
+
 module.exports = (files, pagesReq) => {
   // Remove files that start with an underscore as this indicates
   // the file shouldn't be turned into a page.
@@ -12,7 +26,7 @@ module.exports = (files, pagesReq) => {
 
   const routes = {
     path: prefixLink('/'),
-    component: require('pages/_template'),
+    component: requireComponent(require('pages/_template')),
     childRoutes: [],
     indexRoute: {},
     pages,
@@ -65,7 +79,7 @@ module.exports = (files, pagesReq) => {
     // Create new route for the template.
     const route = {
       path: prefixLink(templateFile.templatePath),
-      component: pagesReq(`./${templateFile.requirePath}`),
+      component: requireComponent(pagesReq(`./${templateFile.requirePath}`)),
       childRoutes: [],
       indexRoute: {},
       pages,
@@ -91,7 +105,9 @@ module.exports = (files, pagesReq) => {
   ]
   const reactComponentFileTypes = [
     'js',
+    'ts',
     'jsx',
+    'tsx',
     'cjsx',
   ]
   const wrappers = {}
@@ -116,7 +132,7 @@ module.exports = (files, pagesReq) => {
       handler = wrappers[page.file.ext]
       page.data = pagesReq(`./${page.requirePath}`)
     } else if (reactComponentFileTypes.indexOf(page.file.ext) !== -1) {
-      handler = pagesReq(`./${page.requirePath}`)
+      handler = requireComponent(pagesReq(`./${page.requirePath}`))
       page.data = (() => {
         if (pagesReq(`./${page.requirePath}`).metadata) {
           return pagesReq(`./${page.requirePath}`).metadata()

--- a/lib/utils/load-context.js
+++ b/lib/utils/load-context.js
@@ -2,10 +2,10 @@
 // This file is auto-written and used by Gatsby to require
 // files from your pages directory.
 module.exports = function (callback) {
-  let context = require.context('./pages', true, /(coffee|cjsx|jsx|js|markdown|md|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
+  let context = require.context('./pages', true, /(coffee|cjsx|ts|tsx|jsx|js|markdown|md|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
   if (module.hot) {
     module.hot.accept(context.id, () => {
-      context = require.context('./pages', true, /(coffee|cjsx|jsx|js|markdown|md|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
+      context = require.context('./pages', true, /(coffee|cjsx|ts|tsx|jsx|js|markdown|md|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
       return callback(context)
     })
   }

--- a/lib/utils/page-file-types.js
+++ b/lib/utils/page-file-types.js
@@ -1,6 +1,8 @@
 const pageFileTypes = [
   'coffee',
   'cjsx',
+  'ts',
+  'tsx',
   'jsx',
   'js',
   'markdown',

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -178,6 +178,8 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         '.jsx',
         '.cjsx',
         '.coffee',
+        '.ts',
+        '.tsx',
         '.json',
         '.less',
         '.css',
@@ -195,6 +197,8 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         directory,
         path.resolve(__dirname, '..', 'isomorphic'),
       ],
+      // Alias for typescript, see: https://github.com/gaearon/react-hot-loader/issues/417#issuecomment-261548082
+      alias: { 'react/lib/ReactMount': 'react-dom/lib/ReactMount' },
       modulesDirectories: [
         `${directory}/node_modules`,
         `${directory}/node_modules/gatsby/node_modules`,
@@ -231,6 +235,13 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     config.loader('coffee', {
       test: /\.coffee$/,
       loader: 'coffee',
+    })
+    config.loader('typescript', {
+      test: /\.tsx?$/,
+      loaders: [
+        'react-hot',
+        'ts-loader',
+      ],
     })
     config.loader('md', {
       test: /\.md$/,

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "toml": "^2.2.2",
     "toml-loader": "^1.0.0",
     "tracer": "^0.8.3",
+    "ts-loader": "^1.2.2",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
     "webpack-configurator": "^0.3.0",


### PR DESCRIPTION
Addresses https://github.com/gatsbyjs/gatsby/issues/577

Supports components in the pages/ directory, including index and _template.
Does not support typescript wrappers or loaders.

Tested on https://github.com/rothfels/gatsby-starter-typescript, gatsby-starter-default, and via `npm test`. 

There's an unfortunate kludge (commented inline) I don't have the context to work around. When generating a site, rather than use `require('pages/_template')` for the root template I thought to load the root template as we do for other pages (via `pagesReq('./path/to/page.ext')`). This works if the site provides a `./pages/_template`, but I suspect gatsby doesn't require one and will provide a default. Tests corroborate that story...they break as long as I don't `require('pages/_template')` directly. The problem is that without the qualified file path (including extension) there's no clean way to know if the root template is a typescript module. Lmk if you have an idea for a workaround.