### PR TITLE
[gatsby-source-wordpress] improve linking acf fields to media nodes

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -271,6 +271,7 @@ exports.mapEntitiesToMedia = entities => {
         media.find(m => m.wordpress_id === field.wordpress_id).id
       const isFeaturedMedia = (value, key) =>
         (_.isNumber(value) || _.isBoolean(value)) && key === 'featured_media'
+      const getMediaItemID = mediaItem => mediaItem ? mediaItem.id : null
 
       // Try to get media node from value:
       //  - special case - check if key is featured_media and value is photo ID
@@ -279,34 +280,34 @@ exports.mapEntitiesToMedia = entities => {
       const getMediaFromACFValue = (value, key) => {
         if (isFeaturedMedia(value, key)) {
           return {
-            mediaItem:
-              _.isNumber(value) ? media.find(m => m.wordpress_id === value) : null,
+            mediaNodeID:
+              _.isNumber(value) ? getMediaItemID(media.find(m => m.wordpress_id === value)) : null,
             deleteField: true
           }
         } else if (isPhotoUrl(value)) {
-          const mediaItem = media.find(m => m.source_url === value);
+          const mediaNodeID = getMediaItemID(media.find(m => m.source_url === value));
           return {
-            mediaItem,
-            deleteField: !!media
+            mediaNodeID,
+            deleteField: !!mediaNodeID
           }
         } else if (isACFPhotoData(value)) {
-          const mediaItem = media.find(m => m.source_url === value.url);
+          const mediaNodeID = getMediaItemID(media.find(m => m.source_url === value.url));
           return {
-            mediaItem,
-            deleteField: !!media
+            mediaNodeID,
+            deleteField: !!mediaNodeID
           }
         }
         return {
-          mediaItem: null,
+          mediaNodeID: null,
           deleteField: false
         };
       }
 
       const replaceFieldsInObject = object => {
         _.each(object, (value, key) => {
-          const { mediaItem, deleteField } = getMediaFromACFValue(value, key);
-          if (mediaItem) {
-            object[`${key}___NODE`] = mediaItem.id;
+          const { mediaNodeID, deleteField } = getMediaFromACFValue(value, key);
+          if (mediaNodeID) {
+            object[`${key}___NODE`] = mediaNodeID;
           }
           if (deleteField) {
             delete object[key];

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -267,8 +267,6 @@ exports.mapEntitiesToMedia = entities => {
       const photoRegex = /\.(gif|jpg|jpeg|tiff|png)$/i
       const isPhotoUrl = filename =>
         _.isString(filename) && photoRegex.test(filename)
-      const replacePhoto = field =>
-        media.find(m => m.wordpress_id === field.wordpress_id).id
       const isFeaturedMedia = (value, key) =>
         (_.isNumber(value) || _.isBoolean(value)) && key === 'featured_media'
       const isACFGallery = field =>

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -252,54 +252,54 @@ exports.mapEntitiesToMedia = entities => {
     // featured_media to 0 when there isn't one which is useless to us.
     delete e.featured_media
 
-    const isPhoto = field =>
-      _.isObject(field) &&
-      field.wordpress_id &&
-      field.url &&
-      field.width &&
-      field.height
-        ? true
-        : false
-
-    const photoRegex = /\.(gif|jpg|jpeg|tiff|png)$/i
-    const isPhotoUrl = filename => photoRegex.test(filename)
-    const replacePhoto = field =>
-      media.find(m => m.wordpress_id === field.wordpress_id).id
-
-    const replaceFieldsInObject = object => {
-      _.each(object, (value, key) => {
-        if (_.isArray(value)) {
-          value.forEach(v => replaceFieldsInObject(v))
-        }
-        if (isPhoto(value)) {
-          object[`${key}___NODE`] = replacePhoto(value)
-          delete object[key]
-        }
-
-        // featured_media can be nested inside ACF fields
-        if (_.isObject(value) && value.featured_media) {
-          featuredMedia = media.find(
-            m => m.wordpress_id === value.featured_media
-          )
-          if (featuredMedia) {
-            value.featured_media___NODE = featuredMedia.id
-          }
-          delete value.featured_media
-        }
-        if (_.isNumber(value) && key == `featured_media`) {
-          featuredMedia = media.find(m => m.wordpress_id === value)
-          if (featuredMedia) {
-            object[`${key}___NODE`] = featuredMedia.id
-          }
-          delete object[key]
-        }
-        if (_.isBoolean(value) && key == `featured_media`) {
-          delete object[key]
-        }
-      })
-    }
-
     if (e.acf) {
+      const isPhoto = field =>
+        _.isObject(field) &&
+        field.wordpress_id &&
+        field.url &&
+        field.width &&
+        field.height
+          ? true
+          : false
+
+      const photoRegex = /\.(gif|jpg|jpeg|tiff|png)$/i
+      const isPhotoUrl = filename => photoRegex.test(filename)
+      const replacePhoto = field =>
+        media.find(m => m.wordpress_id === field.wordpress_id).id
+
+      const replaceFieldsInObject = object => {
+        _.each(object, (value, key) => {
+          if (_.isArray(value)) {
+            value.forEach(v => replaceFieldsInObject(v))
+          }
+          if (isPhoto(value)) {
+            object[`${key}___NODE`] = replacePhoto(value)
+            delete object[key]
+          }
+
+          // featured_media can be nested inside ACF fields
+          if (_.isObject(value) && value.featured_media) {
+            featuredMedia = media.find(
+              m => m.wordpress_id === value.featured_media
+            )
+            if (featuredMedia) {
+              value.featured_media___NODE = featuredMedia.id
+            }
+            delete value.featured_media
+          }
+          if (_.isNumber(value) && key == `featured_media`) {
+            featuredMedia = media.find(m => m.wordpress_id === value)
+            if (featuredMedia) {
+              object[`${key}___NODE`] = featuredMedia.id
+            }
+            delete object[key]
+          }
+          if (_.isBoolean(value) && key == `featured_media`) {
+            delete object[key]
+          }
+        })
+      }
+
       _.each(e.acf, (value, key) => {
         if (_.isString(value) && isPhotoUrl(value)) {
           const me = media.find(m => m.source_url === value)

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -265,7 +265,8 @@ exports.mapEntitiesToMedia = entities => {
           : false
 
       const photoRegex = /\.(gif|jpg|jpeg|tiff|png)$/i
-      const isPhotoUrl = filename => photoRegex.test(filename)
+      const isPhotoUrl = filename =>
+        _.isString(filename) && photoRegex.test(filename)
       const replacePhoto = field =>
         media.find(m => m.wordpress_id === field.wordpress_id).id
 
@@ -303,7 +304,7 @@ exports.mapEntitiesToMedia = entities => {
       }
 
       _.each(e.acf, (value, key) => {
-        if (_.isString(value) && isPhotoUrl(value)) {
+        if (isPhotoUrl(value)) {
           const me = media.find(m => m.source_url === value)
           if (me) {
             e.acf[`${key}___NODE`] = me.id

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -287,9 +287,10 @@ exports.mapEntitiesToMedia = entities => {
           if (_.isArray(value)) {
             value.forEach(v => replaceFieldsInObject(v))
           }
-          if (isACFPhotoData(value)) {
-            object[`${key}___NODE`] = replacePhoto(value)
-            delete object[key]
+          const media = getMediaFromACFValue(value);
+          if (media) {
+            object[`${key}___NODE`] = media.id;
+            delete object[key];
           }
 
           // featured_media can be nested inside ACF fields
@@ -316,12 +317,10 @@ exports.mapEntitiesToMedia = entities => {
       }
 
       _.each(e.acf, (value, key) => {
-        if (isPhotoUrl(value)) {
-          const me = media.find(m => m.source_url === value)
-          if (me) {
-            e.acf[`${key}___NODE`] = me.id
-            delete e.acf[key]
-          }
+        const media = getMediaFromACFValue(value);
+        if (media) {
+          e.acf[`${key}___NODE`] = media.id;
+          delete e.acf[key];
         }
 
         if (_.isArray(value) && value[0] && value[0].acf_fc_layout) {

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -270,6 +270,18 @@ exports.mapEntitiesToMedia = entities => {
       const replacePhoto = field =>
         media.find(m => m.wordpress_id === field.wordpress_id).id
 
+      // Try to get media node from value:
+      //  - check if value is photo url
+      //  - check if value is ACF Image Object
+      const getMediaFromACFValue = value => {
+        if (isPhotoUrl(value)) {
+          return media.find(m => m.source_url === value);
+        } else if (isACFPhotoData(value)) {
+          return media.find(m => m.source_url === value.url);
+        }
+        return null;
+      }
+
       const replaceFieldsInObject = object => {
         _.each(object, (value, key) => {
           if (_.isArray(value)) {

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -253,7 +253,9 @@ exports.mapEntitiesToMedia = entities => {
     delete e.featured_media
 
     if (e.acf) {
-      const isPhoto = field =>
+      // Check if it's value of ACF Image field, that has 'Return value' set to
+      // 'Image Object' ( https://www.advancedcustomfields.com/resources/image/ )
+      const isACFPhotoData = field =>
         _.isObject(field) &&
         field.wordpress_id &&
         field.url &&
@@ -272,7 +274,7 @@ exports.mapEntitiesToMedia = entities => {
           if (_.isArray(value)) {
             value.forEach(v => replaceFieldsInObject(v))
           }
-          if (isPhoto(value)) {
+          if (isACFPhotoData(value)) {
             object[`${key}___NODE`] = replacePhoto(value)
             delete object[key]
           }

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -271,12 +271,15 @@ exports.mapEntitiesToMedia = entities => {
         media.find(m => m.wordpress_id === field.wordpress_id).id
       const isFeaturedMedia = (value, key) =>
         (_.isNumber(value) || _.isBoolean(value)) && key === 'featured_media'
+      const isACFGallery = field =>
+        _.isArray(field) && field.length > 0 && isACFPhotoData(field[0])
       const getMediaItemID = mediaItem => mediaItem ? mediaItem.id : null
 
       // Try to get media node from value:
       //  - special case - check if key is featured_media and value is photo ID
       //  - check if value is photo url
       //  - check if value is ACF Image Object
+      //  - check if value is ACF Gallery
       const getMediaFromACFValue = (value, key) => {
         if (isFeaturedMedia(value, key)) {
           return {
@@ -295,6 +298,13 @@ exports.mapEntitiesToMedia = entities => {
           return {
             mediaNodeID,
             deleteField: !!mediaNodeID
+          }
+        } else if (isACFGallery(value)) {
+          return {
+            mediaNodeID:
+              value.map(item => getMediaFromACFValue(item, key).mediaNodeID)
+                .filter(id => id !== null),
+            deleteField: true
           }
         }
         return {


### PR DESCRIPTION
this makes matching acf fields to media nodes more flexible and adds support for ACF gallery field

it was tested with structure like this:
```
ACF root
 - Image (return URL)
 - Image (return Image Data)
 - Gallery
 - Post Object
   - featured_media
 - Repeater
   - Image (return URL)
   - Image (return Image Data)
   - Gallery
   - Post Object
     - featured_media
   - Flexible Content (nested in repeater)
     - Image (return URL)
     - Image (return Image Data)
     - Gallery
 - Flexible Content
   - Image (return URL)
   - Image (return Image Data)
   - Gallery
   - Post Object
     - featured_media
   - Repeater (nested in flexible content)
     - Image (return URL)
     - Image (return Image Data)
     - Gallery
```

And this is diff of graphql schema (manually edited, exporting schema to file would be extra handy if I would know how) after applying changes in this PR - https://gist.github.com/pieh/876c8e7a47b11a3609b379e10628068c.