### PR TITLE
[www] Features: Use „palette“ colors, misc. UI

### DIFF
--- a/www/src/components/evaluation-cell.js
+++ b/www/src/components/evaluation-cell.js
@@ -33,9 +33,10 @@ class EvaluationCell extends Component {
       width: rhythm(3 / 4),
       display: `block`,
       borderRadius: `50%`,
+      margin: `0 auto`,
       [presets.Mobile]: {
-        height: rhythm(0.95),
-        width: rhythm(0.95),
+        height: rhythm(0.875),
+        width: rhythm(0.875),
       },
     }
     return (

--- a/www/src/components/evaluation-cell.js
+++ b/www/src/components/evaluation-cell.js
@@ -31,7 +31,6 @@ class EvaluationCell extends Component {
     const basicStyling = {
       height: rhythm(3 / 4),
       width: rhythm(3 / 4),
-      display: `block`,
       borderRadius: `50%`,
       margin: `0 auto`,
       [presets.Mobile]: {
@@ -43,7 +42,6 @@ class EvaluationCell extends Component {
       <div
         css={{
           ...basicStyling,
-          verticalAlign: `middle`,
           // border: `1px solid ${presets.brandLight}`,
           backgroundColor:
             [`N/A`, `0`, ``].indexOf(this.props.num) !== -1

--- a/www/src/components/evaluation-cell.js
+++ b/www/src/components/evaluation-cell.js
@@ -5,7 +5,7 @@ import presets from "../utils/presets"
 class EvaluationCell extends Component {
   render() {
     const bgDefault = `#edebf0`
-    const bgFeatureAvailability = presets.brandLight
+    const bgFeatureAvailability = presets.accent
 
     const getBackground = num => {
       switch (num) {

--- a/www/src/components/evaluation-cell.js
+++ b/www/src/components/evaluation-cell.js
@@ -4,16 +4,19 @@ import presets from "../utils/presets"
 
 class EvaluationCell extends Component {
   render() {
+    const bgDefault = `#edebf0`
+    const bgFeatureAvailability = presets.brandLight
+
     const getBackground = num => {
       switch (num) {
         case `3`: {
           return `none`
         }
         case `2`: {
-          return `linear-gradient(90deg, transparent 50%, #dddddd 50%)`
+          return `linear-gradient(90deg, transparent 50%, ${bgDefault} 50%)`
         }
         case `1`: {
-          return `linear-gradient(180deg, transparent 50%, #dddddd 50%), linear-gradient(90deg, transparent 50%, #dddddd 50%)`
+          return `linear-gradient(180deg, transparent 50%, ${bgDefault} 50%), linear-gradient(90deg, transparent 50%, ${bgDefault} 50%)`
         }
         case `0`: {
           return `none`
@@ -30,10 +33,9 @@ class EvaluationCell extends Component {
       width: rhythm(3 / 4),
       display: `block`,
       borderRadius: `50%`,
-      border: `1px solid #9d7cbf`,
       [presets.Mobile]: {
-        height: rhythm(1),
-        width: rhythm(1),
+        height: rhythm(0.95),
+        width: rhythm(0.95),
       },
     }
     return (
@@ -41,10 +43,11 @@ class EvaluationCell extends Component {
         css={{
           ...basicStyling,
           verticalAlign: `middle`,
+          // border: `1px solid ${presets.brandLight}`,
           backgroundColor:
             [`N/A`, `0`, ``].indexOf(this.props.num) !== -1
-              ? `#dddddd`
-              : `#9d7cbf`,
+              ? bgDefault
+              : bgFeatureAvailability,
           backgroundImage: getBackground(this.props.num),
           ...(this.props.style || {}),
         }}

--- a/www/src/components/evaluation-table-section-header-bottom.js
+++ b/www/src/components/evaluation-table-section-header-bottom.js
@@ -4,7 +4,7 @@ import logo from "../gatsby-negative.svg"
 import jekyll from "../assets/jekyll.svg"
 import wordpress from "../assets/wordpress.png"
 import squarespace from "../assets/squarespace-compressed.png"
-import { rhythm } from "../utils/typography"
+import { rhythm, scale, options } from "../utils/typography"
 
 const subHeaderTitles = [
   ``,
@@ -74,30 +74,33 @@ const renderSubHeader = props => (
         key={i}
         css={{
           display: `table-cell`,
-          background: `#f8f8f8`,
-          //borderLeft: i > 1 ? `1px solid #dddddd` : `none`,
-          //borderRight: i === 5 ? `1px solid #dddddd` : `none`,
-          paddingTop: rhythm(1 / 4),
-          paddingLeft: rhythm(1 / 4),
-          paddingRight: i >= 1 ? rhythm(1 / 4) : 0,
-          paddingBottom: rhythm(1 / 4),
-          fontStyle: `italic`,
+          background: `${presets.sidebar}`,
+          // borderLeft: i > 0 ? `1px solid ${presets.brandLighter}` : `none`,
+          // borderRight: i === 5 ? `1px solid ${presets.brandLighter}` : `none`,
           fontWeight: 600,
-          textAlign: `center`,
+          ...scale(-1 / 9),
+          lineHeight: 1.3,
+          textAlign: `left`,
           verticalAlign: `middle`,
-          fontSize: `90%`,
-          lineHeight: `${rhythm(1)}`,
-          "&:last-child": {
-            paddingRight: rhythm(1 / 2),
+          fontFamily: options.headerFontFamily.join(`,`),
+          borderColor: presets.veryLightPurple,
+          "&&": {
+            paddingTop: rhythm(1 / 4),
+            paddingLeft: rhythm(1 / 4),
+            paddingRight: i >= 1 ? rhythm(1 / 2) : 0,
+            paddingBottom: rhythm(1 / 4),
+            "&:last-child": {
+              paddingRight: i >= 1 ? rhythm(1 / 2) : 0,
+            },
           },
           [presets.Mobile]: {
             paddingTop: rhythm(1 / 2),
             paddingLeft: `${rhythm(1 / 2)} !important`,
             paddingRight: rhythm(1 / 2),
+            paddingBottom: rhythm(1 / 2),
             "&:last-child": {
               paddingRight: rhythm(1 / 2),
             },
-            paddingBottom: rhythm(1 / 2),
           },
         }}
       >

--- a/www/src/components/evaluation-table-section-header-bottom.js
+++ b/www/src/components/evaluation-table-section-header-bottom.js
@@ -6,60 +6,22 @@ import wordpress from "../assets/wordpress.png"
 import squarespace from "../assets/squarespace-compressed.png"
 import { rhythm, scale, options } from "../utils/typography"
 
+const subHeaderTitleStyles = {
+  height: rhythm(3 / 4),
+  marginBottom: 0,
+  display: `block`,
+  margin: `auto`,
+  [presets.Mobile]: {
+    height: rhythm(5 / 4),
+  },
+}
+
 const subHeaderTitles = [
   ``,
-  <img
-    src={logo}
-    key="0"
-    css={{
-      height: rhythm(3 / 4),
-      marginBottom: 0,
-      display: `block`,
-      margin: `auto`,
-      [presets.Mobile]: {
-        height: rhythm(5 / 4),
-      },
-    }}
-  />,
-  <img
-    src={jekyll}
-    key="1"
-    css={{
-      height: rhythm(3 / 4),
-      marginBottom: 0,
-      display: `block`,
-      margin: `auto`,
-      [presets.Mobile]: {
-        height: rhythm(5 / 4),
-      },
-    }}
-  />,
-  <img
-    src={wordpress}
-    key="2"
-    css={{
-      height: rhythm(3 / 4),
-      marginBottom: 0,
-      display: `block`,
-      margin: `auto`,
-      [presets.Mobile]: {
-        height: rhythm(5 / 4),
-      },
-    }}
-  />,
-  <img
-    src={squarespace}
-    key="3"
-    css={{
-      height: rhythm(3 / 4),
-      marginBottom: 0,
-      display: `block`,
-      margin: `auto`,
-      [presets.Mobile]: {
-        height: rhythm(5 / 4),
-      },
-    }}
-  />,
+  <img src={logo} key="0" css={subHeaderTitleStyles} />,
+  <img src={jekyll} key="1" css={subHeaderTitleStyles} />,
+  <img src={wordpress} key="2" css={subHeaderTitleStyles} />,
+  <img src={squarespace} key="3" css={subHeaderTitleStyles} />,
 ]
 
 const renderSubHeader = props => (

--- a/www/src/components/evaluation-table-section-header-top.js
+++ b/www/src/components/evaluation-table-section-header-top.js
@@ -1,6 +1,6 @@
 import React from "react"
 import presets from "../utils/presets"
-import { rhythm } from "../utils/typography"
+import { scale, rhythm, options } from "../utils/typography"
 
 const superHeaderTitles = [
   `Feature`,
@@ -11,19 +11,33 @@ const superHeaderTitles = [
 ]
 
 const superHeader = () => (
-  <tr key="head">
+  <tr>
     {superHeaderTitles.map((header, i) => (
       <td
         key={i}
         css={{
+          "&&": {
+            padding: `${rhythm(1 / 2)} ${rhythm(1 / 2)} ${rhythm(3 / 8)}`,
+          },
           display: `none`,
-          padding: rhythm(1 / 2),
           textTransform: `uppercase`,
-          fontSize: `80%`,
-          fontWeight: 600,
+          ...scale(-3 / 6),
+          lineHeight: 1,
+          fontWeight: 500,
           textAlign: `center`,
           verticalAlign: `bottom`,
           width: i === 0 ? 120 : `inherit`,
+          border: 0,
+          // fontFamily: options.headerFontFamily.join(`,`),
+          color: presets.calm,
+          background: presets.sidebar,
+          "&:first-child": {
+            borderTopLeftRadius: presets.radiusLg,
+            textAlign: `left`,
+          },
+          "&:last-child": {
+            borderTopRightRadius: presets.radiusLg,
+          },
           [presets.Mobile]: {
             display: `table-cell`,
             width: 125,
@@ -38,8 +52,8 @@ const superHeader = () => (
       >
         <span
           css={{
-            "-webkitHyphens": `auto`,
-            "-msHyphens": `auto`,
+            WebkitHyphens: `auto`,
+            MsHyphens: `auto`,
             hyphens: `auto`,
             display: `inline-block`,
           }}

--- a/www/src/components/evaluation-table-section-title.js
+++ b/www/src/components/evaluation-table-section-title.js
@@ -2,8 +2,8 @@ import React from "react"
 import PropTypes from "prop-types"
 
 const SectionTitle = props => (
-  <tr style={{ borderBottom: 0 }}>
-    <td style={{ borderBottom: 0 }} colSpan={4}>
+  <tr css={{ borderBottom: 0 }}>
+    <td css={{ borderBottom: 0 }} colSpan={4}>
       <h3>{props.text}</h3>
     </td>
   </tr>

--- a/www/src/components/evaluation-table.js
+++ b/www/src/components/evaluation-table.js
@@ -162,12 +162,18 @@ class EvaluationTable extends Component {
                       <td
                         css={{
                           fontFamily: options.headerFontFamily.join(`,`),
-                          paddingRight: `${rhythm(1)} !important`,
-                          paddingLeft: `${rhythm(1)} !important`,
                           paddingBottom: `calc(${rhythm(1)} - 1px)`,
-                          [presets.Mobile]: {
-                            paddingRight: `${rhythm(2)} !important`,
-                            paddingLeft: `${rhythm(2)} !important`,
+                          "&&": {
+                            paddingRight: `${rhythm(1 / 4)}`,
+                            paddingLeft: `${rhythm(1 / 4)}`,
+                            [presets.Mobile]: {
+                              paddingRight: `${rhythm(1 / 2)}`,
+                              paddingLeft: `${rhythm(1 / 2)}`,
+                            },
+                            [presets.Phablet]: {
+                              paddingRight: `${rhythm(2)}`,
+                              paddingLeft: `${rhythm(2)}`,
+                            },
                           },
                         }}
                         colSpan="5"

--- a/www/src/components/evaluation-table.js
+++ b/www/src/components/evaluation-table.js
@@ -83,22 +83,7 @@ class EvaluationTable extends Component {
         case 2:
         case 3:
         case 4: {
-          return (
-            <div
-              css={{
-                margin: `auto`,
-                height: rhythm(3 / 4),
-                width: rhythm(3 / 4),
-                verticalAlign: `middle`,
-                [presets.Mobile]: {
-                  height: rhythm(1),
-                  width: rhythm(1),
-                },
-              }}
-            >
-              <EvaluationCell num={text} />
-            </div>
-          )
+          return <EvaluationCell num={text} />
         }
       }
     }

--- a/www/src/components/evaluation-table.js
+++ b/www/src/components/evaluation-table.js
@@ -20,17 +20,17 @@ class EvaluationTable extends Component {
         words.slice(0, words.length - 1).join(` `),
         <span
           css={{
-            "-webkitHyphens": `auto`,
-            "-msHyphens": `auto`,
-            hyphens: `auto`,
-            wordBreak: `break-all`,
-            display: `inline-block`,
+            // WebkitHyphens: `auto`,
+            // MsHyphens: `auto`,
+            // hyphens: `auto`,
+            // wordBreak: `break-all`,
+            // display: `inline-block`,
             "&:hover": {
-              background: `#e0d6eb`,
+              background: presets.lightPurple,
             },
           }}
         >
-          &nbsp;
+          {` `}
           {`${words[words.length - 1]} `}
           <img
             src={infoIcon}
@@ -49,19 +49,26 @@ class EvaluationTable extends Component {
         case 0: {
           return (
             <div
-              style={{
-                padding: rhythm(1 / 2),
+              css={{
                 verticalAlign: `middle`,
-                textAlign: `center`,
-                width: 130,
+                textAlign: `left`,
                 display: `inline-block`,
                 marginLeft: `auto`,
                 marginRight: `auto`,
+                padding: `${rhythm(1 / 4)} 0 ${rhythm(1 / 4)} ${rhythm(1 / 4)}`,
+                [presets.Mobile]: {
+                  padding: `${rhythm(1 / 2)} 0 ${rhythm(1 / 2)} ${rhythm(
+                    1 / 2
+                  )}`,
+                },
               }}
             >
               <a
                 css={{
-                  fontWeight: `normal !important`,
+                  "&&": {
+                    fontWeight: `normal`,
+                    borderBottom: 0,
+                  },
                 }}
                 onClick={e => {
                   e.preventDefault()
@@ -125,7 +132,6 @@ class EvaluationTable extends Component {
                       category={row.node.Subcategory}
                     />,
                     <div
-                      key="fake"
                       dangerouslySetInnerHTML={{
                         __html: `<span id="${row.node.Feature
                           .toLowerCase()
@@ -133,7 +139,7 @@ class EvaluationTable extends Component {
                           .join(`-`)}"></span>`,
                       }}
                     />,
-                    <tr key={2 * i}>
+                    <tr>
                       {headers.map((header, j) => (
                         <td
                           key={j}
@@ -143,14 +149,14 @@ class EvaluationTable extends Component {
                               cursor: j >= 0 ? `pointer` : `inherit`,
                             },
                             borderBottom: !showTooltip(s, i)
-                              ? `invalidCSS`
+                              ? `1px solid ${presets.veryLightPurple}`
                               : `none`,
                             minWidth: 40,
                             paddingRight: 0,
                             paddingLeft: 0,
-                            textAlign: `center`,
+                            textAlign: `left`,
                             verticalAlign: `middle`,
-                            fontSize: `80%`,
+                            fontSize: `90%`,
                             lineHeight: `${rhythm(3 / 4)}`,
                           }}
                           onClick={() => {
@@ -164,14 +170,11 @@ class EvaluationTable extends Component {
                       ))}
                     </tr>,
                     <tr
-                      key={2 * i + 1}
                       style={{
                         display: showTooltip(s, i) ? `table-row` : `none`,
-                        borderRight: options.tableBorder,
                       }}
                     >
                       <td
-                        key={1}
                         css={{
                           fontFamily: options.headerFontFamily.join(`,`),
                           paddingRight: `${rhythm(1)} !important`,

--- a/www/src/pages/features.js
+++ b/www/src/pages/features.js
@@ -6,6 +6,8 @@ import Container from "../components/container"
 import { options, rhythm } from "../utils/typography"
 import presets from "../utils/presets"
 
+const legendBorderColor = presets.veryLightPurple
+
 const LegendTable = () => {
   const legendBallStyle = {
     float: `none`,
@@ -19,8 +21,8 @@ const LegendTable = () => {
     verticalAlign: `middle`,
     textAlign: `center`,
     padding: 10,
-    borderLeft: `1px solid ${presets.lightPurple}`,
-    borderBottom: `1px solid ${presets.lightPurple}`,
+    borderLeft: `1px solid ${legendBorderColor}`,
+    borderBottom: `1px solid ${legendBorderColor}`,
   }
 
   const legendExplanationCellStyle = {
@@ -28,8 +30,11 @@ const LegendTable = () => {
     verticalAlign: `middle`,
     textAlign: `center`,
     padding: 10,
-    borderLeft: `1px solid ${presets.lightPurple}`,
-    borderBottom: `1px solid ${presets.lightPurple}`,
+    borderLeft: `1px solid ${legendBorderColor}`,
+    borderBottom: `1px solid ${legendBorderColor}`,
+    [presets.Phablet]: {
+      borderBottom: 0,
+    },
   }
 
   const balls = [
@@ -64,7 +69,7 @@ const LegendTable = () => {
     <div>
       <div
         css={{
-          border: `1px solid ${presets.lightPurple}`,
+          border: `1px solid ${legendBorderColor}`,
           borderLeft: 0,
           fontFamily: options.headerFontFamily.join(`,`),
           display: `none`,
@@ -79,7 +84,7 @@ const LegendTable = () => {
       <div
         css={{
           display: `table`,
-          border: `1px solid ${presets.lightPurple}`,
+          border: `1px solid ${legendBorderColor}`,
           borderLeft: 0,
           fontFamily: options.headerFontFamily.join(`,`),
           display: `table`,

--- a/www/src/pages/features.js
+++ b/www/src/pages/features.js
@@ -19,8 +19,8 @@ const LegendTable = () => {
     verticalAlign: `middle`,
     textAlign: `center`,
     padding: 10,
-    borderLeft: `1px solid #dddddd`,
-    borderBottom: `1px solid #dddddd`,
+    borderLeft: `1px solid ${presets.lightPurple}`,
+    borderBottom: `1px solid ${presets.lightPurple}`,
   }
 
   const legendExplanationCellStyle = {
@@ -28,8 +28,8 @@ const LegendTable = () => {
     verticalAlign: `middle`,
     textAlign: `center`,
     padding: 10,
-    borderLeft: `1px solid #dddddd`,
-    borderBottom: `1px solid #dddddd`,
+    borderLeft: `1px solid ${presets.lightPurple}`,
+    borderBottom: `1px solid ${presets.lightPurple}`,
   }
 
   const balls = [
@@ -64,7 +64,7 @@ const LegendTable = () => {
     <div>
       <div
         css={{
-          border: `1px solid #dddddd`,
+          border: `1px solid ${presets.lightPurple}`,
           borderLeft: 0,
           fontFamily: options.headerFontFamily.join(`,`),
           display: `none`,
@@ -79,7 +79,7 @@ const LegendTable = () => {
       <div
         css={{
           display: `table`,
-          border: `1px solid #dddddd`,
+          border: `1px solid ${presets.lightPurple}`,
           borderLeft: 0,
           fontFamily: options.headerFontFamily.join(`,`),
           display: `table`,

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -44,7 +44,6 @@ const options = {
   blockMarginBottom: 0.75,
   scaleRatio: 2,
   plugins: [new CodePlugin()],
-  tableBorder: `1px solid #dddddd`,
   overrideStyles: ({ rhythm, scale }, options) => {
     return {
       "h1,h2,h4,h5,h6": {


### PR DESCRIPTION
* replace hardcoded colors available in the palette (which could be a little more contrasty, also will open an issue to tidy the color definitions in typography/presets/colors)
* slightly reduce evaluation-cell circle size and remove its border
* left-align first column content – and still quite unsure about this, especially about altering the whitespace/hyphenation treatment
* fix "-webkitHyphens“, "-msHyphens“
* remove a few keys React warned about
* remove typography.tableBorder
* reduce sub-feature toggle underline
* play around with the overall typography a bit
   * Futura and reduced line-height for the main feature title
   * slightly increased font-size for the feature/sub-feature column
   * calmer text color for header-top, apply header-bottom background color

/cc @calcsam 🤗

![image](https://user-images.githubusercontent.com/21834/31756477-97ae8d1c-b4a4-11e7-81f7-677a403b438a.png)
