### PR TITLE
Add smartive.ch showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Websites built with Gatbsy:
 * [angeloocana.com](https://angeloocana.com)
 * [knpw.rs](https://knpw.rs) [(source)](https://github.com/knpwrs/knpw.rs)
 * [Overlap.show](https://overlap.show) [(source)](https://github.com/pouretrebelle/overlap.show)
+* [smartive Company Website](https://smartive.ch)
 
 ## Docs
 


### PR DESCRIPTION
Because why not :)

Were deploying the website with GitLab / CI and with the gatsby Docker image (well, currently our fork, see https://github.com/gatsbyjs/gatsby-docker/pull/7).