### PR TITLE
Remove absolute path

### DIFF
--- a/lib/utils/build-page/path-resolver.js
+++ b/lib/utils/build-page/path-resolver.js
@@ -26,6 +26,9 @@ export default function pathResolver (relativePath: string, pageData: {} = {}) {
     data.templatePath = `/${data.file.dirname}/`
   }
 
+  // Remove the absolute path and isAbsolute bool
+  delete data.file.absolute
+  delete data.file.isAbsolute
+
   return data
 }
-


### PR DESCRIPTION
Removed the `absolute` path, and the `isAbsolute` boolean from the build process as these are not needed in the bundle. 

Resolves #684 