### PR TITLE
Fixes formatting issue on ordered list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,13 +343,13 @@ Gatsby calls this function with the webpack-configurator object and
 "stage" string when it creates a Webpack config. It first
 loads the defaults and then allows you to modify it.
 
-The `stage` can be
+The `stage` can be:
 
-1) develop: for `gatsby develop` command, hot reload and CSS injection into page
-2) develop-html: same as develop without react-hmre in the babel config for html renderer
-3) build-css: build styles.css file
-4) build-html: build all HTML files
-5) build-javascript: Build bundle.js for Single Page App in production
+1. develop: for `gatsby develop` command, hot reload and CSS injection into page
+2. develop-html: same as develop without react-hmre in the babel config for html renderer
+3. build-css: build styles.css file
+4. build-html: build all HTML files
+5. build-javascript: Build bundle.js for Single Page App in production
 
 Consider the following example which removes the default css loader
 and replaces it with a loader that uses css-modules.


### PR DESCRIPTION
In [this section of README.md](https://github.com/gatsbyjs/gatsby#how-to-use-your-own-webpack-loaders), an ordered list is improperly formatted, making it more difficult to read. 

## Before
<img width="907" alt="screen shot 2016-12-09 at 8 16 33 pm" src="https://cloud.githubusercontent.com/assets/2514127/21069916/a2ea2c80-be4c-11e6-9539-be83769e8684.png">

## After
<img width="907" alt="screen shot 2016-12-09 at 8 16 10 pm" src="https://cloud.githubusercontent.com/assets/2514127/21069919/a6f2eeb6-be4c-11e6-8560-39407017888f.png">
