### PR TITLE
[1.0] Fix gatsby-link for undefined nextState

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -3,6 +3,8 @@ import Link from "react-router/lib/Link"
 import createClass from "create-react-class"
 import PropTypes from "prop-types"
 
+const debug = require(`debug`)(`gatsby:link`)
+
 let linkPrefix = ``
 if (__PREFIX_LINKS__) {
   linkPrefix = __LINK_PREFIX__
@@ -16,8 +18,8 @@ const GatsbyLink = createClass({
     to: PropTypes.string.isRequired,
   },
   componentDidMount() {
-    // Only enable prefetching of Link resources in production and for browsers that
-    // don't support service workers *cough* Safari/IE *cough*.
+    // Only enable prefetching of Link resources in production and for browsers
+    // that don't support service workers *cough* Safari/IE *cough*.
     if (
       (process.env.NODE_ENV === `production` &&
         !(`serviceWorker` in navigator)) ||
@@ -35,9 +37,17 @@ const GatsbyLink = createClass({
           [routes],
           createLocation(this.props.to),
           (error, nextState) => {
-            getComponents(nextState, () =>
-              console.log(`loaded assets for ${this.props.to}`)
-            )
+            if (error) {
+              return console.error(error)
+            }
+
+            if (nextState) {
+              getComponents(nextState, () =>
+                debug(`Loaded assets for route ${this.props.to}`)
+              )
+            } else {
+              debug(`No state available for route ${this.props.to}`)
+            }
           }
         )
       }

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -3,8 +3,6 @@ import Link from "react-router/lib/Link"
 import createClass from "create-react-class"
 import PropTypes from "prop-types"
 
-const debug = require(`debug`)(`gatsby:link`)
-
 let linkPrefix = ``
 if (__PREFIX_LINKS__) {
   linkPrefix = __LINK_PREFIX__
@@ -42,11 +40,7 @@ const GatsbyLink = createClass({
             }
 
             if (nextState) {
-              getComponents(nextState, () =>
-                debug(`Loaded assets for route ${this.props.to}`)
-              )
-            } else {
-              debug(`No state available for route ${this.props.to}`)
+              getComponents(nextState)
             }
           }
         )


### PR DESCRIPTION
* Solves errors in production when `/route/child/` is available but `/route/` is not.

@KyleAMathews I thought fetching routes like this is actually a good example of where you'd want to be have a debug statement in place to just switch on. I think the size of the `debug` library is negligible, but if you disagree I can take it out of course.