### PR TITLE
[RFR] fix page not found when path contain uri encoded character

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/find-page.js
+++ b/packages/gatsby/cache-dir/__tests__/find-page.js
@@ -16,6 +16,11 @@ describe(`find-page`, () => {
         jsonName: `about-me.json`,
       },
       {
+        path: `/about/the best/`,
+        componentChunkName: `page-component---src-pages-test-js`,
+        jsonName: `the-best.json`,
+      },
+      {
         path: `/app/`,
         matchPath: `/app/*`,
         componentChunkName: `page-component---src-pages-app-js`,
@@ -28,6 +33,11 @@ describe(`find-page`, () => {
   it(`can find a page`, () => {
     expect(findPage(`/about/`).path).toBe(`/about/`)
     expect(findPage(`/about/me/`).path).toBe(`/about/me/`)
+  })
+
+  it(`can find a page with space in its path`, () => {
+    expect(findPage(`/about/the best/`).path).toBe(`/about/the best/`)
+    expect(findPage(`/about/the%20best/`).path).toBe(`/about/the best/`)
   })
 
   it(`can find a client only path`, () => {

--- a/packages/gatsby/cache-dir/find-page.js
+++ b/packages/gatsby/cache-dir/find-page.js
@@ -3,7 +3,8 @@ import { matchPath } from "react-router-dom"
 
 const pageCache = {}
 
-module.exports = (pages, pathPrefix = ``) => pathname => {
+module.exports = (pages, pathPrefix = ``) => rawPathname => {
+  let pathname = decodeURIComponent(rawPathname)
   // Remove the pathPrefix from the pathname.
   let trimmedPathname = pathname.slice(pathPrefix.length)
 


### PR DESCRIPTION
By using your great tools, I run into the following issue :

If the path contain encoded character in its path eg `%20` instead of ` `, then the page is not found.

example: 
```
A page wasn't found for "/blog/2016/12/08/you%20will%20not%20find%20me.html" loader.js:251 
```
So here is a quick fix.
