### PR TITLE
[www] Aftercare for #1707

### DIFF
--- a/www/src/components/cards.js
+++ b/www/src/components/cards.js
@@ -8,7 +8,7 @@ const Cards = ({ children }) =>
       display: `flex`,
       flex: `0 1 auto`,
       flexWrap: `wrap`,
-      background: `rgba(255, 255, 255, 0.975)`,
+      background: `#fff`,
       borderRadius: presets.radiusLg,
       boxShadow: `0 5px 20px rgba(25, 17, 34, 0.1)`,
     }}

--- a/www/src/components/masthead-bg.js
+++ b/www/src/components/masthead-bg.js
@@ -46,7 +46,6 @@ const MastheadBg = () =>
         },
       }}
     />
-
     <svg
       viewBox="0 0 10 10"
       preserveAspectRatio="xMinYMin slice"
@@ -114,7 +113,7 @@ const MastheadBg = () =>
         width: `calc(180% - + 4vh)`,
         height: `100%`,
         zIndex: -1,
-        transition: `width 100ms linear`,
+        //transition: `width 100ms linear`,
       }}
     >
       <svg

--- a/www/src/components/masthead-bg.js
+++ b/www/src/components/masthead-bg.js
@@ -72,8 +72,8 @@ const MastheadBg = () =>
     </svg>
     <style>
       {`
-          .masthead-bg-left-dark {
-            transition: fill 100ms linear;
+          .masthead-bg-left-light {
+            fill: ${presets.brand};
           }
           @media (max-width: 650px),
           (max-width: 768px) and (orientation:portrait) {
@@ -94,6 +94,10 @@ const MastheadBg = () =>
           ${presets.Desktop}  {
             .masthead-bg-left {
               width: 110%;
+            }
+
+            .masthead-bg-left-light {
+              fill: ${presets.brandLight};
             }
           }
           ${presets.Hd}  {
@@ -124,11 +128,18 @@ const MastheadBg = () =>
         }}
       >
         <rect
+          className="masthead-bg-left-light"
+          width="10000%"
+          height="10000%"
+          fill={presets.brandLight}
+          transform="rotate(45 100 50) translate(0 0)"
+        />
+        <rect
           className="masthead-bg-left-dark"
           width="10000%"
           height="10000%"
           fill={presets.brand}
-          transform="rotate(45 100 50) translate(0 0)"
+          transform="rotate(45 100 50) translate(1.25 0)"
         />
         {/*<polygon fill="blue" points="0,10 10,0 10,10" />*/}
       </svg>

--- a/www/src/components/used-by.js
+++ b/www/src/components/used-by.js
@@ -9,8 +9,12 @@ const Icon = ({ icon }) =>
       marginRight: rhythm(3 / 4),
       display: `inline-block`,
       padding: 0,
-      ":last-child": {
-        marginRight: 0,
+      [presets.Phablet]: {
+        marginBottom: 0,
+        width: `auto`,
+        ":last-child": {
+          marginRight: 0,
+        },
       },
     }}
   >
@@ -18,21 +22,12 @@ const Icon = ({ icon }) =>
       src={icon}
       css={{
         margin: 0,
-        verticalAlign: `text-bottom`,
-        height: `20px`,
-        transition: `height ${presets.animation.speedDefault} ${presets
-          .animation.curveDefault}`,
-        [presets.Mobile]: {
-          height: `14px`,
+        height: `calc(14px + 1vw)`,
+        [presets.Phablet]: {
+          height: `calc(9px + 1vw)`,
         },
         [presets.Tablet]: {
-          height: `20px`,
-        },
-        [presets.Desktop]: {
-          height: `24px`,
-        },
-        [presets.VHd]: {
-          height: `28px`,
+          height: `calc(12px + 1vw)`,
         },
       }}
     />
@@ -81,10 +76,6 @@ const UsedBy = () =>
         flexGrow: `1`,
         flexShrink: `1`,
         alignSelf: `flex-end`,
-        textAlign: `center`,
-        "@media (max-height: 650px)": {
-          textAlign: `right`,
-        },
         [presets.Phablet]: {
           flexGrow: `0`,
         },
@@ -94,24 +85,27 @@ const UsedBy = () =>
         css={{
           color: `#fff`,
           letterSpacing: `0.02em`,
-          marginBottom: 0,
           fontFamily: typography.options.headerFontFamily.join(`,`),
           fontSize: scale(-2 / 5).fontSize,
-          "@media (max-height: 650px)": {
-            textAlign: `right`,
-          },
+          marginBottom: 0,
           [presets.Phablet]: {
-            fontSize: scale(-1 / 5).fontSize,
+            fontSize: scale(-2 / 5).fontSize,
             textAlign: `right`,
           },
-          [presets.Hd]: {
-            fontSize: scale(0 / 5).fontSize,
+          [presets.Desktop]: {
+            fontSize: scale(-1 / 5).fontSize,
           },
         }}
       >
         Used by
       </p>
-      <ul css={{ margin: 0, listStyle: `none`, opacity: 0.75 }}>
+      <ul
+        css={{
+          margin: 0,
+          listStyle: `none`,
+          opacity: 0.75,
+        }}
+      >
         <Icon icon={FabricIcon} />
         <Icon icon={SegmentIcon} />
         <Icon icon={FormidableIcon} />

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -159,7 +159,7 @@ module.exports = React.createClass({
               ? `transparent`
               : `${presets.veryLightPurple}`,
             backgroundColor: isHomepage
-              ? `rgba(0,0,0,0)`
+              ? `rgba(255,255,255,0)`
               : `rgba(255,255,255,0.975)`,
             position: isHomepage ? `absolute` : false,
             height: headerHeight,

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -171,7 +171,6 @@ const IndexRoute = React.createClass({
                   hasSideBar={false}
                   css={{ maxWidth: rhythm(30), paddingBottom: `0 !important` }}
                 >
-                  {` `}
                   <h2
                     css={{
                       textAlign: `left`,


### PR DESCRIPTION
Aftercare for #1707 (…step one ;-):

* Bring back second, brighter stripe in the right part of the masthead background for Desktop screens and up.
* Left-align "Used by" content when displayed below the main content.
* Improve "Used by" logo sizes (slightly), copy and spacing.
* Solid white background for the main homepage content "box" (was slightly transparent).
* Tidy.
