### PR TITLE
Fixes the example for navigateTo.

### DIFF
--- a/packages/gatsby-link/README.md
+++ b/packages/gatsby-link/README.md
@@ -48,7 +48,7 @@ For cases when you can only use event handlers for navigation, you can use `navi
 import { navigateTo } from "gatsby-link"
 
 render () {
-  <div onClick={navigateTo('/example')}>
+  <div onClick={ () => navigateTo('/example')}>
     <p>Example</p>
   </div>
 }


### PR DESCRIPTION
Unfortunately I didn't even notice the mistake until the next morning.
Sorry for that.