### PR TITLE
[gatsby-remark-images] Fix key, fixes #1888

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -65,7 +65,7 @@ module.exports = (
     // Calculate the paddingBottom %
     const ratio = `${1 / responsiveSizesResult.aspectRatio * 100}%`
 
-    const originalImg = responsiveSizesResult.originalImage
+    const originalImg = responsiveSizesResult.originalImg
     const fallbackSrc = responsiveSizesResult.src
     const srcSet = responsiveSizesResult.srcSet
 


### PR DESCRIPTION
gatsby-plugin-sharp responsiveSizes returns `originalImg`, fixes #1888