### PR TITLE
1.0 fix windows scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "jest": "^19.0.2",
     "lerna": "^2.0.0-beta.38",
     "prettier": "^0.22.0",
-    "purdy": "^2.2.1"
+    "purdy": "^2.2.1",
+    "rimraf": "^2.6.1"
   },
   "jest": {
     "verbose": true,

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -163,7 +163,7 @@
     "url": "git+https://github.com/gatsbyjs/gatsby.git"
   },
   "scripts": {
-    "build": "rm -r dist/; babel lib --out-dir dist/",
+    "build": "rm -r dist/ && babel lib --out-dir dist/",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore .",
     "lint:flow": "babel-node scripts/flow-check.js",
@@ -171,6 +171,6 @@
     "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
     "test-integration": "node_modules/.bin/ava test/integration",
     "test-node": "node_modules/.bin/ava test/utils",
-    "watch": "rm -r dist/; babel -w lib --out-dir dist/"
+    "watch": "rm -r dist/ && babel -w lib --out-dir dist/"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -163,7 +163,7 @@
     "url": "git+https://github.com/gatsbyjs/gatsby.git"
   },
   "scripts": {
-    "build": "rm -r dist/ && babel lib --out-dir dist/",
+    "build": "rimraf dist && babel lib --out-dir dist/",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore .",
     "lint:flow": "babel-node scripts/flow-check.js",
@@ -171,6 +171,6 @@
     "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
     "test-integration": "node_modules/.bin/ava test/integration",
     "test-node": "node_modules/.bin/ava test/utils",
-    "watch": "rm -r dist/ && babel -w lib --out-dir dist/"
+    "watch": "rimraf dist && babel -w lib --out-dir dist/"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3523,6 +3523,12 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@~2.5.1, rimraf@~2.
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"


### PR DESCRIPTION
Just littles fixes for building on windows.

- Avoid `;` for chaining commands (not windows compatible)
- Use rimraf to avoid the `rm: cannot remove 'dist/': No such file or directory` error on build