### PR TITLE
remove NamedModulesPlugin from production build

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -323,7 +323,6 @@ module.exports = async (
           new webpack.optimize.OccurenceOrderPlugin(),
           new GatsbyModulePlugin(),
           // new WebpackStableModuleIdAndHash({ seed: 9, hashSize: 47 }),
-          new webpack.NamedModulesPlugin(),
           new HashedChunkIdsPlugin(),
         ]
       }


### PR DESCRIPTION
Follow-up for the discussion in https://github.com/gatsbyjs/gatsby/pull/1450#issuecomment-332719163

All examples are still build, plus there is my two simple demo pages:


* https://public-iubaybnfnq.now.sh/ - current master. [This file](https://public-iubaybnfnq.now.sh/component---src-pages-index-js-4de036b7fc4e26c86a08.js) has absolute paths inside.
* https://public-itvcluqrtd.now.sh/ - Version from this PR. [This file](https://public-itvcluqrtd.now.sh/component---src-pages-index-js-4de036b7fc4e26c86a08.js) doesn't have paths.