### PR TITLE
Further improve infer fields recursion

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
@@ -133,6 +133,37 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     isStringInput(innerObjFields.foo.type)
   })
 
+  it(`handles lists within lists`, async () => {
+    const Row = new GraphQLObjectType({
+      name: `Row`,
+      fields: () => {
+        return {
+          cells: typeField(new GraphQLList(Cell)),
+        }
+      },
+    })
+
+    const Cell = new GraphQLObjectType({
+      name: `Cell`,
+      fields: () => {
+        return {
+          value: typeField(GraphQLInt),
+        }
+      },
+    })
+
+    const fields = {
+      rows: typeField(new GraphQLList(Row)),
+    }
+    
+    expect(() => {
+      inferInputObjectStructureFromFields({
+        fields,
+        typeName: `ListTypes`,
+      })
+    }).not.toThrow()
+  })
+
   it(`protects against infinite recursion on circular definitions`, async () => {
     const TypeA = new GraphQLObjectType({
       name: `TypeA`,

--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -37,13 +37,13 @@ function makeNullable(type: GraphQLInputType): GraphQLNullableInputType<any> {
 
 function convertToInputType(
   type: GraphQLType,
-  typeMap: any
+  typeMap: Set
 ): ?GraphQLInputType {
   // track types already processed in current tree, to avoid infinite recursion
-  if (typeMap[type.name]) {
+  if (typeMap.has(type)) {
     return null
   }
-  const nextTypeMap = { ...typeMap, [type.name]: true }
+  const nextTypeMap = new Set([...typeMap, type])
 
   if (type instanceof GraphQLScalarType || type instanceof GraphQLEnumType) {
     return type
@@ -169,7 +169,7 @@ export function inferInputObjectStructureFromFields({
   const sort = []
 
   _.each(fields, (fieldConfig, key) => {
-    const inputType = convertToInputType(fieldConfig.type, {})
+    const inputType = convertToInputType(fieldConfig.type, new Set())
     const inputFilter =
       inputType && convertToInputFilter(_.upperFirst(key), inputType)
 


### PR DESCRIPTION
Okay:  following upon the last PR (https://github.com/gatsbyjs/gatsby/pull/2436), which successfully fixed the main error I was running into with adding fields containing circularity, I have by necessity been pushing this functionality through a much more rigorous use case, with a relatively large custom schema I am attaching to an object type in a current project. 

As a result, I found two further errors downstream during conversion of large nested types, each of which has been added to the tests and then addressed in this PR:

 - after the PR, nested lists still weren't always protected for circularity correctly -- because, while @Zalastax echoed my thinking that `type.name` is always distinct, it turns out that the type.name key isn't always set yet at that point for hybrid (wrapped) types like `GraphQLList(OtherType)`. So, I went ahead and adopted the helpful prior suggestion of using `Set()` since it was cleared for compatibility in the discussion.

 - the next error occurred when circularity protection ended up leaving a GraphQLObjectType with no child fields, when all were ignored due to circularity. I now test for types to have at least one accepted field before creation.

 - finally, I ran into one further apparent omission, which is the handling of the `GraphQLID` type. It is a scalar and an instance of GraphQLScalarType, but fell into the cracks on the list of types supported for filters, which led to an error if I switched the current recursion unit test to contain GraphQLID rather than GraphQLInt types at the deepest point. This type is now handled like the other scalars. 

After fixing all of those, my large, nested schema attaches without error via a plugin, and given the size of that schema, it should represent a near-comprehensive test of this functionality.

However, in a future PR, I'm very interested in pursuing an alternate API hook to `setFieldsOnGraphQLNodeType` (analogous to the existence of the `-Statefully` alternative for `createPages`). The use case is that there can be a great benefit to adding custom graphql sub-schemas into gatsby's schema via plugins, and some of those (like my current project) are built for querying an API outside of gatsby using various methods, particularly where that other API is far too large to simply import all nodes and let gatsby handle resolution, yet where there is still much to gain from allowing the data to be queried and pre-bundled at the page level with all the other graphql data. For these cases, it is generally not necessary for gatsby to automatically create a _ton_ of filters to use down that long subtree, when those filters are often going to be unusable for these external APIs anyway.  If there are thoughts on that alternative API hook or its naming, I'd be interested in putting it together.