### PR TITLE
[1.0] Added support for html img tags to the gatsby-remark-copy-link plugin

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0-beta.1",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.1",
     "fs-extra": "^3.0.1",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Prior to this fix, only markdown img tags would work. Now html img tags work also.