### PR TITLE
support more new starter uris

### DIFF
--- a/packages/gatsby/lib/bin/cli.js
+++ b/packages/gatsby/lib/bin/cli.js
@@ -25,7 +25,8 @@ console.time(`time to load develop`)
 program
   .command(`develop`)
   .description(
-    `Start development server. Watches files and rebuilds and hot reloads if something changes`
+    `Start development server. Watches files and rebuilds and hot reloads ` +
+      `if something changes`
   ) // eslint-disable-line max-len
   .option(
     `-H, --host <url>`,

--- a/packages/gatsby/lib/utils/new.js
+++ b/packages/gatsby/lib/utils/new.js
@@ -3,17 +3,6 @@ const logger = require(`tracer`).colorConsole()
 
 const initStarter = require(`./init-starter`)
 
-module.exports = (rootPath, starter = `gh:gatsbyjs/gatsby-starter-default`) => {
-  initStarter(
-    starter,
-    {
-      rootPath,
-      logger,
-    },
-    error => {
-      if (error) {
-        logger.error(error)
-      }
-    }
-  )
+module.exports = (rootPath, starter = `gatsbyjs/gatsby-starter-default`) => {
+  initStarter(starter, { rootPath, logger }).catch(error => logger.error(error))
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -56,6 +56,7 @@
     "hapi": "^8.5.1",
     "highlight.js": "^9.8.0",
     "history": "^2.1.2",
+    "hosted-git-info": "^2.4.2",
     "invariant": "^2.2.2",
     "is-relative": "^0.2.1",
     "is-relative-url": "^2.0.0",


### PR DESCRIPTION
Uses the same module as npm for figuring out where to get something from. Supports cloning branches or commits, automatically gives you github, bitbucket, gitlab.

doesn’t support the `gh:` prefix :/ but github: still works