### PR TITLE
Support template literals as frontmatter for JS pages.

### DIFF
--- a/lib/utils/build-page/load-frontmatter.js
+++ b/lib/utils/build-page/load-frontmatter.js
@@ -52,7 +52,15 @@ export default function loadFrontmatter (pagePath: string): {} {
           if (astPath.node.left.type === 'MemberExpression' &&
             astPath.node.left.property.name === 'data') {
             astPath.node.right.properties.forEach((prop) => {
-              data[prop.key.name] = prop.value.value
+              // Experimental basic support for template literals:
+              // Extract and join any text content; ignore interpolations
+              if (prop.value.type === 'TemplateLiteral') {
+                data[prop.key.name] = prop.value.quasis
+                  .map(quasi => quasi.value.cooked)
+                  .join('')
+              } else {
+                data[prop.key.name] = prop.value.value
+              }
             })
           }
         },

--- a/test/fixtures/template-literal-frontmatter/pages/string-literal.js
+++ b/test/fixtures/template-literal-frontmatter/pages/string-literal.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+exports.data = {
+  title: 'Foo',
+}
+
+export default () => (
+  <h1>Foo</h1>
+)

--- a/test/fixtures/template-literal-frontmatter/pages/template-literal.js
+++ b/test/fixtures/template-literal-frontmatter/pages/template-literal.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+exports.data = {
+  // eslint-disable-next-line
+  title: `Bar`,
+}
+
+export default () => (
+  <h1>Bar</h1>
+)

--- a/test/utils/build-page/load-frontmatter.js
+++ b/test/utils/build-page/load-frontmatter.js
@@ -1,0 +1,14 @@
+import loadFrontmatter from '../../../lib/utils/build-page/load-frontmatter'
+import test from 'ava'
+
+test('it works for string literal titles', (t) => {
+  const pagePath = '../../fixtures/template-literal-frontmatter/pages/string-literal.js'
+  const data = loadFrontmatter(pagePath)
+  t.is(data.title, 'Foo')
+})
+
+test('it works for template literal titles', (t) => {
+  const pagePath = '../../fixtures/template-literal-frontmatter/pages/template-literal.js'
+  const data = loadFrontmatter(pagePath)
+  t.is(data.title, 'Bar')
+})


### PR DESCRIPTION
This seems to work well for me. Open to suggestion as far as whether it's the best approach.