### PR TITLE
Add plugin: `gatsby-plugin-purify-css`

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -127,6 +127,7 @@ you can place the files in a `src` subfolder and build them to the plugin folder
 * [gatsby-plugin-i18n-tags](https://github.com/angeloocana/gatsby-plugin-i18n-tags)
 * [gatsby-plugin-i18n-readnext](https://github.com/angeloocana/gatsby-plugin-i18n-readnext)
 * [gatsby-plugin-protoculture](https://github.com/atrauzzi/gatsby-plugin-protoculture)
+* [gatsby-plugin-purify-css](https://github.com/rongierlach/gatsby-plugin-purify-css)
 * [gatsby-plugin-yandex-metrika](https://github.com/viatsko/gatsby-plugin-yandex-metrika)
 * [gatsby-remark-emoji](https://github.com/Rulikkk/gatsby-remark-emoji)
 * [gatsby-source-workable](https://github.com/tumblbug/gatsby-source-workable)


### PR DESCRIPTION
A Gatsby post-build plugin that implements PurifyCSS.
The plugin updates your html files directly, removing any unused inline styles.
Example Gatsby app is in the [repo](https://github.com/rongierlach/gatsby-plugin-purify-css).