### PR TITLE
Update HTML example with double quotes guideline

### DIFF
--- a/docs/docs/gatsby-style-guide.md
+++ b/docs/docs/gatsby-style-guide.md
@@ -141,7 +141,7 @@ Here are specific formatting guidelines for any code:
 - Comments made should have a space between the comment characters and the comment themselves
 - GitHub-flavored markdown supports syntax highlighting in code blocks for many programming languages. To use it, indicate the language after starting ```
    ```html
-        <div class='awesome' id='more-awesome'>
+        <div class="awesome" id="more-awesome">
           <p>This is text in html</p>
         </div>
     ```


### PR DESCRIPTION
The guidelines state to `Use double quotes where applicable` but the first example uses single quotes, which is especially uncommon for HTML.