### PR TITLE
Switch Lerna to publish in "independent mode"

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/*"
   ],
   "hoist": true,
-  "version": "1.6.3"
+  "version": "independent"
 }


### PR DESCRIPTION
https://github.com/lerna/lerna#independent-mode---independent

Before we were bumping every package release to the same version which
didn't make sense. A small bug fix on one package isn't the same as a
minor release on another.

The main thing that matters is the major version but independent mode is
neater.