### PR TITLE
Fix parenting logic for templates

### DIFF
--- a/lib/isomorphic/create-routes.js
+++ b/lib/isomorphic/create-routes.js
@@ -65,7 +65,7 @@ module.exports = (files, pagesReq) => {
       templatesWithoutRoot,
       template =>
         // eslint-disable-next-line comma-dangle
-        templateFile.requirePath.indexOf(template.file.dirname) === 0
+        templateFile.requirePath.indexOf(template.file.dirname) === 0 && templateFile !== template
     )
     // Sort parent templates by directory length. In cases
     // where a template has multiple parents


### PR DESCRIPTION
Currently every template tries to set itself as a parent.  When looking
for itself in the templateHash it will fail so all templates will fall
back to setting the root as their parent.  In the parentTemplates
filter logic, dropping the current template allows for parenting to
work correctly.