### PR TITLE
[plugin-react-next] fix React version check

### DIFF
--- a/packages/gatsby-plugin-react-next/src/gatsby-node.js
+++ b/packages/gatsby-plugin-react-next/src/gatsby-node.js
@@ -1,4 +1,5 @@
-const React = require(`react`)
+const path = require(`path`)
+const React = require(path.resolve(process.cwd(), `node_modules/react`))
 
 exports.modifyWebpackConfig = ({ config, stage }) => {
   if (React.version.slice(0, 2) !== `16`) {


### PR DESCRIPTION
fix https://github.com/gatsbyjs/gatsby/commit/0aff3b78659ad0e658319b734a1f94e3c7495532#commitcomment-24370006

Not sure if that’s the right way to require the root packages https://gist.github.com/branneman/8048520