### PR TITLE
Fix README of wrong example in example/hn

### DIFF
--- a/examples/hn/README.md
+++ b/examples/hn/README.md
@@ -1,6 +1,3 @@
-# Gatsbygram
+# Gatsby Hacker News
 
-https://gatsbygram.gatsbyjs.org/
-
-Built with Gatsby 1.0 (Alpha 11) as a demo of Gatsby's new built-in
-image processing capabilities.
+A clone of Hacker News written in Gatsby


### PR DESCRIPTION
The readme of the Hacker News example is a duplicate of the gatsbygram readme, fixed it to show the relevant info