### PR TITLE
use consistent chunk ids

### DIFF
--- a/packages/gatsby/src/utils/get-hash-fn.js
+++ b/packages/gatsby/src/utils/get-hash-fn.js
@@ -1,0 +1,22 @@
+const createHash = require(`crypto`).createHash
+
+const getHashFn = ({
+    hashFunction = `md5`,
+    hashDigest = `hex`,
+    hashDigestBits = 64,
+    cache = new Set()
+}) => input => {
+    const hash = createHash(hashFunction)
+    hash.update(input)
+    const digest = hash.digest(hashDigest)
+    const partialDigest = digest.substr(0, hashDigestBits / 4)
+    const output = parseInt(partialDigest, 16)
+    // guard against collisions
+    if (cache.has(output)) {
+        throw Error(`Hash collision at f(${ input }) = ${ output }`)
+    }
+    cache.add(output)
+    return output
+};
+
+module.exports = getHashFn

--- a/packages/gatsby/src/utils/hashed-chunk-ids-plugin.js
+++ b/packages/gatsby/src/utils/hashed-chunk-ids-plugin.js
@@ -1,0 +1,25 @@
+/*
+ * HashedChunkIdsPlugin
+ * source https://github.com/webpack/webpack/blob/376badba98d5323bfb342e8b2c438fc3dcc4954b/lib/NamedChunksPlugin.js
+ */
+
+const getHashFn = require(`./get-hash-fn`)
+
+function HashedChunkIdsPlugin(options) {
+    this.options = options || {}
+}
+
+HashedChunkIdsPlugin.prototype.apply = function apply(compiler) {
+    const hashFn = getHashFn(this.options)
+    compiler.plugin(`compilation`, compilation => {
+        compilation.plugin(`before-chunk-ids`, chunks => {
+            chunks.forEach(chunk => {
+                if (chunk.id === null) {
+                    chunk.id = hashFn(chunk.name)
+                }
+            });
+        });
+    });
+};
+
+module.exports = HashedChunkIdsPlugin

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -20,6 +20,7 @@ const ChunkManifestPlugin = require(`chunk-manifest-webpack-plugin`)
 const GatsbyModulePlugin = require(`../loaders/gatsby-module-loader/plugin`)
 const genBabelConfig = require(`./babel-config`)
 const { withBasePath } = require(`./path`)
+const HashedChunkIdsPlugin = require(`./hashed-chunk-ids-plugin`)
 
 // Five stages or modes:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
@@ -304,6 +305,7 @@ module.exports = async (
           new GatsbyModulePlugin(),
           // new WebpackStableModuleIdAndHash({ seed: 9, hashSize: 47 }),
           new webpack.NamedModulesPlugin(),
+          new HashedChunkIdsPlugin()
         ]
       }
       default:


### PR DESCRIPTION
Consistent chunk ids are generated by truncating the md5 of the chunk name to a 64 bit integer.