### PR TITLE
[1.0] Sets up ability to construct global vars that are passed amongst brow…

### DIFF
--- a/packages/gatsby/src/cache-dir/production-app.js
+++ b/packages/gatsby/src/cache-dir/production-app.js
@@ -77,8 +77,10 @@ window.___loadScriptsForPath = loadScriptsForPath
 window.___navigateTo = navigateTo
 
 const history = createHistory()
+const browserApiGlobals = apiRunner(`constructBrowserApiGlobals`, { history })[0]
+
 history.listen((location, action) => {
-  apiRunner(`onRouteUpdate`, location, action)
+  apiRunner(`onRouteUpdate`, { location, browserApiGlobals}, action)
 })
 
 function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
@@ -143,7 +145,7 @@ const renderSite = ({ scripts, props }) => {
 
 const $ = React.createElement
 
-const AltRouter = apiRunner(`replaceRouterComponent`, { history })[0]
+const AltRouter = apiRunner(`replaceRouterComponent`, browserApiGlobals)[0]
 const DefaultRouter = ({ children }) => (
   <Router history={history}>{children}</Router>
 )

--- a/packages/gatsby/src/cache-dir/root.js
+++ b/packages/gatsby/src/cache-dir/root.js
@@ -15,8 +15,10 @@ import pages from "./pages.json"
 console.log(`pages`, pages)
 
 const history = createHistory()
+const browserApiGlobals = apiRunner(`constructBrowserApiGlobals`, { history })[0]
+
 history.listen((location, action) => {
-  apiRunner(`onRouteUpdate`, location, action)
+  apiRunner(`onRouteUpdate`, { location, browserApiGlobals }, action)
 })
 
 function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
@@ -62,7 +64,7 @@ const navigateTo = pathname => {
 
 window.___navigateTo = navigateTo
 
-const AltRouter = apiRunner(`replaceRouterComponent`, { history })[0]
+const AltRouter = apiRunner(`replaceRouterComponent`, browserApiGlobals)[0]
 const DefaultRouter = ({ children }) => (
   <Router history={history}>{children}</Router>
 )


### PR DESCRIPTION
…ser-centric API-runners.

Resolves https://github.com/gatsbyjs/gatsby/issues/970.

As a result, we can now do something like this in `gatsby-browser.js`...

```js
exports.constructBrowserApiGlobals = ({ history }) => {
    const store = makeStore(history);
    return { history, store };
};

exports.onRouteUpdate = ({ location, browserApiGlobals: { store } }) => {
    store.dispatch({
        type: 'PAGE_VIEW'
    });
};

exports.replaceRouterComponent = ({ history, store }) => {
    const ConnectedRouterWrapper = ({ children }) => (
        <Provider store={store}>
            <ConnectedRouter history={history}>{children}</ConnectedRouter>
        </Provider>
    );
    return ConnectedRouterWrapper;
};

```

FWIW, the naming (both around the API and the `const` it returns) are certainly up for debate and could be improved, but IMO this is certainly sufficient for the alpha.