### PR TITLE
[www] Update various svg and image accessibility

### DIFF
--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -200,7 +200,7 @@ const Gatsby = ({ children }) => (
         margin: 0,
         verticalAlign: `middle`,
       }}
-      alt=""
+      alt="Gatsby"
     />
     <ItemDescription>
       <small

--- a/www/src/components/tech-with-icon.js
+++ b/www/src/components/tech-with-icon.js
@@ -7,6 +7,7 @@ const TechWithIcon = ({ icon, height, children }) => {
     <span css={{ whiteSpace: `nowrap` }}>
       {children}&nbsp;<img
         src={icon}
+        alt=""
         css={{
           height: `${h}`,
           margin: 0,

--- a/www/src/components/used-by.js
+++ b/www/src/components/used-by.js
@@ -3,7 +3,7 @@ import presets from "../utils/presets"
 import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
 import { FormidableIcon, FabricIcon, SegmentIcon } from "../assets/logos"
 
-const Icon = ({ icon }) => (
+const Icon = ({ icon, alt }) => (
   <li
     css={{
       marginRight: rhythm(3 / 4),
@@ -20,6 +20,7 @@ const Icon = ({ icon }) => (
   >
     <img
       src={icon}
+      alt={alt}
       css={{
         margin: 0,
         height: `calc(14px + 1vw)`,
@@ -109,9 +110,9 @@ const UsedBy = () => (
           opacity: 0.75,
         }}
       >
-        <Icon icon={FabricIcon} />
-        <Icon icon={SegmentIcon} />
-        <Icon icon={FormidableIcon} />
+        <Icon icon={FabricIcon} alt="Fabric" />
+        <Icon icon={SegmentIcon} alt="Segment" />
+        <Icon icon={FormidableIcon} alt="Formidable" />
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Updated the used-by logos to be accessible, as well as the tech icons to match decorative standards. Previously, some screenreaders were reading the entire base64 URI aloud 😢 . The Gatsby logo in the diagram had an empty alt from #2215, but I'd argue that it needs it to make sense with the "powered by GraphQL" line at that stage in the diagram.