### PR TITLE
add support for json or yaml config file

### DIFF
--- a/lib/loaders/config-loader/index.js
+++ b/lib/loaders/config-loader/index.js
@@ -4,7 +4,7 @@ const path = require('path')
 const globPages = require('../../utils/glob-pages')
 const loadConfig = require('../../utils/load-config')
 
-module.exports = function (source) {
+module.exports = function () {
   this.cacheable()
   const callback = this.async()
   const directory = loaderUtils.parseQuery(this.query).directory

--- a/lib/loaders/config-loader/index.js
+++ b/lib/loaders/config-loader/index.js
@@ -1,14 +1,14 @@
 /* @flow weak */
-const toml = require('toml')
 const loaderUtils = require('loader-utils')
 const path = require('path')
 const globPages = require('../../utils/glob-pages')
+const loadConfig = require('../../utils/load-config')
 
 module.exports = function (source) {
   this.cacheable()
   const callback = this.async()
   const directory = loaderUtils.parseQuery(this.query).directory
-  const config = toml.parse(source)
+  const config = loadConfig(directory)
 
   const value = {}
   value.config = config

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -8,6 +8,7 @@ import buildHTML from './build-html'
 import buildProductionBundle from './build-javascript'
 import postBuild from './post-build'
 import globPages from './glob-pages'
+import loadConfig from './load-config'
 
 function customPost (program, callback) {
   const directory = program.directory
@@ -67,13 +68,7 @@ function bundle (program, callback) {
 
 function html (program, callback) {
   const directory = program.directory
-  let config
-  try {
-    config = toml.parse(fs.readFileSync(`${directory}/config.toml`))
-  } catch (error) {
-    console.log("Couldn't load your site config")
-    callback(error)
-  }
+  let config = loadConfig(directory)
 
   console.log('Generating CSS')
   buildCSS(program, (cssError) => {

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -1,6 +1,4 @@
 /* @flow weak */
-import toml from 'toml'
-import fs from 'fs'
 import _ from 'lodash'
 
 import buildCSS from './build-css'
@@ -68,7 +66,7 @@ function bundle (program, callback) {
 
 function html (program, callback) {
   const directory = program.directory
-  let config = loadConfig(directory)
+  const config = loadConfig(directory)
 
   console.log('Generating CSS')
   buildCSS(program, (cssError) => {

--- a/lib/utils/load-config.js
+++ b/lib/utils/load-config.js
@@ -13,12 +13,12 @@ const CONFIG_FILE_TYPE_MAPPINGS = {
 }
 const FILE_EXTENSIONS = Object.keys(CONFIG_FILE_TYPE_MAPPINGS)
 
-module.exports = function loadConfig(directory) {
+module.exports = function loadConfig (directory) {
   for (let i = 0; i < FILE_EXTENSIONS.length; i++) {
-    let fileExtension = FILE_EXTENSIONS[i]
-    let filePath = path.join(directory, `config.${fileExtension}`)
+    const fileExtension = FILE_EXTENSIONS[i]
+    const filePath = path.join(directory, `config.${fileExtension}`)
     if (fs.existsSync(filePath)) {
-      let loader = CONFIG_FILE_TYPE_MAPPINGS[fileExtension]
+      const loader = CONFIG_FILE_TYPE_MAPPINGS[fileExtension]
       return loader(fs.readFileSync(filePath))
     }
   }

--- a/lib/utils/load-config.js
+++ b/lib/utils/load-config.js
@@ -1,0 +1,26 @@
+import fs from 'fs'
+import path from 'path'
+import toml from 'toml'
+import yaml from 'js-yaml'
+
+const DEFAULT_SITE_CONFIG = {}
+
+const CONFIG_FILE_TYPE_MAPPINGS = {
+  toml: toml.parse,
+  json: JSON.parse,
+  yml: yaml.safeLoad,
+  yaml: yaml.safeLoad,
+}
+const FILE_EXTENSIONS = Object.keys(CONFIG_FILE_TYPE_MAPPINGS)
+
+module.exports = function loadConfig(directory) {
+  for (let i = 0; i < FILE_EXTENSIONS.length; i++) {
+    let fileExtension = FILE_EXTENSIONS[i]
+    let filePath = path.join(directory, `config.${fileExtension}`)
+    if (fs.existsSync(filePath)) {
+      let loader = CONFIG_FILE_TYPE_MAPPINGS[fileExtension]
+      return loader(fs.readFileSync(filePath))
+    }
+  }
+  return DEFAULT_SITE_CONFIG
+}

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -2,11 +2,9 @@ import webpack from 'webpack'
 import StaticSiteGeneratorPlugin from 'static-site-generator-webpack-plugin'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import Config from 'webpack-configurator'
-import fs from 'fs'
 import path from 'path'
 import _ from 'lodash'
 import invariant from 'invariant'
-import toml from 'toml'
 import babelConfig from './babel-config'
 import loadConfig from './load-config'
 
@@ -34,7 +32,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
   const babelStage = suppliedStage
   const stage = (suppliedStage === 'develop-html') ? 'develop' : suppliedStage
 
-  let siteConfig = loadConfig(directory)
+  const siteConfig = loadConfig(directory)
 
   debug(`Loading webpack config for stage "${stage}"`)
   function output () {

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -8,6 +8,7 @@ import _ from 'lodash'
 import invariant from 'invariant'
 import toml from 'toml'
 import babelConfig from './babel-config'
+import loadConfig from './load-config'
 
 const debug = require('debug')('gatsby:webpack-config')
 
@@ -33,15 +34,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
   const babelStage = suppliedStage
   const stage = (suppliedStage === 'develop-html') ? 'develop' : suppliedStage
 
-  let siteConfig = {}
-
-  try {
-    siteConfig = toml.parse(fs.readFileSync(path.join(directory, 'config.toml')))
-  } catch (e) {
-    if (e.code !== 'ENOENT') {
-      throw e
-    }
-  }
+  let siteConfig = loadConfig(directory)
 
   debug(`Loading webpack config for stage "${stage}"`)
   function output () {
@@ -245,8 +238,9 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
       test: /\.ipynb$/,
       loaders: ['json'],
     })
+    // Match everything except config.json.
     config.loader('json', {
-      test: /\.json$/,
+      test: /^((?!config).)*\.json$/,
       loaders: ['json'],
     })
     // Match everything except config.toml.
@@ -254,12 +248,13 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
       test: /^((?!config).)*\.toml$/,
       loaders: ['toml'],
     })
+    // Match everything except config.yaml.
     config.loader('yaml', {
-      test: /\.ya?ml/,
+      test: /^((?!config).)*\.ya?ml/,
       loaders: ['json', 'yaml'],
     })
     config.loader('config', {
-      test: /config\.toml/,
+      test: /config\.(toml|json|ya?ml)/,
       loader: 'config',
       query: {
         directory,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "html-frontmatter": "^1.6.0",
     "image-webpack-loader": "^2.0.0",
     "invariant": "^2.2.1",
+    "js-yaml": "^3.7.0",
     "json-loader": "^0.5.2",
     "json5": "^0.5.0",
     "less": "^2.7.1",


### PR DESCRIPTION
I added this because frontmatter is specified in yaml, and to me having the config in yaml feels more consistent. If found ``config.toml`` still takes precedence, so I don't think there would be any BC breaks. What do you think?