### PR TITLE
[gatsby-plugin-sharp] SVG traced placeholders

### DIFF
--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -306,7 +306,11 @@ export const pageQuery = graphql`
     sizes: imageSharp(id: { regex: "/fecolormatrix-kanye-west.jpg/" }) {
       sizes(
         duotone: { highlight: "#f00e2e", shadow: "#192550" }
-        trace: { color: "#f00e2e" }
+        trace: {
+          color: "#f00e2e"
+          turnPolicy: TURNPOLICY_MINORITY
+          blackOnWhite: false
+        }
         toFormat: PNG
       ) {
         ...GatsbyImageSharpSizes_tracedSVG

--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -306,9 +306,10 @@ export const pageQuery = graphql`
     sizes: imageSharp(id: { regex: "/fecolormatrix-kanye-west.jpg/" }) {
       sizes(
         duotone: { highlight: "#f00e2e", shadow: "#192550" }
+        trace: { color: "#f00e2e" }
         toFormat: PNG
       ) {
-        ...GatsbyImageSharpSizes
+        ...GatsbyImageSharpSizes_tracedSVG
       }
     }
     resolution: imageSharp(id: { regex: "/lol.jpg/" }) {

--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -12,7 +12,6 @@ class Index extends React.Component {
     const cropBottomLeft = this.props.data.cropBottomLeft.resize
     const cropEntropy = this.props.data.cropEntropy.resize
     const cropCenter = this.props.data.cropCenter.resize
-    const tracedSVG = this.props.data.tracedSVG.resolutions
 
     return (
       <div>
@@ -43,15 +42,6 @@ class Index extends React.Component {
             or peep the code of this example site for more information.
           </strong>
         </p>
-
-        <h2>Potrace</h2>
-
-        <img
-          src={tracedSVG.tracedSVG}
-          height={tracedSVG.height}
-          width={tracedSVG.width}
-        />
-        <img src={tracedSVG.src} />
 
         <h2
           style={{
@@ -323,7 +313,7 @@ export const pageQuery = graphql`
     }
     resolution: imageSharp(id: { regex: "/lol.jpg/" }) {
       resolutions(grayscale: true, width: 500) {
-        ...GatsbyImageSharpResolutions
+        ...GatsbyImageSharpResolutions_tracedSVG
       }
     }
     cropDefault: imageSharp(id: { regex: "/gatsby.jpg/" }) {
@@ -344,18 +334,6 @@ export const pageQuery = graphql`
     cropCenter: imageSharp(id: { regex: "/gatsby.jpg/" }) {
       resize(width: 180, height: 180, cropFocus: CENTER) {
         src
-      }
-    }
-    tracedSVG: imageSharp(id: { regex: "/fecolormatrix-kanye-west.jpg/" }) {
-      resolutions(
-        width: 500
-        trace: { background: "#f00e2e", color: "#192550" }
-        duotone: { highlight: "#f00e2e", shadow: "#192550" }
-      ) {
-        src
-        tracedSVG
-        height
-        width
       }
     }
   }

--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -306,7 +306,7 @@ export const pageQuery = graphql`
     sizes: imageSharp(id: { regex: "/fecolormatrix-kanye-west.jpg/" }) {
       sizes(
         duotone: { highlight: "#f00e2e", shadow: "#192550" }
-        trace: {
+        traceSVG: {
           color: "#f00e2e"
           turnPolicy: TURNPOLICY_MINORITY
           blackOnWhite: false

--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -12,6 +12,7 @@ class Index extends React.Component {
     const cropBottomLeft = this.props.data.cropBottomLeft.resize
     const cropEntropy = this.props.data.cropEntropy.resize
     const cropCenter = this.props.data.cropCenter.resize
+    const tracedSVG = this.props.data.tracedSVG.resolutions
 
     return (
       <div>
@@ -42,6 +43,15 @@ class Index extends React.Component {
             or peep the code of this example site for more information.
           </strong>
         </p>
+
+        <h2>Potrace</h2>
+
+        <img
+          src={tracedSVG.tracedSVG}
+          height={tracedSVG.height}
+          width={tracedSVG.width}
+        />
+        <img src={tracedSVG.src} />
 
         <h2
           style={{
@@ -334,6 +344,18 @@ export const pageQuery = graphql`
     cropCenter: imageSharp(id: { regex: "/gatsby.jpg/" }) {
       resize(width: 180, height: 180, cropFocus: CENTER) {
         src
+      }
+    }
+    tracedSVG: imageSharp(id: { regex: "/fecolormatrix-kanye-west.jpg/" }) {
+      resolutions(
+        width: 500
+        trace: { background: "#f00e2e", color: "#192550" }
+        duotone: { highlight: "#f00e2e", shadow: "#192550" }
+      ) {
+        src
+        tracedSVG
+        height
+        width
       }
     }
   }

--- a/examples/using-gatsby-image/src/pages/index.js
+++ b/examples/using-gatsby-image/src/pages/index.js
@@ -58,6 +58,9 @@ class IndexComponent extends React.Component {
             <li>
               <Link to="/background-color/">Background color</Link>
             </li>
+            <li>
+              <Link to="/traced-svg/">Traced SVG</Link>
+            </li>
           </ul>
           <h2>Out of the box it:</h2>
           <ul>
@@ -72,6 +75,9 @@ class IndexComponent extends React.Component {
             <li>
               Uses the "blur-up" effect i.e. it loads a tiny version of the
               image to show while the full image is loading
+            </li>
+            <li>
+              Alternatively provides a "traced placeholder" SVG of the image.
             </li>
             <li>
               Lazy loads images which reduces bandwidth and speeds the initial

--- a/examples/using-gatsby-image/src/pages/traced-svg.js
+++ b/examples/using-gatsby-image/src/pages/traced-svg.js
@@ -1,0 +1,117 @@
+import React from "react"
+import Img from "gatsby-image"
+
+import { rhythm, options } from "../utils/typography"
+
+const TracedSVG = ({ data }) => (
+  <div>
+    <h1>Viribus quid</h1>
+    <h2>Hippason sinu</h2>
+    <Img
+      style={{ display: `inherit` }}
+      css={{
+        marginBottom: rhythm(options.blockMarginBottom),
+        marginLeft: rhythm(options.blockMarginBottom),
+        float: `right`,
+        "&": {
+          "@media (min-width: 500px)": {
+            display: `none`,
+          },
+        },
+      }}
+      title={`Photo by Redd Angelo on Unsplash`}
+      resolutions={data.reddImageMobile.resolutions}
+    />
+    <Img
+      style={{ display: `inherit` }}
+      css={{
+        marginBottom: rhythm(options.blockMarginBottom),
+        marginLeft: rhythm(options.blockMarginBottom),
+        float: `right`,
+        display: `none`,
+        "@media (min-width: 500px)": {
+          display: `inline-block`,
+        },
+      }}
+      title={`Photo by Redd Angelo on Unsplash`}
+      resolutions={data.reddImage.resolutions}
+    />
+    <p>
+      Lorem markdownum nocens, est aut tergo, inmansuetique bella. Neve illud
+      contrarius ad es prior.{` `}
+      <a href="http://nunc.io/fuit.html">Planguntur</a> quondam, sua ferunt
+      uterum semina advertere si fraudesque terram hosti subiecta, nec. Audenti
+      refugitque manibusque aliis infelicem sed mihi aevis! Que ipso templa; tua
+      triformis animumque ad coluit in aliquid.
+    </p>
+    <ul>
+      <li>Infamia lumina sequuntur ulla</li>
+      <li>Aquarum rutilos</li>
+      <li>Hinc vimque</li>
+    </ul>
+    <h2>Et solebat pectus fletus erat furit officium</h2>
+    <p>
+      Proteus ut dis nec exsecrantia data: agrestes, truculenta Peleus. Et
+      diffidunt, talia intravit Thaumantias; figere et <em>et</em> qui socio
+      qui, <a href="http://vixmonet.io/in.html">tuo servet unda</a> hoc{` `}
+      <strong>classi</strong>? Causam <em>quemque</em>? Subigebant cornibus
+      fibras ut per nare nati, cunctis et <strong>illa verba</strong> inrita.
+    </p>
+    <ol>
+      <li>Furori adacto</li>
+      <li>Nocent imagine precari id ante sic</li>
+      <li>Ipsos sine Iuno placabitis silet relinquent blandarum</li>
+      <li>Et pars tabe sociorum et luna illum</li>
+      <li>Et frustra pestifero et inquit cornua victa</li>
+      <li>Constitit nomine senta suspirat et signis genuisse</li>
+    </ol>
+    <Img
+      sizes={data.kenImage.sizes}
+      title={`Photo by Ken Treloar on Unsplash`}
+    />
+    <h2>Levia mihi</h2>
+    <p>
+      Precor Ortygiam, prudens diro stabant prodis moenia; aut tergo{` `}
+      <a href="http://orehaec.io/">loquax et data</a> sua rite in vulnere. Esse
+      lumina plaustrum lacus necopina, iam umbrae nec clipeo sentit{` `}
+      <a href="http://ut.org/hinc">sinistra</a>.
+    </p>
+    <p>
+      Pendebat nitidum vidistis ecce crematisregia fera et lucemque crines.{` `}
+      <a href="http://www.sub.net/">Est sopita satis</a> quod harena
+      Antimachumque tulit fusile. Fieri qui que prosit equidem, meis praescia
+      monebat cacumina tergo acerbo saepe nullaque.
+    </p>
+  </div>
+)
+
+export default TracedSVG
+
+export const query = graphql`
+  query TracedSVGQuery {
+    reddImageMobile: imageSharp(id: { regex: "/redd/" }) {
+      resolutions(width: 125) {
+        ...GatsbyImageSharpResolutions_tracedSVG
+      }
+    }
+    reddImage: imageSharp(id: { regex: "/redd/" }) {
+      resolutions(width: 200) {
+        ...GatsbyImageSharpResolutions_tracedSVG
+      }
+    }
+    kenImage: imageSharp(id: { regex: "/ken-treloar/" }) {
+      sizes(
+        maxWidth: 600
+        traceSVG: {
+          turnPolicy: TURNPOLICY_MINORITY
+          blackOnWhite: true
+          turdSize: 100
+          threshold: 100
+          optTolerance: 1000
+        }
+      ) {
+        ...GatsbyImageSharpSizes_tracedSVG
+      }
+    }
+  }
+`

--- a/examples/using-gatsby-image/src/pages/traced-svg.js
+++ b/examples/using-gatsby-image/src/pages/traced-svg.js
@@ -102,13 +102,7 @@ export const query = graphql`
     kenImage: imageSharp(id: { regex: "/ken-treloar/" }) {
       sizes(
         maxWidth: 600
-        traceSVG: {
-          turnPolicy: TURNPOLICY_MINORITY
-          blackOnWhite: true
-          turdSize: 100
-          threshold: 100
-          optTolerance: 1000
-        }
+        traceSVG: { color: "lightblue", background: "lightcyan" }
       ) {
         ...GatsbyImageSharpSizes_tracedSVG
       }

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -108,6 +108,8 @@ Their fragments are:
 
 If you don't want to use the blur-up effect, choose the fragment with `noBase64` at the end. If you want to use the traced placeholder SVGs, choose the fragment with `tracedSVG` at the end.
 
+_Please see the [gatsby-plugin-sharp](https://www.gatsbyjs.org/packages/gatsby-plugin-sharp/#tracedsvg) documentation for more information on `tracedSVG` and its configuration options._
+
 ## "Resolutions" queries
 
 ### Component

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -16,7 +16,7 @@ But creating optimized images for websites has long been a thorny problem. Ideal
 * Generate multiple smaller images so smartphones and tablets don't download desktop-sized images
 * Strip all unnecessary metadata and optimize JPEG and PNG compression
 * Efficiently lazy load images to speed initial page load and save bandwidth
-* Use the "blur-up" technique to show a preview of the image while it loads
+* Use the "blur-up" technique or a "[traced placeholder](https://github.com/gatsbyjs/gatsby/issues/2435)" SVG to show a preview of the image while it loads
 * Hold the image position so your page doesn't jump while images load
 
 Doing this consistantly across a site feels like sisyphean labor. You manually optimize your images and then… several images are swapped in at the last minute or a design-tweak shaves 100px of width off your images.
@@ -94,8 +94,10 @@ Their fragments are:
 
 * `GatsbyImageSharpResolutions`
 * `GatsbyImageSharpResolutions_noBase64`
+* `GatsbyImageSharpResolutions_tracedSVG`
 * `GatsbyImageSharpSizes`
 * `GatsbyImageSharpSizes_noBase64`
+* `GatsbyImageSharpSizes_tracedSVG`
 
 ### gatsby-source-contentful
 
@@ -104,7 +106,7 @@ Their fragments are:
 * `GatsbyContentfulSizes`
 * `GatsbyContentfulSizes_noBase64`
 
-If you don't want to use the blur-up effect, choose the fragment with `noBase64` at the end.
+If you don't want to use the blur-up effect, choose the fragment with `noBase64` at the end. If you want to use the traced placeholder SVGs, choose the fragment with `tracedSVG` at the end.
 
 ## "Resolutions" queries
 
@@ -120,7 +122,7 @@ Pass in the data returned from the `resolutions` object in your query via the `r
     # Other options include height (set both width and height to crop),
     # grayscale, duotone, rotate, etc.
     resolutions(width: 400) {
-      # Choose either the fragment including a small base64ed image or one without.
+      # Choose either the fragment including a small base64ed image, a traced placeholder SVG, or one without.
       ...GatsbyImageSharpResolutions
     }
   }
@@ -143,7 +145,7 @@ Pass in the data returned from the `sizes` object in your query via the `sizes` 
     # Other options include maxHeight (set both maxWidth and maxHeight to crop),
     # grayscale, duotone, rotate, etc.
     sizes(maxWidth: 700) {
-      # Choose either the fragment including a small base64ed image or one without.
+      # Choose either the fragment including a small base64ed image, a traced placeholder SVG, or one without.
       ...GatsbyImageSharpSizes_noBase64
     }
   }

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -193,6 +193,17 @@ class Image extends React.Component {
               />
             )}
 
+            {/* Show the traced SVG image. */}
+            {image.tracedSVG && (
+              <Img
+                alt={alt}
+                title={title}
+                src={image.tracedSVG}
+                opacity={!this.state.imgLoaded ? 1 : 0}
+                transitionDelay={`0.25s`}
+              />
+            )}
+
             {/* Show a solid background color. */}
             {bgColor && (
               <div
@@ -268,6 +279,17 @@ class Image extends React.Component {
                 src={image.base64}
                 opacity={!this.state.imgLoaded ? 1 : 0}
                 transitionDelay={`0.35s`}
+              />
+            )}
+
+            {/* Show the traced SVG image. */}
+            {image.tracedSVG && (
+              <Img
+                alt={alt}
+                title={title}
+                src={image.tracedSVG}
+                opacity={!this.state.imgLoaded ? 1 : 0}
+                transitionDelay={`0.25s`}
               />
             )}
 

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -163,6 +163,46 @@ the source image colors will be converted to match a gradient color chosen based
 on each pixel's [relative luminance][4].  
 Logic is borrowed from [react-duotone][5].
 
+#### tracedSVG
+
+Generates a traced SVG of your image (see [the original GitHub issue][9]) and
+returns the SVG as "[optimized URL-encoded][10]" `data:` URI.
+It it used in [gatsby-image](https://www.gatsbyjs.org/packages/gatsby-image/) to
+provide an alternative to the default inline base64 placeholder image.
+
+Uses [node-potrace][11] and [SVGO][12] under the hood.
+Default settings for node-potrace:
+
+```javascript
+  {
+    color: `lightgray`,
+    optTolerance: 0.4,
+    turdSize: 100,
+    turnPolicy: TURNPOLICY_MAJORITY,
+  }
+```
+
+All [node-potrace `Potrace` parameters][13] are exposed and can be set via the
+`traceSVG` argument:
+
+```javascript
+responsiveResolution(
+  traceSVG: {
+    color: "#f00e2e"
+    turnPolicy: TURNPOLICY_MINORITY
+    blackOnWhite: false
+  }
+) {
+  src
+  srcSet
+  tracedSVG
+}
+```
+
+Heads up: `tracedSVG` currently traces the _original_ image source. Depending
+on your source image size and settings, please make sure that the generated SVG
+is of reasonable size, especially when using it as a placeholder.
+
 [1]: https://alistapart.com/article/finessing-fecolormatrix
 [2]: http://blog.72lions.com/blog/2015/7/7/duotone-in-js
 [3]: https://ines.io/blog/dynamic-duotone-svg-jade
@@ -171,3 +211,9 @@ Logic is borrowed from [react-duotone][5].
 [6]: http://sharp.dimens.io/en/stable/api-resize/#crop
 [7]: http://sharp.dimens.io/en/stable/api-operation/#rotate
 [8]: http://sharp.dimens.io/en/stable/api-colour/#greyscale
+[9]: https://github.com/gatsbyjs/gatsby/issues/2435
+[10]: https://codepen.io/tigt/post/optimizing-svgs-in-data-uris
+[11]: https://github.com/tooolbox/node-potrace
+[12]: https://github.com/svg/svgo
+[13]: https://github.com/tooolbox/node-potrace#parameters
+[14]: https://github.com/oliver-moran/jimp

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -165,7 +165,7 @@ Logic is borrowed from [react-duotone][5].
 
 #### tracedSVG
 
-Generates a traced SVG of your image (see [the original GitHub issue][9]) and
+Generates a traced SVG of the image (see [the original GitHub issue][9]) and
 returns the SVG as "[optimized URL-encoded][10]" `data:` URI.
 It it used in [gatsby-image](https://www.gatsbyjs.org/packages/gatsby-image/) to
 provide an alternative to the default inline base64 placeholder image.
@@ -200,7 +200,7 @@ responsiveResolution(
 ```
 
 Heads up: `tracedSVG` currently traces the _original_ image source. Depending
-on your source image size and settings, please make sure that the generated SVG
+on source image size and settings, please make sure that the generated SVG
 is of reasonable size, especially when using it as a placeholder.
 
 [1]: https://alistapart.com/article/finessing-fecolormatrix

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -199,10 +199,6 @@ responsiveResolution(
 }
 ```
 
-Heads up: `tracedSVG` currently traces the _original_ image source. Depending
-on source image size and settings, please make sure that the generated SVG
-is of reasonable size, especially when using it as a placeholder.
-
 [1]: https://alistapart.com/article/finessing-fecolormatrix
 [2]: http://blog.72lions.com/blog/2015/7/7/duotone-in-js
 [3]: https://ines.io/blog/dynamic-duotone-svg-jade

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -11,8 +11,10 @@
     "imagemin": "^5.2.2",
     "imagemin-pngquant": "^5.0.0",
     "lodash": "^4.17.4",
+    "potrace": "^2.1.1",
     "progress": "^1.1.8",
-    "sharp": "^0.17.3"
+    "sharp": "^0.17.3",
+    "svgo": "^0.7.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -352,7 +352,12 @@ async function responsiveSizes({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: false,
+    trace: {
+      color: `lightgray`,
+      optTolerance: 0.4,
+      turdSize: 100,
+      turnPolicy: `majority`,
+    },
     pathPrefix: ``,
     toFormat: ``,
   }
@@ -466,7 +471,12 @@ async function resolutions({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: false,
+    trace: {
+      color: `lightgray`,
+      optTolerance: 0.4,
+      turdSize: 100,
+      turnPolicy: `majority`,
+    },
     pathPrefix: ``,
     toFormat: ``,
   }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -648,7 +648,7 @@ function encodeOptimizedSVGDataUri(svgString) {
 
 const optimize = svg => {
   const SVGO = require(`svgo`)
-  const svgo = new SVGO()
+  const svgo = new SVGO({ multipass: true, floatPrecision: 1 })
   return new Promise((resolve, reject) => {
     svgo.optimize(svg, ({ data }) => resolve(data))
   })

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -9,14 +9,9 @@ const imagemin = require(`imagemin`)
 const imageminPngquant = require(`imagemin-pngquant`)
 const queue = require(`async/queue`)
 const path = require(`path`)
-const potrace = require(`potrace`)
-const SVGO = require(`svgo`)
 
 const duotone = require(`./duotone`)
 const { boundActionCreators } = require(`gatsby/dist/redux/actions`)
-
-const svgo = new SVGO()
-const trace = Promise.promisify(potrace.trace)
 
 // Promisify the sharp prototype (methods) to promisify the alternative (for
 // raw) callback-accepting toBuffer(...) method
@@ -571,6 +566,8 @@ async function resolutions({ file, args = {} }) {
 }
 
 async function notMemoizedtraceSVG({ file, args }) {
+  const potrace = require(`potrace`)
+  const trace = Promise.promisify(potrace.trace)
   return await trace(file.absolutePath, args)
     .then(svg => optimize(svg))
     .then(svg => `data:image/svg+xml,${svg.toString(`base64`)}`)
@@ -585,10 +582,13 @@ async function traceSVG(args) {
   return await memoizedTraceSVG(args)
 }
 
-const optimize = svg =>
-  new Promise((resolve, reject) => {
+const optimize = svg => {
+  const SVGO = require(`svgo`)
+  const svgo = new SVGO()
+  return new Promise((resolve, reject) => {
     svgo.optimize(svg, ({ data }) => resolve(data))
   })
+}
 
 exports.queueImageResizing = queueImageResizing
 exports.base64 = base64

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -357,12 +357,7 @@ async function responsiveSizes({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: {
-      color: `#ddd`,
-      optTolerance: 0.4,
-      turdSize: 100,
-      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
-    },
+    trace: false,
     pathPrefix: ``,
     toFormat: ``,
   }
@@ -476,12 +471,7 @@ async function resolutions({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: {
-      color: `#ddd`,
-      optTolerance: 0.4,
-      turdSize: 100,
-      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
-    },
+    trace: false,
     pathPrefix: ``,
     toFormat: ``,
   }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -565,7 +565,7 @@ async function notMemoizedtraceSVG({ file, args }) {
 
 const memoizedTraceSVG = _.memoize(
   notMemoizedtraceSVG,
-  ({ file, args }) => `${file.id}${JSON.stringify(args)}`
+  ({ file, args }) => `${file.absolutePath}${JSON.stringify(args)}`
 )
 
 async function traceSVG(args) {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -352,12 +352,6 @@ async function responsiveSizes({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: {
-      color: `lightgray`,
-      optTolerance: 0.4,
-      turdSize: 100,
-      turnPolicy: `majority`,
-    },
     pathPrefix: ``,
     toFormat: ``,
   }
@@ -435,9 +429,6 @@ async function responsiveSizes({ file, args = {} }) {
   // Get base64 version
   const base64Image = await base64({ file, args: base64Args })
 
-  // Get traced SVG base64
-  const tracedSVG = await traceSVG({ file, args: options.trace })
-
   // Construct src and srcSet strings.
   const originalImg = _.maxBy(images, image => image.width).src
   const fallbackSrc = _.minBy(images, image =>
@@ -450,7 +441,6 @@ async function responsiveSizes({ file, args = {} }) {
 
   return {
     base64: base64Image.src,
-    tracedSVG: tracedSVG,
     aspectRatio: images[0].aspectRatio,
     src: fallbackSrc,
     srcSet,
@@ -471,12 +461,6 @@ async function resolutions({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: {
-      color: `lightgray`,
-      optTolerance: 0.4,
-      turdSize: 100,
-      turnPolicy: `majority`,
-    },
     pathPrefix: ``,
     toFormat: ``,
   }
@@ -535,9 +519,6 @@ async function resolutions({ file, args = {} }) {
   // Get base64 version
   const base64Image = await base64({ file, args: base64Args })
 
-  // Get traced SVG base64
-  const tracedSVG = await traceSVG({ file, args: options.trace })
-
   const fallbackSrc = images[0].src
   const srcSet = images
     .map((image, i) => {
@@ -565,7 +546,6 @@ async function resolutions({ file, args = {} }) {
 
   return {
     base64: base64Image.src,
-    tracedSVG: tracedSVG,
     aspectRatio: images[0].aspectRatio,
     width: images[0].width,
     height: images[0].height,
@@ -615,6 +595,7 @@ const optimize = svg => {
 
 exports.queueImageResizing = queueImageResizing
 exports.base64 = base64
+exports.traceSVG = traceSVG
 exports.responsiveSizes = responsiveSizes
 exports.responsiveResolution = resolutions
 exports.sizes = responsiveSizes

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -355,7 +355,7 @@ async function responsiveSizes({ file, args = {} }) {
     pathPrefix: ``,
     toFormat: ``,
   }
-  const options = _.defaultsDeep({}, args, defaultArgs)
+  const options = _.defaults({}, args, defaultArgs)
   options.maxWidth = parseInt(options.maxWidth, 10)
 
   // Account for images with a high pixel density. We assume that these types of
@@ -464,7 +464,7 @@ async function resolutions({ file, args = {} }) {
     pathPrefix: ``,
     toFormat: ``,
   }
-  const options = _.defaultsDeep({}, args, defaultArgs)
+  const options = _.defaults({}, args, defaultArgs)
   options.width = parseInt(options.width, 10)
 
   // Create sizes for different resolutions — we do 1x, 1.5x, 2x, and 3x.
@@ -558,7 +558,14 @@ async function resolutions({ file, args = {} }) {
 async function notMemoizedtraceSVG({ file, args }) {
   const potrace = require(`potrace`)
   const trace = Promise.promisify(potrace.trace)
-  return await trace(file.absolutePath, args)
+  let defaultArgs = {
+    color: `lightgray`,
+    optTolerance: 0.4,
+    turdSize: 100,
+    turnPolicy: `majority`,
+  }
+  const options = _.defaults({}, args, defaultArgs)
+  return await trace(file.absolutePath, options)
     .then(svg => optimize(svg))
     .then(svg => encodeOptimizedSVGDataUri(svg))
 }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -357,12 +357,7 @@ async function responsiveSizes({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: {
-      color: `lightgray`,
-      optTolerance: 0.4,
-      turdSize: 100,
-      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
-    },
+    trace: false,
     pathPrefix: ``,
     toFormat: ``,
   }
@@ -476,12 +471,7 @@ async function resolutions({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: {
-      color: `lightgray`,
-      optTolerance: 0.4,
-      turdSize: 100,
-      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
-    },
+    trace: false,
     pathPrefix: ``,
     toFormat: ``,
   }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -530,7 +530,7 @@ async function resolutions({ file, args = {} }) {
   const base64Image = await base64({ file, args: base64Args })
 
   // Get traced SVG base64
-  const tracedSVG = await traceSVG(file, options.trace)
+  const tracedSVG = await traceSVG({ file, args: options.trace })
 
   const fallbackSrc = images[0].src
   const srcSet = images
@@ -569,10 +569,19 @@ async function resolutions({ file, args = {} }) {
   }
 }
 
-async function traceSVG(file, args) {
+async function notMemoizedtraceSVG({ file, args }) {
   return await trace(file.absolutePath, args)
     .then(svg => optimize(svg))
     .then(svg => `data:image/svg+xml;utf8,${svg.toString(`base64`)}`)
+}
+
+const memoizedTraceSVG = _.memoize(
+  notMemoizedtraceSVG,
+  ({ file, args }) => `${file.id}${JSON.stringify(args)}`
+)
+
+async function traceSVG(args) {
+  return await memoizedTraceSVG(args)
 }
 
 const optimize = svg =>

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -357,10 +357,15 @@ async function responsiveSizes({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
+    trace: {
+      color: `#ddd`,
+      turdSize: 100,
+      optTolerance: 0.4,
+    },
     pathPrefix: ``,
     toFormat: ``,
   }
-  const options = _.defaults({}, args, defaultArgs)
+  const options = _.defaultsDeep({}, args, defaultArgs)
   options.maxWidth = parseInt(options.maxWidth, 10)
 
   // Account for images with a high pixel density. We assume that these types of
@@ -434,6 +439,9 @@ async function responsiveSizes({ file, args = {} }) {
   // Get base64 version
   const base64Image = await base64({ file, args: base64Args })
 
+  // Get traced SVG base64
+  const tracedSVG = await traceSVG({ file, args: options.trace })
+
   // Construct src and srcSet strings.
   const originalImg = _.maxBy(images, image => image.width).src
   const fallbackSrc = _.minBy(images, image =>
@@ -446,6 +454,7 @@ async function responsiveSizes({ file, args = {} }) {
 
   return {
     base64: base64Image.src,
+    tracedSVG: tracedSVG,
     aspectRatio: images[0].aspectRatio,
     src: fallbackSrc,
     srcSet,
@@ -559,13 +568,13 @@ async function resolutions({ file, args = {} }) {
 
   return {
     base64: base64Image.src,
+    tracedSVG: tracedSVG,
     aspectRatio: images[0].aspectRatio,
     width: images[0].width,
     height: images[0].height,
     src: fallbackSrc,
     srcSet,
     originalName: originalName,
-    tracedSVG: tracedSVG,
   }
 }
 

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -359,8 +359,9 @@ async function responsiveSizes({ file, args = {} }) {
     duotone: false,
     trace: {
       color: `#ddd`,
-      turdSize: 100,
       optTolerance: 0.4,
+      turdSize: 100,
+      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
     },
     pathPrefix: ``,
     toFormat: ``,
@@ -477,8 +478,9 @@ async function resolutions({ file, args = {} }) {
     duotone: false,
     trace: {
       color: `#ddd`,
-      turdSize: 100,
       optTolerance: 0.4,
+      turdSize: 100,
+      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
     },
     pathPrefix: ``,
     toFormat: ``,

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -357,7 +357,12 @@ async function responsiveSizes({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: false,
+    trace: {
+      color: `lightgray`,
+      optTolerance: 0.4,
+      turdSize: 100,
+      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
+    },
     pathPrefix: ``,
     toFormat: ``,
   }
@@ -471,7 +476,12 @@ async function resolutions({ file, args = {} }) {
     pngCompressionLevel: 9,
     grayscale: false,
     duotone: false,
-    trace: false,
+    trace: {
+      color: `lightgray`,
+      optTolerance: 0.4,
+      turdSize: 100,
+      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
+    },
     pathPrefix: ``,
     toFormat: ``,
   }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -570,7 +570,7 @@ async function notMemoizedtraceSVG({ file, args }) {
   const trace = Promise.promisify(potrace.trace)
   return await trace(file.absolutePath, args)
     .then(svg => optimize(svg))
-    .then(svg => `data:image/svg+xml,${svg.toString(`base64`)}`)
+    .then(svg => encodeOptimizedSVGDataUri(svg))
 }
 
 const memoizedTraceSVG = _.memoize(
@@ -580,6 +580,19 @@ const memoizedTraceSVG = _.memoize(
 
 async function traceSVG(args) {
   return await memoizedTraceSVG(args)
+}
+
+// https://codepen.io/tigt/post/optimizing-svgs-in-data-uris
+function encodeOptimizedSVGDataUri(svgString) {
+  var uriPayload = encodeURIComponent(svgString) // encode URL-unsafe characters
+    .replace(/%0A/g, ``) // remove newlines
+    .replace(/%20/g, ` `) // put spaces back in
+    .replace(/%3D/g, `=`) // ditto equals signs
+    .replace(/%3A/g, `:`) // ditto colons
+    .replace(/%2F/g, `/`) // ditto slashes
+    .replace(/%22/g, `'`) // replace quotes with apostrophes (may break certain SVGs)
+
+  return `data:image/svg+xml,` + uriPayload
 }
 
 const optimize = svg => {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -583,7 +583,7 @@ async function resolutions({ file, args = {} }) {
 async function notMemoizedtraceSVG({ file, args }) {
   return await trace(file.absolutePath, args)
     .then(svg => optimize(svg))
-    .then(svg => `data:image/svg+xml;utf8,${svg.toString(`base64`)}`)
+    .then(svg => `data:image/svg+xml,${svg.toString(`base64`)}`)
 }
 
 const memoizedTraceSVG = _.memoize(

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -558,12 +558,13 @@ async function resolutions({ file, args = {} }) {
 async function notMemoizedtraceSVG({ file, args, fileArgs }) {
   const potrace = require(`potrace`)
   const trace = Promise.promisify(potrace.trace)
-  let defaultArgs = {
+  const defaultArgs = {
     color: `lightgray`,
     optTolerance: 0.4,
     turdSize: 100,
-    turnPolicy: `majority`,
+    turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
   }
+  const optionsSVG = _.defaults(args, defaultArgs)
 
   const defaultFileResizeArgs = {
     width: 400,
@@ -618,7 +619,7 @@ async function notMemoizedtraceSVG({ file, args, fileArgs }) {
     })
   )
 
-  return trace(tmpFilePath, options)
+  return trace(tmpFilePath, optionsSVG)
     .then(svg => optimize(svg))
     .then(svg => encodeOptimizedSVGDataUri(svg))
 }

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -83,7 +83,7 @@ const PotraceType = new GraphQLInputObjectType({
       threshold: { type: GraphQLInt },
       blackOnWhite: { type: GraphQLBoolean },
       color: { type: GraphQLString },
-      background: { type: GraphQLString, defaultValue: `#d3d3d3` },
+      background: { type: GraphQLString },
     }
   },
 })

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -146,7 +146,6 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
           base64: { type: GraphQLString },
           tracedSVG: {
             type: GraphQLString,
-            resolve: (image, fieldArgs) => getTracedSVG(image, fieldArgs),
           },
           aspectRatio: { type: GraphQLFloat },
           width: { type: GraphQLFloat },

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -95,7 +95,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
   }
 
   const getTracedSVG = (image, fieldArgs) => {
-    const publicPath = path.join(process.cwd(), `public`, image.originalImg)
+    const publicPath = path.join(process.cwd(), `public`, image.src)
     const promise = traceSVG({
       file: { absolutePath: publicPath },
       args: { ...fieldArgs, pathPrefix },
@@ -146,6 +146,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
           base64: { type: GraphQLString },
           tracedSVG: {
             type: GraphQLString,
+            resolve: (image, fieldArgs) => getTracedSVG(image, fieldArgs),
           },
           aspectRatio: { type: GraphQLFloat },
           width: { type: GraphQLFloat },

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -83,7 +83,7 @@ const PotraceType = new GraphQLInputObjectType({
       threshold: { type: GraphQLInt },
       blackOnWhite: { type: GraphQLBoolean },
       color: { type: GraphQLString },
-      background: { type: GraphQLString },
+      background: { type: GraphQLString, defaultValue: `#d3d3d3` },
     }
   },
 })

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -166,8 +166,9 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
           type: PotraceType,
           defaultValue: {
             color: `#ddd`,
-            turdSize: 100,
             optTolerance: 0.4,
+            turnPolicy: Potrace.TURNPOLICY_MAJORITY,
+            turdSize: 100,
           },
         },
         quality: {
@@ -233,8 +234,9 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
           type: PotraceType,
           defaultValue: {
             color: `#ddd`,
-            turdSize: 100,
             optTolerance: 0.4,
+            turdSize: 100,
+            turnPolicy: Potrace.TURNPOLICY_MAJORITY,
           },
         },
         quality: {

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -98,7 +98,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
       file: {
         absolutePath: parent.image.parent.split(` `)[0],
       },
-      args: { ...parent.fieldArgs.trace },
+      args: { ...parent.fieldArgs.traceSVG },
     })
     return promise
   }
@@ -176,7 +176,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
           type: DuotoneGradientType,
           defaultValue: false,
         },
-        trace: {
+        traceSVG: {
           type: PotraceType,
           defaultValue: false,
         },
@@ -247,7 +247,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
           type: DuotoneGradientType,
           defaultValue: false,
         },
-        trace: {
+        traceSVG: {
           type: PotraceType,
           defaultValue: false,
         },

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -57,6 +57,18 @@ const DuotoneGradientType = new GraphQLInputObjectType({
   },
 })
 
+const PotraceType = new GraphQLInputObjectType({
+  name: `Potrace`,
+  fields: () => {
+    return {
+      background: { type: GraphQLString },
+      color: { type: GraphQLString },
+      turdSize: { type: GraphQLFloat },
+      optTolerance: { type: GraphQLFloat },
+    }
+  },
+})
+
 module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
   if (type.name !== `ImageSharp`) {
     return {}
@@ -109,6 +121,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
           src: { type: GraphQLString },
           srcSet: { type: GraphQLString },
           originalName: { type: GraphQLString },
+          tracedSVG: { type: GraphQLString },
         },
       }),
       args: {
@@ -130,6 +143,14 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         duotone: {
           type: DuotoneGradientType,
           defaultValue: false,
+        },
+        trace: {
+          type: PotraceType,
+          defaultValue: {
+            color: `#ddd`,
+            turdSize: 100,
+            optTolerance: 0.4,
+          },
         },
         quality: {
           type: GraphQLInt,

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -95,7 +95,9 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
 
   const getTracedSVG = parent => {
     const promise = traceSVG({
-      file: { absolutePath: path.join(process.cwd(), `public`, parent.src) },
+      file: {
+        absolutePath: parent.image.parent.split(` `)[0],
+      },
       args: { ...parent.fieldArgs.trace },
     })
     return promise
@@ -204,6 +206,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         ).then(o =>
           Object.assign({}, o, {
             fieldArgs,
+            image,
           })
         ),
     },
@@ -274,6 +277,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         ).then(o =>
           Object.assign({}, o, {
             fieldArgs,
+            image,
           })
         ),
     },

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -19,6 +19,7 @@ const sharp = require(`sharp`)
 const fsExtra = require(`fs-extra`)
 const sizeOf = require(`image-size`)
 const path = require(`path`)
+const Potrace = require(`potrace`).Potrace
 
 const ImageFormatType = new GraphQLEnumType({
   name: `ImageFormat`,
@@ -61,10 +62,27 @@ const PotraceType = new GraphQLInputObjectType({
   name: `Potrace`,
   fields: () => {
     return {
-      background: { type: GraphQLString },
-      color: { type: GraphQLString },
+      turnPolicy: {
+        type: new GraphQLEnumType({
+          name: `PotraceTurnPolicy`,
+          values: {
+            TURNPOLICY_BLACK: { value: Potrace.TURNPOLICY_BLACK },
+            TURNPOLICY_WHITE: { value: Potrace.TURNPOLICY_WHITE },
+            TURNPOLICY_LEFT: { value: Potrace.TURNPOLICY_LEFT },
+            TURNPOLICY_RIGHT: { value: Potrace.TURNPOLICY_RIGHT },
+            TURNPOLICY_MINORITY: { value: Potrace.TURNPOLICY_MINORITY },
+            TURNPOLICY_MAJORITY: { value: Potrace.TURNPOLICY_MAJORITY },
+          },
+        }),
+      },
       turdSize: { type: GraphQLFloat },
+      alphaMax: { type: GraphQLFloat },
+      optCurve: { type: GraphQLBoolean },
       optTolerance: { type: GraphQLFloat },
+      threshold: { type: GraphQLInt },
+      blackOnWhite: { type: GraphQLBoolean },
+      color: { type: GraphQLString },
+      background: { type: GraphQLString },
     }
   },
 })

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -115,13 +115,13 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         name: `ImageSharpResolutions`,
         fields: {
           base64: { type: GraphQLString },
+          tracedSVG: { type: GraphQLString },
           aspectRatio: { type: GraphQLFloat },
           width: { type: GraphQLFloat },
           height: { type: GraphQLFloat },
           src: { type: GraphQLString },
           srcSet: { type: GraphQLString },
           originalName: { type: GraphQLString },
-          tracedSVG: { type: GraphQLString },
         },
       }),
       args: {
@@ -182,6 +182,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         name: `ImageSharpSizes`,
         fields: {
           base64: { type: GraphQLString },
+          tracedSVG: { type: GraphQLString },
           aspectRatio: { type: GraphQLFloat },
           src: { type: GraphQLString },
           srcSet: { type: GraphQLString },
@@ -209,6 +210,14 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         duotone: {
           type: DuotoneGradientType,
           defaultValue: false,
+        },
+        trace: {
+          type: PotraceType,
+          defaultValue: {
+            color: `#ddd`,
+            turdSize: 100,
+            optTolerance: 0.4,
+          },
         },
         quality: {
           type: GraphQLInt,

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -73,15 +73,16 @@ const PotraceType = new GraphQLInputObjectType({
             TURNPOLICY_MINORITY: { value: Potrace.TURNPOLICY_MINORITY },
             TURNPOLICY_MAJORITY: { value: Potrace.TURNPOLICY_MAJORITY },
           },
+          defaultValue: Potrace.TURNPOLICY_MAJORITY,
         }),
       },
-      turdSize: { type: GraphQLFloat },
+      turdSize: { type: GraphQLFloat, defaultValue: 100 },
       alphaMax: { type: GraphQLFloat },
       optCurve: { type: GraphQLBoolean },
-      optTolerance: { type: GraphQLFloat },
+      optTolerance: { type: GraphQLFloat, defaultValue: 0.4 },
       threshold: { type: GraphQLInt },
       blackOnWhite: { type: GraphQLBoolean },
-      color: { type: GraphQLString },
+      color: { type: GraphQLString, defaultValue: `lightgray` },
       background: { type: GraphQLString },
     }
   },
@@ -164,12 +165,6 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         },
         trace: {
           type: PotraceType,
-          defaultValue: {
-            color: `lightgray`,
-            optTolerance: 0.4,
-            turnPolicy: Potrace.TURNPOLICY_MAJORITY,
-            turdSize: 100,
-          },
         },
         quality: {
           type: GraphQLInt,
@@ -232,12 +227,6 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         },
         trace: {
           type: PotraceType,
-          defaultValue: {
-            color: `lightgray`,
-            optTolerance: 0.4,
-            turdSize: 100,
-            turnPolicy: Potrace.TURNPOLICY_MAJORITY,
-          },
         },
         quality: {
           type: GraphQLInt,

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -165,7 +165,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         trace: {
           type: PotraceType,
           defaultValue: {
-            color: `#ddd`,
+            color: `lightgray`,
             optTolerance: 0.4,
             turnPolicy: Potrace.TURNPOLICY_MAJORITY,
             turdSize: 100,
@@ -233,7 +233,7 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         trace: {
           type: PotraceType,
           defaultValue: {
-            color: `#ddd`,
+            color: `lightgray`,
             optTolerance: 0.4,
             turdSize: 100,
             turnPolicy: Potrace.TURNPOLICY_MAJORITY,

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -13,6 +13,7 @@ const {
   base64,
   sizes,
   resolutions,
+  traceSVG,
 } = require(`gatsby-plugin-sharp`)
 
 const sharp = require(`sharp`)
@@ -93,6 +94,15 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
     return {}
   }
 
+  const getTracedSVG = (image, fieldArgs) => {
+    const publicPath = path.join(process.cwd(), `public`, image.originalImg)
+    const promise = traceSVG({
+      file: { absolutePath: publicPath },
+      args: { ...fieldArgs, pathPrefix },
+    })
+    return promise
+  }
+
   return {
     original: {
       type: new GraphQLObjectType({
@@ -134,7 +144,10 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         name: `ImageSharpResolutions`,
         fields: {
           base64: { type: GraphQLString },
-          tracedSVG: { type: GraphQLString },
+          tracedSVG: {
+            type: GraphQLString,
+            resolve: (image, fieldArgs) => getTracedSVG(image, fieldArgs),
+          },
           aspectRatio: { type: GraphQLFloat },
           width: { type: GraphQLFloat },
           height: { type: GraphQLFloat },
@@ -196,7 +209,10 @@ module.exports = ({ type, pathPrefix, getNodeAndSavePathDependency }) => {
         name: `ImageSharpSizes`,
         fields: {
           base64: { type: GraphQLString },
-          tracedSVG: { type: GraphQLString },
+          tracedSVG: {
+            type: GraphQLString,
+            resolve: (image, fieldArgs) => getTracedSVG(image, fieldArgs),
+          },
           aspectRatio: { type: GraphQLFloat },
           src: { type: GraphQLString },
           srcSet: { type: GraphQLString },

--- a/packages/gatsby-transformer-sharp/src/fragments.js
+++ b/packages/gatsby-transformer-sharp/src/fragments.js
@@ -9,6 +9,16 @@ export const gatsbyImageSharpResolutions = graphql`
   }
 `
 
+export const gatsbyImageSharpResolutionsTracedSVG = graphql`
+  fragment GatsbyImageSharpResolutions_tracedSVG on ImageSharpResolutions {
+    tracedSVG
+    width
+    height
+    src
+    srcSet
+  }
+`
+
 export const gatsbyImageSharpResolutionsNoBase64 = graphql`
   fragment GatsbyImageSharpResolutions_noBase64 on ImageSharpResolutions {
     width
@@ -21,6 +31,16 @@ export const gatsbyImageSharpResolutionsNoBase64 = graphql`
 export const gatsbyImageSharpSizes = graphql`
   fragment GatsbyImageSharpSizes on ImageSharpSizes {
     base64
+    aspectRatio
+    src
+    srcSet
+    sizes
+  }
+`
+
+export const gatsbyImageSharpSizesTracedSVG = graphql`
+  fragment GatsbyImageSharpSizes_tracedSVG on ImageSharpSizes {
+    tracedSVG
     aspectRatio
     src
     srcSet

--- a/scripts/publish-site.sh
+++ b/scripts/publish-site.sh
@@ -16,6 +16,8 @@ yarn
 echo "=== Copying built Gatsby to website."
 gatsby-dev --scan-once --quiet
 
+cp ../../packages/gatsby-transformer-sharp/src/fragments.js node_modules/gatsby-transformer-sharp/src/fragments.js
+
 echo "=== Building website"
 # Once we get better cache invalidation, remove the following
 # line.


### PR DESCRIPTION
(See #2435) Using node-potrace (and Jimp…) and SVGO.
Only working with `resolutions` right now, also didn’t check SVG size yet … and still have to look at gatsby-image too. :sneezing_face:

`turdSize`, `optTolerance` and `turnPolicy` defaults for potrace follow https://twitter.com/Martin_Adams/status/918481948217049088

Todo:

- [x] add to `sizes()`
- [x] support all [node-potrace parameters](https://github.com/tooolbox/node-potrace#parameters)
- [x] memoize
- [x] update README
- [x] Fix for IE – https://codepen.io/tigt/post/optimizing-svgs-in-data-uris