### PR TITLE
sassResources webpack config key

### DIFF
--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -12,6 +12,7 @@ import apiRunnerNode from "./api-runner-node"
 // https://github.com/js-dxtools/webpack-validator#customizing
 const validationWhitelist = Joi.object({
   stylus: Joi.any(),
+  sassResources: [Joi.string(), Joi.array().items(Joi.string())],
 })
 
 export default (async function ValidateWebpackConfig(config, stage) {


### PR DESCRIPTION
The `sassResources` key need to be whitelisted in webpack-validator to support sass-resources-loader (https://github.com/shakacode/sass-resources-loader).
I will try to provide a plugin for this loader after my holidays.