### PR TITLE
[1.0] Added support for html image tags in the gatsby-remark-responsive-image

### DIFF
--- a/packages/gatsby-remark-responsive-image/package.json
+++ b/packages/gatsby-remark-responsive-image/package.json
@@ -17,6 +17,7 @@
     "babel-cli": "^6.24.1"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.1",
     "image-size": "^0.5.1",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Prior to this additions

This would work

```
![](image.png)
```

This wouldn't work

```
<img src='image.png' />
```

Now they should both work.