### PR TITLE
Docs: add grommet starter

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -99,4 +99,10 @@ Community:
     * glitch serves assets over CDN, API unclear
     * virtual server container provides [**128MB** for app](https://glitch.com/faq#restrictions) (512MB for assets)
     * server can't install certain gatsby plugins (`sharp`-based; out of mem?)
-  
+
+* [gatsby-starter-grommet](https://github.com/alampros/gatsby-starter-grommet)
+
+  Features:
+  * Barebones configuration for using the [Grommet](https://grommet.github.io/) design system
+  * Uses SASS (with CSS modules support)
+

--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -71,7 +71,7 @@ Community:
   * Blog post listing with previews for each blog post
   * Navigation between posts with a previous/next post button
   * Tags and tag navigation
-  
+
 * [gatsby-advanced-starter](https://github.com/Vagr9K/gatsby-advanced-starter) [(demo)](https://vagr9k.github.io/gatsby-advanced-starter/)
 
   Features:
@@ -100,7 +100,7 @@ Community:
     * virtual server container provides [**128MB** for app](https://glitch.com/faq#restrictions) (512MB for assets)
     * server can't install certain gatsby plugins (`sharp`-based; out of mem?)
 
-* [gatsby-starter-grommet](https://github.com/alampros/gatsby-starter-grommet)
+* [gatsby-starter-grommet](https://github.com/alampros/gatsby-starter-grommet) [(demo)](https://alampros.github.io/gatsby-starter-grommet/)
 
   Features:
   * Barebones configuration for using the [Grommet](https://grommet.github.io/) design system


### PR DESCRIPTION
Adds [alampros/gatsby-starter-grommet](https://github.com/alampros/gatsby-starter-grommet) to the docs