### PR TITLE
Don't remove html files inside public/static when build

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -61,7 +61,7 @@ module.exports = async (args: BootstrapArgs) => {
   // pages from previous builds to stick around.
   let activity = report.activityTimer(`delete html files from previous builds`)
   activity.start()
-  await del([`public/*.html`, `public/**/*.html`])
+  await del([`public/*.html`, `!public/static/**/*.html`, `public/**/*.html`])
   activity.end()
 
   // Try opening the site's gatsby-config.js file.


### PR DESCRIPTION
The `public/static` folder is meant to be the location of those files that you don't want to compile or a place to put static assets, seems incorrect that during the build all html files are deleted from this folder.

This pull request fix that, all files inside the `public/static` folder remains untouched after running `gastby build`.