### PR TITLE
TOC generation throws when document contains no headings

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -173,7 +173,13 @@ module.exports = (
         return cachedToc
       } else {
         const ast = await getAST(markdownNode)
-        const toc = hastToHTML(toHAST(mdastToToc(ast).map))
+        const tocAst = mdastToToc(ast)
+        let toc
+        if (tocAst.map) {
+          toc = hastToHTML(toHAST(tocAst.map))
+        } else {
+          toc = ``
+        }
         cache.set(tableOfContentsCacheKey(markdownNode), toc)
         return toc
       }


### PR DESCRIPTION
mdast-util-toc returns null as the TOC AST when the markdown document's
AST does not contain any headings.