### PR TITLE
Added support for nested img tags in html nodes

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -4,7 +4,7 @@ const isRelativeUrl = require(`is-relative-url`)
 const _ = require(`lodash`)
 const { responsiveSizes } = require(`gatsby-plugin-sharp`)
 const Promise = require(`bluebird`)
-const $ = require(`cheerio`)
+const cheerio = require(`cheerio`)
 
 // If the image is relative (not hosted elsewhere)
 // 1. Find the image file
@@ -26,29 +26,98 @@ module.exports = (
   const options = _.defaults(pluginOptions, defaults)
 
   // This will only work for markdown syntax image tags
-  const imageNodes = select(markdownAST, `image`)
+  const markdownImageNodes = select(markdownAST, `image`)
 
   // This will also allow the use of html image tags
-  const rawHtmlImageNodes = select(markdownAST, `html`).filter(node =>
-    node.value.startsWith(`<img`)
-  )
+  const rawHtmlNodes = select(markdownAST, `html`)
 
-  for (let node of rawHtmlImageNodes) {
-    let formattedImgTag = Object.assign(
-      node,
-      $.parseHTML(node.value)[0].attribs
+  // Takes a node and generates the needed images and then returns
+  // the needed HTML replacement for the image
+  const generateImagesAndUpdateNode = async function(node, resolve) {
+    const imagePath = path.posix.join(
+      getNode(markdownNode.parent).dir,
+      node.url
     )
-    formattedImgTag.url = formattedImgTag.src
-    formattedImgTag.type = `image`
-    formattedImgTag.position = node.position
+    const imageNode = _.find(files, file => {
+      if (file && file.absolutePath) {
+        return file.absolutePath === imagePath
+      }
+      return null
+    })
+    if (!imageNode || !imageNode.absolutePath) {
+      return resolve()
+    }
 
-    imageNodes.push(formattedImgTag)
+    let responsiveSizesResult = await responsiveSizes({
+      file: imageNode,
+      args: options,
+    })
+
+    // console.log("responsiveSizesResult", responsiveSizesResult)
+    // Calculate the paddingBottom %
+    const ratio = `${1 / responsiveSizesResult.aspectRatio * 100}%`
+
+    const originalImg = responsiveSizesResult.originalImage
+    const fallbackSrc = responsiveSizesResult.src
+    const srcSet = responsiveSizesResult.srcSet
+
+    // Generate default alt tag
+    const srcSplit = node.url.split(`/`)
+    const fileName = srcSplit[srcSplit.length - 1]
+    const fileNameNoExt = fileName.replace(/\.[^/.]+$/, ``)
+    const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `)
+
+      // TODO
+      // add support for sub-plugins having a gatsby-node.js so can add a
+      // bit of js/css to add blurry fade-in.
+      // https://www.perpetual-beta.org/weblog/silky-smooth-image-loading.html
+
+      // Construct new image node w/ aspect ratio placeholder
+      let rawHTML = `
+  <span
+    class="gatsby-resp-image-wrapper"
+    style="position: relative; z-index: -1; display: block; ${options.wrapperStyle}"
+  >
+    <span
+      class="gatsby-resp-image-background-image"
+      style="padding-bottom: ${ratio};position: relative; width: 100%; bottom: 0; left: 0; background-image: url('${responsiveSizesResult.base64}'); background-size: cover; display: block;"
+    >
+      <img
+        class="gatsby-resp-image-image"
+        style="width: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px ${options.backgroundColor};"
+        alt="${node.alt ? node.alt : defaultAlt}"
+        title="${node.title ? node.title : ``}"
+        src="${fallbackSrc}"
+        srcset="${srcSet}"
+        sizes="${responsiveSizesResult.sizes}"
+      />
+    </span>
+  </span>
+  `
+
+      // Make linking to original image optional.
+      if (options.linkImagesToOriginal) {
+        rawHTML = `
+  <a
+    class="gatsby-resp-image-link"
+    href="${originalImg}"
+    style="display: block"
+    target="_blank"
+    rel="noopener"
+  >
+  ${rawHTML}
+  </a>
+    `
+      }
+
+    return rawHTML;
   }
 
   return Promise.all(
-    imageNodes.map(
+    // Simple because there is no nesting in markdown
+    markdownImageNodes.map(
       node =>
-        new Promise((resolve, reject) => {
+        new Promise(async (resolve, reject) => {
           const fileType = node.url.slice(-3)
 
           // Ignore gifs as we can't process them,
@@ -58,91 +127,67 @@ module.exports = (
             fileType !== `gif` &&
             fileType !== `svg`
           ) {
-            const imagePath = path.posix.join(
-              getNode(markdownNode.parent).dir,
-              node.url
-            )
-            const imageNode = _.find(files, file => {
-              if (file && file.absolutePath) {
-                return file.absolutePath === imagePath
-              }
-              return null
-            })
-            if (!imageNode || !imageNode.absolutePath) {
-              return resolve()
-            }
-
-            responsiveSizes({
-              file: imageNode,
-              args: options,
-            }).then(responsiveSizesResult => {
-              // console.log("responsiveSizesResult", responsiveSizesResult)
-              // Calculate the paddingBottom %
-              const ratio = `${1 / responsiveSizesResult.aspectRatio * 100}%`
-
-              const originalImg = responsiveSizesResult.originalImage
-              const fallbackSrc = responsiveSizesResult.src
-              const srcSet = responsiveSizesResult.srcSet
-
-              // Generate default alt tag
-              const srcSplit = node.url.split(`/`)
-              const fileName = srcSplit[srcSplit.length - 1]
-              const fileNameNoExt = fileName.replace(/\.[^/.]+$/, ``)
-              const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `)
-
-              // TODO
-              // add support for sub-plugins having a gatsby-node.js so can add a
-              // bit of js/css to add blurry fade-in.
-              // https://www.perpetual-beta.org/weblog/silky-smooth-image-loading.html
-
-              // Construct new image node w/ aspect ratio placeholder
-              let rawHTML = `
-          <span
-            class="gatsby-resp-image-wrapper"
-            style="position: relative; z-index: -1; display: block; ${options.wrapperStyle}"
-          >
-            <span
-              class="gatsby-resp-image-background-image"
-              style="padding-bottom: ${ratio};position: relative; width: 100%; bottom: 0; left: 0; background-image: url('${responsiveSizesResult.base64}'); background-size: cover; display: block;"
-            >
-              <img
-                class="gatsby-resp-image-image"
-                style="width: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px ${options.backgroundColor};"
-                alt="${node.alt ? node.alt : defaultAlt}"
-                title="${node.title ? node.title : ``}"
-                src="${fallbackSrc}"
-                srcset="${srcSet}"
-                sizes="${responsiveSizesResult.sizes}"
-              />
-            </span>
-          </span>
-          `
-
-              // Make linking to original image optional.
-              if (options.linkImagesToOriginal) {
-                rawHTML = `
-          <a
-            class="gatsby-resp-image-link"
-            href="${originalImg}"
-            style="display: block"
-            target="_blank"
-            rel="noopener"
-          >
-          ${rawHTML}
-          </a>
-            `
-              }
-
-              // Replace the image node with an inline HTML node.
-              node.type = `html`
-              node.value = rawHTML
-              return resolve()
-            })
+            const rawHTML = await generateImagesAndUpdateNode(node, resolve)
+            // Replace the image node with an inline HTML node.
+            node.type = `html`
+            node.value = rawHTML
+            return resolve()
           } else {
             // Image isn't relative so there's nothing for us to do.
             return resolve()
           }
         })
     )
-  )
+  ).then(() =>{
+    // HTML image node stuff
+     
+    return Promise.all(
+      // Complex because HTML nodes can contain multiple images
+      rawHtmlNodes.map(
+        node =>
+          new Promise(async (resolve, reject) => {
+            const $ = cheerio.load(node.value);
+            if($('img').length === 0) {
+              // No img tags
+              return resolve();
+            }
+            
+            let imageRefs = [];
+            $('img').each(function() {
+              imageRefs.push($(this));
+            });
+
+            for (let thisImg of imageRefs) {
+              //Get the details we need
+              let formattedImgTag = {};
+              formattedImgTag.url = thisImg.attr('src');
+              formattedImgTag.title = thisImg.attr('title');
+              formattedImgTag.alt = thisImg.attr('alt');
+
+              const fileType = formattedImgTag.url.slice(-3)
+
+              // Ignore gifs as we can't process them,
+              // svgs as they are already responsive by definition
+              if (
+                isRelativeUrl(formattedImgTag.url) &&
+                fileType !== `gif` &&
+                fileType !== `svg`
+              ) {
+                const rawHTML = await generateImagesAndUpdateNode(formattedImgTag, resolve); 
+                // Replace the image string
+                thisImg.replaceWith(rawHTML);
+
+              }
+              
+            };
+
+            // Replace the image node with an inline HTML node.
+            node.type = `html`;
+            node.value = $.html();
+
+            return resolve()
+          })
+      )
+    )
+  });
 }


### PR DESCRIPTION
While migrating some of my larger sites over to Gatsby I noticed that my initial solution for html image tags didn't work nested img tags.

**This would work**

```
<img .../> 
```

**This would not work**

```
<div>
<img .../>
</div> 
```
This should now work for both.
