### PR TITLE
Fix unsupported method in IE

### DIFF
--- a/packages/gatsby/src/cache-dir/root.js
+++ b/packages/gatsby/src/cache-dir/root.js
@@ -53,7 +53,13 @@ function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
   return true
 }
 
-const noMatch = pages.find(r => r.path === `/dev-404-page/`)
+let noMatch;
+for(let i = 0; i < paths.length; i++) {
+    if(paths[i].path === `/dev-404-page/`) {
+        noMatch = paths[i];
+        break;
+    }
+}
 
 const addNotFoundRoute = () => {
   if (noMatch) {

--- a/packages/gatsby/src/cache-dir/root.js
+++ b/packages/gatsby/src/cache-dir/root.js
@@ -53,12 +53,12 @@ function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
   return true
 }
 
-let noMatch;
-for(let i = 0; i < paths.length; i++) {
-    if(paths[i].path === `/dev-404-page/`) {
-        noMatch = paths[i];
-        break;
-    }
+let noMatch
+for (let i = 0; i < paths.length; i++) {
+  if (paths[i].path === `/dev-404-page/`) {
+    noMatch = paths[i]
+    break
+  }
 }
 
 const addNotFoundRoute = () => {


### PR DESCRIPTION
The dev server fails in IE 11 with this message:

```
Object doesn't support property or method 'find'
```

Referencing the Array.prototype.find call.
This method isn't supported in IE.