### PR TITLE
Fix Hot Module Replacement

### DIFF
--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -138,6 +138,8 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     <Router history={history}>{children}</Router>
   )
 
+  const ComponentRendererWithRouter = withRouter(ComponentRenderer)
+
   loader.getResourcesForPathname(window.location.pathname, () => {
     const Root = () =>
       createElement(
@@ -146,7 +148,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
         createElement(
           ScrollContext,
           { shouldUpdateScroll },
-          createElement(withRouter(ComponentRenderer), {
+          createElement(ComponentRendererWithRouter, {
             layout: true,
             children: layoutProps =>
               createElement(Route, {

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -110,6 +110,8 @@ const DefaultRouter = ({ children }) => (
   <Router history={history}>{children}</Router>
 )
 
+const ComponentRendererWithRouter = withRouter(ComponentRenderer)
+
 // Always have to have one top-level layout
 // can have ones below that. Find page, if has different
 // parent layout(s), loop through those until finally the
@@ -122,7 +124,7 @@ const Root = () =>
     createElement(
       ScrollContext,
       { shouldUpdateScroll },
-      createElement(withRouter(ComponentRenderer), {
+      createElement(ComponentRendererWithRouter, {
         layout: true,
         children: layoutProps =>
           createElement(Route, {


### PR DESCRIPTION
React Hot Loader can’t understand components that aren’t topLevel variables, just had to move it to a variable.

Went ahead and changed production-app.js for consistency.