### PR TITLE
[1.0] no trailing slashes example

### DIFF
--- a/examples/no-trailing-slashes/.eslintrc
+++ b/examples/no-trailing-slashes/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "graphql": false
+  }
+}

--- a/examples/no-trailing-slashes/README.md
+++ b/examples/no-trailing-slashes/README.md
@@ -1,0 +1,6 @@
+# Client-only paths
+
+https://client-only-paths.gatsbyjs.org
+
+Example site that demostrates how to build Gatsby sites
+with paths that are client-only.

--- a/examples/no-trailing-slashes/gatsby-config.js
+++ b/examples/no-trailing-slashes/gatsby-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  siteMetadata: {
+    title: `Client only paths`,
+  },
+  plugins: [],
+}

--- a/examples/no-trailing-slashes/gatsby-node.js
+++ b/examples/no-trailing-slashes/gatsby-node.js
@@ -1,7 +1,25 @@
 const _ = require(`lodash`)
 const Promise = require(`bluebird`)
-const path = require(`path`)
-const slash = require(`slash`)
 
-// TODO
-// exports.onUpsertPage = ({ page, boundActionCreators }) => {}
+// Replacing '/' would result in empty string which is invalid
+const replacePath = path => (path === `/`) ? path : path.replace(/\/$/, ``)
+
+exports.onUpsertPage = ({ page, boundActionCreators }) => {
+  const { upsertPage, deletePageByPath } = boundActionCreators
+
+  return new Promise((resolve, reject) => {
+    // Remove trailing slash
+    const oldPath = page.path
+    page.path = replacePath(page.path)
+    if (page.path !== oldPath) {
+
+      // Remove the old page
+      deletePageByPath(oldPath)
+
+      // Add the new page
+      upsertPage(page)
+    }
+
+    resolve()
+  })
+}

--- a/examples/no-trailing-slashes/gatsby-node.js
+++ b/examples/no-trailing-slashes/gatsby-node.js
@@ -1,0 +1,7 @@
+const _ = require(`lodash`)
+const Promise = require(`bluebird`)
+const path = require(`path`)
+const slash = require(`slash`)
+
+// TODO
+// exports.onUpsertPage = ({ page, boundActionCreators }) => {}

--- a/examples/no-trailing-slashes/package.json
+++ b/examples/no-trailing-slashes/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gatsby-example-removing-trailing-slashes",
+  "private": true,
+  "description": "Gatsby example site that removes trailing slashes from internal urls",
+  "version": "1.0.0",
+  "author": "Scotty Eckenthal <scott.eckenthal@gmail.com>",
+  "dependencies": {
+    "gatsby": "canary",
+    "gatsby-link": "canary",
+    "lodash": "^4.16.4",
+    "slash": "^1.0.0"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build"
+  }
+}

--- a/examples/no-trailing-slashes/src/html.js
+++ b/examples/no-trailing-slashes/src/html.js
@@ -1,0 +1,33 @@
+import React from "react"
+
+module.exports = React.createClass({
+  render() {
+    return (
+      <html op="news" lang="en">
+        <head>
+          {this.props.headComponents}
+
+          <meta name="referrer" content="origin" />
+          <meta charSet="utf-8" />
+          <meta
+            name="description"
+            content="Gatsby example site demoing the removal of trailing slashes"
+          />
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0"
+          />
+          <title>Gatsby Client Only Paths</title>
+        </head>
+        <body>
+          <div
+            id="___gatsby"
+            dangerouslySetInnerHTML={{ __html: this.props.body }}
+          />
+          {this.props.postBodyComponents}
+        </body>
+      </html>
+    )
+  },
+})

--- a/examples/no-trailing-slashes/src/layouts/index.js
+++ b/examples/no-trailing-slashes/src/layouts/index.js
@@ -1,0 +1,24 @@
+import React from "react"
+import Link from "gatsby-link"
+
+class DefaultLayout extends React.Component {
+  render() {
+    return (
+      <div>
+        <Link to="/">
+          <h3>
+            Example removing trailing slashes
+          </h3>
+        </Link>
+        <ul>
+          <li><Link to="/a">a</Link></li>
+          <li><Link to="/b">b</Link></li>
+          <li><Link to="/c">c</Link></li>
+        </ul>
+        {this.props.children()}
+      </div>
+    )
+  }
+}
+
+export default DefaultLayout

--- a/examples/no-trailing-slashes/src/pages/a.js
+++ b/examples/no-trailing-slashes/src/pages/a.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const A = () => <p>A</p>
+
+export default A

--- a/examples/no-trailing-slashes/src/pages/b.js
+++ b/examples/no-trailing-slashes/src/pages/b.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const B = () => <p>B</p>
+
+export default B

--- a/examples/no-trailing-slashes/src/pages/c.js
+++ b/examples/no-trailing-slashes/src/pages/c.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const C = () => <p>C</p>
+
+export default C

--- a/examples/no-trailing-slashes/src/pages/index.js
+++ b/examples/no-trailing-slashes/src/pages/index.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const Home = () => <p>Home</p>
+
+export default Home


### PR DESCRIPTION
I created this example while I was testing out solutions to removing trailing slashes (that is, until @KyleAMathews pointed me to the docs).

The example doesn't provide anything that you can't find in the docs aside from the avoidance of manipulation of `'/'` that's rather intuitive anyhow, but I figured I'd PR regardless.

No need to merge if this isn't helpful.