### PR TITLE
[1.0] Throw error and quit if there's a JS parse error for gatsby-config.js fixes #1290

### DIFF
--- a/examples/no-plugins/gatsby-config.js
+++ b/examples/no-plugins/gatsby-config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  siteMetadata: {
-    title: `No plugins`,
-  },
-}

--- a/packages/gatsby-source-contentful/src/process-api-data.js
+++ b/packages/gatsby-source-contentful/src/process-api-data.js
@@ -46,9 +46,9 @@ const makeMakeId = ({ currentLocale, defaultLocale }) => id =>
 
 exports.buildEntryList = ({ contentTypeItems, currentSyncData }) =>
   contentTypeItems.map(contentType =>
-    currentSyncData.entries.filter(entry => {
-      return entry.sys.contentType.sys.id === contentType.sys.id
-    })
+    currentSyncData.entries.filter(
+      entry => entry.sys.contentType.sys.id === contentType.sys.id
+    )
   )
 
 exports.buildResolvableSet = ({

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -56,7 +56,10 @@ module.exports = async (program: any) => {
     // $FlowFixMe
     config = preferDefault(require(`${program.directory}/gatsby-config`))
   } catch (e) {
-    // Ignore. Having a config isn't required.
+    if (!_.includes(e.toString(), `Error: Cannot find module`)) {
+      console.log(e)
+      process.exit(1)
+    }
   }
 
   store.dispatch({


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/1290

Previously we were catching all errors which made it hard to debug errors originating in gatsby-config.js.

Now we only catch module not found errors. Everything else we log and quit.