### PR TITLE
Clarify migration process to gatsby-link 📝 

### DIFF
--- a/docs/docs/migrating-from-v0-to-v1.md
+++ b/docs/docs/migrating-from-v0-to-v1.md
@@ -24,7 +24,7 @@ git mv utils src
 
 ## Replace react-router's Link component with gatsby-link
 
-`gatsby-link` is a wrapper for the `<Link>` component in react-router.  It automatically prefixes urls and handles prefetching on browsers that don't support ServiceWorker.  Gatsby doesn't include it, so you should install it:
+`gatsby-link` is a wrapper for the `<Link>` component in react-router.  It automatically prefixes urls and handles prefetching.  Add `gatsby-link` to your project by running:
 
 `npm install --save gatsby-link`
 
@@ -33,14 +33,14 @@ git mv utils src
 ```jsx
 import Link from 'gatsby-link'
 
-// Equivelant to react-router's <Link>
+// Equivalent to react-router's <Link>
 <Link to="/page-2/">Page 2</Link>
 
-// Equivelant to react-router's <NavLink>
+// Equivalent to react-router's <NavLink>
 <Link to="/page-2/" activeClassName="selected">Page 2</Link>
 
 // `exact` prop replaces <IndexLink> from react-router v3
-<Link to="/" exact>Home</IndexLink>
+<Link to="/" exact>Home</Link>
 ```
 
 ## config.toml is now gatsby-config.js

--- a/docs/docs/migrating-from-v0-to-v1.md
+++ b/docs/docs/migrating-from-v0-to-v1.md
@@ -43,6 +43,10 @@ import Link from 'gatsby-link'
 <Link to="/" exact>Home</Link>
 ```
 
+Prefixing links is also now handled automatically by our new `<Link>` component so remove usages of `prefixLink` in links.
+
+Use `gatsby-link` everywhere and things will Just Work™.
+
 ## config.toml is now gatsby-config.js
 
 If you previously added site metadata to `config.toml`, move that into

--- a/docs/docs/migrating-from-v0-to-v1.md
+++ b/docs/docs/migrating-from-v0-to-v1.md
@@ -24,24 +24,24 @@ git mv utils src
 
 ## Replace react-router's Link component with gatsby-link
 
-Add new package to project.
+`gatsby-link` is a wrapper for the `<Link>` component in react-router.  It automatically prefixes urls and handles prefetching on browsers that don't support ServiceWorker.  Gatsby doesn't include it, so you should install it:
 
 `npm install --save gatsby-link`
 
-Use in place of react-router's Link
+`gatsby-link` auto-detects whether to use a plain `<Link>` or `<NavLink>` based on what props you pass it.  There's no need to wrap `<IndexLink>` because it was dropped in react-router v4 in favor of the `exact` prop.
 
 ```jsx
 import Link from 'gatsby-link'
 
-// Works identically to react-router's <Link>
-<Link to="/another-page/">Another page</Link>
+// Equivelant to react-router's <Link>
+<Link to="/page-2/">Page 2</Link>
+
+// Equivelant to react-router's <NavLink>
+<Link to="/page-2/" activeClassName="selected">Page 2</Link>
+
+// `exact` prop replaces <IndexLink> from react-router v3
+<Link to="/" exact>Home</IndexLink>
 ```
-
-Prefixing links is also now handled automatically by our new `<Link>` component
-so remove usages of `prefixLink` in links.
-
-Use `gatsby-link` everywhere and things will Just Work™.
-
 
 ## config.toml is now gatsby-config.js
 


### PR DESCRIPTION
A [discussion](https://discordapp.com/channels/102860784329052160/103314369600843776?jump=346651787824201730) came up on discord about the how to get the functionality of `<IndexLink>` with `gatsby-link`.

I was all fired up to modify the gatsby-link package and submit a PR when I realized that `<IndexLink>` was dropped in react-router v4 and the new way to do it is by passing the `exact` prop. 🤦‍♀️   So instead of modifying `gatsby-link` I'm (attempting to) improve the documentation. 😄 