### PR TITLE
Update docs to include graphql when creating pages

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -49,7 +49,7 @@ of the markdown file.
 ```javascript
 // Implement the Gatsby API “createPages”. This is called once the
 // data layer is bootstrapped to let plugins create pages from data.
-exports.createPages = ({ boundActionCreators }) => {
+exports.createPages = ({ boundActionCreators, graphql }) => {
   const { createPage } = boundActionCreators
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
GatsbyJS is quickly becoming my favorite static site generator. Thanks for all your hard work in designing and creating this for the community.

This PR adds the reference to `graphql` when creating a page through the API as shown on the [Node APIs page][createPages].

```js
exports.createPages = ({ boundActionCreators, graphql }) => {
}
```

[createPages]: https://www.gatsbyjs.org/docs/node-apis/#createPages