### PR TITLE
[www] Fix #2136

### DIFF
--- a/www/src/components/card.js
+++ b/www/src/components/card.js
@@ -7,6 +7,7 @@ const Card = ({ children }) => (
     css={{
       boxSizing: `border-box`,
       display: `flex`,
+      transform: "translateZ(0)",
       [presets.Tablet]: {
         flex: `0 0 50%`,
         maxWidth: `50%`,
@@ -35,6 +36,7 @@ const Card = ({ children }) => (
       css={{
         padding: rhythm(presets.gutters.default / 2),
         paddingBottom: 0,
+        transform: "translateZ(0)",
         [presets.Mobile]: {
           padding: vP,
           paddingBottom: 0,

--- a/www/src/components/cards.js
+++ b/www/src/components/cards.js
@@ -11,6 +11,7 @@ const Cards = ({ children }) => (
       background: `#fff`,
       borderRadius: presets.radiusLg,
       boxShadow: `0 5px 20px rgba(25, 17, 34, 0.1)`,
+      transform: "translateZ(0)",
     }}
   >
     {children}

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -26,7 +26,7 @@ const stripeBg = {
 }
 const lineAnimation = css.keyframes({
   to: {
-    strokeDashoffset: 1000,
+    strokeDashoffset: 10,
   },
 })
 
@@ -74,16 +74,17 @@ const VerticalLine = () => (
     css={{ margin: `0 auto`, display: `block` }}
   >
     <line
-      className="path"
       x1="10"
+      y1="40"
       x2="10"
-      y1="110"
       y2="-10"
-      stroke={presets.brandLight}
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeDasharray="0.5, 10"
-      css={{ animation: `${lineAnimation} 40s linear infinite` }}
+      css={{
+        stroke: presets.brandLight,
+        strokeWidth: "3",
+        strokeLinecap: "round",
+        strokeDasharray: "0.5 10",
+        animation: `${lineAnimation} 400ms linear infinite`
+      }}
     />
   </svg>
 )

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -60,6 +60,7 @@ const SegmentTitle = ({ children }) => (
       ...scale(-2 / 5),
       lineHeight: 1,
       textTransform: `uppercase`,
+      transform: "translateZ(0)",
     }}
   >
     {children}
@@ -99,6 +100,7 @@ const borderAndBoxShadow = {
   width: `100%`,
   boxShadow: `0 5px 15px rgba(0,0,0,0.035)`,
   borderRadius: presets.radius,
+  transform: "translateZ(0)",
 }
 
 const SourceItems = ({ children }) => (

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -73,11 +73,8 @@ const VerticalLine = () => (
     viewBox="0 0 20 30"
     css={{ margin: `0 auto`, display: `block` }}
   >
-    <line
-      x1="10"
-      y1="40"
-      x2="10"
-      y2="-10"
+    <path
+      d="M10 40 L10 -10"
       css={{
         stroke: presets.brandLight,
         strokeWidth: "3",

--- a/www/src/components/used-by.js
+++ b/www/src/components/used-by.js
@@ -47,6 +47,7 @@ const UsedBy = () => (
         .animation.curveDefault}`,
       order: `3`,
       flexGrow: `1`,
+      transform: "translateZ(0)",
       [presets.Phablet]: {
         paddingTop: rhythm(4),
         marginBottom: 0,
@@ -77,6 +78,7 @@ const UsedBy = () => (
         flexGrow: `1`,
         flexShrink: `1`,
         alignSelf: `flex-end`,
+        transform: "translateZ(0)",
         [presets.Phablet]: {
           flexGrow: `0`,
         },


### PR DESCRIPTION
Lowers the CPU usage of the gatsbyjs.org homepage from ~65% to ~30% in Safari with the window >"Desktop" size (with flexbox layout kicking in for the `<Cards>` components) by giving the elements currently being repainted by Safari their own layers in the compositor – repaints 💨 .
Tested on a Mid-2012 retina MBP in Safari v10.1.2 (11603.3.8). Fixes #2136.