### PR TITLE
[1.0] Fix gatsby-dev-cli regex for windows

### DIFF
--- a/packages/gatsby-dev-cli/index.js
+++ b/packages/gatsby-dev-cli/index.js
@@ -5,14 +5,13 @@ var _ = require("lodash");
 var fs = require("fs-extra");
 var syspath = require("path");
 
-var ignoreRegs = [new RegExp(`\/node_modules\/`, "i"), new RegExp(`\.git`, "i"), new RegExp(`\/src\/`, "i")];
+var ignoreRegs = [/[\/\\]node_modules[\/\\]/i, /\.git/i, /[\/\\]src[\/\\]/i];
 
 module.exports = function (root, packages) {
   packages.forEach(function (p) {
     var prefix = `${root}/packages/${p}`;
     chokidar.watch(prefix, {
       ignored: [function (path, stats) {
-        // console.log("path", path, stats);
         return _.some(ignoreRegs, function (reg) {
           return reg.test(path);
         });
@@ -20,13 +19,12 @@ module.exports = function (root, packages) {
     }).on("all", function (event, path) {
       if (event === "change" || event === "add") {
         // Copy it over local version.
-        // console.log(syspath.relative(prefix, path));
         var newPath = syspath.join(`./node_modules/${p}`, syspath.relative(prefix, path));
-        // console.log("new path", newPath);
-        fs.copySync(path, newPath);
-        console.log(`copied ${path} to ${newPath}`);
+        fs.copy(path, newPath, function (err) {
+          if (err) console.error(err);
+          console.log(`copied ${path} to ${newPath}`);
+        });
       }
-      // console.log(event, path);
     });
   });
 };

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -4,9 +4,9 @@ const fs = require("fs-extra");
 const syspath = require("path");
 
 const ignoreRegs = [
-  new RegExp(`\/node_modules\/`, "i"),
-  new RegExp(`\.git`, "i"),
-  new RegExp(`\/src\/`, "i"),
+  /[\/\\]node_modules[\/\\]/i,
+  /\.git/i,
+  /[\/\\]src[\/\\]/i
 ];
 
 module.exports = (root, packages) => {


### PR DESCRIPTION
Just fix the regex to deal with `path/node_modules` and `path\node_modules`