### PR TITLE
Generate table of contents for Markdown files

### DIFF
--- a/examples/using-remark/src/templates/template-blog-post.js
+++ b/examples/using-remark/src/templates/template-blog-post.js
@@ -60,6 +60,10 @@ class BlogPostRoute extends React.Component {
             {post.timeToRead} min read &middot; {tagsSection}
           </p>
         </header>
+
+        <h2>Contents</h2>
+        <div dangerouslySetInnerHTML={{ __html: post.tableOfContents }} className="toc" />
+
         <div dangerouslySetInnerHTML={{ __html: post.html }} className="post" />
         <hr
           css={{
@@ -122,6 +126,7 @@ export const pageQuery = graphql`
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
       timeToRead
+      tableOfContents
       fields {
         tagSlugs
       }

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -9,6 +9,7 @@
     "hast-util-to-html": "^3.0.0",
     "lodash": "^4.17.4",
     "mdast-util-to-hast": "^2.4.0",
+    "mdast-util-toc": "^2.0.1",
     "remark": "^7.0.1",
     "sanitize-html": "^1.14.1",
     "underscore.string": "^3.3.4",


### PR DESCRIPTION
Remarke generated markdown provides useful fields for blog like pages
(e.g. timeToRead) and overview pages (e.g. excerpt). Table of contents
are a typical use case for documentation and similar pages.

This change adds a new field called tableOfContents which is guaranteed
to be executed after all other remark specific plugins.