### PR TITLE
Keep original image file names when resized

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -15,14 +15,14 @@ Object {
   "aspectRatio": 2.0661764705882355,
   "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAYAAAC0VX7mAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAuUlEQVQoz9WRywqCYBCFff9lq6BFLSIQSoIW1UpIulDZ1VKS7GJiapGWl99cnH7sAdy4cTZzmJnzMcwwyDmYYgAHQYBZGKH2cjEOQ7S8d6r3hKS59/HB+0GqNxFB3fXA0hmReqq0ppAYxjfJd0MzSYp0w1yBPn3Idi+j0+2DF4awbCfTdL0ZEEYTlMoVsFwbjSaHqbj4A+M4xlraQZIVXHQdzuOZCbzbNlRNw3y5gnJQcTydYVpW2vsBqlELaS2F/80AAAAASUVORK5CYII=",
   "density": 144,
-  "originalImg": "/static/1234-f54e4.png",
+  "originalImg": "/static/test-f267f64af5ced8ae6e6e01798a4f54e4.png",
   "originalName": undefined,
   "presentationHeight": 68,
   "presentationWidth": 141,
   "sizes": "(max-width: 141px) 100vw, 141px",
-  "src": "/static/1234-f54e4.png",
-  "srcSet": "/static/1234-a0d9a.png 200w,
-/static/1234-f54e4.png 281w",
+  "src": "/static/test-f267f64af5ced8ae6e6e01798a4f54e4.png",
+  "srcSet": "/static/test-9be9d931b2fd3995c072f4dcff7a0d9a.png 200w,
+/static/test-f267f64af5ced8ae6e6e01798a4f54e4.png 281w",
 }
 `;
 
@@ -31,12 +31,12 @@ Object {
   "aspectRatio": 1,
   "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGElEQVQ4y2P4TwFgGNU8qnlU86jmgdUMAOBEq42KgAyMAAAAAElFTkSuQmCC",
   "density": 72,
-  "originalImg": "/static/1234-18c2a.png",
+  "originalImg": "/static/test-600c1799598009a5cac8671c2f018c2a.png",
   "originalName": undefined,
   "presentationHeight": 1,
   "presentationWidth": 1,
   "sizes": "(max-width: 1px) 100vw, 1px",
-  "src": "/static/1234-18c2a.png",
-  "srcSet": "/static/1234-18c2a.png 1w",
+  "src": "/static/test-600c1799598009a5cac8671c2f018c2a.png",
+  "srcSet": "/static/test-600c1799598009a5cac8671c2f018c2a.png 1w",
 }
 `;

--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -15,14 +15,14 @@ Object {
   "aspectRatio": 2.0661764705882355,
   "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAYAAAC0VX7mAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAuUlEQVQoz9WRywqCYBCFff9lq6BFLSIQSoIW1UpIulDZ1VKS7GJiapGWl99cnH7sAdy4cTZzmJnzMcwwyDmYYgAHQYBZGKH2cjEOQ7S8d6r3hKS59/HB+0GqNxFB3fXA0hmReqq0ppAYxjfJd0MzSYp0w1yBPn3Idi+j0+2DF4awbCfTdL0ZEEYTlMoVsFwbjSaHqbj4A+M4xlraQZIVXHQdzuOZCbzbNlRNw3y5gnJQcTydYVpW2vsBqlELaS2F/80AAAAASUVORK5CYII=",
   "density": 144,
-  "originalImg": "/static/test-f267f64af5ced8ae6e6e01798a4f54e4.png",
+  "originalImg": "/static/test-f54e4.png",
   "originalName": undefined,
   "presentationHeight": 68,
   "presentationWidth": 141,
   "sizes": "(max-width: 141px) 100vw, 141px",
-  "src": "/static/test-f267f64af5ced8ae6e6e01798a4f54e4.png",
-  "srcSet": "/static/test-9be9d931b2fd3995c072f4dcff7a0d9a.png 200w,
-/static/test-f267f64af5ced8ae6e6e01798a4f54e4.png 281w",
+  "src": "/static/test-f54e4.png",
+  "srcSet": "/static/test-a0d9a.png 200w,
+/static/test-f54e4.png 281w",
 }
 `;
 
@@ -31,12 +31,12 @@ Object {
   "aspectRatio": 1,
   "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGElEQVQ4y2P4TwFgGNU8qnlU86jmgdUMAOBEq42KgAyMAAAAAElFTkSuQmCC",
   "density": 72,
-  "originalImg": "/static/test-600c1799598009a5cac8671c2f018c2a.png",
+  "originalImg": "/static/test-18c2a.png",
   "originalName": undefined,
   "presentationHeight": 1,
   "presentationWidth": 1,
   "sizes": "(max-width: 1px) 100vw, 1px",
-  "src": "/static/test-600c1799598009a5cac8671c2f018c2a.png",
-  "srcSet": "/static/test-600c1799598009a5cac8671c2f018c2a.png 1w",
+  "src": "/static/test-18c2a.png",
+  "srcSet": "/static/test-18c2a.png 1w",
 }
 `;

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -31,6 +31,15 @@ describe(`gatsby-plugin-sharp`, () => {
       expect(result.srcSet.indexOf(pathPrefix)).toBe(0)
     })
 
+    it(`keeps original file name`, async () => {
+      const result = await responsiveSizes({
+        file,
+      })
+
+      expect(result.src.indexOf(file.name)).toBe(8)
+      expect(result.srcSet.indexOf(file.name)).toBe(8)
+    })
+
     it(`accounts for pixel density`, async () => {
       const result = await responsiveSizes({
         file: getFileObject(path.join(__dirname, `images/144-density.png`)),
@@ -65,6 +74,7 @@ describe(`gatsby-plugin-sharp`, () => {
 function getFileObject(absolutePath) {
   return {
     id: `${absolutePath} absPath of file`,
+    name: `test`,
     absolutePath,
     extension: `png`,
     internal: {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -224,7 +224,9 @@ function queueImageResizing({ file, args = {} }) {
     .update(JSON.stringify(sortedArgs))
     .digest(`hex`)
 
-  const imgSrc = `/${file.name}-${argsDigest}.${fileExtension}`
+  const argsDigestShort = argsDigest.substr(argsDigest.length - 5)
+
+  const imgSrc = `/${file.name}-${argsDigestShort}.${fileExtension}`
   const filePath = path.join(process.cwd(), `public`, `static`, imgSrc)
 
   // Create function to call when the image is finished.

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -224,10 +224,7 @@ function queueImageResizing({ file, args = {} }) {
     .update(JSON.stringify(sortedArgs))
     .digest(`hex`)
 
-  const argsDigestShort = argsDigest.substr(argsDigest.length - 5)
-
-  const imgSrc = `/${file.internal
-    .contentDigest}-${argsDigestShort}.${fileExtension}`
+  const imgSrc = `/${file.name}-${argsDigest}.${fileExtension}`
   const filePath = path.join(process.cwd(), `public`, `static`, imgSrc)
 
   // Create function to call when the image is finished.


### PR DESCRIPTION
This change adds the image digest to the end of the image name, but otherwise keeps the rest of it intact.

This is important when considering SEO for a site. An image should have a descriptive file name and if it contains keywords you don't want those removed.