### PR TITLE
more accurate component check

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -67,7 +67,7 @@ const fetchResource = (resourceName, cb = () => {}) => {
   } else {
     // Find resource
     const resourceFunction =
-      resourceName.slice(0, 9) === `component`
+      resourceName.slice(0, 12) === `component---`
         ? asyncRequires.components[resourceName] ||
           asyncRequires.layouts[resourceName]
         : asyncRequires.json[resourceName]


### PR DESCRIPTION
I add a `components` folder to the `pages` folder, then I will get a `components.json` resource which should be treated as a json resource but right now it's treated as a component resource because it starts with `component` too