### PR TITLE
Specifying location of gatsby-config.js

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -135,7 +135,7 @@ const typography = new Typography(kirkhamTheme)
 module.exports = typography
 ```
 
-`gatsby-config.js`
+`gatsby-config.js` (must be in the root of your project, not under src)
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
Myself and a couple of other people seemed to be getting the same error with graphQL saying that the siteMetadata was undefined. The solution in my case it seems was the location of my gatsby-config.js file, as I didn't realize that it needed to be in the root directory, not under src as the other files had been.