### PR TITLE
Fixed gatsby-remark-images dependencies list

### DIFF
--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -24,6 +24,9 @@
     "slash": "^1.0.0",
     "unist-util-select": "^1.5.0"
   },
+  "peerDependencies": {
+    "gatsby-plugin-sharp": "^1.6.0"
+  },
   "scripts": {
     "build": "babel src --out-dir .",
     "watch": "babel -w src --out-dir ."


### PR DESCRIPTION
In order for gatsby-remark-images to work, the gatsby-plugin-sharp is needed. However, it won't be automatically installed via yarn add or npm install. To solve this issue, gatsby-plugin-sharp added as a peerDependency.

This commit is related to issue #1751