### PR TITLE
Fix Contentful example URL

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -3,7 +3,7 @@
 Source plugin for pulling content types, entries, and assets into Gatsby from Contentful spaces. It creates links between entry types and asset so they can be queried in Gatsby using GraphQL.
 
 An example site for using this plugin is at
-https://gatsby-using-contentful.netlify.com/
+https://using-contentful.netlify.com/
 
 ## Install
 


### PR DESCRIPTION
As per https://github.com/gatsbyjs/gatsby/blob/master/examples/using-contentful/README.md