### PR TITLE
Add gatsby-starter-blog-no-styles to docs.

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -33,6 +33,11 @@ Official:
 
 Community:
 
+* [gatsby-starter-blog-no-styles](https://github.com/noahg/gatsby-starter-blog-no-styles) [(demo)](http://capricious-spring.surge.sh/)
+
+  Features:
+  * Same as official gatsby-starter-blog but with all styling removed
+
 * [gatsby-material-starter](https://github.com/Vagr9K/gatsby-material-starter) [(demo)](https://vagr9k.github.io/gatsby-material-starter/)
 
   Features:


### PR DESCRIPTION
Added a starter to the docs that is identical to gatsby-starter-blog, but with all styling removed (inline css, react-responsive-grid, gatsby-plugin-typography/compass-vertical-rhythm).

This makes it easier to get started blogging while adding styles using the user's choice of styling options (CSS Modules, Styled Components, etc.).