### PR TITLE
Link prefix in markdown

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -43,6 +43,8 @@ program.command('build')
   .action((command) => {
     // Set NODE_ENV to 'production'
     process.env.NODE_ENV = 'production'
+    process.env.PREFIX_LINKS = command.prefixLinks && 'prefix-links'
+
 
     const build = require('../utils/build')
     const p = {

--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -43,8 +43,6 @@ program.command('build')
   .action((command) => {
     // Set NODE_ENV to 'production'
     process.env.NODE_ENV = 'production'
-    process.env.PREFIX_LINKS = command.prefixLinks && 'prefix-links'
-
 
     const build = require('../utils/build')
     const p = {

--- a/lib/loaders/config-loader/index.js
+++ b/lib/loaders/config-loader/index.js
@@ -1,8 +1,8 @@
 /* @flow weak */
-const toml = require('toml')
-const loaderUtils = require('loader-utils')
-const path = require('path')
-const globPages = require('../../utils/glob-pages')
+import toml from 'toml'
+import loaderUtils from 'loader-utils'
+import path from 'path'
+import globPages from '../../utils/glob-pages'
 
 module.exports = function (source) {
   this.cacheable()

--- a/lib/loaders/markdown-loader/index.js
+++ b/lib/loaders/markdown-loader/index.js
@@ -3,6 +3,8 @@ import frontMatter from 'front-matter'
 import markdownIt from 'markdown-it'
 import hljs from 'highlight.js'
 import objectAssign from 'object-assign'
+import path from 'path'
+import loaderUtils from 'loader-utils'
 
 const highlight = (str, lang) => {
   if ((lang !== null) && hljs.getLanguage(lang)) {
@@ -20,17 +22,28 @@ const highlight = (str, lang) => {
   return ''
 }
 
-const md = markdownIt({
+const md = linkPrefix => markdownIt({
   html: true,
   linkify: true,
   typographer: true,
   highlight,
+  replaceLink: (link) => {
+    if (process.env.PREFIX_LINKS === 'prefix-links' && path.isAbsolute(link)) {
+      return linkPrefix + link
+    }
+    return link
+  },
 })
+  .use(require('markdown-it-replace-link'))
 
 module.exports = function (content) {
   this.cacheable()
+
+  const config = loaderUtils.parseQuery(this.query).config
+  const linkPrefix = config.linkPrefix || ''
+
   const meta = frontMatter(content)
-  const body = md.render(meta.body)
+  const body = md(linkPrefix).render(meta.body)
   const result = objectAssign({}, meta.attributes, {
     body,
   })

--- a/lib/loaders/markdown-loader/index.js
+++ b/lib/loaders/markdown-loader/index.js
@@ -22,13 +22,13 @@ const highlight = (str, lang) => {
   return ''
 }
 
-const md = linkPrefix => markdownIt({
+const md = (linkPrefix, shouldPrefix) => markdownIt({
   html: true,
   linkify: true,
   typographer: true,
   highlight,
   replaceLink: (link) => {
-    if (process.env.PREFIX_LINKS === 'prefix-links' && path.isAbsolute(link)) {
+    if (shouldPrefix && path.isAbsolute(link)) {
       return linkPrefix + link
     }
     return link
@@ -39,11 +39,12 @@ const md = linkPrefix => markdownIt({
 module.exports = function (content) {
   this.cacheable()
 
-  const config = loaderUtils.parseQuery(this.query).config
-  const linkPrefix = config.linkPrefix || ''
+  const query = loaderUtils.parseQuery(this.query)
+  const linkPrefix = query.config.linkPrefix || ''
+  const shouldPrefix = query.shouldPrefix
 
   const meta = frontMatter(content)
-  const body = md(linkPrefix).render(meta.body)
+  const body = md(linkPrefix, shouldPrefix).render(meta.body)
   const result = objectAssign({}, meta.attributes, {
     body,
   })

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -227,6 +227,9 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     config.loader('md', {
       test: /\.(md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee)$/,
       loader: 'markdown',
+      query: {
+        config: siteConfig,
+      },
     })
     config.loader('html', {
       test: /\.html$/,

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -229,6 +229,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
       loader: 'markdown',
       query: {
         config: siteConfig,
+        shouldPrefix: program.prefixLinks,
       },
     })
     config.loader('html', {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "loader-utils": "^0.2.15",
     "lodash": "^4.15.0",
     "markdown-it": "^7.0.1",
+    "markdown-it-replace-link": "^1.0.1",
     "moment": "^2.14.1",
     "negotiator": "^0.6.1",
     "node-cjsx": "^1.0.0",


### PR DESCRIPTION
This PR modifies the markdown default loader so that it automatically prefixes absolute links (such as **/page1**) with the `linkPrefix` property from the `config.toml` file.