### PR TITLE
Building and deploying multiple sites within the same Gatsby app - Issue 2189

### DIFF
--- a/packages/gatsby/src/bin/cli.js
+++ b/packages/gatsby/src/bin/cli.js
@@ -7,7 +7,6 @@ const packageJson = require(`../../package.json`)
 const path = require(`path`)
 const _ = require(`lodash`)
 const Promise = require(`bluebird`)
-const resolveCwd = require(`resolve-cwd`)
 
 const report = require(`../reporter`)
 
@@ -72,14 +71,17 @@ if (inGatsbySite) {
     )
     .option(
       `-r, --rootDir <rootDir>`,
-      `Specify where your node_modules reside.`,
+      `Specify where your project root node_modules are.`,
       `./`
     )
     .option(`-p, --port <port>`, `Set port. Defaults to 8000`, `8000`)
     .option(`-o, --open`, `Open the site in your browser for you.`)
     .action(command => {
       command.rootDir = path.resolve(command.rootDir)
-      const developPath = `../utils/develop`
+      const developPath = path.resolve(
+        command.rootDir,
+        `gatsby/dist/utils/develop`
+      )
       const develop = require(developPath)
       // console.timeEnd(`time to load develop`)
       const { sitePackageJson, browserslist } = getSiteInfo()
@@ -101,15 +103,14 @@ if (inGatsbySite) {
     )
     .option(
       `-r, --rootDir <rootDir>`,
-      `Specify where your node_modules reside.`,
+      `Specify where your project root node_modules are.`,
       `./`
     )
     .action(command => {
       // Set NODE_ENV to 'production'
       process.env.NODE_ENV = `production`
       command.rootDir = path.resolve(command.rootDir)
-      const buildPath = `../utils/build`
-      // const buildPath = resolveCwd(`gatsby/dist/utils/build`)
+      const buildPath = path.resolve(command.rootDir, `gatsby/dist/utils/build`)
       const build = require(buildPath)
       const { sitePackageJson, browserslist } = getSiteInfo()
       const p = {
@@ -132,10 +133,16 @@ if (inGatsbySite) {
       `Set host. Defaults to ${defaultHost}`,
       defaultHost
     )
+    .option(
+      `-r, --rootDir <rootDir>`,
+      `Specify where your project root node_modules are.`,
+      `./`
+    )
     .option(`-p, --port <port>`, `Set port. Defaults to 9000`, `9000`)
     .option(`-o, --open`, `Open the site in your browser for you.`)
     .action(command => {
-      const servePath = resolveCwd(`gatsby/dist/utils/serve`)
+      const servePath = path.resolve(command.rootDir, `gatsby/dist/utils/serve`)
+      command.rootDir = path.resolve(command.rootDir)
       const serve = require(servePath)
       const { sitePackageJson, browserslist } = getSiteInfo()
       const p = {

--- a/packages/gatsby/src/bin/cli.js
+++ b/packages/gatsby/src/bin/cli.js
@@ -70,10 +70,16 @@ if (inGatsbySite) {
       `Set host. Defaults to ${defaultHost}`,
       defaultHost
     )
+    .option(
+      `-r, --rootDir <rootDir>`,
+      `Specify where your node_modules reside.`,
+      `./`
+    )
     .option(`-p, --port <port>`, `Set port. Defaults to 8000`, `8000`)
     .option(`-o, --open`, `Open the site in your browser for you.`)
     .action(command => {
-      const developPath = resolveCwd(`gatsby/dist/utils/develop`)
+      command.rootDir = path.resolve(command.rootDir)
+      const developPath = `../utils/develop`
       const develop = require(developPath)
       // console.timeEnd(`time to load develop`)
       const { sitePackageJson, browserslist } = getSiteInfo()
@@ -93,11 +99,17 @@ if (inGatsbySite) {
       `--prefix-paths`,
       `Build site with link paths prefixed (set prefix in your config).`
     )
+    .option(
+      `-r, --rootDir <rootDir>`,
+      `Specify where your node_modules reside.`,
+      `./`
+    )
     .action(command => {
       // Set NODE_ENV to 'production'
       process.env.NODE_ENV = `production`
-
-      const buildPath = resolveCwd(`gatsby/dist/utils/build`)
+      command.rootDir = path.resolve(command.rootDir)
+      const buildPath = `../utils/build`
+      // const buildPath = resolveCwd(`gatsby/dist/utils/build`)
       const build = require(buildPath)
       const { sitePackageJson, browserslist } = getSiteInfo()
       const p = {

--- a/packages/gatsby/src/gatsby-cli.js
+++ b/packages/gatsby/src/gatsby-cli.js
@@ -21,7 +21,6 @@ if (verDigit < 4) {
 */
 const cliFile = `dist/bin/cli.js`
 const localPath = path.resolve(`node_modules/gatsby`, cliFile)
-const parentPath = path.resolve(`../node_modules/gatsby`, cliFile)
 
 const useGlobalGatsby = function() {
   // Never use global install *except* for new and help commands
@@ -41,8 +40,6 @@ if (fs.existsSync(localPath)) {
   } catch (error) {
     report.error(`A local install of Gatsby exists but failed to load.`, error)
   }
-} else if (fs.existsSync(parentPath)) {
-  require(parentPath)
 } else {
   useGlobalGatsby()
 }

--- a/packages/gatsby/src/gatsby-cli.js
+++ b/packages/gatsby/src/gatsby-cli.js
@@ -21,12 +21,13 @@ if (verDigit < 4) {
 */
 const cliFile = `dist/bin/cli.js`
 const localPath = path.resolve(`node_modules/gatsby`, cliFile)
+const parentPath = path.resolve(`../node_modules/gatsby`, cliFile)
 
 const useGlobalGatsby = function() {
   // Never use global install *except* for new and help commands
   if (!_.includes([`new`, `--help`], process.argv[2])) {
     report.panic(
-      `A local install of Gatsby was not found. \n` +
+      `A local install of Gatsby was not found in the current working directory nor in its parent directory. \n` +
         `You should save Gatsby as a site dependency e.g. npm install --save gatsby`
     )
   }
@@ -40,6 +41,8 @@ if (fs.existsSync(localPath)) {
   } catch (error) {
     report.error(`A local install of Gatsby exists but failed to load.`, error)
   }
+} else if (fs.existsSync(parentPath)) {
+  require(parentPath)
 } else {
   useGlobalGatsby()
 }

--- a/packages/gatsby/src/utils/build-html.js
+++ b/packages/gatsby/src/utils/build-html.js
@@ -9,7 +9,7 @@ const { createErrorFromString } = require(`../reporter/errors`)
 const debug = require(`debug`)(`gatsby:html`)
 
 module.exports = async (program: any) => {
-  const { directory } = program
+  const { rootDir } = program
 
   debug(`generating static HTML`)
   // Reduce pages objects to an array of paths.
@@ -18,7 +18,7 @@ module.exports = async (program: any) => {
   // Static site generation.
   const compilerConfig = await webpackConfig(
     program,
-    directory,
+    rootDir,
     `build-html`,
     null,
     pages
@@ -29,7 +29,7 @@ module.exports = async (program: any) => {
       if (e) {
         return reject(e)
       }
-      const outputFile = `${directory}/public/render-page.js`
+      const outputFile = `${process.cwd()}/public/render-page.js`
       if (stats.hasErrors()) {
         let webpackErrors = stats.toJson().errors
         return reject(

--- a/packages/gatsby/src/utils/develop-html.js
+++ b/packages/gatsby/src/utils/develop-html.js
@@ -7,14 +7,14 @@ const { createErrorFromString } = require(`../reporter/errors`)
 const debug = require(`debug`)(`gatsby:html`)
 
 module.exports = async (program: any) => {
-  const { directory } = program
+  const { rootDir } = program
 
   debug(`generating static HTML`)
 
   // Static site generation.
   const compilerConfig = await webpackConfig(
     program,
-    directory,
+    rootDir,
     `develop-html`,
     null,
     [`/`]
@@ -25,7 +25,7 @@ module.exports = async (program: any) => {
       if (e) {
         return reject(e)
       }
-      const outputFile = `${directory}/public/render-page.js`
+      const outputFile = `${process.cwd()}/public/render-page.js`
       if (stats.hasErrors()) {
         let webpackErrors = stats.toJson().errors
         return reject(

--- a/packages/gatsby/src/utils/develop.js
+++ b/packages/gatsby/src/utils/develop.js
@@ -33,7 +33,7 @@ rlInterface.on(`SIGINT`, () => {
 })
 
 async function startServer(program) {
-  const directory = program.directory
+  const directory = program.rootDir
   const directoryPath = withBasePath(directory)
   const createIndexHtml = () =>
     developHtml(program).catch(err => {
@@ -85,7 +85,7 @@ async function startServer(program) {
     })
   )
 
-  app.use(express.static(__dirname + `/public`))
+  app.use(express.static(process.cwd() + `/public`))
 
   app.use(
     require(`webpack-dev-middleware`)(compiler, {

--- a/packages/gatsby/src/utils/serve.js
+++ b/packages/gatsby/src/utils/serve.js
@@ -12,7 +12,6 @@ const rlInterface = rl.createInterface({
 const debug = require(`debug`)(`gatsby:application`)
 
 function startServer(program, launchPort) {
-  const directory = program.directory
   const serverPort = launchPort || program.port
 
   debug(`Serving /public`)
@@ -28,7 +27,7 @@ function startServer(program, launchPort) {
     path: `/{path*}`,
     handler: {
       directory: {
-        path: `${directory}/public`,
+        path: `${process.cwd()}/public`,
         listing: false,
         index: true,
       },

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = async (
   pages = []
 ) => {
   const babelStage = suppliedStage
-  const directoryPath = withBasePath(directory)
+  const directoryPath = withBasePath(process.cwd())
 
   // We combine develop & develop-html stages for purposes of generating the
   // webpack config.


### PR DESCRIPTION
All gatsby commands (`develop`, `build`, `serve`) now accept an arg `--rootDir` to specify where the root node_modules reside.

NOTE:
Requires `relay-compiler v 1.3.0` for some of the files used in the processes, such as `relayCompilerContext.js`. That file did not exist in `v 1.4.0`

Is a possible solution to the problem discussed in issue #2189 