### PR TITLE
[www] Update nprogress color to match presets.brandLight, hide spinner

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -65,6 +65,7 @@ module.exports = {
       resolve: `gatsby-plugin-nprogress`,
       options: {
         color: `#9D7CBF`,
+        showSpinner: false,
       },
     },
     `gatsby-plugin-glamor`,

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -64,7 +64,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-nprogress`,
       options: {
-        color: `#a2466c`,
+        color: `#9D7CBF`,
       },
     },
     `gatsby-plugin-glamor`,

--- a/www/package.json
+++ b/www/package.json
@@ -13,7 +13,7 @@
     "gatsby-plugin-glamor": "^1.6.0",
     "gatsby-plugin-google-analytics": "^1.0.1",
     "gatsby-plugin-manifest": "^1.0.1",
-    "gatsby-plugin-nprogress": "^1.0.1",
+    "gatsby-plugin-nprogress": "^1.0.5",
     "gatsby-plugin-offline": "^1.0.1",
     "gatsby-plugin-react-helmet": "^1.0.1",
     "gatsby-plugin-sharp": "^1.6.0",

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -198,6 +198,9 @@ const options = {
         // color: `blue`,
         color: colors.b[8],
       },
+      "#nprogress .spinner": {
+        display: `none !important`,
+      },
     }
   },
 }

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -198,9 +198,6 @@ const options = {
         // color: `blue`,
         color: colors.b[8],
       },
-      "#nprogress .spinner": {
-        display: `none !important`,
-      },
     }
   },
 }


### PR DESCRIPTION
This updates the `gatsby-plugin-nprogress` config for www to match the updated brand colors, plus hides the nprogress spinner via CSS because it conflicts with the current layout:

![bildschirmfoto 2017-08-15 um 09 04 02](https://user-images.githubusercontent.com/21834/29779093-c66dd5e2-8c11-11e7-98ad-50eaf2baae52.png)

Will add a new issue for exposing the nprogress configuration options. ✌️ 