### PR TITLE
Update hashed-chunk-ids-plugin.js

### DIFF
--- a/packages/gatsby/src/utils/hashed-chunk-ids-plugin.js
+++ b/packages/gatsby/src/utils/hashed-chunk-ids-plugin.js
@@ -15,7 +15,9 @@ HashedChunkIdsPlugin.prototype.apply = function apply(compiler) {
     compilation.plugin(`before-chunk-ids`, chunks => {
       chunks.forEach(chunk => {
         if (chunk.id === null) {
-          chunk.id = hashFn(chunk.name)
+          if (typeof chunk.name !== "undefined") {
+            chunk.id = hashFn(chunk.name);
+          }
         }
       })
     })


### PR DESCRIPTION
This skips the hash function if the chunk.id is null and chunk.name is undefined. Assume that if the id is null and the name is undefined, then there is something wrong with that module and do not hold up the entire build process.

This is in reference to [#1659](https://github.com/gatsbyjs/gatsby/issues/1659)