### PR TITLE
add gatsby-plugin-antd under community plugins

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -114,3 +114,7 @@ you can place the files in a `src` subfolder and build them to the plugin folder
 ## Official components
 
 * [gatsby-link](/packages/gatsby-link/)
+
+## Community Plugins
+
+* [gatsby-plugin-antd](https://github.com/bskimball/gatsby-plugin-antd)


### PR DESCRIPTION
This pull request adds a community plugins section to the docs. It also adds gatsby-plugin-antd under said community plugin section.