### PR TITLE
[1.0] Fix server/client rendering mismatch

### DIFF
--- a/packages/gatsby/src/cache-dir/component-renderer.js
+++ b/packages/gatsby/src/cache-dir/component-renderer.js
@@ -52,6 +52,19 @@ class ComponentRenderer extends React.Component {
     })
   }
 
+  // Check if the component or json have changed
+  shouldComponentUpdate(nextProps, nextState) {
+    if (
+      this.state.pageResources.component !== nextState.pageResources.component
+    ) {
+      return true
+    }
+    if (this.state.pageResources.json !== nextState.pageResources.json) {
+      return true
+    }
+    return false
+  }
+
   render() {
     if (this.state.pageResources) {
       return createElement(this.state.pageResources.component, {

--- a/packages/gatsby/src/cache-dir/production-app.js
+++ b/packages/gatsby/src/cache-dir/production-app.js
@@ -132,43 +132,39 @@ const loadLayout = cb => {
 }
 
 loadLayout(layout => {
-  const Root = () =>
-    createElement(
-      AltRouter ? AltRouter : DefaultRouter,
-      null,
+  loader.getResourcesForPathname(window.location.pathname, () => {
+    const Root = () =>
       createElement(
-        ScrollContext,
-        { shouldUpdateScroll },
-        createElement(withRouter(layout), {
-          children: layoutProps =>
-            createElement(Route, {
-              render: routeProps => {
-                attachToHistory(routeProps.history)
-                const props = layoutProps ? layoutProps : routeProps
-                if (loader.getPage(props.location.pathname)) {
-                  return createElement(ComponentRenderer, { ...props })
-                } else {
-                  // TODO check (somehow) if we loaded the page
-                  // from a service worker (app shell) as if this
-                  // is the case and we get a 404 we want to kill
-                  // the sw and reload as probably the user is
-                  // trying to visit a page that was created after
-                  // the first time they visited.
-                  return createElement(ComponentRenderer, {
-                    location: { pathname: `/404.html` },
-                  })
-                }
-              },
-            }),
-        })
+        AltRouter ? AltRouter : DefaultRouter,
+        null,
+        createElement(
+          ScrollContext,
+          { shouldUpdateScroll },
+          createElement(withRouter(layout), {
+            children: layoutProps =>
+              createElement(Route, {
+                render: routeProps => {
+                  attachToHistory(routeProps.history)
+                  const props = layoutProps ? layoutProps : routeProps
+                  if (loader.getPage(props.location.pathname)) {
+                    return createElement(ComponentRenderer, { ...props })
+                  } else {
+                    return createElement(ComponentRenderer, {
+                      location: { pathname: `/404.html` },
+                    })
+                  }
+                },
+              }),
+          })
+        )
       )
-    )
 
-  const NewRoot = apiRunner(`wrapRootComponent`, { Root }, Root)[0]
-  ReactDOM.render(
-    <NewRoot />,
-    typeof window !== `undefined`
-      ? document.getElementById(`___gatsby`)
-      : void 0
-  )
+    const NewRoot = apiRunner(`wrapRootComponent`, { Root }, Root)[0]
+    ReactDOM.render(
+      <NewRoot />,
+      typeof window !== `undefined`
+        ? document.getElementById(`___gatsby`)
+        : void 0
+    )
+  })
 })


### PR DESCRIPTION
`production-app.js` wasn't waiting for page resources to load before rendering so
the initial render was of an empty body followed by the full render which caused
a little blink + wastes resources as React has to empty the DOM and the refill it.

This PR fixes this plus adds a `shouldComponentUpdate` to `component-renderer.js`
to avoid re-rendering pages if there's an event signaling new page resources
but the component already had rendered the page.