### PR TITLE
added gatsby-ssr.js similar to gatsby-browser.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,11 @@ files which start with an underscore:
   * Export `modifyRoutes` of type `function(routes: Object) => Object` to modify the react-router routes.
   * Export `shouldUpdateScroll` of type `function(prevRouterProps: Object, nextRouterProps: Object) => boolean`
   to determine if a given route change should scroll.
+  * Export `wrapRootComponent` of type `function(Root: React.Component) => React.Component` to allow you to wrap your `<Root />` component before mounting it with `ReactDOM.render()`.
 * (optional) `gatsby-node.js` - a way to hook into events during build
 and development.
+* (optional) `gatsby-ssr.js` - a way to into events during server-side rendering
+  * Export `wrapRootComponent` of type `function(Root: React.Component) => React.Component` to allow you to wrap your `<Root />` component before `ReactDOMServer.renderToString()`.
 
 ### How to use your own webpack loaders
 

--- a/lib/utils/static-entry.js
+++ b/lib/utils/static-entry.js
@@ -6,6 +6,7 @@ import createRoutes from 'create-routes'
 import Html from 'html'
 import { pages, config } from 'config'
 import { prefixLink } from '../isomorphic/gatsby-helpers'
+import { wrapRootComponent } from 'gatsby-ssr'
 
 const loadContext = require('.gatsby-context')
 
@@ -20,14 +21,21 @@ module.exports = (locals, callback) => {
       console.log(error)
       callback(error)
     } else if (renderProps) {
-      const component = <RouterContext {...renderProps} />
+      const componentToWrap = () => (<RouterContext {...renderProps} />)
       let body
+      let component
+
+      if (wrapRootComponent) {
+        component = wrapRootComponent(componentToWrap)
+      } else {
+        component = componentToWrap
+      }
 
       // If we're not generating a SPA for production, eliminate React IDs.
       if (config.noProductionJavascript) {
-        body = renderToStaticMarkup(component)
+        body = renderToStaticMarkup(component())
       } else {
-        body = renderToString(component)
+        body = renderToString(component())
       }
 
       const html = `<!DOCTYPE html>\n ${renderToStaticMarkup(


### PR DESCRIPTION
to allow for `wrapRootComponent(Root)` in order to add a `<Provider >` for server-side rendering (build)