### PR TITLE
[1.0] Improved plugin error without exit

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -136,18 +136,20 @@ module.exports = async (api, args = {}, pluginSource) =>
 
     apisRunning.push(apiRunInstance)
 
+    let currentPluginName = null
+
     mapSeries(
       noSourcePluginPlugins,
       (plugin, callback) => {
+        currentPluginName = plugin.name
         Promise.resolve(runAPI(plugin, api, args)).asCallback(callback)
       },
       (err, results) => {
         if (err) {
           console.log(``)
-          console.log(`A plugin returned an error`)
+          console.log(`Plugin ${currentPluginName} returned an error:`)
           console.log(``)
           console.log(err)
-          process.exit(1)
         }
         // Remove runner instance
         apisRunning = apisRunning.filter(runner => runner !== apiRunInstance)


### PR DESCRIPTION
This allows you to get plugin errors like this failed graphql query and still start the server for inspection.

```
Plugin default-site-plugin returned an error:

Error: GraphQLError: Field "description" must not have a selection since type "String" has no subfields.
```