### PR TITLE
fix glamor + babel modification

### DIFF
--- a/packages/gatsby-plugin-glamor/src/gatsby-node.js
+++ b/packages/gatsby-plugin-glamor/src/gatsby-node.js
@@ -10,11 +10,11 @@ exports.modifyWebpackConfig = ({ config }) =>
 
 // Add Glamor support
 exports.modifyBabelrc = ({ babelrc }) => {
-  babelrc.plugins.push([
-    `transform-react-jsx`,
-    { pragma: `Glamor.createElement` },
-  ])
-  babelrc.plugins.push(`babel-plugin-glamor`)
-
-  return babelrc
+  return {plugins: babelrc.plugins.concat([
+    [
+      `transform-react-jsx`,
+      { pragma: `Glamor.createElement` },
+    ],
+    `babel-plugin-glamor`,
+  ])}
 }


### PR DESCRIPTION
dunno why this fixes it but it does. Without this change, having `gatsby-plugin-glamor` clobbers babel's import/export transpilation.