### PR TITLE
Check for error path as well.

### DIFF
--- a/packages/gatsby/src/utils/develop.js
+++ b/packages/gatsby/src/utils/develop.js
@@ -111,7 +111,7 @@ async function startServer(program) {
     // Load file but ignore errors.
     res.sendFile(directoryPath(`/public/${req.url}`), err => {
       // No err so a file was sent successfully.
-      if (!err) {
+      if (!err || !err.path) {
         next()
       } else if (err) {
         // There was an error. Let's check if the error was because it


### PR DESCRIPTION
Adding the check here seems to get out of things early enough and triggers `next()` so that things can continue.  My local test sites go back to working.