### PR TITLE
gatsby-remark-images: moved gatsby-plugin-sharp to dependencies

### DIFF
--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -18,14 +18,12 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
+    "gatsby-plugin-sharp": "^1.6.1",
     "image-size": "^0.5.1",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",
     "slash": "^1.0.0",
     "unist-util-select": "^1.5.0"
-  },
-  "peerDependencies": {
-    "gatsby-plugin-sharp": "^1.6.0"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",


### PR DESCRIPTION
Having it in peer dependencies is wrong, as @nickmaltsev mentioned,  and I realized, as it's used in a source.

The only thing it does being in peerDependencies is only warning users about missing dep, but can be easily dismissed.

See also original issue #1751, PR #1755 