### PR TITLE
Fix Gatsby not transpiling files before extracting GraphQL queries

### DIFF
--- a/examples/using-typescript/src/pages/index.tsx
+++ b/examples/using-typescript/src/pages/index.tsx
@@ -12,11 +12,19 @@ interface IndexPageProps {
   };
 }
 
-export default (props: IndexPageProps) =>
-  <div>
-    <h1>Hello Typescript world!</h1>
-    <p>This site is named <strong>{props.data.site.siteMetadata.siteName}</strong></p>
-  </div>;
+export default class extends React.Component<IndexPageProps, {}> {
+  constructor(props:IndexPageProps, context: any){
+    super(props, context);
+  }
+  public render() {
+    return(
+      <div>
+        <h1>Hello Typescript world!</h1>
+        <p>This site is named <strong>{this.props.data.site.siteMetadata.siteName}</strong></p>
+      </div>
+    );
+  }
+}
 
 export const pageQuery = graphql`
   query IndexQuery{

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -11,6 +11,8 @@ const { getGraphQLTag } = require(`../../utils/babel-plugin-extract-graphql`)
 
 import type { DocumentNode, DefinitionNode } from "graphql"
 
+const apiRunnerNode = require(`../../utils/api-runner-node`)
+
 const getMissingNameErrorMessage = file => report.stripIndent`
   GraphQL definitions must be "named".
   The query with the missing name is in ${file}.
@@ -32,16 +34,12 @@ const getMissingNameErrorMessage = file => report.stripIndent`
 async function parseToAst(filePath, fileStr) {
   let ast
 
-  let transpiled
-  // TODO figure out why awaiting apiRunnerNode doesn't work
-  // Currently if I try that it just returns immediately.
-  //
   // Preprocess and attempt to parse source; return an AST if we can, log an
   // error if we can't.
-  // const transpiled = await apiRunnerNode(`preprocessSource`, {
-  // filename: filePath,
-  // contents: fileStr,
-  // })
+  const transpiled = await apiRunnerNode(`preprocessSource`, {
+    filename: filePath,
+    contents: fileStr,
+  })
 
   if (transpiled && transpiled.length) {
     for (const item of transpiled) {


### PR DESCRIPTION
b6c6c2e changes the TypeScript example to demonstrate issue #1741.
39032df uncomments the code mentioned by @KyleAMathews in #1741, fixing #1741.

Doesn't seem to break any tests, but fixes syntax errors caused by TypeScript files not being transpiled when extracting GraphQL queries.