### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@
 
 Websites built with Gatbsy:
 
-* [Bricolage.io](https://www.bricolage.io/) [(source)](https://github.com/KyleAMathews/blog)
 * [Segment's Blog](https://segment.com/blog/)
 * [Fabric](https://meetfabric.com/)
 * [Formidable](https://formidable.com/)
+* [openFDA](https://open.fda.gov/) ([source](https://github.com/FDA/open.fda.gov))
 * [ReasonML Docs](https://reasonml.github.io/) [(source)](https://github.com/reasonml/reasonml.github.io)
+* [Bricolage.io](https://www.bricolage.io/) [(source)](https://github.com/KyleAMathews/blog)
 * [Jamie Henson's Blog](http://jamiehenson.com/) [(source)](https://github.com/jamiehenson/jh47-gatsby)
 * [Sean Coker's Blog](https://sean.is/)
 * [Dustin Schau's Blog](https://dustinschau.com/blog/) [(source)](https://github.com/dschau/blog)


### PR DESCRIPTION
We should re-add openFDA, an official federal government website using Gatsby, to the list of showcase sites. OpenFDA is one of the most visible external users of Gatsby and this list should reflect that.

We should also move Kyle's blog down in line with the other blogs being listed.

The site was removed here:
https://github.com/gatsbyjs/gatsby/commit/96d76b1461cffaa46afab39fe74f12e9a1e4d7f9#diff-04c6e90faac2675aa89e2176d2eec7d8