### PR TITLE
Convert attribute-style CSS to styled-components

### DIFF
--- a/www/src/pages/blog/index.js
+++ b/www/src/pages/blog/index.js
@@ -1,10 +1,64 @@
 import React from "react"
 import Link from "gatsby-link"
+import styled from "styled-components"
 import colors from "../../utils/colors"
 
 import { rhythm, scale } from "../../utils/typography"
 import presets from "../../utils/presets"
 import Container from "../../components/container"
+
+// More obvious that potentially your h1 styles shouldn't
+// have margin by default?
+const H1 = styled.h1`
+  margin-top: 0;
+`
+
+// This could also be a direct-descendant selector on the parent:
+// e.g. <Container vertical spaced> ...
+const Post = styled.div`
+  margin-bottom: ${rhythm(2)};
+`
+
+// This is the third component that only sets margin? To me that
+// indicates a opportunity for refactoring your base styles.
+const Title = styled.h2`
+  margin-bottom: ${rhythm(1 / 8)};
+`
+
+// Names can be as simple as the data they're displaying.
+const Excerpt = styled.p`
+  color: ${colors.b[13]};
+`
+const Avatar = styled.img`
+  border-radius: 100%;
+  display: inline-block;
+  margin-right: ${rhythm(1 / 2)};
+  margin-bottom: 0;
+  vertical-align: top;
+`
+
+// The first time I had to actually invent a name.
+// You might prefer to have a generic <Block inline>
+// component instead (if this component is truly only
+// structural and not semantic)
+const Caption = styled.div`
+  display: inline-block;
+`
+
+// Not sure why this can't just be a styled.small
+// but I decided to reproduce exactly what was there
+// previously.
+const Author = styled.div`
+  color: ${colors.b[12]};
+  line-height: 1.1;
+`
+
+// Again, potentially you can remove the <small>
+// and <em> elements in the markup now.
+const Date = styled.div`
+  color: ${colors.b[12]};
+  line-height: 1.1;
+`
 
 class BlogPostsIndex extends React.Component {
   render() {
@@ -13,75 +67,46 @@ class BlogPostsIndex extends React.Component {
     )
     return (
       <Container>
-        <h1 css={{ marginTop: 0 }}>Blog</h1>
+        <H1>Blog</H1>
         {blogPosts.map(post => {
           const avatar =
             post.frontmatter.author.avatar.childImageSharp.responsiveResolution
           return (
-            <div key={post.fields.slug} css={{ marginBottom: rhythm(2) }}>
+            <Post key={post.fields.slug}>
               <Link to={post.fields.slug}>
-                <h2
-                  css={{
-                    marginBottom: rhythm(1 / 8),
-                  }}
-                >
+                <Title>
                   {post.frontmatter.title}
-                </h2>
-                <p
-                  css={{
-                    color: colors.b[13],
-                  }}
-                >
+                </Title>
+                <Excerpt>
                   {post.frontmatter.excerpt
                     ? post.frontmatter.excerpt
                     : post.excerpt}
-                </p>
+                </Excerpt>
               </Link>
               <div>
-                <img
+                <Avatar
                   alt={`Avatar for ${post.frontmatter.author.id}`}
                   src={avatar.src}
                   srcSet={avatar.srcSet}
                   height={avatar.height}
                   width={avatar.width}
-                  css={{
-                    borderRadius: `100%`,
-                    display: `inline-block`,
-                    marginRight: rhythm(1 / 2),
-                    marginBottom: 0,
-                    verticalAlign: `top`,
-                  }}
                 />
-                <div
-                  css={{
-                    display: `inline-block`,
-                  }}
-                >
-                  <div
-                    css={{
-                      color: colors.b[12],
-                      lineHeight: 1.1,
-                    }}
-                  >
+                <Caption>
+                  <Author>
                     <small>
                       {post.frontmatter.author.id}
                     </small>
-                  </div>
-                  <div
-                    css={{
-                      color: colors.b[12],
-                      lineHeight: 1.1,
-                    }}
-                  >
+                  </Author>
+                  <Date>
                     <small>
                       <em>
                         {post.frontmatter.date}
                       </em>
                     </small>
-                  </div>
-                </div>
+                  </Date>
+                </Caption>
               </div>
-            </div>
+            </Post>
           )
         })}
       </Container>


### PR DESCRIPTION
In response to a [twitter discussion starting from this tweet](https://twitter.com/glenmaddern/status/879866504241487872), Kyle [pointed me](https://twitter.com/kylemathews/status/880575369023062017) at this page so I thought I'd share how I'd refactor it. I left some comments with each component I extracted.

For me, the advantage of styled-components' insistence on component extraction for styling is much like the GraphQL snippet at the end of this file—it colocates a set of information around a single use case in one part of the file.

For the CSS, I believe this makes it easier to notice repetition and redundancy, but in this case I think the real win is in the `render` method. It's now solely concerned with structure and content—anything visual lives elsewhere. It also highlights the elements that have no semantic role (like the `small` and `em` tags) which might mean they're ripe for deletion.

Thanks for sharing a real-world example Kyle. Hope this helps flesh out my points from twitter 🙏