### PR TITLE
fix issue with ssr for redux example

### DIFF
--- a/examples/redux/gatsby-ssr.js
+++ b/examples/redux/gatsby-ssr.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Provider } from 'react-redux'
+import { renderToString } from 'react-dom/server'
 
 import createStore from './src/state/createStore'
 
@@ -12,5 +13,5 @@ exports.replaceRenderer = ({ bodyComponent, replaceBodyHTMLString }) => {
             {bodyComponent}
         </Provider>
     )
-    replaceBodyHTMLString(<ConnectedBody/>)
+    replaceBodyHTMLString(renderToString(<ConnectedBody/>))
 }


### PR DESCRIPTION
Currently, when building using the redux example. the server rendering doesn't render the proper HTML.
![-users-lemuel-cloudfilefinder-public-index html](https://user-images.githubusercontent.com/7395051/27998464-7986f2c8-64dd-11e7-9ce9-05a8e3e9c435.png)

This PR updates the redux example.
