### PR TITLE
Fixes documentation URLs to internal files.

### DIFF
--- a/docs/blog/gatsbygram-case-study/index.md
+++ b/docs/blog/gatsbygram-case-study/index.md
@@ -160,7 +160,7 @@ available.
 
 Here is how we define pages from our JSON data for Gatsbygram at build time in
 the site's [`gatsby-node.js`
-file](https://github.com/gatsbyjs/gatsby/blob/1.0/examples/gatsbygram/gatsby-node.js):
+file](https://github.com/gatsbyjs/gatsby/blob/master/examples/gatsbygram/gatsby-node.js):
 
 ```javascript
 const _ = require(`lodash`)
@@ -246,7 +246,7 @@ As you can see above, when defining a page, we can set "context" data, which is
 passed as a `prop` to the component and as a [GraphQL
 variable](http://graphql.org/learn/queries/#variables) in our `GraphQL` query.
 For the "[post
-template](https://github.com/gatsbyjs/gatsby/blob/1.0/examples/gatsbygram/src/templates/post-page.js)",
+template](https://github.com/gatsbyjs/gatsby/blob/master/examples/gatsbygram/src/templates/post-page.js)",
 we pass the id to the post. Below we use that id to query our `GraphQL` schema
 and return a fully formed page:
 
@@ -329,9 +329,9 @@ Gatsbygram's `about.js` is a simple React component with no query.
 has an infinite scroll implementation to lazy load in image thumbnails.
 
 [Read pages/index.js on
-Github](https://github.com/gatsbyjs/gatsby/blob/1.0/examples/gatsbygram/src/pages/index.js)  
+Github](https://github.com/gatsbyjs/gatsby/blob/master/examples/gatsbygram/src/pages/index.js)
 [Read pages/about.js on
-Github](https://github.com/gatsbyjs/gatsby/blob/1.0/examples/gatsbygram/src/pages/about.js)
+Github](https://github.com/gatsbyjs/gatsby/blob/master/examples/gatsbygram/src/pages/about.js)
 
 ## The Layout Component
 
@@ -380,7 +380,7 @@ sites as it has logic to show clicked images in either a modal on larger
 screens or on their own page on smaller screens.
 
 [Read Gatsbygram's Layout component on
-Github](https://github.com/gatsbyjs/gatsby/blob/1.0/examples/gatsbygram/src/layouts/default.js).
+Github](https://github.com/gatsbyjs/gatsby/blob/master/examples/gatsbygram/src/layouts/default.js).
 
 ## Client routing and pre-caching
 

--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -48,7 +48,7 @@ packages you want to link by using the `--packages` option:
 With this flag, the tool will do an initial scan and copy and then quit. This
 is useful for setting up automated testing/builds of Gatsby sites from the latest
 code. Gatsby's main website (and example websites) are built from HEAD using this
-flag, see https://github.com/gatsbyjs/gatsby/blob/1.0/scripts/publish-site.sh.
+flag, see https://github.com/gatsbyjs/gatsby/blob/master/scripts/publish-site.sh.
 
 #### `--quiet`
 

--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -22,6 +22,6 @@ plugins: [
 
 Above is the minmal configuration required to have it work, however, note that
 the [default
-query](https://github.com/gatsbyjs/gatsby/blob/1.0/packages/gatsby-plugin-sitemap/src/internals.js)
+query](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js)
 only retrieves nodes of type `MarkdownRemark`. Any parameter in
 `defaultOptions` can be overridden.


### PR DESCRIPTION
Fixes docs referencing removed "1.0" branch source code instead of master.

Example:
`https://github.com/gatsbyjs/gatsby/blob/1.0/packages/gatsby-plugin-sitemap/src/internals.js`