### PR TITLE
Update Remark Package Readme

### DIFF
--- a/packages/gatsby-parser-remark/README.md
+++ b/packages/gatsby-parser-remark/README.md
@@ -4,7 +4,7 @@ Parses Markdown files using [Remark](http://remark.js.org/).
 
 ## Install
 
-`npm install --save gatsby-parser-json`
+`npm install --save gatsby-parser-remark`
 
 ## How to use
 


### PR DESCRIPTION
The package name in the npm install command looks like it was copy-pasted from `gatsby-parser-json` and not updated. Figured I'd fix it.