### PR TITLE
Allow gatsby-link to be used in other contexts like Storybook

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -19,6 +19,14 @@ const getNavigateTo = () => {
 }
 
 describe(`<Link />`, () => {
+
+  it(`does not fail to initialize when __PREFIX_PATHS__ is not defined`, () => {
+    expect(() => {
+      const Link = require(`../`).default
+      const link = new Link({}) //eslint-disable-line no-unused-vars
+    }).not.toThrow()
+  })
+
   describe(`path prefixing`, () => {
     it(`does not include path prefix by default`, () => {
       const to = `/path`

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -1,9 +1,10 @@
+/*global __PREFIX_PATHS__, __PATH_PREFIX__ */
 import React from "react"
 import { Link, NavLink } from "react-router-dom"
 import PropTypes from "prop-types"
 
 let pathPrefix = ``
-if (__PREFIX_PATHS__) {
+if (typeof __PREFIX_PATHS__ !== `undefined` && __PREFIX_PATHS__) {
   pathPrefix = __PATH_PREFIX__
 }
 


### PR DESCRIPTION
This afternoon I was experimenting with [Storybook](https://github.com/storybooks/storybook/) to view my Gatsby components and test different states, as preparation for some redesign work on my blog.  

Unfortunately loading in components that imported `gatsby-link` failed in that context since `__PREFIX_PATH__` was undefined.  There are workarounds to this, but there doesn't seem to be any reason that gatsby-link should require that variable to be defined to be used (since it doesn't require it to actually have a value, just a defined reference) so this PR adds a `typeof` check, which will allow it to be imported safely into environments like Storybook.