### PR TITLE
[gatsby-medium-source] convert timestamps to ISO 8601 date string

### DIFF
--- a/packages/gatsby-source-medium/src/gatsby-node.js
+++ b/packages/gatsby-source-medium/src/gatsby-node.js
@@ -40,7 +40,7 @@ exports.sourceNodes = async ({ boundActionCreators }, { username }) => {
 
     const resources = Array.prototype.concat(...importableResources)
     resources.map(resource => {
-      serializeBigInt(resource)
+      serialiseBigInt(resource)
 
       const digest = crypto
         .createHash(`md5`)

--- a/packages/gatsby-source-medium/src/gatsby-node.js
+++ b/packages/gatsby-source-medium/src/gatsby-node.js
@@ -8,6 +8,18 @@ const fetch = username => {
 
 const prefix = `])}while(1);</x>`
 
+const serializeBigInt = (nextObj, prevObj, prevKey) => {
+  if (typeof nextObj === "object") {
+    Object.keys(nextObj).map(function(key) {
+      crawlObject(nextObj[key], nextObj, key)
+    })
+  } else {
+    if (typeof nextObj === 'number' && (nextObj >> 0) !== nextObj) {
+      prevObj[prevKey] = String(nextObj)
+    }
+  }
+}
+
 const strip = payload => payload.replace(prefix, ``)
 
 exports.sourceNodes = async ({ boundActionCreators }, { username }) => {
@@ -29,6 +41,8 @@ exports.sourceNodes = async ({ boundActionCreators }, { username }) => {
 
     const resources = Array.prototype.concat(...importableResources)
     resources.map(resource => {
+      serializeBigInt(resource)
+
       const digest = crypto
         .createHash(`md5`)
         .update(JSON.stringify(resource))

--- a/packages/gatsby-source-medium/src/gatsby-node.js
+++ b/packages/gatsby-source-medium/src/gatsby-node.js
@@ -8,11 +8,10 @@ const fetch = username => {
 
 const prefix = `])}while(1);</x>`
 
-const serializeBigInt = (nextObj, prevObj, prevKey) => {
+const serialiseBigInt = (nextObj, prevObj, prevKey) => {
   if (typeof nextObj === "object") {
-    Object.keys(nextObj).map(function(key) {
-      crawlObject(nextObj[key], nextObj, key)
-    })
+    Object.keys(nextObj).map((key) =>
+      serialiseBigInt(nextObj[key], nextObj, key))
   } else {
     if (typeof nextObj === 'number' && (nextObj >> 0) !== nextObj) {
       prevObj[prevKey] = String(nextObj)

--- a/packages/gatsby-source-medium/src/gatsby-node.js
+++ b/packages/gatsby-source-medium/src/gatsby-node.js
@@ -8,13 +8,15 @@ const fetch = username => {
 
 const prefix = `])}while(1);</x>`
 
-const serialiseBigInt = (nextObj, prevObj, prevKey) => {
-  if (typeof nextObj === "object") {
-    Object.keys(nextObj).map((key) =>
-      serialiseBigInt(nextObj[key], nextObj, key))
+const convertTimestamps = (nextObj, prevObj, prevKey) => {
+  if (typeof nextObj === 'object') {
+    Object.keys(nextObj).map(key => convertTimestamps(nextObj[key], nextObj, key));
   } else {
-    if (typeof nextObj === 'number' && (nextObj >> 0) !== nextObj) {
-      prevObj[prevKey] = String(nextObj)
+    if (typeof nextObj === 'number' && nextObj >> 0 !== nextObj) {
+      const date = new Date(nextObj);
+      if (date.getTime() === nextObj) {
+        prevObj[prevKey] = date.toISOString().slice(0, 10);
+      }
     }
   }
 }
@@ -40,7 +42,7 @@ exports.sourceNodes = async ({ boundActionCreators }, { username }) => {
 
     const resources = Array.prototype.concat(...importableResources)
     resources.map(resource => {
-      serialiseBigInt(resource)
+      convertTimestamps(resource)
 
       const digest = crypto
         .createHash(`md5`)


### PR DESCRIPTION
Serialise values typeof numbers that overflow 32-bit signed integer for graphql Int values. 
More specifically the dates of Medium posts use timestamps which would return null.

### Before
<img width="1010" alt="screenshot 2017-09-13 01 37 39" src="https://user-images.githubusercontent.com/10136079/30354430-7bedbf54-9824-11e7-99da-ed05a977ab5b.png">

### After
<img width="1012" alt="screenshot 2017-09-13 01 39 23" src="https://user-images.githubusercontent.com/10136079/30354431-7bf165c8-9824-11e7-990b-12e524f4d42e.png">
