### PR TITLE
Removed `owner` assignation to prevent error

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -300,7 +300,6 @@ function createGraphQLNode(ent, type, createNode) {
       type: type.toUpperCase(),
       content: JSON.stringify(node),
       mediaType: `text/html`,
-      owner: `gatsby-source-wordpress`,
     },
   }
 
@@ -352,7 +351,6 @@ function addFields(ent, newEnt, createNode) {
         type: `${typePrefix}ACF_Field`,
         content: JSON.stringify(ent.acf),
         mediaType: `application/json`,
-        owner: `gatsby-source-wordpress`,
       },
     }
     acfNode.internal.contentDigest = digest(stringify(acfNode))


### PR DESCRIPTION
Preventing the error `The node internal.owner field is set automatically by Gatsby and not by plugin`