### PR TITLE
[gatsby-remark-copy-linked-files] Fix multiple img tags handling

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -99,6 +99,17 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalled()
   })
 
+  it(`can copy HTML multiple images`, async () => {
+    const path1 = `images/sample-image.gif`
+    const path2 = `images/another-sample-image.gif`
+
+    const markdownAST = remark.parse(`<div><img src="${path1}"><img src="${path2}"></div>`)
+
+    await plugin({ files: [...getFiles(path1), ...getFiles(path2)], markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).toHaveBeenCalledTimes(2)
+  })
+
   it(`leaves absolute file paths alone`, async () => {
     const path = `https://google.com/images/sample-image.gif`
 

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -55,7 +55,7 @@ module.exports = (
 
   // Takes a node and generates the needed images and then returns
   // the needed HTML replacement for the image
-  const generateImagesAndUpdateNode = async function(image) {
+  const generateImagesAndUpdateNode = function(image) {
     const imagePath = path.posix.join(
       getNode(markdownNode.parent).dir,
       image.attr(`src`)
@@ -74,7 +74,7 @@ module.exports = (
     // The link object will be modified to the new location so we'll
     // use that data to update our ref
     const link = { url: image.attr(`src`) }
-    await visitor(link)
+    visitor(link)
     image.attr(`src`, link.url)
 
     let dimensions
@@ -130,7 +130,7 @@ module.exports = (
   })
 
   // For each HTML Node
-  visit(markdownAST, `html`, async node => {
+  visit(markdownAST, `html`, node => {
     const $ = cheerio.load(node.value)
     // Handle Images
     const imageRefs = []
@@ -154,7 +154,7 @@ module.exports = (
           return
         }
 
-        await generateImagesAndUpdateNode(thisImg)
+        generateImagesAndUpdateNode(thisImg)
       } catch (err) {
         // Ignore
       }
@@ -185,7 +185,7 @@ module.exports = (
         // The link object will be modified to the new location so we'll
         // use that data to update our ref
         const link = { url: thisVideo.attr(`src`) }
-        await visitor(link)
+        visitor(link)
         thisVideo.attr(`src`, link.url)
       } catch (err) {
         // Ignore
@@ -217,7 +217,7 @@ module.exports = (
         // The link object will be modified to the new location so we'll
         // use that data to update our ref
         const link = { url: thisATag.attr(`href`) }
-        await visitor(link)
+        visitor(link)
         thisATag.attr(`href`, link.url)
       } catch (err) {
         // Ignore


### PR DESCRIPTION
Hi! First of all thanks for gatsby, it is really awesome! 
While working on my website I found that  gatsby-remark-copy-linked-files does not properly handle multiple img tags in markdown. After debugging I found that this bug was caused by async/await on synchronous function, after removing them fixes the bug.