### PR TITLE
Remove duplicated tests in `gatsby-remark-prismjs`

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/highlight-code.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/highlight-code.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`highlight code and lines with PrismJS highlights code for language cpp 1`] = `
+exports[`highlight code and lines with PrismJS for language cpp 1`] = `
 "<span class=\\"gatsby-highlight-code-line\\">
 </span><span class=\\"gatsby-highlight-code-line\\"><span class=\\"token keyword\\">int</span> <span class=\\"token function\\">sum</span><span class=\\"token punctuation\\">(</span>a<span class=\\"token punctuation\\">,</span> b<span class=\\"token punctuation\\">)</span> <span class=\\"token punctuation\\">{</span>
 </span>  <span class=\\"token keyword\\">return</span> a <span class=\\"token operator\\">+</span> b<span class=\\"token punctuation\\">;</span>
@@ -9,7 +9,7 @@ exports[`highlight code and lines with PrismJS highlights code for language cpp 
 "
 `;
 
-exports[`highlight code and lines with PrismJS highlights code for language jsx 1`] = `
+exports[`highlight code and lines with PrismJS for language jsx 1`] = `
 "
 <span class=\\"token keyword\\">import</span> React <span class=\\"token keyword\\">from</span> <span class=\\"token string\\">\\"react\\"</span>
 

--- a/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
@@ -1,74 +1,27 @@
-const parseLineNumberRange = require(`../parse-line-number-range`)
-
 describe(`highlight code and lines with PrismJS`, () => {
-  it(`parses numeric ranges from the languages variable`, () => {
-    expect(parseLineNumberRange(`jsx{1,5,7-8}`).highlightLines).toEqual([
-      1,
-      5,
-      7,
-      8,
-    ])
-    expect(parseLineNumberRange(`javascript{7-8}`).highlightLines).toEqual([
-      7,
-      8,
-    ])
-    expect(parseLineNumberRange(`javascript{7..8}`).highlightLines).toEqual([
-      7,
-      8,
-    ])
-    expect(parseLineNumberRange(`javascript{2}`).highlightLines).toEqual([2])
-    expect(parseLineNumberRange(`javascript{2,4-5}`).highlightLines).toEqual([
-      2,
-      4,
-      5,
-    ])
-  })
-  it(`ignores negative numbers`, () => {
-    expect(parseLineNumberRange(`jsx{-1,1,5,7-8}`).highlightLines).toEqual([
-      1,
-      5,
-      7,
-      8,
-    ])
-    expect(parseLineNumberRange(`jsx{-1..4}`).highlightLines).toEqual([
-      1,
-      2,
-      3,
-      4,
-    ])
-  })
-  it(`handles bad inputs`, () => {
-    expect(parseLineNumberRange(`jsx{-1`).highlightLines).toEqual([])
-    expect(parseLineNumberRange(`jsx{-1....`).highlightLines).toEqual([])
-  })
-  it(`parses languages without ranges`, () => {
-    expect(parseLineNumberRange(`jsx`).splitLanguage).toEqual(`jsx`)
+  afterEach(() => {
+    jest.resetModules()
   })
 
-  describe(`highlights code for language`, () => {
-    afterEach(() => {
-      jest.resetModules()
-    })
-
-    it(`cpp`, () => {
-      const highlightCode = require(`../highlight-code`)
-      const language = `cpp`
-      const lineNumbersHighlight = [1, 2]
-      const code = `
+  it(`for language cpp`, () => {
+    const highlightCode = require(`../highlight-code`)
+    const language = `cpp`
+    const lineNumbersHighlight = [1, 2]
+    const code = `
 int sum(a, b) {
   return a + b;
 }
 `
-      expect(
-        highlightCode(language, code, lineNumbersHighlight)
-      ).toMatchSnapshot()
-    })
+    expect(
+      highlightCode(language, code, lineNumbersHighlight)
+    ).toMatchSnapshot()
+  })
 
-    it(`jsx`, () => {
-      const highlightCode = require(`../highlight-code`)
-      const language = `jsx`
-      const lineNumbersHighlight = [12, 13, 15]
-      const code = `
+  it(`for language jsx`, () => {
+    const highlightCode = require(`../highlight-code`)
+    const language = `jsx`
+    const lineNumbersHighlight = [12, 13, 15]
+    const code = `
 import React from "react"
 
 class Counter extends React.Component {
@@ -95,9 +48,8 @@ class Counter extends React.Component {
 
 export default Counter
 `
-      expect(
-        highlightCode(language, code, lineNumbersHighlight)
-      ).toMatchSnapshot()
-    })
+    expect(
+      highlightCode(language, code, lineNumbersHighlight)
+    ).toMatchSnapshot()
   })
 })

--- a/packages/gatsby-remark-prismjs/src/__tests__/parse-line-number-range.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/parse-line-number-range.js
@@ -23,6 +23,7 @@ describe(`parses numeric ranges from the languages markdown code directive`, () 
       5,
     ])
   })
+
   it(`ignores negative numbers`, () => {
     expect(parseLineNumberRange(`jsx{-1,1,5,7-8}`).highlightLines).toEqual([
       1,
@@ -37,8 +38,13 @@ describe(`parses numeric ranges from the languages markdown code directive`, () 
       4,
     ])
   })
+
   it(`handles bad inputs`, () => {
     expect(parseLineNumberRange(`jsx{-1`).highlightLines).toEqual([])
     expect(parseLineNumberRange(`jsx{-1....`).highlightLines).toEqual([])
+  })
+
+  it(`parses languages without ranges`, () => {
+    expect(parseLineNumberRange(`jsx`).splitLanguage).toEqual(`jsx`)
   })
 })


### PR DESCRIPTION
The `parseLineNumberRange` tests in `src/__tests__/highlight-code.js` is the same in `src/__tests__/parse-line-number-range.js`. Remove the duplicated tests.

As said in https://github.com/gatsbyjs/gatsby/pull/1921#discussion_r135766730.