### PR TITLE
[1.0] WIP fix infer graphql input type

### DIFF
--- a/packages/gatsby/lib/schema/__tests__/infer-graphql-input-type.js
+++ b/packages/gatsby/lib/schema/__tests__/infer-graphql-input-type.js
@@ -24,6 +24,10 @@ describe(`GraphQL Input args`, () => {
         title: `The world of dash and adventure`,
         blue: 100,
       },
+      anObjectArray: [
+        { aString: `some string`, aNumber: 2, aBoolean: true },
+        { aString: `some string`, aNumber: 2, anArray: [1, 2] },
+      ],
     },
     {
       name: `The Mad Wax`,
@@ -256,6 +260,33 @@ describe(`GraphQL Input args`, () => {
         expect(result.data.allNode.anArray[0].fieldValue).toEqual(`1`)
         expect(result.data.allNode.anArray[0].field).toEqual(`anArray`)
         expect(result.data.allNode.anArray[0].totalCount).toEqual(2)
+      })
+      .catch(err => expect(err).not.toBeDefined()))
+
+  it(`can query object arrays`, () =>
+    graphql(
+      schema,
+      `
+      {
+        allNode {
+          anObjectArray {
+            aString
+            aNumber
+            aBoolean
+          }
+        }
+      }
+      `
+    )
+      .then(result => {
+        expect(result.errors).not.toBeDefined()
+
+        expect(result.data.allNode.anObjectArray).toHaveLength(2)
+        expect(result.data.allNode.anObjectArray[0].aString)
+          .toEqual(`some string`)
+        expect(result.data.allNode.anObjectArray[0].aNumber).toEqual(2)
+        expect(result.data.allNode.anObjectArray[0].aBoolean).toEqual(true)
+        expect(result.data.allNode.anObjectArray[1].anArray).toEqual([1, 2])
       })
       .catch(err => expect(err).not.toBeDefined()))
 })

--- a/packages/gatsby/lib/schema/create-type-name.js
+++ b/packages/gatsby/lib/schema/create-type-name.js
@@ -1,0 +1,14 @@
+const _ = require(`lodash`)
+
+const seenNames = {}
+
+export default function createTypeName(name) {
+  const cameledName = _.camelCase(name)
+  if (seenNames[cameledName]) {
+    seenNames[cameledName] += 1
+    return `${cameledName}_${seenNames[cameledName]}`
+  } else {
+    seenNames[cameledName] = 1
+    return cameledName
+  }
+}

--- a/packages/gatsby/lib/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/lib/schema/infer-graphql-input-fields.js
@@ -8,11 +8,10 @@ const {
   GraphQLList,
   GraphQLEnumType,
   GraphQLNonNull,
-  GraphQLObjectType,
 } = require(`graphql`)
 const _ = require(`lodash`)
-const moment = require(`moment`)
 const typeOf = require(`type-of`)
+const createTypeName = require(`./create-type-name`)
 
 const {
   extractFieldExamples,
@@ -91,7 +90,7 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
 
       return {
         type: new GraphQLInputObjectType({
-          name: _.camelCase(`${namespace} ${selector} ${key}QueryList`),
+          name: createTypeName(`${namespace} ${selector} ${key}QueryList`),
           fields: {
             ...typeFields(headType),
             in: { type: new GraphQLList(inType) },
@@ -101,7 +100,7 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
     case `boolean`:
       return {
         type: new GraphQLInputObjectType({
-          name: _.camelCase(`${namespace} ${selector} ${key}QueryBoolean`),
+          name: createTypeName(`${namespace} ${selector} ${key}QueryBoolean`),
           fields: {
             ...typeFields(`boolean`),
           },
@@ -110,7 +109,7 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
     case `string`:
       return {
         type: new GraphQLInputObjectType({
-          name: _.camelCase(`${namespace} ${selector} ${key}QueryString`),
+          name: createTypeName(`${namespace} ${selector} ${key}QueryString`),
           fields: {
             ...typeFields(`string`),
           },
@@ -119,7 +118,7 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
     case `object`:
       return {
         type: new GraphQLInputObjectType({
-          name: _.camelCase(`${namespace} ${selector} ${key}InputObject`),
+          name: createTypeName(`${namespace} ${selector} ${key}InputObject`),
           fields: inferInputObjectStructureFromNodes(nodes, key, namespace),
         }),
       }
@@ -127,7 +126,7 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
       if (value % 1 === 0) {
         return {
           type: new GraphQLInputObjectType({
-            name: _.camelCase(`${namespace} ${selector} ${key}QueryNumber`),
+            name: createTypeName(`${namespace} ${selector} ${key}QueryNumber`),
             fields: {
               ...typeFields(`int`),
             },
@@ -136,7 +135,7 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
       } else {
         return {
           type: new GraphQLInputObjectType({
-            name: _.camelCase(`${namespace} ${selector} ${key}QueryFloat`),
+            name: createTypeName(`${namespace} ${selector} ${key}QueryFloat`),
             fields: {
               ...typeFields(`float`),
             },

--- a/packages/gatsby/lib/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/lib/schema/infer-graphql-input-fields.js
@@ -8,6 +8,7 @@ const {
   GraphQLList,
   GraphQLEnumType,
   GraphQLNonNull,
+  GraphQLObjectType,
 } = require(`graphql`)
 const _ = require(`lodash`)
 const moment = require(`moment`)
@@ -54,10 +55,11 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
 ) => {
   switch (typeOf(value)) {
     case `array`:
-      let headType = typeOf(value[0])
+      const headValue = value[0]
+      let headType = typeOf(headValue)
       // Check if headType is a number.
       if (headType === `number`) {
-        if (value[0] % 1 === 0) {
+        if (headValue % 1 === 0) {
           headType = `int`
         } else {
           headType = `float`
@@ -78,6 +80,12 @@ const inferGraphQLInputFields = (exports.inferGraphQLInputFields = (
           break
         case `boolean`:
           inType = GraphQLBoolean
+          break
+        case `object`:
+          inType = inferGraphQLInputFields(headValue, key, nodes).type
+          break
+        case `array`:
+          inType = inferGraphQLInputFields(headValue, key, nodes).type
           break
       }
 

--- a/packages/gatsby/lib/schema/infer-graphql-type.js
+++ b/packages/gatsby/lib/schema/infer-graphql-type.js
@@ -15,18 +15,7 @@ const isRelativeUrl = require(`is-relative-url`)
 const { store, getNode, getNodes } = require(`../redux`)
 const { addPageDependency } = require(`../redux/actions/add-page-dependency`)
 const { extractFieldExamples } = require(`./data-tree-utils`)
-
-const seenNames = {}
-const createTypeName = name => {
-  const cameledName = _.camelCase(name)
-  if (seenNames[cameledName]) {
-    seenNames[cameledName] += 1
-    return `${cameledName}_${seenNames[cameledName]}`
-  } else {
-    seenNames[cameledName] = 1
-    return cameledName
-  }
-}
+const createTypeName = require(`./create-type-name`)
 
 const inferGraphQLType = ({ value, selector, fieldName, ...otherArgs }) => {
   const newSelector = selector ? [selector, fieldName].join(`.`) : fieldName


### PR DESCRIPTION
I still can't query object arrays from my data.

Managed to get a bit further but now my app complains `Schema must contain unique named types but contains multiple types named "categoryTagsInputObject".` And `categoryTags` in this case is the key that contains the object array in my data. 

I'm sure it's something simple again, but I can't fully grasp it.