### PR TITLE
gatsby-plugin-emotion correct peerDependencies

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -22,7 +22,7 @@
     "babel-runtime": "^6.26.0"
   },
   "peerDependencies": {
-    "emotion": "7 || 8 ",
-    "emotion-server": "7 || 8"
+    "emotion": "^7.0.0 || ^18.0.0",
+    "emotion-server": "^7.0.0 || ^18.0.0"
   }
 }

--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -22,7 +22,7 @@
     "babel-runtime": "^6.26.0"
   },
   "peerDependencies": {
-    "emotion": "^7.0.0 || ^18.0.0",
-    "emotion-server": "^7.0.0 || ^18.0.0"
+    "emotion": "^7.0.0 || ^8.0.0",
+    "emotion-server": "^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
Getting these errors with emotion and emotion-server 7.3.2:

```
warning "gatsby-plugin-emotion@1.1.8" has unmet peer dependency "emotion@7 || 8 ".
warning "gatsby-plugin-emotion@1.1.8" has unmet peer dependency "emotion-server@7 || 8".
```