### PR TITLE
Fixed siteUrl bug in gatsby-plugin-feed

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -38,6 +38,7 @@ plugins: [
               title
               description
               siteUrl
+              site_url: siteUrl
             }
           }
         }

--- a/packages/gatsby-plugin-feed/src/internals.js
+++ b/packages/gatsby-plugin-feed/src/internals.js
@@ -24,6 +24,7 @@ export const defaultOptions = {
           title
           description
           siteUrl
+          site_url: siteUrl
         }
       }
     }


### PR DESCRIPTION
Site URL was not working previously because we camelCased and
https://github.com/dylang/node-rss uses snake case