### PR TITLE
Handle undefined webpack build error

### DIFF
--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -30,7 +30,7 @@ module.exports = async (program: any) => {
       }
       const outputFile = `${directory}/public/render-page.js`
       if (stats.hasErrors()) {
-        let webpackErrors = stats.toJson().errors
+        let webpackErrors = stats.compilation.errors.filter((e) => e)
         return reject(
           createErrorFromString(webpackErrors[0], `${outputFile}.map`)
         )


### PR DESCRIPTION
I ran into this problem when `gatsby build` failed with 

<details>
<summary>TypeError: Cannot read property 'chunk' of undefined</summary>


> /Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Stats.js:93
>     if(e.chunk) {
>         ^
> 
> TypeError: Cannot read property 'chunk' of undefined
>     at formatError (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Stats.js:93:7)
>     at Array.map (<anonymous>)
>     at Stats.toJson (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Stats.js:123:30)
>     at /Users/<user>/<project>/node_modules/gatsby/dist/utils/build-html.js:70:45
>     at Compiler.<anonymous> (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Compiler.js:194:14)
>     at Compiler.emitRecords (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Compiler.js:282:37)
>     at Compiler.<anonymous> (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Compiler.js:187:11)
>     at /Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Compiler.js:275:11
>     at Compiler.applyPluginsAsync (/Users/<user>/<project>/node_modules/gatsby/node_modules/tapable/lib/Tapable.js:60:69)
>     at Compiler.afterEmit (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Compiler.js:272:8)
>     at Compiler.<anonymous> (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/lib/Compiler.js:267:14)
>     at /Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/node_modules/async/lib/async.js:52:16
>     at done (/Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/node_modules/async/lib/async.js:246:17)
>     at /Users/<user>/<project>/node_modules/gatsby/node_modules/webpack/node_modules/async/lib/async.js:44:16
>     at /Users/<user>/<project>/node_modules/graceful-fs/graceful-fs.js:43:10
>     at FSReqWrap.oncomplete (fs.js:136:15)


</details>

After some digging around I found that this was not the actual build error!

For some reason, `stats.compilation.errors` contained an `undefined` at first place:

<details>
<summary>stats.compilation.errors</summary>

```
errors:
      [ undefined,
        'FirebaseError: Firebase: Firebase App named '[DEFAULT]' already exists (app/duplicate-app).
            at error (render-page.js:52589:22)
            at Object.initializeApp (render-page.js:52488:14)
            at new Ginfo (render-page.js:52021:19)
            at Object.createStore [as default] (render-page.js:51969:16)
            at Template (render-page.js:48337:39)
            at ReactCompositeComponentWrapper._constructComponentWithoutOwner (render-page.js:14596:15)
            at ReactCompositeComponentWrapper._constructComponent (render-page.js:14572:20)
            at ReactCompositeComponentWrapper.mountComponent (render-page.js:14475:22)
            at Object.mountComponent (render-page.js:7457:36)
            at ReactCompositeComponentWrapper.performInitialMount (render-page.js:14658:35)',
        'FirebaseError: Firebase: Firebase App named '[DEFAULT]' already exists (app/duplicate-app).
            at error (render-page.js:52589:22)
            at Object.initializeApp (render-page.js:52488:14)
            at new Ginfo (render-page.js:52021:19)
            at Object.createStore [as default] (render-page.js:51969:16)
            at Template (render-page.js:48337:39)
            at ReactCompositeComponentWrapper._constructComponentWithoutOwner (render-page.js:14596:15)
            at ReactCompositeComponentWrapper._constructComponent (render-page.js:14572:20)
            at ReactCompositeComponentWrapper.mountComponent (render-page.js:14475:22)
            at Object.mountComponent (render-page.js:7457:36)
            at ReactCompositeComponentWrapper.performInitialMount (render-page.js:14658:35)',
        'FirebaseError: Firebase: Firebase App named '[DEFAULT]' already exists (app/duplicate-app).
            at error (render-page.js:52589:22)
            at Object.initializeApp (render-page.js:52488:14)
            at new Ginfo (render-page.js:52021:19)
            at Object.createStore [as default] (render-page.js:51969:16)
            at Template (render-page.js:48337:39)
            at ReactCompositeComponentWrapper._constructComponentWithoutOwner (render-page.js:14596:15)
            at ReactCompositeComponentWrapper._constructComponent (render-page.js:14572:20)
            at ReactCompositeComponentWrapper.mountComponent (render-page.js:14475:22)
            at Object.mountComponent (render-page.js:7457:36)
            at ReactCompositeComponentWrapper.performInitialMount (render-page.js:14658:35)',
        'FirebaseError: Firebase: Firebase App named '[DEFAULT]' already exists (app/duplicate-app).
            at error (render-page.js:52589:22)
            at Object.initializeApp (render-page.js:52488:14)
            at new Ginfo (render-page.js:52021:19)
            at Object.createStore [as default] (render-page.js:51969:16)
            at Template (render-page.js:48337:39)
            at ReactCompositeComponentWrapper._constructComponentWithoutOwner (render-page.js:14596:15)
            at ReactCompositeComponentWrapper._constructComponent (render-page.js:14572:20)
            at ReactCompositeComponentWrapper.mountComponent (render-page.js:14475:22)
            at Object.mountComponent (render-page.js:7457:36)
            at ReactCompositeComponentWrapper.performInitialMount (render-page.js:14658:35)' ],
```


</details>

(Not sure where this `undefined` is coming from and it might still bite my ass when I fix the other errors later).

This `undefined` caused the `TypeError: Cannot read property 'chunk' of undefined` error when calling `stats.toJson` and because of that, my actual errors were swallowed, leaving me scratching my head.


This proposed change filters out `undefined` from `stats.compilation.errors` before handing the first error to the rejection.
I'm not sure why `toJson()` is/was necessary at all since it works right now without.