### PR TITLE
WIP Tutorial Part Two: make CSS for Glamor example match others

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -458,14 +458,19 @@ export default () =>
 
 Let's add the same inline `User` component but this time using Glamor's `css` prop.
 
-```jsx{5-21,27-35}
+```jsx{5-26,32-40}
 import React from "react"
 
 import Container from "../components/container"
 
 const User = props =>
   <div
-    css={{ display: `flex`, alignItems: `center`, margin: `0 auto 12px auto` }}
+    css={{
+      display: `flex`,
+      alignItems: `center`,
+      margin: `0 auto 12px auto`,
+      "&:last-child": { marginBottom: 0 }
+    }}
   >
     <img
       src={props.avatar}


### PR DESCRIPTION
The Tutorial Part Two example for Glamor is missing the `:last-child { marginBottom: 0 }` style that is present in both the CSS Modules and the Styled Components examples.

I added it and reformatted the line because it goes over 80 chars.

I need a little help with the rendering though. For some reason, this:

```javascript
  <div
    css={{
      display: `flex`,
      alignItems: `center`,
      margin: `0 auto 12px auto`,
      "&:last-child": { marginBottom: 0 }
    }}
  >
```

is getting turned into this:

![gatsby js tutorial part two - gatsbyjs 2017-09-14 14-50-25](https://user-images.githubusercontent.com/4315/30452368-7303ff3a-9963-11e7-964d-c206290d1d5d.png)

Further along, a mysterious newline also popped up that shouldn't be there (I didn't even change anything in that area):

![gatsby js tutorial part two - gatsbyjs 2017-09-14 15-07-02 2](https://user-images.githubusercontent.com/4315/30452445-b0dc6874-9963-11e7-8c51-0f58e5d2c28f.png)

Is there anything I'm doing wrong?