### PR TITLE
Lodash webpack plugin

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -1,6 +1,7 @@
 import webpack from 'webpack'
 import StaticSiteGeneratorPlugin from 'static-site-generator-webpack-plugin'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import LodashWebpackPlugin from 'lodash-webpack-plugin'
 import Config from 'webpack-configurator'
 import fs from 'fs'
 import path from 'path'
@@ -143,6 +144,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         config.plugin('extract-text', ExtractTextPlugin, ['styles.css'])
         config.plugin('dedupe', webpack.optimize.DedupePlugin, null)
         config.plugin('uglify', webpack.optimize.UglifyJsPlugin, null)
+        config.plugin('lodash', LodashWebpackPlugin, null)
 
         return config
       default:

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "iflow-debug": "^1.0.15",
     "iflow-lodash": "^1.1.23",
     "iflow-react-router": "^1.1.17",
+    "lodash-webpack-plugin": "^0.11.0",
     "nyc": "^7.0.0"
   },
   "engines": {


### PR DESCRIPTION
Since the project uses lodash with a general import `import _ from 'lodash'` in many places, by adding Lodash Webpack Plugin in addition to Lodash Babel Plugin I was able to reduce the minified `bundle.js` file size by ~20KB.