### PR TITLE
Make the src directory the resolve root

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -340,6 +340,9 @@ module.exports = async (
         directoryPath(`node_modules`),
         directoryPath(`node_modules`, `gatsby/node_modules`),
       ],
+      // Resolve modules in src. Makes it possible to use non-relative module
+      // paths with TypeScript.
+      root: [directoryPath(`src`)],
     }
   }
 


### PR DESCRIPTION
Motivation: consider [this](https://github.com/fabien0102/gatsby-starter/blob/8ec3ff11b8e0ce865913a3f85ade83d336db9153/src/pages/index.tsx#L3) `import` in one of the TypeScript starters. Adding `src` to Webpack's `resolve.root` will make it possible to replace the ugly relative paths like these:

    import HeaderMenu from "../components/HeaderMenu/HeaderMenu";
    import { menuItems } from "../layouts";

with non-relative paths like these:

    import HeaderMenu from "components/HeaderMenu/HeaderMenu";
    import { menuItems } from "layouts";

This patch effectively replaces the code I have in my own `modifyWebpackConfig`:

    config.merge({
        resolve: {
            root: [path.resolve("./src")]
        }
    });