### PR TITLE
[gatsby-plugin-jss] fix the incorrect representation of html entities  in css selectors

### DIFF
--- a/packages/gatsby-plugin-jss/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-jss/src/gatsby-ssr.js
@@ -17,8 +17,11 @@ exports.replaceRenderer = ({
 
   replaceBodyHTMLString(bodyHTML)
   setHeadComponents([
-    <style type="text/css" id="server-side-jss">
-      {sheets.toString()}
-    </style>,
+    <style
+      type="text/css"
+      id="server-side-jss"
+      key="server-side-jss"
+      dangerouslySetInnerHTML={{ __html: sheets.toString() }}
+    />,
   ])
 }


### PR DESCRIPTION
closes #1664