### PR TITLE
Fix typography styles for "image-processing" example build

### DIFF
--- a/examples/image-processing/src/html.js
+++ b/examples/image-processing/src/html.js
@@ -1,4 +1,7 @@
 import React from "react"
+import { TypographyStyle } from "react-typography"
+
+import typography from "./utils/typography"
 
 module.exports = React.createClass({
   render() {
@@ -19,6 +22,7 @@ module.exports = React.createClass({
             content="width=device-width, initial-scale=1.0"
           />
           <title>Gatsby - Image Processing</title>
+          <TypographyStyle typography={typography} />
         </head>
         <body>
           <div


### PR DESCRIPTION
I can't test this right now, still running into `UNHANDLED REJECTION TypeError: Cannot read property 'component' of undefined` – but should be OK ;)