### PR TITLE
fix: Update examples directory URL due to 404 with current link

### DIFF
--- a/docs/docs/building-with-components.md
+++ b/docs/docs/building-with-components.md
@@ -185,4 +185,4 @@ query BlogPostBySlug($slug: String!) {
 `
 ```
 
-These are examples of the different ways React components are used in Gatsby sites. To see full working examples, check out the [examples directory](https://github.com/gatsbyjs/gatsby/tree/1.0/examples) in the Gatsby repo.
+These are examples of the different ways React components are used in Gatsby sites. To see full working examples, check out the [examples directory](https://github.com/gatsbyjs/gatsby/tree/master/examples) in the Gatsby repo.


### PR DESCRIPTION
I was going through the docs and noticed the URL was broken. Figured it would be faster to open a PR than submit an issue about it.