### PR TITLE
Node need an ID in gatsby-source-wordpress normalize.js

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -138,7 +138,10 @@ exports.createGatsbyIds = entities =>
       namespace = typeNamespaces[e.__type]
     }
 
-    e.id = uuidv5(e.wordpress_id.toString(), namespace)
+    e.id = uuidv5(
+      e.wordpress_id ? e.wordpress_id.toString() : Math.floor((1 + Math.random()) * 0x10000).toString(16),
+      namespace
+    )
     return e
   })
 

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -140,7 +140,7 @@ exports.createGatsbyIds = entities =>
     }
 
     e.id = uuidv5(
-      e.wordpress_id ? e.wordpress_id.toString() : stringify(e),
+      e.wordpress_id ? e.wordpress_id.toString() : digest(stringify(e)),
       namespace
     )
     return e

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -3,6 +3,7 @@ const deepMapKeys = require(`deep-map-keys`)
 const _ = require(`lodash`)
 const uuidv5 = require(`uuid/v5`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
+const stringify = require(`json-stringify-safe`)
 
 const colorized = require(`./output-color`)
 const conflictFieldPrefix = `wordpress_`
@@ -139,7 +140,7 @@ exports.createGatsbyIds = entities =>
     }
 
     e.id = uuidv5(
-      e.wordpress_id ? e.wordpress_id.toString() : Math.floor((1 + Math.random()) * 0x10000).toString(16),
+      e.wordpress_id ? e.wordpress_id.toString() : stringify(e),
       namespace
     )
     return e


### PR DESCRIPTION
Fix for https://github.com/gatsbyjs/gatsby/issues/2260

The fix will create an id if there is none. 
`Math.floor((1 + Math.random()) * 0x10000).toString(16)` will generate a random string with numbers and letters.

There may be a better way to fix this. 
Should there be an ID at the first place ?