### PR TITLE
Add "2016 JavaScript Rising Stars"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ it'll be converted to `/docs/index.html`.
 * [Fabric](https://www.meetfabric.com)
 * [eugenyzeiri.xyz](http://eugenyzeiri.xyz)
 * [Reactiflux](https://www.reactiflux.com/) ([source](https://github.com/reactiflux/reactiflux.com))
+* [2016 JavaScript Rising Stars](https://risingstars2016.js.org/) ([source](https://github.com/michaelrambeau/risingstars2016))
 * [Edit this file to add yours!](https://github.com/gatsbyjs/gatsby/blob/master/README.md)
 
 *Note, for the sites that have made their source available, you can


### PR DESCRIPTION
Not only "2016 JavaScript Rising Stars" is a project **built** with Gatsby but also it's a web page that **talks** about Gatsby.

Check by yourself: https://risingstars2016.js.org/#ssg

![image](https://cloud.githubusercontent.com/assets/5546996/22396346/587f3bca-e59a-11e6-8f8f-887f188c64b4.png)

On top of that, it's translated in Japanese, which will open the huge (but somehow difficult to enter) Japanese market to the Great Gatsby!

Isn't it great ? 😄 