### PR TITLE
[1.0] using-remark: preload fonts used on the homepage

### DIFF
--- a/examples/using-remark/src/html.js
+++ b/examples/using-remark/src/html.js
@@ -27,6 +27,18 @@ class HTML extends React.Component {
     return (
       <html lang="en">
         <head>
+          <link
+            rel="preload"
+            href={`/static/spectral-latin-400.bc2de9de.woff2`}
+            as="font"
+            crossOrigin
+          />
+          <link
+            rel="preload"
+            href={`/static/spectral-latin-800.53eca5bf.woff2`}
+            as="font"
+            crossOrigin
+          />
           {this.props.headComponents}
           <meta charSet="utf-8" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />

--- a/examples/using-remark/src/html.js
+++ b/examples/using-remark/src/html.js
@@ -39,6 +39,26 @@ class HTML extends React.Component {
             as="font"
             crossOrigin
           />
+          <link
+            rel="prefetch"
+            href={`/static/spectral-latin-400italic.b0c97eb5.woff2`}
+          />
+          <link
+            rel="prefetch"
+            href={`/static/spectral-latin-700.601f0e2d.woff2`}
+          />
+          <link
+            rel="prefetch"
+            href={`/static/spectral-latin-700italic.64a7de98.woff2`}
+          />
+          <link
+            rel="prefetch"
+            href={`/static/space-mono-latin-400.a8338881.woff2`}
+          />
+          <link
+            rel="prefetch"
+            href={`/static/space-mono-latin-700.eadcd2d5.woff2`}
+          />
           {this.props.headComponents}
           <meta charSet="utf-8" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
Wondering if we should also preload the italic "Spectral" variants and/or "Space Mono" – both are only in use on non-index-routes? I recall Chrome complaining (in the developer console) if a font that is not used on the current page is set to be preloaded; not too familiar with `preload` yet … ;)