### PR TITLE
Format code (on master) with Prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,66 +1,29 @@
 {
-  "parser": "babel-eslint",
   "extends": [
-    "eslint-config-airbnb",
-    "plugin:ava/recommended"
+    "google",
+    "plugin:flowtype/recommended",
+    "plugin:react/recommended",
+    "prettier",
+    "prettier/flowtype",
+    "prettier/react"
   ],
   "plugins": [
-    "ava",
     "flowtype",
-    "flow-vars"
+    "react",
   ],
-  "rules": {
-    "indent": [2, 2, {"SwitchCase": 1}],
-    "no-console": [0],
-    "func-names": [0],
-    "semi": [2, "never"],
-    "no-extra-semi": [2],
-    "space-before-function-paren": [2, "always"],
-    "no-else-return": [0],
-    "space-infix-ops": [0],
-    "react/prefer-es6-class": [0],
-    "react/prefer-stateless-function": [0],
-    "no-underscore-dangle": ["error", { "allow": ["_config"] }],
-    "import/no-unresolved": [0],
-    "global-require": [0],
-    "no-duplicate-imports": [0],
-    "import/no-extraneous-dependencies": [0],
-    "import/extensions": [0],
-    "import/first": [0],
-    "import/no-dynamic-require": [0],
-    "import/newline-after-import": [0],
-    "react/jsx-filename-extension": [0],
-    "react/no-danger": [0],
-    /*"flowtype/require-parameter-type": 1,*/
-    /*"flowtype/require-return-type": [*/
-      /*1,*/
-      /*"always",*/
-      /*{*/
-        /*"annotateUndefined": "never"*/
-      /*}*/
-    /*],*/
-    /*"flowtype/space-after-type-colon": [*/
-      /*1,*/
-      /*"always"*/
-    /*],*/
-    /*"flowtype/space-before-type-colon": [*/
-      /*1,*/
-      /*"never"*/
-    /*],*/
-    /*"flowtype/type-id-match": [*/
-      /*0,*/
-      /*"^([A-Z][a-z0-9]+)+Type$"*/
-    /*],*/
-    /*"flow-vars/define-flow-type": 1,*/
-    /*"flow-vars/use-flow-type": 1,*/
-  },
-  "globals": {
-    "__PREFIX_LINKS__": true,
-    "document": true,
-  },
-  "settings": {
-    "flowtype": {
-      "onlyFilesWithFlowAnnotation": true
+  "parserOptions": {
+    "ecmaVersion": 2016,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
     }
+  },
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "rules": {
+    "valid-jsdoc": [0],
+    "require-jsdoc": [0],
   }
 }

--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+jsfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.jsx\?$' | tr '\n' ' ')
+[ -z "$jsfiles" ] && exit 0
+
+diffs=$(node_modules/.bin/prettier -l $jsfiles)
+[ -z "$diffs" ] && exit 0
+
+echo "here"
+echo >&2 "Javascript files must be formatted with prettier. Please run:"
+echo >&2 "node_modules/.bin/prettier --write "$diffs""
+
+exit 1

--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -10,25 +10,25 @@ const siteDirectory = path.resolve('.')
 const fileName = `${siteDirectory}/.gatsby-context.js`
 fs.copy(gatsbyFile, fileName)
 
-const defaultHost = process.platform === 'win32'
-  ? 'localhost'
-  : '0.0.0.0'
+const defaultHost = process.platform === 'win32' ? 'localhost' : '0.0.0.0'
 
 const directory = path.resolve('.')
 
-program
-  .version(packageJson.version)
-  .usage('[command] [options]')
+program.version(packageJson.version).usage('[command] [options]')
 
-program.command('develop')
-  .description('Start development server. Watches files and rebuilds and hot reloads if something changes') // eslint-disable-line max-len
-  .option('-H, --host <url>',
-          `Set host. Defaults to ${defaultHost}`,
-          defaultHost,
-         )
+program
+  .command('develop')
+  .description(
+    'Start development server. Watches files and rebuilds and hot reloads if something changes'
+  ) // eslint-disable-line max-len
+  .option(
+    '-H, --host <url>',
+    `Set host. Defaults to ${defaultHost}`,
+    defaultHost
+  )
   .option('-p, --port <port>', 'Set port. Defaults to 8000', '8000')
   .option('-o, --open', 'Open the site in your browser for you.')
-  .action((command) => {
+  .action(command => {
     const develop = require('../utils/develop')
     const p = {
       ...command,
@@ -37,10 +37,14 @@ program.command('develop')
     develop(p)
   })
 
-program.command('build')
+program
+  .command('build')
   .description('Build a Gatsby project.')
-  .option('--prefix-links', 'Build site with links prefixed (set prefix in your config).')
-  .action((command) => {
+  .option(
+    '--prefix-links',
+    'Build site with links prefixed (set prefix in your config).'
+  )
+  .action(command => {
     // Set NODE_ENV to 'production'
     process.env.NODE_ENV = 'production'
 
@@ -49,7 +53,7 @@ program.command('build')
       ...command,
       directory,
     }
-    build(p, (err) => {
+    build(p, err => {
       if (err) {
         throw err
       } else {
@@ -58,15 +62,17 @@ program.command('build')
     })
   })
 
-program.command('serve-build')
+program
+  .command('serve-build')
   .description('Serve built site.')
-  .option('-H, --host <url>',
-          `Set host. Defaults to ${defaultHost}`,
-          defaultHost,
-         )
+  .option(
+    '-H, --host <url>',
+    `Set host. Defaults to ${defaultHost}`,
+    defaultHost
+  )
   .option('-p, --port <port>', 'Set port. Defaults to 8000', '8000')
   .option('-o, --open', 'Open the site in your browser for you.')
-  .action((command) => {
+  .action(command => {
     const serve = require('../utils/serve-build')
     const p = {
       ...command,
@@ -84,10 +90,12 @@ program
   })
 
 program.on('--help', () => {
-  console.log(`To show subcommand help:
+  console.log(
+    `To show subcommand help:
 
     gatsby [command] -h
-`)
+`
+  )
 })
 
 // If the user types an unknown sub-command, just display the help.

--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -4,7 +4,7 @@ import last from 'lodash/last'
 import sortBy from 'lodash/sortBy'
 import { prefixLink } from './gatsby-helpers'
 
-function requireComponent (moduleReq) {
+function requireComponent(moduleReq) {
   // Minor differences in `require` behavior across languages
   // are handled by this wrapper.
   //
@@ -22,9 +22,11 @@ module.exports = (files, pagesReq) => {
   // Remove files that start with an underscore as this indicates
   // the file shouldn't be turned into a page.
   const pages = filter(files, file => file.file.name.slice(0, 1) !== '_')
-  const templates = filter(files, file =>
-    // eslint-disable-next-line comma-dangle
-    file.file.name === '_template'
+  const templates = filter(
+    files,
+    file =>
+      // eslint-disable-next-line comma-dangle
+      file.file.name === '_template'
   )
 
   const routes = {
@@ -49,23 +51,27 @@ module.exports = (files, pagesReq) => {
   // 3. For each index file paired with a template, create a default route
   // 4. Create normal routes for each remaining file under the appropriate
   // template
-  const templatesWithoutRoot = filter(files, file =>
-    // eslint-disable-next-line comma-dangle
-    file.file.name === '_template' && file.file.dirname !== ''
+  const templatesWithoutRoot = filter(
+    files,
+    file =>
+      // eslint-disable-next-line comma-dangle
+      file.file.name === '_template' && file.file.dirname !== ''
   )
 
   // Find the parent template for each template file and create a route
   // with it.
-  templatesWithoutRoot.forEach((templateFile) => {
-    let parentTemplates = filter(templatesWithoutRoot, template =>
-      // eslint-disable-next-line comma-dangle
-      templateFile.requirePath.indexOf(template.file.dirname) === 0
+  templatesWithoutRoot.forEach(templateFile => {
+    let parentTemplates = filter(
+      templatesWithoutRoot,
+      template =>
+        // eslint-disable-next-line comma-dangle
+        templateFile.requirePath.indexOf(template.file.dirname) === 0
     )
     // Sort parent templates by directory length. In cases
     // where a template has multiple parents
     // e.g. /_template.js/blog/_template.js/archive/_template.js
     // we want to nest this template under its most immediate parent.
-    parentTemplates = sortBy(parentTemplates, (template) => {
+    parentTemplates = sortBy(parentTemplates, template => {
       if (template) {
         return template.file.dirname.length
       } else {
@@ -114,29 +120,25 @@ module.exports = (files, pagesReq) => {
     'yaml',
     'toml',
   ]
-  const reactComponentFileTypes = [
-    'js',
-    'ts',
-    'jsx',
-    'tsx',
-    'cjsx',
-  ]
+  const reactComponentFileTypes = ['js', 'ts', 'jsx', 'tsx', 'cjsx']
   const wrappers = {}
-  staticFileTypes.forEach((type) => {
+  staticFileTypes.forEach(type => {
     try {
       // $FlowIssue - https://github.com/facebook/flow/issues/1975
       wrappers[type] = require(`wrappers/${type}`)
     } catch (e) {
       // Ignore module not found errors; show others on console
-      if (e.code !== 'MODULE_NOT_FOUND'
-          && (e.message && !e.message.match(/^Cannot find module/))
-          && typeof console !== 'undefined') {
+      if (
+        e.code !== 'MODULE_NOT_FOUND' &&
+        (e.message && !e.message.match(/^Cannot find module/)) &&
+        typeof console !== 'undefined'
+      ) {
         console.error('Error requiring wrapper', type, ':', e)
       }
     }
   })
 
-  pages.forEach((p) => {
+  pages.forEach(p => {
     const page = p
     let handler
     if (staticFileTypes.indexOf(page.file.ext) !== -1) {
@@ -144,16 +146,21 @@ module.exports = (files, pagesReq) => {
       page.data = pagesReq(`./${page.requirePath}`)
     } else if (reactComponentFileTypes.indexOf(page.file.ext) !== -1) {
       handler = pagesReq(`./${page.requirePath}`)
-      page.data = (page.data === undefined) ? {} : page.data
+      page.data = page.data === undefined ? {} : page.data
     }
 
     // Determine parent template for page.
-    const parentTemplates = filter(templatesWithoutRoot, templateFile =>
-      // eslint-disable-next-line comma-dangle
-      page.requirePath.indexOf(templateFile.file.dirname) === 0
+    const parentTemplates = filter(
+      templatesWithoutRoot,
+      templateFile =>
+        // eslint-disable-next-line comma-dangle
+        page.requirePath.indexOf(templateFile.file.dirname) === 0
     )
 
-    const sortedParentTemplates = sortBy(parentTemplates, route => route.file.dirname.length)
+    const sortedParentTemplates = sortBy(
+      parentTemplates,
+      route => route.file.dirname.length
+    )
 
     const parentTemplateFile = last(sortedParentTemplates)
     let parentRoute
@@ -167,8 +174,9 @@ module.exports = (files, pagesReq) => {
 
     // If page is an index page *and* has the same path as its parentRoute,
     // it is the index route (for that template).
-    if (page.file.name === 'index' &&
-        prefixLink(page.path) === parentRoute.path) {
+    if (
+      page.file.name === 'index' && prefixLink(page.path) === parentRoute.path
+    ) {
       parentRoute.indexRoute = {
         component: handler,
         page,

--- a/lib/isomorphic/gatsby-helpers.js
+++ b/lib/isomorphic/gatsby-helpers.js
@@ -3,7 +3,7 @@ import { config } from 'config'
 import invariant from 'invariant'
 import isString from 'lodash/isString'
 
-function isDataURL (s) {
+function isDataURL(s) {
   // Regex from https://gist.github.com/bgrins/6194623#gistcomment-1671744
   // eslint-disable-next-line
   const regex = /^\s*data:([a-z]+\/[a-z0-9\-\+]+(;[a-z\-]+=[a-z0-9\-]+)?)?(;base64)?,[a-z0-9!\$&',\(\)\*\+,;=\-\._~:@\/\?%\s]*\s*$/i
@@ -11,11 +11,13 @@ function isDataURL (s) {
 }
 
 // Function to add prefix to links.
-const prefixLink = (_link) => {
+const prefixLink = _link => {
   if (
-      (typeof __PREFIX_LINKS__ !== 'undefined' && __PREFIX_LINKS__ !== null)
-      && __PREFIX_LINKS__ && (config.linkPrefix !== null
-  )) {
+    typeof __PREFIX_LINKS__ !== 'undefined' &&
+    __PREFIX_LINKS__ !== null &&
+    __PREFIX_LINKS__ &&
+    config.linkPrefix !== null
+  ) {
     const invariantMessage = `
     You're trying to build your site with links prefixed
     but you haven't set 'linkPrefix' in your config.toml.

--- a/lib/isomorphic/html.js
+++ b/lib/isomorphic/html.js
@@ -12,7 +12,7 @@ https://github.com/gatsbyjs/gatsby/blob/master/lib/isomorphic/html.js
 `
 console.info(defaultMessage)
 
-function HTML (props) {
+function HTML(props) {
   return (
     <html lang="en">
       <head>
@@ -24,7 +24,10 @@ function HTML (props) {
         />
       </head>
       <body>
-        <div id="react-mount" dangerouslySetInnerHTML={{ __html: props.body }} />
+        <div
+          id="react-mount"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
         <script src={prefixLink('/bundle.js')} />
       </body>
     </html>

--- a/lib/isomorphic/pages/_template.js
+++ b/lib/isomorphic/pages/_template.js
@@ -10,7 +10,7 @@ https://github.com/gatsbyjs/gatsby/blob/master/lib/isomorphic/pages/_template.js
 `
 console.info(defaultMessage)
 
-function template (props) {
+function template(props) {
   return <div>{props.children}</div>
 }
 

--- a/lib/isomorphic/wrappers/html.js
+++ b/lib/isomorphic/wrappers/html.js
@@ -2,6 +2,7 @@
 import React, { PropTypes } from 'react'
 
 module.exports = React.createClass({
+  displayName: 'Html',
   propTypes: {
     route: PropTypes.shape({
       page: PropTypes.shape({
@@ -10,7 +11,7 @@ module.exports = React.createClass({
     }),
   },
 
-  getDefaultProps () {
+  getDefaultProps() {
     return {
       route: {
         page: {
@@ -20,7 +21,7 @@ module.exports = React.createClass({
     }
   },
 
-  render () {
+  render() {
     const post = this.props.route.page.data
     return (
       <div>

--- a/lib/isomorphic/wrappers/md.js
+++ b/lib/isomorphic/wrappers/md.js
@@ -2,6 +2,7 @@
 import React, { PropTypes } from 'react'
 
 module.exports = React.createClass({
+  displayName: 'Html',
   propTypes: {
     route: PropTypes.shape({
       page: PropTypes.shape({
@@ -10,7 +11,7 @@ module.exports = React.createClass({
     }),
   },
 
-  getDefaultProps () {
+  getDefaultProps() {
     return {
       route: {
         page: {
@@ -20,7 +21,7 @@ module.exports = React.createClass({
     }
   },
 
-  render () {
+  render() {
     const post = this.props.route.page.data
     return (
       <div className="markdown">

--- a/lib/loaders/config-loader/index.js
+++ b/lib/loaders/config-loader/index.js
@@ -4,7 +4,7 @@ import loaderUtils from 'loader-utils'
 import path from 'path'
 import globPages from '../../utils/glob-pages'
 
-module.exports = function (source) {
+module.exports = function(source) {
   this.cacheable()
   const callback = this.async()
   const directory = loaderUtils.parseQuery(this.query).directory
@@ -15,6 +15,9 @@ module.exports = function (source) {
   value.relativePath = path.relative('.', directory)
   globPages(directory, (err, pagesData) => {
     value.pages = pagesData
-    return callback(null, `module.exports = ${JSON.stringify(value, null, '\t')}`)
+    return callback(
+      null,
+      `module.exports = ${JSON.stringify(value, null, '\t')}`
+    )
   })
 }

--- a/lib/loaders/html-loader/index.js
+++ b/lib/loaders/html-loader/index.js
@@ -2,7 +2,7 @@
 import htmlFrontMatter from 'html-frontmatter'
 import objectAssign from 'object-assign'
 
-module.exports = function (content) {
+module.exports = function(content) {
   this.cacheable()
   const data = objectAssign({}, htmlFrontMatter(content), { body: content })
   this.value = data

--- a/lib/loaders/markdown-loader/index.js
+++ b/lib/loaders/markdown-loader/index.js
@@ -7,7 +7,7 @@ import path from 'path'
 import loaderUtils from 'loader-utils'
 
 const highlight = (str, lang) => {
-  if ((lang !== null) && hljs.getLanguage(lang)) {
+  if (lang !== null && hljs.getLanguage(lang)) {
     try {
       return hljs.highlight(lang, str).value
     } catch (_error) {
@@ -22,21 +22,21 @@ const highlight = (str, lang) => {
   return ''
 }
 
-const md = (linkPrefix, shouldPrefix) => markdownIt({
-  html: true,
-  linkify: true,
-  typographer: true,
-  highlight,
-  replaceLink: (link) => {
-    if (shouldPrefix && path.isAbsolute(link)) {
-      return linkPrefix + link
-    }
-    return link
-  },
-})
-  .use(require('markdown-it-replace-link'))
+const md = (linkPrefix, shouldPrefix) =>
+  markdownIt({
+    html: true,
+    linkify: true,
+    typographer: true,
+    highlight,
+    replaceLink: link => {
+      if (shouldPrefix && path.isAbsolute(link)) {
+        return linkPrefix + link
+      }
+      return link
+    },
+  }).use(require('markdown-it-replace-link'))
 
-module.exports = function (content) {
+module.exports = function(content) {
   this.cacheable()
 
   const query = loaderUtils.parseQuery(this.query)

--- a/lib/utils/babel-config.js
+++ b/lib/utils/babel-config.js
@@ -7,7 +7,7 @@ import _ from 'lodash'
 import objectAssign from 'object-assign'
 import invariant from 'invariant'
 
-function defaultConfig () {
+function defaultConfig() {
   return {
     presets: ['react', 'es2015', 'stage-0'],
     plugins: ['add-module-exports', 'transform-object-assign'],
@@ -24,15 +24,18 @@ function defaultConfig () {
  * 4. Checking Gatsby's modules without prefix
  *
  */
-function resolvePlugin (pluginName, directory, type) {
+function resolvePlugin(pluginName, directory, type) {
   const gatsbyPath = path.resolve(__dirname, '..', '..')
 
-  const plugin = resolve(`babel-${type}-${pluginName}`, directory) ||
+  const plugin =
+    resolve(`babel-${type}-${pluginName}`, directory) ||
     resolve(`babel-${type}-${pluginName}`, gatsbyPath) ||
     resolve(pluginName, directory) ||
     resolve(pluginName, gatsbyPath)
 
-  const name = _.startsWith(pluginName, 'babel') ? pluginName : `babel-${type}-${pluginName}`
+  const name = _.startsWith(pluginName, 'babel')
+    ? pluginName
+    : `babel-${type}-${pluginName}`
   const pluginInvariantMessage = `
   You are trying to use a Babel plugin which Gatsby cannot find. You
   can install it using "npm install --save ${name}".
@@ -54,15 +57,18 @@ function resolvePlugin (pluginName, directory, type) {
  * This way babel-loader will correctly resolve Babel plugins
  * regardless of where they are located.
  */
-function normalizeConfig (config, directory) {
+function normalizeConfig(config, directory) {
   const normalizedConfig = { presets: [], plugins: [] }
 
   const presets = config.presets || []
-  presets.forEach((preset) => {
+  presets.forEach(preset => {
     let normalizedPreset
 
     if (_.isArray(preset)) {
-      normalizedPreset = [resolvePlugin(preset[0], directory, 'preset'), preset[1]]
+      normalizedPreset = [
+        resolvePlugin(preset[0], directory, 'preset'),
+        preset[1],
+      ]
     } else {
       normalizedPreset = resolvePlugin(preset, directory, 'preset')
     }
@@ -71,11 +77,14 @@ function normalizeConfig (config, directory) {
   })
 
   const plugins = config.plugins || []
-  plugins.forEach((plugin) => {
+  plugins.forEach(plugin => {
     let normalizedPlugin
 
     if (_.isArray(plugin)) {
-      normalizedPlugin = [resolvePlugin(plugin[0], directory, 'plugin'), plugin[1]]
+      normalizedPlugin = [
+        resolvePlugin(plugin[0], directory, 'plugin'),
+        plugin[1],
+      ]
     } else {
       normalizedPlugin = resolvePlugin(plugin, directory, 'plugin')
     }
@@ -91,7 +100,7 @@ function normalizeConfig (config, directory) {
  * json5 (what Babel uses). It throws an error if the users's .babelrc is
  * not parseable.
  */
-function findBabelrc (directory) {
+function findBabelrc(directory) {
   try {
     const babelrc = fs.readFileSync(path.join(directory, '.babelrc'), 'utf-8')
     return json5.parse(babelrc)
@@ -108,7 +117,7 @@ function findBabelrc (directory) {
  * Reads the user's package.json and returns the "babel" section. It will
  * return undefined when the "babel" section does not exist.
  */
-function findBabelPackage (directory) {
+function findBabelPackage(directory) {
   try {
     // $FlowIssue - https://github.com/facebook/flow/issues/1975
     const packageJson = require(path.join(directory, 'package.json'))
@@ -126,10 +135,11 @@ function findBabelPackage (directory) {
  * Returns a normalized Babel config to use with babel-loader. All of
  * the paths will be absolute so that Babel behaves as expected.
  */
-export default function babelConfig (program, stage) {
+export default function babelConfig(program, stage) {
   const { directory } = program
 
-  const babelrc = findBabelrc(directory) || findBabelPackage(directory) || defaultConfig()
+  const babelrc =
+    findBabelrc(directory) || findBabelPackage(directory) || defaultConfig()
 
   if (stage === 'develop') {
     babelrc.presets.unshift('react-hmre')

--- a/lib/utils/build-html.js
+++ b/lib/utils/build-html.js
@@ -16,7 +16,13 @@ module.exports = (program, callback) => {
     const routes = pages.filter(page => page.path).map(page => page.path)
 
     // Static site generation.
-    const compilerConfig = webpackConfig(program, directory, 'build-html', null, routes)
+    const compilerConfig = webpackConfig(
+      program,
+      directory,
+      'build-html',
+      null,
+      routes
+    )
 
     webpack(compilerConfig.resolve()).run((e, stats) => {
       if (e) {

--- a/lib/utils/build-page/index.js
+++ b/lib/utils/build-page/index.js
@@ -4,10 +4,13 @@ import objectAssign from 'object-assign'
 import pathResolver from './path-resolver'
 import loadFrontmatter from './load-frontmatter'
 
-export default function buildPage (directory: string, page: string) {
+export default function buildPage(directory: string, page: string) {
   const pageData = loadFrontmatter(page)
 
-  const relativePath: string = path.relative(path.join(directory, 'pages'), page)
+  const relativePath: string = path.relative(
+    path.join(directory, 'pages'),
+    page
+  )
   const pathData = pathResolver(relativePath, pageData)
 
   return objectAssign({}, pathData, { data: pageData })

--- a/lib/utils/build-page/load-frontmatter.js
+++ b/lib/utils/build-page/load-frontmatter.js
@@ -7,7 +7,7 @@ import htmlFrontMatter from 'html-frontmatter'
 import * as babylon from 'babylon'
 import traverse from 'babel-traverse'
 
-export default function loadFrontmatter (pagePath: string): {} {
+export default function loadFrontmatter(pagePath: string): {} {
   const ext: string = path.extname(pagePath).slice(1)
 
   // Load data for each file type.
@@ -17,7 +17,9 @@ export default function loadFrontmatter (pagePath: string): {} {
 
   let data
   if (ext.match(/^(md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee)$/)) {
-    const rawData = frontMatter(fs.readFileSync(pagePath, { encoding: 'utf-8' }))
+    const rawData = frontMatter(
+      fs.readFileSync(pagePath, { encoding: 'utf-8' })
+    )
     data = objectAssign({}, rawData.attributes)
   } else if (ext === 'html') {
     const html = fs.readFileSync(pagePath, { encoding: 'utf-8' })
@@ -46,7 +48,7 @@ export default function loadFrontmatter (pagePath: string): {} {
 
       const ast = babylon.parse(code, options)
 
-      const parseData = function parseData (node) {
+      const parseData = function parseData(node) {
         let value
 
         if (node.type === 'TemplateLiteral') {
@@ -55,7 +57,7 @@ export default function loadFrontmatter (pagePath: string): {} {
           value = node.quasis.map(quasi => quasi.value.cooked).join('')
         } else if (node.type === 'ObjectExpression') {
           value = {}
-          node.properties.forEach((elem) => {
+          node.properties.forEach(elem => {
             value[elem.key.name] = parseData(elem.value)
           })
         } else if (node.type === 'ArrayExpression') {
@@ -69,9 +71,12 @@ export default function loadFrontmatter (pagePath: string): {} {
 
       data = {}
       traverse(ast, {
-        AssignmentExpression: function AssignmentExpression (astPath) {
-          if (astPath.node.left.type === 'MemberExpression' && astPath.node.left.property.name === 'data') {
-            astPath.node.right.properties.forEach((node) => {
+        AssignmentExpression: function AssignmentExpression(astPath) {
+          if (
+            astPath.node.left.type === 'MemberExpression' &&
+            astPath.node.left.property.name === 'data'
+          ) {
+            astPath.node.right.properties.forEach(node => {
               data[node.key.name] = parseData(node.value)
             })
           }

--- a/lib/utils/build-page/path-resolver.js
+++ b/lib/utils/build-page/path-resolver.js
@@ -3,8 +3,7 @@ import slash from 'slash'
 import parsePath from 'parse-filepath'
 import urlResolver from './url-resolver'
 
-
-export default function pathResolver (relativePath: string, pageData: {} = {}) {
+export default function pathResolver(relativePath: string, pageData: {} = {}) {
   const data = {}
 
   data.file = parsePath(relativePath)

--- a/lib/utils/build-page/url-resolver.js
+++ b/lib/utils/build-page/url-resolver.js
@@ -14,12 +14,12 @@ try {
   }
 }
 
-export default function pathResolver (pageData, parsedPath) {
+export default function pathResolver(pageData, parsedPath) {
   /**
    * Determines if a hardcoded path was given in the frontmatter of a page.
    * Then enforces a starting and trailing slash where applicable on the url.
    */
-  function hardcodedPath () {
+  function hardcodedPath() {
     if (_.isUndefined(pageData.path)) return undefined
 
     let pagePath = pageData.path
@@ -44,17 +44,19 @@ export default function pathResolver (pageData, parsedPath) {
    * Determines if the path should be rewritten using rules provided by the
    * user in the gatsby-node.js config file in the root of the project.
    */
-  function rewrittenPath () {
+  function rewrittenPath() {
     if (rewritePath) {
       return rewritePath(parsedPath, pageData)
-    } else { return undefined }
+    } else {
+      return undefined
+    }
   }
 
   /**
    * Determines the path of the page using the default of its location on the
    * filesystem.
    */
-  function defaultPath () {
+  function defaultPath() {
     const { dirname } = parsedPath
     let { name } = parsedPath
     if (name === 'template' || name === 'index') {

--- a/lib/utils/build.js
+++ b/lib/utils/build.js
@@ -9,7 +9,7 @@ import buildProductionBundle from './build-javascript'
 import postBuild from './post-build'
 import globPages from './glob-pages'
 
-function customPost (program, callback) {
+function customPost(program, callback) {
   const directory = program.directory
   let customPostBuild
   try {
@@ -18,7 +18,10 @@ function customPost (program, callback) {
     customPostBuild = gatsbyNodeConfig.postBuild
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND' && !_.includes(e.Error, 'gatsby-node')) {
-      console.log('Failed to load gatsby-node.js, skipping custom post build script', e)
+      console.log(
+        'Failed to load gatsby-node.js, skipping custom post build script',
+        e
+      )
     }
   }
 
@@ -26,13 +29,13 @@ function customPost (program, callback) {
     console.log('Performing custom post-build steps')
 
     return globPages(directory, (globError, pages) =>
-      customPostBuild(pages, (error) => {
+      customPostBuild(pages, error => {
         if (error) {
           console.log('customPostBuild function failed')
           callback(error)
         }
         return callback()
-      // eslint-disable-next-line comma-dangle
+        // eslint-disable-next-line comma-dangle
       })
     )
   }
@@ -40,10 +43,10 @@ function customPost (program, callback) {
   return callback()
 }
 
-function post (program, callback) {
+function post(program, callback) {
   console.log('Copying assets')
 
-  postBuild(program, (error) => {
+  postBuild(program, error => {
     if (error) {
       console.log('failed to copy assets')
       return callback(error)
@@ -53,10 +56,10 @@ function post (program, callback) {
   })
 }
 
-function bundle (program, callback) {
+function bundle(program, callback) {
   console.log('Compiling production bundle.js')
 
-  buildProductionBundle(program, (error) => {
+  buildProductionBundle(program, error => {
     if (error) {
       console.log('failed to compile bundle.js')
       return callback(error)
@@ -66,7 +69,7 @@ function bundle (program, callback) {
   })
 }
 
-function html (program, callback) {
+function html(program, callback) {
   const directory = program.directory
   let config
   try {
@@ -77,14 +80,14 @@ function html (program, callback) {
   }
 
   console.log('Generating CSS')
-  buildCSS(program, (cssError) => {
+  buildCSS(program, cssError => {
     if (cssError) {
       console.log('Failed at generating styles.css')
       return callback(cssError)
     }
 
     console.log('Generating Static HTML')
-    return buildHTML(program, (htmlError) => {
+    return buildHTML(program, htmlError => {
       if (htmlError) {
         console.log('Failed at generating HTML')
         return callback(htmlError)

--- a/lib/utils/develop.js
+++ b/lib/utils/develop.js
@@ -29,12 +29,17 @@ const devNoScript = `<noscript>
   'gatsby build' and then serve the built site 'gatsby serve-build'
 </noscript>`
 
-function startServer (program) {
+function startServer(program) {
   const directory = program.directory
 
   // Load pages for the site.
   return globPages(directory, (err, pages) => {
-    const compilerConfig = webpackConfig(program, directory, 'develop', program.port)
+    const compilerConfig = webpackConfig(
+      program,
+      directory,
+      'develop',
+      program.port
+    )
 
     const compiler = webpack(compilerConfig.resolve())
 
@@ -44,158 +49,172 @@ function startServer (program) {
       HTMLPath = '../isomorphic/html'
     }
 
-    const htmlCompilerConfig = webpackConfig(program, directory, 'develop-html', program.port)
+    const htmlCompilerConfig = webpackConfig(
+      program,
+      directory,
+      'develop-html',
+      program.port
+    )
 
-    webpackRequire(htmlCompilerConfig.resolve(), require.resolve(HTMLPath), (error, factory) => {
-      if (error) {
-        console.log(`Failed to require ${directory}/html.js`)
-        error.forEach((e) => {
-          console.log(e)
-        })
-        process.exit()
-      }
-      const HTML = factory()
-      debug('Configuring develop server')
-
-      const server = new Hapi.Server()
-
-      server.connection({
-        host: program.host,
-        port: program.port,
-      })
-
-      server.route({
-        method: 'GET',
-        path: '/html/{path*}',
-        handler: (request, reply) => {
-          if (request.path === 'favicon.ico') {
-            return reply(Boom.notFound())
-          }
-
-          try {
-            const htmlElement = React.createElement(
-              HTML, {
-                body: devNoScript,
-              },
-            )
-            let html = ReactDOMServer.renderToStaticMarkup(htmlElement)
-            html = `<!DOCTYPE html>\n${html}`
-            return reply(html)
-          } catch (e) {
-            console.log(e.stack)
-            throw e
-          }
-        },
-      })
-
-      server.route({
-        method: 'GET',
-        path: '/{path*}',
-        handler: {
-          directory: {
-            path: `${program.directory}/pages`,
-            listing: false,
-            index: false,
-          },
-        },
-      })
-
-      server.ext('onRequest', (request, reply) => {
-        const negotiator = new Negotiator(request.raw.req)
-
-        // Try to map the url path to match an actual path of a file on disk.
-        const parsed = parsePath(request.path)
-        const page = _.find(pages, p => p.path === (`${parsed.dirname}/`))
-
-        let absolutePath = `${program.directory}/pages`
-        let path
-        if (page) {
-          path = `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
-          absolutePath += `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
-        } else {
-          path = request.path
-          absolutePath += request.path
-        }
-        let isFile = false
-        try {
-          isFile = fs.lstatSync(absolutePath).isFile()
-        } catch (e) {
-          // Ignore.
-        }
-
-        // If the path matches a file, return that.
-        if (isFile) {
-          request.setUrl(path)
-          reply.continue()
-        // Let people load the bundle.js directly.
-        } else if (request.path === '/bundle.js') {
-          reply.continue()
-        } else if (negotiator.mediaType() === 'text/html') {
-          // If the path does not end with a slash, add it.
-          if (request.path[request.path.length - 1] !== '/') {
-            request.path += '/' // eslint-disable-line no-param-reassign
-          }
-          request.setUrl(`/html${request.path}`)
-          reply.continue()
-        } else {
-          reply.continue()
-        }
-      })
-
-      const assets = {
-        noInfo: true,
-        reload: true,
-        publicPath: compilerConfig._config.output.publicPath,
-      }
-      const hot = {
-        hot: true,
-        quiet: true,
-        noInfo: true,
-        host: program.host,
-        headers: {
-          'Access-Control-Allow-Origin': '*',
-        },
-        stats: {
-          colors: true,
-        },
-      }
-
-      return server.register({
-        register: WebpackPlugin,
-        options: {
-          compiler,
-          assets,
-          hot,
-        },
-      }, (er) => {
-        if (er) {
-          console.log(er)
+    webpackRequire(
+      htmlCompilerConfig.resolve(),
+      require.resolve(HTMLPath),
+      (error, factory) => {
+        if (error) {
+          console.log(`Failed to require ${directory}/html.js`)
+          error.forEach(e => {
+            console.log(e)
+          })
           process.exit()
         }
+        const HTML = factory()
+        debug('Configuring develop server')
 
-        server.start((e) => {
-          if (e) {
-            if (e.code === 'EADDRINUSE') {
-              // eslint-disable-next-line max-len
-              console.log(chalk.red(`Unable to start Gatsby on port ${program.port} as there's already a process listening on that port.`))
-            } else {
-              console.log(chalk.red(e))
+        const server = new Hapi.Server()
+
+        server.connection({
+          host: program.host,
+          port: program.port,
+        })
+
+        server.route({
+          method: 'GET',
+          path: '/html/{path*}',
+          handler: (request, reply) => {
+            if (request.path === 'favicon.ico') {
+              return reply(Boom.notFound())
             }
 
-            process.exit()
+            try {
+              const htmlElement = React.createElement(HTML, {
+                body: devNoScript,
+              })
+              let html = ReactDOMServer.renderToStaticMarkup(htmlElement)
+              html = `<!DOCTYPE html>\n${html}`
+              return reply(html)
+            } catch (e) {
+              console.log(e.stack)
+              throw e
+            }
+          },
+        })
+
+        server.route({
+          method: 'GET',
+          path: '/{path*}',
+          handler: {
+            directory: {
+              path: `${program.directory}/pages`,
+              listing: false,
+              index: false,
+            },
+          },
+        })
+
+        server.ext('onRequest', (request, reply) => {
+          const negotiator = new Negotiator(request.raw.req)
+
+          // Try to map the url path to match an actual path of a file on disk.
+          const parsed = parsePath(request.path)
+          const page = _.find(pages, p => p.path === `${parsed.dirname}/`)
+
+          let absolutePath = `${program.directory}/pages`
+          let path
+          if (page) {
+            path = `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
+            absolutePath += `/${parsePath(page.requirePath).dirname}/${parsed.basename}`
           } else {
-            if (program.open) {
-              opn(server.info.uri)
+            path = request.path
+            absolutePath += request.path
+          }
+          let isFile = false
+          try {
+            isFile = fs.lstatSync(absolutePath).isFile()
+          } catch (e) {
+            // Ignore.
+          }
+
+          // If the path matches a file, return that.
+          if (isFile) {
+            request.setUrl(path)
+            reply.continue()
+            // Let people load the bundle.js directly.
+          } else if (request.path === '/bundle.js') {
+            reply.continue()
+          } else if (negotiator.mediaType() === 'text/html') {
+            // If the path does not end with a slash, add it.
+            if (request.path[request.path.length - 1] !== '/') {
+              request.path += '/' // eslint-disable-line no-param-reassign
             }
-            console.log(chalk.green('Server started successfully!'))
-            console.log()
-            console.log('Listening at:')
-            console.log()
-            console.log('  ', chalk.cyan(server.info.uri))
+            request.setUrl(`/html${request.path}`)
+            reply.continue()
+          } else {
+            reply.continue()
           }
         })
-      })
-    })
+
+        const assets = {
+          noInfo: true,
+          reload: true,
+          publicPath: compilerConfig._config.output.publicPath,
+        }
+        const hot = {
+          hot: true,
+          quiet: true,
+          noInfo: true,
+          host: program.host,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+          },
+          stats: {
+            colors: true,
+          },
+        }
+
+        return server.register(
+          {
+            register: WebpackPlugin,
+            options: {
+              compiler,
+              assets,
+              hot,
+            },
+          },
+          er => {
+            if (er) {
+              console.log(er)
+              process.exit()
+            }
+
+            server.start(e => {
+              if (e) {
+                if (e.code === 'EADDRINUSE') {
+                  // eslint-disable-next-line max-len
+                  console.log(
+                    chalk.red(
+                      `Unable to start Gatsby on port ${program.port} as there's already a process listening on that port.`
+                    )
+                  )
+                } else {
+                  console.log(chalk.red(e))
+                }
+
+                process.exit()
+              } else {
+                if (program.open) {
+                  opn(server.info.uri)
+                }
+                console.log(chalk.green('Server started successfully!'))
+                console.log()
+                console.log('Listening at:')
+                console.log()
+                console.log('  ', chalk.cyan(server.info.uri))
+              }
+            })
+          }
+        )
+      }
+    )
   })
 }
 

--- a/lib/utils/getProcessForPort.js
+++ b/lib/utils/getProcessForPort.js
@@ -11,15 +11,15 @@ const execOptions = {
   ],
 }
 
-function isProcessAReactApp (processCommand) {
+function isProcessAReactApp(processCommand) {
   return /^node .*react-scripts\/scripts\/start\.js\s?$/.test(processCommand)
 }
 
-function getProcessIdOnPort (port) {
+function getProcessIdOnPort(port) {
   return execSync(`lsof -i:${port} -P -t -sTCP:LISTEN`, execOptions).trim()
 }
 
-function getPackageNameInDirectory (directory) {
+function getPackageNameInDirectory(directory) {
   const packagePath = path.join(directory.trim(), 'package.json')
 
   try {
@@ -29,22 +29,28 @@ function getPackageNameInDirectory (directory) {
   }
 }
 
-function getProcessCommand (processId, processDirectory) {
-  const command = execSync(`ps -o command -p ${processId} | sed -n 2p`, execOptions)
+function getProcessCommand(processId, processDirectory) {
+  const command = execSync(
+    `ps -o command -p ${processId} | sed -n 2p`,
+    execOptions
+  )
 
   if (isProcessAReactApp(command)) {
     const packageName = getPackageNameInDirectory(processDirectory)
-    return (packageName) ? `${packageName}\n` : command
+    return packageName ? `${packageName}\n` : command
   } else {
     return command
   }
 }
 
-function getDirectoryOfProcessById (processId) {
-  return execSync(`lsof -p ${processId} | grep cwd | awk '{print $9}'`, execOptions).trim()
+function getDirectoryOfProcessById(processId) {
+  return execSync(
+    `lsof -p ${processId} | grep cwd | awk '{print $9}'`,
+    execOptions
+  ).trim()
 }
 
-function getProcessForPort (port) {
+function getProcessForPort(port) {
   try {
     const processId = getProcessIdOnPort(port)
     const directory = getDirectoryOfProcessById(processId)

--- a/lib/utils/glob-pages.js
+++ b/lib/utils/glob-pages.js
@@ -5,20 +5,22 @@ import pageFileTypes from './page-file-types'
 
 const debug = require('debug')('gatsby:glob')
 
-function globQuery (directory) {
+function globQuery(directory) {
   const fileGlobQuery = pageFileTypes.map(type => `*.${type}`)
   const joinedFileQuery = fileGlobQuery.join('|')
   return `${directory}/pages/**/?(${joinedFileQuery})`
 }
 
 let globCache
-function createCache (directory, callback) {
+function createCache(directory, callback) {
   const pagesData = []
 
   glob(globQuery(directory), { follow: true }, (err, pages) => {
-    if (err) { return callback(err) }
+    if (err) {
+      return callback(err)
+    }
 
-    pages.forEach((page) => {
+    pages.forEach(page => {
       pagesData.push(buildPage(directory, page))
     })
 
@@ -28,7 +30,7 @@ function createCache (directory, callback) {
   })
 }
 
-module.exports = function globPages (directory, callback) {
+module.exports = function globPages(directory, callback) {
   if (typeof globCache === 'undefined') {
     createCache(directory, callback)
   } else {

--- a/lib/utils/init-starter.js
+++ b/lib/utils/init-starter.js
@@ -55,7 +55,7 @@ const ignored = path => !/^\.(git|hg)$/.test(sysPath.basename(path))
 // Returns nothing.
 const copy = (starterPath, rootPath, callback) => {
   const copyDirectory = () => {
-    fs.copy(starterPath, rootPath, { filter: ignored }, (error) => {
+    fs.copy(starterPath, rootPath, { filter: ignored }, error => {
       if (error !== null) return callback(new Error(error))
       logger.log('Created starter directory layout')
       install(rootPath, callback)
@@ -65,9 +65,9 @@ const copy = (starterPath, rootPath, callback) => {
 
   // Chmod with 755.
   // 493 = parseInt('755', 8)
-  fs.mkdirp(rootPath, { mode: 493 }, (error) => {
+  fs.mkdirp(rootPath, { mode: 493 }, error => {
     if (error !== null) callback(new Error(error))
-    return fsexists(starterPath, (exists) => {
+    return fsexists(starterPath, exists => {
       if (!exists) {
         const chmodError = `starter ${starterPath} doesn't exist`
         return callback(new Error(chmodError))
@@ -89,8 +89,9 @@ const copy = (starterPath, rootPath, callback) => {
 // Returns nothing.
 const clone = (address, rootPath, callback) => {
   const gitHubRe = /(gh|github):(?:\/\/)?/
-  const url = gitHubRe.test(address) ?
-    `git://github.com/${address.replace(gitHubRe, '')}.git` : address
+  const url = gitHubRe.test(address)
+    ? `git://github.com/${address.replace(gitHubRe, '')}.git`
+    : address
   logger.log(`Cloning git repo ${url} to ${rootPath}...`)
   const cmd = `git clone --depth=1 ${url} ${rootPath}`
   exec(cmd, (error, stdout, stderr) => {
@@ -98,7 +99,7 @@ const clone = (address, rootPath, callback) => {
       return callback(new Error(`Git clone error: ${stderr.toString()}`))
     }
     logger.log('Created starter directory layout')
-    return fs.remove(sysPath.join(rootPath, '.git'), (removeError) => {
+    return fs.remove(sysPath.join(rootPath, '.git'), removeError => {
       if (error !== null) return callback(new Error(removeError))
       install(rootPath, callback)
       return true
@@ -119,9 +120,11 @@ const initStarter = (starter, options = {}, callback) => {
   if (options.logger) logger = options.logger
 
   const uriRe = /(?:https?|git(hub)?|gh)(?::\/\/|@)?/
-  fsexists(sysPath.join(rootPath, 'package.json'), (exists) => {
+  fsexists(sysPath.join(rootPath, 'package.json'), exists => {
     if (exists) {
-      return callback(new Error(`Directory ${rootPath} is already an npm project`))
+      return callback(
+        new Error(`Directory ${rootPath} is already an npm project`)
+      )
     }
     const isGitUri = starter && uriRe.test(starter)
     const get = isGitUri ? clone : copy

--- a/lib/utils/load-context.js
+++ b/lib/utils/load-context.js
@@ -1,11 +1,19 @@
 /* @flow weak */
 // This file is auto-written and used by Gatsby to require
 // files from your pages directory.
-module.exports = function (callback) {
-  let context = require.context('./pages', true, /(coffee|cjsx|ts|tsx|jsx|js|md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
+module.exports = function(callback) {
+  let context = require.context(
+    './pages',
+    true,
+    /(coffee|cjsx|ts|tsx|jsx|js|md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee|ipynb|html|json|yaml|toml)$/
+  ) // eslint-disable-line
   if (module.hot) {
     module.hot.accept(context.id, () => {
-      context = require.context('./pages', true, /(coffee|cjsx|ts|tsx|jsx|js|md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee|ipynb|html|json|yaml|toml)$/) // eslint-disable-line
+      context = require.context(
+        './pages',
+        true,
+        /(coffee|cjsx|ts|tsx|jsx|js|md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee|ipynb|html|json|yaml|toml)$/
+      ) // eslint-disable-line
       return callback(context)
     })
   }

--- a/lib/utils/new.js
+++ b/lib/utils/new.js
@@ -3,16 +3,17 @@ const logger = require('tracer').colorConsole()
 
 const initStarter = require('./init-starter')
 
-module.exports = (rootPath, starter='gh:gatsbyjs/gatsby-starter-default') => {
+module.exports = (rootPath, starter = 'gh:gatsbyjs/gatsby-starter-default') => {
   initStarter(
     starter,
     {
       rootPath,
       logger,
-    }, (error) => {
+    },
+    error => {
       if (error) {
         logger.error(error)
       }
-    },
+    }
   )
 }

--- a/lib/utils/post-build.js
+++ b/lib/utils/post-build.js
@@ -9,14 +9,13 @@ import globPages from './glob-pages'
 
 const debug = require('debug')('gatsby:post-build')
 
-
 module.exports = (program, cb) => {
   const directory = program.directory
 
   return globPages(directory, (err, pages) => {
     debug('copying files')
     // Async callback to copy each file.
-    const copy = function copyFile (file, callback) {
+    const copy = function copyFile(file, callback) {
       // Map file to path generated for that directory.
       // e.g. if file is in directory 2015-06-16-my-sweet-blog-post that got
       // rewritten to my-sweet-blog-post, we find that path rewrite so
@@ -33,7 +32,7 @@ module.exports = (program, cb) => {
       }
 
       if (!(oldDirectory === '/')) {
-        const page = _.find(pages, (p) => {
+        const page = _.find(pages, p => {
           // Ignore files that start with underscore (they're not pages).
           if (p.file.name.slice(0, 1) !== '_') {
             return parsePath(p.requirePath).dirname === oldDirectory
@@ -57,13 +56,17 @@ module.exports = (program, cb) => {
     }
 
     // Copy static assets to public folder.
-    const assetTypes = '*.jpg|*.jpeg|*.png|*.pdf|*.gif|*.ico|*.svg|*.pdf|*.txt|CNAME'
+    const assetTypes =
+      '*.jpg|*.jpeg|*.png|*.pdf|*.gif|*.ico|*.svg|*.pdf|*.txt|CNAME'
     const globString = `${directory}/pages/**/?(${assetTypes})`
     return glob(globString, { follow: true }, (e, files) =>
-      async.map(files, copy, (error, results) =>
+      async.map(
+        files,
+        copy,
+        (error, results) =>
+          // eslint-disable-next-line comma-dangle
+          cb(error, results)
         // eslint-disable-next-line comma-dangle
-        cb(error, results)
-      // eslint-disable-next-line comma-dangle
       )
     )
   })

--- a/lib/utils/serve-build.js
+++ b/lib/utils/serve-build.js
@@ -6,7 +6,7 @@ import startWithDynamicPort from './startWithDynamicPort'
 
 const debug = require('debug')('gatsby:application')
 
-function startServer (program, launchPort) {
+function startServer(program, launchPort) {
   const directory = program.directory
   const serverPort = launchPort || program.port
 
@@ -30,12 +30,15 @@ function startServer (program, launchPort) {
     },
   })
 
-
-  server.start((e) => {
+  server.start(e => {
     if (e) {
       if (e.code === 'EADDRINUSE') {
         // eslint-disable-next-line max-len
-        console.log(chalk.red(`Unable to start Gatsby on port ${serverPort} as there's already a process listening on that port.`))
+        console.log(
+          chalk.red(
+            `Unable to start Gatsby on port ${serverPort} as there's already a process listening on that port.`
+          )
+        )
       } else {
         console.log(chalk.red(e))
       }

--- a/lib/utils/startWithDynamicPort.js
+++ b/lib/utils/startWithDynamicPort.js
@@ -8,7 +8,7 @@ const rlInterface = rl.createInterface({
   output: process.stdout,
 })
 
-module.exports = startServer => (program) => {
+module.exports = startServer => program => {
   const port = typeof program.port === 'string'
     ? parseInt(program.port, 10)
     : program.port
@@ -23,9 +23,11 @@ module.exports = startServer => (program) => {
 
     if (port !== _port) {
       // eslint-disable-next-line max-len
-      const question = chalk.yellow(`Something is already running on port ${port}.\n${(existingProcess) ? ` Probably:\n  ${existingProcess}\n` : ''}\nWould you like to run the app at another port instead? [Y/n]`)
+      const question = chalk.yellow(
+        `Something is already running on port ${port}.\n${existingProcess ? ` Probably:\n  ${existingProcess}\n` : ''}\nWould you like to run the app at another port instead? [Y/n]`
+      )
 
-      return rlInterface.question(question, (answer) => {
+      return rlInterface.question(question, answer => {
         if (answer.length === 0 || answer.match(/^yes|y$/i)) {
           program.port = _port // eslint-disable-line no-param-reassign
         }

--- a/lib/utils/static-entry.js
+++ b/lib/utils/static-entry.js
@@ -11,7 +11,7 @@ import { prefixLink } from '../isomorphic/gatsby-helpers'
 const loadContext = require('.gatsby-context')
 
 let routes
-loadContext((pagesReq) => {
+loadContext(pagesReq => {
   routes = createRoutes(pages, pagesReq)
 })
 
@@ -44,6 +44,6 @@ module.exports = (locals, callback) => {
           <Html body={body} {...renderProps} />)}`
         callback(null, html)
       }
-    },
+    }
   )
 }

--- a/lib/utils/web-entry.js
+++ b/lib/utils/web-entry.js
@@ -4,11 +4,18 @@ import ReactDOM from 'react-dom'
 import { applyRouterMiddleware, browserHistory, Router } from 'react-router'
 import useScroll from 'react-router-scroll/lib/useScroll'
 import createRoutes from 'create-routes'
-import { onRouteChange, onRouteUpdate, modifyRoutes, shouldUpdateScroll, replaceDOMRenderer, wrapRootComponent } from 'gatsby-browser'
+import {
+  onRouteChange,
+  onRouteUpdate,
+  modifyRoutes,
+  shouldUpdateScroll,
+  replaceDOMRenderer,
+  wrapRootComponent,
+} from 'gatsby-browser'
 
 const loadContext = require('.gatsby-context')
 
-function loadConfig (cb) {
+function loadConfig(cb) {
   const stuff = require('config')
 
   if (module.hot) {
@@ -19,21 +26,23 @@ function loadConfig (cb) {
 
 let currentLocation = null
 
-browserHistory.listen((location) => {
+browserHistory.listen(location => {
   currentLocation = location
   if (onRouteChange) {
-    console.warn('onRouteChange is now deprecated and will be removed in the next major Gatsby release (0.13). Please use onRouteUpdate instead. See the PR for more info (https://github.com/gatsbyjs/gatsby/pull/321).')
+    console.warn(
+      'onRouteChange is now deprecated and will be removed in the next major Gatsby release (0.13). Please use onRouteUpdate instead. See the PR for more info (https://github.com/gatsbyjs/gatsby/pull/321).'
+    )
     onRouteChange(location)
   }
 })
 
-function onUpdate () {
+function onUpdate() {
   if (onRouteUpdate) {
     onRouteUpdate(currentLocation)
   }
 }
 
-function defaultShouldUpdateScroll (prevRouterProps, nextRouterProps) {
+function defaultShouldUpdateScroll(prevRouterProps, nextRouterProps) {
   if (shouldUpdateScroll) {
     return shouldUpdateScroll(prevRouterProps, nextRouterProps)
   }
@@ -49,7 +58,7 @@ function defaultShouldUpdateScroll (prevRouterProps, nextRouterProps) {
 
 let routes
 loadConfig(() =>
-  loadContext((pagesReq) => {
+  loadContext(pagesReq => {
     const { pages } = require('config')
 
     if (!routes) {
@@ -78,7 +87,12 @@ loadConfig(() =>
     if (replaceDOMRenderer) {
       replaceDOMRenderer({ routes, defaultShouldUpdateScroll, onUpdate })
     } else {
-      ReactDOM.render(<Root />, typeof window !== 'undefined' ? document.getElementById('react-mount') : undefined)
+      ReactDOM.render(
+        <Root />,
+        typeof window !== 'undefined'
+          ? document.getElementById('react-mount')
+          : undefined
+      )
     }
-  }),
+  })
 )

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = (
   directory,
   suppliedStage,
   webpackPort = 1500,
-  routes = [],
+  routes = []
 ) => {
   const babelStage = suppliedStage
   const stage = suppliedStage === 'develop-html' ? 'develop' : suppliedStage
@@ -43,7 +43,7 @@ module.exports = (
 
   try {
     siteConfig = toml.parse(
-      fs.readFileSync(path.join(directory, 'config.toml')),
+      fs.readFileSync(path.join(directory, 'config.toml'))
     )
   } catch (e) {
     if (e.code !== 'ENOENT') {
@@ -52,7 +52,7 @@ module.exports = (
   }
 
   debug(`Loading webpack config for stage "${stage}"`)
-  function output () {
+  function output() {
     let publicPath = '/'
 
     if (program.prefixLinks && _.isString(siteConfig.linkPrefix)) {
@@ -98,7 +98,7 @@ module.exports = (
     }
   }
 
-  function entry () {
+  function entry() {
     switch (stage) {
       case 'develop':
         return [
@@ -120,12 +120,12 @@ module.exports = (
     }
   }
 
-  function plugins (config) {
+  function plugins(config) {
     config.plugin('define', webpack.DefinePlugin, [
       {
         'process.env': {
           NODE_ENV: JSON.stringify(
-            process.env.NODE_ENV ? process.env.NODE_ENV : 'development',
+            process.env.NODE_ENV ? process.env.NODE_ENV : 'development'
           ),
         },
         __PREFIX_LINKS__: program.prefixLinks,
@@ -137,12 +137,12 @@ module.exports = (
         config.plugin(
           'optimize-order',
           webpack.optimize.OccurenceOrderPlugin,
-          null,
+          null
         )
         config.plugin(
           'hot-module-replacement',
           webpack.HotModuleReplacementPlugin,
-          null,
+          null
         )
         config.plugin('no-errors', webpack.NoErrorsPlugin, null)
 
@@ -174,7 +174,7 @@ module.exports = (
     }
   }
 
-  function resolve () {
+  function resolve() {
     return {
       extensions: [
         '',
@@ -209,7 +209,7 @@ module.exports = (
     }
   }
 
-  function devtool () {
+  function devtool() {
     switch (stage) {
       case 'develop':
         return 'eval'
@@ -222,7 +222,7 @@ module.exports = (
     }
   }
 
-  function loaders (config) {
+  function loaders(config) {
     // Common config for every env.
     config.loader('cjsx', {
       test: /\.cjsx$/,
@@ -348,7 +348,7 @@ module.exports = (
         })
 
         config.merge({
-          postcss (wp) {
+          postcss(wp) {
             return [
               require('postcss-import')({ addDependencyTo: wp }),
               require('postcss-cssnext')(),
@@ -488,7 +488,7 @@ module.exports = (
     }
   }
 
-  function module (config) {
+  function module(config) {
     plugins(config)
     loaders(config)
 
@@ -531,7 +531,7 @@ module.exports = (
               You must return an object when modifying the Webpack config.
               Returned: ${modifiedWebpackConfig}
               stage: ${stage}
-              `,
+              `
     )
     return modifiedWebpackConfig
   } else {

--- a/package.json
+++ b/package.json
@@ -103,19 +103,23 @@
     "babel-register": "^6.24.1",
     "bluebird": "^3.5.0",
     "cheerio": "^0.22.0",
-    "eslint": "^3.18.0",
+    "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
+    "eslint-config-google": "^0.7.1",
+    "eslint-config-prettier": "^1.6.0",
     "eslint-plugin-ava": "^4.2.0",
     "eslint-plugin-flow-vars": "^0.5.0",
     "eslint-plugin-flowtype": "^2.30.4",
     "eslint-plugin-import": "2.2.x",
     "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-prettier": "^2.0.1",
     "eslint-plugin-react": "^6.10.3",
     "flow-bin": "^0.42.0",
     "iflow-debug": "^1.0.15",
     "iflow-lodash": "^1.1.23",
     "iflow-react-router": "^1.1.17",
-    "nyc": "^10.1.2"
+    "nyc": "^10.1.2",
+    "prettier": "^1.1.0"
   },
   "engines": {
     "node": ">0.12.0"
@@ -139,6 +143,7 @@
   "scripts": {
     "build": "babel lib --out-dir dist/",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
+    "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"lib/**/*.js\" \"test/**/*.js\"",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore .",
     "lint:flow": "babel-node scripts/flow-check.js",
     "publish-patch": "npm run build && npm version patch && npm publish; git push; git push --tags",

--- a/test/fixtures/javascript-pages-frontmatter/pages/array-literal.js
+++ b/test/fixtures/javascript-pages-frontmatter/pages/array-literal.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React from 'react'
 
 exports.data = {

--- a/test/fixtures/javascript-pages-frontmatter/pages/object-literal.js
+++ b/test/fixtures/javascript-pages-frontmatter/pages/object-literal.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React from 'react'
 
 exports.data = {

--- a/test/fixtures/javascript-pages-frontmatter/pages/string-literal.js
+++ b/test/fixtures/javascript-pages-frontmatter/pages/string-literal.js
@@ -1,9 +1,8 @@
+/* eslint-disable react/display-name */
 import React from 'react'
 
 exports.data = {
   title: 'Foo',
 }
 
-export default () => (
-  <h1>Foo</h1>
-)
+export default () => <h1>Foo</h1>

--- a/test/fixtures/javascript-pages-frontmatter/pages/template-literal.js
+++ b/test/fixtures/javascript-pages-frontmatter/pages/template-literal.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React from 'react'
 
 exports.data = {
@@ -5,6 +6,4 @@ exports.data = {
   title: `Bar`,
 }
 
-export default () => (
-  <h1>Bar</h1>
-)
+export default () => <h1>Bar</h1>

--- a/test/fixtures/path-rewrite/gatsby-node.js
+++ b/test/fixtures/path-rewrite/gatsby-node.js
@@ -1,4 +1,4 @@
-exports.rewritePath = function rewritePath (parsedPath) {
+exports.rewritePath = function rewritePath(parsedPath) {
   if (parsedPath.name === 'move-me') {
     return '/moved/'
   } else {

--- a/test/integration/cli-returns-help.js
+++ b/test/integration/cli-returns-help.js
@@ -3,34 +3,34 @@ import packageJson from '../../package.json'
 import { gatsby } from '../support'
 
 // eslint-disable-next-line
-test('cli can be called and exits with 0', async (t) => {
+test('cli can be called and exits with 0', async t => {
   const noArgs = await gatsby()
   t.is(noArgs.code, 0)
 })
 
 // eslint-disable-next-line
-test('cli returns help when called without args', async (t) => {
+test('cli returns help when called without args', async t => {
   const noArgs = await gatsby([])
   const help = await gatsby(['--help'])
   t.is(noArgs.stdout, help.stdout)
 })
 
 // eslint-disable-next-line
-test('cli returns help when called with unknown args', async (t) => {
+test('cli returns help when called with unknown args', async t => {
   const asdf = await gatsby(['asdf'])
   const help = await gatsby(['--help'])
   t.is(asdf.stdout, help.stdout)
 })
 
 // eslint-disable-next-line
-test('cli does not return help when called with --version', async (t) => {
+test('cli does not return help when called with --version', async t => {
   const version = await gatsby(['--version'])
   const help = await gatsby(['--help'])
   t.not(version.stdout, help.stdout)
 })
 
 // eslint-disable-next-line
-test('cli returns the gatsby version when called with --version', async (t) => {
+test('cli returns the gatsby version when called with --version', async t => {
   const versionCli = await gatsby(['--version'])
   const versionPackage = packageJson.version
   t.true(versionCli.stdout.indexOf(versionPackage) > -1)

--- a/test/integration/install-starter.js
+++ b/test/integration/install-starter.js
@@ -6,9 +6,8 @@ import { gatsby } from '../support'
 const fs = Promise.promisifyAll(fse)
 const tmpdir = require('os').tmpdir()
 
-
 // eslint-disable-next-line
-test('calling gatsby new succesfully creates new site from default starter', async (t) => {
+test('calling gatsby new succesfully creates new site from default starter', async t => {
   const sitePath = `${tmpdir}/gatsby-default-starter`
   await fs.remove(sitePath)
   const noArgs = await gatsby(['new', sitePath])

--- a/test/integration/static-html-wrappers.js
+++ b/test/integration/static-html-wrappers.js
@@ -10,7 +10,7 @@ test.before('build the site ', async () => {
 })
 
 // eslint-disable-next-line
-test('html/index.html has an h1 that states file extention', async (t) => {
+test('html/index.html has an h1 that states file extention', async t => {
   const filePath = path.join(fixturePath, 'public', 'html', 'index.html')
   const $ = await dom(filePath)
 
@@ -21,7 +21,7 @@ test('html/index.html has an h1 that states file extention', async (t) => {
 })
 
 // eslint-disable-next-line
-test('md/index.html has an h1 that states file extention', async (t) => {
+test('md/index.html has an h1 that states file extention', async t => {
   const filePath = path.join(fixturePath, 'public', 'md', 'index.html')
   const $ = await dom(filePath)
 

--- a/test/integration/user-rewrites-path-not-ending-in-slash.js
+++ b/test/integration/user-rewrites-path-not-ending-in-slash.js
@@ -14,16 +14,26 @@ test.before('build the site', async () => {
 })
 
 // eslint-disable-next-line
-test('the index page has been moved to the hardcoded path', async (t) => {
-  const indexPath = path.resolve(fixturePath, 'public', 'hello-world', 'index.html')
+test('the index page has been moved to the hardcoded path', async t => {
+  const indexPath = path.resolve(
+    fixturePath,
+    'public',
+    'hello-world',
+    'index.html'
+  )
   const file = await fs.statAsync(indexPath)
 
   t.truthy(file)
 })
 
 // eslint-disable-next-line
-test("the image has been moved to match the moved page's path", async (t) => {
-  const imagePath = path.resolve(fixturePath, 'public', 'hello-world', 'image.jpg')
+test("the image has been moved to match the moved page's path", async t => {
+  const imagePath = path.resolve(
+    fixturePath,
+    'public',
+    'hello-world',
+    'image.jpg'
+  )
   const file = await fs.statAsync(imagePath)
 
   t.truthy(file)

--- a/test/integration/user-rewrites-path.js
+++ b/test/integration/user-rewrites-path.js
@@ -14,7 +14,7 @@ test.before('build the site', async () => {
 })
 
 // eslint-disable-next-line
-test('the move-me file has been moved', async (t) => {
+test('the move-me file has been moved', async t => {
   const movedPath = path.resolve(fixturePath, 'public', 'moved', 'index.html')
   const file = await fs.statAsync(movedPath)
 
@@ -22,8 +22,13 @@ test('the move-me file has been moved', async (t) => {
 })
 
 // eslint-disable-next-line
-test('the dont-move-me file has not been moved', async (t) => {
-  const dontMovePath = path.resolve(fixturePath, 'public', 'dont-move-me', 'index.html')
+test('the dont-move-me file has not been moved', async t => {
+  const dontMovePath = path.resolve(
+    fixturePath,
+    'public',
+    'dont-move-me',
+    'index.html'
+  )
   const file = await fs.statAsync(dontMovePath)
 
   t.truthy(file)

--- a/test/support.js
+++ b/test/support.js
@@ -8,16 +8,20 @@ const remove = Promise.promisify(fs.remove)
 const gatsbyCli = path.resolve('..', '..', 'lib', 'bin', 'cli.js')
 const babel = path.resolve('..', '..', 'node_modules', '.bin', 'babel-node')
 
-export function spawn (command, args = [], options = {}) {
+export function spawn(command, args = [], options = {}) {
   return new Promise((resolve, reject) => {
     let stdout = ''
     let stderr = ''
     Object.assign(options, { shell: true })
     const child = spawnNative(command, args, options)
-    child.stdout.on('data', (data) => { stdout += data })
-    child.stderr.on('data', (data) => { stderr += data })
+    child.stdout.on('data', data => {
+      stdout += data
+    })
+    child.stderr.on('data', data => {
+      stderr += data
+    })
     child.on('error', error => reject({ error, stderr, stdout }))
-    child.on('exit', (code) => {
+    child.on('exit', code => {
       if (code === 0) {
         resolve({ code, stdout, stderr })
       } else {
@@ -27,19 +31,17 @@ export function spawn (command, args = [], options = {}) {
   })
 }
 
-export function gatsby (args = [], options = {}) {
+export function gatsby(args = [], options = {}) {
   const spawnArguments = _.concat(['--', gatsbyCli], args)
   return spawn(babel, spawnArguments, options)
 }
 
-export function build (fixturePath) {
+export function build(fixturePath) {
   const buildPath = path.resolve(fixturePath, 'public')
-  return remove(buildPath)
-    .then(() => gatsby(['build'], { cwd: fixturePath }))
+  return remove(buildPath).then(() => gatsby(['build'], { cwd: fixturePath }))
 }
 
-export function dom (filePath) {
+export function dom(filePath) {
   const readFile = Promise.promisify(fs.readFile)
-  return readFile(filePath)
-    .then(html => cheerio.load(html))
+  return readFile(filePath).then(html => cheerio.load(html))
 }

--- a/test/utils/babel-config.js
+++ b/test/utils/babel-config.js
@@ -3,12 +3,12 @@ import path from 'path'
 import includes from 'lodash/includes'
 import babelConfig from '../../lib/utils/babel-config'
 
-function programStub (fixture) {
+function programStub(fixture) {
   const directory = path.resolve('..', 'fixtures', fixture)
   return { directory }
 }
 
-test('it returns a default babel config for babel-loader query', (t) => {
+test('it returns a default babel config for babel-loader query', t => {
   const program = programStub('site-without-babelrc')
   const config = babelConfig(program)
 
@@ -17,7 +17,7 @@ test('it returns a default babel config for babel-loader query', (t) => {
   t.truthy(config.plugins.length)
 })
 
-test('all plugins are absolute paths to avoid babel lookups', (t) => {
+test('all plugins are absolute paths to avoid babel lookups', t => {
   const program = programStub('site-without-babelrc')
   const config = babelConfig(program)
 
@@ -25,27 +25,27 @@ test('all plugins are absolute paths to avoid babel lookups', (t) => {
   config.plugins.forEach(plugin => t.true(path.resolve(plugin) === plugin))
 })
 
-test('fixture can resolve plugins in gatsby directory (crawling up)', (t) => {
+test('fixture can resolve plugins in gatsby directory (crawling up)', t => {
   const program = programStub('site-with-valid-babelrc')
 
   const config = babelConfig(program)
   t.truthy(config.presets.length)
 })
 
-test('throws error when babelrc is not parseable', (t) => {
+test('throws error when babelrc is not parseable', t => {
   const program = programStub('site-with-invalid-babelrc')
 
   t.throws(() => babelConfig(program))
 })
 
-test('can read babel from packagejson', (t) => {
+test('can read babel from packagejson', t => {
   const program = programStub('site-with-valid-babelpackage')
 
   const config = babelConfig(program)
   t.truthy(config.presets.length)
 })
 
-test('when in development has hmre', (t) => {
+test('when in development has hmre', t => {
   const program = programStub('site-without-babelrc')
   const config = babelConfig(program, 'develop')
 
@@ -54,13 +54,15 @@ test('when in development has hmre', (t) => {
   t.true(includes(presetNames, 'babel-preset-react-hmre'))
 })
 
-test('throws when a plugin is not available', (t) => {
+test('throws when a plugin is not available', t => {
   const program = programStub('site-with-unresolvable-babelrc')
   t.throws(() => babelConfig(program))
 })
 
-test('throws when a configured preset is not availiable', (t) => {
-  const program = programStub('site-with-unresovleable-configured-preset-babelrc')
+test('throws when a configured preset is not availiable', t => {
+  const program = programStub(
+    'site-with-unresovleable-configured-preset-babelrc'
+  )
   try {
     babelConfig(program)
   } catch (error) {

--- a/test/utils/build-page/load-frontmatter.js
+++ b/test/utils/build-page/load-frontmatter.js
@@ -1,21 +1,21 @@
 import test from 'ava'
 import loadFrontmatter from '../../../lib/utils/build-page/load-frontmatter'
 
-test('it works for string literal titles', (t) => {
+test('it works for string literal titles', t => {
   const pagePath =
     '../../fixtures/javascript-pages-frontmatter/pages/string-literal.js'
   const data = loadFrontmatter(pagePath)
   t.is(data.title, 'Foo')
 })
 
-test('it works for template literal titles', (t) => {
+test('it works for template literal titles', t => {
   const pagePath =
     '../../fixtures/javascript-pages-frontmatter/pages/template-literal.js'
   const data = loadFrontmatter(pagePath)
   t.is(data.title, 'Bar')
 })
 
-test('it works with array literal values', (t) => {
+test('it works with array literal values', t => {
   const pagePath =
     '../../fixtures/javascript-pages-frontmatter/pages/array-literal.js'
   const data = loadFrontmatter(pagePath)
@@ -23,7 +23,7 @@ test('it works with array literal values', (t) => {
   t.is(data.titles[1], 'My other title')
 })
 
-test('it works with object literal values', (t) => {
+test('it works with object literal values', t => {
   const pagePath =
     '../../fixtures/javascript-pages-frontmatter/pages/object-literal.js'
   const data = loadFrontmatter(pagePath)

--- a/test/utils/build-page/path-resolver.js
+++ b/test/utils/build-page/path-resolver.js
@@ -3,46 +3,46 @@ import path from 'path'
 import startsWith from 'lodash/startsWith'
 import pathResolver from '../../../lib/utils/build-page/path-resolver'
 
-test('it returns an object', (t) => {
+test('it returns an object', t => {
   const pagePath = '/'
   const result = pathResolver(pagePath)
   t.truthy(result)
   t.is(typeof result, 'object')
 })
 
-test('it has a require path', (t) => {
+test('it has a require path', t => {
   const pagePath = '/a-blog-post/index.md'
   const result = pathResolver(pagePath)
   t.truthy(result.requirePath)
   t.is(typeof result.requirePath, 'string')
 })
 
-test('it does not has a path if the name start with _', (t) => {
+test('it does not has a path if the name start with _', t => {
   t.is(pathResolver('/_metadata.js').path, undefined)
   t.is(pathResolver('/_template.html.erb').path, undefined)
   t.is(pathResolver('/_notapage.json').path, undefined)
 })
 
-test('it has a path if the name doesnt start with _', (t) => {
+test('it has a path if the name doesnt start with _', t => {
   t.truthy(pathResolver('/2015/back-to-the-future.md').path)
   t.truthy(pathResolver('/my-first-blog.md').path)
   t.truthy(pathResolver('/index.md').path)
 })
 
-test('it has a templatePath if the name is _template', (t) => {
+test('it has a templatePath if the name is _template', t => {
   const pagePath = '/_template.js'
   const result = pathResolver(pagePath)
   t.truthy(result.templatePath)
   t.is(typeof result.templatePath, 'string')
 })
 
-test('it does not have a templatePath if not a _template', (t) => {
+test('it does not have a templatePath if not a _template', t => {
   t.is(pathResolver('/index.md').templatePath, undefined)
   t.is(pathResolver('/another-page.toml').templatePath, undefined)
   t.is(pathResolver('/something-else/good-stuff.html').templatePath, undefined)
 })
 
-test('the directory name has / slashes', (t) => {
+test('the directory name has / slashes', t => {
   const pagePath = '/2016/testing-middleman-sites-with-capybara/index.md'
   const result = pathResolver(pagePath)
 
@@ -50,7 +50,7 @@ test('the directory name has / slashes', (t) => {
   t.is(result.file.dirname, '/2016/testing-middleman-sites-with-capybara')
 })
 
-test('the ext doesnt have a leading .', (t) => {
+test('the ext doesnt have a leading .', t => {
   const result = pathResolver('/index.md')
   t.false(startsWith(result.file.ext, '.'))
 })

--- a/test/utils/build-page/url-resolver.js
+++ b/test/utils/build-page/url-resolver.js
@@ -1,77 +1,77 @@
 import test from 'ava'
 import urlResolver from '../../../lib/utils/build-page/url-resolver'
 
-test('returns undefined when filename starts with _', (t) => {
+test('returns undefined when filename starts with _', t => {
   const parsedPath = { name: '_notapage' }
   const data = {}
   const pagePath = urlResolver(data, parsedPath)
   t.true(pagePath === undefined)
 })
 
-test('uses the path from page data', (t) => {
+test('uses the path from page data', t => {
   const parsedPath = { name: 'page', dirname: 'a-directory/' }
   const data = { path: '/page-at-root/' }
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/page-at-root/')
 })
 
-test('appends a trailing slash to path from page data', (t) => {
+test('appends a trailing slash to path from page data', t => {
   const parsedPath = { name: 'page', dirname: 'a-directory/' }
   const data = { path: '/user-defined-path' }
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/user-defined-path/')
 })
 
-test('does not append trailing slash to .html paths from page data', (t) => {
+test('does not append trailing slash to .html paths from page data', t => {
   const parsedPath = { name: 'page', dirname: 'a-directory/' }
   const data = { path: '/user-defined-path.html' }
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/user-defined-path.html')
 })
 
-test('prepends a slash to all paths from page data', (t) => {
+test('prepends a slash to all paths from page data', t => {
   const parsedPath = { name: 'page', dirname: 'a-directory/' }
   const data = { path: 'user-defined-path/' }
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/user-defined-path/')
 })
 
-test('removes index from path', (t) => {
+test('removes index from path', t => {
   const parsedPath = { name: 'index', dirname: 'foo/bar' }
   const data = {}
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/foo/bar/')
 })
 
-test('removes template from path', (t) => {
+test('removes template from path', t => {
   const parsedPath = { name: 'template', dirname: 'foo/bar' }
   const data = {}
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/foo/bar/')
 })
 
-test('template at root has root path', (t) => {
+test('template at root has root path', t => {
   const parsedPath = { name: 'template', dirname: '' }
   const data = {}
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/')
 })
 
-test('index at root has root path', (t) => {
+test('index at root has root path', t => {
   const parsedPath = { name: 'index', dirname: '' }
   const data = {}
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/')
 })
 
-test('if not an index create a path like /foo/bar/', (t) => {
+test('if not an index create a path like /foo/bar/', t => {
   const parsedPath = { name: 'creating-static-websites', dirname: 'blog/2016' }
   const data = {}
   const pagePath = urlResolver(data, parsedPath)
   t.is(pagePath, '/blog/2016/creating-static-websites/')
 })
 
-test('if not an index create a path like /foo/bar/ from file at root', (t) => {
+test('if not an index create a path like /foo/bar/ from file at root', t => {
   const parsedPath = { name: 'about-us', dirname: '' }
   const data = {}
   const pagePath = urlResolver(data, parsedPath)

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+  dependencies:
+    color-convert "^1.0.0"
+
 ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
@@ -217,6 +223,10 @@ assert@^1.1.1:
 ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
+ast-types@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.8.tgz#6cb6a40beba31f49f20928e28439fc14a3dab078"
 
 async-each-series@^1.1.0:
   version "1.1.0"
@@ -403,7 +413,7 @@ babel-cli@^6.24.1:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.7.5:
+babel-code-frame@6.22.0, babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.7.5:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -1284,6 +1294,10 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babylon@7.0.0-beta.8:
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
+
 babylon@^6.1.0, babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.16.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
@@ -1660,15 +1674,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
-  dependencies:
-    ansi-styles "~1.0.0"
-    has-color "~0.1.0"
-    strip-ansi "~0.1.0"
-
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1677,6 +1683,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 cheerio@^0.22.0:
   version "0.22.0"
@@ -1844,7 +1858,7 @@ color-convert@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
 
-color-convert@^1.3.0:
+color-convert@^1.0.0, color-convert@^1.3.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
@@ -2710,6 +2724,16 @@ eslint-config-airbnb@^14.1.0:
   dependencies:
     eslint-config-airbnb-base "^11.1.0"
 
+eslint-config-google@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.7.1.tgz#5598f8498e9e078420f34b80495b8d959f651fb2"
+
+eslint-config-prettier@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-1.6.0.tgz#56e53a8eb461c06eced20cec40d765c185100fd5"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-import-resolver-node@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
@@ -2774,6 +2798,12 @@ eslint-plugin-jsx-a11y@^4.0.0:
     jsx-ast-utils "^1.0.0"
     object-assign "^4.0.1"
 
+eslint-plugin-prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.0.1.tgz#2ae1216cf053dd728360ca8560bf1aabc8af3fa9"
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-react@^6.10.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
@@ -2784,9 +2814,9 @@ eslint-plugin-react@^6.10.3:
     jsx-ast-utils "^1.3.4"
     object.assign "^4.0.4"
 
-eslint@^3.18.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.18.0.tgz#647e985c4ae71502d20ac62c109f66d5104c8a4b"
+eslint@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
@@ -2878,7 +2908,7 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-esutils@^2.0.0, esutils@^2.0.2:
+esutils@2.0.2, esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -3163,6 +3193,10 @@ flow-bin@^0.42.0:
   version "0.42.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.42.0.tgz#05dd754b6b052de7b150f9210e2160746961e3cf"
 
+flow-parser@0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"
+
 fn-name@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
@@ -3296,6 +3330,10 @@ get-proxy@^1.0.1:
   dependencies:
     rc "^1.1.2"
 
+get-stdin@5.0.1, get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -3364,17 +3402,7 @@ glob@5.0.x, glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@~7.1.1:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3382,6 +3410,16 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@~7.1.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -4281,6 +4319,22 @@ items@1.x.x, items@^1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/items/-/items-1.1.1.tgz#435b5dd21bca28b3cfd25bb5c6b278b715010fd9"
 
+jest-matcher-utils@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^19.0.0"
+
+jest-validate@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
+  dependencies:
+    chalk "^1.1.1"
+    jest-matcher-utils "^19.0.0"
+    leven "^2.0.0"
+    pretty-format "^19.0.0"
+
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
@@ -4514,6 +4568,10 @@ less@^2.7.1:
     promise "^7.1.1"
     request "^2.72.0"
     source-map "^0.5.3"
+
+leven@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -5018,7 +5076,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -6232,6 +6290,27 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.1.0.tgz#9d6ad005703efefa66b6999b8916bfc6afeaf9f8"
+  dependencies:
+    ast-types "0.9.8"
+    babel-code-frame "6.22.0"
+    babylon "7.0.0-beta.8"
+    chalk "1.1.3"
+    esutils "2.0.2"
+    flow-parser "0.43.0"
+    get-stdin "5.0.1"
+    glob "7.1.1"
+    jest-validate "19.0.0"
+    minimist "1.2.0"
+
+pretty-format@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
+  dependencies:
+    ansi-styles "^3.0.0"
+
 pretty-ms@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-0.2.2.tgz#da879a682ff33a37011046f13d627f67c73b84f6"
@@ -6732,6 +6811,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 resolve-cwd@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I've add a "format" npm script as well as a Git pre-commit script
so prettier will get run for contributors.

I've also modified the eslint config to be more Prettier friendly. E.g.
remove all formatting rules and just focus on potential JS errors, etc.