### PR TITLE
Make default sitemap meet expectations

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -22,7 +22,6 @@ export const defaultOptions = {
       }
       
       allSitePage(
-        limit: 1000000000,
         filter: {
           path: {ne: "/dev-404-page/"}
         }

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -20,29 +20,27 @@ export const defaultOptions = {
           siteUrl
         }
       }
-      allMarkdownRemark(
-        limit: 1000,
+      
+      allSitePage(
+        limit: 1000000000,
         filter: {
-          frontmatter: {
-            draft: { ne: true }
-          }
+          path: {ne: "/dev-404-page/"}
         }
       ) {
         edges {
           node {
-            fields {
-              slug
-            }
+            path
           }
         }
       }
-    }
-  `,
+  }`,
   output: `/sitemap.xml`,
-  serialize: ({ site, allMarkdownRemark }) =>
-    allMarkdownRemark.edges.map(edge => {
+  serialize: ({ site, allSitePage }) =>
+    allSitePage.edges.map(edge => {
       return {
-        url: site.siteMetadata.siteUrl + edge.node.fields.slug,
+        url: site.siteMetadata.siteUrl + edge.node.path,
+        changefreq: 'daily',
+        priority: 0.7,
       }
-    }),
+  }),
 }


### PR DESCRIPTION
The current default for the sitemap query only displays blog posts.

I'd assume that the default sitemap query would be a sitemap of the whole website.

Just my opinion but if you agree, here's a Pull request!