### PR TITLE
Pin our version of Relay Compiler

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -97,7 +97,7 @@
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "redux": "^3.6.0",
-    "relay-compiler": "^1.1.0",
+    "relay-compiler": "1.3.0",
     "remote-redux-devtools": "^0.5.7",
     "resolve-cwd": "^2.0.0",
     "sift": "^3.2.6",


### PR DESCRIPTION
Apparently the new version of relay-compiler broke us. In any case,
 we should be pinning as we're reaching into their internals which significantly ups the odds of us seeing problems on new versions.