### PR TITLE
[gatsby-plugin-sharp] Prepend contentDigest to tmp traceSVG img name

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -644,7 +644,8 @@ async function notMemoizedtraceSVG({ file, args, fileArgs }) {
   }
 
   const tmpDir = require(`os`).tmpdir()
-  const tmpFilePath = `${tmpDir}/${file.name}-${crypto
+  const tmpFilePath = `${tmpDir}/${file.internal
+    .contentDigest}-${file.name}-${crypto
     .createHash(`md5`)
     .update(JSON.stringify(fileArgs))
     .digest(`hex`)}.${file.extension}`


### PR DESCRIPTION
Fixes #2634