### PR TITLE
Rely on specific Glamor version, not tag

### DIFF
--- a/packages/gatsby-plugin-glamor/package.json
+++ b/packages/gatsby-plugin-glamor/package.json
@@ -8,7 +8,7 @@
     "glamor": "next",
     "glamor-inline": "^1.0.5",
     "glamor-react": "^3.0.0-1",
-    "glamor-server": "next"
+    "glamor-server": "^3.0.0-3"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1"


### PR DESCRIPTION
`@next` doesn't seem to exist anymore, and it's a community convention at best, so I advise we don't rely on it.