### PR TITLE
Lower hashDigestBits to 48 to work around IE/Edge issue

### DIFF
--- a/packages/gatsby/src/utils/get-hash-fn.js
+++ b/packages/gatsby/src/utils/get-hash-fn.js
@@ -3,7 +3,7 @@ const createHash = require(`crypto`).createHash
 const getHashFn = ({
   hashFunction = `md5`,
   hashDigest = `hex`,
-  hashDigestBits = 64,
+  hashDigestBits = 48,
   cache = new Set(),
 }) => input => {
   const hash = createHash(hashFunction)


### PR DESCRIPTION
This results in a smaller chunk id which keeps the IE/Edge precision bug from happening.  fixes #1704