### PR TITLE
Fix sharp image quality and force file format

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -54,12 +54,12 @@ const processFile = (file, jobs, cb) => {
       .png({
         compressionLevel: args.pngCompressionLevel,
         adaptiveFiltering: false,
-        force: false,
+        force: args.toFormat === `png`,
       })
       .jpeg({
         quality: args.quality,
         progressive: args.jpegProgressive,
-        force: false,
+        force: args.toFormat === `jpg`,
       })
 
     // grayscale
@@ -84,7 +84,7 @@ const processFile = (file, jobs, cb) => {
           .buffer(sharpBuffer, {
             plugins: [
               imageminPngquant({
-                quality: `${args.quality}-${args.quality + 25}`, // e.g. 40-65
+                quality: `${args.quality}-${Math.min(args.quality + 25, 100)}`, // e.g. 40-65
               }),
             ],
           })

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -1,5 +1,5 @@
 const sharp = require(`sharp`)
-const qs = require(`qs`)
+const crypto = require(`crypto`)
 const imageSize = require(`image-size`)
 const _ = require(`lodash`)
 const Promise = require(`bluebird`)
@@ -175,7 +175,15 @@ function queueImageResizing({ file, args = {} }) {
   })
   const sortedArgs = _.sortBy(filteredArgs, arg => arg[0] === `width`)
   const fileExtension = options.toFormat ? options.toFormat : file.extension
-  const imgSrc = `/${file.internal.contentDigest}-${qs.stringify(_.fromPairs(sortedArgs))}.${fileExtension}`
+
+  const argsDigest = crypto
+    .createHash(`md5`)
+    .update(JSON.stringify(sortedArgs))
+    .digest(`hex`)
+
+  const argsDigestShort = argsDigest.substr(argsDigest.length - 5)
+
+  const imgSrc = `/${file.internal.contentDigest}-${argsDigestShort}.${fileExtension}`
   const filePath = `${process.cwd()}/public${imgSrc}`
   // Create function to call when the image is finished.
   let outsideResolve


### PR DESCRIPTION
* Fix the issue where you can't specify a quality above 75 for png images.
* Force image pipeline to use jpg or png if specified in toFormat.
* Replace long query string in filename with a short hash.