### PR TITLE
Replace class=language-* w data-language=* to avoid potential Prism bug

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -16,7 +16,16 @@ plugins: [
     resolve: `gatsby-transformer-remark`,
     options: {
       plugins: [
-        `gatsby-remark-prismjs`,
+        {
+          resolve: `gatsby-remark-prismjs`,
+          options: {
+            // Use a data attribute for language instead of a class for
+            // <pre> tags containing syntax highlighting; defaults to false.
+            // If you use Prism directly within your site,
+            // you may use this to prevent Prism from re-processing syntax.
+            useDataAttribute: false,
+          },
+        },
       ]
     }
   }

--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -9,7 +9,8 @@
     "unist-util-visit": "^1.1.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1"
+    "babel-cli": "^6.24.1",
+    "remark": "^7.0.1"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`remark prism plugin generates a <pre> tag with a data attribute if configured to do so 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "js",
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 3,
+          "offset": 17,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight\\">
+      <pre data-language=\\"js\\"><code><span class=\\"token comment\\" spellcheck=\\"true\\">// Fake</span>
+</code></pre>
+      </div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 4,
+      "line": 3,
+      "offset": 17,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`remark prism plugin generates a <pre> tag with a language class by default 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "js",
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 3,
+          "offset": 17,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight\\">
+      <pre class=\\"language-js\\"><code><span class=\\"token comment\\" spellcheck=\\"true\\">// Fake</span>
+</code></pre>
+      </div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 4,
+      "line": 3,
+      "offset": 17,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -1,0 +1,18 @@
+const remark = require(`remark`)
+const plugin = require(`../index`)
+
+describe(`remark prism plugin`, () => {
+  it(`generates a <pre> tag with a language class by default`, () => {
+    const code = '```js\n// Fake\n```'
+    const markdownAST = remark.parse(code)
+    plugin({ markdownAST })
+    expect(markdownAST).toMatchSnapshot()
+  })
+
+  it(`generates a <pre> tag with a data attribute if configured to do so`, () => {
+    const code = '```js\n// Fake\n```'
+    const markdownAST = remark.parse(code)
+    plugin({ markdownAST }, { useDataAttribute: true})
+    expect(markdownAST).toMatchSnapshot()
+  })
+})

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -23,9 +23,14 @@ module.exports = ({ markdownAST }) => {
 
     // Replace the node with the markup we need to make
     // 100% width highlighted code lines work
+    // We use `data-language=*` rather than class="language-*" to avoid
+    // breaking line highlights if Prism is required by any other code.
+    // The language attribute enables custom user-styling without
+    // causing Prism to re-process our already-highlighted markup.
+    // @see https://github.com/gatsbyjs/gatsby/issues/1486
     node.type = `html`
     node.value = `<div class="gatsby-highlight">
-      <pre class="language-${preCssClassLanguage}"><code>${highlightCode(
+      <pre data-language="${preCssClassLanguage}"><code>${highlightCode(
       language,
       node.value,
       highlightLines

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -3,7 +3,7 @@ const visit = require(`unist-util-visit`)
 const parseLineNumberRange = require(`./parse-line-number-range`)
 const highlightCode = require(`./highlight-code`)
 
-module.exports = ({ markdownAST }) => {
+module.exports = ({ markdownAST }, { useDataAttribute = false } = {}) => {
   visit(markdownAST, `code`, node => {
     let language = node.lang
     let { splitLanguage, highlightLines } = parseLineNumberRange(language)
@@ -15,22 +15,26 @@ module.exports = ({ markdownAST }) => {
     // outcome without any additional CSS.
     //
     // @see https://github.com/PrismJS/prism/blob/1d5047df37aacc900f8270b1c6215028f6988eb1/themes/prism.css#L49-L54
-    let preCssClassLanguage = `none`
+    let languageName = `none`
     if (language) {
       language = language.toLowerCase()
-      preCssClassLanguage = language
+      languageName = language
     }
 
-    // Replace the node with the markup we need to make
-    // 100% width highlighted code lines work
-    // We use `data-language=*` rather than class="language-*" to avoid
-    // breaking line highlights if Prism is required by any other code.
+    // Use a data attribute rather than a class name to avoid breaking
+    // line highlights if Prism is required by any other code.
     // The language attribute enables custom user-styling without
     // causing Prism to re-process our already-highlighted markup.
     // @see https://github.com/gatsbyjs/gatsby/issues/1486
+    const languageFlag = useDataAttribute
+      ? `data-language="${languageName}"`
+      : `class="language-${languageName}"`
+
+    // Replace the node with the markup we need to make
+    // 100% width highlighted code lines work
     node.type = `html`
     node.value = `<div class="gatsby-highlight">
-      <pre data-language="${preCssClassLanguage}"><code>${highlightCode(
+      <pre ${languageFlag}><code>${highlightCode(
       language,
       node.value,
       highlightLines


### PR DESCRIPTION
Potential bug fix for issue #1486

Note that this would be a breaking change in terms of custom themes. If this approach seems reasonable going forward, I could hide it behind an option flag.