### PR TITLE
Fix require statement and bump version in preact plugin

### DIFF
--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -17,8 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "preact": "^8.1.0",
-    "preact-compat": "^3.16.0"
+    "preact": "^8.2.5",
+    "preact-compat": "^3.17.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/gatsby-plugin-preact/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-browser.js
@@ -1,5 +1,5 @@
 exports.onClientEntry = () => {
   if (process.env.NODE_ENV !== `production`) {
-    require(`preact/debug`)
+    require('preact/debug')
   }
 }


### PR DESCRIPTION
Made a silly formatting mistake by listening to eslint instead of my brain, which broke everything in previous update. Also, bumped to the latest non-breaking preact and preact-compat for good measure. 