### PR TITLE
Add my homepage to the showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Websites built with Gatsby:
 * [David James' Portfolio](http://dfjames.com) [(source)](https://github.com/daviddeejjames/dfjames-gatsby)
 * [Tic Tac Toe AI](https://tic-tac-toe-ai.surge.sh) [(source)](https://github.com/angeloocana/tic-tac-toe-ai)
 * [Etcetera Design](https://etcetera.design) [(source)](https://github.com/etceteradesign/website)
+* [Azer Koçulu](http://azer.bike)
 
 ## Docs
 


### PR DESCRIPTION
I loved using Gatsby to build my new website. Excellent tool! I'm hoping to write a blog post about it soon.

This is a tiny commit for adding [azer.bike](http://azer.bike) to the showcase list in the README. 