### PR TITLE
Adapting webpack config to use webpack-configurator plugin method

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -71,7 +71,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
           publicPath,
         }
       case 'build-html':
-        // A temp file required by static-site-generator-plugin. See plugins() below.
+        // A temp file required by static-site-generator-plugin. See plugins function.
         // Deleted by build-html.js, since it's not needed for production.
         return {
           path: `${directory}/public`,
@@ -114,57 +114,37 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     }
   }
 
-  function plugins () {
+  function plugins (config) {
+    config.plugin('define', webpack.DefinePlugin, [{
+      'process.env': {
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'development'),
+      },
+      __PREFIX_LINKS__: program.prefixLinks,
+    }])
+
     switch (stage) {
       case 'develop':
-        return [
-          new webpack.optimize.OccurenceOrderPlugin(),
-          new webpack.HotModuleReplacementPlugin(),
-          new webpack.NoErrorsPlugin(),
-          new webpack.DefinePlugin({
-            'process.env': {
-              NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'development'),
-            },
-            __PREFIX_LINKS__: program.prefixLinks,
-          }),
-        ]
+        config.plugin('optimize-order', webpack.optimize.OccurenceOrderPlugin, null)
+        config.plugin('hot-module-replacement', webpack.HotModuleReplacementPlugin, null)
+        config.plugin('no-errors', webpack.NoErrorsPlugin, null)
+
+        return config
       case 'build-css':
-        return [
-          new webpack.DefinePlugin({
-            'process.env': {
-              NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'production'),
-            },
-            __PREFIX_LINKS__: program.prefixLinks,
-          }),
-          new ExtractTextPlugin('styles.css'),
-        ]
+        config.plugin('extract-text', ExtractTextPlugin, ['styles.css'])
+
+        return config
       case 'build-html':
-        return [
-          new StaticSiteGeneratorPlugin('render-page.js', routes),
-          new webpack.DefinePlugin({
-            'process.env': {
-              NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'production'),
-            },
-            __PREFIX_LINKS__: program.prefixLinks,
-          }),
-          new ExtractTextPlugin('styles.css'),
-        ]
+        config.plugin('static-site-generator', StaticSiteGeneratorPlugin, ['render-page.js', routes])
+        config.plugin('extract-text', ExtractTextPlugin, ['styles.css'])
+
+        return config
       case 'build-javascript':
-        return [
-          // Moment.js includes 100s of KBs of extra localization data
-          // by default in Webpack that most sites don't want.
-          // This line disables that.
-          new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-          new webpack.DefinePlugin({
-            'process.env': {
-              NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'production'),
-            },
-            __PREFIX_LINKS__: program.prefixLinks,
-          }),
-          new ExtractTextPlugin('styles.css'),
-          new webpack.optimize.DedupePlugin(),
-          new webpack.optimize.UglifyJsPlugin(),
-        ]
+        config.plugin('ignore', webpack.IgnorePlugin, [/^\.\/locale$/, /moment$/])
+        config.plugin('extract-text', ExtractTextPlugin, ['styles.css'])
+        config.plugin('dedupe', webpack.optimize.DedupePlugin, null)
+        config.plugin('uglify', webpack.optimize.UglifyJsPlugin, null)
+
+        return config
       default:
         throw new Error(`The state requested ${stage} doesn't exist.`)
     }
@@ -221,7 +201,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     }
   }
 
-  function module (config) {
+  function loaders (config) {
     // Common config for every env.
     config.loader('cjsx', {
       test: /\.cjsx$/,
@@ -476,6 +456,13 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     }
   }
 
+  function module (config) {
+    plugins(config)
+    loaders(config)
+
+    return config
+  }
+
   const config = new Config()
 
   config.merge({
@@ -501,7 +488,6 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         path.resolve(directory, 'node_modules/gatsby/node_modules'),
       ],
     },
-    plugins: plugins(),
     resolve: resolve(),
   })
 


### PR DESCRIPTION
This PR aims to use the webpack configurator plugin methods so that the user can remove and add/customise webpack plugins. The documentation on README.md already describes this behavior so I don't think it needs to be updated. 

I did not find any tests regarding the usage of the **loaders** methods of wp-configurator, so I did not add for the **plugin**, @KyleAMathews do you feel its needed?

(This feature request is mentioned [here](https://github.com/gatsbyjs/gatsby/issues/405))