### PR TITLE
Enable all feature sets by default and allow opting out

### DIFF
--- a/packages/gatsby-plugin-lodash/README.md
+++ b/packages/gatsby-plugin-lodash/README.md
@@ -16,3 +16,15 @@ plugins: [
 ]
 ```
 
+By default this plugin enables all [feature sets](https://github.com/lodash/lodash-webpack-plugin#feature-sets). If you know you don't need some of them, you can remove support for features sets by setting a `disabledFeatures` option like the following:
+
+```javascript
+plugins: [
+  {
+    resolve: `gatsby-plugin-lodash`,
+    options: {
+      disabledFeatures: [`shorthands`, `cloning`]
+    },
+  },
+]
+```

--- a/packages/gatsby-plugin-lodash/src/gatsby-node.js
+++ b/packages/gatsby-plugin-lodash/src/gatsby-node.js
@@ -1,9 +1,31 @@
 const webpackLodashPlugin = require(`lodash-webpack-plugin`)
 
 // Add Lodash webpack plugin
-exports.modifyWebpackConfig = ({ config, stage }) => {
+exports.modifyWebpackConfig = ({ config, stage }, { disabledFeatures }) => {
   if (stage === `build-javascript`) {
-    config.plugin(`Lodash`, webpackLodashPlugin, null)
+    const features = {
+      shorthands: true,
+      cloning: true,
+      currying: true,
+      caching: true,
+      collections: true,
+      exotics: true,
+      guards: true,
+      metadata: true,
+      deburring: true,
+      unicode: true,
+      chaining: true,
+      memoizing: true,
+      coercions: true,
+      flattening: true,
+      paths: true,
+      placeholders: true,
+    }
+
+    disabledFeatures.forEach(feature => {
+      delete features[feature]
+    })
+    config.plugin(`Lodash`, webpackLodashPlugin, features)
   }
 
   return


### PR DESCRIPTION
This is a safer default as it won't break anyone's site unexpectedly per conversation yesterday with @jdalton https://github.com/gatsbyjs/gatsby/pull/2162#discussion_r139573055