### PR TITLE
fix: ensure pathPrefix is added to responsive images

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -51,6 +51,7 @@ module.exports = (
     let responsiveSizesResult = await responsiveSizes({
       file: imageNode,
       args: options,
+      pathPrefix
     })
 
     // console.log("responsiveSizesResult", responsiveSizesResult)


### PR DESCRIPTION
Fixes #1505

Add pathPrefix to the responsive image plugin in `gatsby-remark-sharp`

Note: I'll add tests and that kind of thing, but I'm correct in assuming there aren't any tests for this plugin currently, correct?

If so, looks like you expect them in `packages/gatsby-remark-images/src/__tests__/`, and that's where I should start editing them?