### PR TITLE
Fixing sw.js 404-ing because of pathPrefix not being prefixed to sw.js properly. Fixing #1539

### DIFF
--- a/packages/gatsby/src/cache-dir/register-service-worker.js
+++ b/packages/gatsby/src/cache-dir/register-service-worker.js
@@ -2,7 +2,7 @@ import emitter from "./emitter"
 
 let pathPrefix = `/`
 if (__PREFIX_PATHS__) {
-  pathPrefix = __PATH_PREFIX__ + '/'
+  pathPrefix = __PATH_PREFIX__ + `/`
 }
 
 if (`serviceWorker` in navigator) {

--- a/packages/gatsby/src/cache-dir/register-service-worker.js
+++ b/packages/gatsby/src/cache-dir/register-service-worker.js
@@ -2,7 +2,7 @@ import emitter from "./emitter"
 
 let pathPrefix = `/`
 if (__PREFIX_PATHS__) {
-  pathPrefix = __PATH_PREFIX__
+  pathPrefix = __PATH_PREFIX__ + '/'
 }
 
 if (`serviceWorker` in navigator) {


### PR DESCRIPTION
The pathPrefix does not include the trailing slash so we have to make sure to include it so that sw.js gets loaded properly and does not 404