### PR TITLE
Add camelCase option for css-loader

### DIFF
--- a/packages/gatsby-1-config-css-modules/src/index.js
+++ b/packages/gatsby-1-config-css-modules/src/index.js
@@ -2,6 +2,6 @@ const LOCAL_IDENT_NAME = `[path]---[name]---[local]---[hash:base64:5]`
 exports.LOCAL_IDENT_NAME = LOCAL_IDENT_NAME
 
 exports.cssModulesConfig = stage => {
-  const loader = `css?modules&minimize&importLoaders=1&localIdentName=${LOCAL_IDENT_NAME}`
+  const loader = `css?modules&camelCase=true&minimize&importLoaders=1&localIdentName=${LOCAL_IDENT_NAME}`
   return stage.startsWith(`build`) ? loader : `${loader}&sourceMap`
 }


### PR DESCRIPTION
Resolves #376 

Docs: https://github.com/webpack-contrib/css-loader#camelcase

This is **not** a breaking change, given css
```css
.my-header { color: blue}
```
will result in such object
```js
{
    my-header: "src-pages----index-module---my-header---2Xmei", 
    myHeader: "src-pages----index-module---my-header---2Xmei"
}
```
