### PR TITLE
Use ellipsis instead of `...` for pruning excerpts

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -254,7 +254,7 @@ module.exports = (
           return getAST(markdownNode).then(ast => {
             const textNodes = []
             visit(ast, `text`, textNode => textNodes.push(textNode.value))
-            return prune(textNodes.join(` `), pruneLength)
+            return prune(textNodes.join(` `), pruneLength, '\u2026')
           })
         },
       },

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -254,7 +254,7 @@ module.exports = (
           return getAST(markdownNode).then(ast => {
             const textNodes = []
             visit(ast, `text`, textNode => textNodes.push(textNode.value))
-            return prune(textNodes.join(` `), pruneLength, '\u2026')
+            return prune(textNodes.join(` `), pruneLength, '…')
           })
         },
       },


### PR DESCRIPTION
Additionally, I would like to suggest adding a property for overriding the overflow indicator string.