### PR TITLE
[1.0] RFC - (WIP) Redirects example

### DIFF
--- a/examples/redirects/.eslintrc
+++ b/examples/redirects/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "graphql": false
+  }
+}

--- a/examples/redirects/README.md
+++ b/examples/redirects/README.md
@@ -1,0 +1,5 @@
+# Redirects
+
+https://redirects.gatsbyjs.org
+
+Gatsby example site that shows ability to render client-side redirects.

--- a/examples/redirects/gatsby-config.js
+++ b/examples/redirects/gatsby-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  siteMetadata: {
+    title: `Redirects`,
+  },
+}

--- a/examples/redirects/gatsby-config.js
+++ b/examples/redirects/gatsby-config.js
@@ -2,4 +2,5 @@ module.exports = {
   siteMetadata: {
     title: `Redirects`,
   },
+  plugins: [],
 }

--- a/examples/redirects/gatsby-node.js
+++ b/examples/redirects/gatsby-node.js
@@ -1,0 +1,19 @@
+const path = require(`path`)
+const Promise = require(`bluebird`)
+
+const RedirectPage = path.resolve(`src/components/RedirectPage.js`)
+
+exports.createPages = ({ boundActionCreators }) => {
+    const { upsertPage } = boundActionCreators
+
+    return new Promise((resolve, reject) => {
+        upsertPage({
+            path: `/redirect/`,
+            component: RedirectPage,
+            context: {
+                to: `/b/`,
+            },
+        })
+        resolve()
+    })
+}

--- a/examples/redirects/gatsby-node.js
+++ b/examples/redirects/gatsby-node.js
@@ -4,10 +4,10 @@ const Promise = require(`bluebird`)
 const RedirectPage = path.resolve(`src/components/RedirectPage.js`)
 
 exports.createPages = ({ boundActionCreators }) => {
-    const { upsertPage } = boundActionCreators
+    const { createPage } = boundActionCreators
 
     return new Promise((resolve, reject) => {
-        upsertPage({
+        createPage({
             path: `/redirect/`,
             component: RedirectPage,
             context: {

--- a/examples/redirects/package.json
+++ b/examples/redirects/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gatsby-example-redirects",
+  "private": true,
+  "description": "Gatsby example site that shows ability to render client-side redirects.",
+  "version": "1.0.0",
+  "author": "Scotty Eckenthal <scott.eckenthal@gmail.com>",
+  "dependencies": {
+    "gatsby": "canary",
+    "gatsby-link": "canary",
+    "lodash": "^4.16.4",
+    "slash": "^1.0.0"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build"
+  }
+}

--- a/examples/redirects/src/components/RedirectPage.js
+++ b/examples/redirects/src/components/RedirectPage.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Route, Redirect } from 'react-router'
+
+class RedirectPage extends React.Component {
+
+    componentDidMount() {
+        if (process.env.NODE_ENV === `production`) {
+            window.___navigateTo(`/b/`)
+        }
+    }
+
+    render() {
+        return (
+            <Route
+                path="*"
+                render={() => <Redirect to={`/b/`} />}
+            />
+        )
+    }
+}
+
+export default RedirectPage

--- a/examples/redirects/src/html.js
+++ b/examples/redirects/src/html.js
@@ -1,0 +1,33 @@
+import React from "react"
+
+module.exports = React.createClass({
+  render() {
+    return (
+      <html op="news" lang="en">
+        <head>
+          {this.props.headComponents}
+
+          <meta name="referrer" content="origin" />
+          <meta charSet="utf-8" />
+          <meta
+            name="description"
+            content="Gatsby example site showing use with no plugins"
+          />
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0"
+          />
+          <title>Gatsby - Redirects</title>
+        </head>
+        <body>
+          <div
+            id="___gatsby"
+            dangerouslySetInnerHTML={{ __html: this.props.body }}
+          />
+          {this.props.postBodyComponents}
+        </body>
+      </html>
+    )
+  },
+})

--- a/examples/redirects/src/layouts/index.js
+++ b/examples/redirects/src/layouts/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import Link from 'gatsby-link'
+
+class DefaultLayout extends React.Component {
+  render() {
+    return (
+      <div>
+        <Link to="/">
+          <h3>
+            Example showing redirects
+          </h3>
+          <p>Navigate to <Link to="/redirect/">/redirect</Link>. It should redirect you :).</p>
+        </Link>
+        <ul>
+          <li><Link to="/a/">a</Link></li>
+          <li><Link to="/b/">b</Link></li>
+          <li><Link to="/c/">c</Link></li>
+        </ul>
+        {this.props.children()}
+      </div>
+    )
+  }
+}
+
+export default DefaultLayout

--- a/examples/redirects/src/layouts/index.js
+++ b/examples/redirects/src/layouts/index.js
@@ -9,8 +9,8 @@ class DefaultLayout extends React.Component {
           <h3>
             Example showing redirects
           </h3>
-          <p>Navigate to <Link to="/redirect/">/redirect</Link>. It should redirect you :).</p>
         </Link>
+        <p>Navigate to <Link to="/redirect/">/redirect</Link>. It should redirect you :).</p>
         <ul>
           <li><Link to="/a/">a</Link></li>
           <li><Link to="/b/">b</Link></li>

--- a/examples/redirects/src/pages/a.js
+++ b/examples/redirects/src/pages/a.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const A = () => <p>A</p>
+
+export default A

--- a/examples/redirects/src/pages/b.js
+++ b/examples/redirects/src/pages/b.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const B = () => <p>B</p>
+
+export default B

--- a/examples/redirects/src/pages/c.js
+++ b/examples/redirects/src/pages/c.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const C = () => <p>C</p>
+
+export default C

--- a/examples/redirects/src/pages/index.js
+++ b/examples/redirects/src/pages/index.js
@@ -1,0 +1,5 @@
+import React from "react"
+
+const Home = () => <p>Home</p>
+
+export default Home

--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -144,11 +144,12 @@ module.exports = (locals, callback) => {
   ]
   dascripts.forEach(script => {
     const fetchKey = `assetsByChunkName[${script}]`
-    let prefixedScript = `${linkPrefix}${get(stats, fetchKey, ``)}`
 
+    let fetchedScript = get(stats, fetchKey)
     // If sourcemaps are enabled, then the entry will be an array with
     // the script name as the first entry.
-    prefixedScript = isArray(prefixedScript) ? prefixedScript[0] : prefixedScript
+    fetchedScript = isArray(fetchedScript) ? fetchedScript[0] : fetchedScript
+    const prefixedScript = `${linkPrefix}${fetchedScript}`
 
       // If sourcemaps are enabled, then the entry will be an array with
       // the script name as the first entry.

--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -141,14 +141,9 @@ module.exports = (locals, callback) => {
     pathChunkName(locals.path),
     pages.find(page => page.path === locals.path).componentChunkName,
   ]
-    .map(s => {
-      const fetchKey = `assetsByChunkName[${s}]`
-
-      let fetchedScript = get(stats, fetchKey)
-
-      if (!fetchedScript) {
-        return null
-      }
+  dascripts.forEach(script => {
+    const fetchKey = `assetsByChunkName[${script}]`
+    const prefixedScript = `${linkPrefix}${get(stats, fetchKey, ``)}`
 
       // If sourcemaps are enabled, then the entry will be an array with
       // the script name as the first entry.

--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -1,7 +1,8 @@
 import React from "react"
 import { renderToString, renderToStaticMarkup } from "react-dom/server"
 import { StaticRouter, Route, withRouter } from "react-router-dom"
-import { kebabCase, get, merge, isArray, isString } from "lodash"
+import Html from "../src/html"
+import { kebabCase, get, merge, isArray } from "lodash"
 import apiRunner from "./api-runner-ssr"
 import pages from "./pages.json"
 import syncRequires from "./sync-requires"
@@ -143,7 +144,11 @@ module.exports = (locals, callback) => {
   ]
   dascripts.forEach(script => {
     const fetchKey = `assetsByChunkName[${script}]`
-    const prefixedScript = `${linkPrefix}${get(stats, fetchKey, ``)}`
+    let prefixedScript = `${linkPrefix}${get(stats, fetchKey, ``)}`
+
+    // If sourcemaps are enabled, then the entry will be an array with
+    // the script name as the first entry.
+    prefixedScript = isArray(prefixedScript) ? prefixedScript[0] : prefixedScript
 
       // If sourcemaps are enabled, then the entry will be an array with
       // the script name as the first entry.


### PR DESCRIPTION
_WIP - DO NOT MERGE_

POC of client-side redirects in gatsby. I plan to eventually pull this out into a plugin as well.

Currently, if I navigate directly to `/redirect/`, the following error is thrown:

![gatsby_-_redirects](https://cloud.githubusercontent.com/assets/3766777/26606014/402d21bc-455e-11e7-89ad-3cdc1229080f.jpg)

Note that this only occurs in a built instance and not in a dev server.