### PR TITLE
Infer input fields from setFieldsOnGraphQLNodeType

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
@@ -1,0 +1,251 @@
+const _ = require(`lodash`)
+const {
+  graphql,
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLList,
+  GraphQLSchema,
+  GraphQLInputObjectType,
+} = require(`graphql`)
+const { connectionArgs, connectionDefinitions } = require(`graphql-skip-limit`)
+
+const {
+  createSortField,
+  inferInputObjectStructureFromFields,
+} = require(`../infer-graphql-input-fields-from-fields.js`)
+
+function isIntInput(type) {
+  expect(type instanceof GraphQLInputObjectType).toBeTruthy()
+  expect(type.getFields()).toEqual({
+    eq: { name: `eq`, type: GraphQLInt },
+    ne: { name: `ne`, type: GraphQLInt },
+  })
+}
+
+function isStringInput(type) {
+  expect(type instanceof GraphQLInputObjectType).toBeTruthy()
+  expect(type.getFields()).toEqual({
+    eq: { name: `eq`, type: GraphQLString },
+    ne: { name: `ne`, type: GraphQLString },
+    regex: { name: `regex`, type: GraphQLString },
+    glob: { name: `glob`, type: GraphQLString },
+  })
+}
+
+function typeField(type) {
+  return {
+    type,
+  }
+}
+
+describe(`GraphQL Input args from fields, test-only`, () => {
+  function oddValue(value) {
+    return value % 2 === 1 ? value : null
+  }
+
+  const OddType = new GraphQLScalarType({
+    name: `Odd`,
+    serialize: oddValue,
+    parseValue: oddValue,
+    parseLiteral(ast) {
+      if (ast.kind === Kind.INT) {
+        return oddValue(parseInt(ast.value, 10))
+      }
+      return null
+    },
+  })
+
+  it(`handles all known scalars`, async () => {
+    const fields = {
+      scal_int: typeField(GraphQLInt),
+      scal_float: typeField(GraphQLFloat),
+      scal_string: typeField(GraphQLString),
+      scal_bool: typeField(GraphQLBoolean),
+      scal_odd_unknown: typeField(OddType),
+    }
+
+    const { inferredFields } = inferInputObjectStructureFromFields({
+      fields,
+      typeName: `AType`,
+    })
+
+    const int = inferredFields.scal_int.type
+    expect(int.name).toBe(`scalIntQueryInt`)
+    isIntInput(int)
+
+    const float = inferredFields.scal_float.type
+    expect(float.name).toBe(`scalFloatQueryFloat`)
+    expect(float instanceof GraphQLInputObjectType).toBeTruthy()
+    expect(float.getFields()).toEqual({
+      eq: { name: `eq`, type: GraphQLFloat },
+      ne: { name: `ne`, type: GraphQLFloat },
+    })
+
+    const string = inferredFields.scal_string.type
+    expect(string.name).toBe(`scalStringQueryString`)
+    isStringInput(string)
+
+    const bool = inferredFields.scal_bool.type
+    expect(bool.name).toBe(`scalBoolQueryBoolean`)
+    expect(bool instanceof GraphQLInputObjectType).toBeTruthy()
+    expect(bool.getFields()).toEqual({
+      eq: { name: `eq`, type: GraphQLBoolean },
+      ne: { name: `ne`, type: GraphQLBoolean },
+    })
+
+    expect(inferredFields).not.toHaveProperty(`scal_odd_unknown`)
+  })
+
+  it(`recursively converts object types`, async () => {
+    const fields = {
+      obj: typeField(
+        new GraphQLObjectType({
+          name: `Obj`,
+          fields: {
+            foo: typeField(GraphQLInt),
+            bar: typeField(
+              new GraphQLObjectType({
+                name: `Jbo`,
+                fields: {
+                  foo: typeField(GraphQLString),
+                },
+              })
+            ),
+          },
+        })
+      ),
+    }
+
+    const { inferredFields } = inferInputObjectStructureFromFields({
+      fields,
+      typeName: `AType`,
+    })
+
+    const obj = inferredFields.obj.type
+    const objFields = obj.getFields()
+
+    expect(obj instanceof GraphQLInputObjectType).toBeTruthy()
+    isIntInput(objFields.foo.type)
+
+    const innerObj = objFields.bar.type
+    const innerObjFields = innerObj.getFields()
+    isStringInput(innerObjFields.foo.type)
+  })
+
+  it(`recovers from unknown output types`, async () => {
+    const fields = {
+      obj: {
+        type: new GraphQLObjectType({
+          name: `Obj`,
+          fields: {
+            aa: typeField(OddType),
+            foo: typeField(GraphQLInt),
+            bar: typeField(
+              new GraphQLObjectType({
+                name: `Jbo`,
+                fields: {
+                  aa: typeField(OddType),
+                  foo: typeField(GraphQLString),
+                  ba: typeField(OddType),
+                  bar: typeField(GraphQLInt),
+                },
+              })
+            ),
+          },
+        }),
+      },
+      odd: typeField(OddType),
+    }
+
+    const { inferredFields } = inferInputObjectStructureFromFields({
+      fields,
+      typeName: `AType`,
+    })
+
+    expect(inferredFields.odd).toBeUndefined()
+
+    const obj = inferredFields.obj.type
+    const objFields = obj.getFields()
+
+    expect(obj instanceof GraphQLInputObjectType).toBeTruthy()
+    isIntInput(objFields.foo.type)
+    expect(objFields.aa).toBeUndefined()
+
+    const innerObj = objFields.bar.type
+    const innerObjFields = innerObj.getFields()
+    expect(innerObjFields.aa).toBeUndefined()
+    isStringInput(innerObjFields.foo.type)
+    expect(innerObjFields.ba).toBeUndefined()
+    isIntInput(innerObjFields.bar.type)
+  })
+
+  it(`includes the filters of list elements`, async () => {
+    const fields = {
+      list: typeField(new GraphQLList(GraphQLFloat)),
+    }
+
+    const { inferredFields } = inferInputObjectStructureFromFields({
+      fields,
+      typeName: `AType`,
+    })
+
+    const list = inferredFields.list.type
+
+    expect(list instanceof GraphQLInputObjectType).toBeTruthy()
+    expect(list.getFields()).toEqual({
+      eq: { name: `eq`, type: GraphQLFloat },
+      ne: { name: `ne`, type: GraphQLFloat },
+      in: { name: `in`, type: new GraphQLList(GraphQLFloat) },
+    })
+  })
+
+  it(`strips away NonNull`, async () => {
+    const fields = {
+      nonNull: typeField(new GraphQLNonNull(GraphQLInt)),
+    }
+
+    const { inferredFields } = inferInputObjectStructureFromFields({
+      fields,
+      typeName: `AType`,
+    })
+
+    isIntInput(inferredFields.nonNull.type)
+  })
+
+  it(`extracts the fields you can sort on`, async () => {
+    const fields = {
+      foo: typeField(GraphQLString),
+      bar: typeField(GraphQLFloat),
+      baz: typeField(
+        new GraphQLObjectType({
+          name: `Baz`,
+          fields: {
+            ka: typeField(GraphQLFloat),
+            ma: typeField(
+              new GraphQLList(
+                new GraphQLObjectType({
+                  name: `Hol`,
+                  fields: {
+                    go: typeField(GraphQLFloat),
+                  },
+                })
+              )
+            ),
+          },
+        })
+      ),
+    }
+
+    const { sort } = inferInputObjectStructureFromFields({
+      fields,
+      typeName: `AType`,
+    })
+
+    expect(sort.sort()).toEqual([`bar`, `baz___ka`, `baz___ma`, `foo`])
+  })
+})

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -14,6 +14,9 @@ const buildConnectionFields = require(`../build-connection-fields`)
 const {
   inferInputObjectStructureFromNodes,
 } = require(`../infer-graphql-input-fields`)
+const {
+  createSortField,
+} = require(`../infer-graphql-input-fields-from-fields.js`)
 
 function queryResult(nodes, query, { types = [] } = {}) {
   const nodeType = new GraphQLObjectType({
@@ -48,7 +51,7 @@ function queryResult(nodes, query, { types = [] } = {}) {
             type: nodeConnection,
             args: {
               ...connectionArgs,
-              sort,
+              sort: createSortField(`RootQueryType`, sort),
               filter: {
                 type: new GraphQLInputObjectType({
                   name: _.camelCase(`filter test`),
@@ -62,6 +65,7 @@ function queryResult(nodes, query, { types = [] } = {}) {
                 args,
                 nodes,
                 connection: true,
+                type: nodeType,
               })
             },
           },

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -7,9 +7,13 @@ const {
   GraphQLList,
   GraphQLString,
 } = require(`graphql`)
+import { NAMED_TYPE } from "graphql/language/kinds"
 
 const apiRunner = require(`../utils/api-runner-node`)
 const { inferObjectStructureFromNodes } = require(`./infer-graphql-type`)
+const {
+  inferInputObjectStructureFromFields,
+} = require(`./infer-graphql-input-fields-from-fields`)
 const {
   inferInputObjectStructureFromNodes,
 } = require(`./infer-graphql-input-fields`)
@@ -129,6 +133,11 @@ module.exports = async () => {
     })
 
     const mergedFieldsFromPlugins = _.merge(...fieldsFromPlugins)
+
+    const inferredInputFieldsFromPlugins = inferInputObjectStructureFromFields({
+      fields: mergedFieldsFromPlugins,
+    })
+
     const gqlType = new GraphQLObjectType({
       name: typeName,
       description: `Node of type ${typeName}`,
@@ -142,6 +151,12 @@ module.exports = async () => {
       typeName,
     })
 
+    const filterFields = _.merge(
+      {},
+      inferedInputFields.inferredFields,
+      inferredInputFieldsFromPlugins.inferredFields
+    )
+
     const proccesedType: ProcessedNodeType = {
       ...intermediateType,
       fieldsFromPlugins: mergedFieldsFromPlugins,
@@ -149,7 +164,7 @@ module.exports = async () => {
       node: {
         name: typeName,
         type: gqlType,
-        args: inferedInputFields.inferredFields,
+        args: filterFields,
         resolve(a, args, context) {
           const runSift = require(`./run-sift`)
           const latestNodes = _.filter(
@@ -163,6 +178,7 @@ module.exports = async () => {
             args: { filter: { ...args } },
             nodes: latestNodes,
             path: context.path ? context.path : `LAYOUT___${context.id}`,
+            type: gqlType,
           })
         },
       },

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -103,9 +103,23 @@ const buildFieldEnumValues = (nodes: any[]) => {
   return enumValues
 }
 
+// extract a list of field names
+// nested objects get flattened to "outer___inner" which will be converted back to
+// "outer.inner" by run-sift
+const extractFieldNames = (nodes: any[]) => {
+  const values = flatten(extractFieldExamples(nodes), {
+    maxDepth: 3,
+    safe: true, // don't flatten arrays.
+    delimiter: `___`,
+  })
+
+  return Object.keys(values)
+}
+
 module.exports = {
   INVALID_VALUE,
   extractFieldExamples,
   buildFieldEnumValues,
+  extractFieldNames,
   isEmptyObjectOrArray,
 }

--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -1,0 +1,240 @@
+// @flow
+
+const {
+  GraphQLInputObjectType,
+  GraphQLBoolean,
+  GraphQLString,
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLEnumType,
+  GraphQLNonNull,
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+} = require(`graphql`)
+
+import type { GraphQLInputType, GraphQLType } from "graphql"
+
+const { oneLine } = require(`common-tags`)
+const _ = require(`lodash`)
+const invariant = require(`invariant`)
+const typeOf = require(`type-of`)
+const createTypeName = require(`./create-type-name`)
+const createKey = require(`./create-key`)
+const {
+  extractFieldExamples,
+  buildFieldEnumValues,
+  isEmptyObjectOrArray,
+} = require(`./data-tree-utils`)
+
+import type {
+  GraphQLInputFieldConfig,
+  GraphQLInputFieldConfigMap,
+} from "graphql/type/definition"
+
+type GraphQLNullableInputType<T> =
+  | GraphQLScalarType
+  | GraphQLEnumType
+  | GraphQLInputObjectType
+  | GraphQLList<T>
+
+function makeNullable(type: GraphQLInputType): GraphQLNullableInputType<any> {
+  if (type instanceof GraphQLNonNull) {
+    return type.ofType
+  }
+  return type
+}
+
+function convertToInputType(type: GraphQLType): GraphQLInputType {
+  if (type instanceof GraphQLScalarType || type instanceof GraphQLEnumType) {
+    return type
+  } else if (type instanceof GraphQLObjectType) {
+    return new GraphQLInputObjectType({
+      name: createTypeName(`${type.name}InputObject`),
+      fields: _.mapValues(type.getFields(), fieldConfig => {return {
+        type: convertToInputType(fieldConfig.type),
+      }}),
+    })
+  } else if (type instanceof GraphQLList) {
+    return new GraphQLList(makeNullable(convertToInputType(type.ofType)))
+  } else if (type instanceof GraphQLNonNull) {
+    return new GraphQLNonNull(makeNullable(convertToInputType(type.ofType)))
+  } else if (type instanceof GraphQLInterfaceType) {
+    throw new Error(`GraphQLInterfaceType not yet implemented`)
+  } else if (type instanceof GraphQLUnionType) {
+    throw new Error(`GraphQLUnionType not yet implemented`)
+  } else {
+    throw new Error(
+      `Invalid input type ${type && type.constructor && type.constructor.name}`
+    )
+  }
+}
+
+const scalarFilterMap = {
+  Int: {
+    eq: { type: GraphQLInt },
+    ne: { type: GraphQLInt },
+  },
+  Float: {
+    eq: { type: GraphQLFloat },
+    ne: { type: GraphQLFloat },
+  },
+  String: {
+    eq: { type: GraphQLString },
+    ne: { type: GraphQLString },
+    regex: { type: GraphQLString },
+    glob: { type: GraphQLString },
+  },
+  Boolean: {
+    eq: { type: GraphQLBoolean },
+    ne: { type: GraphQLBoolean },
+  },
+}
+
+function convertToInputFilter(
+  prefix: string,
+  type: GraphQLInputType
+): GraphQLInputObjectType {
+  if (type instanceof GraphQLScalarType) {
+    const name = type.name
+    const fields = scalarFilterMap[name]
+
+    if (fields == null) {
+      throw new Error(`Unknown scalar type for input filter`)
+    }
+
+    return new GraphQLInputObjectType({
+      name: createTypeName(`${prefix}Query${name}`),
+      fields: fields,
+    })
+  } else if (type instanceof GraphQLInputObjectType) {
+    return new GraphQLInputObjectType({
+      name: createTypeName(`${prefix}{type.name}`),
+      fields: _.mapValues(type.getFields(), (fieldConfig, key) => {
+        try {
+          return {
+            type: convertToInputFilter(
+              `${prefix}${_.upperFirst(key)}`,
+              fieldConfig.type
+            ),
+          }
+        } catch (e) {
+          console.log(e)
+          return undefined
+        }
+      }),
+    })
+  } else if (type instanceof GraphQLList) {
+    const innerType = type.ofType
+    let innerFields = {}
+    try {
+      innerFields = convertToInputFilter(
+        `${prefix}ListElem`,
+        innerType
+      ).getFields()
+    } catch (e) {
+      console.log(e)
+    }
+
+    return new GraphQLInputObjectType({
+      name: createTypeName(`${prefix}QueryList`),
+      fields: {
+        ...innerFields,
+        in: { type: new GraphQLList(innerType) },
+      },
+    })
+  } else if (type instanceof GraphQLNonNull) {
+    return convertToInputFilter(prefix, type.ofType)
+  }
+
+  throw new Error(`Unknown input field type`)
+}
+
+function extractFieldNamesFromInputField(
+  prefix: string,
+  type: GraphQLInputType,
+  accu: string[]
+) {
+  if (type instanceof GraphQLScalarType || type instanceof GraphQLList) {
+    accu.push(prefix)
+  } else if (type instanceof GraphQLInputObjectType) {
+    _.each(type.getFields(), (fieldConfig, key) => {
+      extractFieldNamesFromInputField(
+        `${prefix}___${key}`,
+        fieldConfig.type,
+        accu
+      )
+    })
+  } else if (type instanceof GraphQLNonNull) {
+    extractFieldNamesFromInputField(prefix, type.ofType, accu)
+  } else {
+    throw new Error(`Unknown input field type`)
+  }
+}
+
+// convert output fields to output fields and a list of fields to sort on
+export function inferInputObjectStructureFromFields({
+  fields,
+  typeName = ``,
+}: any) {
+  const inferredFields = {}
+  const sort = []
+
+  _.each(fields, (fieldConfig, key) => {
+    try {
+      const inputType = convertToInputType(fieldConfig.type)
+      const filterType = convertToInputFilter(_.upperFirst(key), inputType)
+
+      inferredFields[createKey(key)] = {
+        type: filterType,
+      }
+
+      // Add sorting (but only to the top level).
+      if (typeName) {
+        extractFieldNamesFromInputField(key, inputType, sort)
+      }
+    } catch (e) {
+      console.log(key, fieldConfig, e)
+    }
+  })
+
+  return { inferredFields, sort }
+}
+
+// builds an input field for sorting, given an array of names to sort on
+export function createSortField(typeName: string, fieldNames: string[]) {
+  const enumValues = {}
+  fieldNames.forEach(field => {
+    enumValues[createKey(field)] = { value: field }
+  })
+
+  const SortByType = new GraphQLEnumType({
+    name: `${typeName}SortByFieldsEnum`,
+    values: enumValues,
+  })
+
+  return {
+    type: new GraphQLInputObjectType({
+      name: _.camelCase(`${typeName} sort`),
+      fields: {
+        fields: {
+          name: _.camelCase(`${typeName} sortFields`),
+          type: new GraphQLNonNull(new GraphQLList(SortByType)),
+        },
+        order: {
+          name: _.camelCase(`${typeName} sortOrder`),
+          defaultValue: `asc`,
+          type: new GraphQLEnumType({
+            name: _.camelCase(`${typeName} sortOrderValues`),
+            values: {
+              ASC: { value: `asc` },
+              DESC: { value: `desc` },
+            },
+          }),
+        },
+      },
+    }),
+  }
+}

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -17,7 +17,7 @@ const createTypeName = require(`./create-type-name`)
 const createKey = require(`./create-key`)
 const {
   extractFieldExamples,
-  buildFieldEnumValues,
+  extractFieldNames,
   isEmptyObjectOrArray,
 } = require(`./data-tree-utils`)
 
@@ -185,7 +185,7 @@ export function inferInputObjectStructureFromNodes({
   typeName = ``,
   prefix = ``,
   exampleValue = extractFieldExamples(nodes),
-}: InferInputOptions): GraphQLInputFieldConfigMap {
+}: InferInputOptions): Object {
   const inferredFields = {}
   const isRoot = !prefix
 
@@ -210,37 +210,9 @@ export function inferInputObjectStructureFromNodes({
   })
 
   // Add sorting (but only to the top level).
-  let sort
+  let sort = []
   if (typeName) {
-    const enumValues = buildFieldEnumValues(nodes)
-
-    const SortByType = new GraphQLEnumType({
-      name: `${typeName}SortByFieldsEnum`,
-      values: enumValues,
-    })
-
-    sort = {
-      type: new GraphQLInputObjectType({
-        name: _.camelCase(`${typeName} sort`),
-        fields: {
-          fields: {
-            name: _.camelCase(`${typeName} sortFields`),
-            type: new GraphQLNonNull(new GraphQLList(SortByType)),
-          },
-          order: {
-            name: _.camelCase(`${typeName} sortOrder`),
-            defaultValue: `asc`,
-            type: new GraphQLEnumType({
-              name: _.camelCase(`${typeName} sortOrderValues`),
-              values: {
-                ASC: { value: `asc` },
-                DESC: { value: `desc` },
-              },
-            }),
-          },
-        },
-      }),
-    }
+    sort = extractFieldNames(nodes)
   }
 
   return { inferredFields, sort }

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -5,13 +5,36 @@ const { connectionFromArray } = require(`graphql-skip-limit`)
 const { store } = require(`../redux/`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const prepareRegex = require(`./prepare-regex`)
+const Promise = require(`bluebird`)
 
 type Node = {
   id: String,
   type: String,
 }
 
-module.exports = ({ args, nodes, connection = false, path = `` }) => {
+function awaitSiftField(fields, node, k) {
+  const field = fields[k]
+  if (field.resolve) {
+    return field.resolve(node)
+  } else if (node[k]) {
+    return node[k]
+  }
+
+  return undefined
+}
+
+/*
+* Filters a list of nodes using mongodb-like syntax
+* Returns a single unwrapped element if connection = false
+*
+*/
+module.exports = ({
+  args,
+  nodes,
+  type,
+  connection = false,
+  path = ``,
+}: Object) => {
   // Clone args as for some reason graphql-js removes the constructor
   // from nested objects which breaks a check in sift.js.
   const clonedArgs = JSON.parse(JSON.stringify(args))
@@ -37,30 +60,85 @@ module.exports = ({ args, nodes, connection = false, path = `` }) => {
     return newObject
   }
 
+  // build an object that excludes the innermost leafs,
+  // this avoids including { eq: x } when resolving fields
+  function extractFieldsToSift(prekey, key, preobj, obj, val) {
+    if (_.isObject(val) && !_.isArray(val)) {
+      _.forEach((val: any), (v, k) => {
+        preobj[prekey] = obj
+        extractFieldsToSift(key, k, obj, {}, v)
+      })
+    } else {
+      preobj[prekey] = true
+    }
+  }
+
   const siftArgs = []
+  const fieldsToSift = {}
   if (clonedArgs.filter) {
     _.each(clonedArgs.filter, (v, k) => {
       // Ignore connection and sorting args
       if (_.includes([`skip`, `limit`, `sort`], k)) return
 
       siftArgs.push(siftifyArgs({ [k]: v }))
+      extractFieldsToSift(``, k, {}, fieldsToSift, v)
     })
   }
 
-  let result = _.isEmpty(siftArgs) ? nodes : sift({ $and: siftArgs }, nodes)
-
-  if (!result || !result.length) return
-
-  // Sort results.
-  if (clonedArgs.sort) {
-    const convertedFields = clonedArgs.sort.fields.map(field =>
-      field.replace(/___/g, `.`)
-    )
-
-    result = _.orderBy(result, convertedFields, clonedArgs.sort.order)
+  // resolves every field used in the sift
+  function resolveRecursive(node, siftFieldsObj, gqFields) {
+    return Promise.all(
+      _.keys(siftFieldsObj).map(k =>
+        Promise.resolve(awaitSiftField(gqFields, node, k))
+          .then(v => {
+            const innerSift = siftFieldsObj[k]
+            const innerGqConfig = gqFields[k]
+            if (_.isObject(innerSift) && v != null) {
+              return resolveRecursive(
+                v,
+                innerSift,
+                innerGqConfig.type.getFields()
+              )
+            } else {
+              return v
+            }
+          })
+          .then(v => [k, v])
+      )
+    ).then(resolvedFields => {
+      const myNode = { ...node }
+      resolvedFields.forEach(([k, v]) => (myNode[k] = v))
+      return myNode
+    })
   }
 
-  if (connection) {
+  return Promise.all(
+    nodes.map(node => resolveRecursive(node, fieldsToSift, type.getFields()))
+  ).then(myNodes => {
+    if (!connection) {
+      const index = _.isEmpty(siftArgs)
+        ? 0
+        : sift.indexOf({ $and: siftArgs }, myNodes)
+      return myNodes[index]
+    }
+
+    let result = _.isEmpty(siftArgs)
+      ? myNodes
+      : sift({ $and: siftArgs }, myNodes)
+
+    if (!result || !result.length) return
+
+    // Sort results.
+    if (clonedArgs.sort) {
+      // create functions that return the item to compare on
+      // uses _.get so nested fields can be retrieved
+      const convertedFields = clonedArgs.sort.fields
+        .map(field => field.replace(/___/g, `.`))
+        .map(field => v => _.get(v, field))
+
+      result = _.orderBy(result, convertedFields, clonedArgs.sort.order)
+    }
+
     const connectionArray = connectionFromArray(result, args)
     connectionArray.totalCount = result.length
     if (result.length > 0 && result[0].internal) {
@@ -70,12 +148,5 @@ module.exports = ({ args, nodes, connection = false, path = `` }) => {
       })
     }
     return connectionArray
-  }
-
-  createPageDependency({
-    path,
-    nodeId: result[0].id,
   })
-
-  return result[0]
 }


### PR DESCRIPTION
Makes fields added by `setFieldsOnGraphQLNodeType` filterable and sortable.
I didn't see any uses of `setFieldsOnGraphQLNodeType` in the tests so adding new tests felt like a non-starter.

Closes #1931