### PR TITLE
[gatsby-plugins-canonical-urls] Add default pathname

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-exports.onRenderBody = ({ setHeadComponents, pathname }, pluginOptions) => {
+exports.onRenderBody = ({ setHeadComponents, pathname = `/` }, pluginOptions) => {
   const url = `${pluginOptions.siteUrl}${pathname}`
   setHeadComponents([<link rel="canonical" key={url} href={url} />])
 }


### PR DESCRIPTION
Fixes #2362 by preventing generated canonial urls from appending
`undefined` in development mode