### PR TITLE
Replace backslash in requirePath to slash

### DIFF
--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -141,6 +141,8 @@ module.exports = (files, pagesReq) => {
     let handler
     if (staticFileTypes.indexOf(page.file.ext) !== -1) {
       handler = wrappers[page.file.ext]
+      //replace the backslash in path
+      page.requirePath = page.requirePath.replace(/\\/g, '/');
       page.data = pagesReq(`./${page.requirePath}`)
     } else if (reactComponentFileTypes.indexOf(page.file.ext) !== -1) {
       handler = pagesReq(`./${page.requirePath}`)


### PR DESCRIPTION
It will cause error when there is a backslash in page.requirePath