### PR TITLE
Fix redux example

### DIFF
--- a/examples/using-redux/gatsby-browser.js
+++ b/examples/using-redux/gatsby-browser.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BrowserRouter as Router } from 'react-router-dom'
+import { Router } from 'react-router-dom'
 import { Provider } from 'react-redux'
 
 import createStore from './src/state/createStore'


### PR DESCRIPTION
Hello! 

A really small PR to fix the redux example:

BrowserRouter doesn't provide any `history` props. We need to use Browser instead.

> \<BrowserRouter\> ignores the history prop. To use a custom history, use `import { Router }` instead of `import { BrowserRouter as Router }`.

source: https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/BrowserRouter.js#L24