### PR TITLE
Fix url in Contentful example

### DIFF
--- a/examples/using-contentful/src/layouts/index.js
+++ b/examples/using-contentful/src/layouts/index.js
@@ -31,8 +31,8 @@ class DefaultLayout extends React.Component {
         <p>
           The src for this website is at
           {` `}
-          <a href="https://github.com/gatsbyjs/gatsby/tree/1.0/examples/using-contentful">
-            https://github.com/gatsbyjs/gatsby/tree/1.0/examples/using-contentful
+          <a href="https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful">
+            https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful
           </a>
         </p>
         <p>


### PR DESCRIPTION
Branch 1.0 seems not to exist anymore, so the link is ending up in a 404 page. I now linked master branch.

The same error also exists in the Drupal example as far as I have seen.