### PR TITLE
Move old default starter to 'kitchen-sink' and replace with minimal starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ starter](https://github.com/gatsbyjs/gatsby-starter-default).
 There are several starters that have been created. Create a PR to
 include yours!
 
-* [Kitchen sink default starter](https://github.com/gatsbyjs/gatsby-starter-default) ([Demo](http://gatsbyjs.github.io/gatsby-starter-default/))
+* [Default minimal starter](https://github.com/gatsbyjs/gatsby-starter-default) ([Demo](http://gatsbyjs.github.io/gatsby-starter-default/))
+* [Kitchen sink starter](https://github.com/gatsbyjs/gatsby-starter-kitchen-sink) ([Demo](http://gatsbyjs.github.io/gatsby-starter-kitchen-sink/))
 * [Simple blog](https://github.com/gatsbyjs/gatsby-starter-blog) ([Demo](http://gatsbyjs.github.io/gatsby-starter-blog/))
 * [Simple documentation site](https://github.com/gatsbyjs/gatsby-starter-documentation) ([Demo](http://gatsbyjs.github.io/gatsby-starter-documentation/))
 * [Lumen](https://github.com/wpioneer/gatsby-starter-lumen) ([Demo](http://wpioneer.github.io/gatsby-starter-lumen/))


### PR DESCRIPTION
I've been hearing pretty consistent feedback from people trying Gatsby
that the old default starter is confusing as it was built to show off
many of the capabilities of Gatsby which is far more than someone new to
Gatsby wants to see. So I moved the old default starter to
gatsby-starter-kitchen-sink and replaced it with one much more minimal
that'll be much easier to use for people new to Gatsby and just trying
to understand things and to established users of Gatsby who want
something minimal as a base to build out a new site.

https://gatsbyjs.github.io/gatsby-starter-default/

<img width="656" alt="screen shot 2017-04-14 at 4 27 48 pm" src="https://cloud.githubusercontent.com/assets/71047/25058537/5abfa1d8-212f-11e7-859c-9e96bfc16edb.png">
