### PR TITLE
fix path generation for windows operating systems

### DIFF
--- a/packages/gatsby/src/query-runner/pages-writer.js
+++ b/packages/gatsby/src/query-runner/pages-writer.js
@@ -2,24 +2,14 @@ const _ = require(`lodash`)
 const glob = require(`glob`)
 const parseFilepath = require(`parse-filepath`)
 const fs = require(`fs`)
-const path = require('path')
-const os = require('os');
-
-function joinPath(...paths) {
-  const joinedPath = path.join(...paths)
-  if(os.platform() === 'win32') {
-    return joinedPath.replace(/\\/g, '\\\\');
-  }
-  else {
-    return joinedPath;
-  }
-}
 
 const { store } = require(`../redux/`)
 import {
   layoutComponentChunkName,
   pathChunkName,
 } from "../utils/js-chunk-names"
+
+import {joinPath} from '../utils/path';
 
 // Write out pages information.
 const writePages = () => {
@@ -97,7 +87,6 @@ const preferDefault = m => m && m.default || m
 }`
 
   fs.writeFile(`${program.directory}/.cache/sync-requires.js`, syncRequires)
-console.log('josch debug', program.directory)
   // Create file with async requires of layouts/components/json files.
   let asyncRequires = `// prefer default export if available
 const preferDefault = m => m && m.default || m

--- a/packages/gatsby/src/utils/path.js
+++ b/packages/gatsby/src/utils/path.js
@@ -1,0 +1,12 @@
+const path = require('path')
+const os = require('os');
+
+export function joinPath(...paths) {
+  const joinedPath = path.join(...paths)
+  if(os.platform() === 'win32') {
+    return joinedPath.replace(/\\/g, '\\\\');
+  }
+  else {
+    return joinedPath;
+  }
+}


### PR DESCRIPTION
ensure that the cache file will be generated with escaped file paths.

*ATTENTION*
I introduced a utility called joinPath for that. The question is where do I put that and how should the test strategy be? Is there already some windows based test run?

Some details about the Problem:

pages-write produces a cache file which contains various require statements. On Windows based systems the paths of the generated require statements should be escaped. 

E.g. 
```js
exports.components = {
  "page-component---src-templates-template-blog-post-js": preferDefault(require("D:\projects\websites\gatsby-starter-blog\src/templates/template-blog-post.js")),
  "page-component---src-pages-index-js": preferDefault(require("D:\projects\websites\gatsby-starter-blog\src/pages/index.js"))
}
```

should turn into

```js
exports.components = {
  "page-component---src-templates-template-blog-post-js": preferDefault(require("D:\\projects\\websites\\gatsby-starter-blog\\src\\templates\\template-blog-post.js")),
  "page-component---src-pages-index-js": preferDefault(require("D:\\projects\\websites\\gatsby-starter-blog\\src\\pages\\index.js"))
}
```