### PR TITLE
Strip ACF key from response when not an object

### DIFF
--- a/packages/gatsby-source-wordpress/src/__tests__/normalize.js
+++ b/packages/gatsby-source-wordpress/src/__tests__/normalize.js
@@ -48,6 +48,16 @@ describe(`Process WordPress data`, () => {
     entities = normalize.mapEntitiesToMedia(entities)
     expect(entities).toMatchSnapshot()
   })
+  it(`Removes the acf key when acf is not an object`, () => {
+    let dummyEntities = [
+      { id: 1, acf: false },
+      { id: 2, acf: {} },
+    ]
+    expect(normalize.normalizeACF(dummyEntities)).toEqual([
+      { id: 1 },
+      { id: 2, acf: {} },
+    ])
+  })
 
   // Actually let's not test this since it's a bit tricky to mock
   // as it needs access to the store/cache + would download file.

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -51,6 +51,9 @@ exports.sourceNodes = async (
 
   // Normalize data & create nodes
 
+  // Remove ACF key if it's not an object
+  entities = normalize.normalizeACF(entities)
+
   // Creates entities from object collections of entities
   entities = normalize.normalizeEntities(entities)
 

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -60,13 +60,10 @@ exports.getValidKey = getValidKey
 // Remove the ACF key from the response when it's not an object
 const normalizeACF = entities =>
   entities.map(e => {
-    Object.keys(e)
-      .forEach(key => {
-        if (!_.isObject(e[`acf`])) {
-          delete e[`acf`]
-        }
-      })
-      return e
+    if (!_.isObject(e[`acf`])) {
+      delete e[`acf`]
+    }
+    return e
   })
 
 exports.normalizeACF = normalizeACF

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -57,6 +57,20 @@ function getValidKey({ key, verbose = false }) {
 
 exports.getValidKey = getValidKey
 
+// Remove the ACF key from the response when it's not an object
+const normalizeACF = entities =>
+  entities.map(e => {
+    Object.keys(e)
+      .forEach(key => {
+        if (!_.isObject(e[`acf`])) {
+          delete e[`acf`]
+        }
+      })
+      return e
+  })
+
+exports.normalizeACF = normalizeACF
+
 // Create entities from the few the WordPress API returns as an object for presumably
 // legacy reasons.
 const normalizeEntities = entities => {


### PR DESCRIPTION
Fixes: #2471 

This PR removes `acf: false` from the WP API response.

When a post doesn't have any ACF fields, the WP API is set to `acf: false` which breaks all posts in that post type. Instead, we should just remove `acf: false` as it's not required.

