### PR TITLE
gatsby-plugin-netlify tweaks

### DIFF
--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "fs-extra": "^4.0.2",
     "lodash": "^4.17.4",
-    "pify": "3.0.0",
     "webpack-assets-manifest": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -1,6 +1,5 @@
 import _ from "lodash"
-import fs from "fs"
-import pify from "pify"
+import { writeFile } from "fs-extra"
 
 import {
   ROOT_WILDCARD,
@@ -10,8 +9,6 @@ import {
   LINK_REGEX,
   NETLIFY_HEADERS_FILENAME,
 } from "./constants"
-
-const writeFile = pify(fs.writeFile)
 
 function validHeaders(headers) {
   if (!headers || !_.isObject(headers)) {
@@ -228,9 +225,7 @@ const applyTransfromHeaders = ({ transformHeaders }) => headers =>
   _.mapValues(headers, transformHeaders)
 
 const transformToString = headers =>
-  `## Created with gatsby-plugin-netlify\n\n${stringifyHeaders(
-    headers
-  )}`
+  `## Created with gatsby-plugin-netlify\n\n${stringifyHeaders(headers)}`
 
 const writeHeadersFile = ({ publicFolder }) => contents =>
   writeFile(publicFolder(NETLIFY_HEADERS_FILENAME), contents)

--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -1,5 +1,6 @@
 import _ from "lodash"
 import { writeFile } from "fs-extra"
+import { HEADER_COMMENT } from "./constants"
 
 import {
   ROOT_WILDCARD,
@@ -225,7 +226,7 @@ const applyTransfromHeaders = ({ transformHeaders }) => headers =>
   _.mapValues(headers, transformHeaders)
 
 const transformToString = headers =>
-  `## Created with gatsby-plugin-netlify\n\n${stringifyHeaders(headers)}`
+  `${HEADER_COMMENT}\n\n${stringifyHeaders(headers)}`
 
 const writeHeadersFile = ({ publicFolder }) => contents =>
   writeFile(publicFolder(NETLIFY_HEADERS_FILENAME), contents)

--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -31,3 +31,5 @@ export const LINK_REGEX = /^(Link: <\/)(.+)(>;.+)/
 export const ROOT_WILDCARD = `/*`
 
 export const COMMON_BUNDLES = [`commons`, `app`]
+
+export const HEADER_COMMENT = `## Created with gatsby-plugin-netlify`

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -14,8 +14,6 @@ export default async function writeRedirectsFile(pluginData, redirects) {
       return `${redirect.fromPath}  ${redirect.toPath}  ${status}`
     })
 
-    const data = `${HEADER_COMMENT}\n\n${redirects.join(`\n`)}`
-
     let appendToFile = false
 
     // Websites may also have statically defined redirects
@@ -28,6 +26,8 @@ export default async function writeRedirectsFile(pluginData, redirects) {
         appendToFile = true
       }
     }
+
+    const data = `${HEADER_COMMENT}\n\n${redirects.join(`\n`)}`
 
     return appendToFile
       ? appendFile(FILE_PATH, `\n\n${data}`)

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -1,4 +1,5 @@
-import { appendFile, exists, writeFile } from "fs-extra"
+import { HEADER_COMMENT } from "./constants"
+import { appendFile, exists, readFile, writeFile } from "fs-extra"
 
 export default async function writeRedirectsFile(pluginData, redirects) {
   const { publicFolder } = pluginData
@@ -6,19 +7,29 @@ export default async function writeRedirectsFile(pluginData, redirects) {
   if (redirects.length > 0) {
     const FILE_PATH = publicFolder(`_redirects`)
 
+    // Map redirect data to the format Netlify expects
     // https://www.netlify.com/docs/redirects/
     redirects = redirects.map(redirect => {
       const status = redirect.isPermanent ? 301 : 302
       return `${redirect.fromPath}  ${redirect.toPath}  ${status}`
     })
 
-    const data = `## Created with gatsby-plugin-netlify\n\n${redirects.join(
-      `\n`
-    )}`
+    const data = `${HEADER_COMMENT}\n\n${redirects.join(`\n`)}`
 
+    let appendToFile = false
+
+    // Websites may also have statically defined redirects
+    // In that case we should append to them (not overwrite)
+    // Make sure we aren't just looking at previous build results though
     const fileExists = await exists(FILE_PATH)
+    if (fileExists) {
+      const fileContents = await readFile(FILE_PATH)
+      if (fileContents.indexOf(HEADER_COMMENT) < 0) {
+        appendToFile = true
+      }
+    }
 
-    return fileExists
+    return appendToFile
       ? appendFile(FILE_PATH, `\n\n${data}`)
       : writeFile(FILE_PATH, data)
   }

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -1,16 +1,25 @@
-import fs from "fs"
-import pify from "pify"
+import { appendFile, exists, writeFile } from "fs-extra"
 
-const writeFile = pify(fs.writeFile)
-
-export default function writeRedirectsFile(pluginData, redirects) {
+export default async function writeRedirectsFile(pluginData, redirects) {
   const { publicFolder } = pluginData
 
-  // https://www.netlify.com/docs/redirects/
-  const data = redirects.map(redirect => {
-    const status = redirect.isPermanent ? 301 : 302
-    return `${redirect.fromPath}  ${redirect.toPath}  ${status}`
-  })
+  if (redirects.length > 0) {
+    const FILE_PATH = publicFolder(`_redirects`)
 
-  return writeFile(publicFolder(`_redirects`), data.join(`\n`))
+    // https://www.netlify.com/docs/redirects/
+    redirects = redirects.map(redirect => {
+      const status = redirect.isPermanent ? 301 : 302
+      return `${redirect.fromPath}  ${redirect.toPath}  ${status}`
+    })
+
+    const data = `## Created with gatsby-plugin-netlify\n\n${redirects.join(
+      `\n`
+    )}`
+
+    const fileExists = await exists(FILE_PATH)
+
+    return fileExists
+      ? appendFile(FILE_PATH, `\n\n${data}`)
+      : writeFile(FILE_PATH, data)
+  }
 }

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -35,6 +35,8 @@ exports.onPostBuild = async ({ store, pathPrefix }, userPluginOptions) => {
 
   const { redirects } = store.getState()
 
-  await buildHeadersProgram(pluginData, pluginOptions)
-  await createRedirects(pluginData, redirects)
+  await Promise.all([
+    buildHeadersProgram(pluginData, pluginOptions),
+    createRedirects(pluginData, redirects),
+  ])
 }


### PR DESCRIPTION
* Only write `_redirects` file if redirects have been declared.
* Append to `_redirects` file is user has defined one already in the `static` folder.
* Write header and redirects files in parallel.
* Replaced `pify` package with `fs-extra`.

Follow-up to #2185