### PR TITLE
[1.0] Reduce font-size of the mobile menu labels

### DIFF
--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -277,7 +277,7 @@ module.exports = React.createClass({
         </div>
         <div
           css={{
-            ...scale(-1 / 5),
+            ...scale(-2 / 5),
             position: `fixed`,
             display: `flex`,
             justifyContent: `space-around`,
@@ -307,7 +307,7 @@ module.exports = React.createClass({
           >
             <DocumentIcon
               css={{
-                fontSize: rhythm(1),
+                fontSize: rhythm(0.9),
               }}
             />
             <div>
@@ -381,7 +381,7 @@ module.exports = React.createClass({
           >
             <PencilIcon
               css={{
-                fontSize: rhythm(1),
+                fontSize: rhythm(0.9),
               }}
             />
             <div>


### PR DESCRIPTION
… to take away a little of the overall visual weight of the mobile nav.
Icon labels are still readable and IMO feel much better especially on small devices.

Also slightly reduce size of the icons for "Docs" and "Blog" to provide a little more consistency in visual weight/proportion across mobile menu icons.

After/before (note that the screenshot is taken on a HiDPI display and is downsized here on GitHub; also can't figure out how to post images without them being blown up to the full width of the content, so…):

![image](https://user-images.githubusercontent.com/21834/27257459-c483c0ce-53d7-11e7-8384-5a918db89644.png)
