### PR TITLE
Fix bad character escape sequence in typography.js on Windows

### DIFF
--- a/packages/gatsby-plugin-typography/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-node.js
@@ -1,5 +1,6 @@
 const fs = require(`fs`)
 const path = require(`path`)
+const os= require(`os`)
 
 // Write out a typography module to .cache.
 
@@ -13,6 +14,9 @@ exports.sourceNodes = ({ store }, pluginOptions) => {
       program.directory,
       pluginOptions.pathToConfigModule
     )}")`
+    if(os.platform() == `win32`){
+      module = module.split(`\\`).join(`\\\\`)
+    }
   } else {
     module = `const Typography = require("typography")
 const typography = new Typography()


### PR DESCRIPTION
Fixes the issue discussed here lately: #1669 
This replace single backslashes on windows with double backslashes. Without this the following error occurs on Windows machines:

> Error: Module parse failed: C:\src\node_modules\gatsby-plugin-typography.cache\typography.js Bad character escape sequence (1:56) You may need an appropriate loader to handle this file type. SyntaxError: Bad character escape sequence (1:56)