### PR TITLE
remove log when mutateSource

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -70,7 +70,6 @@ module.exports = (
             pluginOptions.plugins.map(plugin => {
               const requiredPlugin = require(plugin.resolve)
               if (_.isFunction(requiredPlugin.mutateSource)) {
-                console.log(`running plugin to mutate markdown source`)
                 return requiredPlugin.mutateSource(
                   {
                     markdownNode,


### PR DESCRIPTION
following #2009 , when I mutate the content of markdownNode, there will be a batch of logs `running plugin to mutate markdown source` which flush the logs