### PR TITLE
Add devtools and debugging support to gatsby-plugin-preact

### DIFF
--- a/packages/gatsby-plugin-preact/gatsby-browser.js
+++ b/packages/gatsby-plugin-preact/gatsby-browser.js
@@ -1,0 +1,7 @@
+"use strict";
+
+exports.onClientEntry = () => {
+  if (process.env.NODE_ENV !== "production") {
+    require("preact/debug");
+  }
+};

--- a/packages/gatsby-plugin-preact/gatsby-browser.js
+++ b/packages/gatsby-plugin-preact/gatsby-browser.js
@@ -1,7 +1,7 @@
 "use strict";
 
 exports.onClientEntry = () => {
-  if (process.env.NODE_ENV !== "production") {
-    require("preact/debug");
+  if (process.env.NODE_ENV !== `production`) {
+    require(`preact/debug`);
   }
 };

--- a/packages/gatsby-plugin-preact/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-browser.js
@@ -1,5 +1,5 @@
 exports.onClientEntry = () => {
-  if (process.env.NODE_ENV !== "production") {
-    require("preact/debug")
+  if (process.env.NODE_ENV !== `production`) {
+    require(`preact/debug`)
   }
 }

--- a/packages/gatsby-plugin-preact/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-browser.js
@@ -1,0 +1,5 @@
+exports.onClientEntry = () => {
+  if (process.env.NODE_ENV !== "production") {
+    require("preact/debug")
+  }
+}


### PR DESCRIPTION
Drop in support for react devtools and preact debug/warning messages in non-production environments.