### PR TITLE
[1.0] Ignore SVGs in gatsby-remark-responsive-image (#1145)

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -44,9 +44,12 @@ module.exports = ({ files, markdownNode, markdownAST, getNode }) => {
     visitor(link)
   })
 
-  // Also copy gifs since Sharp can't process them.
+  // Also copy gifs since Sharp can't process them,
+  // and svgs since we exclude them from the image processing pipeline in
+  // gatsby-remark-responsive-image
   visit(markdownAST, `image`, image => {
-    if (image.url.slice(-3) === `gif`) {
+    const fileType = image.url.slice(-3)
+    if (fileType === `gif` || fileType === `svg`) {
       visitor(image)
     }
   })

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -48,8 +48,14 @@ module.exports = ({ files, markdownNode, markdownAST, getNode }) => {
   // and svgs since we exclude them from the image processing pipeline in
   // gatsby-remark-responsive-image
   visit(markdownAST, `image`, image => {
-    const fileType = image.url.slice(-3)
-    if (fileType === `gif` || fileType === `svg`) {
+    const imagePath = path.join(getNode(markdownNode.parent).dir, image.url)
+    const imageNode = _.find(files, file => {
+      if (file && file.absolutePath) {
+        return file.absolutePath === imagePath
+      }
+      return null
+    })
+    if (imageNode.extension === `gif` || imageNode.extension === `svg`) {
       visitor(image)
     }
   })

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -23,10 +23,10 @@ module.exports = ({ files, markdownNode, markdownAST, getNode }) => {
         const newPath = path.join(
           process.cwd(),
           `public`,
-          `${linkNode.contentDigest}.${linkNode.extension}`
+          `${linkNode.internal.contentDigest}.${linkNode.extension}`
         )
         const relativePath = path.join(
-          `/${linkNode.contentDigest}.${linkNode.extension}`
+          `/${linkNode.internal.contentDigest}.${linkNode.extension}`
         )
         link.url = `${relativePath}`
         if (!fsExtra.existsSync(newPath)) {

--- a/packages/gatsby-remark-responsive-image/src/index.js
+++ b/packages/gatsby-remark-responsive-image/src/index.js
@@ -31,8 +31,15 @@ module.exports = ({
     imageNodes.map(
       node =>
         new Promise((resolve, reject) => {
-          // Ignore gifs as we can't process them.
-          if (isRelativeUrl(node.url) && node.url.slice(-3) !== `gif`) {
+          const fileType = node.url.slice(-3)
+
+          // Ignore gifs as we can't process them,
+          // svgs as they are already responsive by definition
+          if (
+            isRelativeUrl(node.url) &&
+            fileType !== `gif` &&
+            fileType !== `svg`
+          ) {
             const imagePath = path.posix.join(
               getNode(markdownNode.parent).dir,
               node.url


### PR DESCRIPTION
…and instead just copy them alongside GIFs in gatsby-remark-copy-linked-files.

WIP, currently all SVGs get copied to `public` as `undefined.svg` :D