### PR TITLE
[gatsby-remark-images] Remove negative z-index for .gatsby-resp-image-wrapper

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -83,7 +83,7 @@ module.exports = (
     let rawHTML = `
   <span
     class="gatsby-resp-image-wrapper"
-    style="position: relative; z-index: -1; display: block; ${options.wrapperStyle}"
+    style="position: relative; display: block; ${options.wrapperStyle}"
   >
     <span
       class="gatsby-resp-image-background-image"


### PR DESCRIPTION
Fixes #1935 plus the missing half of #1888.

Currently `gatsby-remark-images` adds an inline style containing `z-index: -1` for [`gatsby-resp-image-wrapper`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-images/src/index.js#L86). Our (now also optional) wrapper for the latter, [`gatsby-resp-image-link`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-images/src/index.js#L108), does not provide a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) of its own. This results in `.gatsby-resp-image-wrapper` being "stacked" relative to the parent element that provides this context.

In the case where one of the parent elements of `.gatsby-resp-image-wrapper` defines a `background` (color or image), and the stacking context will be provided by another parent of that element with the background, `.gatsby-resp-image-wrapper` will be covered by that background of that parent in between itself and the parent providing context. This is very likely to happen (as reported in #1888 and #1935).

gatsbyjs.org is not currently affected by this simply because we do not define any background color for one of the parent elements that `.gatsby-resp-image-wrapper` are rendered in. If we apply one for e. g. `.main-body`, all content added by `gatsby-remark-images` will be covered.

Furthermore, I can't find a reason why we should need `z-index` here – `.gatsby-resp-image-image` should always display "above" the base64-encoded, blurred background-image defined inline for `.gatsby-resp-image-background-image`.
