### PR TITLE
Webpack modules resolving

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -324,8 +324,8 @@ module.exports = async (
       // directory if you need to install a specific version of a module for a
       // part of your site.
       modulesDirectories: [
-        directoryPath(`node_modules`),
         `node_modules`,
+        directoryPath(`node_modules`),
         directoryPath(`node_modules`, `gatsby`, `node_modules`),
       ],
     }


### PR DESCRIPTION
When secondary dependencie (dependencie of dependencie) have version conflicts with main dependencie, it is installed in a nested way:
![image](https://user-images.githubusercontent.com/30589191/28794606-3cfcd55a-7650-11e7-9b6d-23176fc5c0e8.png)
But in current config, modules resolving starting from root `node_modules`, instead of package inner `node_modules`.