### PR TITLE
[gatsby-plugin-nprogress] Pass plugin options on to NProgress.configure()

### DIFF
--- a/packages/gatsby-plugin-nprogress/README.md
+++ b/packages/gatsby-plugin-nprogress/README.md
@@ -25,6 +25,6 @@ plugins: [
 ]
 ```
 
-In addition to `color`, a configuration option specific to
+In addition to `color` – a configuration option specific to
 `gatsby-plugin-nprogress` that saves some time [customizing the nprogress CSS](https://github.com/rstacruz/nprogress#customization) to match your site
-colors, you may pass all available [nprogress configuration options](https://github.com/rstacruz/nprogress#configuration) with the exception of `parent`.
+colors – you may pass all available [nprogress configuration options](https://github.com/rstacruz/nprogress#configuration).

--- a/packages/gatsby-plugin-nprogress/README.md
+++ b/packages/gatsby-plugin-nprogress/README.md
@@ -18,7 +18,13 @@ plugins: [
     options: {
       // Setting a color is optional.
       color: `tomato`,
+      // Disable the loading spinner.
+      showSpinner: false,
     }
   }
 ]
 ```
+
+In addition to `color`, a configuration option specific to
+`gatsby-plugin-nprogress` that saves some time [customizing the nprogress CSS](https://github.com/rstacruz/nprogress#customization) to match your site
+colors, you may pass all available [nprogress configuration options](https://github.com/rstacruz/nprogress#configuration) with the exception of `parent`.

--- a/packages/gatsby-plugin-nprogress/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-nprogress/src/gatsby-browser.js
@@ -2,6 +2,7 @@ import NProgress from "nprogress"
 
 exports.onClientEntry = (a, pluginOptions = { color: `#29d` }) => {
   window.___emitter.on(`onDelayedLoadPageResources`, () => {
+    NProgress.configure(pluginOptions)
     NProgress.start()
   })
   window.___emitter.on(`onPostLoadPageResources`, () => {


### PR DESCRIPTION
This PR changes `gatsby-plugin-nprogress` to simply pass the plugin options to [NProgress.configure](https://github.com/rstacruz/nprogress#configuration).
It aims to fix #1938 (also ref. #1937).

At first I couldn't figure out how to properly trigger `onDelayedLoadPageResources`, so I just removed it for testing (using `gatsby develop`). These were the results:

 * 👍  nprogress doesn't choke on our custom option `color`
 * 👍  All but one available configuration option work fine –`minimum`, `template`, `easing`, `speed`, `trickle`, `trickleSpeed`, `showSpinner` do what they should –
* 👎  however `parent` yields an error similar to https://github.com/rstacruz/nprogress/issues/103).

Then it dawned on me that I probably would need to `gatsby build && gatsby serve` to properly test this (by loading the page, then quickly switch to "Offline" in the Chrome dev console). So I brought back `onDelayedLoadPageResources`, and now also the `parent` option works fine when testing with `gatsby build/serve` as well as `gatsby develop`. 😆 

That said, I'm still a little unsure and would appreciate a quick look over this @KyleAMathews.