### PR TITLE
[1.0][gatsby-plugin-glamor] Fix typo

### DIFF
--- a/packages/gatsby-plugin-glamor/README.md
+++ b/packages/gatsby-plugin-glamor/README.md
@@ -24,7 +24,7 @@ One particularly convenient (and suggested) way is to use its `css` prop. It
 works exactly the same as the [default `style`
 prop](https://facebook.github.io/react/docs/dom-elements.html#style) except it
 supports the entire CSS language. So things not supported by inline styles are
-supported with Glamor like psudeo classes/elements, `@media` queries,
+supported with Glamor like pseudo-classes/-elements, `@media` queries,
 parent/child/contextual selectors, etc.
 
 ```jsx


### PR DESCRIPTION
Hyphen according to MDN:
* https://developer.mozilla.org/en-US/docs/Web/CSS/pseudo-classes
* https://developer.mozilla.org/en-US/docs/Web/CSS/pseudo-elements