### PR TITLE
[1.0] Fixes 1317 Google Analytics plugin; updates attachHistory listener logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{*.json, *.svg}]
+indent_style = space
+indent_size = 4
+
+# Matches the exact package.json, or *rc
+[{package.json,*.yml,*rc}]
+indent_style = space
+indent_size = 2

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,12 +1,7 @@
-var lastPath = null
 exports.onRouteUpdate = function(newRoute) {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production`) {
-    var newPath = newRoute.pathname || newRoute.location.pathname
-    if (lastPath !== newPath) {
-      lastPath = newPath
-      ga(`set`, `page`, newPath)
-      ga(`send`, `pageview`)
-    }
+    ga(`set`, `page`, (newRoute.location || {}).pathname)
+    ga(`send`, `pageview`)
   }
 }

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,7 +1,7 @@
-exports.onRouteUpdate = function(newRoute) {
+exports.onRouteUpdate = function({ location }) {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production`) {
-    ga(`set`, `page`, (newRoute.location || {}).pathname)
+    ga(`set`, `page`, (location || {}).pathname)
     ga(`send`, `pageview`)
   }
 }

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,7 +1,12 @@
-exports.onRouteUpdate = function(location) {
+var lastPath = null
+exports.onRouteUpdate = function(newRoute) {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production`) {
-    ga(`set`, `page`, location.pathname)
-    ga(`send`, `pageview`)
+    var newPath = newRoute.pathname || newRoute.location.pathname
+    if (lastPath !== newPath) {
+      lastPath = newPath
+      ga(`set`, `page`, newPath)
+      ga(`send`, `pageview`)
+    }
   }
 }

--- a/packages/gatsby/src/cache-dir/production-app.js
+++ b/packages/gatsby/src/cache-dir/production-app.js
@@ -77,11 +77,13 @@ window.___navigateTo = navigateTo
 const history = createHistory()
 
 function attachToHistory(history) {
-  window.___history = history
+  if(!window.___history) {
+    window.___history = history
 
-  history.listen((location, action) => {
-    apiRunner(`onRouteUpdate`, { location, action })
-  })
+    history.listen((location, action) => {
+      apiRunner(`onRouteUpdate`, { location, action })
+    })
+  }
 }
 
 function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {

--- a/packages/gatsby/src/cache-dir/root.js
+++ b/packages/gatsby/src/cache-dir/root.js
@@ -20,11 +20,13 @@ window.___loader = loader
 const history = createHistory()
 
 function attachToHistory(history) {
-  window.___history = history
+  if(!window.___history) {
+    window.___history = history
 
-  history.listen((location, action) => {
-    apiRunner(`onRouteUpdate`, { location, action })
-  })
+    history.listen((location, action) => {
+      apiRunner(`onRouteUpdate`, { location, action })
+    })
+  }
 }
 
 function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {


### PR DESCRIPTION
Fixes #1317

GA metrics shows whatever the first SSR-served landing page is because page will never change due to an `undefined` reference.

Also found a linearly growing page view bug where each call to onRouteUpdate is called more than one time. Added the "solution" to outline the problem but wanted to chat about it since I know we can probably see about preventing the handler from being attached more than once.

Also adds:
- .editorconfig as there wasn't one (helps IDEs stay sane)