### PR TITLE
[WIP] Add automated release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,10 @@ install:
 
 script:
   - npm test
+
+after_success:
+  - yarn run semantic-release
+
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - npm test
 
 after_success:
-  - yarn run semantic-release
+  - yarn run lerna-semantic-release
 
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "publish-canary": "lerna publish --canary --yes",
     "publish-next": "lerna publish --npm-tag=next",
     "remotedev": "remotedev --hostname=localhost --port=19999",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "lerna-semantic-release": "lerna-semantic-release pre && lerna-semantic-release perform && lerna-semantic-release post",
     "test": "jest",
     "test:update": "jest --updateSnapshot",
     "test:watch": "jest --watch",
@@ -61,12 +61,13 @@
     "watch": "lerna run watch --no-sort --stream --concurrency 999"
   },
   "devDependencies": {
+    "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",
     "semantic-release": "^8.0.0"
   },
   "config": {
     "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
+      "path": "./node_modules/cz-lerna-changelog"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,10 +53,20 @@
     "publish-canary": "lerna publish --canary --yes",
     "publish-next": "lerna publish --npm-tag=next",
     "remotedev": "remotedev --hostname=localhost --port=19999",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "test": "jest",
     "test:update": "jest --updateSnapshot",
     "test:watch": "jest --watch",
     "test_bkup": "npm run lint && npm run test-node && npm run test-integration",
     "watch": "lerna run watch --no-sort --stream --concurrency 999"
+  },
+  "devDependencies": {
+    "cz-conventional-changelog": "^2.0.0",
+    "semantic-release": "^8.0.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
So this PR is adding `lerna-semantic-release`.

Why? 
* No need to share credentials between maintainers to be able to publish plugins.
* Automatic versioning based on commit messages.
* Automatic publishing to npm and changelog generation (Github releases)

### TODO

- [ ] @KyleAMathews you need to add these env params to Travis CI.
```
NPM_CONFIG_EMAIL 
NPM_CONFIG_USERNAME 
NPM_TOKEN 
GH_TOKEN 
RELEASE_GH_TOKEN
RELEASE_GH_USERNAME
```
- [ ] Update CONTRIBUTE.md
