### PR TITLE
fix broken gatsby link definition for typescript 2.4.2

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -5,4 +5,4 @@ export interface GatsbyLinkProps {
   onClick?: (event: any) => void
 }
 
-export default class GatsbyLink extends React.Component<GatsbyLinkProps, void> { }
+export default class GatsbyLink extends React.Component<GatsbyLinkProps> { }


### PR DESCRIPTION
This PR fixes issue #1627, a broken typescript definition for `GatsbyLink` when using typescript 2.4.2 in strict mode.