### PR TITLE
Update built-html.js fixin `fs.unlinkSync()` error

### DIFF
--- a/packages/gatsby/src/utils/build-html.js
+++ b/packages/gatsby/src/utils/build-html.js
@@ -33,8 +33,11 @@ module.exports = async (program: any) => {
       }
 
       // Remove the temp JS bundle file built for the static-site-generator-plugin
-      fs.unlinkSync(`${directory}/public/render-page.js`)
-
+      try {
+        fs.unlinkSync(`${directory}/public/render-page.js`)
+      } catch (e) {
+        // This function will fail on Windows with no further consequences.
+      }
       return resolve(null, stats)
     })
   })


### PR DESCRIPTION
This fails on Windows. Doing a check for filename validity on Windows [is costly](https://github.com/sindresorhus/filename-reserved-regex/blob/master/index.js) and should probably be done by the user but in this case if the file doesn't exists then so does the link.
Surrounding this with a `try...catch` solves the issue with no further consequences.

This should be solved once [libuv v2.0](https://github.com/libuv/libuv) will be out.

Report of the error : 
```
fs.js:1103
  return binding.unlink(pathModule._makeLong(path));
                 ^

Error: ENOENT: no such file or directory, unlink 'C:\{your-path}\public\render-page.js'
    at Error (native)
    at Object.fs.unlinkSync (fs.js:1103:18)
    at C:\{your-path}\node_modules\gatsby\dist\utils\develop-html.js:59:30
    at Compiler.<anonymous> (C:\{your-path}\node_modules\webpack\lib\Compiler.js:194:14)
    at Compiler.emitRecords (C:\{your-path}\node_modules\webpack\lib\Compiler.js:282:37)
    at Compiler.<anonymous> (C:\{your-path}\node_modules\webpack\lib\Compiler.js:187:11)
    at C:\{your-path}\node_modules\webpack\lib\Compiler.js:275:11
    at Compiler.applyPluginsAsync (C:\{your-path}\node_modules\tapable\lib\Tapable.js:60:69)
    at Compiler.afterEmit (C:\{your-path}\node_modules\webpack\lib\Compiler.js:272:8)
    at Compiler.<anonymous> (C:\{your-path}\node_modules\webpack\lib\Compiler.js:267:14)
    at C:\{your-path}\node_modules\webpack\node_modules\async\lib\async.js:52:16
    at done (C:\{your-path}\node_modules\webpack\node_modules\async\lib\async.js:246:17)
    at C:\{your-path}\node_modules\webpack\node_modules\async\lib\async.js:44:16
    at C:\{your-path}\node_modules\graceful-fs\graceful-fs.js:43:10
    at FSReqWrap.oncomplete (fs.js:123:15)
```

Related to https://github.com/gatsbyjs/gatsby/pull/1473 https://github.com/gatsbyjs/gatsby/issues/1442