### PR TITLE
Remove NamedModulesPlugin from production builds

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -300,7 +300,6 @@ module.exports = async (
           new webpack.optimize.OccurenceOrderPlugin(),
           new GatsbyModulePlugin(),
           // new WebpackStableModuleIdAndHash({ seed: 9, hashSize: 47 }),
-          new webpack.NamedModulesPlugin(),
         ]
       }
       default:


### PR DESCRIPTION
Looks like Gatsby uses `webpack.NamedModulesPlugin()` in both production and development modes, diespite this comment in the development case: 

> Names module ids with their filepath. We use this in development
> to make it easier to see what modules have hot reloaded, etc. as
> the numerical IDs aren't useful. In production we use numerical module
> ids to reduce filesize.

Removing this plugin reduces the output filesize commons bundle from `268KB` to `213KB` for a single component test site.