### PR TITLE
Add option for using hashHistory with react router

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Once your pages are converted to markdown, change the file extensions to
 `.md` from the `.markdown` the tool outputs and then use them in your
 site.
 
-## Using hash history with React Router
+### Using hash history with React Router
 It is possible to use the `hashHistory` instead of the `browserHistory` with
 Gatsby's React Router. Add `history = "hashHistory"` to your `config.toml` to
 enable it. In other cases the `browserHistory` will be used.

--- a/README.md
+++ b/README.md
@@ -532,3 +532,10 @@ Jekyll has a [comprehensive import tool](http://import.jekyllrb.com/) for these 
 Once your pages are converted to markdown, change the file extensions to
 `.md` from the `.markdown` the tool outputs and then use them in your
 site.
+
+## Using hash history with React Router
+
+It is possible to use the `hashHistory` instead of the `browserHistory` with
+Gatsby's React Router. Add `history = "hashHistory"` to your `config.toml` to
+enable it. In other cases the `browserHistory` will be used.
+

--- a/README.md
+++ b/README.md
@@ -534,8 +534,6 @@ Once your pages are converted to markdown, change the file extensions to
 site.
 
 ## Using hash history with React Router
-
 It is possible to use the `hashHistory` instead of the `browserHistory` with
 Gatsby's React Router. Add `history = "hashHistory"` to your `config.toml` to
 enable it. In other cases the `browserHistory` will be used.
-

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -115,3 +115,9 @@ Jekyll has a [comprehensive import tool](http://import.jekyllrb.com/) for these 
 Once your pages are converted to markdown, change the file extensions to
 `.md` from the `.markdown` the tool outputs and then use them in your
 site.
+
+## Using hash history with React Router
+
+It is possible to use the `hashHistory` instead of the `browserHistory` with
+Gatsby's React Router. Add `history = "hashHistory"` to your `config.toml` to
+enable it. In other cases the `browserHistory` will be used.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -117,7 +117,6 @@ Once your pages are converted to markdown, change the file extensions to
 site.
 
 ## Using hash history with React Router
-
 It is possible to use the `hashHistory` instead of the `browserHistory` with
 Gatsby's React Router. Add `history = "hashHistory"` to your `config.toml` to
 enable it. In other cases the `browserHistory` will be used.

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { applyRouterMiddleware, browserHistory, Router } from 'react-router'
+import { applyRouterMiddleware, browserHistory, hashHistory, Router } from 'react-router'
 import useScroll from 'react-router-scroll/lib/useScroll'
 
 import createRoutes from 'create-routes'
@@ -45,16 +45,21 @@ function shouldUpdateScroll (prevRouterProps, { location: { pathname } }) {
 let routes
 loadConfig(() =>
   loadContext((pagesReq) => {
-    const { pages } = require('config')
+    const { pages, history } = require('config')
     if (!routes) {
       routes = createRoutes(pages, pagesReq)
     } else {
       createRoutes(pages, pagesReq)
     }
 
+    let theHistory = browserHistory;
+    if (history && history === 'hashHistory') {
+      theHistory = hashHistory;
+    }
+
     ReactDOM.render(
       <Router
-        history={browserHistory}
+        history={theHistory}
         routes={routes}
         render={applyRouterMiddleware(useScroll(shouldUpdateScroll))}
         onUpdate={onUpdate}

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -45,7 +45,7 @@ function shouldUpdateScroll (prevRouterProps, { location: { pathname } }) {
 let routes
 loadConfig(() =>
   loadContext((pagesReq) => {
-    const { pages, history } = require('config')
+    const { pages, config } = require('config')
     if (!routes) {
       routes = createRoutes(pages, pagesReq)
     } else {
@@ -53,7 +53,7 @@ loadConfig(() =>
     }
 
     let theHistory = browserHistory
-    if (history && history === 'hashHistory') {
+    if (config.history && config.history === 'hashHistory') {
       theHistory = hashHistory
     }
 

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -52,9 +52,9 @@ loadConfig(() =>
       createRoutes(pages, pagesReq)
     }
 
-    let theHistory = browserHistory;
+    let theHistory = browserHistory
     if (history && history === 'hashHistory') {
-      theHistory = hashHistory;
+      theHistory = hashHistory
     }
 
     ReactDOM.render(


### PR DESCRIPTION
Add `history = "hashHistory"` to your `config.toml` to enable it. In other cases the `browserHistory` will be used