### PR TITLE
Fix docs referencing outdated React Router <Link> API

### DIFF
--- a/packages/gatsby-link/README.md
+++ b/packages/gatsby-link/README.md
@@ -2,10 +2,10 @@
 
 A `<Link>` component for Gatsby.
 
-It's a wrapper around [React Router's Link
-component](https://github.com/ReactTraining/react-router/blob/6eeb7ad358f987520f5b519e48bdd31f725cbade/docs/API.md#link)
-that adds enhancements specific to Gatsby. All props are passed through
+It's a wrapper around [React Router's Link component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md) that adds enhancements specific to Gatsby. All props are passed through
 to React Router's Link.
+
+You can set the `activeStyle` or `activeClassName` prop to add styling attributes to the rendered element when it matches the current URL. If either of these props are set, then [React Router's NavLink component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md) will be used instead of Link.
 
 Gatsby does per-route code splitting. This means that when navigating to
 a new page, the code chunks necessary for that page might not be loaded.


### PR DESCRIPTION
The [current docs](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link) reference [this react-router page](https://github.com/ReactTraining/react-router/blob/6eeb7ad358f987520f5b519e48bdd31f725cbade/docs/API.md#link) which is outdated. For instance it mentions the `onlyActiveOnIndex` prop which does not exist anymore in react-router.
