### PR TITLE
Fixes component-renderer to allow for use of client-only-paths

### DIFF
--- a/packages/gatsby/src/cache-dir/component-renderer.js
+++ b/packages/gatsby/src/cache-dir/component-renderer.js
@@ -52,14 +52,20 @@ class ComponentRenderer extends React.Component {
     })
   }
 
-  // Check if the component or json have changed
   shouldComponentUpdate(nextProps, nextState) {
-    if (
-      this.state.pageResources.component !== nextState.pageResources.component
-    ) {
+    // Check if the component or json have changed.
+    if (this.state.pageResources.component !== nextState.pageResources.component) {
       return true
     }
     if (this.state.pageResources.json !== nextState.pageResources.json) {
+      return true
+    }
+    // Check if location has changed on a page using internal routing
+    // via matchPath configuration.
+    if (
+      (this.state.location.key !== nextState.location.key)
+      && nextState.pageResources.page && nextState.pageResources.page.matchPath
+    ) {
       return true
     }
     return false

--- a/packages/gatsby/src/cache-dir/loader.js
+++ b/packages/gatsby/src/cache-dir/loader.js
@@ -237,6 +237,7 @@ const queue = {
       const pageResources = {
         component: syncRequires.components[page.componentChunkName],
         json: syncRequires.json[page.jsonName],
+        page,
       }
       cb(pageResources)
       return pageResources
@@ -248,7 +249,7 @@ const queue = {
         console.log(`A page wasn't found for "${path}"`)
         return
       }
-
+      
       // Use the path from the page so the pathScriptsCache uses
       // the normalized path.
       path = page.path
@@ -274,8 +275,8 @@ const queue = {
       // we move on.
       const done = () => {
         if (component && json) {
-          pathScriptsCache[path] = { component, json }
-          const pageResources = { component, json }
+          pathScriptsCache[path] = { component, json, page }
+          const pageResources = { component, json, page }
           cb(pageResources)
           emitter.emit(`onPostLoadPageResources`, {
             page,


### PR DESCRIPTION
According to https://github.com/gatsbyjs/gatsby/issues/1501, it looks like client-only-paths are broken in `1.0`. (It actually looks like this has been broken since `v1.0.0-beta.6`.)

Looks like `componentShouldUpdate` assumes that, a route-change should only trigger a re-render if its accompanied by a corresponding change in the higher-level `pageResources.component`. In theory, this makes sense, though it's directly in conflict with the notion of client-only paths. My thought is that the re-render should be triggered if either the component changes OR the found page has a corresponding `matchPath`, (as demonstrated in the client-only-paths docs), in which case gatsby may not know whether or not a re-render is necessary and should optimistically trigger one.

If there's a better way to go about this, great. 😎 