### PR TITLE
Support for WP Rest API paging

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -95,23 +95,6 @@ The Authentication on Wordpress.com is not supported yet. This means that you wo
   ]
 ```
 
-
-### How to raise the default and maximum number of posts to be returned in result set from REST API
-
-To modify the `per_page` `default` and `maximum` arguments add the following to your functions.php
-
-```php
-  add_filter( 'rest_endpoints', function( $endpoints ){
-      if ( ! isset( $endpoints['/wp/v2/posts'] ) ) {
-          return $endpoints;
-      }
-      $endpoints['/wp/v2/posts'][0]['args']['per_page']['default'] = 200; // defaults to 10
-      $endpoints['/wp/v2/posts'][0]['args']['per_page']['maximum'] = 200; // defaults to 100
-      return $endpoints;
-  });
-```
-
-
 ## How to query : GraphQL
 
 You can query nodes created from Wordpress using GraphQL like the following:

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -8,6 +8,13 @@
     "lodash": "^4.17.4",
     "qs": "^6.4.0"
   },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
+    "babel-runtime": "^6.25.0"
+  },
   "deprecated": false,
   "description": "Gatsby source plugin for building websites using the Wordpress CMS as a data source.",
   "keywords": [
@@ -21,5 +28,20 @@
     "build": "babel src --out-dir .",
     "watch": "babel -w src --out-dir ."
   },
-  "version": "1.6.3"
+  "version": "1.6.3",
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-0"
+    ],
+    "plugins": [
+      [
+        "transform-runtime",
+        {
+          "polyfill": false,
+          "regenerator": true
+        }
+      ]
+    ]
+  }
 }

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -8,13 +8,6 @@
     "lodash": "^4.17.4",
     "qs": "^6.4.0"
   },
-  "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
-    "babel-runtime": "^6.25.0"
-  },
   "deprecated": false,
   "description": "Gatsby source plugin for building websites using the Wordpress CMS as a data source.",
   "keywords": [
@@ -28,20 +21,5 @@
     "build": "babel src --out-dir .",
     "watch": "babel -w src --out-dir ."
   },
-  "version": "1.6.3",
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-0"
-    ],
-    "plugins": [
-      [
-        "transform-runtime",
-        {
-          "polyfill": false,
-          "regenerator": true
-        }
-      ]
-    ]
-  }
+  "version": "1.6.3"
 }

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -18,6 +18,7 @@ let _getNode
 let _useACF
 let _hostingWPCOM
 let _auth
+let _perPage
 
 let _parentChildNodes = []
 
@@ -31,7 +32,7 @@ const refactoredEntityTypes = {
 // ========= Main ===========
 exports.sourceNodes = async (
   { boundActionCreators, getNode, hasNodeChanged, store },
-  { baseUrl, protocol, hostingWPCOM, useACF, auth, verboseOutput }
+  { baseUrl, protocol, hostingWPCOM, useACF, auth, verboseOutput, perPage = 10 }
 ) => {
   const {
     createNode,
@@ -45,6 +46,7 @@ exports.sourceNodes = async (
   _useACF = useACF
   _hostingWPCOM = hostingWPCOM
   _auth = auth
+  _perPage = perPage
 
   // If the site is hosted on wordpress.com, the API Route differs.
   // Same entity types are exposed (excepted for medias and users which need auth)
@@ -348,8 +350,8 @@ function getValidRoutes (allRoutes, url, baseUrl) {
 
 /**
  * Extract the raw entity type from route
- * 
- * @param {any} route 
+ *
+ * @param {any} route
  */
 const getRawEntityType = route =>
   route._links.self.substring(
@@ -359,8 +361,8 @@ const getRawEntityType = route =>
 
 /**
  * Extract the route manufacturer
- * 
- * @param {any} route 
+ *
+ * @param {any} route
  */
 const getManufacturer = route =>
   route.namespace.substring(0, route.namespace.lastIndexOf(`/`))
@@ -392,7 +394,7 @@ async function fetchData(route, createNode, parentNodeId) {
     if (_verbose) console.time(`Fetching the ${type} took`)
   }
 
-  const routeResponse = await axiosPaginator(url, 40, 1)
+  const routeResponse = await axiosPaginator(url, _perPage, 1)
 
   if (routeResponse) {
     // Process entities to creating GraphQL Nodes.
@@ -433,8 +435,8 @@ async function fetchData(route, createNode, parentNodeId) {
 
 /**
  * Encrypts a String using md5 hash of hexadecimal digest.
- * 
- * @param {any} str 
+ *
+ * @param {any} str
  */
 const digest = str => crypto.createHash(`md5`).update(str).digest(`hex`)
 
@@ -494,9 +496,9 @@ function createGraphQLNode(ent, type, createNode, parentNodeId) {
 
 /**
  * Loop through fields to validate naming conventions and extract child nodes.
- * 
+ *
  * @param {any} ent
- * @param {any} newEnt 
+ * @param {any} newEnt
  * @returns the new entity with fields
  */
 function addFields(ent, newEnt, createNode) {
@@ -535,9 +537,9 @@ function addFields(ent, newEnt, createNode) {
 
 /**
  * Add fields recursively
- * 
- * @param {any} ent 
- * @param {any} newEnt 
+ *
+ * @param {any} ent
+ * @param {any} newEnt
  * @returns the new node
  */
 function recursiveAddFields(ent, newEnt) {
@@ -566,8 +568,8 @@ function recursiveAddFields(ent, newEnt) {
 
 /**
  * Validate the GraphQL naming convetions & protect specific fields.
- * 
- * @param {any} key 
+ *
+ * @param {any} key
  * @returns the valid name
  */
 function getValidName(key) {

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -162,7 +162,7 @@ exports.sourceNodes = async (
   return
 }
 
-async function axiosPaginator (url, perPage = 10, page = 1) {
+async function getPages (url, perPage = 10, page = 1) {
   try {
     let result = []
 
@@ -397,7 +397,7 @@ async function fetchData(route, createNode, parentNodeId) {
     if (_verbose) console.time(`Fetching the ${type} took`)
   }
 
-  const routeResponse = await axiosPaginator(url, _perPage, 1)
+  const routeResponse = await getPages(url, _perPage, 1)
 
   if (routeResponse) {
     // Process entities to creating GraphQL Nodes.

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -170,35 +170,33 @@ async function axiosHelper(url) {
 
 /**
  * Handles HTTP Exceptions (axios)
- * 
- * @param {any} e 
+ *
+ * @param {any} e
  */
-function httpExceptionHandler(e) {
+function httpExceptionHandler (e) {
+  const { status, statusText, data: { message } } = e.response
   console.log(
     colorized.out(
-      `The server response was "${e.response.status} ${e.response.statusText}"`,
+      `The server response was "${status} ${statusText}"`,
       colorized.color.Font.FgRed
     )
   )
-  if (e.response.data.message != undefined)
+  if (message != undefined) {
     console.log(
       colorized.out(
-        `Inner exception message : "${e.response.data.message}"`,
+        `Inner exception message : "${message}"`,
         colorized.color.Font.FgRed
       )
     )
-  if (
-    e.response.status == 400 ||
-    e.response.status == 401 ||
-    e.response.status == 402 ||
-    e.response.status == 403
-  )
+  }
+  if ([400, 401, 402, 403].indexOf(status !== 'undefined')) {
     console.log(
       colorized.out(
         `Auth on endpoint is not implemented on this gatsby-source plugin.`,
         colorized.color.Font.FgRed
       )
     )
+  }
 }
 
 /**

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -1,6 +1,6 @@
 const axios = require(`axios`)
 const crypto = require(`crypto`)
-const querystring = require('querystring')
+const querystring = require(`querystring`)
 const _ = require(`lodash`)
 const stringify = require(`json-stringify-safe`)
 const colorized = require(`./output-color`)
@@ -162,17 +162,18 @@ exports.sourceNodes = async (
   return
 }
 
-async function getPages (url, perPage = 10, page = 1) {
+async function getPages(url, perPage = 10, page = 1) {
   try {
     let result = []
 
     const getOptions = (perPage, page) => {
       return {
         method: `get`,
-        url: `${url}?${querystring.stringify({ 'per_page': perPage, 'page': page })}`,
-        auth: _auth
-          ? { username: _auth.user, password: _auth.pass }
-          : null
+        url: `${url}?${querystring.stringify({
+          per_page: perPage,
+          page: page,
+        })}`,
+        auth: _auth ? { username: _auth.user, password: _auth.pass } : null,
       }
     }
 
@@ -185,7 +186,7 @@ async function getPages (url, perPage = 10, page = 1) {
     result = result.concat(response.data)
 
     // Get total number of entities
-    const total = parseInt(response.headers['x-wp-total'])
+    const total = parseInt(response.headers[`x-wp-total`])
     const totalPages = Math.ceil(total / perPage)
 
     if (_verbose) {
@@ -198,7 +199,7 @@ async function getPages (url, perPage = 10, page = 1) {
     }
 
     // For each X entities, make an HTTP request to page N
-    const requests = _.range(2, totalPages + 1).map((getPage) => {
+    const requests = _.range(2, totalPages + 1).map(getPage => {
       const options = getOptions(perPage, getPage)
       return axios(options)
     })
@@ -220,7 +221,7 @@ async function getPages (url, perPage = 10, page = 1) {
  *
  * @param {any} e
  */
-function httpExceptionHandler (e) {
+function httpExceptionHandler(e) {
   const { status, statusText, data: { message } } = e.response
   console.log(
     colorized.out(
@@ -254,7 +255,7 @@ function httpExceptionHandler (e) {
  * @param {any} baseUrl
  * @returns
  */
-function getValidRoutes (allRoutes, url, baseUrl) {
+function getValidRoutes(allRoutes, url, baseUrl) {
   let validRoutes = []
 
   for (let key of Object.keys(allRoutes.data.routes)) {
@@ -406,20 +407,12 @@ async function fetchData(route, createNode, parentNodeId) {
         await createGraphQLNode(ent, type, createNode, parentNodeId)
       }
     } else {
-      await createGraphQLNode(
-        routeResponse,
-        type,
-        createNode,
-        parentNodeId
-      )
+      await createGraphQLNode(routeResponse, type, createNode, parentNodeId)
     }
 
     // TODO : Get the number of created nodes using the nodes in state.
     let length
-    if (
-      routeResponse != undefined &&
-      Array.isArray(routeResponse)
-    ) {
+    if (routeResponse != undefined && Array.isArray(routeResponse)) {
       length = routeResponse.length
     } else if (
       routeResponse != undefined &&

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -31,7 +31,7 @@ const refactoredEntityTypes = {
 
 // ========= Main ===========
 exports.sourceNodes = async (
-  { boundActionCreators, getNode, hasNodeChanged, store },
+  { boundActionCreators, getNode, store },
   { baseUrl, protocol, hostingWPCOM, useACF, auth, verboseOutput, perPage = 10 }
 ) => {
   const {

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -228,7 +228,7 @@ function httpExceptionHandler (e) {
       colorized.color.Font.FgRed
     )
   )
-  if (message != undefined) {
+  if (message) {
     console.log(
       colorized.out(
         `Inner exception message : "${message}"`,
@@ -236,7 +236,7 @@ function httpExceptionHandler (e) {
       )
     )
   }
-  if ([400, 401, 402, 403].indexOf(status !== 'undefined')) {
+  if ([400, 401, 402, 403].includes(status)) {
     console.log(
       colorized.out(
         `Auth on endpoint is not implemented on this gatsby-source plugin.`,

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -32,7 +32,7 @@ const refactoredEntityTypes = {
 // ========= Main ===========
 exports.sourceNodes = async (
   { boundActionCreators, getNode, store },
-  { baseUrl, protocol, hostingWPCOM, useACF, auth, verboseOutput, perPage = 10 }
+  { baseUrl, protocol, hostingWPCOM, useACF, auth, verboseOutput, perPage = 100 }
 ) => {
   const {
     createNode,
@@ -471,7 +471,7 @@ function createGraphQLNode(ent, type, createNode, parentNodeId) {
 
   node = addFields(ent, node, createNode)
 
-  if (type === refactoredEntityTypes.post || Ztype === refactoredEntityTypes.page) {
+  if (type === refactoredEntityTypes.post || type === refactoredEntityTypes.page) {
     // TODO : Move this to field recursive and add other fields that have rendered field
     node.title = ent.title.rendered
     node.content = ent.content.rendered

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -169,7 +169,10 @@ async function axiosPaginator (url, perPage = 10, page = 1) {
     const getOptions = (perPage, page) => {
       return {
         method: `get`,
-        url: `${url}?${querystring.stringify({ 'per_page': perPage, 'page': page })}`
+        url: `${url}?${querystring.stringify({ 'per_page': perPage, 'page': page })}`,
+        auth: _auth
+          ? { username: _auth.user, password: _auth.pass }
+          : null
       }
     }
 


### PR DESCRIPTION
**Package: gatsby-source-wordpress**

Currently you have to increase the default `per_page` value of the REST API in functions.php to get more posts. In this PR, the `X-WP-Total` header is used to create multiple async requests* for each WP entity type in order to get all of the entities without having to change anything in Wordpress

**Before**:
Max 10 posts returned without editing Wordpress backend

**Now**:
All entities retrieved with no Wordpress modification

![image](https://user-images.githubusercontent.com/1243909/29002209-a0015486-7a9d-11e7-8fe9-ade914c14467.png)

\* Waterfall approach might be better in terms of server load, but can take a lot longer if there are a lot of pages. Perhaps adding `request-rate-limiter` (or equivalent) might help with this

P.S. Sorry about the diff, my editor removes trailing whitespace