### PR TITLE
Use localized space

### DIFF
--- a/examples/using-contentful/gatsby-config.js
+++ b/examples/using-contentful/gatsby-config.js
@@ -6,8 +6,8 @@ module.exports = {
     {
       resolve: `gatsby-source-contentful`,
       options: {
-        spaceId: `ubriaw6jfhm1`,
-        accessToken: `e481b0f7c5572374474b29f81a91e8ac487bb27d70a6f14dd12142837d8e980a`,
+        spaceId: `rocybtov1ozk`,
+        accessToken: `6f35edf0db39085e9b9c19bd92943e4519c77e72c852d961968665f1324bfc94`,
       },
     },
     `gatsby-transformer-remark`,


### PR DESCRIPTION
Hi @KyleAMathews ,

Here's a PR that add a test space with two locales 😉 , English `en-US` and German `de`.
I can add more if you want.
One thing to take consideration that some fields might not be localized in purpose like companyName or image which is a normal workflow. in that case, the content will be in `companyName['en-US']` which is the default locale.
Also, we have a feature called [fallback locale](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/localization), for example, you can configure it in a way that if you don't specify some content for `de` localisedField[`de`] will get filled with the localisedField[`en-US`]

I'll be glad to help further with this if any issue is popping up. Also since the test space is in my personal org I can invite you as a space admin if you wish, should I use the same email I have?.

Best,
Khaled