### PR TITLE
Change StackOverflow tag to gatsby.

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -26,7 +26,7 @@ Twitter](https://twitter.com/gatsbyjs).
 
 Many members of the community use Stack Overflow to ask questions. Read
 through the [existing
-questions](http://stackoverflow.com/questions/tagged/gatsbyjs) tagged
+questions](http://stackoverflow.com/questions/tagged/gatsby) tagged
 with **gatsby** or [ask your
 own](http://stackoverflow.com/questions/ask?tags=gatsby)!
 


### PR DESCRIPTION
Existing questions already use the gatsby tag.

I tried following the community guidelines, but when running npm test, I get errors related to import and spread operator syntax.

I see in .babelrc, test folder is ignored. If I temporarily remove that, the tests will all pass.

I assume that maybe something in my local environment is not set up correctly.

Regardless, I can't imagine my change would break any tests. ^_^