### PR TITLE
Fix TravisCI by installing latest npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "4"
   - "6"
   - "7"
+  - "8"
 
 os: [linux, osx]
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "4"
   - "6"
-  - "7"
   - "8"
 
 os: [linux, osx]
@@ -17,7 +16,7 @@ cache:
     - $(npm config get cache)
 
 before_install:
-  - npm i -g npm@5
+  - npm i -g npm@latest
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
     - $(npm config get cache)
 
 before_install:
-  - npm i -g npm@latest
+  - npm i -g npm@5
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ os: [linux, osx]
 dist: trusty
 sudo: false
 
+cache:
+  directories:
+    - ~/.npm
+
 before_install:
   - npm i -g npm@5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: node_js
 node_js:
+  - "4"
   - "6"
   - "7"
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+
+os: [linux, osx]
+dist: trusty
+sudo: false
+
+before_install:
+  - npm i -g npm@5
+
+install:
+  - npm install
+
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ os: [linux, osx]
 dist: trusty
 sudo: required
 
+# by caching the npm local cache, instead of ./node_modules,
+# we theoretically avoid accidentally having npm keep around
+# old modules in the tree
 cache:
   directories:
-    - ~/.npm
+    - $(npm config get cache)
 
 before_install:
   - npm i -g npm@5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,8 @@ os: [linux, osx]
 dist: trusty
 sudo: required
 
-# by caching the npm local cache, instead of ./node_modules,
-# we theoretically avoid accidentally having npm keep around
-# old modules in the tree
-cache:
-  directories:
-    - $(npm config get cache)
-
 before_install:
-  - npm i -g npm@5
+  - npm i -g npm@latest
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 
 os: [linux, osx]
 dist: trusty
-sudo: false
+sudo: required
 
 cache:
   directories:


### PR DESCRIPTION
Closes https://github.com/gatsbyjs/gatsby/issues/984

I took a stab at cleaning up the 1.0 `.travis.yml`, and (if I install npm@5 first) everything passes properly.

I re-enabled mac builds, and put node@4 back in, too. (Here's an [example build](https://travis-ci.org/hawkrives/gatsby/builds/237372618), along with the [config](https://github.com/hawkrives/gatsby/blob/1.0/.travis.yml).)