### PR TITLE
[1.0] using-remark fixes

### DIFF
--- a/examples/using-remark/src/pages/2016-04-15---hello-world-kitchen-sink/index.md
+++ b/examples/using-remark/src/pages/2016-04-15---hello-world-kitchen-sink/index.md
@@ -288,7 +288,7 @@ Quote break.
 
 You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
 
-```no-highlight
+```html
 <dl>
   <dt>Definition list</dt>
   <dd>Is something people use sometimes.</dd>

--- a/examples/using-remark/src/pages/2017-01-02---responsive-images-and-iframes/index.md
+++ b/examples/using-remark/src/pages/2017-01-02---responsive-images-and-iframes/index.md
@@ -19,8 +19,8 @@ are here to take care of all your basic Markdown image and iframe issues.
 ## Images
 
 [gatsby-remark-responsive-image][1] provides _out-of-the-box progressive image
-loading_ for all local JPGs and PNGs in your Markdown documents as popularized
-by [Medium][3] and [Facebook][4].
+loading_ (as popularized by [Medium][3] and [Facebook][4]) for all local JPGs
+and PNGs in your Markdown documents.
 
 Let's see some more photos by [Max Boettinger](https://unsplash.com/@maxboettinger) ([I](https://unsplash.com/photos/T7Lnl3PFISM), [II](https://unsplash.com/@maxboettinger?photo=SUFS6CPjB5Q)):
 
@@ -28,10 +28,12 @@ Let's see some more photos by [Max Boettinger](https://unsplash.com/@maxboetting
 
 ![](max-boettinger-288448.jpg)
 
-Okay, nice! But what about GIFs?
+### Okay, nice! But what about GIFs?
+
 Sadly, [Sharp](https://github.com/lovell/sharp) – the library that does the
-actual image processing for us – is not able to write out the GIF file format.
-We will just copy them over for you, instead:
+actual image processing for us in [gatsby-plugin-sharp][5] – is not able to
+write out the GIF file format. We will just copy them over for you, instead,
+and also do that with SVGs.
 
 An animated GIF of the Select2 Logo: ![Select2 Logo animation](select2-logo.gif)
 
@@ -51,3 +53,4 @@ Let's add a YouTube video to show off responsive iFrames real quick:
 [2]: https://www.gatsbyjs.org/docs/packages/gatsby-remark-responsive-iframe/
 [3]: https://jmperezperez.com/medium-image-progressive-loading-placeholder/
 [4]: https://code.facebook.com/posts/991252547593574/the-technology-behind-preview-photos/
+[5]: https://www.gatsbyjs.org/docs/packages/gatsby-plugin-sharp/

--- a/examples/using-remark/src/utils/typography.js
+++ b/examples/using-remark/src/utils/typography.js
@@ -92,6 +92,7 @@ const options = {
         display: `block`,
         textAlign: `right`,
         marginTop: rhythm(2 / 4),
+        marginBottom: rhythm(1),
         color: `${colors.light}`,
       },
       // code highlighting

--- a/examples/using-remark/src/utils/typography.js
+++ b/examples/using-remark/src/utils/typography.js
@@ -106,6 +106,16 @@ const options = {
         backgroundColor: `#fef9ec`,
         borderRadius: `2px`,
       },
+      // Add space before and after code/tt elements.
+      // @see https://github.com/KyleAMathews/typography.js/blob/66f78f0f4b8d2c5abf0262bcc1118610139c3b5f/packages/typography-plugin-code/src/index.js#L38-L46
+      "code:before,code:after,tt:before,tt:after": {
+        letterSpacing: `-0.2em`,
+        content: `"\u00A0"`,
+      },
+      // But don't add spaces if the code is inside a pre.
+      "pre code:before,pre code:after,pre tt:before,pre tt:after": {
+        content: `""`,
+      },
       ".gatsby-highlight": {
         backgroundColor: `#fef9ec`,
         borderRadius: `.15rem`,

--- a/examples/using-remark/src/utils/typography.js
+++ b/examples/using-remark/src/utils/typography.js
@@ -64,11 +64,13 @@ const options = {
         background: `${colors.smoke}`,
         height: `2px`,
       },
-      // style gatsby-remark-responsive-image images
+      // Style gatsby-remark-responsive-image elements.
       ".gatsby-resp-image-link": {
         boxShadow: `none`,
-        marginLeft: rhythm(-3 / 4), // 3/4 rhythm is amount of padding on mobile.
-        marginRight: rhythm(-3 / 4),
+      },
+      ".gatsby-resp-image-link:hover": {
+        background: `none`,
+        boxShadow: `none`,
       },
       "@media only screen and (min-width:38rem)": {
         ".gatsby-resp-image-link": {
@@ -76,15 +78,15 @@ const options = {
           overflow: `hidden`,
         },
       },
-      ".post > .gatsby-highlight, .gatsby-resp-iframe-wrapper": {
+      // Pull highlighted code blocks and iframes into the horizontal
+      // padding of their container.
+      // Note that we only do this for code blocks that are direct children of
+      // .post so that code blocks are correctly indented e. g. in lists.
+      ".post > .gatsby-highlight, .gatsby-resp-iframe-wrapper, .gatsby-resp-image-link": {
         marginLeft: rhythm(-3 / 4), // 3/4 rhythm is amount of padding on mobile.
         marginRight: rhythm(-3 / 4),
       },
-      ".gatsby-resp-image-link:hover": {
-        background: `none`,
-        boxShadow: `none`,
-      },
-      // fake image captions
+      // Fake image captions.
       ".post .gatsby-resp-image-link + em": {
         ...scale(0 / 5),
         fontFamily: `Spectral, serif`,
@@ -95,7 +97,7 @@ const options = {
         marginBottom: rhythm(1),
         color: `${colors.light}`,
       },
-      // code highlighting
+      // Code highlighting.
       "tt, code": {
         fontFamily: `"Space Mono",Consolas,"Roboto Mono","Droid Sans Mono","Liberation Mono",Menlo,Courier,monospace`,
         // Disable ligatures as they look funny w/ Space Mono as code.
@@ -117,6 +119,7 @@ const options = {
       "pre code:before,pre code:after,pre tt:before,pre tt:after": {
         content: `""`,
       },
+      // Highlighted code blocks in Markdown via gatsby-remark-prismjs.
       ".gatsby-highlight": {
         backgroundColor: `#fef9ec`,
         borderRadius: `.15rem`,
@@ -144,7 +147,7 @@ const options = {
         paddingLeft: rhythm(2 / 4),
         borderLeft: `${rhythm(1 / 4)} solid #ffd9b3`,
       },
-      // fancy links
+      // Fancy underline links in .post.
       ".post a:not(.gatsby-resp-image-link):not(.anchor), .link-underline": {
         position: `relative`,
         backgroundImage: `linear-gradient(${colors.link},${colors.link})`,
@@ -162,14 +165,16 @@ const options = {
         textShadow: `0 !important`,
         backgroundImage: `0 !important`,
       },
-      // fancy external links
+      // Fancy external links in posts, borrowed from
+      // https://github.com/comfusion/after-dark/
+      // @see https://github.com/comfusion/after-dark/blob/8fdbe2f480ac40315cf0e01cece785d2b5c4b0c3/layouts/partials/critical-theme.css#L36-L39
       ".post a[href*='//']:after": {
         content: `" " url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20class='i-external'%20viewBox='0%200%2032%2032'%20width='14'%20height='14'%20fill='none'%20stroke='%23${linkRaw}'%20stroke-linecap='round'%20stroke-linejoin='round'%20stroke-width='9.38%'%3E%3Cpath%20d='M14%209%20L3%209%203%2029%2023%2029%2023%2018%20M18%204%20L28%204%2028%2014%20M28%204%20L14%2018'/%3E%3C/svg%3E")`,
       },
       ".post a[href*='//']:hover:after": {
         content: `" " url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20class='i-external'%20viewBox='0%200%2032%2032'%20width='14'%20height='14'%20fill='none'%20stroke='%23${linkHoverRaw}'%20stroke-linecap='round'%20stroke-linejoin='round'%20stroke-width='9.38%'%3E%3Cpath%20d='M14%209%20L3%209%203%2029%2023%2029%2023%2018%20M18%204%20L28%204%2028%2014%20M28%204%20L14%2018'/%3E%3C/svg%3E")`,
       },
-      // increase base font-size for phablet and desktop
+      // Increase base font-size for phablet and desktop.
       [presets.Phablet]: {
         html: {
           fontSize: `${18 / 16 * 100}%`,


### PR DESCRIPTION
A bunch of fixes, the important ones:

* fix "Inline HTML" code example
* fix inline `<code>` horizontal whitespace by borrowing from typography-plugin-code