### PR TITLE
Check for undefined Value When Deleting Pages

### DIFF
--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -6,6 +6,7 @@ const _ = require(`lodash`)
 
 const { emitter } = require(`../../redux`)
 const { boundActionCreators } = require(`../../redux/actions`)
+const { getNode } = require(`../../redux`)
 
 function transformPackageJson(json) {
   const transformDeps = deps =>
@@ -150,6 +151,6 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
 // Listen for DELETE_PAGE and delete page nodes.
 emitter.on(`DELETE_PAGE`, action => {
   const nodeId = createPageId(action.payload.path)
-  const node = boundActionCreators.getNode(nodeId)
+  const node = getNode(nodeId)
   boundActionCreators.deleteNode(nodeId, node)
 })

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -149,5 +149,7 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
 
 // Listen for DELETE_PAGE and delete page nodes.
 emitter.on(`DELETE_PAGE`, action => {
-  boundActionCreators.deleteNode(createPageId(action.payload.path))
+  const nodeId = createPageId(action.payload.path)
+  const node = boundActionCreators.getNode(nodeId)
+  boundActionCreators.deleteNode(nodeId, node)
 })

--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -107,14 +107,15 @@ const findDirtyIds = actions => {
   const state = store.getState()
   return actions.reduce((dirtyIds, action) => {
     const node = action.payload
+    if (!_.isUndefined(node)) {
+      // find invalid pagesAndLayouts
+      dirtyIds = dirtyIds.concat(state.componentDataDependencies.nodes[node.id])
 
-    // find invalid pagesAndLayouts
-    dirtyIds = dirtyIds.concat(state.componentDataDependencies.nodes[node.id])
-
-    // Find invalid connections
-    dirtyIds = dirtyIds.concat(
-      state.componentDataDependencies.connections[node.internal.type]
-    )
+      // Find invalid connections
+      dirtyIds = dirtyIds.concat(
+        state.componentDataDependencies.connections[node.internal.type]
+      )
+    }
 
     return _.compact(dirtyIds)
   }, [])

--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -107,15 +107,14 @@ const findDirtyIds = actions => {
   const state = store.getState()
   return actions.reduce((dirtyIds, action) => {
     const node = action.payload
-    if (!_.isUndefined(node)) {
-      // find invalid pagesAndLayouts
-      dirtyIds = dirtyIds.concat(state.componentDataDependencies.nodes[node.id])
 
-      // Find invalid connections
-      dirtyIds = dirtyIds.concat(
-        state.componentDataDependencies.connections[node.internal.type]
-      )
-    }
+    // find invalid pagesAndLayouts
+    dirtyIds = dirtyIds.concat(state.componentDataDependencies.nodes[node.id])
+
+    // Find invalid connections
+    dirtyIds = dirtyIds.concat(
+      state.componentDataDependencies.connections[node.internal.type]
+    )
 
     return _.compact(dirtyIds)
   }, [])


### PR DESCRIPTION
Hey there!

I wanted to use `gatsby-plugin-sitemap` but wanted all `loc`s without trailing slashes (our webserver is configured this way as well). I followed your example [here](https://github.com/gatsbyjs/gatsby/tree/524ff171cd890b79ce9535d6dc10550c70365d33/examples/no-trailing-slashes) to remove trailing slashes in all `path`s, but unfortunately the build fails with:

```
error UNHANDLED REJECTION


  TypeError: Cannot read property 'id' of undefined

  - page-query-runner.js:164
    [name]/[gatsby]/dist/internal-plugins/query-runner/page-query-runner.js:164:74

  - Array.reduce

  - page-query-runner.js:160 findDirtyIds
    [name]/[gatsby]/dist/internal-plugins/query-runner/page-query-runner.js:160:18

  - page-query-runner.js:47 _callee$
    [name]/[gatsby]/dist/internal-plugins/query-runner/page-query-runner.js:47:22

  - index.js:400 _callee$
    [name]/[gatsby]/dist/bootstrap/index.js:400:20
```

This is because `emitter` listens to the `DELETE_PAGE` action being triggered [here](https://github.com/gatsbyjs/gatsby/blob/379a290fa96527da8bcf9ce59d876420251e84a0/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js#L151) and then calling `deleteNode(createPageId(action.payload.path))` (note that one param is passed). `deleteNode` accepts two arguments; `nodeId` and `node` (plus `plugin` with a default value). Both values, `nodeId` _and_ `node` are passed as the action's payload. 

[Here](https://github.com/gatsbyjs/gatsby/blob/379a290fa96527da8bcf9ce59d876420251e84a0/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js#L43) the `emitter` listens to `DELETE_PAGE` actions, and pushes `action.node` into the `queuedDirtyActions` array - in my case `action.node` is `undefined`.

Later, the pager query runner tries to find dirty IDs [here](https://github.com/gatsbyjs/gatsby/blob/379a290fa96527da8bcf9ce59d876420251e84a0/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js#L109) by reading `queudDirtyActions` - `node` is still `undefined` and therefore reading `node.id` on L112 results in an error.

I'm not convinced that this is the best solution, but honestly, I don't understand the process well enough to decide this. Maybe it makes more sense to pass the node, but I wouldn't know how to find and get the correct one. Or even checking in `deleteNode` whether `node` is defined, and only passing it then - the same were the `emitter` is listening for the `DELETE_NODE` action.

I hope this all made sense to you! Let me know what you think.

Cheers,
Rob