### PR TITLE
Update gatsby-plugin-emotion to the latest version of emotion

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "emotion": "^5.2.0"
+    "emotion": "^7.3.2",
+    "react-emotion": "^7.3.2"
   }
 }


### PR DESCRIPTION
I've bumped the package versions of emotion / react-emotion for the plugin as this version is 2 majors behind.

Please note, I've noticed some issues I couldn't figure out with both old and new versions, the following fails I've noticed:

````javascript
import styled from "react-emotion";
import { css } from "emotion";

const MyDiv = props => (
  <div css={`background-color: green`}>{props.children}</div>
);

const NewDiv = styled(MyDiv)`background-color: red;`;
// This will render with background green, as if the new rule is ignored.

I believe this was happening with the previous version also though.
````