### PR TITLE
Update index.d.ts

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -5,4 +5,4 @@ export interface GatsbyLinkProps {
   onClick?: (event: any) => void
 }
 
-export default class GatbyLink extends React.Component<GatsbyLinkProps, void>;
+export default class GatsbyLink extends React.Component<GatsbyLinkProps, void> { }


### PR DESCRIPTION
Fix Typing for gatsby-link. The .d.ts file mustn't include a semicolon after the expression and has to include the empty `{}`. Otherwise you get a TS1005 error. Tested with `ts 2.2.1`.

This is an example of the `react-router` typings: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-router/index.d.ts#L40