### PR TITLE
Do not overwrite global options in image optimization

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -38,6 +38,16 @@ describe(`gatsby-plugin-sharp`, () => {
 
       expect(result).toMatchSnapshot()
     })
+
+    it(`does not change the arguments object it is given`, async () => {
+      const args = { maxWidth: 400 }
+      await responsiveSizes({
+        file,
+        args,
+      })
+
+      expect(args).toEqual({ maxWidth: 400 })
+    })
   })
 
   describe(`base64`, () => {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -355,7 +355,7 @@ async function responsiveSizes({ file, args = {} }) {
     pathPrefix: ``,
     toFormat: ``,
   }
-  const options = _.defaults(args, defaultArgs)
+  const options = _.defaults({}, args, defaultArgs)
   options.maxWidth = parseInt(options.maxWidth, 10)
 
   // Account for images with a high pixel density. We assume that these types of
@@ -460,7 +460,7 @@ async function responsiveResolution({ file, args = {} }) {
     pathPrefix: ``,
     toFormat: ``,
   }
-  const options = _.defaults(args, defaultArgs)
+  const options = _.defaults({}, args, defaultArgs)
   options.width = parseInt(options.width, 10)
 
   // Create sizes for different resolutions — we do 1x, 1.5x, 2x, and 3x.


### PR DESCRIPTION
responsiveSizes overwrites the global gatsby-remark-images plugin
options. This is especially problematic as options.sizes depends on the
image which is currently being optimized.

This is a bug right now which results in all images to be sized
according to the first image passed to responsiveSizes. This is not
desired, produces the wrong result and is not determistic.