### PR TITLE
[1.0] Fix feed example readme

### DIFF
--- a/examples/feed/README.md
+++ b/examples/feed/README.md
@@ -1,5 +1,5 @@
-# No plugins
+# RSS Feed Example
 
-https://no-plugins.gatsbyjs.org
+https://feed.gatsbyjs.org
 
-Gatsby example site that proves functionality without the use of plugins.
+Gatsby example site demonstrating how to use the RSS Feed generator plugin.


### PR DESCRIPTION
I accidentally committed the wrong README. This should fix it, and add documentation for the RSS feed example site.