### PR TITLE
Typo: fix missing verb object and punctuation

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -269,7 +269,7 @@ Try editing the title in `siteMetadata`—change the title back to "Pandas Eatin
 
 Graph*i*QL is the GraphQL IDE. It's a powerful (and all-around awesome) tool you'll use often while building Gatsby websites.
 
-You can access when your site's development server is running—normally at http://localhost:8000/___graphql
+You can access it when your site's development server is running—normally at http://localhost:8000/___graphql.
 
 <video controls="controls" autoplay="true" loop="true">
   <source type="video/mp4" src="/graphiql-explore.mp4"></source>


### PR DESCRIPTION
I tested the site locally and the `.` doesn't interfere with the link.