### PR TITLE
[1.0] Don't filter boolean values

### DIFF
--- a/packages/gatsby/lib/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
+++ b/packages/gatsby/lib/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
@@ -17,6 +17,9 @@ Object {
   "frontmatter___date": Object {
     "field": "frontmatter.date",
   },
+  "frontmatter___draft": Object {
+    "field": "frontmatter.draft",
+  },
   "frontmatter___title": Object {
     "field": "frontmatter.title",
   },
@@ -42,6 +45,7 @@ Object {
     "blue": 10010,
     "circle": "happy",
     "date": "2006-07-22T22:39:53.000Z",
+    "draft": false,
     "title": "The world of slash and adventure",
   },
   "hair": 2,

--- a/packages/gatsby/lib/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/lib/schema/__tests__/data-tree-utils-test.js
@@ -27,6 +27,7 @@ describe(`Gatsby data tree utils`, () => {
         title: `The world of slash and adventure`,
         blue: 10010,
         circle: `happy`,
+        draft: false,
       },
     },
   ]

--- a/packages/gatsby/lib/schema/data-tree-utils.js
+++ b/packages/gatsby/lib/schema/data-tree-utils.js
@@ -7,27 +7,14 @@ const extractFieldExamples = (exports.extractFieldExamples = ({
   selector,
   deleteNodeFields = false,
 }) => {
-  let examples = {}
-  _.each(nodes, node => {
-    let subNode
-    if (selector) {
-      subNode = _.get(node, selector)
-    } else {
-      subNode = node
-    }
+  let examples = nodes.reduce((mem, node) => {
+    let subNode = selector ? _.get(node, selector) : node
+
     // Ignore undefined/null subnodes
-    if (subNode) {
-      const flattened = flatten(subNode, { maxDepth: 3, flatten: true })
-      // Remove non-truthy values
-      const truthyExamples = {}
-      _.each(flattened, (v, k) => {
-        if (v) {
-          truthyExamples[k] = v
-        }
-      })
-      examples = _.assign(examples, truthyExamples)
-    }
-  })
+    subNode = _.omitBy(flatten(subNode || {}), _.isNil)
+
+    return Object.assign({}, mem, subNode)
+  }, {})
 
   examples = flatten.unflatten(examples, { safe: true })
 


### PR DESCRIPTION
## Use case

I want to have all posts tags without draft (as bricolage.io)

My graphql query:

```graphql
{
  allMarkdownRemark(
      limit: 2000,
      frontmatter: {
        draft: {
          ne: true
        }
      }
    ) {
      groupBy(field: frontmatter___tags) {
        fieldValue
        totalCount
      }
    }
}
```
BUT! No one of my posts have `draft: true`, so I can't query on `draft` (no present in my schema)… BTW, I tried to add a `draft: false` to force have `draft` into my schema! So, I find a new issue (all non-truthy values are removed)