### PR TITLE
Allow responsive-loader settings

### DIFF
--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -14,6 +14,7 @@ const validationWhitelist = Joi.object({
   stylus: Joi.any(),
   sassLoader: Joi.any(),
   sassResources: [Joi.string(), Joi.array().items(Joi.string())],
+  responsiveLoader: Joi.any(),
 })
 
 export default (async function ValidateWebpackConfig(config, stage) {


### PR DESCRIPTION
Responsive Loader: https://github.com/herrstucki/responsive-loader  requires settings in the root of the webpack config. This is a temporary workaround until webpack 3 support lands.