### PR TITLE
Fix utils/develop path extension check to support location.search

### DIFF
--- a/packages/gatsby/src/utils/develop.js
+++ b/packages/gatsby/src/utils/develop.js
@@ -108,7 +108,7 @@ async function startServer(program) {
   // Render an HTML page and serve it.
   app.use((req, res, next) => {
     const parsedPath = parsePath(req.originalUrl)
-    if (parsedPath.extname === `` || parsedPath.extname.indexOf(`.html`) === 0) {
+    if (parsedPath.extname === `` || parsedPath.extname.startsWith(`.html`)) {
       res.sendFile(directoryPath(`public/index.html`), err => {
         if (err) {
           res.status(500).end()

--- a/packages/gatsby/src/utils/develop.js
+++ b/packages/gatsby/src/utils/develop.js
@@ -108,7 +108,7 @@ async function startServer(program) {
   // Render an HTML page and serve it.
   app.use((req, res, next) => {
     const parsedPath = parsePath(req.originalUrl)
-    if (parsedPath.extname === `` || parsedPath.extname === `.html`) {
+    if (parsedPath.extname === `` || parsedPath.extname.indexOf(`.html`) === 0) {
       res.sendFile(directoryPath(`public/index.html`), err => {
         if (err) {
           res.status(500).end()


### PR DESCRIPTION
This PR adds the ability to define a [client-side route](https://www.gatsbyjs.org/docs/creating-and-modifying-pages/#creating-client-only-routes) that properly supports a dynamic querystring (`location.search`) in development mode.

For example
```js
exports.onCreatePage = async ({ page, boundActionCreators }) => {
  const { createPage } = boundActionCreators;

  return new Promise((resolve, reject) => {
    if (someCriteriaCheck) {
      page.matchPath = 'path.html:args?';

      createPage(page);
    }

    resolve();
  })
};
```

URL | Works before? | Works after?
---|:---:|:---:
localhost:8000/path.html | ✓ | ✓
localhost:8000/path.html/foo | ✓ | ✓
localhost:8000/path.html/?foo | ✓ | ✓
localhost:8000/path.html?foo | ✖ | ✓

More context available in [this discussion thread](https://github.com/gatsbyjs/gatsby/issues/33#issuecomment-322610162).

I have not yet tested the production build of the Gatsby site I'm working on but I assume this will work there as-is. (If not I'll follow up with another PR.)