### PR TITLE
Fixing component key warning

### DIFF
--- a/examples/using-contentful/src/pages/index.js
+++ b/examples/using-contentful/src/pages/index.js
@@ -8,7 +8,7 @@ const propTypes = {
 }
 
 const Product = ({ node }) => (
-  <div key={node.id}>
+  <div>
     <Link
       style={{ color: `inherit`, textDecoration: `none` }}
       to={`/products/${node.id}/`}
@@ -63,11 +63,11 @@ class IndexPage extends React.Component {
           nodes from a single locale
         </p>
         <h3>en-US</h3>
-        {usProductEdges.map(({ node }, i) => <Product node={node} />)}
+        {usProductEdges.map(({ node }, i) => <Product node={node} key={node.id} />)}
         <br />
         <br />
         <h3>de</h3>
-        {deProductEdges.map(({ node }, i) => <Product node={node} />)}
+        {deProductEdges.map(({ node }, i) => <Product node={node} key={node.id} />)}
       </div>
     )
   }


### PR DESCRIPTION
Key should be set on the component instead of inside of it. Setting the key inside the component will cause a warning and not actually set the key. You can see this listed as incorrect usage here: https://facebook.github.io/react/docs/lists-and-keys.html#extracting-components-with-keys

⚠️  I didn't do any of the steps in the contributing guideline. I just wanted to make sure I didn't forget about it.