### PR TITLE
[1.0] examples/redux use latest Gatsby APIs

### DIFF
--- a/examples/redux/gatsby-ssr.js
+++ b/examples/redux/gatsby-ssr.js
@@ -1,20 +1,16 @@
 import React from 'react'
-import { renderToString } from 'react-dom/server'
 import { Provider } from 'react-redux'
 
 import createStore from './src/state/createStore'
 
-exports.replaceServerBodyRender = ({ component: body }) => {
+exports.replaceRenderer = ({ bodyComponent, replaceBodyHTMLString }) => {
 
     const store = createStore()
 
     const ConnectedBody = () => (
         <Provider store={store}>
-            {body}
+            {bodyComponent}
         </Provider>
     )
-
-    return {
-        body: renderToString(<ConnectedBody/>),
-    }
+    replaceBodyHTMLString(<ConnectedBody/>)
 }

--- a/examples/redux/package.json
+++ b/examples/redux/package.json
@@ -5,8 +5,8 @@
   "version": "1.0.0",
   "author": "Scotty Eckenthal <scott.eckenthal@gmail.com>",
   "dependencies": {
-    "gatsby": "1.0.0-alpha15-alpha.330d917d",
-    "gatsby-link": "1.0.0-alpha15-alpha.330d917d",
+    "gatsby": "canary",
+    "gatsby-link": "canary",
     "lodash": "^4.16.4",
     "react-redux": "5.0.5",
     "react-router-redux": "4.0.8",
@@ -20,6 +20,7 @@
   "main": "n/a",
   "scripts": {
     "develop": "gatsby develop",
-    "build": "gatsby build"
+    "build": "gatsby build",
+    "serve": "gatsby serve"
   }
 }


### PR DESCRIPTION
Small changes to update examples/redux to use the latest Gatsby APIs.