### PR TITLE
Fix test spawn for Windows

### DIFF
--- a/test/support.js
+++ b/test/support.js
@@ -12,6 +12,7 @@ export function spawn (command, args = [], options = {}) {
   return new Promise((resolve, reject) => {
     let stdout = ''
     let stderr = ''
+    Object.assign(options, { shell: true })
     const child = spawnNative(command, args, options)
     child.stdout.on('data', (data) => { stdout += data })
     child.stderr.on('data', (data) => { stderr += data })


### PR DESCRIPTION
Integration tests were failing with an `ENOENT` on `spawn` on Windows, fixed by adding `shell: true` to `spawn` options.
More info: https://github.com/nodejs/node-v0.x-archive/issues/2318
