### PR TITLE
Refactor propTypes and React.createClass

### DIFF
--- a/lib/isomorphic/html.js
+++ b/lib/isomorphic/html.js
@@ -1,6 +1,6 @@
 /* @flow weak */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 import { prefixLink } from 'gatsby-helpers'
 
 const defaultMessage = `
@@ -12,29 +12,29 @@ https://github.com/gatsbyjs/gatsby/blob/master/lib/isomorphic/html.js
 `
 console.info(defaultMessage)
 
-function HTML(props) {
-  return (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0 maximum-scale=5.0"
-        />
-      </head>
-      <body>
-        <div
-          id="react-mount"
-          dangerouslySetInnerHTML={{ __html: props.body }}
-        />
-        <script src={prefixLink('/bundle.js')} />
-      </body>
-    </html>
-  )
+const Html = (props = (
+  <html lang="en">
+    <head>
+      <meta charSet="utf-8" />
+      <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0 maximum-scale=5.0"
+      />
+    </head>
+    <body>
+      <div id="react-mount" dangerouslySetInnerHTML={{ __html: props.body }} />
+      <script src={prefixLink('/bundle.js')} />
+    </body>
+  </html>
+))
+
+Html.propTypes = {
+  body: PropTypes.node,
 }
 
-HTML.propTypes = { body: PropTypes.node }
-HTML.defaultProps = { body: '' }
+Html.defaultProps = {
+  body: '',
+}
 
-module.exports = HTML
+export default Html

--- a/lib/isomorphic/html.js
+++ b/lib/isomorphic/html.js
@@ -12,7 +12,7 @@ https://github.com/gatsbyjs/gatsby/blob/master/lib/isomorphic/html.js
 `
 console.info(defaultMessage)
 
-const Html = (props = (
+const Html = props => (
   <html lang="en">
     <head>
       <meta charSet="utf-8" />
@@ -27,7 +27,7 @@ const Html = (props = (
       <script src={prefixLink('/bundle.js')} />
     </body>
   </html>
-))
+)
 
 Html.propTypes = {
   body: PropTypes.node,

--- a/lib/isomorphic/html.js
+++ b/lib/isomorphic/html.js
@@ -1,6 +1,6 @@
 /* @flow weak */
-
-import React, { PropTypes } from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 import { prefixLink } from 'gatsby-helpers'
 
 const defaultMessage = `

--- a/lib/isomorphic/pages/_template.js
+++ b/lib/isomorphic/pages/_template.js
@@ -1,6 +1,6 @@
 /* @flow weak */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const defaultMessage = `
 Gatsby is currently using the default _template. You can override it by

--- a/lib/isomorphic/pages/_template.js
+++ b/lib/isomorphic/pages/_template.js
@@ -1,5 +1,6 @@
 /* @flow weak */
-import React, { PropTypes } from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const defaultMessage = `
 Gatsby is currently using the default _template. You can override it by

--- a/lib/isomorphic/wrappers/html.js
+++ b/lib/isomorphic/wrappers/html.js
@@ -1,34 +1,31 @@
 /* @flow weak */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 
-module.exports = React.createClass({
-  displayName: 'Html',
-  propTypes: {
-    route: PropTypes.shape({
-      page: PropTypes.shape({
-        data: PropTypes.object,
-      }),
+const Html = props => {
+  const post = props.route.page.data
+  return (
+    <div>
+      <h1>{post.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.html }} />
+    </div>
+  )
+}
+
+Html.propTypes = {
+  route: PropTypes.shape({
+    page: PropTypes.shape({
+      data: PropTypes.object,
     }),
-  },
+  }),
+}
 
-  getDefaultProps() {
-    return {
-      route: {
-        page: {
-          data: {},
-        },
-      },
-    }
+Html.defaultProps = {
+  route: {
+    page: {
+      data: {},
+    },
   },
+}
 
-  render() {
-    const post = this.props.route.page.data
-    return (
-      <div>
-        <h1>{post.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: post.html }} />
-      </div>
-    )
-  },
-})
+export default Html

--- a/lib/isomorphic/wrappers/html.js
+++ b/lib/isomorphic/wrappers/html.js
@@ -1,5 +1,6 @@
 /* @flow weak */
-import React, { PropTypes } from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 module.exports = React.createClass({
   displayName: 'Html',

--- a/lib/isomorphic/wrappers/md.js
+++ b/lib/isomorphic/wrappers/md.js
@@ -1,34 +1,31 @@
 /* @flow weak */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 
-module.exports = React.createClass({
-  displayName: 'Html',
-  propTypes: {
-    route: PropTypes.shape({
-      page: PropTypes.shape({
-        data: PropTypes.object,
-      }),
+const Html = props => {
+  const post = props.route.page.data
+  return (
+    <div className="markdown">
+      <h1>{post.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.body }} />
+    </div>
+  )
+}
+
+Html.propTypes = {
+  route: PropTypes.shape({
+    page: PropTypes.shape({
+      data: PropTypes.object,
     }),
-  },
+  }),
+}
 
-  getDefaultProps() {
-    return {
-      route: {
-        page: {
-          data: {},
-        },
-      },
-    }
+Html.defaultProps = {
+  route: {
+    page: {
+      data: {},
+    },
   },
+}
 
-  render() {
-    const post = this.props.route.page.data
-    return (
-      <div className="markdown">
-        <h1>{post.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: post.body }} />
-      </div>
-    )
-  },
-})
+export default Html

--- a/lib/isomorphic/wrappers/md.js
+++ b/lib/isomorphic/wrappers/md.js
@@ -1,5 +1,6 @@
 /* @flow weak */
-import React, { PropTypes } from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 module.exports = React.createClass({
   displayName: 'Html',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "postcss-import": "^8.1.2",
     "postcss-loader": "^0.13.0",
     "postcss-reporter": "^1.4.1",
+    "prop-types": "^15.5.8",
     "raw-loader": "^0.5.1",
     "react": "^15.5.3",
     "react-document-title": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6367,6 +6367,12 @@ prop-types@^15.5.2, prop-types@~15.5.0:
   dependencies:
     fbjs "^0.8.9"
 
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 proper-lockfile@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-1.2.0.tgz#ceff5dd89d3e5f10fb75e1e8e76bc75801a59c34"


### PR DESCRIPTION
Refactoring due to deprecation on propTypes and React.createClass in React 0.15.5 to make the codebase future-ready.