### PR TITLE
[gatsby-transformer-sharp] Add option to set file extensions

### DIFF
--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -22,7 +22,7 @@ plugins: [
 
 ## Parsing algorithm
 
-It recognizes files with the following extensions as images.
+Per default it recognizes files with the following extensions as images:
 
 * jpeg
 * jpg
@@ -30,6 +30,21 @@ It recognizes files with the following extensions as images.
 * webp
 * tif
 * tiff
-* svg
+
+If you want to modify the extensions of files being parsed as images you can
+use the `fileExtensions` option of the plugin as follows:
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: 'gatsby-transformer-sharp',
+    options: {
+      // add support for SVG files as well
+      fileExtensions: ['jpeg', 'jpg', 'png', 'webp', 'tif', 'tiff', 'svg']
+    }
+  },
+]
+```
 
 Each image file is parsed into a node of type `ImageSharp`.

--- a/packages/gatsby-transformer-sharp/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/__tests__/gatsby-node.js
@@ -1,18 +1,26 @@
 const { onCreateNode } = require(`../gatsby-node`)
 
 describe(`Process image nodes correctly`, () => {
-  it(`correctly creates an ImageSharp node from a file image node`, async () => {
-    const node = {
-      extension: `png`,
+  let node
+  let createNode
+  let createParentChildLink
+  let boundActionCreators
+
+  beforeEach(() => {
+    node = {
       id: `whatever`,
       children: [],
       internal: {
         contentDigest: `whatever`,
       },
     }
-    const createNode = jest.fn()
-    const createParentChildLink = jest.fn()
-    const boundActionCreators = { createNode, createParentChildLink }
+    createNode = jest.fn()
+    createParentChildLink = jest.fn()
+    boundActionCreators = { createNode, createParentChildLink }
+  })
+
+  it(`correctly creates an ImageSharp node from a file image node`, async () => {
+    node.extension = `png`
 
     await onCreateNode({
       node,
@@ -20,6 +28,32 @@ describe(`Process image nodes correctly`, () => {
     }).then(() => {
       expect(createNode.mock.calls).toMatchSnapshot()
       expect(createParentChildLink.mock.calls).toMatchSnapshot()
+      expect(createNode).toHaveBeenCalledTimes(1)
+      expect(createParentChildLink).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it(`ignores nodes with non-supported extensions`, async () => {
+    node.extension = `json`
+
+    await onCreateNode({
+      node,
+      boundActionCreators,
+    }).then(() => {
+      expect(createNode).toHaveBeenCalledTimes(0)
+      expect(createParentChildLink).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  it(`correctly creates an ImageSharp node from a file image node with a user-defined extension`, async () => {
+    node.extension = `svg`
+
+    await onCreateNode({
+      node,
+      boundActionCreators,
+    }, {
+      fileExtensions: [`jpeg`, `jpg`, `png`, `webp`, `tif`, `tiff`, `svg`],
+    }).then(() => {
       expect(createNode).toHaveBeenCalledTimes(1)
       expect(createParentChildLink).toHaveBeenCalledTimes(1)
     })

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,10 +1,12 @@
 const _ = require(`lodash`)
 
-module.exports = async function onCreateNode({ node, boundActionCreators }) {
+module.exports = async function onCreateNode(
+  { node, boundActionCreators },
+  { fileExtensions = [`jpeg`, `jpg`, `png`, `webp`, `tif`, `tiff`] }
+) {
   const { createNode, createParentChildLink } = boundActionCreators
 
-  const extensions = [`jpeg`, `jpg`, `png`, `webp`, `tif`, `tiff`]
-  if (!_.includes(extensions, node.extension)) {
+  if (!_.includes(fileExtensions, node.extension)) {
     return
   }
 

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,12 +1,13 @@
 const _ = require(`lodash`)
 
-module.exports = async function onCreateNode(
-  { node, boundActionCreators },
-  { fileExtensions = [`jpeg`, `jpg`, `png`, `webp`, `tif`, `tiff`] }
-) {
+module.exports = async function onCreateNode({ node, boundActionCreators }, pluginOptions) {
   const { createNode, createParentChildLink } = boundActionCreators
+  const defaultOptions = {
+    fileExtensions: [`jpeg`, `jpg`, `png`, `webp`, `tif`, `tiff`],
+  }
+  const options = _.defaults(pluginOptions, defaultOptions)
 
-  if (!_.includes(fileExtensions, node.extension)) {
+  if (!_.includes(options.fileExtensions, node.extension)) {
     return
   }
 


### PR DESCRIPTION
In #1996 `svg` got removed from the file extension list that `gatsby-transformer-sharp` can handle. This caused our application to stop working since we rely on SVG images. Other than stated in the pull request mentioned above SVGs used to work just fine for us.

## Proposed solution
Add a plugin option `fileExtensions` which lets the user configure, which files should be treated as images.

## Open for discussion
The default option in this pull request remained being `['jpeg', 'jpg', 'png', 'webp', 'tif', 'tiff']`. In my opinion this is a breaking change to the plugin itself which could cause working applications to crash when updating `gatsby-transformer-sharp`. A possible solution would be to re-add `svg` to the list of default options. I will leave this decision to the Gatsby maintainers to decide.