### PR TITLE
Properly load options for Remark

### DIFF
--- a/examples/using-remark/src/pages/2016-04-15---hello-world-kitchen-sink/index.md
+++ b/examples/using-remark/src/pages/2016-04-15---hello-world-kitchen-sink/index.md
@@ -36,6 +36,7 @@ This is intended as a quick reference and showcase. For more complete info, see 
 [Links](#links)  
 [Images](#images)  
 [Tables](#tables)  
+[Footnotes](#footnotes)  
 [Blockquotes](#blockquotes)  
 [Inline HTML](#html)  
 [Horizontal Rule](#hr)  
@@ -262,6 +263,21 @@ Markdown | Less | Pretty
 *Still* | `renders` | **nicely**
 1 | 2 | 3
 
+<a name="footnotes"></a>
+
+## Footnotes
+
+Footnotes are also not a core feature of markdown, but they're a common extension feature.  The footnote syntax looks like this:
+
+```markdown
+This line has a footnote [^1].  Scroll down or click the link to see it.
+```
+
+That renders like this:
+
+This line has a footnote [^1].  Scroll down or click the link to see it.
+
+
 <a name="blockquotes"></a>
 
 ## Blockquotes
@@ -361,6 +377,11 @@ This line is separated from the one above by two newlines, so it will be a *sepa
 
 This line is also begins a separate paragraph, but...  
 This line is only separated by a single newline, so it's a separate line in the *same paragraph*.
+
+
+
+
+[^1]: The footnote appears at the bottom of the page
 
 [1]: https://www.gatsbyjs.org/docs/packages/gatsby-transformer-remark/
 [2]: http://remark.js.org/

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -38,11 +38,11 @@ module.exports = (
 
   return new Promise((resolve, reject) => {
     // Setup Remark.
-    const remark = new Remark({
+    const remark = new Remark().data('settings', {
       commonmark: true,
       footnotes: true,
       pedantic: true,
-    })
+    });
 
     async function getAST(markdownNode) {
       const cachedAST = await cache.get(astCacheKey(markdownNode))


### PR DESCRIPTION
Fixes #1434

Remark now loads options with a `data` method instead of directly in the constructor. 
This change isn't really well documented right now, but you can see the details [in this issue](https://github.com/wooorm/remark/issues/247).