### PR TITLE
Fallback to frontmatter excerpt if available

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -10,7 +10,7 @@ const serialize = ({ query: { site, allMarkdownRemark } }) =>
   allMarkdownRemark.edges.map(edge => {
     return {
       ...edge.node.frontmatter,
-      description: edge.node.excerpt,
+      description: edge.node.excerpt || edge.node.frontmatter.excerpt,
       url: site.siteMetadata.siteUrl + edge.node.fields.slug,
       guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
       custom_elements: [{ "content:encoded": edge.node.html }],

--- a/packages/gatsby-plugin-feed/src/internals.js
+++ b/packages/gatsby-plugin-feed/src/internals.js
@@ -58,6 +58,7 @@ export const defaultOptions = {
             node {
               frontmatter {
                 title
+                excerpt
                 date
               }
               fields {


### PR DESCRIPTION
Currently if there is no node.edge.excerpt, the frontmatter excerpt is still overwritten.

This fixes that.