### PR TITLE
Fix queries with filter where filtered value is falsy

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -100,6 +100,7 @@ describe(`GraphQL Input args`, () => {
         { aString: `some string`, aNumber: 2, aBoolean: true },
         { aString: `some string`, aNumber: 2, anArray: [1, 2] },
       ],
+      boolean: true,
     },
     {
       name: `The Mad Wax`,
@@ -112,6 +113,7 @@ describe(`GraphQL Input args`, () => {
         blue: 10010,
         circle: `happy`,
       },
+      boolean: false,
     },
   ]
 
@@ -261,6 +263,22 @@ describe(`GraphQL Input args`, () => {
     expect(result.errors).not.toBeDefined()
     expect(result.data.allNode.edges.length).toEqual(1)
     expect(result.data.allNode.edges[0].node.hair).toEqual(2)
+  })
+
+  it(`handles eq operator with false value`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: {boolean: { eq: false }}) {
+            edges { node { name }}
+          }
+        }
+      `
+    )
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(1)
+    expect(result.data.allNode.edges[0].node.name).toEqual(`The Mad Wax`)
   })
 
   it(`handles ne operator`, async () => {

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -10,7 +10,7 @@ function awaitSiftField(fields, node, k) {
   const field = fields[k]
   if (field.resolve) {
     return field.resolve(node)
-  } else if (node[k]) {
+  } else if (node[k] !== undefined) {
     return node[k]
   }
 


### PR DESCRIPTION
Currently when a filter is used in a query and its value is falsy (e.g. `eq: false` or `eq: 0`), the related value in a node is converted to `undefined` and the result of the whole query is just `null`. 

This PR fixes this issue, adds a new test for the case with `false` value and surprisingly doesn't break any other tests. It should also fix the issue mentioned in https://github.com/gatsbyjs/gatsby/pull/2416.