### PR TITLE
WIP: fix: fixes regression with pathPrefix and gatsby-link

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,9 @@ module.exports = {
   roots: pkgs,
   modulePathIgnorePatterns: distDirs,
   coveragePathIgnorePatterns: distDirs,
+  globals: {
+    __PREFIX_PATHS__: false
+  },
   testPathIgnorePatterns: [
     `/examples/`,
     `/www/`,

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const getInstance = (to, pathPrefix = '') => {
+  if (pathPrefix) {
+    global.__PREFIX_PATHS__ = true;
+    global.__PATH_PREFIX__ = pathPrefix;
+  } else {
+    global.__PREFIX_PATHS__ = false;
+  }
+  const Link = require('../').default;
+  return new Link({
+    to
+  });
+};
+
+test('it does not prefix paths by default', () => {
+  const instance = getInstance('/some-path');
+
+  expect(instance.state.to).toBe('/some-path');
+});
+
+test.skip('it prefixes paths if __PREFIX_PATHS__ and __PATH_PREFIX__ are defined', () => {
+  const instance = getInstance('/some-path', '/blog');
+
+  expect(instance.state.to).toBe('/blog/some-path');
+});

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 
 let pathPrefix = ``
 if (__PREFIX_PATHS__) {
-  pathPrefix = `${__PATH_PREFIX__}/`
+  pathPrefix = __PATH_PREFIX__;
 }
 
 class GatsbyLink extends React.Component {


### PR DESCRIPTION
Note: this is not done! Want to get the tests actually working. Unsure why the globals aren't setting, and why I need to use Jest globals :/

Also similar to #1574. We should probably consolidate our efforts