### PR TITLE
[1.0] Fix gatsby package watch task

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -145,6 +145,6 @@
     "build:cli": "babel src/gatsby-cli.js --out-file dist/gatsby-cli.js --presets es2015",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
-    "watch": "rimraf dist && mkdir dist && npm run build:cli && npm run build:src -- --watch && npm run build:internal-plugins && npm run build:rawfiles"
+    "watch": "npm run build -- --watch"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -145,6 +145,6 @@
     "build:cli": "babel src/gatsby-cli.js --out-file dist/gatsby-cli.js --presets es2015",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
-    "watch": "npm run build -- --watch"
+    "watch": "rimraf dist && npm run build:src && npm run build:cli && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"
   }
 }


### PR DESCRIPTION
After doing a `yarn watch` in combination with `gatsby-dev` I noticed that the internal plugins weren't built properly (package.json files were missing from the copied dist). The watch script seems to be messed up, starting the watch before building everything and thus blocking what comes after.