### PR TITLE
Removes Gatsby-specific browserlist config

### DIFF
--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -335,7 +335,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
           postcss (wp) {
             return [
               require('postcss-import')({ addDependencyTo: wp }),
-              require('postcss-cssnext')({ browsers: 'last 2 versions' }),
+              require('postcss-cssnext')(),
               require('postcss-browser-reporter'),
               require('postcss-reporter'),
             ]
@@ -376,9 +376,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         config.merge({
           postcss: [
             require('postcss-import')(),
-            require('postcss-cssnext')({
-              browsers: 'last 2 versions',
-            }),
+            require('postcss-cssnext')(),
           ],
         })
         return config


### PR DESCRIPTION
Currently, you can’t supply a custom browserlist for Autoprefixer without without re-writing the PostCSS loader in`gatsby-node.js`.

This PR removes the Gatsby-specific browserlist config, so the default browserlist config [in postcss-cssnext](https://github.com/MoOx/postcss-cssnext/blob/master/docs/content/usage.md#browsers) is used instead. Then, you can override it in a `.browserslist` file or in your `package.json` .

Thanks for taking the time to look this over!