### PR TITLE
Install the latest version of Yarn when building sites

### DIFF
--- a/scripts/publish-site.sh
+++ b/scripts/publish-site.sh
@@ -1,3 +1,6 @@
+echo "=== Updating Yarn ==="
+npm install -g yarn@latest
+
 echo "=== Building ES5 version of Gatsby"
 ./node_modules/.bin/lerna run build
 

--- a/scripts/publish-site.sh
+++ b/scripts/publish-site.sh
@@ -1,7 +1,5 @@
-echo "=== Updating Yarn ==="
-npm install -g yarn@latest
-
 echo "=== Building ES5 version of Gatsby"
+yarn bootstrap
 ./node_modules/.bin/lerna run build
 
 yarn global add gatsby-dev-cli


### PR DESCRIPTION
Netlify is using Yarn version 0.18 which is kinda ancient by this point.

I think it's the reason a few sites keep failing.