### PR TITLE
[gatsby-source-wordpress] Normalize all featured_media fields

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -236,6 +236,7 @@ exports.mapTagsCategoriesToTaxonomies = entities =>
 
 exports.mapEntitiesToMedia = entities => {
   const media = entities.filter(e => e.__type === `wordpress__wp_media`)
+
   return entities.map(e => {
     // Map featured_media to its media node
     let featuredMedia
@@ -272,6 +273,24 @@ exports.mapEntitiesToMedia = entities => {
         }
         if (isPhoto(value)) {
           object[`${key}___NODE`] = replacePhoto(value)
+          delete object[key]
+        }
+
+        // featured_media can be nested inside ACF fields
+        if (_.isObject(value) && value.featured_media) {
+          featuredMedia = media.find(
+            m => m.wordpress_id === value.featured_media
+          )
+          if (featuredMedia) {
+            value.featured_media___NODE = featuredMedia.id
+          }
+          delete value.featured_media
+        }
+        if (_.isNumber(value) && key == `featured_media`) {
+          featuredMedia = media.find(m => m.wordpress_id === value)
+          if (featuredMedia) {
+            object[`${key}___NODE`] = featuredMedia.id
+          }
           delete object[key]
         }
       })


### PR DESCRIPTION
You can now have an _image graphql node_ linked to nested featured medias.
This should cover use cases like : 

- I want to use the featured media of a post (of any type) linked as a 'Post Object' in ACF (Repeater, Clone, Link Object, were tested).

![image](https://user-images.githubusercontent.com/5808108/31828513-bdec44f8-b5ba-11e7-8e81-5540f812d3f3.png)

- I want to use any image in an ACF field, then I name the field `featured_media` and return the 'Image ID'

![image](https://user-images.githubusercontent.com/5808108/31828407-6b9dbc68-b5ba-11e7-856c-e5279e603559.png)
