### PR TITLE
Queue processing add events that arrive before chokidar fires ready

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -62,10 +62,14 @@ exports.sourceNodes = (
     touchNode,
     updateSourcePluginStatus,
   } = boundActionCreators
+
+  let ready = false
+
   updateSourcePluginStatus({
     plugin: `source-filesystem --- ${pluginOptions.name}`,
-    ready: false,
+    ready,
   })
+
   const watcher = chokidar.watch(pluginOptions.path, {
     ignored: [
       `**/*.un~`,
@@ -78,26 +82,62 @@ exports.sourceNodes = (
     ],
   })
 
-  watcher.on(`add`, path => {
-    // console.log("Added file at", path)
-    readFile(path, pluginOptions, (err, file) => {
-      createNode(file)
+  // For every path that is reported before the 'ready' event, we throw them
+  // into a queue and then flush the queue when 'ready' event arrives.
+  // After 'ready', we handle the 'add' event without putting it into a queue.
+  let pathQueue = []
+  const flushPathQueue = onComplete => {
+    let queue = pathQueue
+    pathQueue = []
+
+    let numPathsProcessed = 0
+    let numPaths = queue.length
+
+    queue.forEach(path => {
+      readFile(path, pluginOptions, (err, file) => {
+        createNode(file)
+
+        numPathsProcessed++
+        if (numPathsProcessed === numPaths) {
+          onComplete()
+        }
+      })
     })
+  }
+
+  watcher.on(`add`, path => {
+    if (ready) {
+      console.log("added file at", path)
+      readFile(path, pluginOptions, (err, file) => {
+        createNode(file)
+      })
+    } else {
+      pathQueue.push(path)
+    }
   })
   watcher.on(`change`, path => {
     console.log("changed file at", path)
     readFile(path, pluginOptions, (err, file) => {
+      // TODO: this should update rather than create
       createNode(file)
     })
   })
   watcher.on(`unlink`, path => {
     console.log("file deleted at", path)
+    // TODO: deleteNode is not a function and this throws an error
     deleteNode(createId(path))
   })
   watcher.on(`ready`, () => {
-    updateSourcePluginStatus({
-      plugin: `source-filesystem --- ${pluginOptions.name}`,
-      ready: true,
+    if (ready) {
+      return
+    }
+
+    ready = true
+    flushPathQueue(() => {
+      updateSourcePluginStatus({
+        plugin: `source-filesystem --- ${pluginOptions.name}`,
+        ready,
+      })
     })
   })
 


### PR DESCRIPTION
As discussed on Slack, if we don't do this then it randomly breaks for me.