### PR TITLE
Add src to resolve modulesDirectories for easy imports

### DIFF
--- a/packages/gatsby/lib/utils/webpack.config.js
+++ b/packages/gatsby/lib/utils/webpack.config.js
@@ -272,7 +272,11 @@ module.exports = async (
       // modules. But also make it possible to install modules within the src
       // directory if you need to install a specific version of a module for a
       // part of your site.
-      modulesDirectories: [`${directory}/node_modules`, `node_modules`],
+      modulesDirectories: [
+        `${directory}/src`,
+        `${directory}/node_modules`,
+        `node_modules`,
+      ],
     }
   }
 


### PR DESCRIPTION
* Allows imports relative to the src directory, e.g.`import joy from 'components/joy'` anywhere.