### PR TITLE
[1.0] Improve manifest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-// Place your settings in this file to overwrite the default settings
-{
-  "editor.formatOnSave": true,
-  "prettier.semi": false,
-  "prettier.trailingComma": "all"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 // Place your settings in this file to overwrite the default settings
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "prettier.semi": false,
+  "prettier.trailingComma": "all"
 }

--- a/packages/gatsby-plugin-manifest/.gitignore
+++ b/packages/gatsby-plugin-manifest/.gitignore
@@ -2,3 +2,5 @@
 /gatsby-ssr.js
 /gatsby-browser.js
 /app-shell.js
+/__mocks__/
+/__tests__/

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -37,3 +37,6 @@ plugins: [
 ]
 ```
 
+## Note for es-lint
+
+You can write keys in any case (as camel case), they will automaticly parsed into snake case to be compliant with `manifest.json` specs.

--- a/packages/gatsby-plugin-manifest/src/__mocks__/fs.js
+++ b/packages/gatsby-plugin-manifest/src/__mocks__/fs.js
@@ -1,0 +1,5 @@
+const fs = jest.genMockFromModule(`fs`)
+
+fs.__setWriteFileSyncFn = fn => (fs.writeFileSync = fn)
+
+module.exports = fs

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gatsby-plugin-manifest should omit plugins key 1`] = `
+Array [
+  Array [
+    "./public/manifest.json",
+    "{\\"name\\":\\"Gatsby website\\",\\"short_name\\":\\"Gatsby website\\",\\"start_url\\":\\"/\\",\\"background_color\\":\\"#f7f7f7\\",\\"theme_color\\":\\"#191919\\",\\"display\\":\\"minimal-ui\\"}",
+  ],
+]
+`;
+
+exports[`gatsby-plugin-manifest should parse keys into snake case 1`] = `
+Array [
+  Array [
+    "./public/manifest.json",
+    "{\\"name\\":\\"Gatsby website\\",\\"short_name\\":\\"Gatsby website\\",\\"start_url\\":\\"/\\",\\"background_color\\":\\"#f7f7f7\\",\\"theme_color\\":\\"#191919\\",\\"display\\":\\"minimal-ui\\",\\"sidebar_action\\":{\\"default_icon\\":{\\"16\\":\\"button/geo-16.png\\"}}}",
+  ],
+]
+`;

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -1,0 +1,46 @@
+jest.mock(`fs`)
+
+const { postBuild } = require(`../gatsby-node`)
+
+describe(`gatsby-plugin-manifest`, () => {
+  it(`should omit plugins key`, () => {
+    const fsMock = jest.fn()
+    require(`fs`).__setWriteFileSyncFn(fsMock)
+
+    const manifest = {
+      name: `Gatsby website`,
+      short_name: `Gatsby website`,
+      start_url: `/`,
+      background_color: `#f7f7f7`,
+      theme_color: `#191919`,
+      display: `minimal-ui`,
+      plugins: `here`,
+    }
+
+    postBuild(null, manifest)
+    expect(fsMock.mock.calls).toMatchSnapshot()
+  })
+
+  it(`should parse keys into snake case`, () => {
+    const fsMock = jest.fn()
+    require(`fs`).__setWriteFileSyncFn(fsMock)
+
+    const manifest = {
+      name: `Gatsby website`,
+      shortName: `Gatsby website`,
+      startUrl: `/`,
+      backgroundColor: `#f7f7f7`,
+      themeColor: `#191919`,
+      display: `minimal-ui`,
+      sidebarAction: {
+        defaultIcon: {
+          "16": `button/geo-16.png`,
+        },
+      },
+      plugins: `here`,
+    }
+
+    postBuild(null, manifest)
+    expect(fsMock.mock.calls).toMatchSnapshot()
+  })
+})

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -1,10 +1,16 @@
 const fs = require(`fs`)
-const Promise = require(`bluebird`)
+const _ = require(`lodash`)
+
+const mapKeysDeep = (obj, cb) =>
+  _.mapValues(
+    _.mapKeys(obj, cb),
+    val => (_.isObject(val) ? mapKeysDeep(val, cb) : val),
+  )
 
 exports.postBuild = (args, pluginOptions) =>
   new Promise(resolve => {
-    const manifest = { ...pluginOptions }
-    delete manifest.plugins
+    let manifest = _.omit(pluginOptions, [`plugins`])
+    manifest = mapKeysDeep(manifest, (v, k) => _.snakeCase(k))
     fs.writeFileSync(`./public/manifest.json`, JSON.stringify(manifest))
     resolve()
   })

--- a/packages/gatsby-transformer-json/.gitignore
+++ b/packages/gatsby-transformer-json/.gitignore
@@ -1,1 +1,2 @@
 /gatsby-node.js
+/__tests__/

--- a/packages/gatsby-transformer-remark/.gitignore
+++ b/packages/gatsby-transformer-remark/.gitignore
@@ -1,1 +1,2 @@
 /gatsby-node.js
+/__tests__/

--- a/packages/gatsby-transformer-sharp/.gitignore
+++ b/packages/gatsby-transformer-sharp/.gitignore
@@ -1,1 +1,2 @@
 /gatsby-node.js
+/__tests__/

--- a/packages/gatsby-transformer-yaml/.gitignore
+++ b/packages/gatsby-transformer-yaml/.gitignore
@@ -1,1 +1,2 @@
 /gatsby-node.js
+/__tests__/


### PR DESCRIPTION
`manifest.json` needs to have snake case in each keys but my es-lint don't really like this ^^

So I've just add a little parser allow camel case config (or what ever you want) 😄 

Notes: I add some fixes for autosave on IDE (it was totally broken since last update)
