### PR TITLE
Expose crop focus parameter and make consistent with base64

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -46,11 +46,7 @@ const processFile = (file, jobs, cb) => {
     const roundedWidth = Math.round(args.width)
     clonedPipeline = clonedPipeline
       .resize(roundedWidth, roundedHeight)
-      // Use a more effective cropping strategy at the expense of some additional
-      // processing time (how much?).
-      .crop(sharp.strategy.attention)
-
-    clonedPipeline
+      .crop(args.cropFocus)
       .png({
         compressionLevel: args.pngCompressionLevel,
         adaptiveFiltering: false,
@@ -239,15 +235,16 @@ async function notMemoizedbase64({ file, args = {} }) {
   let pipeline = sharp(file.absolutePath).rotate()
   pipeline
     .resize(options.width, options.height)
+    .crop(options.cropFocus)
     .png({
       compressionLevel: options.pngCompressionLevel,
       adaptiveFiltering: false,
-      force: false,
+      force: args.toFormat === `png`,
     })
     .jpeg({
       quality: options.quality,
       progressive: options.jpegProgressive,
-      force: false,
+      force: args.toFormat === `jpg`,
     })
 
   // grayscale

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -14,6 +14,8 @@ const {
   responsiveResolution,
 } = require(`gatsby-plugin-sharp`)
 
+const sharp = require(`sharp`)
+
 const ImageFormatType = new GraphQLEnumType({
   name: `ImageFormat`,
   values: {
@@ -21,6 +23,23 @@ const ImageFormatType = new GraphQLEnumType({
     JPG: { value: `jpg` },
     PNG: { value: `png` },
     WEBP: { value: `webp` },
+  },
+})
+
+const ImageCropFocusType = new GraphQLEnumType({
+  name: `ImageCropFocus`,
+  values: {
+    CENTER: { value: sharp.gravity.center },
+    NORTH: { value: sharp.gravity.north },
+    NORTHEAST: { value: sharp.gravity.northeast },
+    EAST: { value: sharp.gravity.east },
+    SOUTHEAST: { value: sharp.gravity.southeast },
+    SOUTH: { value: sharp.gravity.south },
+    SOUTHWEST: { value: sharp.gravity.southwest },
+    WEST: { value: sharp.gravity.west },
+    NORTHWEST: { value: sharp.gravity.northwest },
+    ENTROPY: { value: sharp.strategy.entropy },
+    ATTENTION: { value: sharp.strategy.attention },
   },
 })
 
@@ -62,6 +81,10 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
           type: ImageFormatType,
           defaultValue: ``,
         },
+        cropFocus: {
+          type: ImageCropFocusType,
+          defaultValue: sharp.strategy.attention,
+        },
       },
       resolve(image, fieldArgs, context) {
         const promise = responsiveResolution({
@@ -100,6 +123,10 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
         toFormat: {
           type: ImageFormatType,
           defaultValue: ``,
+        },
+        cropFocus: {
+          type: ImageCropFocusType,
+          defaultValue: sharp.strategy.attention,
         },
       },
       resolve(image, fieldArgs, context) {
@@ -150,6 +177,10 @@ module.exports = ({ type, linkPrefix, getNodeAndSavePathDependency }) => {
         toFormat: {
           type: ImageFormatType,
           defaultValue: ``,
+        },
+        cropFocus: {
+          type: ImageCropFocusType,
+          defaultValue: sharp.strategy.attention,
         },
       },
       resolve(image, fieldArgs, context) {


### PR DESCRIPTION
I noticed that there was a difference in image cropping between base64 true/false, and found that one of them was using `sharp.strategy.attention`. I decided to set the default back to the sharp default (center) and expose all the different options in the API.

I also found that the force format fix from earlier today still had to be applied to the base64 part.