### PR TITLE
Prevent duplicative styles with CSS modules

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -212,7 +212,7 @@ module.exports = async (
             __PATH_PREFIX__: JSON.stringify(store.getState().config.pathPrefix),
             __POLYFILL__: store.getState().config.polyfill,
           }),
-          new ExtractTextPlugin(`build-html-styles.css`),
+          new ExtractTextPlugin(`build-html-styles.css`, { allChunks: true }),
         ]
       case `build-javascript`: {
         // Get array of page template component names.
@@ -286,7 +286,7 @@ module.exports = async (
             __POLYFILL__: store.getState().config.polyfill,
           }),
           // Extract CSS so it doesn't get added to JS bundles.
-          new ExtractTextPlugin(`build-js-styles.css`),
+          new ExtractTextPlugin(`build-js-styles.css`, { allChunks: true }),
           // Write out mapping between chunk names and their hashed names. We use
           // this to add the needed javascript files to each HTML page.
           new StatsWriterPlugin(),


### PR DESCRIPTION
This PR adds { allChunks: true } to the `build-html` and `build-javascript` build phases. This allows CSS modules to strip out of their associated JavaScript modules, eliminating duplicative CSS.

This should provide a fix for #1881, reproduced by http://gatsby-duplicate-css-modules.surge.sh/.

I was able to confirm this by editing local node_modules. I'd like to link the `gatsby` package to my test case repo, but `yarn build` doesn't generate a package.json. Any suggestions?