### PR TITLE
read GATSBY_* env vars and feed to webpack

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -32,7 +32,7 @@ GATSBY_ASSETS_URL=http://s3.amazonaws.com/bucketname
 ```
 # Usage
 
-<img src={`${GATSBY_ASSETS_URL}/logo.png`} />
+<img src={`${process.env.GATSBY_ASSETS_URL}/logo.png`} />
 
 ```
 

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -21,6 +21,23 @@ API_URL=https://example.com/api
 
 These variables will be available to your site as `process.env.API_URL`.
 
+In addition any variable in the environment prefixed with `GATSBY_` will be available.
+
+## Example
+
+```
+GATSBY_ASSETS_URL=http://s3.amazonaws.com/bucketname
+```
+
+```
+# Usage
+
+<img src={`${GATSBY_ASSETS_URL}/logo.png`} />
+
+```
+
+
+
 > You can not override certain environment variables as some are used internally for optimizations during build
 
 Reserved environment variables:

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -29,11 +29,15 @@ In addition any variable in the environment prefixed with `GATSBY_` will be avai
 GATSBY_ASSETS_URL=http://s3.amazonaws.com/bucketname
 ```
 
-```
-# Usage
-
-<img src={`${process.env.GATSBY_ASSETS_URL}/logo.png`} />
-
+```jsx
+// usage
+render() {
+  return (
+    <div>
+      <img src={`${process.env.GATSBY_ASSETS_URL}/logo.png`} />
+    </div>
+  )
+}
 ```
 
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -64,11 +64,18 @@ module.exports = async (
       return acc
     }, {})
 
+    const gatsbyVarObject = Object.keys(process.env).reduce((acc, key) => {
+      if (key.match(/^GATSBY_/)) {
+        acc[key] = JSON.stringify(process.env[key])
+      }
+      return acc
+    }, {})
+
     // Don't allow overwriting of NODE_ENV, PUBLIC_DIR as to not break gatsby things
     envObject.NODE_ENV = JSON.stringify(env)
     envObject.PUBLIC_DIR = JSON.stringify(`${process.cwd()}/public`)
 
-    return envObject
+    return Object.assign(envObject, gatsbyVarObject)
   }
 
   debug(`Loading webpack config for stage "${stage}"`)


### PR DESCRIPTION
I'd like to have these kinds of variables in addition to the .env file.  Does anyone see any problem with this method? I think it's close to what CRA does.  I'll add to the readme once it's approved.

NOTE: GATSBY_* vars defined in the environment will overwrite those defined in .env.  I thought that made sense. Not sure though.

also should the variables be case insensitive?