### PR TITLE
gatsby-transformer-yaml: add unist-util-select as a dependency

### DIFF
--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.0",
+    "unist-util-select": "^1.5.0"
     "js-yaml": "3.7.0"
   },
   "devDependencies": {

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "unist-util-select": "^1.5.0"
+    "unist-util-select": "^1.5.0",
     "js-yaml": "3.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
After adding `gatsby-transformer-yaml` to a project, `gatsby develop` complained about not being able to find `unist-util-select` (macOS 10.12.5 / Node 6.13.0 / Yarn 0.27.5). Hence, I've added `unist-util-select` as a dependency for the YAML transformer.