### PR TITLE
Don't use es6 modules in node.js code

### DIFF
--- a/packages/gatsby-1-config-css-modules/README.md
+++ b/packages/gatsby-1-config-css-modules/README.md
@@ -8,7 +8,7 @@ CSS Modules configuration for Gatsby v1 plugins
 Example from [`gatsby-plugin-sass`](../gatsby-plugin-sass/):
 ```javascript
 // in gatsby-node.js
-import cssModulesConfig from "gatsby-1-config-css-modules"
+const { cssModulesConfig } = require("gatsby-1-config-css-modules")
 
 exports.modifyWebpackConfig = ({ config, stage }, { precision }) => {
   const sassFiles = /\.s[ac]ss$/

--- a/packages/gatsby-1-config-css-modules/src/__tests__/index.js
+++ b/packages/gatsby-1-config-css-modules/src/__tests__/index.js
@@ -1,4 +1,4 @@
-import cssModulesConfig, { LOCAL_IDENT_NAME } from "../index"
+const { cssModulesConfig, LOCAL_IDENT_NAME } = require("../index")
 
 describe(`gatsby-1-config-css-modules`, () => {
   ;[

--- a/packages/gatsby-1-config-css-modules/src/index.js
+++ b/packages/gatsby-1-config-css-modules/src/index.js
@@ -1,6 +1,6 @@
-export const LOCAL_IDENT_NAME = `[path]---[name]---[local]---[hash:base64:5]`
+exports.LOCAL_IDENT_NAME = `[path]---[name]---[local]---[hash:base64:5]`
 
-export default function cssModulesConfig(stage) {
+exports.cssModulesConfig = stage => {
   const loader = `css?modules&minimize&importLoaders=1&localIdentName=${LOCAL_IDENT_NAME}`
   return stage.startsWith(`build`) ? loader : `${loader}&sourceMap`
 }

--- a/packages/gatsby-plugin-postcss-sass/package.json
+++ b/packages/gatsby-plugin-postcss-sass/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babel-runtime": "6.26.0",
     "extract-text-webpack-plugin": "^1.0.1",
-    "gatsby-1-config-css-modules": "^1.0.1",
+    "gatsby-1-config-css-modules": "^1.0.2",
     "node-sass": "^4.5.2",
     "sass-loader": "^4.1.1"
   },

--- a/packages/gatsby-plugin-postcss-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-postcss-sass/src/gatsby-node.js
@@ -1,5 +1,5 @@
-import ExtractTextPlugin from "extract-text-webpack-plugin"
-import cssModulesConfig from "gatsby-1-config-css-modules"
+const ExtractTextPlugin = require("extract-text-webpack-plugin")
+const { cssModulesConfig } = require("gatsby-1-config-css-modules")
 
 exports.modifyWebpackConfig = (
   { config, stage },

--- a/packages/gatsby-plugin-react-css-modules/package.json
+++ b/packages/gatsby-plugin-react-css-modules/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "babel-plugin-react-css-modules": "^3.2.1",
     "babel-runtime": "^6.26.0",
-    "gatsby-1-config-css-modules": "^1.0.1"
+    "gatsby-1-config-css-modules": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1"

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babel-runtime": "6.26.0",
     "extract-text-webpack-plugin": "^1.0.1",
-    "gatsby-1-config-css-modules": "^1.0.1",
+    "gatsby-1-config-css-modules": "^1.0.2",
     "node-sass": "^4.5.2",
     "sass-loader": "^4.1.1",
     "webpack": "^1.13.3"

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -1,5 +1,5 @@
-import ExtractTextPlugin from "extract-text-webpack-plugin"
-import cssModulesConfig from "gatsby-1-config-css-modules"
+const ExtractTextPlugin = require("extract-text-webpack-plugin")
+const { cssModulesConfig } = require("gatsby-1-config-css-modules")
 
 exports.modifyWebpackConfig = ({ config, stage }, { precision }) => {
   const sassFiles = /\.s[ac]ss$/
@@ -29,7 +29,10 @@ exports.modifyWebpackConfig = ({ config, stage }, { precision }) => {
 
       config.loader(`sassModules`, {
         test: sassModulesFiles,
-        loader: ExtractTextPlugin.extract(`style`, [cssModulesConfig(stage), sassLoader]),
+        loader: ExtractTextPlugin.extract(`style`, [
+          cssModulesConfig(stage),
+          sassLoader,
+        ]),
       })
       return config
     }
@@ -44,7 +47,10 @@ exports.modifyWebpackConfig = ({ config, stage }, { precision }) => {
 
       config.loader(`sassModules`, {
         test: sassModulesFiles,
-        loader: ExtractTextPlugin.extract(`style`, [cssModulesConfig(stage), sassLoader]),
+        loader: ExtractTextPlugin.extract(`style`, [
+          cssModulesConfig(stage),
+          sassLoader,
+        ]),
       })
       return config
     }

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babel-runtime": "6.26.0",
     "extract-text-webpack-plugin": "^1.0.1",
-    "gatsby-1-config-css-modules": "^1.0.1",
+    "gatsby-1-config-css-modules": "^1.0.2",
     "stylus": "^0.54.5",
     "stylus-loader": "webpack1"
   },

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -19,8 +19,8 @@
  *   },
  * ],
  */
-import ExtractTextPlugin from "extract-text-webpack-plugin"
-import cssModulesConfig from "gatsby-1-config-css-modules"
+const ExtractTextPlugin = require("extract-text-webpack-plugin")
+const { cssModulesConfig } = require("gatsby-1-config-css-modules")
 
 exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
   // Pass in stylus options regardless of stage.

--- a/packages/gatsby-plugin-typescript/.gitignore
+++ b/packages/gatsby-plugin-typescript/.gitignore
@@ -2,3 +2,4 @@ node_modules
 typescript
 /index.js
 /gatsby-node.js
+/__tests__

--- a/packages/gatsby-remark-prismjs/.gitignore
+++ b/packages/gatsby-remark-prismjs/.gitignore
@@ -1,3 +1,5 @@
 /index.js
 /highlight-code.js
 /parse-line-number-range.js
+/load-prism-language.js
+/prism-language-dependencies.js

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -50,7 +50,7 @@
     "friendly-errors-webpack-plugin": "^1.6.1",
     "front-matter": "^2.1.0",
     "fs-extra": "^3.0.1",
-    "gatsby-1-config-css-modules": "^1.0.1",
+    "gatsby-1-config-css-modules": "^1.0.2",
     "gatsby-module-loader": "^1.0.4",
     "glob": "^7.1.1",
     "graphql": "^0.10.3",

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -8,7 +8,7 @@ import ExtractTextPlugin from "extract-text-webpack-plugin"
 import StaticSiteGeneratorPlugin from "static-site-generator-webpack-plugin"
 import { StatsWriterPlugin } from "webpack-stats-plugin"
 import FriendlyErrorsWebpackPlugin from "friendly-errors-webpack-plugin"
-import cssModulesConfig from "gatsby-1-config-css-modules"
+import { cssModulesConfig } from "gatsby-1-config-css-modules"
 
 // This isn't working right it seems.
 // import WebpackStableModuleIdAndHash from 'webpack-stable-module-id-and-hash'


### PR DESCRIPTION
@mingaldrichgan it occurred to me finally why the tests were failing even though
they worked locally + when running from NPM.

You'd written the config module using es6 exports. When we do production builds, it
got compiled to commonjs (I'm pretty sure) so the tests worked. But since Node.js doesn't
natively handle es6 exports, tests failed on TravisCI (where we target the version of
node) which meant the modules couldn't be imported.

That's my theory anyways…

Anyways, for future reference, just use commonjs for node code. There's a few places
in the code base where we're not that still needs converted over. Using commonjs is much
better for Node code IMO because of these issues.