### PR TITLE
[gatsby-source-contentful] [fix] Return empty field when no fallback …

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -122,7 +122,7 @@ describe(`Gets field value based on current locale`, () => {
       })
     ).toBe(field[`de`])
   })
-  it(`falls back to the default locale if passed a locale that doesn't have a field nor a fallbackCode`, () => {
+  it(`returns null if passed a locale that doesn't have a field nor a fallbackCode`, () => {
     expect(
       normalize.getLocalizedField({
         field,
@@ -132,7 +132,7 @@ describe(`Gets field value based on current locale`, () => {
           fallbackCode: `null`,
         },
       })
-    ).toBe(field[`en-US`])
+    ).toEqual(null)
   })
 })
 

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -17,7 +17,7 @@ const getLocalizedField = ({ field, defaultLocale, locale }) => {
   } else if (field[locale.fallbackCode]) {
     return field[locale.fallbackCode]
   } else {
-    return field[defaultLocale]
+    return null
   }
 }
 


### PR DESCRIPTION
…locale (#2539)

If a field is empty for a locale with no fallback locale, it should be empty and not be filled in with the default locale.