### PR TITLE
Only apply responsive wrapper if dimensions are unitless or in pixels

### DIFF
--- a/packages/gatsby-remark-responsive-iframe/README.md
+++ b/packages/gatsby-remark-responsive-iframe/README.md
@@ -1,8 +1,6 @@
 # gatsby-remark-responsive-iframe
 
-Wraps iframes (e.g. embedded YouTube videos) in markdown files in a
-responsive elastic container so the iframes always span 100% of
-the width of their container.
+Wraps iframes or objects (e.g. embedded YouTube videos) within markdown files in a responsive elastic container with a fixed aspect ratio. This ensures that the iframe or object will scale proportionally and to the full width of its container. 
 
 ## Install
 
@@ -26,7 +24,9 @@ plugins: [
 
 ### Usage in Markdown
 
-This plugin requires a `width` and `height` attribute on the iframe for setting the aspect ratio. Example usage: 
+This plugin requires both `width` and `height` attributes to be set on the iframe or object tag so that the correct aspect ratio can be calculated. Both unitless and pixel values are supported. If any other value is detected (for example a percentage width), the wrapper will not be applied.
+
+Example usage: 
 
     This is a beautiful iframe:
 

--- a/packages/gatsby-remark-responsive-iframe/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-responsive-iframe/src/__tests__/__snapshots__/index.js.snap
@@ -1,6 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gatsby-remark-responsive-iframe transforms an iframe 1`] = `
+exports[`gatsby-remark-responsive-iframe doesn't transform an iframe with dimensions: '100%' '100' 1`] = `
+"  <iframe url=\\"http://www.example.com/\\" width=\\"100%\\" height=\\"100\\"></iframe>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe doesn't transform an iframe with dimensions: '100' '100%' 1`] = `
+"  <iframe url=\\"http://www.example.com/\\" width=\\"100\\" height=\\"100%\\"></iframe>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe doesn't transform an iframe with dimensions: '100' 'invalid' 1`] = `
+"  <iframe url=\\"http://www.example.com/\\" width=\\"100\\" height=\\"invalid\\"></iframe>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe doesn't transform an iframe with dimensions: 'invalid' '100' 1`] = `
+"  <iframe url=\\"http://www.example.com/\\" width=\\"invalid\\" height=\\"100\\"></iframe>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe doesn't transform an object with dimensions: '100%' '100' 1`] = `
+"  <object url=\\"http://www.example.com/\\" width=\\"100%\\" height=\\"100\\"></object>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe doesn't transform an object with dimensions: '100' '100%' 1`] = `
+"  <object url=\\"http://www.example.com/\\" width=\\"100\\" height=\\"100%\\"></object>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe doesn't transform an object with dimensions: '100' 'invalid' 1`] = `
+"  <object url=\\"http://www.example.com/\\" width=\\"100\\" height=\\"invalid\\"></object>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe doesn't transform an object with dimensions: 'invalid' '100' 1`] = `
+"  <object url=\\"http://www.example.com/\\" width=\\"invalid\\" height=\\"100\\"></object>
+      "
+`;
+
+exports[`gatsby-remark-responsive-iframe transforms an iframe with pixel width and height 1`] = `
+"
+          <div
+            class=\\"gatsby-resp-iframe-wrapper\\"
+            style=\\"padding-bottom: NaN%; position: relative; height: 0; overflow: hidden;\\"
+          >
+            <html><head></head><body><iframe url=\\"http://www.example.com/\\" style=\\"
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+          \\"></iframe>
+    </body></html>
+          </div>
+          "
+`;
+
+exports[`gatsby-remark-responsive-iframe transforms an iframe with unitless width and height 1`] = `
 "
           <div
             class=\\"gatsby-resp-iframe-wrapper\\"
@@ -11,7 +69,24 @@ exports[`gatsby-remark-responsive-iframe transforms an iframe 1`] = `
           "
 `;
 
-exports[`gatsby-remark-responsive-iframe transforms an object 1`] = `
+exports[`gatsby-remark-responsive-iframe transforms an object with pixel width and height 1`] = `
+"
+          <div
+            class=\\"gatsby-resp-iframe-wrapper\\"
+            style=\\"padding-bottom: NaN%; position: relative; height: 0; overflow: hidden;\\"
+          >
+            <html><head></head><body><object url=\\"http://www.example.com/\\" style=\\"
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+          \\"></object></body></html>
+          </div>
+          "
+`;
+
+exports[`gatsby-remark-responsive-iframe transforms an object with unitless width and height 1`] = `
 "
           <div
             class=\\"gatsby-resp-iframe-wrapper\\"

--- a/packages/gatsby-remark-responsive-iframe/src/__tests__/index.js
+++ b/packages/gatsby-remark-responsive-iframe/src/__tests__/index.js
@@ -1,5 +1,6 @@
 const Remark = require(`remark`)
-const visit = require(`unist-util-visit`)
+const find = require(`unist-util-find`)
+const _ = require(`lodash`)
 
 const plugin = require(`../`)
 
@@ -9,19 +10,82 @@ const remark = new Remark().data(`settings`, {
   pedantic: true,
 })
 
+const extractObjectTag = mdast =>
+  _.reduce(
+    mdast.children[0].children,
+    (result, child) => result + child.value,
+    ``
+  )
+
+const extractIframeTag = mdast => mdast.children[0].value
+
+const shouldntTransform = [
+  [`100%`, `100`],
+  [`100`, `100%`],
+  [`invalid`, `100`],
+  [`100`, `invalid`],
+]
+
 describe(`gatsby-remark-responsive-iframe`, () => {
   ;[`iframe`, `object`].forEach(tag => {
-    it(`transforms an ${tag}`, async () => {
+    it(`transforms an ${tag} with unitless width and height`, async () => {
       const markdownAST = remark.parse(`
 <${tag} url="http://www.example.com/" width="600" height="400"></${tag}>
     `)
 
       const transformed = await plugin({ markdownAST })
+      const node = find(transformed, function(node) {
+        return node.type === `unknown`
+      })
+      expect(node).toBeDefined()
+      expect(node.data).toBeDefined()
+      expect(node.data.hChildren).toBeDefined()
+      expect(node.data.hChildren.length).toBeGreaterThan(0)
+      const [child] = node.data.hChildren
+      expect(child.value).toMatchSnapshot()
+    })
+  })
+  ;[`iframe`, `object`].forEach(tag => {
+    it(`transforms an ${tag} with pixel width and height`, async () => {
+      const markdownAST = remark.parse(`
+<${tag} url="http://www.example.com/" width="600px" height="400px"></${tag}>
+    `)
 
-      visit(transformed, `unknown`, node => {
-        expect(node.data.hChildren.length).toBeGreaterThan(0)
-        const [child] = node.data.hChildren
-        expect(child.value).toMatchSnapshot()
+      const transformed = await plugin({ markdownAST })
+      const node = find(transformed, function(node) {
+        return node.type === `unknown`
+      })
+      expect(node).toBeDefined()
+      expect(node.data).toBeDefined()
+      expect(node.data.hChildren).toBeDefined()
+      expect(node.data.hChildren.length).toBeGreaterThan(0)
+      const [child] = node.data.hChildren
+      expect(child.value).toMatchSnapshot()
+    })
+  })
+
+  _.map(shouldntTransform, ([width, height]) => {
+    ;[`iframe`, `object`].forEach(tag => {
+      it(`doesn't transform an ${tag} with dimensions: '${width}' '${height}'`, async () => {
+        const markdownAST = remark.parse(`
+  <${tag} url="http://www.example.com/" width="${width}" height="${height}"></${tag}>
+      `)
+        const transformed = await plugin({ markdownAST })
+        // Note: Remark treats iframes (block level) and object (inline) tags
+        // differently, wrapping an object tag in <p></p> tags. It also parses
+        // out the object tag into three separate nodes - one for the opening
+        // tag, one for the closing tag and one for a newline inside. So for any
+        // tests that recieve untransformed node back from the plugin, we strip
+        // the p tags and combine the nodes into a single html string.
+        if (tag === `iframe`) {
+          const iframeHTML = extractIframeTag(transformed)
+          expect(iframeHTML).toBeDefined()
+          expect(iframeHTML).toMatchSnapshot()
+        } else {
+          const objectHTML = extractObjectTag(transformed)
+          expect(objectHTML).toBeDefined()
+          expect(objectHTML).toMatchSnapshot()
+        }
       })
     })
   })

--- a/packages/gatsby-remark-responsive-iframe/src/index.js
+++ b/packages/gatsby-remark-responsive-iframe/src/index.js
@@ -3,6 +3,21 @@ const cheerio = require(`cheerio`)
 const Promise = require(`bluebird`)
 const _ = require(`lodash`)
 
+const isPixelNumber = n => /\d+px$/.test(n)
+
+const isUnitlessNumber = n => {
+  const nToNum = _.toNumber(n)
+  return _.isFinite(nToNum)
+}
+
+const isUnitlessOrPixelNumber = n =>
+  n && (isUnitlessNumber(n) || isPixelNumber(n))
+
+// Aspect ratio can only be determined if both width and height are unitless or
+// pixel values. Any other values mean the responsive wrapper is not applied.
+const acceptedDimensions = (width, height) =>
+  isUnitlessOrPixelNumber(width) && isUnitlessOrPixelNumber(height)
+
 module.exports = ({ markdownAST }, pluginOptions = {}) =>
   new Promise(resolve => {
     const defaults = {
@@ -12,11 +27,11 @@ module.exports = ({ markdownAST }, pluginOptions = {}) =>
     visit(markdownAST, `html`, node => {
       const $ = cheerio.load(node.value)
       const iframe = $(`iframe, object`)
-      if (iframe) {
+      if (iframe.length) {
         const width = iframe.attr(`width`)
         const height = iframe.attr(`height`)
 
-        if (width && height) {
+        if (acceptedDimensions(width, height)) {
           $(`iframe, object`).attr(
             `style`,
             `


### PR DESCRIPTION
- Ignore invalid dimensions and return original object or iframe.
- Add tests for explicit pixel values.
- Add tests for invalid values.
- Fix bad logic checking for match in AST.
- Fix tests never run if no match found.
- Update docs

Closes #2468