### PR TITLE
Fix typo in gatsby-plugin-emotion README.MD.

### DIFF
--- a/packages/gatsby-plugin-emotion/README.md
+++ b/packages/gatsby-plugin-emotion/README.md
@@ -12,6 +12,6 @@ Add the plugin to your `gatsby-config.js`.
 
 ```js
 plugins: [
-  'gatbsy-plugin-emotion'
+  'gatsby-plugin-emotion'
 ]
 ```


### PR DESCRIPTION
This PR fixes a typo in the gatsby-plugin-emotion README.MD that leads to confusion.