### PR TITLE
Add failing test for query `eq: 0` error

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-input-type-test.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-input-type-test.js.snap
@@ -26,6 +26,11 @@ Object {
             "anObjectArray": null,
           },
         },
+        Object {
+          "node": Object {
+            "anObjectArray": null,
+          },
+        },
       ],
     },
   },

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -113,6 +113,17 @@ describe(`GraphQL Input args`, () => {
         circle: `happy`,
       },
     },
+    {
+      name: `The Mad Wax`,
+      hair: 0,
+      date: `2006-07-22T22:39:53.000Z`,
+      frontmatter: {
+        date: `2006-07-22T22:39:53.000Z`,
+        title: `The world of shave and adventure`,
+        blue: 10010,
+        circle: `happy`,
+      },
+    },
   ]
 
   it(`filters out null example values`, async () => {
@@ -263,6 +274,23 @@ describe(`GraphQL Input args`, () => {
     expect(result.data.allNode.edges[0].node.hair).toEqual(2)
   })
 
+  it(`handles eq operator with 0`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: {hair: { eq: 0 }}) {
+            edges { node { hair }}
+          }
+        }
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(1)
+    expect(result.data.allNode.edges[0].node.hair).toEqual(0)
+  })
+
   it(`handles ne operator`, async () => {
     let result = await queryResult(
       nodes,
@@ -276,7 +304,7 @@ describe(`GraphQL Input args`, () => {
     )
 
     expect(result.errors).not.toBeDefined()
-    expect(result.data.allNode.edges.length).toEqual(1)
+    expect(result.data.allNode.edges.length).toEqual(2)
     expect(result.data.allNode.edges[0].node.hair).toEqual(1)
   })
 
@@ -292,7 +320,7 @@ describe(`GraphQL Input args`, () => {
     `
     )
     expect(result.errors).not.toBeDefined()
-    expect(result.data.allNode.edges.length).toEqual(1)
+    expect(result.data.allNode.edges.length).toEqual(2)
     expect(result.data.allNode.edges[0].node.name).toEqual(`The Mad Wax`)
   })
 
@@ -324,7 +352,7 @@ describe(`GraphQL Input args`, () => {
       `
     )
     expect(result.errors).not.toBeDefined()
-    expect(result.data.allNode.edges.length).toEqual(1)
+    expect(result.data.allNode.edges.length).toEqual(2)
     expect(result.data.allNode.edges[0].node.name).toEqual(`The Mad Wax`)
   })
 
@@ -346,7 +374,7 @@ describe(`GraphQL Input args`, () => {
       `
     )
     expect(result.errors).not.toBeDefined()
-    expect(result.data.allNode.edges.length).toEqual(2)
+    expect(result.data.allNode.edges.length).toEqual(3)
     expect(result.data.allNode.edges[0].node.name).toEqual(`The Mad Wax`)
   })
 


### PR DESCRIPTION
This just adds a failing test that demonstrates the error described in #2415

The other tests in the changed file have been updated to account for the additional object in the `nodes` array.

Test output looks like this:

```shell
 FAIL  packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
  ● GraphQL Input args › handles eq operator with 0

    TypeError: Cannot read property 'edges' of null

      at Object.it (packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js:290:31)
          at <anonymous>

  GraphQL Input args
    ✓ filters out null example values (22ms)
    ✓ filters out empty objects (3ms)
    ✓ filters out empty arrays (2ms)
    ✓ filters out sparse arrays (2ms)
    ✓ uses correct keys for linked fields (6ms)
    ✓ Replaces unsupported values in keys (1ms)
    ✓ Removes specific root fields (1ms)
    ✓ handles eq operator (25ms)
    ✕ handles eq operator with 0 (14ms)
    ✓ handles ne operator (18ms)
    ✓ handles the regex operator (14ms)
    ✓ handles the in operator (14ms)
    ✓ handles the glob operator (13ms)
    ✓ sorts results (18ms)
    ✓ returns list of distinct values in a field (15ms)
    ✓ handles the group connection field (15ms)
    ✓ can query object arrays (16ms)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 16 passed, 17 total
Snapshots:   1 passed, 1 total
Time:        2.121s
Ran all test suites related to changed files.
```