### PR TITLE
[1.0] WIP infer deep object input type

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -5,19 +5,21 @@ Array [
   Array [
     Object {
       "children": Array [],
-      "content": "
-Where oh where is my little pony?
-    ",
-      "contentDigest": "54cfa2ad99756f2fa232cac585280a37",
       "frontmatter": Object {
         "date": "12/12/2014",
         "parent": "whatever",
         "title": "my little pony",
       },
       "id": "whatever >>> MarkdownRemark",
-      "mediaType": "text/x-markdown",
+      "internal": Object {
+        "content": "
+Where oh where is my little pony?
+    ",
+        "contentDigest": "54cfa2ad99756f2fa232cac585280a37",
+        "mediaType": "text/x-markdown",
+        "type": "MarkdownRemark",
+      },
       "parent": "whatever",
-      "type": "MarkdownRemark",
     },
   ],
 ]
@@ -37,9 +39,11 @@ date: \\"12/12/2014\\"
 
 Where oh where is my little pony?
     ",
-      "contentDigest": "whatever",
       "id": "whatever",
-      "mediaType": "text/x-markdown",
+      "internal": Object {
+        "contentDigest": "whatever",
+        "mediaType": "text/x-markdown",
+      },
     },
   ],
 ]

--- a/packages/gatsby-transformer-sharp/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-sharp/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,32 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Process image nodes correctly correctly creates an ImageSharp node from a file image node 1`] = `
-Array [
-  Array [
-    Object {
-      "children": Array [],
-      "contentDigest": "whatever",
-      "id": "whatever >> ImageSharp",
-      "logical": true,
-      "mediaType": undefined,
-      "parent": "whatever",
-      "type": "ImageSharp",
-    },
-  ],
-]
-`;
+exports[`Process image nodes correctly correctly creates an ImageSharp node from a file image node 1`] = `Array []`;
 
-exports[`Process image nodes correctly correctly creates an ImageSharp node from a file image node 2`] = `
-Array [
-  Array [
-    Object {
-      "children": Array [
-        "whatever >> ImageSharp",
-      ],
-      "contentDigest": "whatever",
-      "extension": "png",
-      "id": "whatever",
-    },
-  ],
-]
-`;
+exports[`Process image nodes correctly correctly creates an ImageSharp node from a file image node 2`] = `Array []`;

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -77,6 +77,15 @@ describe(`GraphQL Input args`, () => {
         { aString: `some string`, aNumber: 2, aBoolean: true },
         { aString: `some string`, aNumber: 2, anArray: [1, 2] },
       ],
+      deepObject: {
+        level1: 1,
+        deepObject: {
+          level2: 2,
+          deepObject: {
+            level3: 3,
+          },
+        },
+      },
     },
     {
       name: `The Mad Wax`,


### PR DESCRIPTION
Trying to use a nested object in the graphql input data resulted in errors. I've added the deep object test and this result in the following error. Will try to look into it further.

```
● GraphQL Input args › encountered a declaration exception

    RangeError: Maximum call stack size exceeded
      
      at node_modules/flat/index.js:16:41
      at Array.forEach (native)
      at step (node_modules/flat/index.js:16:25)
      at node_modules/flat/index.js:32:16
      at Array.forEach (native)
      at step (node_modules/flat/index.js:16:25)
      at flatten (node_modules/flat/index.js:39:3)
      at reduceSubNode (packages/gatsby/lib/schema/data-tree-utils.js:15:21)
      at packages/gatsby/lib/schema/data-tree-utils.js:30:14
      at Array.reduce (native)
      at Object.<anonymous>.exports.extractFieldExamples (packages/gatsby/lib/schema/data-tree-utils.js:10:24)
      at Object.<anonymous>.exports.inferInputObjectStructureFromNodes (packages/gatsby/lib/schema/infer-graphql-input-fields.js:155:23)
      at Object.<anonymous>.exports.inferGraphQLInputFields (packages/gatsby/lib/schema/infer-graphql-input-fields.js:122:19)
      at packages/gatsby/lib/schema/infer-graphql-input-fields.js:163:25
```