### PR TITLE
Add icons to gatsby-plugin-manifest example options

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -34,9 +34,9 @@ plugins: [
       display: "minimal-ui",
       icons: [
         {
-          // Everything in /src/static will be copied to an equivalent
+          // Everything in /static will be copied to an equivalent
           // directory in /public during development and build, so
-          // assuming your favicons are in /src/static/favicons,
+          // assuming your favicons are in /static/favicons,
           // you can reference them here
           src: `/favicons/android-chrome-192x192.png`,
           sizes: `192x192`,
@@ -52,4 +52,3 @@ plugins: [
   },
 ]
 ```
-

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -26,12 +26,28 @@ plugins: [
   {
     resolve: `gatsby-plugin-manifest`,
     options: {
-      "name": "GatsbyJS",
-      "short_name": "GatsbyJS",
-      "start_url": "/",
-      "background_color": "#f7f0eb",
-      "theme_color": "#a2466c",
-      "display": "minimal-ui",
+      name: "GatsbyJS",
+      short_name: "GatsbyJS",
+      start_url: "/",
+      background_color: "#f7f0eb",
+      theme_color: "#a2466c",
+      display: "minimal-ui",
+      icons: [
+        {
+          // Everything in /src/static will be copied to an equivalent
+          // directory in /public during development and build, so
+          // assuming your favicons are in /src/static/favicons,
+          // you can reference them here
+          src: `/favicons/android-chrome-192x192.png`,
+          sizes: `192x192`,
+          type: `image/png`,
+        },
+        {
+          src: `/favicons/android-chrome-512x512.png`,
+          sizes: `512x512`,
+          type: `image/png`,
+        },
+      ],
     },
   },
 ]


### PR DESCRIPTION
Also mention the ['static' directory](https://github.com/gatsbyjs/gatsby/pull/956).