### PR TITLE
[1.0] Fix babel compilation so targets uglify

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,8 @@
       "env",
       {
         "targets": {
-          "node": 4.0
+          "node": 4.0,
+          "uglify": true,
         }
       }
     ],


### PR DESCRIPTION
Targeting Node 4 causes trouble with Uglify as it leaves some >ES5 code uncompiled
e.g. template literals (back ticks).

Adding Uglify as a target fixes this.