### PR TITLE
[1.0] Fix for gatsby develop hiccuping on gatsby-ssr.js using `import`

### DIFF
--- a/examples/redux/gatsby-ssr.js
+++ b/examples/redux/gatsby-ssr.js
@@ -1,20 +1,16 @@
 import React from 'react'
-import { renderToString } from 'react-dom/server'
 import { Provider } from 'react-redux'
 
 import createStore from './src/state/createStore'
 
-exports.replaceServerBodyRender = ({ component: body }) => {
+exports.replaceRenderer = ({ bodyComponent, replaceBodyHTMLString }) => {
 
     const store = createStore()
 
     const ConnectedBody = () => (
         <Provider store={store}>
-            {body}
+            {bodyComponent}
         </Provider>
     )
-
-    return {
-        body: renderToString(<ConnectedBody/>),
-    }
+    replaceBodyHTMLString(<ConnectedBody/>)
 }

--- a/examples/redux/package.json
+++ b/examples/redux/package.json
@@ -5,8 +5,8 @@
   "version": "1.0.0",
   "author": "Scotty Eckenthal <scott.eckenthal@gmail.com>",
   "dependencies": {
-    "gatsby": "1.0.0-alpha15-alpha.330d917d",
-    "gatsby-link": "1.0.0-alpha15-alpha.330d917d",
+    "gatsby": "canary",
+    "gatsby-link": "canary",
     "lodash": "^4.16.4",
     "react-redux": "5.0.5",
     "react-router-redux": "4.0.8",
@@ -20,6 +20,7 @@
   "main": "n/a",
   "scripts": {
     "develop": "gatsby develop",
-    "build": "gatsby build"
+    "build": "gatsby build",
+    "serve": "gatsby serve"
   }
 }

--- a/packages/gatsby/src/utils/develop.js
+++ b/packages/gatsby/src/utils/develop.js
@@ -100,28 +100,9 @@ async function startServer(program) {
           return res.send(htmlStr)
         } else {
           try {
-            const apiRunner = require(`${directory}/.cache/api-runner-ssr`)
-
             let headComponents = []
             let postBodyComponents = []
             let bodyProps = {}
-
-            const setHeadComponents = components => {
-              headComponents = headComponents.concat(components)
-            }
-
-            const setPostBodyComponents = components => {
-              postBodyComponents = postBodyComponents.concat(components)
-            }
-
-            const setBodyProps = props => {
-              bodyProps = _.merge({}, bodyProps, props)
-            }
-            apiRunner(`onRenderBody`, {
-              setHeadComponents,
-              setPostBodyComponents,
-              setBodyProps,
-            })
 
             const htmlElement = React.createElement(HTML, {
               ...bodyProps,


### PR DESCRIPTION
@KyleAMathews this doesn't feel right given what you wrote in [PR 1081](https://github.com/gatsbyjs/gatsby/pull/1081#issuecomment-306925029) but I wasn't sure how to apply your comment. This workaround seems to work, but I'm not sure if it has downstream effects. Still acquainting myself with the code but thought I'd put this for review to get more ideas / feedback and collaborate on this issue.

The issue, to restate it, is when using ES6 features that require webpack like `import` in `gatsby-ssr.js` then running `gatsby develop` dies a quick death.

```
(function (exports, require, module, __filename, __dirname) { import React from 'react'
                                                              ^^^^^^
SyntaxError: Unexpected token import
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/mericsson/dev/gatsby-using-redux/.cache/api-runner-ssr.js:2:15)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
```

Appreciate any help to dig into this. Thanks!