### PR TITLE
Allow for env files

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -1,0 +1,29 @@
+---
+title: "Environment Variables"
+---
+
+You can easily provide environment variables to your site. Just add a `.env.development` and/or `.env.production` file in your root folder for development or production builds respectively. The environment variables are embedded during build time using Webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/). Because these variables are provided at build time, you will need restart your dev server or rebuild your site after changing them.
+
+## Example
+
+```
+# Example .env.development file
+
+API_URL=https://dev.example.com/api
+```
+
+```
+# Example .env.production file
+
+API_URL=https://example.com/api
+
+```
+
+These variables will be available to your site as `process.env.API_URL`.
+
+> You can not override certain environment variables as some are used internally for optimizations during build
+
+Reserved environment variables:
+
+- `NODE_ENV`
+- `PUBLIC_DIR`

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -34,6 +34,7 @@
     "css-loader": "^0.26.1",
     "debug": "^2.6.0",
     "detect-port": "^1.2.1",
+    "dotenv": "^4.0.0",
     "eventemitter2": "^4.1.0",
     "express": "^4.14.0",
     "express-graphql": "^0.6.6",


### PR DESCRIPTION
Usually dotenv is used to throw variables on `process.env` but in this case I'm just using the `parse` method and adding those variables to webpack's DefinePlugin. This way `process.env` never gets altered. 

This also make sure not to overwrite `NODE_ENV` or `PUBLIC_DIR`.

To use, you'd just put an `.env.development` or `.env.production` file in your root folder and those variables will be provided at dev/build time.

Could fix #660