### PR TITLE
[1.0] Don't catch links where target="_blank"

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -19,6 +19,10 @@ module.exports = function(root, cb) {
     }
     if (!anchor) return true
 
+    // Don't catch links where a target (other than self) is set
+    // e.g. _blank.
+    if (anchor.target && anchor.target.toLowerCase() !== `_self`) return true
+
     // IE clears the host value if the anchor href changed after creation, e.g.
     // in React. Creating a new anchor element to ensure host value is present
     var a1 = document.createElement(`a`)

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -27,7 +27,9 @@ exports.postBuild = (args, pluginOptions) => {
     // example.com/cheeseburger.jpg will not.
     // We only want the service worker to handle our "clean"
     // URLs and not any files hosted on the site.
-    navigateFallbackWhitelist: [/^.*(?!\.\w?$)/],
+    //
+    // Regex from http://stackoverflow.com/a/18017805
+    navigateFallbackWhitelist: [/^.*[^.]{5}$/],
     cacheId: `gatsby-plugin-offline`,
     // Do cache bust JS URLs until can figure out how to make Webpack's
     // URLs truely content-addressed.


### PR DESCRIPTION
Right now gatsby-plugin-catch-link catches links with target="_blank". This checks for this and lets the click go through.