### PR TITLE
fix links

### DIFF
--- a/www/src/pages/docs/tutorial-links.yml
+++ b/www/src/pages/docs/tutorial-links.yml
@@ -4,8 +4,8 @@
 - title: Part One
   links:
     Part one: /tutorial/part-one/
-    ">> Check Environment": /tutorial/part-one/#check-environment
-    ">> Creating a Gatsby site from scratch": /tutorial/part-one/#creating-a-gatsby-site-from-scratch
+    ">> Check Environment": /tutorial/part-one/#check-your-development-environment
+    ">> Creating a Gatsby site from scratch": /tutorial/part-one/#install-the-hello-world-starter
     ">> Linking between pages": /tutorial/part-one/#linking-between-pages
     ">> Interactive page": /tutorial/part-one/#interactive-page
     ">> Deploying Gatsby.js websites on the web": /tutorial/part-one/#deploying-gatsbyjs-websites-on-the-web


### PR DESCRIPTION
Fix the wrong anchor links for tutorial - part one.

IMHO, we should keep sidebar's items and anchor's title of main content matched (or as much as possible). e.g. "Check Environment " vs "Check your development environment" is OK. However "Creating a Gatsby site from scratch" vs "Install the Hello World starter" is a little confused when navigating. 