### PR TITLE
Add instructions to run build to generate manifest

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -52,3 +52,4 @@ plugins: [
   },
 ]
 ```
+To create `manifest.json`, you need to run `gatsby build`.


### PR DESCRIPTION
It wasn't clear to me that I needed to run `gatsby build` in order to generate the manifest, so adding instructions to make that more clear.