### PR TITLE
Allow client to modify react-router routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ files which start with an underscore:
   found' page. If you `<Link>` to an unknown URL, this page will be shown. Note: in
   production, you'll need to [set up your server host to show this page when it can't find
   the requested file](https://github.com/gatsbyjs/gatsby/pull/121#issuecomment-194715068).
-* (optional) `gatsby-browser.js` - a way to hook into key application events. Export
-`onRouteUpdate` of type `function()` to be notified whenever React-Router
-navigates.
+* (optional) `gatsby-browser.js` - a way to hook into key application events.
+  * Export `onRouteUpdate` of type `function()` to be notified whenever React-Router navigates.
+  * Export `modifyRoutes` of type `function(routes: Object) => Object` to modify the react-router routes.
 * (optional) `gatsby-node.js` - a way to hook into events during build
 and development.
 

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom'
 import { applyRouterMiddleware, browserHistory, Router } from 'react-router'
 import useScroll from 'react-router-scroll/lib/useScroll'
 import createRoutes from 'create-routes'
-import { onRouteChange, onRouteUpdate } from 'gatsby-browser'
+import { onRouteChange, onRouteUpdate, modifyRoutes } from 'gatsby-browser'
 import { config } from 'config'
 
 const loadContext = require('.gatsby-context')
@@ -59,6 +59,10 @@ loadConfig(() =>
       routes.childRoutes.forEach((entry) => {
         entry.path = entry.path.replace(/\/$/, '') // eslint-disable-line no-param-reassign
       })
+    }
+
+    if (modifyRoutes) {
+      routes = modifyRoutes(routes)
     }
 
     ReactDOM.render(


### PR DESCRIPTION
We're currently handling redirects in our API gateway layer. This PR will allow redirects to happen client side. For example, a client may specify a list of redirects in their `gatsby-browser.js` as follows.

```js
exports.modifyRoutes = routes => {
    const redirects = [
        {
            path: '/cat',
            onEnter: (nextState, replace) => replace('/dog?utm_campaign=cat')
        }
    ];
    const childRoutesLength = routes.childRoutes.length;
    const childRoutesButLast = routes.childRoutes.slice(0, childRoutesLength - 1);
    const childRoutesLast = routes.childRoutes[childRoutesLength - 1];
    routes.childRoutes = childRoutesButLast.concat(redirects).concat([childRoutesLast]);
    return routes;
};
```