### PR TITLE
[1.0] gatsby-plugin-feed .gitignore

### DIFF
--- a/packages/gatsby-plugin-feed/.gitignore
+++ b/packages/gatsby-plugin-feed/.gitignore
@@ -1,0 +1,2 @@
+/*.js
+!index.js


### PR DESCRIPTION
gatsby-plugin-feed missing its .gitignore

Files such as: gatsby-node.js, gatsby-ssr.js, and internals.js were being picked up by git locally when gatsby was built locally.