### PR TITLE
Add replaceDOMRenderer API (#658).

### DIFF
--- a/docs/structure-of-a-gatsby-site.md
+++ b/docs/structure-of-a-gatsby-site.md
@@ -15,8 +15,11 @@ files which start with an underscore:
   found' page. If you `<Link>` to an unknown URL, this page will be shown. Note: in
   production, you'll need to [set up your server host to show this page when it can't find
   the requested file](https://github.com/gatsbyjs/gatsby/pull/121#issuecomment-194715068).
-* (optional) `gatsby-browser.js` - a way to hook into key application events. Export
-`onRouteUpdate` of type `function()` to be notified whenever React-Router
-navigates.
+* (optional) `gatsby-browser.js` - a way to hook into key application events.
+  * Export `onRouteUpdate` of type `function()` to be notified whenever React-Router
+  navigates.
+  * Export `wrapRootComponent` of type `function()` to wrap the root component in another
+  component (for example, the Redux Provider).
+  * Export `replaceDOMRenderer` of type `function()` to override the call to `ReactDOM.render()`.
 * (optional) `gatsby-node.js` - a way to hook into events during build
 and development.

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom'
 import { applyRouterMiddleware, browserHistory, Router } from 'react-router'
 import useScroll from 'react-router-scroll/lib/useScroll'
 import createRoutes from 'create-routes'
-import { onRouteChange, onRouteUpdate, modifyRoutes, shouldUpdateScroll, replaceDOMRenderer } from 'gatsby-browser'
+import { onRouteChange, onRouteUpdate, modifyRoutes, shouldUpdateScroll, replaceDOMRenderer, wrapRootComponent } from 'gatsby-browser'
 
 const loadContext = require('.gatsby-context')
 
@@ -62,17 +62,23 @@ loadConfig(() =>
       routes = modifyRoutes(routes)
     }
 
+    let root = (
+      <Router
+        history={browserHistory}
+        routes={routes}
+        render={applyRouterMiddleware(useScroll(defaultShouldUpdateScroll))}
+        onUpdate={onUpdate}
+      />
+    )
+
+    if (wrapRootComponent) {
+      root = wrapRootComponent(root)
+    }
+
     if (replaceDOMRenderer) {
-      replaceDOMRenderer({ routes, onUpdate, defaultShouldUpdateScroll })
+      replaceDOMRenderer({ routes, defaultShouldUpdateScroll, onUpdate })
     } else {
-      ReactDOM.render(
-        <Router
-          history={browserHistory}
-          routes={routes}
-          render={applyRouterMiddleware(useScroll(defaultShouldUpdateScroll))}
-          onUpdate={onUpdate}
-        />,
-        typeof window !== 'undefined' ? document.getElementById('react-mount') : undefined)
+      ReactDOM.render(root, typeof window !== 'undefined' ? document.getElementById('react-mount') : undefined)
     }
   }),
 )

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -63,7 +63,7 @@ loadConfig(() =>
     }
 
     if (replaceDOMRenderer) {
-      replaceDOMRenderer({ routes, onUpdate, useScroll: useScroll(defaultShouldUpdateScroll) })
+      replaceDOMRenderer({ routes, onUpdate, defaultShouldUpdateScroll })
     } else {
       ReactDOM.render(
         <Router

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom'
 import { applyRouterMiddleware, browserHistory, Router } from 'react-router'
 import useScroll from 'react-router-scroll/lib/useScroll'
 import createRoutes from 'create-routes'
-import { onRouteChange, onRouteUpdate, modifyRoutes, shouldUpdateScroll } from 'gatsby-browser'
+import { onRouteChange, onRouteUpdate, modifyRoutes, shouldUpdateScroll, replaceDOMRenderer } from 'gatsby-browser'
 
 const loadContext = require('.gatsby-context')
 
@@ -62,13 +62,17 @@ loadConfig(() =>
       routes = modifyRoutes(routes)
     }
 
-    ReactDOM.render(
-      <Router
-        history={browserHistory}
-        routes={routes}
-        render={applyRouterMiddleware(useScroll(defaultShouldUpdateScroll))}
-        onUpdate={onUpdate}
-      />,
-      typeof window !== 'undefined' ? document.getElementById('react-mount') : undefined)
+    if (replaceDOMRenderer) {
+      replaceDOMRenderer({ routes, onUpdate, useScroll: useScroll(defaultShouldUpdateScroll) })
+    } else {
+      ReactDOM.render(
+        <Router
+          history={browserHistory}
+          routes={routes}
+          render={applyRouterMiddleware(useScroll(defaultShouldUpdateScroll))}
+          onUpdate={onUpdate}
+        />,
+        typeof window !== 'undefined' ? document.getElementById('react-mount') : undefined)
+    }
   }),
 )


### PR DESCRIPTION
Adds the ability to replace the default ReactDOM.render() call. This allows you to customize the render call and wrap the router with additional components (like the Redux store provider).