### PR TITLE
Use lowercase require for "rss"

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -1,5 +1,5 @@
 import path from "path"
-import RSS from "RSS"
+import RSS from "rss"
 import { defaultOptions, runQuery, writeFile } from "./internals"
 
 const publicPath = `./public`


### PR DESCRIPTION
I'm chasing down a bug where the "RSS" module cannot be found on differing filesystems. I have a hunch it has to do with the uppercase usage here.