### PR TITLE
Don't use the sass loader on build-javascript

### DIFF
--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -48,7 +48,7 @@ exports.modifyWebpackConfig = ({ config, stage }) => {
       config.loader(`sass`, {
         test: /\.s(a|c)ss$/,
         exclude: /\.module\.s(a|c)ss$/,
-        loader: ExtractTextPlugin.extract([`css`, `sass`]),
+        loader: `null`,
       })
 
       config.loader(`sassModules`, {


### PR DESCRIPTION
I believe this fixes #1277.

We have this same issue on the built-in postcss loader though when using css packages from npm packages, and I don't have a solution for that.