### PR TITLE
fix gatsby link typescript definition

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
+import { NavLinkProps } from "react-router-dom";
 
-export interface GatsbyLinkProps {
+export interface GatsbyLinkProps extends NavLinkProps {
   to: string;
   onClick?: (event: any) => void
 }


### PR DESCRIPTION
The typescript definition only declared the props that GatsbyLink **added**, omitting the fact that the props of `NavLink` are available and valid as well.

Currently, this leads to typescript errors like 
```
Property 'className' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<GatsbyLink> & Readonly<{ children?: ReactNode; }> ...'.
```

In this case, I wanted to specify a `className` for a `GatsbyLink`.


By extending the `GatsbyLinkProps` from  `NavLinkProps`, Typescript knows that all the `NavLinkProps` are available and valid as well.