### PR TITLE
Adds createAt and updatedAt fields

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -255,8 +255,8 @@ exports.createContentTypeNodes = ({
 
       let entryNode = {
         id: mId(entryItem.sys.id),
-        createdAt: entry.sys.createdAt,
-        updatedAt: entry.sys.updatedAt,
+        createdAt: entryItem.sys.createdAt,
+        updatedAt: entryItem.sys.updatedAt,
         parent: contentTypeItemId,
         children: [],
         internal: {

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -255,6 +255,8 @@ exports.createContentTypeNodes = ({
 
       let entryNode = {
         id: mId(entryItem.sys.id),
+        createdAt: entry.sys.createdAt,
+        updatedAt: entry.sys.updatedAt,
         parent: contentTypeItemId,
         children: [],
         internal: {


### PR DESCRIPTION
This PR adds `createdAt` and `updatedAt` fields to the entry node

![screen shot 2017-10-09 at 13 42 38](https://user-images.githubusercontent.com/1156093/31337943-c6005bb8-acfd-11e7-97c0-0607c843ff71.png)
