### PR TITLE
[www] Sidebar UI, active state for sidebar links

### DIFF
--- a/www/src/components/markdown-page-footer.js
+++ b/www/src/components/markdown-page-footer.js
@@ -47,10 +47,11 @@ export default class MarkdownPageFooter extends React.Component {
                 this.setState({ feedbackSubmitted: true })
               }}
               css={{
-                color: `green`,
-                fontSize: rhythm(1.5),
+                color: `#37b635`,
+                fontSize: rhythm(1.3),
+                padding: rhythm(0.2),
                 position: `relative`,
-                top: -6,
+                top: -3,
                 marginLeft: rhythm(1 / 4),
                 cursor: `pointer`,
               }}
@@ -61,7 +62,12 @@ export default class MarkdownPageFooter extends React.Component {
                 sendReview(false, this.props.page.parent.relativePath)
                 this.setState({ feedbackSubmitted: true })
               }}
-              css={{ color: `red`, fontSize: rhythm(1.5), cursor: `pointer` }}
+              css={{
+                color: `#ec1818`,
+                fontSize: rhythm(1.3),
+                padding: rhythm(0.2),
+                cursor: `pointer`,
+              }}
             />
           </span>
         )}

--- a/www/src/components/sidebar-body.js
+++ b/www/src/components/sidebar-body.js
@@ -1,123 +1,208 @@
 import React from "react"
 import Link from "gatsby-link"
+import gray from "gray-percentage"
 
 import typography, { rhythm, scale, options } from "../utils/typography"
 import presets from "../utils/presets"
 
+const accentColor = presets.brand
+const listStyles = {
+  listStyle: `none`,
+  margin: 0,
+  padding: 0,
+  fontFamily: typography.options.headerFontFamily.join(`,`),
+  "& li": {
+    marginBottom: options.blockMarginBottom / 2,
+    lineHeight: 1.3,
+    paddingTop: rhythm(1 / 8),
+    paddingBottom: rhythm(1 / 8),
+    "& .nav-link": {
+      position: `relative`,
+      "&:before": {
+        content: ` `,
+        height: 4,
+        width: 4,
+        borderRadius: `100%`,
+        top: `50%`,
+        marginTop: -2,
+        left: `-.7em`,
+        fontWeight: `normal`,
+        position: `absolute`,
+        transform: `scale(0.1)`,
+        transition: `all ${presets.animation.speedDefault} ${presets.animation
+          .curveDefault}`,
+        [presets.Hd]: {
+          height: 6,
+          width: 6,
+          marginTop: -3,
+          left: `-1em`,
+        },
+      },
+    },
+    "& .nav-link-active": {
+      opacity: 1,
+      color: accentColor,
+      fontWeight: `600`,
+      "&:before": {
+        background: accentColor,
+        transform: `scale(1)`,
+      },
+    },
+  },
+}
+
+const Section = props => (
+  <div>
+    <h3
+      css={{
+        ...props.headerStyles,
+        marginTop: props.index === 0 ? 0 : rhythm(3 / 2),
+      }}
+    >
+      {props.title}
+    </h3>
+    <SectionLinks
+      {...props}
+      title={props.title}
+      isTutorial={props.title === `Tutorial`}
+    />
+  </div>
+)
+
+const SectionLinks = props => {
+  const tutorialStyles = props.isTutorial
+    ? {
+        "&&": {
+          "& > li": {
+            marginBottom: `1rem`,
+            "& > .nav-link": {
+              fontWeight: `bold`,
+            },
+          },
+        },
+      }
+    : false
+
+  return (
+    <ul
+      css={{
+        ...listStyles,
+        "& ul": {
+          ...listStyles,
+        },
+        ...tutorialStyles,
+      }}
+    >
+      {props.items.map((item, index) => (
+        <SectionLink
+          node={item}
+          children={item.items}
+          key={index}
+          isInline={props.isInline}
+        />
+      ))}
+    </ul>
+  )
+}
+
+const SectionLink = props => {
+  // Don't show the main docs link on mobile as we put these
+  // links on that main docs page so it's confusing to have
+  // the page link to itself.
+  if (props.isInline && props.node.link === `/docs/`) {
+    return null
+  }
+
+  let childnodes = null
+  if (props.children) {
+    childnodes = props.children.map((childnode, index) => (
+      <SectionLink key={index} node={childnode} children={childnode.items} />
+    ))
+  }
+
+  const item = props.node
+
+  // If the last character is a * then the doc page is still in draft
+  const isDraft = item.title.slice(-1) === `*`
+  const title = isDraft ? item.title.slice(0, -1) : item.title
+  const linkStyle = {
+    "&&": {
+      "& .nav-link": {
+        borderBottom: `none`,
+        boxShadow: `none`,
+        color: isDraft ? gray(50, 270) : gray(30, 270),
+        fontWeight: `normal`,
+        fontStyle: isDraft ? `italic` : false,
+      },
+      "& .nav-link-active": {
+        color: accentColor,
+        fontWeight: `bold`,
+        fontStyle: isDraft ? `italic` : false,
+      },
+    },
+  }
+
+  return (
+    <li key={item.title} css={linkStyle}>
+      {item.link.charAt(0) == `#` ? (
+        <a href={item.link} className="nav-link">
+          {title}
+        </a>
+      ) : (
+        <Link
+          to={item.link}
+          activeClassName="nav-link-active"
+          className="nav-link"
+          exact
+        >
+          {title}
+        </Link>
+      )}
+      {childnodes ? <ul>{childnodes}</ul> : null}
+    </li>
+  )
+}
+
 class SidebarBody extends React.Component {
   render() {
     const menu = this.props.yaml
+    const isInline = this.props.inline
 
     // Use original sizes on mobile as the text is inline
     // but smaller on > tablet so as not to compete with body text.
-    const fontSize = this.props.inline
-      ? scale(0).fontSize
-      : scale(-2 / 10).fontSize
-    const headerStyles = this.props.inline
+    const fontSize = isInline ? scale(0).fontSize : scale(-2 / 10).fontSize
+    const headerStyles = isInline
       ? {
           fontSize: scale(2 / 5).fontSize,
-          fontStyle: false,
-          color: false,
         }
       : {
-          fontSize: scale(-1 / 3).fontSize,
-          fontStyle: `normal`,
+          fontSize: scale(-2 / 5).fontSize,
           color: presets.brandLight,
+          textTransform: `uppercase`,
+          letterSpacing: `.15em`,
+          fontWeight: `normal`,
         }
-    const headerTextTransform = this.props.inline ? false : `uppercase`
+
     return (
       <div
         css={{
-          marginBottom: rhythm(1),
-          padding: this.props.inline ? 0 : rhythm(3 / 4),
+          padding: isInline ? 0 : rhythm(3 / 4),
         }}
       >
         {menu.map((section, index) => (
           <div
-            key={section.title}
+            key={index}
             css={{
               fontSize,
             }}
           >
-            <h3
-              css={{
-                ...headerStyles,
-                textTransform: headerTextTransform,
-                marginTop: index === 0 ? 0 : false,
-              }}
-            >
-              {section.title}
-            </h3>
-            <ul
-              css={{
-                listStyle: `none`,
-                margin: 0,
-                fontFamily: typography.options.headerFontFamily.join(`,`),
-              }}
-            >
-              {Object.keys(section.links).map(title => {
-                // Don't show the main docs link on mobile as we put these
-                // links on that main docs page so it's confusing to have
-                // the page link to itself.
-                if (this.props.inline && section.links[title] === `/docs/`) {
-                  return null
-                }
-
-                // If the last character is a * then the doc page is still in draft
-                let changedTitle = title
-                let linkStyle = {
-                  "&&": {
-                    borderBottom: `none`,
-                    boxShadow: `none`,
-                    fontWeight: `normal`,
-                    ":hover": {
-                      color: `inherit`,
-                      borderBottom: `none`,
-                      boxShadow: `none`,
-                    },
-                  },
-                }
-                if (title.slice(-1) === `*`) {
-                  changedTitle = title.slice(0, -1)
-                  linkStyle = {
-                    // Increase specifity to override `.main-body a` styles
-                    // defined in src/utils/typography.js.
-                    "&&": {
-                      color: presets.calm,
-                      borderBottomColor: presets.veryLightPurple,
-                      borderBottom: `none`,
-                      boxShadow: `inset 0 -5px 0px 0px ${presets.veryLightPurple}`,
-                      boxShadow: `none`,
-                      fontStyle: `italic`,
-                      fontWeight: `normal`,
-                      ":hover": {
-                        color: `inherit`,
-                        borderBottomColor: presets.lightPurple,
-                        boxShadow: `inset 0 -5px 0px 0px ${presets.lightPurple}`,
-                        borderBottom: `none`,
-                        boxShadow: `none`,
-                      },
-                    },
-                  }
-                }
-                return (
-                  <li
-                    key={section.links[title]}
-                    css={{ marginBottom: options.blockMarginBottom / 2 }}
-                  >
-                    {section.links[title][0] == `#` ? (
-                      <a href={section.links[title]} css={linkStyle}>
-                        {changedTitle}
-                      </a>
-                    ) : (
-                      <Link to={section.links[title]} css={linkStyle}>
-                        {changedTitle}
-                      </Link>
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
+            <Section
+              {...section}
+              title={section.title}
+              headerStyles={headerStyles}
+              index={index}
+              isInline={isInline}
+            />
           </div>
         ))}
       </div>

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -33,12 +33,14 @@ class DefaultLayout extends React.Component {
     const sidebarStyles = {
       borderRight: `1px solid ${colors.b[0]}`,
       backgroundColor: presets.sidebar,
-      float: `left`,
+      boxShadow: `inset 0 4px 5px 0 rgba(116, 76, 158, ${presets.shadowKeyPenumbraOpacity}), inset 0 1px 10px 0 rgba(${presets.shadowColor}, ${presets.shadowAmbientShadowOpacity}), inset 0 2px 4px -1px rgba(${presets.shadowColor}, ${presets.shadowKeyUmbraOpacity})`,
       width: rhythm(10),
       display: `none`,
       position: `fixed`,
+      top: `calc(${presets.headerHeight} - 1px)`,
       overflowY: `auto`,
-      height: `calc(100vh - ${presets.headerHeight})`,
+      zIndex: 1,
+      height: `calc(100vh - ${presets.headerHeight} + 1px)`,
       WebkitOverflowScrolling: `touch`,
       "::-webkit-scrollbar": {
         width: `6px`,
@@ -49,6 +51,10 @@ class DefaultLayout extends React.Component {
       },
       "::-webkit-scrollbar-track": {
         background: presets.brandLighter,
+      },
+      [presets.Desktop]: {
+        width: rhythm(12),
+        padding: rhythm(1),
       },
     }
 
@@ -119,6 +125,9 @@ class DefaultLayout extends React.Component {
             css={{
               [presets.Tablet]: {
                 paddingLeft: hasSidebar ? rhythm(10) : 0,
+              },
+              [presets.Desktop]: {
+                paddingLeft: hasSidebar ? rhythm(12) : 0,
               },
             }}
           >

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -1,38 +1,68 @@
 - title: Quick Start
-  links:
-    Getting Started: /docs/
-    Migrating from v0 to v1: /docs/migrating-from-v0-to-v1/
-    Building with Components: /docs/building-with-components/
-    Querying with GraphQL*: /docs/querying-with-graphql/
-    Lifecycle APIs: /docs/gatsby-lifecycle-apis/
-    Deploying: /docs/deploy-gatsby/
-    Starters: /docs/gatsby-starters/
-    Plugins: /docs/plugins/
-    PRPL Pattern: /docs/prpl-pattern/
-    Gatsby on Windows: /docs/gatsby-on-windows/
+  items:
+    - title: Getting Started
+      link: /docs/
+    - title: Migrating from v0 to v1
+      link: /docs/migrating-from-v0-to-v1/
+    - title: Building with Components
+      link: /docs/building-with-components/
+    - title: Querying with GraphQL*
+      link: /docs/querying-with-graphql/
+    - title: Lifecycle APIs
+      link: /docs/gatsby-lifecycle-apis/
+    - title: Deploying
+      link: /docs/deploy-gatsby/
+    - title: Starters
+      link: /docs/gatsby-starters/
+    - title: Plugins
+      link: /docs/plugins/
+    - title: PRPL Pattern
+      link: /docs/prpl-pattern/
+    - title: Gatsby on Windows
+      link: /docs/gatsby-on-windows/
 - title: Guides
-  links:
-    404 Pages: /docs/add-404-page/
-    Adding Images, Fonts, and Files: /docs/adding-images-fonts-files/
-    Browser Support: /docs/browser-support/
-    Creating and Modifying Pages: /docs/creating-and-modifying-pages/
-    Create a source plugin: /docs/create-source-plugin/
-    Custom webpack config: /docs/add-custom-webpack-config/
-    Customizing html.js: /docs/custom-html/
-    Debugging HTML Builds: /docs/debugging-html-builds/
-    Environment Variables: /docs/environment-variables/
-    Path Prefix: /docs/path-prefix/
-    Proxying API Requests: /docs/api-proxy/
+  items:
+    - title: 404 Pages
+      link: /docs/add-404-page/
+    - title: Adding Images, Fonts, and Files
+      link: /docs/adding-images-fonts-files/
+    - title: Browser Support
+      link: /docs/browser-support/
+    - title: Creating and Modifying Pages
+      link: /docs/creating-and-modifying-pages/
+    - title: Create a source plugin
+      link: /docs/create-source-plugin/
+    - title: Custom webpack config
+      link: /docs/add-custom-webpack-config/
+    - title: Customizing html.js
+      link: /docs/custom-html/
+    - title: Debugging HTML Builds
+      link: /docs/debugging-html-builds/
+    - title: Environment Variables
+      link: /docs/environment-variables/
+    - title: Path Prefix
+      link: /docs/path-prefix/
+    - title: Proxying API Requests
+      link: /docs/api-proxy/
 - title: Reference
-  links:
-    Node Interface: /docs/node-interface/
-    API Specification: /docs/api-specification/
-    Bound Action Creators: /docs/bound-action-creators/
-    Gatsby Browser APIs: /docs/browser-apis/
-    Gatsby Node APIs: /docs/node-apis/
-    Gatsby SSR APIs: /docs/ssr-apis/
+  items:
+    - title: Node Interface
+      link: /docs/node-interface/
+    - title: API Specification
+      link: /docs/api-specification/
+    - title: Bound Action Creators
+      link: /docs/bound-action-creators/
+    - title: Gatsby Browser APIs
+      link: /docs/browser-apis/
+    - title: Gatsby Node APIs
+      link: /docs/node-apis/
+    - title: Gatsby SSR APIs
+      link: /docs/ssr-apis/
 - title: Contributing
-  links:
-    How to Contribute: /docs/how-to-contribute/
-    Gatsby Style Guide: /docs/gatsby-style-guide/
-    Design Principles*: /docs/design-principles/
+  items:
+    - title: How to Contribute
+      link: /docs/how-to-contribute/
+    - title: Gatsby Style Guide
+      link: /docs/gatsby-style-guide/
+    - title: Design Principles*
+      link: /docs/design-principles/

--- a/www/src/pages/docs/features-links.yaml
+++ b/www/src/pages/docs/features-links.yaml
@@ -1,41 +1,72 @@
 - title: Introduction
-  links:
-    Introduction: "#introduction"
-    Legend: "#legend"
+  items:
+    - title: Introduction
+      link: "#introduction"
+    - title: Legend
+      link: "#legend"
 - title: Performance
-  links:
-    Static content: "#static-content"
-    CDN: "#cdn"
-    AMP support: "#amp-support"
-    Offline access: "#offline-access"
-    Prefetch linked pages: "#prefetch-linked-pages"
-    Page caching: "#page-caching"
-    No extraneous code fetching: "#no-extraneous-code-fetching"
-    Progressive image loading: "#progressive-image-loading"
-    Responsive image loading: "#responsive-image-loading"
-    Inlines critical CSS: "#inlines-critical-css"
-    Font self-hosting: "#font-self-hosting"
+  items:
+    - title: Static content
+      link: "#static-content"
+    - title: CDN
+      link: "#cdn"
+    - title: AMP support
+      link: "#amp-support"
+    - title: Offline access
+      link: "#offline-access"
+    - title: Prefetch linked pages
+      link: "#prefetch-linked-pages"
+    - title: Page caching
+      link: "#page-caching"
+    - title: No extraneous code fetching
+      link: "#no-extraneous-code-fetching"
+    - title: Progressive image loading
+      link: "#progressive-image-loading"
+    - title: Responsive image loading
+      link: "#responsive-image-loading"
+    - title: Inlines critical CSS
+      link: "#inlines-critical-css"
+    - title: Font self-hosting
+      link: "#font-self-hosting"
 - title: Developer Experience
-  links:
-    Serverless: "#serverless"
-    Export as Code: "#export-as-code"
-    Refresh or link to preview: "#refresh-or-link-to-preview"
-    Hot reload content: "#hot-reload-content"
-    Hot reload code: "#hot-reload-code"
-    Componentization: "#componentization"
-    One-way data binding: "#one-way-data-binding"
-    Declarative API data queries (GraphQL): "#declarative-api-data-queries-(graphql)"
-    Declarative UI: "#declarative-ui"
-    Asset pipelines: "#asset-pipelines"
-    CSS Extensions (eg Sass): "#css-extensions-(eg-sass)"
-    Advanced Javascript syntax: "#advanced-javascript-syntax"
+  items:
+    - title: Serverless
+      link: "#serverless"
+    - title: Export as Code
+      link: "#export-as-code"
+    - title: Refresh or link to preview
+      link: "#refresh-or-link-to-preview"
+    - title: Hot reload content
+      link: "#hot-reload-content"
+    - title: Hot reload code
+      link: "#hot-reload-code"
+    - title: Componentization
+      link: "#componentization"
+    - title: One-way data binding
+      link: "#one-way-data-binding"
+    - title: Declarative API data queries (GraphQL)
+      link: "#declarative-api-data-queries-(graphql)"
+    - title: Declarative UI
+      link: "#declarative-ui"
+    - title: Asset pipelines
+      link: "#asset-pipelines"
+    - title: CSS Extensions (eg Sass)
+      link: "#css-extensions-(eg-sass)"
+    - title: Advanced Javascript syntax
+      link: "#advanced-javascript-syntax"
 - title: Ecosystem
-  links:
-    Component ecosystem: "#component-ecosystem"
-    Hosted option: "#hosted-option"
-    Theme ecosystem: "#theme-ecosystem"
+  items:
+    - title: Component ecosystem
+      link: "#component-ecosystem"
+    - title: Hosted option
+      link: "#hosted-option"
+    - title: Theme ecosystem
+      link: "#theme-ecosystem"
 - title: Design
-  links:
-    Programmatic Design: "#programmatic-design"
-    Design systems: "#design-systems"
-    Component library: "#component-library"
+  items:
+    - title: Programmatic Design
+      link: "#programmatic-design"
+    - title: Design systems
+      link: "#design-systems"
+    - title: Component library
+      link: "#component-library"

--- a/www/src/pages/docs/tutorial-links.yml
+++ b/www/src/pages/docs/tutorial-links.yml
@@ -1,39 +1,64 @@
-- title: Tutorial Introduction
-  links:
-    Introduction: /tutorial/
-- title: Part One
-  links:
-    Part one: /tutorial/part-one/
-    ">> Check Environment": /tutorial/part-one/#check-your-development-environment
-    ">> Creating a Gatsby site from scratch": /tutorial/part-one/#install-the-hello-world-starter
-    ">> Linking between pages": /tutorial/part-one/#linking-between-pages
-    ">> Interactive page": /tutorial/part-one/#interactive-page
-    ">> Deploying Gatsby.js websites on the web": /tutorial/part-one/#deploying-gatsbyjs-websites-on-the-web
-- title: Part Two
-  links:
-    Part two: /tutorial/part-two/
-    ">> Building with components": /tutorial/part-two/#building-with-components
-    ">> Creating Global Styles": /tutorial/part-two/#creating-global-styles
-    ">> Typography.js": /tutorial/part-two/#typographyjs
-    ">> Gatsby Plugins": /tutorial/part-two/#gatsby-plugins
-    ">> Component CSS": /tutorial/part-two/#component-css
-    ">> CSS Modules": /tutorial/part-two/#css-modules
-    ">> Glamor": /tutorial/part-two/#glamor
-    ">> Styled Components": /tutorial/part-two/#styled-components
-- title: Part Three
-  links:
-    Part three: /tutorial/part-three/
-    ">> Our first layout component": /tutorial/part-three/#our-first-layout-component
-- title: Part Four
-  links:
-    Part four: /tutorial/part-four/
-    ">> Recap of first half of the tutorial": /tutorial/part-four/#recap-of-first-half-of-the-tutorial
-    ">> Data in Gatsby": /tutorial/part-four/#data-in-gatsby
-    ">> How Gatsby’s data layer uses GraphQL to pull data into components": /tutorial/part-four/#how-gatsbys-data-layer-uses-graphql-to-pull-data-into-components
-    ">> Our first GraphQL query": /tutorial/part-four/#our-first-graphql-query
-    ">> Introducing GraphiQL": /tutorial/part-four/#introducing-graphiql
-    ">> Source Plugins": /tutorial/part-four/#source-plugins
-    ">> Build a page with a GraphQL query": /tutorial/part-four/#build-a-page-with-a-graphql-query
-    ">> Transformer Plugins": /tutorial/part-four/#transformer-plugins
-    ">> Create a list of our site’s markdown files in src/pages/index.js": /tutorial/part-four/#create-a-list-of-our-sites-markdown-files-in-srcpagesindexjs
-    ">> Programmatically creating pages from data": /tutorial/part-four/#programmatically-creating-pages-from-data
+- title: Tutorial
+  items:
+    - title: Introduction
+      link: /tutorial/
+    - title: Part One
+      link: /tutorial/part-one/
+      items:
+        - title: Check Environment
+          link: /tutorial/part-one/#check-your-development-environment
+        - title: Creating a Gatsby site from scratch
+          link: /tutorial/part-one/#install-the-hello-world-starter
+        - title: Linking between pages
+          link: /tutorial/part-one/#linking-between-pages
+        - title: Interactive page
+          link: /tutorial/part-one/#interactive-page
+        - title: Deploying Gatsby.js websites on the web
+          link: /tutorial/part-one/#deploying-gatsbyjs-websites-on-the-web
+    - title: Part Two
+      link: /tutorial/part-two/
+      items:
+        - title: Building with components
+          link: /tutorial/part-two/#building-with-components
+        - title: Creating Global Styles
+          link: /tutorial/part-two/#creating-global-styles
+        - title: Typography.js
+          link: /tutorial/part-two/#typographyjs
+        - title: Gatsby Plugins
+          link: /tutorial/part-two/#gatsby-plugins
+        - title: Component CSS
+          link: /tutorial/part-two/#component-css
+        - title: CSS Modules
+          link: /tutorial/part-two/#css-modules
+        - title: Glamor
+          link: /tutorial/part-two/#glamor
+        - title: Styled Components
+          link: /tutorial/part-two/#styled-components
+    - title: Part Three
+      link: /tutorial/part-three/
+      items:
+        - title: Our first layout component
+          link: /tutorial/part-three/#our-first-layout-component
+    - title: Part Four
+      link: /tutorial/part-four/
+      items:
+        - title: Recap of first half of the tutorial
+          link: /tutorial/part-four/#recap-of-first-half-of-the-tutorial
+        - title: Data in Gatsby
+          link: /tutorial/part-four/#data-in-gatsby
+        - title: "How Gatsby’s data layer uses GraphQL to pull data into components"
+          link: /tutorial/part-four/#how-gatsbys-data-layer-uses-graphql-to-pull-data-into-components
+        - title: Our first GraphQL query
+          link: /tutorial/part-four/#our-first-graphql-query
+        - title: Introducing GraphiQL
+          link: /tutorial/part-four/#introducing-graphiql
+        - title: Source Plugins
+          link: /tutorial/part-four/#source-plugins
+        - title: Build a page with a GraphQL query
+          link: /tutorial/part-four/#build-a-page-with-a-graphql-query
+        - title: Transformer Plugins
+          link: /tutorial/part-four/#transformer-plugins
+        - title: "Create a list of our site’s markdown files in src/pages/index.js"
+          link: /tutorial/part-four/#create-a-list-of-our-sites-markdown-files-in-srcpagesindexjs
+        - title: Programmatically creating pages from data
+          link: /tutorial/part-four/#programmatically-creating-pages-from-data

--- a/www/src/utils/presets.js
+++ b/www/src/utils/presets.js
@@ -35,6 +35,10 @@ module.exports = {
     VHdR: 3,
     VVHdR: 4.5,
   },
+  shadowKeyUmbraOpacity: 0.1,
+  shadowKeyPenumbraOpacity: 0.07,
+  shadowAmbientShadowOpacity: 0.06,
+  shadowColor: `157, 124, 191`,
   animation: {
     curveDefault: `cubic-bezier(0.4, 0, 0.2, 1)`,
     speedDefault: `250ms`,

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -76,6 +76,9 @@ const options = {
           options.blockMarginBottom / 4
         )} solid ${presets.brandLighter}`,
       },
+      hr: {
+        backgroundColor: presets.brandLighter,
+      },
       "tt,code": {
         // background: `hsla(23, 60%, 97%, 1)`,
         background: colors.a[0],


### PR DESCRIPTION
* update docs/*.yaml data structure – more verbose, but was the easiest and probably had to happen some time anyway
* sidebar items now can have nested items and will generate a nested <ul> for those
* add active state for sidebar items (currently using font-weight:bold … :-/)
* increase sidebar width and padding for presets.Desktop and up
* add an inset box-shadow to the sidebar (…)
* calmer sidebar section headlines
* remove section headlines for the „Tutorial“ parts and introduction
* remove „>>“ prefix from „Tutorial“ anchor links

Along the way:

* <hr> color from the „palette“
* adjust markdown-page-footer thumb icon colors to be a bit friendlier and reduce icon size while keeping the clickable area the same size