### PR TITLE
Rearranging webpack.config.js CSS modules

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -314,10 +314,6 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         })
 
         // CSS modules
-        config.loader('cssModules', {
-          test: /\.module\.css$/,
-          loaders: ['style', cssModulesConfDev, 'postcss'],
-        })
         config.loader('lessModules', {
           test: /\.module\.less/,
           loaders: ['style', cssModulesConfDev, 'less'],
@@ -325,6 +321,10 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         config.loader('sassModules', {
           test: /\.module\.(sass|scss)/,
           loaders: ['style', cssModulesConfDev, 'sass'],
+        })
+        config.loader('cssModules', {
+          test: /\.module\.css$/,
+          loaders: ['style', cssModulesConfDev, 'postcss'],
         })
 
         config.merge({


### PR DESCRIPTION
I've moved `postcss` after `sass` and `less` for cases where you're using `sass` AND something like `lost` (https://github.com/peterramsing/lost).  In that case, I need sass to transpile before postcss.