### PR TITLE
removed babel-preset-2015 from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
-    "babel-preset-es2015": "^6.24.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",


### PR DESCRIPTION
Noticed that we don't use 2015 preset in the bablerc file.  so It would be best to remove it also babel-preset-env is more powerful and it is used at the moment.