### PR TITLE
add friendly webpack ouput

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -41,6 +41,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "flat": "^2.0.1",
+    "friendly-errors-webpack-plugin": "^1.6.1",
     "front-matter": "^2.1.0",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.1",
@@ -146,6 +147,6 @@
     "build:cli": "babel src/gatsby-cli.js --out-file dist/gatsby-cli.js --presets es2015",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
-    "watch": "rimraf dist && npm run build:src -- --watch && npm run build:internal-plugins && npm run build:rawfiles"
+    "watch": "rimraf dist && mkdir dist && npm run build:cli && npm run build:src -- --watch && npm run build:internal-plugins && npm run build:rawfiles"
   }
 }

--- a/packages/gatsby/src/utils/develop.js
+++ b/packages/gatsby/src/utils/develop.js
@@ -79,7 +79,7 @@ async function startServer(program) {
     const app = express()
     app.use(
       require(`webpack-hot-middleware`)(compiler, {
-        log: console.log,
+        log: () => {},
         path: `/__webpack_hmr`,
         heartbeat: 10 * 1000,
       })
@@ -143,9 +143,11 @@ async function startServer(program) {
         return next()
       }
     })
+
     app.use(
       require(`webpack-dev-middleware`)(compiler, {
         noInfo: true,
+        quiet: true,
         publicPath: devConfig.output.publicPath,
       })
     )
@@ -190,14 +192,6 @@ async function startServer(program) {
         const host = listener.address().address === `127.0.0.1`
           ? `localhost`
           : listener.address().address
-        console.log(
-          `
-The development server is listening at: http://${host}:${listener.address()
-            .port}
-GraphiQL can be accessed at: http://${host}:${listener.address()
-            .port}/___graphql
-          `
-        )
       }
     })
   })

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -6,6 +6,8 @@ import Config from "webpack-configurator"
 import ExtractTextPlugin from "extract-text-webpack-plugin"
 import StaticSiteGeneratorPlugin from "static-site-generator-webpack-plugin"
 import { StatsWriterPlugin } from "webpack-stats-plugin"
+import FriendlyErrorsWebpackPlugin from 'friendly-errors-webpack-plugin'
+
 // This isn't working right it seems.
 // import WebpackStableModuleIdAndHash from 'webpack-stable-module-id-and-hash'
 
@@ -135,6 +137,14 @@ module.exports = async (
           // the numerical IDs aren't useful. In production we use numerical module
           // ids to reduce filesize.
           new webpack.NamedModulesPlugin(),
+          new FriendlyErrorsWebpackPlugin({
+            compilationSuccessInfo: {
+              messages: [
+                `Your site is running at http://localhost:${program.port}`,
+                `Your graphql debugger is running at http://localhost:${program.port}/___graphql`
+              ]
+            }
+          })
         ]
       case `build-css`:
         return [


### PR DESCRIPTION
Connects to https://github.com/gatsbyjs/gatsby/issues/1231. 

<img width="362" alt="screen shot 2017-06-23 at 11 42 31" src="https://user-images.githubusercontent.com/9499917/27479211-dea40374-580a-11e7-902c-db5c59108f3a.png">
<img width="531" alt="screen shot 2017-06-23 at 11 40 03" src="https://user-images.githubusercontent.com/9499917/27479212-dea80438-580a-11e7-9040-c1215e4f7d8e.png">

I had some troubles getting the dev up and running because the `build:cli` cmd never ran on `npm watch`. Maybe I was doing something wrong, but I've committed my fix for that too, maybe not be the best approach.