### PR TITLE
[1.0] Ensure navigator.serviceWorker exists

### DIFF
--- a/packages/gatsby/src/cache-dir/app.js
+++ b/packages/gatsby/src/cache-dir/app.js
@@ -14,12 +14,14 @@ import { AppContainer as HotContainer } from "react-hot-loader"
  *
  * Let's unregister the service workers in development, and tidy up a few errors.
  */
-navigator.serviceWorker.getRegistrations()
-  .then(registrations => {
-    for (let registration of registrations) {
-      registration.unregister()
-    }
-  })
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations()
+    .then(registrations => {
+      for (let registration of registrations) {
+        registration.unregister()
+      }
+    })
+}
 
 const rootElement = document.getElementById(`___gatsby`)
 


### PR DESCRIPTION
Let's ensure the browser supports service workers before we attempt to get registrations.