### PR TITLE
Fix "createFilePath" to use "dir" (not "dirname") in "gatsby-source-filesystem"

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-file-path.js
+++ b/packages/gatsby-source-filesystem/src/create-file-path.js
@@ -43,8 +43,8 @@ module.exports = ({
     slash(basePath),
     slash(fileNode.relativePath)
   )
-  const { dirname = ``, name } = path.parse(relativePath)
+  const { dir = ``, name } = path.parse(relativePath)
   const parsedName = name === `index` ? `` : name
 
-  return path.posix.join(`/`, dirname, parsedName, trailingSlash ? `/` : ``)
+  return path.posix.join(`/`, dir, parsedName, trailingSlash ? `/` : ``)
 }


### PR DESCRIPTION
Seems there's a minor issue in above-mentioned function, that leads to most (all) gatsby sites not recognizing deep folder structure, e.g. `src/pages/notes/friday/...`.

Use `dir` instead of `dirname`, since `path.parse` returns `dir`. See https://nodejs.org/api/path.html#path_path_parse_path