### PR TITLE
[gatsby-source-contentful] add missing host param in createClient

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -11,6 +11,7 @@ module.exports = async ({ spaceId, accessToken, host, syncToken }) => {
   const client = contentful.createClient({
     space: spaceId,
     accessToken,
+    host: host || `cdn.contentful.com`
   })
 
   // The sync API puts the locale in all fields in this format { fieldName:


### PR DESCRIPTION
## Summary
This PR fixes a problem when using Contentful Preview API. 

I was getting in my terminal the following error after the support of Preview API was published yesterday:

`spaceId/accessToken source and transform nodesAccessing your Contentful space failed. Perhaps you're offline or the spaceId/accessToken is incorrect.`

Initial implementation of Contentful Preview API support - https://github.com/gatsbyjs/gatsby/pull/1464