### PR TITLE
Wordpress Basic Authentication Fix

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -87,10 +87,7 @@ async function fetch({
         password: _auth.htaccess_pass,
       }
     }
-    allRoutes = await axios({
-      method: `get`,
-      url: url,
-    })
+    allRoutes = await axios(options)
   } catch (e) {
     httpExceptionHandler(e)
   }


### PR DESCRIPTION
Maybe there was a careless mistake when the lines were written.
It did not make sense to set user and password above, but not passing them in axios()...
Now you should be able to use basic auth ...