### PR TITLE
Allow sassLoader to webpack validation config

### DIFF
--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -12,6 +12,7 @@ import apiRunnerNode from "./api-runner-node"
 // https://github.com/js-dxtools/webpack-validator#customizing
 const validationWhitelist = Joi.object({
   stylus: Joi.any(),
+  sassLoader: Joi.any(),
   sassResources: [Joi.string(), Joi.array().items(Joi.string())],
 })
 


### PR DESCRIPTION
This relates to #2058.