### PR TITLE
Contentful plugin fixId will convert non string ids to string

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -29,13 +29,12 @@ exports.getLocalizedField = getLocalizedField
 // If the id starts with a number, left-pad it with a c (for Contentful of
 // course :-))
 const fixId = id => {
-  if (!typeof id === 'string') {
+  if (!_.isString(id)) {
     id = id.toString();
   }
   if (!isNaN(id.slice(0, 1))) {
     return `c${id}`
-  }
-  
+  }  
   return id
 }
 exports.fixId = fixId

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -29,10 +29,13 @@ exports.getLocalizedField = getLocalizedField
 // If the id starts with a number, left-pad it with a c (for Contentful of
 // course :-))
 const fixId = id => {
+  if (!typeof id === 'string') {
+    id = id.toString();
+  }
   if (!isNaN(id.slice(0, 1))) {
     return `c${id}`
   }
-
+  
   return id
 }
 exports.fixId = fixId


### PR DESCRIPTION
Contentful has a custom JSON field type where ids on entries can be manually set. In the case that an id property on an object is not a string, the 'fixId' function will break.

An example of how a custom JSON object in contentful would appear
![image](https://user-images.githubusercontent.com/5719229/30522985-025a27ac-9b96-11e7-9ecd-2c2e47b7af50.png)

If there is a better way or better place to do this, I am open to suggestions. Thanks.
