### PR TITLE
[1.0] Fix duplicate node

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -17,7 +17,7 @@ function readFile(file, pluginOptions, cb) {
       // Stringify date objects.
       const newFile = JSON.parse(
         JSON.stringify({
-          id: `${slashedFile.absolutePath} >>> ${contentDigest}`,
+          id: `${slashedFile.absolutePath}`,
           contentDigest: contentDigest,
           children: [],
           parent: `___SOURCE___`,

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -44,7 +44,10 @@ function readFile(file, pluginOptions, cb) {
   })
 }
 
-exports.sourceNodes = ({ boundActionCreators, getNode }, pluginOptions) => {
+exports.sourceNodes = (
+  { boundActionCreators, getNode, hasNodeChanged },
+  pluginOptions
+) => {
   const { createNode, updateSourcePluginStatus } = boundActionCreators
   updateSourcePluginStatus({
     plugin: `source-filesystem --- ${pluginOptions.name}`,
@@ -66,7 +69,7 @@ exports.sourceNodes = ({ boundActionCreators, getNode }, pluginOptions) => {
     // console.log("Added file at", path)
     readFile(path, pluginOptions, (err, file) => {
       // Only create node if the content digest has changed.
-      if (!getNode(file.id)) {
+      if (!getNode(file.id) || hasNodeChanged(file.id, file.contentDigest)) {
         createNode(file)
       } else {
         // console.log("not creating node cause it already exists", file.id)
@@ -77,7 +80,7 @@ exports.sourceNodes = ({ boundActionCreators, getNode }, pluginOptions) => {
     console.log("changed file at", path)
     readFile(path, pluginOptions, (err, file) => {
       // Only create node if the content digest has changed.
-      if (!getNode(file.id)) {
+      if (!getNode(file.id) || hasNodeChanged(file.id, file.contentDigest)) {
         createNode(file)
       }
     })

--- a/packages/gatsby/lib/redux/actions.js
+++ b/packages/gatsby/lib/redux/actions.js
@@ -3,7 +3,7 @@ import chalk from "chalk"
 const _ = require("lodash")
 const { bindActionCreators } = require("redux")
 
-const { getNode } = require("./index")
+const { getNode, hasNodeChanged } = require("./index")
 
 const { store } = require("./index")
 import * as joiSchemas from "../joi-schemas/joi"
@@ -66,7 +66,7 @@ actions.createNode = node => {
   }
 
   // Check if the node has already been processed.
-  if (getNode(node.id)) {
+  if (getNode(node.id) && !hasNodeChanged(node.id, node.contentDigest)) {
     console.log("NODE_ALREADY_CREATED", node.pluginName, node.id)
     console.log(node)
     console.trace()

--- a/packages/gatsby/lib/redux/index.js
+++ b/packages/gatsby/lib/redux/index.js
@@ -2,7 +2,6 @@ const Redux = require("redux")
 const Promise = require("bluebird")
 const _ = require("lodash")
 const { composeWithDevTools } = require("remote-redux-devtools")
-const apiRunnerNode = require("../utils/api-runner-node")
 const fs = require("fs")
 
 // Reducers
@@ -49,6 +48,10 @@ const getNode = id => {
   return store.getState().nodes[id]
 }
 exports.getNode = getNode
+exports.hasNodeChanged = (id, digest) => {
+  const node = store.getState().nodes[id]
+  return node.contentDigest !== digest
+}
 
 exports.loadNodeContent = node => {
   if (node.content) {

--- a/packages/gatsby/lib/redux/reducers/nodes.js
+++ b/packages/gatsby/lib/redux/reducers/nodes.js
@@ -3,7 +3,10 @@ const _ = require("lodash")
 
 const saveState = _.debounce(state => {
   console.log("===============saving node state")
-  fs.writeFile(`${process.cwd()}/.cache/node-data.json`, JSON.stringify(state))
+  fs.writeFile(
+    `${process.cwd()}/.cache/node-data.json`,
+    JSON.stringify(state, null, 2)
+  )
 }, 1000)
 
 module.exports = (state = {}, action) => {

--- a/packages/gatsby/lib/utils/api-runner-node.js
+++ b/packages/gatsby/lib/utils/api-runner-node.js
@@ -40,6 +40,7 @@ const runAPI = (plugin, api, args) => {
     loadNodeContent,
     getNodes,
     getNode,
+    hasNodeChanged,
     getNodeAndSavePathDependency,
   } = require("../redux")
   const { boundActionCreators } = require("../redux/actions")
@@ -66,6 +67,7 @@ const runAPI = (plugin, api, args) => {
         store,
         getNodes,
         getNode,
+        hasNodeChanged,
         getNodeAndSavePathDependency,
         cache,
       },


### PR DESCRIPTION
Issue: #821

Small fix to avoid node duplication -> don't use `contentDigest` for `node.id`

(Maybe a good reason to use `contentDigest` but I don't understand why)