### PR TITLE
Fix typo tred => tread

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -27,7 +27,7 @@ When adding this plugin to your `gatsby-config.js`, you can pass in options to
 override the default sw-precache config.
 
 The default config is as following. Warning, you can break the offline support
-and AppCache setup by changing these options so tred carefully.
+and AppCache setup by changing these options so tread carefully.
 
 ```javascript
 const options = {


### PR DESCRIPTION
You might also want to change :

> is as following

to 

> is as follows

in the readme.

