### PR TITLE
minor fix in gatsby-source-contentful and examples/using-contentful fixes

### DIFF
--- a/examples/using-contentful/gatsby-config.js
+++ b/examples/using-contentful/gatsby-config.js
@@ -10,5 +10,6 @@ module.exports = {
         accessToken: `e481b0f7c5572374474b29f81a91e8ac487bb27d70a6f14dd12142837d8e980a`,
       },
     },
+    `gatsby-transformer-remark`,
   ],
 }

--- a/examples/using-contentful/package.json
+++ b/examples/using-contentful/package.json
@@ -10,6 +10,7 @@
     "gatsby-plugin-google-analytics": "next",
     "gatsby-plugin-offline": "next",
     "gatsby-source-contentful": "next",
+    "gatsby-transformer-remark": "next",
     "lodash": "^4.16.4",
     "react-typography": "^0.15.0",
     "slash": "^1.0.0",
@@ -22,8 +23,8 @@
   "license": "MIT",
   "main": "n/a",
   "scripts": {
-    "dev": "gatsby develop",
+    "develop": "gatsby develop",
     "build": "gatsby build",
-    "start": "gatsby serve-build"
+    "start": "gatsby serve"
   }
 }

--- a/examples/using-contentful/src/pages/index.js
+++ b/examples/using-contentful/src/pages/index.js
@@ -16,7 +16,12 @@ class IndexPage extends React.Component {
           return (
             <div key={product.id}>
               <Link to={`/products/${product.id}/`}>
-                <h4>{product.productName}</h4>
+                <h4>
+                  {
+                    product.childContentfulProductProductNameTextNode
+                      .productName
+                  }
+                </h4>
                 {product.image[0].file.url &&
                   <img src={product.image[0].file.url} />}
               </Link>
@@ -38,7 +43,7 @@ query PageQuery {
     edges {
       node {
         id
-        productName
+        childContentfulProductProductNameTextNode { productName }
         image {
           file {
             url

--- a/examples/using-contentful/src/templates/category.js
+++ b/examples/using-contentful/src/templates/category.js
@@ -11,7 +11,8 @@ const propTypes = {
 class CategoryTemplate extends React.Component {
   render() {
     const category = this.props.data.contentfulCategory
-    const { title, product, icon } = category
+    const { childContentfulCategoryTitleTextNode, product, icon } = category
+    const { title } = childContentfulCategoryTitleTextNode
     const imageUrl = icon.file.url
     return (
       <div>
@@ -39,7 +40,9 @@ class CategoryTemplate extends React.Component {
             {product &&
               product.map((p, i) =>
                 <li key={i}>
-                  <Link to={`/products/${p.id}`}>{p.productName}</Link>
+                  <Link to={`/products/${p.id}`}>
+                    {p.childContentfulProductProductNameTextNode.productName}
+                  </Link>
                 </li>
               )}
           </ul>
@@ -56,7 +59,7 @@ export default CategoryTemplate
 export const pageQuery = graphql`
   query categoryQuery($id: String!) {
     contentfulCategory(id: { eq: $id }) {
-      title
+      childContentfulCategoryTitleTextNode { title }
       icon {
         file {
           url
@@ -64,7 +67,7 @@ export const pageQuery = graphql`
       }
       product {
         id
-        productName
+        childContentfulProductProductNameTextNode { productName }
       }
     }
   }

--- a/examples/using-contentful/src/templates/product.js
+++ b/examples/using-contentful/src/templates/product.js
@@ -20,9 +20,6 @@ class ProductTemplate extends React.Component {
       categories,
     } = product
     const { productName } = childContentfulProductProductNameTextNode
-    const {
-      productDescription,
-    } = childContentfulProductProductDescriptionTextNode
     return (
       <div>
         <div style={{ display: `flex`, marginBottom: rhythm(1 / 2) }}>
@@ -48,7 +45,13 @@ class ProductTemplate extends React.Component {
         </h4>
         <div>
           <span>Price: ${price}</span>
-          <div dangerouslySetInnerHTML={{ __html: productDescription }} />
+          <div
+            dangerouslySetInnerHTML={{
+              __html:
+                childContentfulProductProductDescriptionTextNode
+                  .childMarkdownRemark.html,
+            }}
+          />
           <div>
             <span>See other: </span>
             <ul>
@@ -75,7 +78,11 @@ export const pageQuery = graphql`
   query productQuery($id: String!) {
     contentfulProduct(id: { eq: $id }) {
       childContentfulProductProductNameTextNode { productName }
-      childContentfulProductProductDescriptionTextNode { productDescription }
+      childContentfulProductProductDescriptionTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
       price
       image {
         file {

--- a/examples/using-contentful/src/templates/product.js
+++ b/examples/using-contentful/src/templates/product.js
@@ -12,13 +12,17 @@ class ProductTemplate extends React.Component {
   render() {
     const product = this.props.data.contentfulProduct
     const {
-      productName,
-      productDescription,
+      childContentfulProductProductNameTextNode,
+      childContentfulProductProductDescriptionTextNode,
       price,
       image,
       brand,
       categories,
     } = product
+    const { productName } = childContentfulProductProductNameTextNode
+    const {
+      productDescription,
+    } = childContentfulProductProductDescriptionTextNode
     return (
       <div>
         <div style={{ display: `flex`, marginBottom: rhythm(1 / 2) }}>
@@ -39,7 +43,9 @@ class ProductTemplate extends React.Component {
           </div>
         </div>
         <h1>{productName}</h1>
-        <h4>Made by {brand.companyName}</h4>
+        <h4>
+          Made by {brand.childContentfulBrandCompanyNameTextNode.companyName}
+        </h4>
         <div>
           <span>Price: ${price}</span>
           <div dangerouslySetInnerHTML={{ __html: productDescription }} />
@@ -49,7 +55,7 @@ class ProductTemplate extends React.Component {
               {categories.map((category, i) =>
                 <li key={i}>
                   <Link key={i} to={`/categories/${category.id}`}>
-                    {category.title}
+                    {category.childContentfulCategoryTitleTextNode.title}
                   </Link>
                 </li>
               )}
@@ -68,8 +74,8 @@ export default ProductTemplate
 export const pageQuery = graphql`
   query productQuery($id: String!) {
     contentfulProduct(id: { eq: $id }) {
-      productName
-      productDescription
+      childContentfulProductProductNameTextNode { productName }
+      childContentfulProductProductDescriptionTextNode { productDescription }
       price
       image {
         file {
@@ -77,11 +83,11 @@ export const pageQuery = graphql`
         }
       }
       brand {
-        companyName
+        childContentfulBrandCompanyNameTextNode { companyName }
       }
       categories {
         id
-        title
+        childContentfulCategoryTitleTextNode { title }
       }
     }
   }

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -251,7 +251,10 @@ exports.sourceNodes = async (
         }
 
         const fieldType = contentTypeItem.fields.find(
-          f => f.id === entryItemFieldKey
+          f =>
+            (restrictedNodeFields.includes(f.id)
+              ? `${conflictFieldPrefix}${f.id}`
+              : f.id) === entryItemFieldKey
         ).type
         if (fieldType === `Text`) {
           entryItemFields[`${entryItemFieldKey}___NODE`] = createTextNode(

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -276,8 +276,6 @@ exports.sourceNodes = async (
     })
 
     // Create a node for each content type
-    const contentTypeItemStr = stringify(contentTypeItem)
-
     const contentTypeNode = {
       id: contentTypeItemId,
       parent: `__SOURCE__`,
@@ -304,8 +302,6 @@ exports.sourceNodes = async (
 
   assets.items.forEach(assetItem => {
     // Create a node for each asset. They may be referenced by Entries
-    const assetItemStr = stringify(assetItem)
-
     const assetNode = {
       id: assetItem.sys.id,
       parent: `__SOURCE__`,


### PR DESCRIPTION
Minor fix is handling conflicting fields between gatsby & contentful with the new TextNode generation.

Otherwise just improvements to using-contentful. After including gatsby-transformer-remark can do fun things like use the HTML from contentful product description:

![image](https://user-images.githubusercontent.com/36717/27399474-bf60a93a-5671-11e7-9983-0b855444299e.png)
