### PR TITLE
[1.0] Clear existing service workers on start

### DIFF
--- a/packages/gatsby/src/cache-dir/app.js
+++ b/packages/gatsby/src/cache-dir/app.js
@@ -6,6 +6,21 @@ import React from "react"
 import ReactDOM from "react-dom"
 import { AppContainer as HotContainer } from "react-hot-loader"
 
+/**
+ * Service Workers are persistent by nature. They stick around,
+ * serving a cached version of the site if they aren't removed.
+ * This is especially frustrating when you need to test the
+ * production build on your local machine.
+ *
+ * Let's unregister the service workers in development, and tidy up a few errors.
+ */
+navigator.serviceWorker.getRegistrations()
+  .then(registrations => {
+    for (let registration of registrations) {
+      registration.unregister()
+    }
+  })
+
 const rootElement = document.getElementById(`___gatsby`)
 
 let Root = require(`./root`)


### PR DESCRIPTION
Service Workers are persistent by nature. They stick around, serving a cached version of the site if they aren't removed. This is especially frustrating when you need to test the production build on your local machine.

Let's [unregister the service workers](https://stackoverflow.com/questions/33704791/how-do-i-uninstall-a-service-worker) in development, and tidy up a few errors.