### PR TITLE
Change output filename for extracted styles on the HTML/JS build steps

### DIFF
--- a/lib/utils/static-entry.js
+++ b/lib/utils/static-entry.js
@@ -5,8 +5,8 @@ import { match, RouterContext } from 'react-router'
 import createRoutes from 'create-routes'
 import Html from 'html'
 import { pages, config } from 'config'
-import { prefixLink } from '../isomorphic/gatsby-helpers'
 import { wrapRootComponent } from 'gatsby-ssr'
+import { prefixLink } from '../isomorphic/gatsby-helpers'
 
 const loadContext = require('.gatsby-context')
 
@@ -16,33 +16,34 @@ loadContext((pagesReq) => {
 })
 
 module.exports = (locals, callback) => {
-  match({ routes, location: prefixLink(locals.path) }, (error, redirectLocation, renderProps) => {
-    if (error) {
-      console.log(error)
-      callback(error)
-    } else if (renderProps) {
-      const componentToWrap = () => (<RouterContext {...renderProps} />)
-      let body
-      let component
+  match(
+    { routes, location: prefixLink(locals.path) },
+    (error, redirectLocation, renderProps) => {
+      if (error) {
+        console.log(error)
+        callback(error)
+      } else if (renderProps) {
+        const componentToWrap = () => <RouterContext {...renderProps} />
+        let body
+        let component
 
-      if (wrapRootComponent) {
-        component = wrapRootComponent(componentToWrap)
-      } else {
-        component = componentToWrap
+        if (wrapRootComponent) {
+          component = wrapRootComponent(componentToWrap)
+        } else {
+          component = componentToWrap
+        }
+
+        // If we're not generating a SPA for production, eliminate React IDs.
+        if (config.noProductionJavascript) {
+          body = renderToStaticMarkup(component())
+        } else {
+          body = renderToString(component())
+        }
+
+        const html = `<!DOCTYPE html>\n ${renderToStaticMarkup(// eslint-disable-next-line comma-dangle
+          <Html body={body} {...renderProps} />)}`
+        callback(null, html)
       }
-
-      // If we're not generating a SPA for production, eliminate React IDs.
-      if (config.noProductionJavascript) {
-        body = renderToStaticMarkup(component())
-      } else {
-        body = renderToString(component())
-      }
-
-      const html = `<!DOCTYPE html>\n ${renderToStaticMarkup(
-        // eslint-disable-next-line comma-dangle
-        <Html body={body} {...renderProps} />
-      )}`
-      callback(null, html)
-    }
-  })
+    },
+  )
 }

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -29,14 +29,22 @@ try {
 //   4) build-html: build all HTML files
 //   5) build-javascript: Build bundle.js for Single Page App in production
 
-module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes = []) => {
+module.exports = (
+  program,
+  directory,
+  suppliedStage,
+  webpackPort = 1500,
+  routes = [],
+) => {
   const babelStage = suppliedStage
-  const stage = (suppliedStage === 'develop-html') ? 'develop' : suppliedStage
+  const stage = suppliedStage === 'develop-html' ? 'develop' : suppliedStage
 
   let siteConfig = {}
 
   try {
-    siteConfig = toml.parse(fs.readFileSync(path.join(directory, 'config.toml')))
+    siteConfig = toml.parse(
+      fs.readFileSync(path.join(directory, 'config.toml')),
+    )
   } catch (e) {
     if (e.code !== 'ENOENT') {
       throw e
@@ -106,26 +114,36 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
           main: `${__dirname}/static-entry`,
         }
       case 'build-javascript':
-        return [
-          `${__dirname}/web-entry`,
-        ]
+        return [`${__dirname}/web-entry`]
       default:
         throw new Error(`The state requested ${stage} doesn't exist.`)
     }
   }
 
   function plugins (config) {
-    config.plugin('define', webpack.DefinePlugin, [{
-      'process.env': {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV ? process.env.NODE_ENV : 'development'),
+    config.plugin('define', webpack.DefinePlugin, [
+      {
+        'process.env': {
+          NODE_ENV: JSON.stringify(
+            process.env.NODE_ENV ? process.env.NODE_ENV : 'development',
+          ),
+        },
+        __PREFIX_LINKS__: program.prefixLinks,
       },
-      __PREFIX_LINKS__: program.prefixLinks,
-    }])
+    ])
 
     switch (stage) {
       case 'develop':
-        config.plugin('optimize-order', webpack.optimize.OccurenceOrderPlugin, null)
-        config.plugin('hot-module-replacement', webpack.HotModuleReplacementPlugin, null)
+        config.plugin(
+          'optimize-order',
+          webpack.optimize.OccurenceOrderPlugin,
+          null,
+        )
+        config.plugin(
+          'hot-module-replacement',
+          webpack.HotModuleReplacementPlugin,
+          null,
+        )
         config.plugin('no-errors', webpack.NoErrorsPlugin, null)
 
         return config
@@ -134,13 +152,19 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
 
         return config
       case 'build-html':
-        config.plugin('static-site-generator', StaticSiteGeneratorPlugin, ['render-page.js', routes])
-        config.plugin('extract-text', ExtractTextPlugin, ['styles.css'])
+        config.plugin('static-site-generator', StaticSiteGeneratorPlugin, [
+          'render-page.js',
+          routes,
+        ])
+        config.plugin('extract-text', ExtractTextPlugin, ['.styles.css'])
 
         return config
       case 'build-javascript':
-        config.plugin('ignore', webpack.IgnorePlugin, [/^\.\/locale$/, /moment$/])
-        config.plugin('extract-text', ExtractTextPlugin, ['styles.css'])
+        config.plugin('ignore', webpack.IgnorePlugin, [
+          /^\.\/locale$/,
+          /moment$/,
+        ])
+        config.plugin('extract-text', ExtractTextPlugin, ['.styles.css'])
         config.plugin('dedupe', webpack.optimize.DedupePlugin, null)
         config.plugin('uglify', webpack.optimize.UglifyJsPlugin, null)
 
@@ -174,10 +198,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
       // Then in the special directory of isomorphic modules Gatsby ships with.
       // Then the site's node_modules directory
       // and last the Gatsby node_modules directory.
-      root: [
-        directory,
-        path.resolve(__dirname, '..', 'isomorphic'),
-      ],
+      root: [directory, path.resolve(__dirname, '..', 'isomorphic')],
       // Alias for typescript, see: https://github.com/gaearon/react-hot-loader/issues/417#issuecomment-261548082
       alias: { 'react/lib/ReactMount': 'react-dom/lib/ReactMount' },
       modulesDirectories: [
@@ -219,10 +240,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     })
     config.loader('typescript', {
       test: /\.tsx?$/,
-      loaders: [
-        'react-hot',
-        'ts-loader',
-      ],
+      loaders: ['react-hot', 'ts-loader'],
     })
     config.loader('md', {
       test: /\.(md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee)$/,
@@ -295,12 +313,10 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     })
 
     const cssModulesConf = 'css?modules&minimize&importLoaders=1'
-    const cssModulesConfDev =
-      `${cssModulesConf}&sourceMap&localIdentName=[name]---[local]---[hash:base64:5]`
+    const cssModulesConfDev = `${cssModulesConf}&sourceMap&localIdentName=[name]---[local]---[hash:base64:5]`
 
     switch (stage) {
       case 'develop':
-
         config.loader('css', {
           test: /\.css$/,
           exclude: /\.module\.css$/,
@@ -352,18 +368,29 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         config.loader('less', {
           test: /\.less/,
           exclude: /\.module\.less$/,
-          loader: ExtractTextPlugin.extract(['css?minimize', 'postcss', 'less']),
+          loader: ExtractTextPlugin.extract([
+            'css?minimize',
+            'postcss',
+            'less',
+          ]),
         })
         config.loader('sass', {
           test: /\.(sass|scss)/,
           exclude: /\.module\.(sass|scss)$/,
-          loader: ExtractTextPlugin.extract(['css?minimize', 'postcss', 'sass']),
+          loader: ExtractTextPlugin.extract([
+            'css?minimize',
+            'postcss',
+            'sass',
+          ]),
         })
 
         // CSS modules
         config.loader('cssModules', {
           test: /\.module\.css$/,
-          loader: ExtractTextPlugin.extract('style', [cssModulesConf, 'postcss']),
+          loader: ExtractTextPlugin.extract('style', [
+            cssModulesConf,
+            'postcss',
+          ]),
         })
         config.loader('lessModules', {
           test: /\.module\.less/,
@@ -374,10 +401,7 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
           loader: ExtractTextPlugin.extract('style', [cssModulesConf, 'sass']),
         })
         config.merge({
-          postcss: [
-            require('postcss-import')(),
-            require('postcss-cssnext')(),
-          ],
+          postcss: [require('postcss-import')(), require('postcss-cssnext')()],
         })
         return config
 
@@ -405,7 +429,10 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         // CSS modules
         config.loader('cssModules', {
           test: /\.module\.css$/,
-          loader: ExtractTextPlugin.extract('style', [cssModulesConf, 'postcss']),
+          loader: ExtractTextPlugin.extract('style', [
+            cssModulesConf,
+            'postcss',
+          ]),
         })
         config.loader('lessModules', {
           test: /\.module\.less/,
@@ -441,7 +468,10 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
         // CSS modules
         config.loader('cssModules', {
           test: /\.module\.css$/,
-          loader: ExtractTextPlugin.extract('style', [cssModulesConf, 'postcss']),
+          loader: ExtractTextPlugin.extract('style', [
+            cssModulesConf,
+            'postcss',
+          ]),
         })
         config.loader('lessModules', {
           test: /\.module\.less/,
@@ -495,12 +525,14 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
 
   if (modifyWebpackConfig) {
     const modifiedWebpackConfig = modifyWebpackConfig(module(config), stage)
-    invariant(_.isObject(modifiedWebpackConfig),
-              `
+    invariant(
+      _.isObject(modifiedWebpackConfig),
+      `
               You must return an object when modifying the Webpack config.
               Returned: ${modifiedWebpackConfig}
               stage: ${stage}
-              `)
+              `,
+    )
     return modifiedWebpackConfig
   } else {
     return module(config)

--- a/test/utils/build-page/load-frontmatter.js
+++ b/test/utils/build-page/load-frontmatter.js
@@ -1,27 +1,31 @@
-import loadFrontmatter from '../../../lib/utils/build-page/load-frontmatter'
 import test from 'ava'
+import loadFrontmatter from '../../../lib/utils/build-page/load-frontmatter'
 
 test('it works for string literal titles', (t) => {
-  const pagePath = '../../fixtures/javascript-pages-frontmatter/pages/string-literal.js'
+  const pagePath =
+    '../../fixtures/javascript-pages-frontmatter/pages/string-literal.js'
   const data = loadFrontmatter(pagePath)
   t.is(data.title, 'Foo')
 })
 
 test('it works for template literal titles', (t) => {
-  const pagePath = '../../fixtures/javascript-pages-frontmatter/pages/template-literal.js'
+  const pagePath =
+    '../../fixtures/javascript-pages-frontmatter/pages/template-literal.js'
   const data = loadFrontmatter(pagePath)
   t.is(data.title, 'Bar')
 })
 
 test('it works with array literal values', (t) => {
-  const pagePath = '../../fixtures/javascript-pages-frontmatter/pages/array-literal.js'
+  const pagePath =
+    '../../fixtures/javascript-pages-frontmatter/pages/array-literal.js'
   const data = loadFrontmatter(pagePath)
   t.is(data.titles[0], 'My title')
   t.is(data.titles[1], 'My other title')
 })
 
 test('it works with object literal values', (t) => {
-  const pagePath = '../../fixtures/javascript-pages-frontmatter/pages/object-literal.js'
+  const pagePath =
+    '../../fixtures/javascript-pages-frontmatter/pages/object-literal.js'
   const data = loadFrontmatter(pagePath)
   t.is(data.titles.main, 'My title')
   t.is(data.titles.sub, 'My other title')


### PR DESCRIPTION
Fixes #798

We leave CSS Modules running in the html/js build steps so that
JavaScript has access to the generated classnames. But as a side effect,
we're still extracting styles during these steps and (before this PR)
were overwritting the styles.css file generated in the build-css step.

This PR changes the output filename of the extracted styles in
build-html and build-js to .styles.css to hide them away.