### PR TITLE
Make sure to always return array within reduce function

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -93,7 +93,7 @@ const findDirtyIds = actions => {
     const node = state.nodes[action.payload.id]
     // Check if the node was deleted
     if (!node) {
-      return
+      return dirtyIds
     }
 
     // find invalid pagesAndLayouts


### PR DESCRIPTION
Went to update my site and noticed I can't currently build my site. Not sure what happened between now and the last time I built my site as things were working fine. I assume things are broken for me now because of the non-exact dependency versions. In hopes of fixing my problem, I tried upgrading gatsby (from 1.4.1 to the latest 1.8.11) and got an error at the `.concat` call within the `findDirtyIds` function where `dirtyIds` was `undefined`. I would think using reduce should always return the accumulator argument.

Adding this fix now gives me the error listed here #1659. 

In case you need the output from the console.
```
$ node -v
v7.1.0
$ gatsby -V
1.8.11
$ gatsby build
info One or more of your plugins have changed since the last time you ran Gatsby. As
a precaution, we're deleting your site's cache to ensure there's not any stale
data
success copy gatsby files — 0.049 s
success source and transform nodes — 0.308 s
success building schema — 0.320 s
success createLayouts — 0.009 s
success createPages — 0.055 s
success createPagesStatefully — 0.039 s
success extract queries from components — 0.177 s
error UNHANDLED REJECTION


  TypeError: Cannot read property 'concat' of undefined

  - page-query-runner.js:152
    [web]/[gatsby]/dist/internal-plugins/query-runner/page-query-runner.js:152:24

  - Array.reduce

  - page-query-runner.js:144 findDirtyIds
    [web]/[gatsby]/dist/internal-plugins/query-runner/page-query-runner.js:144:18

  - page-query-runner.js:46 _callee$
    [web]/[gatsby]/dist/internal-plugins/query-runner/page-query-runner.js:46:22

  - index.js:386 _callee$
    [web]/[gatsby]/dist/bootstrap/index.js:386:20
```