### PR TITLE
Update alpha13 to alpha15

### DIFF
--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -33,7 +33,7 @@ class IndexRoute extends React.Component {
         <p>
           The best way to get started is by installing Gatsby Starters. There are four
           sites that currently works with
-          <code>gatsby@1.0.0-alpha13</code>:
+          <code>gatsby@1.0.0-alpha15</code>:
         </p>
         <ul>
           <li>


### PR DESCRIPTION
The Getting started page on the docs was showing that the gatsby official templates were made for alpha13, when they have already been updated to alpha15. This was causing a dependency issue while loading with `gatsby develop`