### PR TITLE
Fix shouldUseYarn check

### DIFF
--- a/lib/utils/init-starter.js
+++ b/lib/utils/init-starter.js
@@ -32,7 +32,7 @@ const install = (rootPath, callback) => {
   const prevDir = process.cwd()
   logger.log('Installing packages...')
   process.chdir(rootPath)
-  const installCmd = shouldUseYarn ? 'yarnpkg' : 'npm install'
+  const installCmd = shouldUseYarn() ? 'yarnpkg' : 'npm install'
   exec(installCmd, (error, stdout, stderr) => {
     process.chdir(prevDir)
     if (stdout) console.log(stdout.toString())


### PR DESCRIPTION
This change is to actually invoke the `shouldUseYarn` function, otherwise yarn always gets picked instead of npm.