### PR TITLE
fix for mailto in docs

### DIFF
--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -87,7 +87,7 @@ export default () =>
   <div>
     <h1>I'd love to talk! Email me at the address below</h1>
     <p>
-      <a mailto="me@example.com">me@example.com</a>
+      <a href="mailto:me@example.com">me@example.com</a>
     </p>
   </div>
 ```


### PR DESCRIPTION
I hope I'm not making a newbie mistake here but the docs refer to the prop `mailto` on an `<a>` tag, but my React for Chrome Devtools says this property is invalid ... so I've changed it to a `href` with `mailto:` at the start of the link string.

Really hope this is ok...!