### PR TITLE
Update react-helmet syntax to new simplified API

### DIFF
--- a/examples/using-mongodb/src/layouts/index.js
+++ b/examples/using-mongodb/src/layouts/index.js
@@ -8,16 +8,13 @@ class DefaultLayout extends React.Component {
 
     return (
       <div className="websites">
-        <Helmet
-          defaultTitle={siteMetadata.title}
-          meta={[
-            {
-              name: `description`,
-              content: `An example site to show how to use mongoDB with Gatsby.JS`,
-            },
-            { name: `keywords`, content: `websites listings` },
-          ]}
-        />
+        <Helmet defaultTitle={siteMetadata.title}>
+          <meta
+            name="description"
+            content="An example site to show how to use mongoDB with Gatsby.JS"
+          />
+          <meta name="keywords" content="websites listings" />
+        </Helmet>
         <Link style={{ textDecoration: `none` }} to="/">
           <h3 style={{ color: `tomato` }}>
             Example of using mongoDB as a data source for a Gatsby site

--- a/examples/using-wordpress/src/pages/index.js
+++ b/examples/using-wordpress/src/pages/index.js
@@ -19,7 +19,9 @@ class Home extends Component {
       <div>
         <Page>
           <Row>
-            <Helmet title={siteMetadata.title} />
+            <Helmet>
+              <title>{siteMetadata.title}</title>
+            </Helmet>
             <Header
               title={siteMetadata.title}
               subtitle={siteMetadata.subtitle}

--- a/examples/using-wordpress/src/templates/page.js
+++ b/examples/using-wordpress/src/templates/page.js
@@ -16,7 +16,9 @@ class PageTemplate extends Component {
       <div>
         <Page>
           <Row>
-            <Helmet title={siteMetadata.title} />
+            <Helmet>
+              <title>{siteMetadata.title}</title>
+            </Helmet>
             <Header
               title={siteMetadata.title}
               subtitle={siteMetadata.subtitle}

--- a/examples/using-wordpress/src/templates/post.js
+++ b/examples/using-wordpress/src/templates/post.js
@@ -18,7 +18,9 @@ class PostTemplate extends Component {
       <div>
         <Page>
           <Row>
-            <Helmet title={siteMetadata.title} />
+            <Helmet>
+              <title>{siteMetadata.title}</title>
+            </Helmet>
             <Header
               title={siteMetadata.title}
               subtitle={siteMetadata.subtitle}

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -137,21 +137,11 @@ module.exports = React.createClass({
         <Helmet
           defaultTitle={`GatsbyJS`}
           titleTemplate={`%s | GatsbyJS`}
-          meta={[
-            {
-              name: `twitter:site`,
-              content: `@gatsbyjs`,
-            },
-            {
-              name: `og:type`,
-              content: `website`,
-            },
-            {
-              name: `og:site_name`,
-              content: `GatsbyJS`,
-            },
-          ]}
-        />
+        >
+          <meta name="twitter:site" content="@gatsbyjs" />
+          <meta name="og:type" content="website" />
+          <meta name="og:site_name" content="GatsbyJS" />
+        </Helmet>
         <div
           css={{
             borderBottom: `1px solid ${presets.veryLightPurple}`,

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -27,71 +27,23 @@ const BlogPostTemplate = React.createClass({
     return (
       <Container>
         {/* Add long list of social meta tags */}
-        <Helmet
-          title={post.frontmatter.title}
-          link={[
-            {
-              rel: `author`,
-              href: `https://gatsbyjs.org${post.frontmatter.author.slug}`,
-            },
-          ]}
-          meta={[
-            {
-              name: `description`,
-              content: post.frontmatter.excerpt
-                ? post.frontmatter.excerpt
-                : post.excerpt,
-            },
-            {
-              name: `og:description`,
-              content: post.excerpt,
-            },
-            {
-              name: `twitter:description`,
-              content: post.excerpt,
-            },
-            {
-              name: `og:title`,
-              content: post.frontmatter.title,
-            },
-            {
-              name: `og:image`,
-              content: post.frontmatter.image.childImageSharp.resize.src,
-            },
-            {
-              name: `twitter:image`,
-              content: post.frontmatter.image.childImageSharp.resize.src,
-            },
-            {
-              name: `og:type`,
-              content: `article`,
-            },
-            {
-              name: `article:author`,
-              content: post.frontmatter.author.id,
-            },
-            {
-              name: `twitter:creator`,
-              content: post.frontmatter.author.twitter,
-            },
-            {
-              name: `author`,
-              content: post.frontmatter.author.id,
-            },
-            {
-              name: `twitter:label1`,
-              content: `Reading time`,
-            },
-            {
-              name: `twitter:data1`,
-              content: `${post.timeToRead} min read`,
-            },
-            {
-              name: `article:published_time`,
-              content: post.frontmatter.rawDate,
-            },
-          ]}
-        />
+        <Helmet>
+          <title>{post.frontmatter.title}</title>
+          <link rel="author" href={`https://gatsbyjs.org${post.frontmatter.author.slug}`} />
+          <meta name="description" content={post.frontmatter.excerpt ? post.frontmatter.excerpt : post.excerpt} />
+          <meta name="og:description" content={post.excerpt} />
+          <meta name="twitter:description" content={post.excerpt} />
+          <meta name="og:title" content={post.frontmatter.title} />
+          <meta name="og:image" content={post.frontmatter.image.childImageSharp.resize.src} />
+          <meta name="twitter:image" content={post.frontmatter.image.childImageSharp.resize.src} />
+          <meta name="og:type" content="article" />
+          <meta name="article:author" content={post.frontmatter.author.id} />
+          <meta name="twitter:creator" content={post.frontmatter.author.twitter} />
+          <meta name="author" content={post.frontmatter.author.id} />
+          <meta name="twitter:label1" content="Reading time" />
+          <meta name="twitter:data1" content={`${post.timeToRead} min read`} />
+          <meta name="article:published_time" content={post.frontmatter.rawDate} />
+        </Helmet>
         <header
           css={{
             display: `flex`,

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -9,39 +9,16 @@ const DocsTemplate = React.createClass({
     const page = this.props.data.markdownRemark
     return (
       <Container>
-        <Helmet
-          title={page.frontmatter.title}
-          meta={[
-            {
-              name: `description`,
-              content: page.excerpt,
-            },
-            {
-              name: `og:description`,
-              content: page.excerpt,
-            },
-            {
-              name: `twitter:description`,
-              content: page.excerpt,
-            },
-            {
-              name: `og:title`,
-              content: page.frontmatter.title,
-            },
-            {
-              name: `og:type`,
-              content: `article`,
-            },
-            {
-              name: `twitter:label1`,
-              content: `Reading time`,
-            },
-            {
-              name: `twitter:data1`,
-              content: `${page.timeToRead} min read`,
-            },
-          ]}
-        />
+        <Helmet>
+          <title>{page.frontmatter.title}</title>
+          <meta name="description" content={page.excerpt} />
+          <meta name="og:description" content={page.excerpt} />
+          <meta name="twitter:description" content={page.excerpt} />
+          <meta name="og:title" content={page.frontmatter.title} />
+          <meta name="og:type" content="article" />
+          <meta name="twitter.label1" content="Reading time" />
+          <meta name="twitter:data1" content={`${page.timeToRead} min read`} />
+        </Helmet>
         <h1 css={{ marginTop: 0 }}>
           {page.frontmatter.title}
         </h1>

--- a/www/src/templates/template-docs-packages.js
+++ b/www/src/templates/template-docs-packages.js
@@ -11,39 +11,16 @@ const DocsTemplate = React.createClass({
     const page = this.props.data.markdownRemark
     return (
       <Container>
-        <Helmet
-          title={page.fields.title}
-          meta={[
-            {
-              name: `description`,
-              content: page.excerpt,
-            },
-            {
-              name: `og:description`,
-              content: page.excerpt,
-            },
-            {
-              name: `twitter:description`,
-              content: page.excerpt,
-            },
-            {
-              name: `og:title`,
-              content: page.fields.title,
-            },
-            {
-              name: `og:type`,
-              content: `article`,
-            },
-            {
-              name: `twitter:label1`,
-              content: `Reading time`,
-            },
-            {
-              name: `twitter:data1`,
-              content: `${page.timeToRead} min read`,
-            },
-          ]}
-        />
+        <Helmet>
+          <title>{page.fields.title}</title>
+          <meta name="description" content={page.excerpt} />
+          <meta name="og:description" content={page.excerpt} />
+          <meta name="twitter:description" content={page.excerpt} />
+          <meta name="og:title" content={page.fields.title} />
+          <meta name="og:type" content="article" />
+          <meta name="twitter.label1" content="Reading time" />
+          <meta name="twitter:data1" content={`${page.timeToRead} min read`} />
+        </Helmet>
         <strong>
           <a
             href={`https://github.com/gatsbyjs/gatsby/tree/master/packages/${packageName}`}


### PR DESCRIPTION
Closes #1906. Converts most examples, as well as the gatsbyjs.org site source to use the new simplified api in `react-helmet`. One notable exception being the `examples/using-javascript-transforms` files, as the example fails to run and probably deserves it's own PR with some updates.