### PR TITLE
Actually exit build when there's errors

### DIFF
--- a/packages/gatsby/lib/bin/cli.js
+++ b/packages/gatsby/lib/bin/cli.js
@@ -7,7 +7,7 @@ console.log(`bin/cli: time since started:`, process.uptime())
 
 // Improve Promise error handling. Maybe... what's the best
 // practice for this these days?
-global.Promise = require("bluebird")
+global.Promise = require(`bluebird`)
 Promise.onPossiblyUnhandledRejection(error => {
   throw error
 })

--- a/packages/gatsby/lib/query-runner/query-runner.js
+++ b/packages/gatsby/lib/query-runner/query-runner.js
@@ -24,6 +24,22 @@ module.exports = async (page, component) => {
     result = await graphql(component.query, { ...page, ...page.context })
   }
 
+  // If there's an error log the error. If we're building, also quit.
+  if (result && result.errors) {
+    console.log(``)
+    console.log(`The GraphQL query from ${component.componentPath} failed`)
+    console.log(``)
+    console.log(`Query:`)
+    console.log(component.query)
+    console.log(``)
+    console.log(`GraphQL Error:`)
+    console.log(result.errors)
+    // Perhaps this isn't the best way to see if we're building?
+    if (program._name === `build`) {
+      process.exit(1)
+    }
+  }
+
   // Add the path context onto the results.
   result.pathContext = page.context
   const resultJSON = JSON.stringify(result, null, 4)

--- a/packages/gatsby/lib/redux/index.js
+++ b/packages/gatsby/lib/redux/index.js
@@ -51,7 +51,7 @@ const saveState = _.debounce(state => {
     `${process.cwd()}/.cache/redux-state.json`,
     JSON.stringify(pickedState, null, 2),
     () => {
-      console.log("---saved redux state")
+      console.log(`---saved redux state`)
     }
   )
 }, 1000)

--- a/packages/gatsby/lib/utils/build.js
+++ b/packages/gatsby/lib/utils/build.js
@@ -12,14 +12,22 @@ async function html(program: any) {
   const { graphqlRunner } = await bootstrap(program)
 
   console.log(`Generating CSS`)
-  await buildCSS(program).catch(err =>
+  await buildCSS(program).catch(err => {
+    console.log(``)
     console.log(`Generating CSS failed`, err)
-  )
+    console.log(``)
+    console.log(err)
+    process.exit(1)
+  })
 
   console.log(`Compiling production bundle.js`)
-  await buildProductionBundle(program).catch(err =>
+  await buildProductionBundle(program).catch(err => {
+    console.log(``)
     console.log(`Generating JS failed`, err)
-  )
+    console.log(``)
+    console.log(err)
+    process.exit(1)
+  })
 
   console.log(`Generating Static HTML`)
   // Write out pages data to file so it's available to the static-entry.js
@@ -28,9 +36,13 @@ async function html(program: any) {
     `${program.directory}/public/tmp-pages.json`,
     JSON.stringify(store.getState().pages)
   )
-  await buildHTML(program).catch(err =>
-    console.log(`Generating HTML failed`, err)
-  )
+  await buildHTML(program).catch(err => {
+    console.log(``)
+    console.log(`Generating HTML failed`)
+    console.log(``)
+    console.log(err)
+    process.exit(1)
+  })
 
   console.log(`Running postBuild plugins`)
   await apiRunnerNode(`postBuild`, { graphql: graphqlRunner })


### PR DESCRIPTION
Before we'd catch the errors and then move on... which isn't right at all. If there's an error we should exit immediately. This has led to partially or fully broken sites being deployed. Continuous deployment of code is best but Gatsby has to actually die if thing go wrong.