### PR TITLE
Correct gatsby-plugin-glamor README

### DIFF
--- a/packages/gatsby-plugin-glamor/README.md
+++ b/packages/gatsby-plugin-glamor/README.md
@@ -14,7 +14,7 @@ First add the plugin to your `gatsby-config.js`.
 
 ```javascript
 plugins: [
-  `gatsby-parser-yaml`,
+  `gatsby-plugin-glamor`,
 ]
 ```
 


### PR DESCRIPTION
Fixes a small copy-paste error:
    
    gatsby-parser-yaml -> gatsby-plugin-glamor

Thanks again for your work on this Kyle. ❤️ 