### PR TITLE
add tests to gatsby-remark-images

### DIFF
--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it transforms HTML img tags 1`] = `
+"<html><head></head><body>
+  <a class=\\"gatsby-resp-image-link\\" href=\\"not-a-real-dir/image/my-image.jpeg\\" style=\\"display: block\\" target=\\"_blank\\" rel=\\"noopener\\">
+  
+  <span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; z-index: -1; display: block; \\">
+    <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%;position: relative; width: 100%; bottom: 0; left: 0; background-image: url(&apos;url(&apos;data:image/png;base64, iVBORw)&apos;); background-size: cover; display: block;\\">
+      <img class=\\"gatsby-resp-image-image\\" style=\\"width: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px white;\\" alt=\\"my image\\" title=\\"\\" src=\\"not-a-real-dir/image/my-image.jpeg\\" srcset=\\"not-a-real-dir/image/my-image.jpeg, not-a-real-dir/image/my-image.jpeg\\" sizes=\\"(max-width: 650px) 100vw, 650px\\">
+    </span>
+  </span>
+  
+  </a>
+    </body></html>"
+`;
+
+exports[`it transforms images in markdown 1`] = `
+"
+  <a
+    class=\\"gatsby-resp-image-link\\"
+    href=\\"not-a-real-dir/images/my-image.jpeg\\"
+    style=\\"display: block\\"
+    target=\\"_blank\\"
+    rel=\\"noopener\\"
+  >
+  
+  <span
+    class=\\"gatsby-resp-image-wrapper\\"
+    style=\\"position: relative; z-index: -1; display: block; \\"
+  >
+    <span
+      class=\\"gatsby-resp-image-background-image\\"
+      style=\\"padding-bottom: 133.33333333333331%;position: relative; width: 100%; bottom: 0; left: 0; background-image: url('url('data:image/png;base64, iVBORw)'); background-size: cover; display: block;\\"
+    >
+      <img
+        class=\\"gatsby-resp-image-image\\"
+        style=\\"width: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px white;\\"
+        alt=\\"image\\"
+        title=\\"\\"
+        src=\\"not-a-real-dir/images/my-image.jpeg\\"
+        srcset=\\"not-a-real-dir/images/my-image.jpeg, not-a-real-dir/images/my-image.jpeg\\"
+        sizes=\\"(max-width: 650px) 100vw, 650px\\"
+      />
+    </span>
+  </span>
+  
+  </a>
+    "
+`;

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -1,0 +1,151 @@
+jest.mock('gatsby-plugin-sharp', () => {
+  return {
+    responsiveSizes({
+      file,
+      args
+    }) {
+      return Promise.resolve({
+        aspectRatio: 0.75,
+        originalImage: file.absolutePath,
+        src: file.absolutePath,
+        srcSet: `${file.absolutePath}, ${file.absolutePath}`,
+        sizes: `(max-width: ${args.maxWidth}px) 100vw, ${args.maxWidth}px`,
+        base64: `url('data:image/png;base64, iVBORw)`
+      });
+    }
+  };
+})
+
+const Remark = require('remark')
+
+const plugin = require('../')
+
+const remark = new Remark().data(`settings`, {
+  commonmark: true,
+  footnotes: true,
+  pedantic: true,
+})
+
+const createNode = content => {
+  const node = {
+    id: 1234
+  }
+
+  const markdownNode = {
+    id: `${node.id} >>> MarkdownRemark`,
+    children: [],
+    parent: node.id,
+    internal: {
+      content,
+      contentDigest: `some-hash`,
+      type: `MarkdownRemark`,
+    },
+  }
+
+  markdownNode.frontmatter = {
+    title: ``, // always include a title
+    parent: node.id,
+  }
+
+  return markdownNode;
+}
+
+const createPluginOptions = (content, imagePaths = '/') => {
+  const dirName = 'not-a-real-dir';
+  return {
+    files: [].concat(imagePaths)
+      .map(imagePath => ({
+        absolutePath: `${dirName}/${imagePath}`
+      })),
+    markdownNode: createNode(content),
+    markdownAST: remark.parse(content),
+    getNode: () => {
+      return {
+        dir: dirName
+      };
+    }
+  };
+}
+
+test('it returns empty array when 0 images', async () => {
+  const content = `
+# hello world
+
+Look ma, no images
+  `.trim()
+
+  const result = await plugin(createPluginOptions(content));
+
+  expect(result).toEqual([]);
+})
+
+test('it leaves non-relative images alone', async () => {
+  const imagePath = `https://google.com/images/an-image.jpeg`;
+  const content = `
+![asdf](${imagePath}) 
+  `.trim();
+
+  const result = await plugin(createPluginOptions(content, imagePath));
+
+  expect(result).toEqual([]);
+})
+
+test('it transforms images in markdown', async () => {
+  const imagePath = 'images/my-image.jpeg';
+  const content = `
+
+![image](./${imagePath})
+  `.trim();
+
+  const nodes = await plugin(createPluginOptions(content, imagePath));
+
+  expect(nodes.length).toBe(1);
+
+  const node = nodes.pop();
+  expect(node.type).toBe('html');
+  expect(node.value).toMatchSnapshot();
+})
+
+test('it transforms multiple images in markdown', async () => {
+  const imagePaths = [
+    'images/my-image.jpeg',
+    'images/other-image.jpeg'
+  ]
+
+  const content = `
+![image 1](./${imagePaths[0]})
+![image 2](./${imagePaths[1]})
+  `.trim();
+
+  const nodes = await plugin(createPluginOptions(content, imagePaths))
+
+  expect(nodes.length).toBe(imagePaths.length)
+})
+
+test('it transforms HTML img tags', async () => {
+  const imagePath = `image/my-image.jpeg`;
+
+  const content = `
+<img src="./${imagePath}">
+  `.trim();
+
+  const nodes = await plugin(createPluginOptions(content, imagePath));
+
+  expect(nodes.length).toBe(1);
+
+  const node = nodes.pop();
+  expect(node.type).toBe('html');
+  expect(node.value).toMatchSnapshot();
+})
+
+test('it leaves non-relative HTML img tags alone', async () => {
+  const imagePath = `https://google.com/images/this-was-an-image.jpeg`;
+
+  const content = `
+<img src="${imagePath}">
+  `.trim()
+
+  const nodes = await plugin(createPluginOptions(content, imagePath))
+
+  expect(nodes.length).toBe(0)
+})

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -1,24 +1,21 @@
-jest.mock('gatsby-plugin-sharp', () => {
+jest.mock(`gatsby-plugin-sharp`, () => {
   return {
-    responsiveSizes({
-      file,
-      args
-    }) {
+    responsiveSizes({ file, args }) {
       return Promise.resolve({
         aspectRatio: 0.75,
         originalImage: file.absolutePath,
         src: file.absolutePath,
         srcSet: `${file.absolutePath}, ${file.absolutePath}`,
         sizes: `(max-width: ${args.maxWidth}px) 100vw, ${args.maxWidth}px`,
-        base64: `url('data:image/png;base64, iVBORw)`
-      });
-    }
-  };
+        base64: `url('data:image/png;base64, iVBORw)`,
+      })
+    },
+  }
 })
 
-const Remark = require('remark')
+const Remark = require(`remark`)
 
-const plugin = require('../')
+const plugin = require(`../`)
 
 const remark = new Remark().data(`settings`, {
   commonmark: true,
@@ -28,7 +25,7 @@ const remark = new Remark().data(`settings`, {
 
 const createNode = content => {
   const node = {
-    id: 1234
+    id: 1234,
   }
 
   const markdownNode = {
@@ -47,99 +44,95 @@ const createNode = content => {
     parent: node.id,
   }
 
-  return markdownNode;
+  return markdownNode
 }
 
-const createPluginOptions = (content, imagePaths = '/') => {
-  const dirName = 'not-a-real-dir';
+const createPluginOptions = (content, imagePaths = `/`) => {
+  const dirName = `not-a-real-dir`
   return {
-    files: [].concat(imagePaths)
-      .map(imagePath => ({
-        absolutePath: `${dirName}/${imagePath}`
-      })),
+    files: [].concat(imagePaths).map(imagePath => {return {
+      absolutePath: `${dirName}/${imagePath}`,
+    }}),
     markdownNode: createNode(content),
     markdownAST: remark.parse(content),
     getNode: () => {
       return {
-        dir: dirName
-      };
-    }
-  };
+        dir: dirName,
+      }
+    },
+  }
 }
 
-test('it returns empty array when 0 images', async () => {
+test(`it returns empty array when 0 images`, async () => {
   const content = `
 # hello world
 
 Look ma, no images
   `.trim()
 
-  const result = await plugin(createPluginOptions(content));
+  const result = await plugin(createPluginOptions(content))
 
-  expect(result).toEqual([]);
+  expect(result).toEqual([])
 })
 
-test('it leaves non-relative images alone', async () => {
-  const imagePath = `https://google.com/images/an-image.jpeg`;
+test(`it leaves non-relative images alone`, async () => {
+  const imagePath = `https://google.com/images/an-image.jpeg`
   const content = `
 ![asdf](${imagePath}) 
-  `.trim();
+  `.trim()
 
-  const result = await plugin(createPluginOptions(content, imagePath));
+  const result = await plugin(createPluginOptions(content, imagePath))
 
-  expect(result).toEqual([]);
+  expect(result).toEqual([])
 })
 
-test('it transforms images in markdown', async () => {
-  const imagePath = 'images/my-image.jpeg';
+test(`it transforms images in markdown`, async () => {
+  const imagePath = `images/my-image.jpeg`
   const content = `
 
 ![image](./${imagePath})
-  `.trim();
+  `.trim()
 
-  const nodes = await plugin(createPluginOptions(content, imagePath));
+  const nodes = await plugin(createPluginOptions(content, imagePath))
 
-  expect(nodes.length).toBe(1);
+  expect(nodes.length).toBe(1)
 
-  const node = nodes.pop();
-  expect(node.type).toBe('html');
-  expect(node.value).toMatchSnapshot();
+  const node = nodes.pop()
+  expect(node.type).toBe(`html`)
+  expect(node.value).toMatchSnapshot()
 })
 
-test('it transforms multiple images in markdown', async () => {
-  const imagePaths = [
-    'images/my-image.jpeg',
-    'images/other-image.jpeg'
-  ]
+test(`it transforms multiple images in markdown`, async () => {
+  const imagePaths = [`images/my-image.jpeg`, `images/other-image.jpeg`]
 
   const content = `
 ![image 1](./${imagePaths[0]})
 ![image 2](./${imagePaths[1]})
-  `.trim();
+  `.trim()
 
   const nodes = await plugin(createPluginOptions(content, imagePaths))
 
   expect(nodes.length).toBe(imagePaths.length)
 })
 
-test('it transforms HTML img tags', async () => {
-  const imagePath = `image/my-image.jpeg`;
+test(`it transforms HTML img tags`, async () => {
+  const imagePath = `image/my-image.jpeg`
 
   const content = `
 <img src="./${imagePath}">
-  `.trim();
+  `.trim()
 
-  const nodes = await plugin(createPluginOptions(content, imagePath));
+  const nodes = await plugin(createPluginOptions(content, imagePath))
 
-  expect(nodes.length).toBe(1);
+  expect(nodes.length).toBe(1)
 
-  const node = nodes.pop();
-  expect(node.type).toBe('html');
-  expect(node.value).toMatchSnapshot();
+  const node = nodes.pop()
+  expect(node.type).toBe(`html`)
+  expect(node.value).toMatchSnapshot()
 })
 
-test('it leaves non-relative HTML img tags alone', async () => {
-  const imagePath = `https://google.com/images/this-was-an-image.jpeg`;
+test(`it leaves non-relative HTML img tags alone`, async () => {
+  const imagePath = `https://google.com/images/this-was-an-image.jpeg`
 
   const content = `
 <img src="${imagePath}">

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -116,7 +116,7 @@ module.exports = (
   </a>
     `
     }
-
+  
     return rawHTML
   }
 
@@ -138,68 +138,74 @@ module.exports = (
             // Replace the image node with an inline HTML node.
             node.type = `html`
             node.value = rawHTML
-            return resolve()
+            return resolve(node)
           } else {
             // Image isn't relative so there's nothing for us to do.
             return resolve()
           }
         })
     )
-  ).then(() =>
-    // HTML image node stuff
-
-    Promise.all(
-      // Complex because HTML nodes can contain multiple images
-      rawHtmlNodes.map(
-        node =>
-          new Promise(async (resolve, reject) => {
-            if (!node.value) {
-              return resolve()
-            }
-
-            const $ = cheerio.load(node.value)
-            if ($(`img`).length === 0) {
-              // No img tags
-              return resolve()
-            }
-
-            let imageRefs = []
-            $(`img`).each(function() {
-              imageRefs.push($(this))
-            })
-
-            for (let thisImg of imageRefs) {
-              //Get the details we need
-              let formattedImgTag = {}
-              formattedImgTag.url = thisImg.attr(`src`)
-              formattedImgTag.title = thisImg.attr(`title`)
-              formattedImgTag.alt = thisImg.attr(`alt`)
-
-              const fileType = formattedImgTag.url.slice(-3)
-
-              // Ignore gifs as we can't process them,
-              // svgs as they are already responsive by definition
-              if (
-                isRelativeUrl(formattedImgTag.url) &&
-                fileType !== `gif` &&
-                fileType !== `svg`
-              ) {
-                const rawHTML = await generateImagesAndUpdateNode(
-                  formattedImgTag,
-                  resolve
-                )
-                // Replace the image string
-                thisImg.replaceWith(rawHTML)
-              }
-            }
-
-            // Replace the image node with an inline HTML node.
-            node.type = `html`
-            node.value = $.html()
-
-            return resolve()
-          })
-      )
-    )
   )
+    .then((markdownImageNodes) => {
+      // HTML image node stuff
+      return Promise.all(
+        // Complex because HTML nodes can contain multiple images
+        rawHtmlNodes.map(
+          node =>
+            new Promise(async (resolve, reject) => {
+              if (!node.value) {
+                return resolve()
+              }
+
+              const $ = cheerio.load(node.value)
+              if ($(`img`).length === 0) {
+                // No img tags
+                return resolve()
+              }
+
+              let imageRefs = []
+              $(`img`).each(function () {
+                imageRefs.push($(this))
+              })
+
+              for (let thisImg of imageRefs) {
+                //Get the details we need
+                let formattedImgTag = {}
+                formattedImgTag.url = thisImg.attr(`src`)
+                formattedImgTag.title = thisImg.attr(`title`)
+                formattedImgTag.alt = thisImg.attr(`alt`)
+
+                const fileType = formattedImgTag.url.slice(-3)
+
+
+                // Ignore gifs as we can't process them,
+                // svgs as they are already responsive by definition
+                if (
+                  isRelativeUrl(formattedImgTag.url) &&
+                  fileType !== `gif` &&
+                  fileType !== `svg`
+                ) {
+                  const rawHTML = await generateImagesAndUpdateNode(
+                    formattedImgTag,
+                    resolve
+                  )
+                  // Replace the image string
+                  thisImg.replaceWith(rawHTML)
+                } else {
+                  return resolve()
+                }
+              }
+
+              // Replace the image node with an inline HTML node.
+              node.type = `html`
+              node.value = $.html()
+
+              return resolve(node)
+            })
+        )
+      ).then(htmlImageNodes => {
+        return markdownImageNodes.concat(htmlImageNodes)
+          .filter(node => !!node)
+      })
+    })
 }


### PR DESCRIPTION
Added some basic unit tests (and snapshots) to gatsby-remark-images

Note: there's probably more we can do here, but it's a start! Let me know how it looks

One thing I may want to do is re-run prettier on the code base, so I can do that too