### PR TITLE
Fix bug where the webpack build target is incorrectly set

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -520,7 +520,7 @@ module.exports = async (
     // and server (see
     // https://github.com/defunctzombie/package-browser-field-spec); setting
     // the target tells webpack which file to include, ie. browser vs main.
-    target: stage === (`build-html` || `develop-html`) ? `node` : `web`,
+    target: (stage === `build-html` || stage === `develop-html`) ? `node` : `web`,
     profile: stage === `production`,
     devtool: devtool(),
     output: output(),


### PR DESCRIPTION
In `webpack.config.js`, the `target` is incorrectly set, causing errors such as `Cannot find module "fs"`.

"stage === (`build-html` || `develop-html`)" is the equivalent of "stage === `build-html`". Both strings are non-empty, so both will evaluate to true. When the expression is essentially`(true || true)`, the first one will return.

Therefore, when the stage is `develop-html`, target incorrectly evaluates to `web` instead of `node`.