### PR TITLE
[1.0] Make mediaType optional

### DIFF
--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -15,6 +15,8 @@ parent: String,
 fields: Object,
 internal: {
   contentDigest: String,
+  // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate
+  // to transformer plugins this node has data they can futher process.
   mediaType: String,
   // A globally unique node type choosen by the plugin owner.
   type: String,
@@ -22,7 +24,8 @@ internal: {
   owner: String,
   // Stores which plugins created which fields.
   fieldOwners: Object,
-  // Raw content for this node.
+  // Optional field exposing the raw content for this node
+  // that transformer plugins can take and further process.
   content: String,
 }
 ...other node type specific fields

--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -325,8 +325,8 @@ export const pageQuery = graphql`
     }
     sizes: imageSharp(id: { regex: "/fecolormatrix-kanye-west.jpg/" }) {
       responsiveSizes(
-        duotone: { highlight: "#f00e2e", shadow: "#192550" },
-        toFormat: PNG,
+        duotone: { highlight: "#f00e2e", shadow: "#192550" }
+        toFormat: PNG
       ) {
         base64
         aspectRatio

--- a/examples/using-remark/src/pages/index.js
+++ b/examples/using-remark/src/pages/index.js
@@ -82,9 +82,9 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      limit: 2000,
-      sort: { fields: [frontmatter___date], order: DESC },
-      filter: { frontmatter: { draft: { ne: true } } },
+      limit: 2000
+      sort: { fields: [frontmatter___date], order: DESC }
+      filter: { frontmatter: { draft: { ne: true } } }
     ) {
       edges {
         node {

--- a/examples/using-remark/src/pages/tags.js
+++ b/examples/using-remark/src/pages/tags.js
@@ -38,8 +38,8 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      limit: 2000,
-      filter: { frontmatter: { draft: { ne: true } } },
+      limit: 2000
+      filter: { frontmatter: { draft: { ne: true } } }
     ) {
       group(field: frontmatter___tags) {
         fieldValue

--- a/examples/using-remark/src/templates/template-blog-post.js
+++ b/examples/using-remark/src/templates/template-blog-post.js
@@ -136,10 +136,10 @@ export const pageQuery = graphql`
             children {
               ... on ImageSharp {
                 responsiveResolution(
-                  width: 50,
-                  height: 50,
-                  quality: 75,
-                  grayscale: true,
+                  width: 50
+                  height: 50
+                  quality: 75
+                  grayscale: true
                 ) {
                   src
                   srcSet

--- a/examples/using-remark/src/templates/template-tag-page.js
+++ b/examples/using-remark/src/templates/template-tag-page.js
@@ -34,9 +34,9 @@ export default TagRoute
 export const pageQuery = graphql`
   query TagPage($tag: String) {
     allMarkdownRemark(
-      limit: 1000,
-      sort: { fields: [frontmatter___date], order: DESC },
-      filter: { frontmatter: { tags: { in: [$tag] }, draft: { ne: true } } },
+      limit: 1000
+      sort: { fields: [frontmatter___date], order: DESC }
+      filter: { frontmatter: { tags: { in: [$tag] }, draft: { ne: true } } }
     ) {
       totalCount
       edges {

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -3,7 +3,7 @@ const isRelativeUrl = require(`is-relative-url`)
 const fsExtra = require(`fs-extra`)
 const path = require(`path`)
 const _ = require(`lodash`)
-const $ = require('cheerio');
+const $ = require(`cheerio`)
 
 module.exports = ({ files, markdownNode, markdownAST, getNode }) => {
   // Copy linked files to the public directory and modify the AST to point to
@@ -63,14 +63,14 @@ module.exports = ({ files, markdownNode, markdownAST, getNode }) => {
       visitor(image)
     }
   })
-  
+
   // Same as the above except it only works for html img tags
   visit(markdownAST, `html`, node => {
-    if(node.value.startsWith('<img')){
-      let image = Object.assign(node, $.parseHTML(node.value)[0].attribs);
-      image.url = image.src;
-      image.type = 'image';
-      image.position =  node.position;
+    if (node.value.startsWith(`<img`)) {
+      let image = Object.assign(node, $.parseHTML(node.value)[0].attribs)
+      image.url = image.src
+      image.type = `image`
+      image.position = node.position
 
       const imagePath = path.join(getNode(markdownNode.parent).dir, image.url)
       const imageNode = _.find(files, file => {

--- a/packages/gatsby-remark-responsive-image/src/index.js
+++ b/packages/gatsby-remark-responsive-image/src/index.js
@@ -4,7 +4,7 @@ const isRelativeUrl = require(`is-relative-url`)
 const _ = require(`lodash`)
 const { responsiveSizes } = require(`gatsby-plugin-sharp`)
 const Promise = require(`bluebird`)
-const $ = require('cheerio');
+const $ = require(`cheerio`)
 
 // If the image is relative (not hosted elsewhere)
 // 1. Find the image file
@@ -23,22 +23,23 @@ module.exports = (
   }
 
   const options = _.defaults(pluginOptions, defaults)
-  
+
   // This will only work for markdown syntax image tags
-  const imageNodes = select(markdownAST, 'image');
+  const imageNodes = select(markdownAST, `image`)
 
   // This will also allow the use of html image tags
-  const rawHtmlImageNodes = select(markdownAST, 'html').filter((node) => {
-    return node.value.startsWith('<img');
-  });
+  const rawHtmlImageNodes = select(markdownAST, `html`).filter(node => node.value.startsWith(`<img`))
 
-  for(let node of rawHtmlImageNodes) {
-    let formattedImgTag = Object.assign(node, $.parseHTML(node.value)[0].attribs);
-    formattedImgTag.url = formattedImgTag.src;
-    formattedImgTag.type = 'image';
-    formattedImgTag.position =  node.position;
+  for (let node of rawHtmlImageNodes) {
+    let formattedImgTag = Object.assign(
+      node,
+      $.parseHTML(node.value)[0].attribs
+    )
+    formattedImgTag.url = formattedImgTag.src
+    formattedImgTag.type = `image`
+    formattedImgTag.position = node.position
 
-    imageNodes.push(formattedImgTag);
+    imageNodes.push(formattedImgTag)
   }
 
   return Promise.all(

--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/process-api-data.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/process-api-data.js.snap
@@ -1643,8 +1643,7 @@ Array [
       },
       "id": "c3wtvPBbBjiMKqKKga8I2Cu",
       "internal": Object {
-        "contentDigest": "e6055b51f252aa3e074bb20bdbd41cb7",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "43e3a9f67eded60f2c1634c6ce7f39e8",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -1670,8 +1669,7 @@ Array [
       },
       "id": "c3wtvPBbBjiMKqKKga8I2Cu___de",
       "internal": Object {
-        "contentDigest": "4866eca667e03e17daa4db338cd1d73c",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "6eb0098e14334397dc09d59a6261620f",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -1697,8 +1695,7 @@ Array [
       },
       "id": "KTRF62Q4gg60q6WCsWKw8",
       "internal": Object {
-        "contentDigest": "e56f6c1a0c09f7d335a5fb3231fa0835",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "bf9a0d0de62f282e697a0ef0f3ed72c4",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -1724,8 +1721,7 @@ Array [
       },
       "id": "KTRF62Q4gg60q6WCsWKw8___de",
       "internal": Object {
-        "contentDigest": "9f3e99634d12ba0c56568c2374c26361",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "e670d625738719f465fcc9b26598dc24",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -1751,8 +1747,7 @@ Array [
       },
       "id": "Xc0ny7GWsMEMCeASWO2um",
       "internal": Object {
-        "contentDigest": "01b3bb588fa70c34e8dcc5c8248e4c44",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "f225dd9133ae1bde1951d8eeddf680d0",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -1778,8 +1773,7 @@ Array [
       },
       "id": "Xc0ny7GWsMEMCeASWO2um___de",
       "internal": Object {
-        "contentDigest": "4416c700c1f8e1c28423a27f639dc33e",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "6918579454142f54a263c1fac87e91c7",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -1805,8 +1799,7 @@ Array [
       },
       "id": "c2Y8LhXLnYAYqKCGEWG4EKI",
       "internal": Object {
-        "contentDigest": "032d7e2159afcce429661709b10f9eee",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "2f0f28be19bf3cfbe3d938b87da588f9",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -1832,8 +1825,7 @@ Array [
       },
       "id": "c2Y8LhXLnYAYqKCGEWG4EKI___de",
       "internal": Object {
-        "contentDigest": "0fe651ccf83729b64e30f64c52e5ee5c",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "a3c3e4f02948569528decf59ec9ab5c4",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -1859,8 +1851,7 @@ Array [
       },
       "id": "c6t4HKjytPi0mYgs240wkG",
       "internal": Object {
-        "contentDigest": "2d6be7f9657a60bf6c467ecbdb2e2005",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "a1607d653dfd3089e839e4ba19595d78",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -1886,8 +1877,7 @@ Array [
       },
       "id": "c6t4HKjytPi0mYgs240wkG___de",
       "internal": Object {
-        "contentDigest": "0ff921d4041f8792f07925cc91d9335c",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "42fbabbcbbbff9f1e32b2f89a9a3d756",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -1913,8 +1903,7 @@ Array [
       },
       "id": "c1MgbdJNTsMWKI0W68oYqkU",
       "internal": Object {
-        "contentDigest": "227deaa500d7ffc635096e6f61ff5f43",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "ddd6b1dceea3ab8a65677cc8e3650e3a",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -1940,8 +1929,7 @@ Array [
       },
       "id": "c1MgbdJNTsMWKI0W68oYqkU___de",
       "internal": Object {
-        "contentDigest": "9cbd453b4bd1c259d07ec1ce54b8c4d1",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "66bde7bf64462aa73aab9774fe90e808",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -1967,8 +1955,7 @@ Array [
       },
       "id": "c6m5AJ9vMPKc8OUoQeoCS4o",
       "internal": Object {
-        "contentDigest": "3ba07b3d786dc349e1438cb6b08c4c9f",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "80435eafd174b15f162c9cbb558f066b",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -1994,8 +1981,7 @@ Array [
       },
       "id": "c6m5AJ9vMPKc8OUoQeoCS4o___de",
       "internal": Object {
-        "contentDigest": "42bf983b56cf0cdc19566dc57611ac8f",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "d70afd1dcd2f7b4a8fac37f3bd3afcfd",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2021,8 +2007,7 @@ Array [
       },
       "id": "c4zj1ZOfHgQ8oqgaSKm4Qo2",
       "internal": Object {
-        "contentDigest": "fc73ffe6349440d23de331ad9daf0e1d",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "9b296971a74d8965c5a18f3f79c7aaa0",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2048,8 +2033,7 @@ Array [
       },
       "id": "c4zj1ZOfHgQ8oqgaSKm4Qo2___de",
       "internal": Object {
-        "contentDigest": "c08f3ff2a13145873fbd6d0d56fb7bdb",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "708a1765ea2f3de4b854123a21559465",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2075,8 +2059,7 @@ Array [
       },
       "id": "wtrHxeu3zEoEce2MokCSi",
       "internal": Object {
-        "contentDigest": "e5b4eb3846e78d3eb83c7c344ff25985",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "fe0db6af559185a8d46a71e30abc6ca5",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2102,8 +2085,7 @@ Array [
       },
       "id": "wtrHxeu3zEoEce2MokCSi___de",
       "internal": Object {
-        "contentDigest": "2bbe52d619eae4c5cb8f87ee406ef232",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "1c7ad806677dc5b76225fbac243ee5e8",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2129,8 +2111,7 @@ Array [
       },
       "id": "c10TkaLheGeQG6qQGqWYqUI",
       "internal": Object {
-        "contentDigest": "60bbe485bc171caeafd119a08b21ebb2",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "80e5d70dc47a66bf3488f8fbd277c502",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2156,8 +2137,7 @@ Array [
       },
       "id": "c10TkaLheGeQG6qQGqWYqUI___de",
       "internal": Object {
-        "contentDigest": "a2f5ccb33a8fa1249ed70123757320a4",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "762fabadc314d4f1c73ba7dbd17b2f89",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2183,8 +2163,7 @@ Array [
       },
       "id": "c6s3iG2OVmoUcosmA8ocqsG",
       "internal": Object {
-        "contentDigest": "5df5f3dbaf854d908057cf6f873d2b74",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "a4417ce2f7fbdc6e4c6ca14139ef2829",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2210,8 +2189,7 @@ Array [
       },
       "id": "c6s3iG2OVmoUcosmA8ocqsG___de",
       "internal": Object {
-        "contentDigest": "be8889140e19b69654de80ad25fbdab0",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "b9170371fcb773b0bae452bbeb8e768f",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2287,8 +2265,7 @@ Array [
       "displayField": "title",
       "id": "Category",
       "internal": Object {
-        "contentDigest": "d02aa7b2f06395cfee461388f47de493",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "9e51d4bbdb873453a2039464c41c160a",
         "type": "ContentfulContentType",
       },
       "name": "Category",
@@ -2305,8 +2282,7 @@ Array [
       "icon___NODE": "c6m5AJ9vMPKc8OUoQeoCS4o",
       "id": "c7LAnCobuuWYSqks6wAwY2a",
       "internal": Object {
-        "contentDigest": "fd0cc67cb09ef934e3093fc6e94dd764",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "d710fa5401174d699db2695d2d6dbe1b",
         "type": "ContentfulCategory",
       },
       "node_locale": "en-US",
@@ -2329,8 +2305,7 @@ Array [
       "icon___NODE": "c6t4HKjytPi0mYgs240wkG",
       "id": "c24DPGBDeGEaYy8ms4Y8QMQ",
       "internal": Object {
-        "contentDigest": "a65a57f88293fe9f73e3678fb2d9ce54",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "133ccb0a4a27a92c8c5219e428379100",
         "type": "ContentfulCategory",
       },
       "node_locale": "en-US",
@@ -2404,8 +2379,7 @@ Array [
       "displayField": "title",
       "id": "Category",
       "internal": Object {
-        "contentDigest": "d02aa7b2f06395cfee461388f47de493",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "9e51d4bbdb873453a2039464c41c160a",
         "type": "ContentfulContentType",
       },
       "name": "Category",
@@ -2422,8 +2396,7 @@ Array [
       "icon___NODE": "c6m5AJ9vMPKc8OUoQeoCS4o___de",
       "id": "c7LAnCobuuWYSqks6wAwY2a___de",
       "internal": Object {
-        "contentDigest": "8f3d527ab04bd97259dcb7d46edfa5f6",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "782c5003ad12305b2e4c4e47403fed0c",
         "type": "ContentfulCategory",
       },
       "node_locale": "de",
@@ -2446,8 +2419,7 @@ Array [
       "icon___NODE": "c6t4HKjytPi0mYgs240wkG___de",
       "id": "c24DPGBDeGEaYy8ms4Y8QMQ___de",
       "internal": Object {
-        "contentDigest": "b6bb3b1d0a7574c652a76e32b61d0a94",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "361860c2867f9ae83419aac277aec067",
         "type": "ContentfulCategory",
       },
       "node_locale": "de",
@@ -2569,8 +2541,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "displayField": "companyName",
       "id": "Brand",
       "internal": Object {
-        "contentDigest": "1e38edb6da67d8b16b80d0d44f692e31",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "cce9b42a3ad6123072ef35684990d2e1",
         "type": "ContentfulContentType",
       },
       "name": "Brand",
@@ -2588,8 +2559,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "email": "normann@normann-copenhagen.com",
       "id": "c651CQ8rLoIYCeY6G0QG22q",
       "internal": Object {
-        "contentDigest": "34d5206cc4db942e73f6e44ced222c0c",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "8e98ed0688bc63cb90cdc1eaad4ea28a",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "c3wtvPBbBjiMKqKKga8I2Cu",
@@ -2617,8 +2587,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "email": "info@acgears.com",
       "id": "c4LgMotpNF6W20YKmuemW0a",
       "internal": Object {
-        "contentDigest": "0f1a6855d2364c7134786ef7de92f520",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "179698e2d0fdeafe064c16dc552905e0",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "c2Y8LhXLnYAYqKCGEWG4EKI",
@@ -2643,8 +2612,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "companyName___NODE": "JrePkDVYomE8AwcuCUyMicompanyNameTextNode",
       "id": "JrePkDVYomE8AwcuCUyMi",
       "internal": Object {
-        "contentDigest": "e5202ad597ae508b4f82840c38a5a6ab",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "60153e88a39483fa024d4bf41ab95b6a",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "c4zj1ZOfHgQ8oqgaSKm4Qo2",
@@ -2767,8 +2735,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "displayField": "companyName",
       "id": "Brand",
       "internal": Object {
-        "contentDigest": "1e38edb6da67d8b16b80d0d44f692e31",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "cce9b42a3ad6123072ef35684990d2e1",
         "type": "ContentfulContentType",
       },
       "name": "Brand",
@@ -2786,8 +2753,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "email": "normann@normann-copenhagen.com",
       "id": "c651CQ8rLoIYCeY6G0QG22q___de",
       "internal": Object {
-        "contentDigest": "5426a323c0c82f27d9da95d2616a69b8",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "c6e5adb15bcb9067b7ad56bbeea5fd98",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "c3wtvPBbBjiMKqKKga8I2Cu___de",
@@ -2815,8 +2781,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "email": "info@acgears.com",
       "id": "c4LgMotpNF6W20YKmuemW0a___de",
       "internal": Object {
-        "contentDigest": "d8c0805a035d9d583d0cc1756c44b822",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "6e4e76e159aef9a4c09d87404ffb6009",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "c2Y8LhXLnYAYqKCGEWG4EKI___de",
@@ -2841,8 +2806,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "companyName___NODE": "JrePkDVYomE8AwcuCUyMi___decompanyNameTextNode",
       "id": "JrePkDVYomE8AwcuCUyMi___de",
       "internal": Object {
-        "contentDigest": "4544b86dd8c900f6a6ab0cf93bdd2cde",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "51ead6a16ac5a54cc51e571eb8a0923d",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "c4zj1ZOfHgQ8oqgaSKm4Qo2___de",
@@ -2973,8 +2937,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "displayField": "productName",
       "id": "Product",
       "internal": Object {
-        "contentDigest": "c69f340cf628e5616c7f3deb12e1491b",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "e887987a927829ca888bcd801fa07a8b",
         "type": "ContentfulContentType",
       },
       "name": "Product",
@@ -2996,8 +2959,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "wtrHxeu3zEoEce2MokCSi",
       ],
       "internal": Object {
-        "contentDigest": "7a0a2a1512617d54c44d73bef7a218e0",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "b0a4e6d7a09a2487247f8175ada55df3",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3034,8 +2996,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "Xc0ny7GWsMEMCeASWO2um",
       ],
       "internal": Object {
-        "contentDigest": "d81b107967209c8eea62b432065be9a7",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "31da8eac993220daceef2fc26fe11c69",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3070,8 +3031,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "c10TkaLheGeQG6qQGqWYqUI",
       ],
       "internal": Object {
-        "contentDigest": "bb93389f537453c3d4aee3cd362a8813",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "89d75668c3b4761bb9e61b076aedb71f",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3108,8 +3068,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "KTRF62Q4gg60q6WCsWKw8",
       ],
       "internal": Object {
-        "contentDigest": "34b8bbee9ea18c220c98f9ed6a6505db",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "ace91d1cdb5e4ac5a6d56900b1778793",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3250,8 +3209,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "displayField": "productName",
       "id": "Product",
       "internal": Object {
-        "contentDigest": "c69f340cf628e5616c7f3deb12e1491b",
-        "mediaType": "text/x-contentful",
+        "contentDigest": "e887987a927829ca888bcd801fa07a8b",
         "type": "ContentfulContentType",
       },
       "name": "Product",
@@ -3273,8 +3231,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "wtrHxeu3zEoEce2MokCSi___de",
       ],
       "internal": Object {
-        "contentDigest": "67df4ece73c096cfce54896487daac86",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "ee75439b6d259c421ef1ed52af438c56",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",
@@ -3311,8 +3268,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "Xc0ny7GWsMEMCeASWO2um___de",
       ],
       "internal": Object {
-        "contentDigest": "f907328aef31dd0664a78801f38d8895",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "ce088f3b00992d17d7f42a9a4f5c9fcc",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",
@@ -3347,8 +3303,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "c10TkaLheGeQG6qQGqWYqUI___de",
       ],
       "internal": Object {
-        "contentDigest": "aace11e6dae6499754cb506f5c6274e2",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "baa15cb2eef6c764ac6a60f4952aa79b",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",
@@ -3385,8 +3340,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "KTRF62Q4gg60q6WCsWKw8___de",
       ],
       "internal": Object {
-        "contentDigest": "c771bcf98e87eaf8ae195bc1c9674a41",
-        "mediaType": "application/x-contentful",
+        "contentDigest": "06956db9289919569c860ed366ec0512",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",

--- a/packages/gatsby-source-contentful/src/__tests__/process-api-data.js
+++ b/packages/gatsby-source-contentful/src/__tests__/process-api-data.js
@@ -87,8 +87,8 @@ describe(`Fix contentful IDs`, () => {
 
 describe(`Gets field value based on current locale`, () => {
   const field = {
-    de: "Playsam Streamliner Klassisches Auto, Espresso",
-    "en-US": "Playsam Streamliner Classic Car, Espresso",
+    de: `Playsam Streamliner Klassisches Auto, Espresso`,
+    "en-US": `Playsam Streamliner Classic Car, Espresso`,
   }
   it(`Gets the specified locale`, () => {
     expect(

--- a/packages/gatsby-source-contentful/src/process-api-data.js
+++ b/packages/gatsby-source-contentful/src/process-api-data.js
@@ -253,7 +253,6 @@ exports.createContentTypeNodes = ({
         children: [],
         internal: {
           type: `${makeTypeName(contentTypeItemId)}`,
-          mediaType: `application/x-contentful`,
         },
       }
 
@@ -315,7 +314,6 @@ exports.createContentTypeNodes = ({
       description: contentTypeItem.description,
       internal: {
         type: `${makeTypeName(`ContentType`)}`,
-        mediaType: `text/x-contentful`,
       },
     }
 
@@ -362,7 +360,6 @@ exports.createAssetNodes = ({
       node_locale: locale.code,
       internal: {
         type: `${makeTypeName(`Asset`)}`,
-        mediaType: `text/x-contentful`,
       },
     }
 

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -87,8 +87,6 @@ exports.sourceNodes = async (
       internal: {
         ...node.internal,
         type: makeTypeName(node.internal.type),
-        content: nodeStr,
-        mediaType: `application/json`,
       },
       author___NODE: result.data.data[i].relationships.uid.data.id,
     }
@@ -120,8 +118,6 @@ exports.sourceNodes = async (
             parent: `__SOURCE__`,
             internal: {
               type: makeTypeName(user.internal.type),
-              content: userStr,
-              mediaType: `application/json`,
             },
           }
 

--- a/packages/gatsby-source-hacker-news/src/gatsby-node.js
+++ b/packages/gatsby-source-hacker-news/src/gatsby-node.js
@@ -105,7 +105,6 @@ fragment commentsFragment on HackerNewsItem {
       content: storyStr,
       internal: {
         type: `HNStory`,
-        mediaType: `application/json`,
       },
       domain,
       order: i + 1,
@@ -136,7 +135,6 @@ fragment commentsFragment on HackerNewsItem {
           parent,
           internal: {
             type: `HNComment`,
-            mediaType: `application/json`,
           },
           order: i + 1,
         }

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -40,31 +40,7 @@ apple()",
     ],
     "id": "documentationJS node_1 comment #0",
     "internal": Object {
-      "content": "{
-    \\"kind\\": \\"constant\\",
-    \\"name\\": \\"apple\\",
-    \\"params\\": [
-        {
-            \\"title\\": \\"param\\",
-            \\"name\\": \\"apple\\",
-            \\"type\\": {
-                \\"type\\": \\"NameExpression\\",
-                \\"name\\": \\"string\\"
-            },
-            \\"description___NODE\\": \\"documentationJS node_1 comment #0--DocumentationJSComponentDescription--apple\\"
-        }
-    ],
-    \\"returns\\": [],
-    \\"examples\\": [
-        {
-            \\"raw\\": \\"const apple = require('apple')\\\\napple()\\",
-            \\"highlighted\\": \\"<span class=\\\\\\"token keyword\\\\\\">const</span> apple <span class=\\\\\\"token operator\\\\\\">=</span> <span class=\\\\\\"token function\\\\\\">require</span><span class=\\\\\\"token punctuation\\\\\\">(</span><span class=\\\\\\"token string\\\\\\">'apple'</span><span class=\\\\\\"token punctuation\\\\\\">)</span>\\\\n<span class=\\\\\\"token function\\\\\\">apple</span><span class=\\\\\\"token punctuation\\\\\\">(</span><span class=\\\\\\"token punctuation\\\\\\">)</span>\\"
-        }
-    ],
-    \\"description___NODE\\": \\"documentationJS node_1 comment #0--DocumentationJSComponentDescription--comment.description\\"
-}",
       "contentDigest": "b635e85506044a6cdcebbcd7fda00b7d",
-      "mediaType": "text/x-javascript-metadata",
       "type": "DocumentationJs",
     },
     "kind": "constant",

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -161,9 +161,7 @@ exports.onCreateNode = async ({
         children: [],
         internal: {
           contentDigest: digest(strContent),
-          content: strContent,
           type: `DocumentationJs`,
-          mediaType: `text/x-javascript-metadata`,
         },
       }
 

--- a/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -9,9 +9,7 @@ Array [
       "funny": "yup",
       "id": "foo",
       "internal": Object {
-        "content": "{\\"id\\":\\"foo\\",\\"blue\\":true,\\"funny\\":\\"yup\\"}",
         "contentDigest": "8838e569ae02d98806532310fb2a577a",
-        "mediaType": "application/json",
         "type": "UndefinedJson",
       },
       "parent": "whatever",
@@ -24,9 +22,7 @@ Array [
       "funny": "nope",
       "id": "whatever [1] >>> JSON",
       "internal": Object {
-        "content": "{\\"blue\\":false,\\"funny\\":\\"nope\\"}",
         "contentDigest": "f624311d932d73dcd416d2a8bea2b67d",
-        "mediaType": "application/json",
         "type": "UndefinedJson",
       },
       "parent": "whatever",
@@ -45,9 +41,7 @@ Array [
         "funny": "yup",
         "id": "foo",
         "internal": Object {
-          "content": "{\\"id\\":\\"foo\\",\\"blue\\":true,\\"funny\\":\\"yup\\"}",
           "contentDigest": "8838e569ae02d98806532310fb2a577a",
-          "mediaType": "application/json",
           "type": "UndefinedJson",
         },
         "parent": "whatever",
@@ -73,9 +67,7 @@ Array [
         "funny": "nope",
         "id": "whatever [1] >>> JSON",
         "internal": Object {
-          "content": "{\\"blue\\":false,\\"funny\\":\\"nope\\"}",
           "contentDigest": "f624311d932d73dcd416d2a8bea2b67d",
-          "mediaType": "application/json",
           "type": "UndefinedJson",
         },
         "parent": "whatever",

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -6,14 +6,6 @@ const crypto = require(`crypto`)
 async function onCreateNode({ node, boundActionCreators, loadNodeContent }) {
   const { createNode, createParentChildLink } = boundActionCreators
 
-  // Don't reprocess our own nodes!  (note: this doesn't normally happen
-  // but since this transformer creates new nodes with the same media-type
-  // as its parent node, we have to add this check that we didn't create
-  // the node).
-  if (node.internal.owner === `gatsby-transformer-json`) {
-    return
-  }
-
   // We only care about JSON content.
   if (node.internal.mediaType !== `application/json`) {
     return
@@ -38,12 +30,10 @@ async function onCreateNode({ node, boundActionCreators, loadNodeContent }) {
         parent: node.id,
         internal: {
           contentDigest,
-          mediaType: `application/json`,
           // TODO make choosing the "type" a lot smarter. This assumes
           // the parent node is a file.
           // PascalCase
           type: _.upperFirst(_.camelCase(`${node.name} Json`)),
-          content: objStr,
         },
       }
     })

--- a/packages/gatsby-transformer-react-docgen/src/on-node-create.js
+++ b/packages/gatsby-transformer-react-docgen/src/on-node-create.js
@@ -46,8 +46,6 @@ function createPropNodes(node, component, boundActionCreators) {
       parentType: prop.type,
       internal: {
         type: `ComponentProp`,
-        mediaType: `text/x-react-metadata`,
-        content,
         contentDigest: digest(content),
       },
     }
@@ -86,9 +84,7 @@ export default function onCreateNode(
           parent: node.id,
           internal: {
             contentDigest,
-            content: strContent,
             type: `ComponentMetadata`,
-            mediaType: `text/x-react-metadata`,
           },
         }
 

--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -12,11 +12,7 @@ Array [
       },
       "id": "whatever >>> MarkdownRemark",
       "internal": Object {
-        "content": "
-Where oh where is my little pony?
-    ",
         "contentDigest": "54cfa2ad99756f2fa232cac585280a37",
-        "mediaType": "text/x-markdown",
         "type": "MarkdownRemark",
       },
       "parent": "whatever",
@@ -38,11 +34,7 @@ Array [
         },
         "id": "whatever >>> MarkdownRemark",
         "internal": Object {
-          "content": "
-Where oh where is my little pony?
-    ",
           "contentDigest": "54cfa2ad99756f2fa232cac585280a37",
-          "mediaType": "text/x-markdown",
           "type": "MarkdownRemark",
         },
         "parent": "whatever",

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -9,14 +9,6 @@ module.exports = async function onCreateNode({
 }) {
   const { createNode, createParentChildLink } = boundActionCreators
 
-  // Don't reprocess our own nodes!  (note: this doesn't normally happen
-  // but since this transformer creates new nodes with the same media-type
-  // as its parent node, we have to add this check that we didn't create
-  // the node).
-  if (node.internal.type === `MarkdownRemark`) {
-    return
-  }
-
   // We only care about markdown content.
   if (node.internal.mediaType !== `text/x-markdown`) {
     return
@@ -35,8 +27,6 @@ module.exports = async function onCreateNode({
     internal: {
       contentDigest,
       type: `MarkdownRemark`,
-      mediaType: `text/x-markdown`,
-      content: data.content,
     },
   }
   markdownNode.frontmatter = {

--- a/packages/gatsby-transformer-sharp/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-sharp/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -8,7 +8,6 @@ Array [
       "id": "whatever >> ImageSharp",
       "internal": Object {
         "contentDigest": "whatever",
-        "mediaType": undefined,
         "type": "ImageSharp",
       },
       "parent": "whatever",
@@ -26,7 +25,6 @@ Array [
         "id": "whatever >> ImageSharp",
         "internal": Object {
           "contentDigest": "whatever",
-          "mediaType": undefined,
           "type": "ImageSharp",
         },
         "parent": "whatever",

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -15,7 +15,6 @@ module.exports = async function onCreateNode({ node, boundActionCreators }) {
     internal: {
       contentDigest: `${node.internal.contentDigest}`,
       type: `ImageSharp`,
-      mediaType: node.internal.mediaType,
     },
   }
 

--- a/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -9,9 +9,7 @@ Array [
       "funny": "yup",
       "id": "whatever [0] >>> YAML",
       "internal": Object {
-        "content": "{\\"blue\\":true,\\"funny\\":\\"yup\\"}",
         "contentDigest": "73901821b17d5aa9dd6026181f73b64c",
-        "mediaType": "application/json",
         "type": "TestYaml",
       },
       "parent": "whatever",
@@ -24,9 +22,7 @@ Array [
       "funny": "nope",
       "id": "whatever [1] >>> YAML",
       "internal": Object {
-        "content": "{\\"blue\\":false,\\"funny\\":\\"nope\\"}",
         "contentDigest": "f624311d932d73dcd416d2a8bea2b67d",
-        "mediaType": "application/json",
         "type": "TestYaml",
       },
       "parent": "whatever",
@@ -45,9 +41,7 @@ Array [
         "funny": "yup",
         "id": "whatever [0] >>> YAML",
         "internal": Object {
-          "content": "{\\"blue\\":true,\\"funny\\":\\"yup\\"}",
           "contentDigest": "73901821b17d5aa9dd6026181f73b64c",
-          "mediaType": "application/json",
           "type": "TestYaml",
         },
         "parent": "whatever",
@@ -77,9 +71,7 @@ Array [
         "funny": "nope",
         "id": "whatever [1] >>> YAML",
         "internal": Object {
-          "content": "{\\"blue\\":false,\\"funny\\":\\"nope\\"}",
           "contentDigest": "f624311d932d73dcd416d2a8bea2b67d",
-          "mediaType": "application/json",
           "type": "TestYaml",
         },
         "parent": "whatever",

--- a/packages/gatsby-transformer-yaml/src/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml/src/gatsby-node.js
@@ -34,8 +34,6 @@ async function onCreateNode({ node, boundActionCreators, loadNodeContent }) {
           // the parent node is a file.
           // PascalCase
           type: _.upperFirst(_.camelCase(`${node.name} Yaml`)),
-          mediaType: `application/json`,
-          content: objStr,
         },
       }
     })

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -54,9 +54,7 @@ exports.sourceNodes = ({ boundActionCreators, store }) => {
     parent: `SOURCE`,
     children: [],
     internal: {
-      mediaType: `application/json`,
       type: `SitePage`,
-      content: JSON.stringify(page),
       contentDigest: crypto
         .createHash(`md5`)
         .update(JSON.stringify(page))
@@ -79,8 +77,6 @@ exports.sourceNodes = ({ boundActionCreators, store }) => {
           .createHash(`md5`)
           .update(JSON.stringify(plugin))
           .digest(`hex`),
-        mediaType: `application/json`,
-        content: JSON.stringify(plugin),
         type: `SitePlugin`,
       },
     })
@@ -112,8 +108,6 @@ exports.sourceNodes = ({ boundActionCreators, store }) => {
           .createHash(`md5`)
           .update(JSON.stringify(node))
           .digest(`hex`),
-        content: JSON.stringify(node),
-        mediaType: `application/json`,
         type: `Site`,
       },
     })
@@ -145,9 +139,7 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
     parent: `SOURCE`,
     children: [],
     internal: {
-      mediaType: `application/json`,
       type: `SitePage`,
-      content: JSON.stringify(page),
       contentDigest: crypto
         .createHash(`md5`)
         .update(JSON.stringify(page))

--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -29,7 +29,7 @@ export const nodeSchema = Joi.object()
     fields: Joi.object(),
     internal: Joi.object().keys({
       contentDigest: Joi.string().required(),
-      mediaType: Joi.string().required(),
+      mediaType: Joi.string(),
       type: Joi.string().required(),
       owner: Joi.string().required(),
       fieldOwners: Joi.array(),

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/nodes.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/nodes.js.snap
@@ -13,7 +13,6 @@ Object {
       "fieldOwners": Object {
         "joy": "test",
       },
-      "mediaType": "test",
       "owner": "tests",
       "type": "Test",
     },
@@ -30,7 +29,6 @@ Object {
     "id": "hi",
     "internal": Object {
       "contentDigest": "hasdfljds",
-      "mediaType": "test",
       "owner": "tests",
       "type": "Test",
     },
@@ -52,7 +50,6 @@ Object {
     "id": "hi",
     "internal": Object {
       "contentDigest": "hasdfljds",
-      "mediaType": "test",
       "owner": "tests",
       "type": "Test",
     },
@@ -87,7 +84,6 @@ exports[`Create and update nodes throws error if a node is created by a plugin n
     \\"parent\\": \\"test\\",
     \\"internal\\": {
         \\"contentDigest\\": \\"hasdfljds\\",
-        \\"mediaType\\": \\"test\\",
         \\"owner\\": \\"pluginB\\",
         \\"type\\": \\"mineOnly\\"
     },
@@ -119,7 +115,6 @@ exports[`Create and update nodes throws error if a node sets a value on "fields"
     },
     \\"internal\\": {
         \\"contentDigest\\": \\"hasdfljds\\",
-        \\"mediaType\\": \\"test\\",
         \\"owner\\": \\"pluginA\\",
         \\"type\\": \\"mineOnly\\"
     },

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/nodes.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/nodes.js.snap
@@ -84,8 +84,8 @@ exports[`Create and update nodes throws error if a node is created by a plugin n
     \\"parent\\": \\"test\\",
     \\"internal\\": {
         \\"contentDigest\\": \\"hasdfljds\\",
-        \\"owner\\": \\"pluginB\\",
-        \\"type\\": \\"mineOnly\\"
+        \\"type\\": \\"mineOnly\\",
+        \\"owner\\": \\"pluginB\\"
     },
     \\"pickle\\": true
 }
@@ -115,8 +115,8 @@ exports[`Create and update nodes throws error if a node sets a value on "fields"
     },
     \\"internal\\": {
         \\"contentDigest\\": \\"hasdfljds\\",
-        \\"owner\\": \\"pluginA\\",
-        \\"type\\": \\"mineOnly\\"
+        \\"type\\": \\"mineOnly\\",
+        \\"owner\\": \\"pluginA\\"
     },
     \\"pickle\\": true
 }

--- a/packages/gatsby/src/redux/__tests__/nodes.js
+++ b/packages/gatsby/src/redux/__tests__/nodes.js
@@ -11,7 +11,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          mediaType: `test`,
           owner: `tests`,
           type: `Test`,
         },
@@ -31,7 +30,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          mediaType: `test`,
           owner: `tests`,
           type: `Test`,
         },
@@ -49,7 +47,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          mediaType: `test`,
           owner: `tests`,
           type: `Test`,
         },
@@ -78,7 +75,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          mediaType: `test`,
           owner: `tests`,
           type: `Test`,
         },
@@ -98,7 +94,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          mediaType: `test`,
           owner: `tests`,
           type: `Test`,
         },
@@ -128,7 +123,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          mediaType: `test`,
           owner: `tests`,
           type: `Test`,
         },
@@ -169,7 +163,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          mediaType: `test`,
           owner: `pluginA`,
           type: `mineOnly`,
         },
@@ -186,7 +179,6 @@ describe(`Create and update nodes`, () => {
           parent: `test`,
           internal: {
             contentDigest: `hasdfljds`,
-            mediaType: `test`,
             owner: `pluginB`,
             type: `mineOnly`,
           },
@@ -211,7 +203,6 @@ describe(`Create and update nodes`, () => {
           },
           internal: {
             contentDigest: `hasdfljds`,
-            mediaType: `test`,
             owner: `pluginA`,
             type: `mineOnly`,
           },

--- a/packages/gatsby/src/redux/__tests__/nodes.js
+++ b/packages/gatsby/src/redux/__tests__/nodes.js
@@ -11,7 +11,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          owner: `tests`,
           type: `Test`,
         },
         pickle: true,
@@ -30,7 +29,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          owner: `tests`,
           type: `Test`,
         },
         pickle: true,
@@ -47,7 +45,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          owner: `tests`,
           type: `Test`,
         },
         pickle: false,
@@ -75,7 +72,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          owner: `tests`,
           type: `Test`,
         },
         pickle: true,
@@ -94,7 +90,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          owner: `tests`,
           type: `Test`,
         },
         pickle: true,
@@ -123,7 +118,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          owner: `tests`,
           type: `Test`,
         },
         pickle: true,
@@ -163,7 +157,6 @@ describe(`Create and update nodes`, () => {
         parent: `test`,
         internal: {
           contentDigest: `hasdfljds`,
-          owner: `pluginA`,
           type: `mineOnly`,
         },
         pickle: true,
@@ -179,7 +172,6 @@ describe(`Create and update nodes`, () => {
           parent: `test`,
           internal: {
             contentDigest: `hasdfljds`,
-            owner: `pluginB`,
             type: `mineOnly`,
           },
           pickle: true,
@@ -203,7 +195,6 @@ describe(`Create and update nodes`, () => {
           },
           internal: {
             contentDigest: `hasdfljds`,
-            owner: `pluginA`,
             type: `mineOnly`,
           },
           pickle: true,

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -179,6 +179,17 @@ actions.createNode = (node, plugin, traceId) => {
     node.internal = {}
   }
 
+  // Tell user not to set the owner name themself.
+  if (node.internal.owner) {
+    console.log(JSON.stringify(node, null, 4))
+    console.log(
+      chalk.bold.red(
+        `The node internal.owner field is set automatically by Gatsby and not by plugin`
+      )
+    )
+    process.exit(1)
+  }
+
   // Add the plugin name to the internal object.
   if (plugin) {
     node.internal.owner = plugin.name

--- a/www/src/pages/blog/index.js
+++ b/www/src/pages/blog/index.js
@@ -94,11 +94,11 @@ export default BlogPostsIndex
 export const pageQuery = graphql`
   query BlogPostsIndexQuery {
     allMarkdownRemark(
-      sort: { order: DESC, fields: [frontmatter___date] },
+      sort: { order: DESC, fields: [frontmatter___date] }
       filter: {
-        frontmatter: { draft: { ne: true } },
-        fileAbsolutePath: { regex: "/blog/" },
-      },
+        frontmatter: { draft: { ne: true } }
+        fileAbsolutePath: { regex: "/blog/" }
+      }
     ) {
       edges {
         node {

--- a/www/src/pages/docs/bound-action-creators.js
+++ b/www/src/pages/docs/bound-action-creators.js
@@ -42,8 +42,8 @@ export default ActionCreatorsDocs
 export const pageQuery = graphql`
   query ActionCreatorDocsQuery {
     allDocumentationJs(
-      filter: { id: { regex: "/src.*actions.js/" } },
-      sort: { fields: [name] },
+      filter: { id: { regex: "/src.*actions.js/" } }
+      sort: { fields: [name] }
     ) {
       edges {
         node {

--- a/www/src/pages/docs/browser-apis.js
+++ b/www/src/pages/docs/browser-apis.js
@@ -33,8 +33,8 @@ export default BrowserAPIDocs
 export const pageQuery = graphql`
   query BrowserAPIDocsQuery {
     allDocumentationJs(
-      filter: { id: { regex: "/src.*api-browser-docs.js/" } },
-      sort: { fields: [name] },
+      filter: { id: { regex: "/src.*api-browser-docs.js/" } }
+      sort: { fields: [name] }
     ) {
       edges {
         node {

--- a/www/src/pages/docs/node-apis.js
+++ b/www/src/pages/docs/node-apis.js
@@ -37,8 +37,8 @@ export default NodeAPIDocs
 export const pageQuery = graphql`
   query APINodeDocsQuery {
     allDocumentationJs(
-      filter: { id: { regex: "/src.*api-node-docs.js/" } },
-      sort: { fields: [name] },
+      filter: { id: { regex: "/src.*api-node-docs.js/" } }
+      sort: { fields: [name] }
     ) {
       edges {
         node {

--- a/www/src/pages/docs/ssr-apis.js
+++ b/www/src/pages/docs/ssr-apis.js
@@ -33,8 +33,8 @@ export default SSRAPIs
 export const pageQuery = graphql`
   query SSRAPIsQuery {
     allDocumentationJs(
-      filter: { id: { regex: "/src.*api-ssr-docs.js/" } },
-      sort: { fields: [name] },
+      filter: { id: { regex: "/src.*api-ssr-docs.js/" } }
+      sort: { fields: [name] }
     ) {
       edges {
         node {


### PR DESCRIPTION
When designing Gatsby's data system I originally thought all nodes
should have a media type as a way of signaling to transformer plugins
how they could transform its data.

But while writing more source/transformer plugins and sites I've realized
that most nodes are at a terminal/leaf state, full decomposed with no more need of
transformation. For these nodes, they have no need to set a mediaType because
they're already 100% primitive data types.

So setting mediaType is now opt-in and should only be used when a node
has unprocessed raw data that they don't want to take responsibility for processing
themselves futher.

A common example is markdown. Markdown is commonly used for building websites
and is a supported input type for many CMSs or other online content creation
services.

A source plugin for one of these services will generally want to create nodes
for the markdown and set the mediaType to `text/x-markdown` so Gatsby transformer
plugins that understand Markdown can then handle converting the markdown into
other formats.

But the markdown transformer plugin, when it creates transformed nodes, won't want
to set a mediaType as the nodes it creates will now be fully decomposed into
transformed HTML, frontmatter fields, etc.