### PR TITLE
[1.0] Use pure function to build RSS feed config

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -1,4 +1,5 @@
 import path from "path"
+import RSS from "RSS"
 import { defaultOptions, runQuery, writeFile } from "./internals"
 
 const publicPath = `./public`
@@ -37,7 +38,7 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
 
     const output = path.join(publicPath, f.output)
     const ctx = { ...globals, ...locals }
-    const feed = setup({ ...rest, ...ctx })
+    const feed = new RSS(setup({ ...rest, ...ctx }))
     const items = f.serialize ? f.serialize(ctx) : serialize(ctx)
 
     items.forEach(i => feed.item(i))

--- a/packages/gatsby-plugin-feed/src/internals.js
+++ b/packages/gatsby-plugin-feed/src/internals.js
@@ -1,5 +1,4 @@
 import fs from "fs"
-import RSS from "rss"
 import pify from "pify"
 
 export const writeFile = pify(fs.writeFile)
@@ -31,8 +30,9 @@ export const defaultOptions = {
   `,
 
   // Setup a few RSS object, merging on various feed-speciupfic options.
-  setup: ({ site: { siteMetadata }, ...rest }) =>
-    new RSS({ ...siteMetadata, ...rest }),
+  setup: ({ site: { siteMetadata }, ...rest }) => ({
+    ...siteMetadata, ...rest
+  }),
 
   // Create a default RSS feed. Others may be added by using the format below.
   feeds: [


### PR DESCRIPTION
I prefer to keep config functions pure.

The original API contained a mistake I uncovered while building more complex sites (with multiple feeds), and this PR corrects it. Every `feed` object should create its own `RSS` instance.