### PR TITLE
[gatsby-source-drupal] amend graphql author node key

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -88,7 +88,7 @@ exports.sourceNodes = async (
         ...node.internal,
         type: makeTypeName(node.internal.type),
       },
-      author___NODE: result.data.data[i].relationships.uid.data.id,
+      uid: result.data.data[i].relationships.uid.data.id,
     }
 
     // Get content digest of node.


### PR DESCRIPTION
Hello,

The author node key seems to have an additional underscore. When graphql tries to infer a type it fails. While author__NODE works fine, the uid key is not passed in the node attributes. The uid key also matches it's relationship key returned from Drupal. Not sure how comfortable you feel about this simplification tho. This makes the graph query for getting page context like:

`
allDrupalNodeArticle(limit: 1000) {
  edges {
    node {
      id
      nid
      uid
    }
  }
}
`