### PR TITLE
Allow toFormat as a parameter to sharp image processing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-// Place your settings in this file to overwrite the default settings
-{
-  "editor.formatOnSave": true
-}

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -154,6 +154,7 @@ function queueImageResizing({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     linkPrefix: ``,
+    toFormat: ``,
   }
   const options = _.defaults(args, defaultArgs)
   // Filter out false args, and args not for this extension and put width at
@@ -173,7 +174,8 @@ function queueImageResizing({ file, args = {} }) {
     return true
   })
   const sortedArgs = _.sortBy(filteredArgs, arg => arg[0] === `width`)
-  const imgSrc = `/${file.contentDigest}-${qs.stringify(_.fromPairs(sortedArgs))}.${file.extension}`
+  const fileExtension = options.toFormat ? options.toFormat : file.extension
+  const imgSrc = `/${file.contentDigest}-${qs.stringify(_.fromPairs(sortedArgs))}.${fileExtension}`
   const filePath = `${process.cwd()}/public${imgSrc}`
   // Create function to call when the image is finished.
   let outsideResolve
@@ -208,6 +210,7 @@ function queueImageResizing({ file, args = {} }) {
     inputPath: file.absolutePath,
     outputPath: filePath,
   }
+
   queueJob(job)
 
   // Prefix the image src.
@@ -230,6 +233,7 @@ async function notMemoizedbase64({ file, args = {} }) {
     jpegProgressive: true,
     pngCompressionLevel: 9,
     grayscale: false,
+    toFormat: ``,
   }
   const options = _.defaults(args, defaultArgs)
   let pipeline = sharp(file.absolutePath).rotate()
@@ -283,6 +287,7 @@ async function responsiveSizes({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     linkPrefix: ``,
+    toFormat: ``,
   }
   const options = _.defaults(args, defaultArgs)
   options.maxWidth = parseInt(options.maxWidth, 10)
@@ -357,6 +362,7 @@ async function responsiveResolution({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     linkPrefix: ``,
+    toFormat: ``,
   }
   const options = _.defaults(args, defaultArgs)
   options.width = parseInt(options.width, 10)

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -4,6 +4,7 @@ const {
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
+  GraphQLEnumType,
 } = require(`graphql`)
 const {
   queueImageResizing,
@@ -11,6 +12,16 @@ const {
   responsiveSizes,
   responsiveResolution,
 } = require(`gatsby-plugin-sharp`)
+
+const ImageFormatType = new GraphQLEnumType({
+  name: `ImageFormat`,
+  values: {
+    default: { value: `` },
+    jpg: { value: `jpg` },
+    png: { value: `png` },
+    webp: { value: `webp` },
+  },
+})
 
 module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
   if (type.name !== `ImageSharp`) {
@@ -47,7 +58,7 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
           defaultValue: 50,
         },
         toFormat: {
-          type: GraphQLString,
+          type: ImageFormatType,
           defaultValue: ``,
         },
       },
@@ -86,7 +97,7 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
           defaultValue: 50,
         },
         toFormat: {
-          type: GraphQLString,
+          type: ImageFormatType,
           defaultValue: ``,
         },
       },
@@ -136,7 +147,7 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
           defaultValue: false,
         },
         toFormat: {
-          type: GraphQLString,
+          type: ImageFormatType,
           defaultValue: ``,
         },
       },

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -46,6 +46,10 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
           type: GraphQLInt,
           defaultValue: 50,
         },
+        toFormat: {
+          type: GraphQLString,
+          defaultValue: ``,
+        },
       },
       resolve(image, fieldArgs, context) {
         const promise = responsiveResolution({
@@ -80,6 +84,10 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
         quality: {
           type: GraphQLInt,
           defaultValue: 50,
+        },
+        toFormat: {
+          type: GraphQLString,
+          defaultValue: ``,
         },
       },
       resolve(image, fieldArgs, context) {
@@ -126,6 +134,10 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
         base64: {
           type: GraphQLBoolean,
           defaultValue: false,
+        },
+        toFormat: {
+          type: GraphQLString,
+          defaultValue: ``,
         },
       },
       resolve(image, fieldArgs, context) {

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -16,10 +16,10 @@ const {
 const ImageFormatType = new GraphQLEnumType({
   name: `ImageFormat`,
   values: {
-    default: { value: `` },
-    jpg: { value: `jpg` },
-    png: { value: `png` },
-    webp: { value: `webp` },
+    NO_CHANGE: { value: `` },
+    JPG: { value: `jpg` },
+    PNG: { value: `png` },
+    WEBP: { value: `webp` },
   },
 })
 


### PR DESCRIPTION
With this change you can write `responsiveSizes(maxWidth: 250, toFormat: "jpg")` in your query.