### PR TITLE
include *.zip as static asset

### DIFF
--- a/lib/utils/post-build.js
+++ b/lib/utils/post-build.js
@@ -57,7 +57,7 @@ module.exports = (program, cb) => {
 
     // Copy static assets to public folder.
     const assetTypes =
-      '*.jpg|*.jpeg|*.png|*.pdf|*.gif|*.ico|*.svg|*.pdf|*.txt|CNAME'
+      '*.jpg|*.jpeg|*.png|*.pdf|*.gif|*.ico|*.svg|*.pdf|*.txt|*.zip|CNAME'
     const globString = `${directory}/pages/**/?(${assetTypes})`
     return glob(globString, { follow: true }, (e, files) =>
       async.map(


### PR DESCRIPTION
currently ZIP-files are not supported as a static asset in a pages folder.
 this PR aims to fix this.