### PR TITLE
fix: service worker failed to install when `pathPrefix` option was set

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -26,6 +26,11 @@ exports.onPostBuild = (args, pluginOptions) => {
       `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
     ],
     stripPrefix: rootDir,
+    // If `pathPrefix` is configured by user, we should replace
+    // the `public` prefix with `pathPrefix`.
+    // See more at:
+    // https://github.com/GoogleChrome/sw-precache#replaceprefix-string
+    replacePrefix: args.pathPrefix || '',
     navigateFallback: `/offline-plugin-app-shell-fallback/index.html`,
     // Only match URLs without extensions.
     // So example.com/about/ will pass but


### PR DESCRIPTION
### Problem

> I use the [Vagr9K/gatsby-advanced-starter](https://github.com/Vagr9K/gatsby-advanced-starter) repo to illustrate the problem.

Service worker failed to install page caches when `pathPrefix` option was set.

[demo](https://vagr9k.github.io/gatsby-advanced-starter/):

![gatsby-service-worker-error](https://user-images.githubusercontent.com/6076919/29716924-dfd2fdac-89df-11e7-9860-a3d46c47fb7f.png)

### What Cause the Problem

In the built [`sw.js` of `Vagr9K/gatsby-advanced-starter`](https://github.com/Vagr9K/gatsby-advanced-starter/blob/2981228b78b4226aff13792d9b55b33bcc3b5d67/sw.js), each `precachedConfig` item is started with `/`([source](https://github.com/Vagr9K/gatsby-advanced-starter/blob/2981228b78b4226aff13792d9b55b33bcc3b5d67/sw.js#L40
)):

```js
var precacheConfig = [["/app-7ab9dc184b7d3049a294.js","3d59a3d5acf6826942d983aa505b95d5"],["/commons-5a25b4f277d17d73c441.js","25d10092faa49cd22c42f1e9fb69b902"],["/index.html","e17744bd031cc8a71fc8d8f2162e71c5"],["/manifest.json","53da04d3756b99d845311cf0dab7b6fa"],["/offline-plugin-app-shell-fallback/index.html","8475e6e45e61110e101c99888a1831b2"]];

```

and the assets url is generated by([source](https://github.com/Vagr9K/gatsby-advanced-starter/blob/2981228b78b4226aff13792d9b55b33bcc3b5d67/sw.js#L134-L137)):

```js
var absoluteUrl = new URL(relativeUrl, self.location);
// relativeUrl: "/app-7ab9dc184b7d3049a294.js"
// self.location: { href: "https://vagr9k.github.io/gatsby-advanced-starter/sw.js", ... }
// so absoluteUrl => { href: "https://vagr9k.github.io/app-7ab9dc184b7d3049a294.js", ... }
```

We want the `absoluteUrl` to be <code>https://vagr9k.github.io<b>/gatsby-advanced-starter</b>/app-7ab9dc184b7d3049a294.js</code>, but we got `https://vagr9k.github.io/app-7ab9dc184b7d3049a294.js`.

### How to Fix the Problem

Let the generated `precachedConfig` array items to be prefixed(lol):

> `/app-7ab9dc184b7d3049a294.js`  => `/gatsby-advanced-starter/app-7ab9dc184b7d3049a294.js`


There exists a [`replacePrefix` option in `sw-precache`](https://github.com/GoogleChrome/sw-precache#replaceprefix-string). If `pathPrefix` is configured by user, we should replace the `public` prefix(`rootDir`, used as `stripPrefix`) with `pathPrefix`. That's how this pull request fix it.

> Note 1:
> We can also use the [`stripPrefixMulti` option](https://github.com/GoogleChrome/sw-precache#stripprefixmulti-object), but `replacePrefix` is enough here.

> Note 2:
> User can also set the `replacePrefix` or `stripPrefixMulti` option manually to fix the problem:
> ```js
> // in gatsby-config.js
> {
>   resolve: 'gatsby-plugin-offline',
>   options: {
>     replacePrefix: '/myprefix',
>   },
> }
> ```
> But obviously this should be fixed by offline plugin.


### How to Verify the Fixes

I have manually tested it, and it works. But you can quickly view the result of `replacePrefix` option by:

1. install sw-precache cli:  
```bash
$ npm install --global sw-precache
```
2. generate `service-worker.js` by:  
```bash
$ sw-precache --root=public --static-file-globs='public/**/*.js' --stripPrefix='public' --replacePrefix='/blog'
```

3. view the content of generated `service-worker.js`.

