### PR TITLE
Appveyor build control

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - echo This example is built on %buildon% and the commit tag is %APPVEYOR_REPO_TAG% and the tag is %APPVEYOR_REPO_TAG_NAME%
     # we kill the build for most examples unless it is a release or a forced build
   - ps: |
-      if (($env:buildon -eq "tag") -and ($env:APPVEYOR_REPO_COMMIT_MESSAGE -ne "Publish") -and ($env:APPVEYOR_FORCED_BUILD -ne "True"))
+      if (($env:buildon -eq "tag") -and ($env:APPVEYOR_REPO_COMMIT_MESSAGE -ne "Publish") -and ($env:APPVEYOR_REPO_COMMIT_MESSAGE -notlike "* --build-all") -and ($env:APPVEYOR_FORCED_BUILD -ne "True"))
       {
         Exit-AppVeyorBuild
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,11 @@ cache:
 
 skip_branch_with_pr: true
 
+skip_commits:
+  files:
+    - docs/*
+    - www/*
+
 environment:
   nodejs_version: "8"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ environment:
 install:
   - echo This example is built on %buildon% and the commit tag is %APPVEYOR_REPO_TAG% and the tag is %APPVEYOR_REPO_TAG_NAME%
     # we kill the build for most examples unless it is a release or a forced build
+    # if you append --build-all to your commit message (not PR) then it will still build all the examples
   - ps: |
       if (($env:buildon -eq "tag") -and ($env:APPVEYOR_REPO_COMMIT_MESSAGE -ne "Publish") -and ($env:APPVEYOR_REPO_COMMIT_MESSAGE -notlike "* --build-all") -and ($env:APPVEYOR_FORCED_BUILD -ne "True"))
       {


### PR DESCRIPTION
This has two additions:
 - excludes builds from being started if commit/PR only edits the docs or www
 - if you append --build-all to the end of your commit message then it will build all of the examples for you
   - [in action](https://ci.appveyor.com/project/KyleAMathews/gatsby/build/1.0.2584)