### PR TITLE
Fix bootstrap command for fresh checkouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "private": true,
   "scripts": {
-    "bootstrap": "yarn && npm run check-versions && lerna run prepublish",
+    "bootstrap": "yarn && npm run check-versions && lerna bootstrap",
     "check-versions": "babel-node scripts/check-versions.js",
     "format": "npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts",
     "format-cache-dir": "prettier-eslint --write \"packages/gatsby/cache-dir/*.js\"",


### PR DESCRIPTION
Fixes #2395 

I'm not 100% on the differences between `lerna bootstrap` and `lerna run prepublish`. I _think_ this should fix the issue reported above though.

On a fresh checkout of the gatsby repo, `yarn run bootstrap`, followed by `yarn test` will both work.

Refs: https://github.com/gatsbyjs/gatsby/pull/2383 
Refs: https://github.com/gatsbyjs/gatsby/pull/2308. 