### PR TITLE
[gatsby-link] withPrefix fixes

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -16,6 +16,14 @@ const getNavigateTo = () => {
   return require(`../`).navigateTo
 }
 
+const getWithPrefix = (pathPrefix = ``) => {
+  Object.assign(global.window, {
+    __PREFIX_PATHS__: pathPrefix ? true : false,
+    __PATH_PREFIX__: pathPrefix,
+  })
+  return require(`../`).withPrefix
+}
+
 describe(`<Link />`, () => {
   it(`does not fail to initialize when __PREFIX_PATHS__ is not defined`, () => {
     expect(() => {
@@ -56,5 +64,26 @@ describe(`<Link />`, () => {
     getNavigateTo()(`/some-path`)
 
     expect(global.window.___navigateTo).toHaveBeenCalledWith(`/some-path`)
+  })
+})
+
+describe(`withRouter`, () => {
+  describe(`works with default prefix`, () => {
+    it(`default prefix does not return "//"`, () => {
+      const to = `/`
+      const root = getWithPrefix()(to)
+      expect(root).toEqual(to)
+    })
+
+    /*
+     * Same as above, settings a path perfix does not work because the 
+     * link module sets variables on first import
+     */
+    it.skip(`respects path prefix`, () => {
+      const to = `/abc/`
+      const pathPrefix = `/blog`
+      const root = getWithPrefix(pathPrefix)(to)
+      expect(root).toEqual(`${pathPrefix}${to}`)
+    })
   })
 })

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -9,7 +9,7 @@ if (typeof __PREFIX_PATHS__ !== `undefined` && __PREFIX_PATHS__) {
 }
 
 export function withPrefix(path) {
-  return pathPrefix + path
+  return normalizePath(pathPrefix + path)
 }
 
 function normalizePath(path) {
@@ -53,7 +53,7 @@ class GatsbyLink extends React.Component {
     }
 
     this.state = {
-      to: normalizePath(withPrefix(props.to)),
+      to: withPrefix(props.to),
       IOSupported,
     }
     this.handleRef = this.handleRef.bind(this)
@@ -62,7 +62,7 @@ class GatsbyLink extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.to !== nextProps.to) {
       this.setState({
-        to: normalizePath(withPrefix(nextProps.to)),
+        to: withPrefix(nextProps.to),
       })
       // Preserve non IO functionality if no support
       if (!this.state.IOSupported) {
@@ -163,5 +163,5 @@ GatsbyLink.contextTypes = {
 export default GatsbyLink
 
 export const navigateTo = pathname => {
-  window.___navigateTo(normalizePath(withPrefix(pathname)))
+  window.___navigateTo(withPrefix(pathname))
 }


### PR DESCRIPTION
The documentation states that withPrefix('/') would return the prefixed root of the site.
With default settings it actually returns '//'
This normalizes the path before returning it. A small test case is included. 
It is currently kind of hard to actually test the prefix implementation as it relies on global variables at import time.



	