### PR TITLE
Replace `modifyDate` references with `modifiedTime`

### DIFF
--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -12,7 +12,7 @@ For example:
 The [`gatsby-source-filesystem`](/packages/gatsby-source-filesystem/)
 plugin "sources" data about files from the file system. It creates nodes with
 a type `File`, each File node corresponding to a file on the filesystem. On
-each node are fields like the `absolutePath`, `extension`, `modifyDate`, etc.
+each node are fields like the `absolutePath`, `extension`, `modifiedTime`, etc.
 
 And importantly, each node created by the filesystem source plugin includes the
 raw content of the file and its *media type*.

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -50,7 +50,7 @@ You can query file nodes like the following:
       node {
         extension
         dir
-        modifyDate
+        modifiedTime
       }
     }
   }


### PR DESCRIPTION
The documentation for `gatsby-source-filesystem` has this code sample:

```graphql
{
  allFile {
    edges {
      node {
        extension
        dir
        modifyDate
      }
    }
  }
}
```

When running it within GraphQL, I got the following error:
```
{
  "errors": [
    {
      "message": "Cannot query field \"modifyDate\" on type \"File\". Did you mean \"modifiedTime\"?",
      "locations": [
        {
          "line": 7,
          "column": 9
        }
      ]
    }
  ]
}
```

It appears that `modifyDate` does not exist anymore. I've updated two README files to reflect this. Hopefully this is correct!