### PR TITLE
[using-gatsby-image] Tidy

### DIFF
--- a/examples/using-gatsby-image/src/components/navigation.js
+++ b/examples/using-gatsby-image/src/components/navigation.js
@@ -3,6 +3,50 @@ import Link from "gatsby-link"
 
 import { rhythm, scale, options } from "../utils/typography"
 
+const NavItem = ({ title, to }) => (
+  <li
+    css={{
+      display: `inline`,
+      fontFamily: options.headerFontFamily.join(`,`),
+      fontWeight: `300`,
+      "&:after": {
+        color: options.bodyColor,
+        content: ` / `,
+        opacity: 0.2,
+        padding: `0 ${rhythm(options.blockMarginBottom / 4)}`,
+      },
+      "&:last-child:after": {
+        display: `none`,
+      },
+      // These are not directly applied to <Link> to avoid React Router's
+      // <NavLink> from complaining about className not being a string
+      // but an object
+      // https://github.com/ReactTraining/react-router/issues/5593
+      "& .nav-link": {
+        backgroundImage: `none`,
+        color: options.bodyColor,
+        letterSpacing: `.005em`,
+        opacity: 0.57,
+        textTransform: `uppercase`,
+        transition: `all 200ms ease-out`,
+        whiteSpace: `nowrap`,
+      },
+      "& .nav-link-active, & .nav-link:hover": {
+        backgroundImage: `linear-gradient(to top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 1px, ${options.accentColor} 1px, ${options.accentColor} 2px, rgba(0, 0, 0, 0) 2px)`,
+        color: options.accentColor,
+        opacity: 1,
+      },
+      "& .nav-link-active": {
+        // fontWeight: `700`,
+      },
+    }}
+  >
+    <Link to={to} className="nav-link" activeClassName="nav-link-active">
+      {title}
+    </Link>
+  </li>
+)
+
 const Navigation = () => (
   <div>
     <h1
@@ -23,60 +67,14 @@ const Navigation = () => (
     </h1>
     <ul
       css={{
-        fontFamily: options.headerFontFamily.join(`,`),
         margin: 0,
         listStyle: `none`,
-        "& li": {
-          display: `inline`,
-          fontWeight: `300`,
-        },
-        "& li:after": {
-          content: ` / `,
-          color: options.bodyColor,
-          opacity: 0.2,
-          padding: `0 ${rhythm(options.blockMarginBottom / 4)}`,
-        },
-        "& li:last-child:after": {
-          display: `none`,
-        },
-        "& a": {
-          color: options.bodyColor,
-          opacity: 0.57,
-          textTransform: `uppercase`,
-          backgroundImage: `none`,
-          transition: `all 200ms ease-out`,
-          letterSpacing: `.005em`,
-        },
-        "& .nav-link-active, & a:hover": {
-          color: options.accentColor,
-          opacity: 1,
-          backgroundImage: `linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 1px, ${options.accentColor} 1px, ${options.accentColor} 2px, rgba(0, 0, 0, 0) 2px);`,
-        },
-        "& .nav-link-active": {
-          // fontWeight: `700`,
-        },
       }}
     >
-      <li>
-        <Link to="/blur-up/" activeClassName="nav-link-active">
-          Blur Up
-        </Link>
-      </li>
-      <li>
-        <Link to="/background-color/" activeClassName="nav-link-active">
-          Background Color
-        </Link>
-      </li>
-      <li>
-        <Link to="/traced-svg/" activeClassName="nav-link-active">
-          Traced SVG
-        </Link>
-      </li>
-      <li>
-        <Link to="/prefer-webp/" activeClassName="nav-link-active">
-          Prefer WebP
-        </Link>
-      </li>
+      <NavItem to="/blur-up/" title="Blur Up" />
+      <NavItem to="/background-color/" title="Background Color" />
+      <NavItem to="/traced-svg/" title="Traced SVG" />
+      <NavItem to="/prefer-webp/" title="Prefer WebP" />
     </ul>
   </div>
 )

--- a/examples/using-gatsby-image/src/pages/traced-svg.js
+++ b/examples/using-gatsby-image/src/pages/traced-svg.js
@@ -33,9 +33,9 @@ const UnsplashMasonry = edges => (
         },
       }}
     >
-      {edges.images.map(image => (
+      {edges.images.map((image, index) => (
         <div
-          key={image.node.src}
+          key={index}
           css={{
             border: `4px solid transparent`,
             breakInside: `avoid`,


### PR DESCRIPTION
* refactor navigation links to component
* remove semicolon from CSS rule
* fix unique keys warning for <UnsplashGallery />
* switch active nav state from „overline“ to „underline“