### PR TITLE
Add children fields for each type of children e.g. childrenMarkdownRemark

### DIFF
--- a/examples/gatsbygram/gatsby-node.js
+++ b/examples/gatsbygram/gatsby-node.js
@@ -25,7 +25,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
     graphql(
       `
       {
-        allPosts(limit: 1000) {
+        allPostsJson(limit: 1000) {
           edges {
             node {
               id
@@ -45,7 +45,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
       // Instagram post. Since the scrapped Instagram data
       // already includes an ID field, we just use that for
       // each page's path.
-      _.each(result.data.allPosts.edges, edge => {
+      _.each(result.data.allPostsJson.edges, edge => {
         // Gatsby uses Redux to manage its internal state.
         // Plugins and sites can use functions like "upsertPage"
         // to interact with Gatsby.

--- a/examples/gatsbygram/src/components/post-detail.js
+++ b/examples/gatsbygram/src/components/post-detail.js
@@ -19,7 +19,7 @@ class PostDetail extends React.Component {
       text,
       avatar,
     } = this.props.post
-    const { big } = image.children[0]
+    const { big } = image.childImageSharp
 
     const UserBar = () => (
       <div

--- a/examples/gatsbygram/src/components/post.js
+++ b/examples/gatsbygram/src/components/post.js
@@ -17,7 +17,7 @@ class Post extends React.Component {
 
   render() {
     const { image, likes, id } = this.props.post
-    const { small } = image.children[0]
+    const { small } = image.childImageSharp
     return (
       <Link
         to={`/${id}/`}

--- a/examples/gatsbygram/src/pages/index.js
+++ b/examples/gatsbygram/src/pages/index.js
@@ -52,7 +52,7 @@ class Index extends React.Component {
 
   render() {
     console.log(this.props)
-    this.context.setEdges(this.props.data.allPosts.edges)
+    this.context.setEdges(this.props.data.allPostsJson.edges)
     return (
       <div
         css={{
@@ -122,17 +122,17 @@ class Index extends React.Component {
                 fontWeight: `normal`,
               }}
             >
-              {this.props.data.allPosts.edges[0].node.username}
+              {this.props.data.allPostsJson.edges[0].node.username}
             </h3>
             <p>
-              <strong>{this.props.data.allPosts.edges.length}</strong> posts
+              <strong>{this.props.data.allPostsJson.edges.length}</strong> posts
               <strong css={{ marginLeft: rhythm(1) }}>192k</strong> followers
             </p>
           </div>
         </div>
         {/* posts */}
         {chunk(
-          this.props.data.allPosts.edges.slice(0, this.state.postsToShow),
+          this.props.data.allPostsJson.edges.slice(0, this.state.postsToShow),
           3
         ).map(chunk => {
           return (
@@ -152,7 +152,7 @@ class Index extends React.Component {
                 <Post
                   key={edge.node.id}
                   post={edge.node}
-                  edges={this.props.data.allPosts.edges}
+                  edges={this.props.data.allPostsJson.edges}
                   location={this.props.location}
                   onClick={post => this.setState({ activePost: post })}
                 />
@@ -211,8 +211,8 @@ export default Index
 
 export const pageQuery = `
 query allImages {
-  user: allPosts(limit: 1) { edges { node { avatar, username }}}
-  allPosts {
+  user: allPostsJson(limit: 1) { edges { node { avatar, username }}}
+  allPostsJson {
     edges {
       node {
         likes
@@ -220,16 +220,14 @@ query allImages {
         text
         weeksAgo: time(difference: "weeks")
         image {
-          children {
-            ... on ImageSharp {
-              small: responsiveSizes(maxWidth: 292, maxHeight: 292) {
-                src
-                srcSet
-              }
-              big: responsiveSizes(maxWidth: 640, maxHeight: 640) {
-                src
-                srcSet
-              }
+          childImageSharp {
+            small: responsiveSizes(maxWidth: 292, maxHeight: 292) {
+              src
+              srcSet
+            }
+            big: responsiveSizes(maxWidth: 640, maxHeight: 640) {
+              src
+              srcSet
             }
           }
         }

--- a/examples/gatsbygram/src/templates/post-page.js
+++ b/examples/gatsbygram/src/templates/post-page.js
@@ -6,7 +6,7 @@ class PostTemplate extends React.Component {
     return (
       // PostDetail is used for this detail page and
       // also in the modal.
-      <PostDetail post={this.props.data.posts} />
+      <PostDetail post={this.props.data.postsJson} />
     )
   }
 }
@@ -20,9 +20,9 @@ export default PostTemplate
 // All GraphQL queries in Gatsby are run at build-time and
 // loaded as plain JSON files so have minimal client cost.
 export const pageQuery = `
-  query PostPage($id: String!) {
+  query PostPageJson($id: String!) {
     # Select the post which equals this id.
-    posts(id: { eq: $id }) {
+    postsJson(id: { eq: $id }) {
       # Specify the fields from the post we need.
       username
       avatar
@@ -36,17 +36,15 @@ export const pageQuery = `
       # for the client.
       weeksAgo: time(difference: "weeks")
       image {
-        children {
-          ... on ImageSharp {
-            # Here we query for *multiple* image thumbnails to be
-            # created. So with no effort on our part, 100s of
-            # thumbnails are created. This makes iterating on
-            # designs effortless as we simply change the args
-            # for the query and we get new thumbnails.
-            big: responsiveSizes(maxWidth: 640) {
-              src
-              srcSet
-            }
+        childImageSharp {
+          # Here we query for *multiple* image thumbnails to be
+          # created. So with no effort on our part, 100s of
+          # thumbnails are created. This makes iterating on
+          # designs effortless as we simply change the args
+          # for the query and we get new thumbnails.
+          big: responsiveSizes(maxWidth: 640) {
+            src
+            srcSet
           }
         }
       }

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -33,7 +33,8 @@ async function onNodeCreate({ node, boundActionCreators, loadNodeContent }) {
       parent: node.id,
       // TODO make choosing the "type" a lot smarter. This assumes
       // the parent node is a file.
-      type: _.capitalize(node.name),
+      // PascalCase
+      type: _.upperFirst(_.camelCase(`${node.name} Json`)),
       children: [],
       content: objStr,
     }

--- a/packages/gatsby-transformer-yaml/src/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml/src/gatsby-node.js
@@ -20,7 +20,7 @@ async function onNodeCreate({ node, boundActionCreators, loadNodeContent }) {
       ...obj,
       id: obj.id ? obj.id : `${node.id} [${i}] >>> YAML`,
       contentDigest,
-      type: _.capitalize(node.name),
+      type: _.upperFirst(_.camelCase(`${node.name} Yaml`)),
       mediaType: `application/json`,
       parent: node.id,
       children: [],

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     title: `Gatsby`,
   },
   mapping: {
-    "MarkdownRemark.frontmatter.author": `Author`,
+    "MarkdownRemark.frontmatter.author": `AuthorYaml`,
   },
   plugins: [
     {

--- a/www/src/pages/blog/index.js
+++ b/www/src/pages/blog/index.js
@@ -25,7 +25,7 @@ const IndexRoute = React.createClass({
         <h1>Blog</h1>
         {blogPosts.map(post => {
           const avatar =
-            post.frontmatter.author.avatar.children[0].responsiveResolution
+            post.frontmatter.author.avatar.childImageSharp.responsiveResolution
           return (
             <div>
               <Link to={post.slug}>
@@ -109,14 +109,12 @@ export const pageQuery = `
           author {
             id
             avatar {
-              children {
-                ... on ImageSharp {
-                  responsiveResolution(width: 35, height: 35) {
-                    width
-                    height
-                    src
-                    srcSet
-                  }
+              childImageSharp {
+                responsiveResolution(width: 35, height: 35) {
+                  width
+                  height
+                  src
+                  srcSet
                 }
               }
             }

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -72,7 +72,7 @@ const BlogPostTemplate = React.createClass({
             },
             {
               name: `og:image`,
-              content: post.frontmatter.image.children[0].resize.src,
+              content: post.frontmatter.image.childImageSharp.resize.src,
             },
             {
               name: `og:type`,
@@ -118,12 +118,12 @@ const BlogPostTemplate = React.createClass({
           >
             <img
               src={
-                post.frontmatter.author.avatar.children[0].responsiveResolution
-                  .src
+                post.frontmatter.author.avatar.childImageSharp
+                  .responsiveResolution.src
               }
               srcSet={
-                post.frontmatter.author.avatar.children[0].responsiveResolution
-                  .srcSet
+                post.frontmatter.author.avatar.childImageSharp
+                  .responsiveResolution.srcSet
               }
               css={{
                 height: rhythm(2.75),
@@ -191,11 +191,9 @@ export const pageQuery = `
         date(formatString: "MMM D, YYYY")
         rawDate: date
         image {
-          children {
-            ... on ImageSharp {
-              resize(width: 1500) {
-                src
-              }
+          childImageSharp {
+            resize(width: 1500) {
+              src
             }
           }
         }
@@ -204,12 +202,10 @@ export const pageQuery = `
           bio
           twitter
           avatar {
-            children {
-              ... on ImageSharp {
-                responsiveResolution(width: 75, height: 75, quality: 75) {
-                  src
-                  srcSet
-                }
+            childImageSharp {
+              responsiveResolution(width: 75, height: 75, quality: 75) {
+                src
+                srcSet
               }
             }
           }


### PR DESCRIPTION
This simplifies children queries as the syntax for querying
the node interface of "children" is verbose and requires
advanced GraphQL skills.

So now you could do queries like:

```graphql
{
  allFile(absolutePath: { eq: $file }) {
    childrenMarkdownRemark {
      html
    }
  }
}
```