### PR TITLE
Note on the Plugin Custom Post Types UI

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -83,7 +83,7 @@ We welcome PRs adding support for data from other plugins.
 
 These plugins were tested. We welcome PRs adding support for data from other plugins.
 
-- [x] Custom Post Types : it will work seemlessly, no further option needs to be activated.
+- [x] Custom Post Types : it will work seemlessly, no further option needs to be activated. ("Show in REST API" setting needs to be set to true on the custom post in the plugin settings for this to work. It's set to "false" by default.)
 
 - [x] [ACF](https://www.advancedcustomfields.com/) The option `useACF: true` must be activated in your site's `gatsby-config.js`.
   *  You must have the plugin [acf-to-rest-api](https://github.com/airesvsg/acf-to-rest-api) installed in WordPress.


### PR DESCRIPTION
Custom Post Types UI sets the custom post to not show in REST API by default, so this needs to be enabled in order for this to work.