### PR TITLE
Support 'import' option in gatsby-plugin-stylus

### DIFF
--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -14,6 +14,7 @@
  *     resolve: `gatsby-plugin-stylus`,
  *     options: {
  *       use: [],
+ *       import: []
  *     },
  *   },
  * ],
@@ -24,7 +25,7 @@ exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
   const cssModulesConfProd = `css?modules&minimize&importLoaders=1`
   const cssModulesConfDev = `css?modules&importLoaders=1&localIdentName=[name]---[local]---[hash:base64:5]`
 
-  // Pass in stylus plugins regardless of stage.
+  // Pass in stylus options regardless of stage.
   if (Array.isArray(options.use)) {
     config.merge(current => {
       current.stylus = {
@@ -35,6 +36,18 @@ exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
   } else if (options.use) {
     throw new Error(
       `gatsby-plugin-stylus "use" option passed with ${options.use}. Pass an array of stylus plugins instead`
+    )
+  }
+  if (Array.isArray(options.import)) {
+    config.merge(current => {
+      current.stylus = {
+        import: options.import,
+      }
+      return current
+    })
+  } else if (options.import) {
+    throw new Error(
+      `gatsby-plugin-stylus "import" option passed with ${options.import}. Pass an array of filenames instead`
     )
   }
 


### PR DESCRIPTION
Hi there! This patch adds support to `gatsby-plugin-stylus` for the `import` option used by `stylus-loader`. It lets you define one or more files that will always be implicitly imported to all of your `.styl` files. (Typically I use it for variable definitions and other things that I want to use globally.)