### PR TITLE
[gatsby-source-wordpress] Support for unrequired featured_media

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -293,6 +293,9 @@ exports.mapEntitiesToMedia = entities => {
           }
           delete object[key]
         }
+        if (_.isBoolean(value) && key == `featured_media`) {
+          delete object[key]
+        }
       })
     }
 


### PR DESCRIPTION
WordPress will send a boolean with the value `false` for an unrequired `featured_media` field instead of a number if it has not been chosen from UI (WordPress Core and ACF). 
This field value should therefore be filtered during normalization of entites.