### PR TITLE
Add stylus support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "iflow-lodash": "^1.1.24",
     "iflow-react-router": "^1.2.1",
     "jest": "^20.0.4",
+    "jest-cli": "^20.0.4",
     "lerna": "^2.0.0-rc.5",
     "plop": "^1.7.4",
     "prettier": "^1.5.2",

--- a/packages/gatsby-plugin-stylus/README.md
+++ b/packages/gatsby-plugin-stylus/README.md
@@ -33,3 +33,24 @@ plugins: [
   },
 ],
 ```
+
+### With Stylus plugins
+
+This plugin has the same API as [stylus-loader](https://github.com/shama/stylus-loader#stylus-plugins), which means you can add stylus plugins with `use`:
+
+```javascript
+// in gatsby-config.js
+const rupture = require('rupture');
+
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-stylus',
+      options: {
+        modules: true,
+        use: [rupture()],
+      },
+    },
+  ],
+};
+```

--- a/packages/gatsby-plugin-stylus/README.md
+++ b/packages/gatsby-plugin-stylus/README.md
@@ -1,3 +1,35 @@
 # gatsby-plugin-stylus
 
-Stub README
+Provides drop-in support for Stylus with or without CSS Modules
+
+## Install
+
+`yarn add gatsby-plugin-stylus`
+
+## How to use
+
+1. Include the plugin in your `gatsby-config.js` file.
+2. Write your stylesheets in Stylus (`.styl` files) and require/import them
+
+### Without CSS Modules
+
+```javascript
+// in gatsby-config.js
+plugins: [
+  `gatsby-plugin-stylus`
+]
+```
+
+### With CSS Modules
+
+```javascript
+// in gatsby-config.js
+plugins: [
+  {
+    resolve: 'gatsby-plugin-stylus',
+    options: {
+      modules: true,
+    },
+  },
+],
+```

--- a/packages/gatsby-plugin-stylus/README.md
+++ b/packages/gatsby-plugin-stylus/README.md
@@ -22,17 +22,7 @@ plugins: [
 
 ### With CSS Modules
 
-```javascript
-// in gatsby-config.js
-plugins: [
-  {
-    resolve: 'gatsby-plugin-stylus',
-    options: {
-      modules: true,
-    },
-  },
-],
-```
+Using CSS modules requires no additional configuration. Simply prepend `.module` to the extension. For example: `App.styl` -> `App.module.styl`. Any file with the `module` extension will use CSS modules.
 
 ### With Stylus plugins
 
@@ -47,7 +37,6 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-stylus',
       options: {
-        modules: true,
         use: [rupture()],
       },
     },

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -1,18 +1,25 @@
 {
   "name": "gatsby-plugin-stylus",
+  "description": "Gatsby support for Stylus",
   "version": "1.0.1",
-  "description": "Stub description for gatsby-plugin-stylus",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
+  "author": "Ian Sinnott <ian@iansinnott.com>",
+  "dependencies": {
+    "babel-cli": "^6.24.1",
+    "extract-text-webpack-plugin": "^1.0.1",
+    "stylus": "^0.54.5",
+    "stylus-loader": "webpack1"
   },
+  "devDependencies": {},
   "keywords": [
-    "gatsby"
+    "gatsby",
+    "gatsby-plugin",
+    "stylus"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
-  "devDependencies": {
-    "babel-cli": "^6.24.1"
+  "main": "./gatsby-node.js",
+  "readme": "README.md",
+  "scripts": {
+    "build": "babel src --out-dir .",
+    "watch": "babel -w src --out-dir ."
   }
 }

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -27,7 +27,6 @@ exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
 
   // Pass in stylus plugins regardless of stage.
   if (Array.isArray(options.use)) {
-    config.veryINvalid = true
     config.merge(current => {
       current.stylus = {
         use: options.use,

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -1,0 +1,97 @@
+/**
+ * Usage:
+ *
+ * // gatsby-config.js
+ * plugins: [
+ *  `gatsby-plugin-stylus`,
+ * ],
+ *
+ * // Usage with options:
+ *
+ * // gatsby-config.js
+ * plugins: [
+ *   {
+ *     resolve: `gatsby-plugin-stylus`,
+ *     options: {
+ *       modules: true,
+ *       use: [],
+ *     },
+ *   },
+ * ],
+ */
+const ExtractTextPlugin = require(`extract-text-webpack-plugin`)
+
+exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
+  const modules = Boolean(options.modules)
+  const cssModulesConfProd = `css?modules&minimize&importLoaders=1`
+  const cssModulesConfDev =
+    `css?modules&importLoaders=1&localIdentName=[name]---[local]---[hash:base64:5]`
+
+  // Pass in stylus plugins regardless of stage.
+  if (Array.isArray(options.use)) {
+    console.log(`WARNING: gatsby-plugin-stylus \`use\` option is not yet supported. See https://github.com/gatsbyjs/gatsby/issues/1432`)
+    console.log()
+    // config.merge(current => {
+    //   current.stylus = {
+    //     use: options.use,
+    //   }
+    //   return current
+    // })
+  } else if (options.use) {
+    throw new Error(`gatsby-plugin-stylus "use" option passed with ${options.use}. Pass an array of stylus plugins instead`)
+  }
+
+  switch (stage) {
+    case `develop`: {
+      config.loader(`stylus`, {
+        test: /\.styl$/,
+        loaders: [`style`, modules ? cssModulesConfDev : `css`, `postcss`, `stylus`],
+      })
+      return config
+    }
+
+    case `build-css`: {
+      config.loader(`stylus`, {
+        test: /\.styl$/,
+        loader: ExtractTextPlugin.extract(`style`, [
+          modules ? cssModulesConfProd : `css?minimize`,
+          `postcss`,
+          `stylus`,
+        ]),
+      })
+      return config
+    }
+
+    case `develop-html`:
+    case `build-html`: {
+      const moduleLoader = ExtractTextPlugin.extract(`style`, [
+        cssModulesConfProd,
+        `postcss`,
+        `stylus`,
+      ])
+
+      config.loader(`stylus`, {
+        test: /\.styl$/,
+        loader: modules ? moduleLoader : `null`,
+      })
+      return config
+    }
+
+    case `build-javascript`: {
+      const moduleLoader = ExtractTextPlugin.extract(`style`, [
+        cssModulesConfProd,
+        `stylus`,
+      ])
+      config.loader(`stylus`, {
+        test: /\.styl$/,
+        loader: modules ? moduleLoader : `null`,
+      })
+
+      return config
+    }
+
+    default: {
+      return config
+    }
+  }
+}

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -29,14 +29,12 @@ exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
 
   // Pass in stylus plugins regardless of stage.
   if (Array.isArray(options.use)) {
-    console.log(`WARNING: gatsby-plugin-stylus \`use\` option is not yet supported. See https://github.com/gatsbyjs/gatsby/issues/1432`)
-    console.log()
-    // config.merge(current => {
-    //   current.stylus = {
-    //     use: options.use,
-    //   }
-    //   return current
-    // })
+    config.merge(current => {
+      current.stylus = {
+        use: options.use,
+      }
+      return current
+    })
   } else if (options.use) {
     throw new Error(`gatsby-plugin-stylus "use" option passed with ${options.use}. Pass an array of stylus plugins instead`)
   }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -29,6 +29,7 @@
     "chokidar": "^1.7.0",
     "chunk-manifest-webpack-plugin": "0.1.0",
     "commander": "^2.9.0",
+    "common-tags": "^1.4.0",
     "convert-hrtime": "^2.0.0",
     "copyfiles": "^1.2.0",
     "css-loader": "^0.26.1",

--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -1,8 +1,20 @@
 import _ from "lodash"
 import invariant from "invariant"
 import path from "path"
-import validate from "webpack-validator"
+import validate, { Joi } from "webpack-validator"
 import apiRunnerNode from "./api-runner-node"
+
+// We whitelist special config keys that are not part of a standard Webpack v1
+// config but are in common usage. We should be able to completely remove this
+// once we're on Webpack v3.
+//
+// For info on whitelisting with webpack-validator see:
+// https://github.com/js-dxtools/webpack-validator#customizing
+const validationWhitelist = Joi.object({
+  stylus: Joi.object({
+    use: Joi.any(),
+  }),
+})
 
 export default (async function ValidateWebpackConfig(config, stage) {
   // We don't care about the return as plugins just mutate the config directly.
@@ -21,6 +33,7 @@ export default (async function ValidateWebpackConfig(config, stage) {
 
   const validationState = validate(config.resolve(), {
     returnValidation: true,
+    schemaExtension: validationWhitelist,
   })
 
   if (!validationState.error) {
@@ -34,6 +47,13 @@ export default (async function ValidateWebpackConfig(config, stage) {
     console.log(err.type, `,`, err.message)
     console.log(`\n`)
   })
+
+  console.log(
+    `Your Webpack config does not appear to be valid. This could be because of
+something you added or a plugin. If you don't recognize the invalid keys listed
+above try removing plugins and rebuilding to identify the culprit.
+`
+  )
 
   return process.exit(1)
 })

--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -11,9 +11,7 @@ import apiRunnerNode from "./api-runner-node"
 // For info on whitelisting with webpack-validator see:
 // https://github.com/js-dxtools/webpack-validator#customizing
 const validationWhitelist = Joi.object({
-  stylus: Joi.object({
-    use: Joi.any(),
-  }),
+  stylus: Joi.any(),
 })
 
 export default (async function ValidateWebpackConfig(config, stage) {

--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -1,7 +1,7 @@
 import _ from "lodash"
 import invariant from "invariant"
-import path from "path"
 import validate, { Joi } from "webpack-validator"
+import stripIndent from 'common-tags/lib/stripIndent'
 import apiRunnerNode from "./api-runner-node"
 
 // We whitelist special config keys that are not part of a standard Webpack v1
@@ -46,12 +46,11 @@ export default (async function ValidateWebpackConfig(config, stage) {
     console.log(`\n`)
   })
 
-  console.log(
-    `Your Webpack config does not appear to be valid. This could be because of
-something you added or a plugin. If you don't recognize the invalid keys listed
-above try removing plugins and rebuilding to identify the culprit.
-`
-  )
+  console.log(stripIndent`
+    Your Webpack config does not appear to be valid. This could be because of
+    something you added or a plugin. If you don't recognize the invalid keys listed
+    above try removing plugins and rebuilding to identify the culprit.
+  `)
 
   return process.exit(1)
 })


### PR DESCRIPTION
**What changed**

* I filled out the gatsby-plugin-stylus module. We now have stylus support.
* I added `"stylus"` as a whitelisted key in webpack-validator. This allows full support of the [stylus-loader](https://github.com/shama/stylus-loader#stylus-plugins)
* I added what I hope is a helpfel error message for when the webpack validation fails

Fixes #1432