### PR TITLE
Wordpress -> WordPress

### DIFF
--- a/examples/using-wordpress/README.md
+++ b/examples/using-wordpress/README.md
@@ -1,6 +1,6 @@
 # Using Wordpress
 
-[TODO : Insert Hosted Gatsby Wordpress site URL.]
+[TODO : Insert Hosted Gatsby WordPress site URL.]
 
 Example site that demonstrates how to build Gatsby sites
-that pull data from the [Wordpress CMS API](https://www.wordpress.com/).
+that pull data from the [WordPress CMS API](https://www.wordpress.com/).


### PR DESCRIPTION
If we are fixing docs to be correct I think it would be best to stay consistent with the capital "P" in WordPress.