### PR TITLE
Allow index.html to be served from file protocol

### DIFF
--- a/packages/gatsby/cache-dir/find-page.js
+++ b/packages/gatsby/cache-dir/find-page.js
@@ -55,7 +55,12 @@ module.exports = (pages, pathPrefix = ``) => pathname => {
         return true
       }
 
-      if (trimmedPathname == page.path + 'index.html') {
+      // Finally, try and match request with default document.
+      if (
+        matchPath(trimmedPathname, {
+          path: page.path + 'index.html'
+        })
+      ) {
         foundPage = page
         pageCache[trimmedPathname] = page
         return true

--- a/packages/gatsby/cache-dir/find-page.js
+++ b/packages/gatsby/cache-dir/find-page.js
@@ -54,6 +54,12 @@ module.exports = (pages, pathPrefix = ``) => pathname => {
         pageCache[trimmedPathname] = page
         return true
       }
+
+      if (trimmedPathname == page.path + 'index.html') {
+        foundPage = page
+        pageCache[trimmedPathname] = page
+        return true
+      }
     }
 
     return false


### PR DESCRIPTION
Hey Kyle, hope you're well. 

recently we've had a situation where Gatsby had to be built and shipped off to a closed system. There are extreme security requirements around this system and therefore no web server could be used to serve Gatsby. While setting pathPrefix eliminated the majority of our issues we still had a problem serving the index of each page / the index.html from each subfolder. Named pages, such as 404.html worked fine.