### PR TITLE
Fix data corruption error by passing safe to flatten

### DIFF
--- a/packages/gatsby/lib/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
+++ b/packages/gatsby/lib/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
@@ -35,10 +35,9 @@ Object {
 exports[`Gatsby data tree utils builds field examples from an array of nodes 1`] = `
 Object {
   "anArray": Array [
-    1,
-    2,
-    5,
     4,
+    6,
+    2,
   ],
   "date": "2006-07-22T22:39:53.000Z",
   "frontmatter": Object {
@@ -48,7 +47,7 @@ Object {
     "draft": false,
     "title": "The world of slash and adventure",
   },
-  "hair": 2,
+  "hair": 4,
   "name": "The Mad Wax",
 }
 `;

--- a/packages/gatsby/lib/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/lib/schema/__tests__/data-tree-utils-test.js
@@ -30,6 +30,34 @@ describe(`Gatsby data tree utils`, () => {
         draft: false,
       },
     },
+    {
+      name: `The Mad Wax`,
+      hair: 3,
+      date: `2006-07-22T22:39:53.000Z`,
+      anArray: [],
+      iAmNull: null,
+      frontmatter: {
+        date: `2006-07-22T22:39:53.000Z`,
+        title: `The world of slash and adventure`,
+        blue: 10010,
+        circle: `happy`,
+        draft: false,
+      },
+    },
+    {
+      name: `The Mad Wax`,
+      hair: 4,
+      date: `2006-07-22T22:39:53.000Z`,
+      anArray: [4, 6, 2],
+      iAmNull: null,
+      frontmatter: {
+        date: `2006-07-22T22:39:53.000Z`,
+        title: `The world of slash and adventure`,
+        blue: 10010,
+        circle: `happy`,
+        draft: false,
+      },
+    },
   ]
 
   it(`builds field examples from an array of nodes`, () => {

--- a/packages/gatsby/lib/schema/data-tree-utils.js
+++ b/packages/gatsby/lib/schema/data-tree-utils.js
@@ -11,12 +11,12 @@ const extractFieldExamples = (exports.extractFieldExamples = ({
     let subNode = selector ? _.get(node, selector) : node
 
     // Ignore undefined/null subnodes
-    subNode = _.omitBy(flatten(subNode || {}), _.isNil)
+    subNode = _.omitBy(flatten(subNode || {}, { safe: true }), _.isNil)
 
     return Object.assign({}, mem, subNode)
   }, {})
 
-  examples = flatten.unflatten(examples, { safe: true })
+  examples = flatten.unflatten(examples)
 
   if (deleteNodeFields) {
     // Remove fields for traversing through nodes as we want to control


### PR DESCRIPTION
It looks like this was just put in the wrong place since safe isn't an
option for unflatten on that lib.  The test has been expanded to have
an empty array, which is what triggered the issue.