### PR TITLE
Remove unused dependencies

### DIFF
--- a/examples/using-redux/package.json
+++ b/examples/using-redux/package.json
@@ -7,11 +7,8 @@
   "dependencies": {
     "gatsby": "latest",
     "gatsby-link": "latest",
-    "lodash": "^4.16.4",
     "react-redux": "5.0.5",
-    "react-router-redux": "4.0.8",
-    "redux": "3.6.0",
-    "slash": "^1.0.0"
+    "redux": "3.6.0"
   },
   "keywords": ["gatsby"],
   "license": "MIT",


### PR DESCRIPTION
I removed these deps as I couldn't see them being used in the example. `develop` and `build` both work after removing them.