### PR TITLE
[WIP] Support page loaders

### DIFF
--- a/packages/gatsby/src/utils/build-css.js
+++ b/packages/gatsby/src/utils/build-css.js
@@ -1,13 +1,13 @@
 /* @flow */
-import webpack from "webpack"
-import fs from "fs-extra"
-import Promise from "bluebird"
-import webpackConfig from "./webpack.config"
+import webpack from 'webpack'
+import fs from 'fs-extra'
+import Promise from 'bluebird'
+import webpackConfig from './webpack.config'
 
 module.exports = async (program: any) => {
   const { directory } = program
 
-  const compilerConfig = await webpackConfig(program, directory, `build-css`)
+  const compilerConfig = await webpackConfig(`build-css`, { program })
 
   return new Promise((resolve, reject) => {
     webpack(compilerConfig.resolve()).run(err => {

--- a/packages/gatsby/src/utils/build-html.js
+++ b/packages/gatsby/src/utils/build-html.js
@@ -1,8 +1,8 @@
 /* @flow */
-import webpack from "webpack"
-import Promise from "bluebird"
-import fs from "fs"
-import webpackConfig from "./webpack.config"
+import webpack from 'webpack'
+import Promise from 'bluebird'
+import fs from 'fs'
+import webpackConfig from './webpack.config'
 const { store } = require(`../redux`)
 
 const debug = require(`debug`)(`gatsby:html`)
@@ -12,16 +12,13 @@ module.exports = async (program: any) => {
 
   debug(`generating static HTML`)
   // Reduce pages objects to an array of paths.
-  const pages = store.getState().pages.map(page => page.path)
+  const pages = store.getState().pages
 
   // Static site generation.
-  const compilerConfig = await webpackConfig(
+  const compilerConfig = await webpackConfig(`build-html`, {
     program,
-    directory,
-    `build-html`,
-    null,
-    pages
-  )
+    pages,
+  })
 
   return new Promise((resolve, reject) => {
     webpack(compilerConfig.resolve()).run((e, stats) => {

--- a/packages/gatsby/src/utils/build-javascript.js
+++ b/packages/gatsby/src/utils/build-javascript.js
@@ -1,16 +1,17 @@
 /* @flow */
-import webpack from "webpack"
-import Promise from "bluebird"
-import webpackConfig from "./webpack.config"
+import webpack from 'webpack'
+import Promise from 'bluebird'
+import webpackConfig from './webpack.config'
+
+const { store } = require(`../redux`)
 
 module.exports = async program => {
-  const { directory } = program
+  const pages = store.getState().pages
 
-  const compilerConfig = await webpackConfig(
+  const compilerConfig = await webpackConfig(`build-javascript`, {
     program,
-    directory,
-    `build-javascript`
-  )
+    pages,
+  })
 
   return new Promise(resolve => {
     webpack(compilerConfig.resolve()).run(() => resolve())

--- a/packages/gatsby/src/utils/develop.js
+++ b/packages/gatsby/src/utils/develop.js
@@ -30,8 +30,6 @@ rlInterface.on(`SIGINT`, () => {
 })
 
 async function startServer(program) {
-  const directory = program.directory
-
   // Start bootstrap process.
   await bootstrap(program)
   await developHtml(program).catch(err => {
@@ -39,12 +37,12 @@ async function startServer(program) {
     process.exit(1)
   })
 
-  const compilerConfig = await webpackConfig(
+  const pages = store.getState().pages
+
+  const compilerConfig = await webpackConfig(`develop`, {
     program,
-    directory,
-    `develop`,
-    program.port
-  )
+    pages,
+  })
 
   const devConfig = compilerConfig.resolve()
   const compiler = webpack(devConfig)


### PR DESCRIPTION
Haven’t had the time i wanted to work on this, but I thought i’d throw up what I have for the moment.

The reason I went with doing this in the webpack config vs, inlining the loader in the page require is that this positions the feature better for a webpack2/3 upgrade. Ultimately you’ll get the most power from the API if you don’t need your loader and options to be string serializable.