### PR TITLE
Fix babel-preset-env modules setting fixes #1809

### DIFF
--- a/packages/gatsby/src/utils/babel-config.js
+++ b/packages/gatsby/src/utils/babel-config.js
@@ -151,7 +151,7 @@ module.exports = async function babelConfig(program, stage) {
       {
         loose: true,
         uglify: true,
-        modules: false,
+        modules: `commonjs`,
         targets: {
           browsers: program.browserslist,
         },


### PR DESCRIPTION
reason I'd set `modules` to `false` which meant es6 code wasn't being compiled
to commonjs. I probably did that because in webpack 2+ that's the correct setting
and I was just copying the defaults from the babel-preset-env README.

Anyways, now that #1787 fixed the merging bug, es6 stopped being compiled so this PR
fixes that.