### PR TITLE
syntax should now be 'func'

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -49,7 +49,7 @@ const Img = props => {
 
 Img.propTypes = {
   opacity: PropTypes.number,
-  onLoad: PropTypes.function,
+  onLoad: PropTypes.func
 }
 
 class Image extends React.Component {


### PR DESCRIPTION
The official syntax for requiring PropTypes to be a function is now **".func"**, as per [the prop-types docs](https://github.com/facebook/prop-types).

The gatsby-image example site runs fine, but I was having issues getting my config to be okay with the old ".function" syntax, so moving to the new standard that will work for everyone seems like a good solution.