### PR TITLE
Closes #569 Add port process conflict resolution and Chalk

### DIFF
--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -15,6 +15,7 @@ import opn from 'opn'
 import fs from 'fs'
 import glob from 'glob'
 import rl from 'readline'
+import chalk from 'chalk'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,
@@ -173,9 +174,9 @@ function startServer (program) {
           if (e) {
             if (e.code === 'EADDRINUSE') {
               // eslint-disable-next-line max-len
-              console.log(`Unable to start Gatsby on port ${program.port} as there's already a process listing on that port.`)
+              console.log(chalk.red(`Unable to start Gatsby on port ${serverPort} as there's already a process listing on that port.`))
             } else {
-              console.log(e)
+              console.log(chalk.red(e))
             }
 
             process.exit()
@@ -183,7 +184,11 @@ function startServer (program) {
             if (program.open) {
               opn(server.info.uri)
             }
-            console.log('Listening at:', server.info.uri)
+            console.log(chalk.green('Server started successfully!'))
+            console.log()
+            console.log('Listening at:')
+            console.log()
+            console.log('  ', chalk.cyan(server.info.uri))
           }
         })
       })

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -175,7 +175,7 @@ function startServer (program) {
           if (e) {
             if (e.code === 'EADDRINUSE') {
               // eslint-disable-next-line max-len
-              console.log(chalk.red(`Unable to start Gatsby on port ${serverPort} as there's already a process listing on that port.`))
+              console.log(chalk.red(`Unable to start Gatsby on port ${program.port} as there's already a process listing on that port.`))
             } else {
               console.log(chalk.red(e))
             }

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -16,6 +16,7 @@ import fs from 'fs'
 import glob from 'glob'
 import rl from 'readline'
 import chalk from 'chalk'
+import getProcessForPort from 'react-dev-utils/getProcessForPort'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,
@@ -201,6 +202,8 @@ module.exports = (program) => {
     ? parseInt(program.port, 10)
     : program.port
 
+  const existingProcess = getProcessForPort(port)
+
   detect(port, (err, _port) => {
     if (err) {
       console.error(err)
@@ -209,7 +212,11 @@ module.exports = (program) => {
 
     if (port !== _port) {
       // eslint-disable-next-line max-len
-      const question = `Something is already running at port ${port} \nWould you like to run the app at another port instead? [Y/n] `
+      const question = chalk.yellow(`Something is already running on port ${port}.
+      ${(existingProcess) ? ` Probably:\n  ${existingProcess}` : ''}
+
+      Would you like to run the app at another port instead? [Y/n]`)
+
 
       return rlInterface.question(question, (answer) => {
         if (answer.length === 0 || answer.match(/^yes|y$/i)) {

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -16,7 +16,7 @@ import fs from 'fs'
 import glob from 'glob'
 import rl from 'readline'
 import chalk from 'chalk'
-import getProcessForPort from '@gutenye/react-dev-utils/getProcessForPort'
+import getProcessForPort from './getProcessForPort'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,
@@ -212,11 +212,7 @@ module.exports = (program) => {
 
     if (port !== _port) {
       // eslint-disable-next-line max-len
-      const question = chalk.yellow(`Something is already running on port ${port}.
-      ${(existingProcess) ? ` Probably:\n  ${existingProcess}` : ''}
-
-      Would you like to run the app at another port instead? [Y/n]`)
-
+      const question = chalk.yellow(`Something is already running on port ${port}.\n${(existingProcess) ? ` Probably:\n  ${existingProcess}\n` : ''}\nWould you like to run the app at another port instead? [Y/n]`)
 
       return rlInterface.question(question, (answer) => {
         if (answer.length === 0 || answer.match(/^yes|y$/i)) {

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -16,7 +16,7 @@ import fs from 'fs'
 import glob from 'glob'
 import rl from 'readline'
 import chalk from 'chalk'
-import getProcessForPort from 'react-dev-utils/getProcessForPort'
+import getProcessForPort from '@gutenye/react-dev-utils/getProcessForPort'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,

--- a/lib/utils/getProcessForPort.js
+++ b/lib/utils/getProcessForPort.js
@@ -1,0 +1,58 @@
+import chalk from 'chalk'
+import { execSync } from 'child_process'
+import path from 'path'
+
+const execOptions = {
+  encoding: 'utf8',
+  stdio: [
+    'pipe', // stdin (default)
+    'pipe', // stdout (default)
+    'ignore', // stderr
+  ],
+}
+
+function isProcessAReactApp (processCommand) {
+  return /^node .*react-scripts\/scripts\/start\.js\s?$/.test(processCommand)
+}
+
+function getProcessIdOnPort (port) {
+  return execSync(`lsof -i:${port} -P -t -sTCP:LISTEN`, execOptions).trim()
+}
+
+function getPackageNameInDirectory (directory) {
+  const packagePath = path.join(directory.trim(), 'package.json')
+
+  try {
+    return require(packagePath).name
+  } catch (e) {
+    return null
+  }
+}
+
+function getProcessCommand (processId, processDirectory) {
+  const command = execSync(`ps -o command -p ${processId} | sed -n 2p`, execOptions)
+
+  if (isProcessAReactApp(command)) {
+    const packageName = getPackageNameInDirectory(processDirectory)
+    return (packageName) ? '${packageName}\n' : command
+  } else {
+    return command
+  }
+}
+
+function getDirectoryOfProcessById (processId) {
+  return execSync(`lsof -p ${processId} | grep cwd | awk \'{print $9}\'`, execOptions).trim()
+}
+
+function getProcessForPort (port) {
+  try {
+    const processId = getProcessIdOnPort(port)
+    const directory = getDirectoryOfProcessById(processId)
+    const command = getProcessCommand(processId, directory)
+    return chalk.cyan(command) + chalk.blue('  in ') + chalk.cyan(directory)
+  } catch (e) {
+    return null
+  }
+}
+
+module.exports = getProcessForPort

--- a/lib/utils/serve-build.js
+++ b/lib/utils/serve-build.js
@@ -4,6 +4,7 @@ import Hapi from 'hapi'
 import opn from 'opn'
 import rl from 'readline'
 import chalk from 'chalk'
+import getProcessForPort from 'react-dev-utils/getProcessForPort'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,
@@ -61,6 +62,8 @@ function startServer (program, launchPort) {
 }
 
 module.exports = (program) => {
+  const existingProcess = getProcessForPort(program.port)
+
   detect(program.port, (err, _port) => {
     if (err) {
       console.error(err)
@@ -69,7 +72,10 @@ module.exports = (program) => {
 
     if (program.port !== _port) {
       // eslint-disable-next-line max-len
-      const question = `Something is already running at port ${program.port} \nWould you like to run the app at another port instead? [Y/n] `
+      const question = chalk.yellow(`Something is already running on port ${program.port}.
+      ${(existingProcess) ? ` Probably:\n  ${existingProcess}` : ''}
+
+      Would you like to run the app at another port instead? [Y/n]`)
 
       return rlInterface.question(question, (answer) => {
         let launchPort = program.port

--- a/lib/utils/serve-build.js
+++ b/lib/utils/serve-build.js
@@ -4,7 +4,7 @@ import Hapi from 'hapi'
 import opn from 'opn'
 import rl from 'readline'
 import chalk from 'chalk'
-import getProcessForPort from '@gutenye/react-dev-utils/getProcessForPort'
+import getProcessForPort from './getProcessForPort'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,
@@ -72,10 +72,7 @@ module.exports = (program) => {
 
     if (program.port !== _port) {
       // eslint-disable-next-line max-len
-      const question = chalk.yellow(`Something is already running on port ${program.port}.
-      ${(existingProcess) ? ` Probably:\n  ${existingProcess}` : ''}
-
-      Would you like to run the app at another port instead? [Y/n]`)
+      const question = chalk.yellow(`Something is already running on port ${program.port}.\n${(existingProcess) ? ` Probably:\n  ${existingProcess}\n` : ''}\nWould you like to run the app at another port instead? [Y/n]`)
 
       return rlInterface.question(question, (answer) => {
         let launchPort = program.port

--- a/lib/utils/serve-build.js
+++ b/lib/utils/serve-build.js
@@ -4,7 +4,7 @@ import Hapi from 'hapi'
 import opn from 'opn'
 import rl from 'readline'
 import chalk from 'chalk'
-import getProcessForPort from 'react-dev-utils/getProcessForPort'
+import getProcessForPort from '@gutenye/react-dev-utils/getProcessForPort'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,

--- a/lib/utils/serve-build.js
+++ b/lib/utils/serve-build.js
@@ -3,6 +3,7 @@ import detect from 'detect-port'
 import Hapi from 'hapi'
 import opn from 'opn'
 import rl from 'readline'
+import chalk from 'chalk'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,
@@ -40,9 +41,9 @@ function startServer (program, launchPort) {
     if (e) {
       if (e.code === 'EADDRINUSE') {
         // eslint-disable-next-line max-len
-        console.log(`Unable to start Gatsby on port ${serverPort} as there's already a process listing on that port.`)
+        console.log(chalk.red(`Unable to start Gatsby on port ${serverPort} as there's already a process listing on that port.`))
       } else {
-        console.log(e)
+        console.log(chalk.red(e))
       }
 
       process.exit()
@@ -50,7 +51,11 @@ function startServer (program, launchPort) {
       if (program.open) {
         opn(server.info.uri)
       }
-      console.log('Listening at:', server.info.uri)
+      console.log(chalk.green('Server started successfully!'))
+      console.log()
+      console.log('Listening at:')
+      console.log()
+      console.log('  ', chalk.cyan(server.info.uri))
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "yaml-loader": "^0.4.0"
   },
   "devDependencies": {
-    "@gutenye/react-dev-utils": "^0.3.4",
     "ava": "^0.16.0",
     "ava-http": "^0.2.1",
     "babel-cli": "^6.11.4",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "yaml-loader": "^0.4.0"
   },
   "devDependencies": {
+    "@gutenye/react-dev-utils": "^0.3.4",
     "ava": "^0.16.0",
     "ava-http": "^0.2.1",
     "babel-cli": "^6.11.4",

--- a/package.json
+++ b/package.json
@@ -111,8 +111,7 @@
     "iflow-debug": "^1.0.15",
     "iflow-lodash": "^1.1.23",
     "iflow-react-router": "^1.1.17",
-    "nyc": "^7.0.0",
-    "react-dev-utils": "^0.3.0"
+    "nyc": "^7.0.0"
   },
   "engines": {
     "node": ">0.12.0"

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-register": "^6.11.6",
     "bluebird": "^3.4.1",
+    "chalk": "^1.1.3",
     "cheerio": "^0.20.0",
     "eslint": "^2.11.1",
     "eslint-config-airbnb": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "iflow-debug": "^1.0.15",
     "iflow-lodash": "^1.1.23",
     "iflow-react-router": "^1.1.17",
-    "nyc": "^7.0.0"
+    "nyc": "^7.0.0",
+    "react-dev-utils": "^0.3.0"
   },
   "engines": {
     "node": ">0.12.0"


### PR DESCRIPTION
I tested this out, it seems to work great, but I had to add someone else's repo as a dependency because the `getProcessForPort` method hasn't been pushed to the officially available `react-dev-utils` package on npm.

I also added some chalk here and there.

If you want me to change the wording or add the dependency a different way let me know 👍 