### PR TITLE
[1.0] improve gatsby-dev-cli

### DIFF
--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -1,0 +1,35 @@
+# gatsby-dev-cli
+
+A dev cli tool for Gatsby.
+
+It's a simple cli tool for have easily a functionnal development environment for working on Gatsby.
+
+## Install
+
+Fork gatsby repo and clone it.
+
+```bash
+$ npm install -g gatsby-cli-tools@canary
+$ gatsby-dev --set-path-to-repo /path/to/my/cloned/version/gatsby
+```
+
+
+## How to use
+
+Go to your project and execute corresponding following command to use local version of gatsby.
+
+Note: First time can be very long, be patient ;)
+
+### Repo with gatsby dependencies
+
+```bash
+$ gatsby-dev
+```
+
+Tools automaticly find gatsby packages into current `package.json`, copy it from your local fork and watch!
+
+### Repo without gatby dependencies
+
+```bash
+$ gatsby-dev --packages gatsby gatsby-typegen-remark
+```

--- a/packages/gatsby-dev-cli/bin/gatsby-dev
+++ b/packages/gatsby-dev-cli/bin/gatsby-dev
@@ -4,8 +4,21 @@ const Configstore = require("configstore");
 const pkg = require("../package.json");
 const argv = require("yargs").array("packages").argv;
 const isAbsolute = require("is-absolute");
+const _ = require("lodash");
 
 const conf = new Configstore(pkg.name);
+
+const fs = require("fs-extra");
+const havePackageJsonFile = fs.existsSync("package.json");
+
+if (!havePackageJsonFile) {
+  console.log("Current folder must have a package.json file!");
+  process.exit();
+}
+
+const localPkg = JSON.parse(fs.readFileSync("package.json"));
+const packages = Object.keys(localPkg.dependencies);
+const gatsbyPackages = packages.filter(p => p.startsWith("gatsby"));
 
 // Test that the path is absolute
 if (argv.setPathToRepo && !isAbsolute(argv.setPathToRepo)) {
@@ -33,9 +46,11 @@ gatsby-dev --set-path-to-repo /path/to/my/cloned/version/gatsby
   process.exit();
 }
 
-if (!argv.packages) {
+if (!argv.packages && _.isEmpty(gatsbyPackages)) {
   console.log(
     `
+You haven't got any gatsby dependencies into your current package.json
+
 You probably want to pass in a list of packages to start
 developing on! For example:
 
@@ -46,4 +61,4 @@ gatsby-dev --packages gatsby gatsby-typegen-remark
 }
 
 const watch = require("../");
-watch(gatsbyLocation, argv.packages);
+watch(gatsbyLocation, argv.packages || gatsbyPackages);

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -1,39 +1,37 @@
-const chokidar = require("chokidar")
-const _ = require("lodash")
-const fs = require("fs-extra")
-const syspath = require("path")
+const chokidar = require("chokidar");
+const _ = require("lodash");
+const fs = require("fs-extra");
+const syspath = require("path");
 
 const ignoreRegs = [
   new RegExp(`\/node_modules\/`, "i"),
   new RegExp(`\.git`, "i"),
   new RegExp(`\/src\/`, "i"),
-]
+];
 
 module.exports = (root, packages) => {
   packages.forEach(p => {
-    const prefix = `${root}/packages/${p}`
+    const prefix = `${root}/packages/${p}`;
     chokidar
       .watch(prefix, {
         ignored: [
           (path, stats) => {
-            // console.log("path", path, stats);
-            return _.some(ignoreRegs, reg => reg.test(path))
+            return _.some(ignoreRegs, reg => reg.test(path));
           },
         ],
       })
       .on("all", (event, path) => {
         if (event === "change" || event === "add") {
           // Copy it over local version.
-          // console.log(syspath.relative(prefix, path));
           const newPath = syspath.join(
             `./node_modules/${p}`,
             syspath.relative(prefix, path)
-          )
-          // console.log("new path", newPath);
-          fs.copySync(path, newPath)
-          console.log(`copied ${path} to ${newPath}`)
+          );
+          fs.copy(path, newPath, err => {
+            if (err) console.error(err);
+            console.log(`copied ${path} to ${newPath}`);
+          });
         }
-        // console.log(event, path);
-      })
-  })
-}
+      });
+  });
+};


### PR DESCRIPTION
- No need to list packages if package.json have gatsby dependencies
- EsLint, remove unused log
- Add a README (maybe redondant with CONTRIBUTING.md, but always usefull)

@KyleAMathews BTW `fs.copy` is not really more efficient than `fs.copySync` in this context (but permit to have log on error 😉 )