### PR TITLE
Change L25 to 125 in gatsby-image docs example

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -56,7 +56,7 @@ export const query = graphql`
       childImageSharp {
         # Specify the image processing steps right in the query
         # Makes it trivial to update as your page's design changes.
-        resolutions(width: l25, height: 125) {
+        resolutions(width: 125, height: 125) {
           ...GatsbyImageSharpResolutions
         }
       }


### PR DESCRIPTION
Docs have a typo, example code has L25 (but lowercase) instead of 125. Pretty much impossible to spot, until you copy paste it into your project ;)