### PR TITLE
Get WordPress Menus' Items

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -214,7 +214,23 @@ async function fetchData({
       routeResponse.__type = type
       entities.push(routeResponse)
     }
-
+    // WordPress exposes the menu items in meta links.
+    if (type == `wordpress__wp_api_menus_menus`) {
+      for (let menu of routeResponse) {
+        if (menu.meta && menu.meta.links && menu.meta.links.self) {
+          entities = entities.concat(
+            await fetchData({
+              route: { url: menu.meta.links.self, type: `${type}_items` },
+              _verbose,
+              _perPage,
+              _hostingWPCOM,
+              _auth,
+              _accessToken,
+            })
+          )
+        }
+      }
+    }
     // TODO : Get the number of created nodes using the nodes in state.
     let length
     if (routeResponse && Array.isArray(routeResponse)) {


### PR DESCRIPTION
To get WordPress menus' items require an extra call to fetchData. 

To query your menus and its items all at once, you can now do this : 

```gql

 allWordpressWpApiMenusMenusItems {
    edges {
      node {
        name
        count
        items {
          order
          title
          url
          wordpress_children {
            wordpress_id
            title
            url
          }
        }
      }
    }
  }

```
`wordpress_children` node isn't required if your menus are not nested.