### PR TITLE
Open external image link with rel='noopener'

### DIFF
--- a/packages/gatsby-remark-responsive-image/src/index.js
+++ b/packages/gatsby-remark-responsive-image/src/index.js
@@ -76,6 +76,7 @@ module.exports = (
             href="${originalImg}"
             style="display: block"
             target="_blank"
+            rel="noopener"
           >
             <span
               class="gatsby-resp-image-wrapper"


### PR DESCRIPTION
Open new tabs using `rel="noopener"` to improve performance and prevent security vulnerabilities.

Reference:
https://developers.google.com/web/tools/lighthouse/audits/noopener