### PR TITLE
[www] New icons for mobile navigation

### DIFF
--- a/www/src/assets/blog.svg
+++ b/www/src/assets/blog.svg
@@ -3,27 +3,27 @@
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st0{fill:none;stroke:#9966CC;stroke-width:1.4173;stroke-miterlimit:10;}
 	.st1{fill:url(#SVGID_1_);}
-	.st2{fill:#744DA3;}
-	.st3{fill:none;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st2{fill:#744C9E;}
+	.st3{fill:none;stroke:#744C9E;stroke-width:1.4173;stroke-miterlimit:10;}
 </style>
 <g>
 	<line class="st0" x1="24.1" y1="10.7" x2="28.3" y2="10.7"/>
-	<line class="st0" x1="21.2" y1="13.6" x2="26.9" y2="13.6"/>
-	<line class="st0" x1="19.8" y1="15" x2="19.7" y2="9.2"/>
-	<line class="st0" x1="17" y1="17.8" x2="16.9" y2="12.1"/>
+	<line class="st0" x1="21.2" y1="13.5" x2="26.9" y2="13.5"/>
+	<line class="st0" x1="19.8" y1="14.9" x2="19.7" y2="9.2"/>
+	<line class="st0" x1="17" y1="17.8" x2="16.9" y2="12"/>
 	
-		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-270.0929" y1="395.1235" x2="-270.0929" y2="374.1235" gradientTransform="matrix(0.7071 0.7071 -0.7071 0.7071 483.1198 -66.3545)">
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-274.6005" y1="392.2683" x2="-274.6005" y2="371.2683" gradientTransform="matrix(0.7071 0.7071 -0.7071 0.7071 484.2914 -61.1829)">
 		<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
-		<stop  offset="1" style="stop-color:#EABD52"/>
+		<stop  offset="1" style="stop-color:#FFB238"/>
 	</linearGradient>
-	<path class="st1" d="M27.6,12.9l-9.2,9.2c-1.6,1.6-5.7,0-5.7,0l0,0c0,0-1.6-4.1,0-5.7l9.2-9.2c1.6-1.6,4.1-1.6,5.7,0l0,0
-		C29.2,8.8,29.2,11.3,27.6,12.9z"/>
+	<path class="st1" d="M27.6,12.8L18.4,22c-1.6,1.6-5.7,0-5.7,0l0,0c0,0-1.6-4.1,0-5.7l9.2-9.2c1.6-1.6,4.1-1.6,5.7,0l0,0
+		C29.2,8.7,29.2,11.3,27.6,12.8z"/>
 	<line class="st0" x1="27.6" y1="7.2" x2="13.1" y2="21.7"/>
 	<g>
-		<polygon class="st2" points="10.4,25.4 8,25.8 12.9,20.9 14,21.9 		"/>
+		<polygon class="st2" points="10.4,25.4 8,25.8 12.9,20.8 14,21.8 		"/>
 	</g>
-	<path class="st3" d="M27.6,12.9l-9.2,9.2h-5.7l0,0v-5.7l9.2-9.2c1.6-1.6,4.1-1.6,5.7,0l0,0C29.2,8.8,29.2,11.3,27.6,12.9z"/>
+	<path class="st3" d="M27.6,12.8L18.4,22h-5.7l0,0v-5.7l9.2-9.2c1.6-1.6,4.1-1.6,5.7,0l0,0C29.2,8.7,29.2,11.3,27.6,12.8z"/>
 </g>
 </svg>

--- a/www/src/assets/blog.svg
+++ b/www/src/assets/blog.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st1{fill:url(#SVGID_1_);}
+	.st2{fill:#744DA3;}
+	.st3{fill:none;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
+</style>
+<g>
+	<line class="st0" x1="24.1" y1="10.7" x2="28.3" y2="10.7"/>
+	<line class="st0" x1="21.2" y1="13.6" x2="26.9" y2="13.6"/>
+	<line class="st0" x1="19.8" y1="15" x2="19.7" y2="9.2"/>
+	<line class="st0" x1="17" y1="17.8" x2="16.9" y2="12.1"/>
+	
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-270.0929" y1="395.1235" x2="-270.0929" y2="374.1235" gradientTransform="matrix(0.7071 0.7071 -0.7071 0.7071 483.1198 -66.3545)">
+		<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#EABD52"/>
+	</linearGradient>
+	<path class="st1" d="M27.6,12.9l-9.2,9.2c-1.6,1.6-5.7,0-5.7,0l0,0c0,0-1.6-4.1,0-5.7l9.2-9.2c1.6-1.6,4.1-1.6,5.7,0l0,0
+		C29.2,8.8,29.2,11.3,27.6,12.9z"/>
+	<line class="st0" x1="27.6" y1="7.2" x2="13.1" y2="21.7"/>
+	<g>
+		<polygon class="st2" points="10.4,25.4 8,25.8 12.9,20.9 14,21.9 		"/>
+	</g>
+	<path class="st3" d="M27.6,12.9l-9.2,9.2h-5.7l0,0v-5.7l9.2-9.2c1.6-1.6,4.1-1.6,5.7,0l0,0C29.2,8.8,29.2,11.3,27.6,12.9z"/>
+</g>
+</svg>

--- a/www/src/assets/community.svg
+++ b/www/src/assets/community.svg
@@ -3,13 +3,14 @@
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
-	.st1{fill:url(#SVGID_1_);stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st0{fill:none;stroke:#744C9E;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st1{fill:url(#SVGID_1_);stroke:#9966CC;stroke-width:1.4173;stroke-miterlimit:10;}
 </style>
-<path class="st0" d="M18,18h4.5l5,3.5V18H29c1.7,0,3-1.3,3-3V9c0-1.7-1.3-3-3-3H18c-1.7,0-3,1.3-3,3v6C15,16.7,16.3,18,18,18z"/>
-<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.75" y1="32.75" x2="18.8713" y2="19.6287" gradientTransform="matrix(1 0 0 1 0 -8)">
+<path class="st0" d="M18,18h4.5l5,3.5l0-3.5H29c1.7,0,3-1.3,3-3V9c0-1.7-1.3-3-3-3H18c-1.7,0-3,1.3-3,3v6C15,16.7,16.3,18,18,18z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.75" y1="24.75" x2="18.8713" y2="11.6287">
 	<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
-	<stop  offset="1" style="stop-color:#EABD52"/>
+	<stop  offset="1" style="stop-color:#FFB238"/>
 </linearGradient>
-<path class="st1" d="M18,24h-4.5l-5,3.5V24H7c-1.7,0-3-1.3-3-3v-6c0-1.7,1.3-3,3-3h11c1.7,0,3,1.3,3,3v6C21,22.7,19.7,24,18,24z"/>
+<path class="st1" d="M18,24h-4.5l-5,3.5l0-3.5H7c-1.7,0-3-1.3-3-3v-6c0-1.7,1.3-3,3-3h11c1.7,0,3,1.3,3,3v6C21,22.7,19.7,24,18,24z"
+	/>
 </svg>

--- a/www/src/assets/community.svg
+++ b/www/src/assets/community.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st1{fill:url(#SVGID_1_);stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:10;}
+</style>
+<path class="st0" d="M18,18h4.5l5,3.5V18H29c1.7,0,3-1.3,3-3V9c0-1.7-1.3-3-3-3H18c-1.7,0-3,1.3-3,3v6C15,16.7,16.3,18,18,18z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="5.75" y1="32.75" x2="18.8713" y2="19.6287" gradientTransform="matrix(1 0 0 1 0 -8)">
+	<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	<stop  offset="1" style="stop-color:#EABD52"/>
+</linearGradient>
+<path class="st1" d="M18,24h-4.5l-5,3.5V24H7c-1.7,0-3-1.3-3-3v-6c0-1.7,1.3-3,3-3h11c1.7,0,3,1.3,3,3v6C21,22.7,19.7,24,18,24z"/>
+</svg>

--- a/www/src/assets/docs.svg
+++ b/www/src/assets/docs.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:none;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st2{fill:none;stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st3{fill:#FFFFFF;stroke:#744DA3;stroke-width:1.4173;stroke-linejoin:bevel;stroke-miterlimit:140;}
+</style>
+<g>
+	
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="17.5" y1="15" x2="17.5" y2="33" gradientTransform="matrix(1 0 0 1 0 -8)">
+		<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#EABD52"/>
+	</linearGradient>
+	<path class="st0" d="M10,7c1.6,0,3,1.4,3,3v12c0,1.6,1.3,3,3,3s3-1.4,3-3s-1.4-3-3-3h9v-9c0-1.6-1.4-3-3-3H10z"/>
+	<path class="st1" d="M10,7c-1.6,0-3,1.4-3,3v2h6"/>
+	<path class="st2" d="M16,25c-1.7,0-3-1.4-3-3V10c0-1.6-1.4-3-3-3h12c1.6,0,3,1.4,3,3v9"/>
+	<path class="st2" d="M7,10"/>
+	<path class="st3" d="M16,25h9c1.6,0,3-1.4,3-3s-1.4-3-3-3h-9c1.6,0,3,1.4,3,3S17.6,25,16,25z"/>
+</g>
+<line class="st2" x1="16" y1="11" x2="19" y2="11"/>
+<line class="st2" x1="20" y1="11" x2="22" y2="11"/>
+<line class="st2" x1="16" y1="14" x2="22" y2="14"/>
+</svg>

--- a/www/src/assets/docs.svg
+++ b/www/src/assets/docs.svg
@@ -3,12 +3,12 @@
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#CBB3E7;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st0{fill:#CCB2E5;stroke:#744C9E;stroke-width:1.4173;stroke-miterlimit:10;}
 	.st1{fill:url(#SVGID_1_);}
 	.st2{fill:none;stroke:url(#SVGID_2_);stroke-width:1.4173;stroke-miterlimit:10;}
 	.st3{fill:none;stroke:url(#SVGID_3_);stroke-width:1.4173;stroke-miterlimit:10;}
-	.st4{fill:#FFFFFF;stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:140;}
-	.st5{fill:#744DA3;}
+	.st4{fill:#FFFFFF;stroke:#9966CC;stroke-width:1.4173;stroke-miterlimit:140;}
+	.st5{fill:#744C9E;}
 	.st6{fill:url(#SVGID_4_);}
 </style>
 <g>
@@ -16,24 +16,24 @@
 	
 		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="41.5" y1="-55" x2="41.5" y2="-37" gradientTransform="matrix(1 0 0 1 -24 62)">
 		<stop  offset="0" style="stop-color:#FFFFFF"/>
-		<stop  offset="0.1907" style="stop-color:#FFFEFC"/>
-		<stop  offset="0.3439" style="stop-color:#FDFAF2"/>
-		<stop  offset="0.4841" style="stop-color:#FBF4E1"/>
-		<stop  offset="0.6165" style="stop-color:#F8EAC9"/>
-		<stop  offset="0.7436" style="stop-color:#F5DFAA"/>
-		<stop  offset="0.8664" style="stop-color:#F0D085"/>
-		<stop  offset="0.984" style="stop-color:#EBC059"/>
-		<stop  offset="1" style="stop-color:#EABD52"/>
+		<stop  offset="0.1799" style="stop-color:#FFFEFC"/>
+		<stop  offset="0.3245" style="stop-color:#FFFAF2"/>
+		<stop  offset="0.4568" style="stop-color:#FFF3E1"/>
+		<stop  offset="0.5818" style="stop-color:#FFEAC9"/>
+		<stop  offset="0.7017" style="stop-color:#FFDEAA"/>
+		<stop  offset="0.8177" style="stop-color:#FFD084"/>
+		<stop  offset="0.9285" style="stop-color:#FFBF59"/>
+		<stop  offset="1" style="stop-color:#FFB238"/>
 	</linearGradient>
 	<path class="st1" d="M10,7c1.6,0,3,1.4,3,3v12c0,1.6,1.3,3,3,3s3-1.4,3-3h6V10c0-1.6-1.4-3-3-3H10z"/>
 	<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="17.8543" y1="22" x2="17.8543" y2="6.2913">
-		<stop  offset="0" style="stop-color:#9768CE"/>
-		<stop  offset="1" style="stop-color:#744DA3"/>
+		<stop  offset="0" style="stop-color:#9966CC"/>
+		<stop  offset="1" style="stop-color:#744C9E"/>
 	</linearGradient>
 	<path class="st2" d="M10,7h12c1.6,0,3,1.4,3,3v12"/>
 	<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="13" y1="25.7087" x2="13" y2="6.2913">
-		<stop  offset="0" style="stop-color:#9768CE"/>
-		<stop  offset="1" style="stop-color:#744DA3"/>
+		<stop  offset="0" style="stop-color:#9966CC"/>
+		<stop  offset="1" style="stop-color:#744C9E"/>
 	</linearGradient>
 	<path class="st3" d="M16,25c-1.7,0-3-1.4-3-3V10c0-1.6-1.4-3-3-3"/>
 	<path class="st4" d="M16,25h9c1.6,0,3-1.4,3-3v-1h-9v1C19,23.6,17.6,25,16,25z"/>
@@ -41,8 +41,8 @@
 <path class="st5" d="M17,10.5c0.6,0,1,0.4,1,1s-0.4,1-1,1c-0.6,0-1-0.4-1-1C16,10.9,16.6,10.5,17,10.5z"/>
 <path class="st5" d="M21.2,10.6c0.6,0,1,0.4,1,1s-0.4,1-1,1c-0.6,0-1-0.4-1-1C20.3,11.1,20.6,10.6,21.2,10.6z"/>
 <linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="19.2503" y1="14.5" x2="19.2503" y2="18.3161">
-	<stop  offset="0" style="stop-color:#9768CE"/>
-	<stop  offset="1" style="stop-color:#744DA3"/>
+	<stop  offset="0" style="stop-color:#9966CC"/>
+	<stop  offset="1" style="stop-color:#744C9E"/>
 </linearGradient>
 <path class="st6" d="M22.2,14.5c0,0,0,1.1,0,1.3c0,0.6-0.3,1.1-0.8,1.6c-0.5,0.5-1.3,0.9-2.2,0.9s-1.7-0.4-2.2-0.9
 	c-0.5-0.5-0.8-1-0.8-1.6c0-0.3,0-1.3,0-1.3C17.9,14.5,20.6,14.5,22.2,14.5z"/>

--- a/www/src/assets/docs.svg
+++ b/www/src/assets/docs.svg
@@ -3,24 +3,47 @@
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:url(#SVGID_1_);}
-	.st1{fill:none;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
-	.st2{fill:none;stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:10;}
-	.st3{fill:#FFFFFF;stroke:#744DA3;stroke-width:1.4173;stroke-linejoin:bevel;stroke-miterlimit:140;}
+	.st0{fill:#CBB3E7;stroke:#744DA3;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st1{fill:url(#SVGID_1_);}
+	.st2{fill:none;stroke:url(#SVGID_2_);stroke-width:1.4173;stroke-miterlimit:10;}
+	.st3{fill:none;stroke:url(#SVGID_3_);stroke-width:1.4173;stroke-miterlimit:10;}
+	.st4{fill:#FFFFFF;stroke:#9768CE;stroke-width:1.4173;stroke-miterlimit:140;}
+	.st5{fill:#744DA3;}
+	.st6{fill:url(#SVGID_4_);}
 </style>
 <g>
+	<path class="st0" d="M10,7c-1.6,0-3,1.4-3,3v2h10"/>
 	
-		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="17.5" y1="15" x2="17.5" y2="33" gradientTransform="matrix(1 0 0 1 0 -8)">
-		<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="41.5" y1="-55" x2="41.5" y2="-37" gradientTransform="matrix(1 0 0 1 -24 62)">
+		<stop  offset="0" style="stop-color:#FFFFFF"/>
+		<stop  offset="0.1907" style="stop-color:#FFFEFC"/>
+		<stop  offset="0.3439" style="stop-color:#FDFAF2"/>
+		<stop  offset="0.4841" style="stop-color:#FBF4E1"/>
+		<stop  offset="0.6165" style="stop-color:#F8EAC9"/>
+		<stop  offset="0.7436" style="stop-color:#F5DFAA"/>
+		<stop  offset="0.8664" style="stop-color:#F0D085"/>
+		<stop  offset="0.984" style="stop-color:#EBC059"/>
 		<stop  offset="1" style="stop-color:#EABD52"/>
 	</linearGradient>
-	<path class="st0" d="M10,7c1.6,0,3,1.4,3,3v12c0,1.6,1.3,3,3,3s3-1.4,3-3s-1.4-3-3-3h9v-9c0-1.6-1.4-3-3-3H10z"/>
-	<path class="st1" d="M10,7c-1.6,0-3,1.4-3,3v2h6"/>
-	<path class="st2" d="M16,25c-1.7,0-3-1.4-3-3V10c0-1.6-1.4-3-3-3h12c1.6,0,3,1.4,3,3v9"/>
-	<path class="st2" d="M7,10"/>
-	<path class="st3" d="M16,25h9c1.6,0,3-1.4,3-3s-1.4-3-3-3h-9c1.6,0,3,1.4,3,3S17.6,25,16,25z"/>
+	<path class="st1" d="M10,7c1.6,0,3,1.4,3,3v12c0,1.6,1.3,3,3,3s3-1.4,3-3h6V10c0-1.6-1.4-3-3-3H10z"/>
+	<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="17.8543" y1="22" x2="17.8543" y2="6.2913">
+		<stop  offset="0" style="stop-color:#9768CE"/>
+		<stop  offset="1" style="stop-color:#744DA3"/>
+	</linearGradient>
+	<path class="st2" d="M10,7h12c1.6,0,3,1.4,3,3v12"/>
+	<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="13" y1="25.7087" x2="13" y2="6.2913">
+		<stop  offset="0" style="stop-color:#9768CE"/>
+		<stop  offset="1" style="stop-color:#744DA3"/>
+	</linearGradient>
+	<path class="st3" d="M16,25c-1.7,0-3-1.4-3-3V10c0-1.6-1.4-3-3-3"/>
+	<path class="st4" d="M16,25h9c1.6,0,3-1.4,3-3v-1h-9v1C19,23.6,17.6,25,16,25z"/>
 </g>
-<line class="st2" x1="16" y1="11" x2="19" y2="11"/>
-<line class="st2" x1="20" y1="11" x2="22" y2="11"/>
-<line class="st2" x1="16" y1="14" x2="22" y2="14"/>
+<path class="st5" d="M17,10.5c0.6,0,1,0.4,1,1s-0.4,1-1,1c-0.6,0-1-0.4-1-1C16,10.9,16.6,10.5,17,10.5z"/>
+<path class="st5" d="M21.2,10.6c0.6,0,1,0.4,1,1s-0.4,1-1,1c-0.6,0-1-0.4-1-1C20.3,11.1,20.6,10.6,21.2,10.6z"/>
+<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="19.2503" y1="14.5" x2="19.2503" y2="18.3161">
+	<stop  offset="0" style="stop-color:#9768CE"/>
+	<stop  offset="1" style="stop-color:#744DA3"/>
+</linearGradient>
+<path class="st6" d="M22.2,14.5c0,0,0,1.1,0,1.3c0,0.6-0.3,1.1-0.8,1.6c-0.5,0.5-1.3,0.9-2.2,0.9s-1.7-0.4-2.2-0.9
+	c-0.5-0.5-0.8-1-0.8-1.6c0-0.3,0-1.3,0-1.3C17.9,14.5,20.6,14.5,22.2,14.5z"/>
 </svg>

--- a/www/src/assets/mobile-nav-icons.js
+++ b/www/src/assets/mobile-nav-icons.js
@@ -1,0 +1,4 @@
+export CommunityIcon from "./community.svg"
+export BlogIcon from "./blog.svg"
+export DocsIcon from "./docs.svg"
+export TutorialIcon from "./tutorial.svg"

--- a/www/src/assets/tutorial.svg
+++ b/www/src/assets/tutorial.svg
@@ -4,10 +4,10 @@
 	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
-	.st1{fill:#FFFFFF;stroke:#EABD52;stroke-width:1.4173;stroke-miterlimit:10;}
-	.st2{fill:#9768CE;}
+	.st1{fill:#FFFFFF;stroke:#FFB238;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st2{fill:#9966CC;}
 	.st3{fill:url(#SVGID_1_);}
-	.st4{fill:#744DA3;}
+	.st4{fill:#744C9E;}
 </style>
 <circle class="st0" cx="15.4" cy="19.2" r="6.8"/>
 <polygon class="st1" points="25.3,21.5 17.7,21.5 21.5,14.8 25.3,8.2 29.2,14.8 33,21.5 "/>
@@ -16,10 +16,9 @@
 		C11.4,12,8,15.4,8,19.5s3.4,7.5,7.5,7.5s7.5-3.4,7.5-7.5S19.6,12,15.5,12L15.5,12z"/>
 </g>
 <g>
-	
-		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="9" y1="25.3" x2="9" y2="14.7175" gradientTransform="matrix(1 0 0 1 0 -8)">
+	<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="9" y1="17.2915" x2="9" y2="6.7085">
 		<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
-		<stop  offset="1" style="stop-color:#EABD52"/>
+		<stop  offset="1" style="stop-color:#FFB238"/>
 	</linearGradient>
 	<rect x="3.7" y="6.7" class="st3" width="10.6" height="10.6"/>
 	<path class="st4" d="M13.6,7.4v9.2H4.4V7.4H13.6 M15,6H3v12h12V6L15,6z"/>

--- a/www/src/assets/tutorial.svg
+++ b/www/src/assets/tutorial.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 36 32" style="enable-background:new 0 0 36 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#FFFFFF;stroke:#EABD52;stroke-width:1.4173;stroke-miterlimit:10;}
+	.st2{fill:#9768CE;}
+	.st3{fill:url(#SVGID_1_);}
+	.st4{fill:#744DA3;}
+</style>
+<circle class="st0" cx="15.4" cy="19.2" r="6.8"/>
+<polygon class="st1" points="25.3,21.5 17.7,21.5 21.5,14.8 25.3,8.2 29.2,14.8 33,21.5 "/>
+<g>
+	<path class="st2" d="M15.5,13.4c3.4,0,6.1,2.7,6.1,6.1s-2.7,6.1-6.1,6.1s-6.1-2.7-6.1-6.1S12.1,13.4,15.5,13.4 M15.5,12
+		C11.4,12,8,15.4,8,19.5s3.4,7.5,7.5,7.5s7.5-3.4,7.5-7.5S19.6,12,15.5,12L15.5,12z"/>
+</g>
+<g>
+	
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="9" y1="25.3" x2="9" y2="14.7175" gradientTransform="matrix(1 0 0 1 0 -8)">
+		<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#EABD52"/>
+	</linearGradient>
+	<rect x="3.7" y="6.7" class="st3" width="10.6" height="10.6"/>
+	<path class="st4" d="M13.6,7.4v9.2H4.4V7.4H13.6 M15,6H3v12h12V6L15,6z"/>
+</g>
+</svg>

--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -17,7 +17,7 @@ const MobileNavItem = ({ linkTo, label, icon }) => (
     css={{
       color: presets.brand,
       fontSize: scale(-1 / 2).fontSize,
-      fontWeight: `bold`,
+      letterSpacing: `0.0075rem`,
       lineHeight: 1,
       padding: `${rhythm(options.blockMarginBottom / 4)} ${rhythm(
         options.blockMarginBottom
@@ -42,8 +42,7 @@ export default () => (
       left: 0,
       right: 0,
       zIndex: 1,
-      background: presets.veryLightPurple,
-      borderTop: `1px solid ${colors.b[0]}`,
+      borderTop: `1px solid ${presets.veryLightPurple}`,
       background: presets.sidebar,
       fontFamily: typography.options.headerFontFamily.join(`,`),
       [presets.Tablet]: {

--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -1,37 +1,38 @@
 import React from "react"
 import Link from "gatsby-link"
-import CodeIcon from "react-icons/lib/go/code"
-import DocumentIcon from "react-icons/lib/go/file-text"
-import PencilIcon from "react-icons/lib/go/pencil"
-import PersonIcon from "react-icons/lib/md/person"
 
+import {
+  BlogIcon,
+  CommunityIcon,
+  DocsIcon,
+  TutorialIcon,
+} from "../assets/mobile-nav-icons"
 import colors from "../utils/colors"
 import presets from "../utils/presets"
-import typography, { rhythm, scale } from "../utils/typography"
+import typography, { rhythm, scale, options } from "../utils/typography"
 
-const MobileNavItem = ({ linkTo, title, children }) => (
+const MobileNavItem = ({ linkTo, label, icon }) => (
   <Link
     to={linkTo}
     css={{
       color: presets.brand,
       fontSize: scale(-1 / 2).fontSize,
-      letterSpacing: `0.07em`,
+      fontWeight: `bold`,
+      padding: `${rhythm(options.blockMarginBottom / 4)} ${rhythm(
+        options.blockMarginBottom
+      )} ${rhythm(options.blockMarginBottom / 2)} `,
       textDecoration: `none`,
       textAlign: `center`,
-      textTransform: `uppercase`,
     }}
   >
-    {children}
-    <div css={{ opacity: 0.8, lineHeight: 1, marginTop: rhythm(1 / 8) }}>
-      {title}
-    </div>
+    <img src={icon} css={{ height: 32, display: `block`, margin: `0 auto` }} />
+    <div css={{ opacity: 0.8, lineHeight: 1 }}>{label}</div>
   </Link>
 )
 
 export default () => (
   <div
     css={{
-      lineHeight: 2,
       position: `fixed`,
       display: `flex`,
       justifyContent: `space-around`,
@@ -39,7 +40,6 @@ export default () => (
       bottom: 0,
       left: 0,
       right: 0,
-      height: rhythm(2.3),
       background: presets.veryLightPurple,
       borderTop: `1px solid ${colors.b[0]}`,
       background: presets.sidebar,
@@ -49,47 +49,13 @@ export default () => (
       },
     }}
   >
-    <MobileNavItem linkTo="/docs/" title="Docs">
-      <DocumentIcon
-        css={{
-          fontSize: rhythm(0.7),
-        }}
-      />
-    </MobileNavItem>
-    <MobileNavItem linkTo="/tutorial/" title="Tutorial">
-      <CodeIcon
-        css={{
-          fontSize: rhythm(0.8),
-        }}
-      />
-    </MobileNavItem>
-    <MobileNavItem linkTo="/community/" title="Community">
-      <PersonIcon
-        css={{
-          fontSize: rhythm(5 / 8),
-          position: `relative`,
-          right: -4,
-        }}
-      />
-      <PersonIcon
-        css={{
-          fontSize: rhythm(5 / 8),
-        }}
-      />
-      <PersonIcon
-        css={{
-          fontSize: rhythm(5 / 8),
-          position: `relative`,
-          left: -4,
-        }}
-      />
-    </MobileNavItem>
-    <MobileNavItem linkTo="/blog/" title="Blog">
-      <PencilIcon
-        css={{
-          fontSize: rhythm(0.7),
-        }}
-      />
-    </MobileNavItem>
+    <MobileNavItem linkTo="/docs/" label="Docs" icon={DocsIcon} />
+    <MobileNavItem linkTo="/tutorial/" label="Tutorial" icon={TutorialIcon} />
+    <MobileNavItem
+      linkTo="/community/"
+      label="Community"
+      icon={CommunityIcon}
+    />
+    <MobileNavItem linkTo="/blog/" label="Blog" icon={BlogIcon} />
   </div>
 )

--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -40,6 +40,7 @@ export default () => (
       bottom: 0,
       left: 0,
       right: 0,
+      zIndex: 1,
       background: presets.veryLightPurple,
       borderTop: `1px solid ${colors.b[0]}`,
       background: presets.sidebar,

--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -18,6 +18,7 @@ const MobileNavItem = ({ linkTo, label, icon }) => (
       color: presets.brand,
       fontSize: scale(-1 / 2).fontSize,
       fontWeight: `bold`,
+      lineHeight: 1,
       padding: `${rhythm(options.blockMarginBottom / 4)} ${rhythm(
         options.blockMarginBottom
       )} ${rhythm(options.blockMarginBottom / 2)} `,
@@ -26,7 +27,7 @@ const MobileNavItem = ({ linkTo, label, icon }) => (
     }}
   >
     <img src={icon} css={{ height: 32, display: `block`, margin: `0 auto` }} />
-    <div css={{ opacity: 0.8, lineHeight: 1 }}>{label}</div>
+    <div>{label}</div>
   </Link>
 )
 


### PR DESCRIPTION
At iPhone5 size/144ppi:

<img width="362" alt="bildschirmfoto 2017-09-08 um 02 40 58" src="https://user-images.githubusercontent.com/21834/30191153-3eab479e-943f-11e7-8ca7-f8408bf045a8.png">

1:1:

![image](https://user-images.githubusercontent.com/21834/30191190-877979dc-943f-11e7-95a1-d0cdc9118a33.png)

On a …"second" look, bold might be too much.
Also fixes the author link in `<BlogPostPreviewItem>😁` from rendering on top of the mobile nav.