### PR TITLE
gatsby-remark-responsive-image: fix misaligned images

### DIFF
--- a/packages/gatsby-remark-responsive-image/src/index.js
+++ b/packages/gatsby-remark-responsive-image/src/index.js
@@ -87,7 +87,7 @@ module.exports = (
               >
                 <img
                   class="gatsby-resp-image-image"
-                  style="width: 100%; margin: 0; vertical-align: middle; position: absolute; box-shadow: inset 0px 0px 0px 400px ${options.backgroundColor};"
+                  style="width: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px ${options.backgroundColor};"
                   alt="${node.alt ? node.alt : ``}"
                   title="${node.title ? node.title : ``}"
                   src="${fallbackSrc}"


### PR DESCRIPTION
Looks like this without it:

![image](https://user-images.githubusercontent.com/74385/27252980-4d28a100-539d-11e7-81ff-b85219111f50.png)
