### PR TITLE
Fix "Creating Pages" example's variable reference

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -77,8 +77,9 @@ exports.createPages = ({ boundActionCreators }) => {
 
         // Create pages for each markdown file.
         result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+          const path = node.frontmatter.path;
           createPage({
-            path: node.path,
+            path,
             component: blogPostTemplate,
             // In your blog post template's graphql query, you can use path
             // as a GraphQL variable to query for data from the markdown file.


### PR DESCRIPTION
The example was referencing `path` twice, but not including the full "path" to the variable, and using `node.path` or `path` rather than `node.frontmatter.path`.  This declares a new `path` variable and uses it in both places