### PR TITLE
Always add leading slash to Gatsby Links, prevent double render during hydration

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -3,9 +3,13 @@ import React from "react"
 import { Link, NavLink } from "react-router-dom"
 import PropTypes from "prop-types"
 
-let pathPrefix = ``
+let pathPrefix = `/`
 if (typeof __PREFIX_PATHS__ !== `undefined` && __PREFIX_PATHS__) {
   pathPrefix = __PATH_PREFIX__
+}
+
+function normalizePath(path) {
+  return path.replace(/^\/\//g, '/')
 }
 
 const NavLinkPropTypes = {
@@ -21,7 +25,7 @@ class GatsbyLink extends React.Component {
   constructor(props) {
     super()
     this.state = {
-      to: pathPrefix + props.to,
+      to: normalizePath(pathPrefix + props.to),
     }
   }
   propTypes: {
@@ -33,7 +37,7 @@ class GatsbyLink extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.to !== nextProps.to) {
       this.setState({
-        to: pathPrefix + nextProps.to,
+        to: normalizePath(pathPrefix + nextProps.to),
       })
       ___loader.enqueue(this.state.to)
     }
@@ -101,5 +105,5 @@ GatsbyLink.contextTypes = {
 export default GatsbyLink
 
 export const navigateTo = pathname => {
-  window.___navigateTo(pathPrefix + pathname)
+  window.___navigateTo(normalizePath(pathPrefix + pathname))
 }

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
@@ -11,6 +11,7 @@ Array [
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
+    "updatedAt": "2017-08-23T02:25:12.551Z",
   },
   Object {
     "component": "/whatever/index.js",
@@ -21,6 +22,7 @@ Array [
     "path": "/hi/pizza/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
+    "updatedAt": "2017-08-23T02:25:12.552Z",
   },
 ]
 `;
@@ -36,6 +38,7 @@ Object {
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
+    "updatedAt": "2017-08-23T02:25:12.519Z",
   },
   "plugin": Object {
     "id": "test",
@@ -57,6 +60,7 @@ Array [
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
+    "updatedAt": "2017-08-23T02:25:12.519Z",
   },
 ]
 `;
@@ -74,6 +78,7 @@ Object {
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
+    "updatedAt": "2017-08-23T02:25:12.546Z",
   },
   "plugin": Object {
     "id": "test",
@@ -97,6 +102,7 @@ Array [
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
+    "updatedAt": "2017-08-23T02:25:12.546Z",
   },
 ]
 `;
@@ -114,6 +120,7 @@ Array [
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
+    "updatedAt": "2017-08-23T02:25:12.557Z",
   },
 ]
 `;


### PR DESCRIPTION
Good evening! 

This commit normalizes `to` on Gatsby Link to avoid leading double slashes, allowing a leading slash to consistently be inserted at the beginning of anchor tag hrefs.

This prevents a mismatch between server and client rendering, causing
a double render.

**Reproduction:**
http://gatsby-slash-append.surge.sh/

**The fix:**

http://gatsby-slash-append-fix.surge.sh/

---

Fixes #1883 

![double-render](https://user-images.githubusercontent.com/590904/29595899-4085b266-8788-11e7-8784-0e123596ea36.gif)


