### PR TITLE
Allow subobjects in markdown frontmatter arrays to link to files

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -6,6 +6,7 @@ Array [
     Object {
       "children": Array [],
       "frontmatter": Object {
+        "___PARENT": "whatever",
         "date": "2017-09-18T23:19:51.246Z",
         "parent": "whatever",
         "title": "my little pony",
@@ -35,6 +36,7 @@ Array [
       "child": Object {
         "children": Array [],
         "frontmatter": Object {
+          "___PARENT": "whatever",
           "date": "2017-09-18T23:19:51.246Z",
           "parent": "whatever",
           "title": "my little pony",

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -47,9 +47,26 @@ module.exports = async function onCreateNode({
       type: `MarkdownRemark`,
     },
   }
+
+  // Add ___PARENT to sub-object in the frontmatter so we can
+  // use this to find the root markdown node when running GraphQL
+  // queries. Yes this is lame. But it's because in GraphQL child nodes
+  // can't access their parent nodes so we use this ___PARENT convention
+  // to get around this.
+  _.each(data.data, (v, k) => {
+    if (_.isArray(v) && _.isObject(v[0])) {
+      data.data[k] = v.map(o => {
+        return { ...o, ___PARENT: node.id }
+      })
+    }
+  })
+
   markdownNode.frontmatter = {
     title: ``, // always include a title
     ...data.data,
+    ___PARENT: node.id,
+    // TODO Depreciate this at v2 as much larger chance of conflicting with a
+    // user supplied field.
     parent: node.id,
   }
 

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -345,11 +345,15 @@ function findRootNode(node) {
   let rootNode = node
   let whileCount = 0
   while (
-    rootNode.parent &&
-    getNode(rootNode.parent) !== undefined &&
+    (rootNode.___PARENT || rootNode.parent) &&
+    (getNode(rootNode.parent) !== undefined || getNode(rootNode.___PARENT)) &&
     whileCount < 101
   ) {
-    rootNode = getNode(rootNode.parent)
+    if (rootNode.___PARENT) {
+      rootNode = getNode(rootNode.___PARENT)
+    } else {
+      rootNode = getNode(rootNode.parent)
+    }
     whileCount += 1
     if (whileCount > 100) {
       console.log(
@@ -363,13 +367,6 @@ function findRootNode(node) {
 }
 
 function shouldInferFile(nodes, key, value) {
-  // Find the node used for this example.
-  const node = nodes.find(n => _.get(n, key) === value)
-
-  if (!node) {
-    return false
-  }
-
   const looksLikeFile =
     _.isString(value) &&
     mime.lookup(value) !== `application/octet-stream` &&
@@ -380,6 +377,68 @@ function shouldInferFile(nodes, key, value) {
 
   if (!looksLikeFile) {
     return false
+  }
+
+  // Find the node used for this example.
+  let node = nodes.find(n => _.get(n, key) === value)
+
+  if (!node) {
+    // Try another search as our "key" isn't always correct e.g.
+    // it doesn't support arrays so the right key could be "a.b[0].c" but
+    // this function will get "a.b.c".
+    //
+    // We loop through every value of nodes until we find
+    // a match.
+    const visit = (current, selector = [], fn) => {
+      for (let i = 0, keys = Object.keys(current); i < keys.length; i++) {
+        const key = keys[i]
+        const value = current[key]
+
+        if (value === undefined || value === null) continue
+
+        if (typeof value === "object" || typeof value === "function") {
+          visit(current[key], selector.concat([key]), fn)
+          continue
+        }
+
+        let proceed = fn(current[key], key, selector, current)
+
+        // returning false (and only false)
+        // from the visitor function will stop the
+        // visitations
+        if (proceed === false) {
+          break
+        }
+      }
+    }
+
+    const isNormalInteger = str => /^\+?(0|[1-9]\d*)$/.test(str)
+
+    node = nodes.find(n => {
+      let isMatch = false
+      visit(n, [], (v, k, selector, parent) => {
+        if (v === value) {
+          const normalizedSelector = selector
+            .map(s => (isNormalInteger(s) ? `` : s))
+            .filter(s => s !== ``)
+          const fullSelector = `${normalizedSelector.join(`.`)}.${k}`
+          if (fullSelector === key) {
+            isMatch = true
+            return false
+          }
+        }
+
+        // Not a match so we continue
+        return true
+      })
+
+      return isMatch
+    })
+
+    // Still no node.
+    if (!node) {
+      return false
+    }
   }
 
   const rootNode = findRootNode(node)
@@ -498,6 +557,7 @@ export function inferObjectStructureFromNodes({
       // Third if the field is pointing to a file (from another file).
     } else if (
       nodes[0].internal.type !== `File` &&
+      _.isString(value) &&
       shouldInferFile(nodes, nextSelector, value)
     ) {
       inferredField = inferFromUri(key, types)

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -396,16 +396,13 @@ function shouldInferFile(nodes, key, value) {
 
         if (value === undefined || value === null) continue
 
-        if (typeof value === "object" || typeof value === "function") {
+        if (typeof value === `object` || typeof value === `function`) {
           visit(current[key], selector.concat([key]), fn)
           continue
         }
 
         let proceed = fn(current[key], key, selector, current)
 
-        // returning false (and only false)
-        // from the visitor function will stop the
-        // visitations
         if (proceed === false) {
           break
         }
@@ -418,6 +415,8 @@ function shouldInferFile(nodes, key, value) {
       let isMatch = false
       visit(n, [], (v, k, selector, parent) => {
         if (v === value) {
+          // Remove integers as they're for arrays, which our passed
+          // in object path doesn't have.
           const normalizedSelector = selector
             .map(s => (isNormalInteger(s) ? `` : s))
             .filter(s => s !== ``)


### PR DESCRIPTION
This was a tricky issue that made me work at remembering design decisions from
early this year. Like that saying goes, code you wrote 6 months ago might as well
have been written by someone else :-)

Anyways, the problem was their was some YAML data in a markdown frontmatter that looked like:

```yaml
blocks:
- head: Servers
  image: ../../assets/images/servers.png
- head: Another
  image: ../../assets/images/another.png
```

So in JavaScript, an array of objects with the image field pointing to files.

Which we'd assume would be inferred as a link to a File node but it wasn't until
this PR fixed things by fixing

* our ability to find the parent node while inferring fields
* setting (new convention) `___PARENT` on each subobject in the frontmatter
* and using that to complete the query.