### PR TITLE
[1.0] Fixed a small typo in gatsby-plugin-postcss-sass that prevented CSS modules from working

### DIFF
--- a/packages/gatsby-plugin-postcss-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-postcss-sass/src/gatsby-node.js
@@ -23,7 +23,7 @@ exports.modifyWebpackConfig = ({ config, stage }, { postCssPlugins }) => {
 
       config.loader(`sassModules`, {
         test: /\.module\.s(a|c)ss$/,
-        loaders: [`style`, `cssModulesConfDev`, `postcss`, `sass`],
+        loaders: [`style`, cssModulesConfDev, `postcss`, `sass`],
       })
       return config
     }


### PR DESCRIPTION
`cssModulesConfDev` was a string instead of a variable.