### PR TITLE
update website to the showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Websites built with Gatsby:
 * [David James' Portfolio](http://dfjames.com) [(source)](https://github.com/daviddeejjames/dfjames-gatsby)
 * [Tic Tac Toe AI](https://tic-tac-toe-ai.surge.sh) [(source)](https://github.com/angeloocana/tic-tac-toe-ai)
 * [Etcetera Design](https://etcetera.design) [(source)](https://github.com/etceteradesign/website)
+* [Phu Quoc Island TEA & Coffee](http://trasuaphuquoc.com)
 
 ## Docs
 


### PR DESCRIPTION
trasuaphuquoc.com is newest website for customer at Phu Quoc Island, Vietnam.