### PR TITLE
only catch left mouse button clicks to support browser tab handling

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -1,6 +1,7 @@
 module.exports = function(root, cb) {
   root.addEventListener(`click`, function(ev) {
     if (
+      ev.button !== 0 ||
       ev.altKey ||
       ev.ctrlKey ||
       ev.metaKey ||


### PR DESCRIPTION
Only apply navigation handling logic for left mouse button events to avoid breaking of default browser tab handling (e.g. open in new tab, ...)

fixes #1716