### PR TITLE
Add gatsby-plugin-feed to www

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -9,6 +9,7 @@
     "gatsby-link": "^1.0.1",
     "gatsby-plugin-canonical-urls": "^1.0.1",
     "gatsby-plugin-catch-links": "^1.0.1",
+    "gatsby-plugin-feed": "^1.3.0",
     "gatsby-plugin-glamor": "^1.0.1",
     "gatsby-plugin-google-analytics": "^1.0.1",
     "gatsby-plugin-manifest": "^1.0.1",


### PR DESCRIPTION
I'm not 100% on-board with defining logic in `gatsby-config`. What do you think?

Otherwise, the API exposed by the feed plugin makes this very simple to do.