### PR TITLE
[gatsby-source-wordpress] Refactored featured_media map for deep nodes

### DIFF
--- a/packages/gatsby-source-wordpress/src/__tests__/__snapshots__/normalize.js.snap
+++ b/packages/gatsby-source-wordpress/src/__tests__/__snapshots__/normalize.js.snap
@@ -5858,11 +5858,10 @@ Array [
     "date": "2017-09-02T10:36:43.000Z",
     "description": "<p class=\\"attachment\\"><a href='http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg'><img width=\\"300\\" height=\\"200\\" src=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg\\" class=\\"attachment-medium size-medium\\" alt=\\"\\" srcset=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg 300w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-768x512.jpeg 768w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-1024x683.jpeg 1024w\\" sizes=\\"(max-width: 300px) 100vw, 300px\\" /></a></p>
 ",
-    "guid": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg",
+    "guid___NODE": "61ef7ef2-032f-5c90-bba3-99d04c9a1f07",
     "id": "61ef7ef2-032f-5c90-bba3-99d04c9a1f07",
     "link": "http://dev-gatbsyjswp.pantheonsite.io/sample-post-1/pexels-photo-534327/",
     "media_details": Object {
-      "file": "2017/09/pexels-photo-534327.jpeg",
       "height": 4000,
       "image_meta": Object {
         "aperture": "7.1",
@@ -5880,35 +5879,30 @@ Array [
       },
       "sizes": Object {
         "full": Object {
-          "file": "pexels-photo-534327.jpeg",
           "height": 4000,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg",
           "width": 6000,
         },
         "large": Object {
-          "file": "pexels-photo-534327-1024x683.jpeg",
           "height": 683,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-1024x683.jpeg",
           "width": 1024,
         },
         "medium": Object {
-          "file": "pexels-photo-534327-300x200.jpeg",
           "height": 200,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg",
           "width": 300,
         },
         "medium_large": Object {
-          "file": "pexels-photo-534327-768x512.jpeg",
           "height": 512,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-768x512.jpeg",
           "width": 768,
         },
         "thumbnail": Object {
-          "file": "pexels-photo-534327-150x150.jpeg",
           "height": 150,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-150x150.jpeg",
@@ -5970,11 +5964,10 @@ Array [
     "date": "2017-09-02T10:35:16.000Z",
     "description": "<p class=\\"attachment\\"><a href='http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg'><img width=\\"300\\" height=\\"200\\" src=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg\\" class=\\"attachment-medium size-medium\\" alt=\\"\\" srcset=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg 300w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-768x512.jpeg 768w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-1024x683.jpeg 1024w\\" sizes=\\"(max-width: 300px) 100vw, 300px\\" /></a></p>
 ",
-    "guid": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg",
+    "guid___NODE": "950513a1-a720-5588-b262-9533aa598624",
     "id": "950513a1-a720-5588-b262-9533aa598624",
     "link": "http://dev-gatbsyjswp.pantheonsite.io/gatsby-sample-home-page/pexels-photo-534351/",
     "media_details": Object {
-      "file": "2017/09/pexels-photo-534351.jpeg",
       "height": 4000,
       "image_meta": Object {
         "aperture": "10",
@@ -5992,35 +5985,30 @@ Array [
       },
       "sizes": Object {
         "full": Object {
-          "file": "pexels-photo-534351.jpeg",
           "height": 4000,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg",
           "width": 6000,
         },
         "large": Object {
-          "file": "pexels-photo-534351-1024x683.jpeg",
           "height": 683,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-1024x683.jpeg",
           "width": 1024,
         },
         "medium": Object {
-          "file": "pexels-photo-534351-300x200.jpeg",
           "height": 200,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg",
           "width": 300,
         },
         "medium_large": Object {
-          "file": "pexels-photo-534351-768x512.jpeg",
           "height": 512,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-768x512.jpeg",
           "width": 768,
         },
         "thumbnail": Object {
-          "file": "pexels-photo-534351-150x150.jpeg",
           "height": 150,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-150x150.jpeg",
@@ -11413,15 +11401,14 @@ Array [
       "date": "2017-09-02T10:36:43.000Z",
       "description": "<p class=\\"attachment\\"><a href='http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg'><img width=\\"300\\" height=\\"200\\" src=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg\\" class=\\"attachment-medium size-medium\\" alt=\\"\\" srcset=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg 300w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-768x512.jpeg 768w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-1024x683.jpeg 1024w\\" sizes=\\"(max-width: 300px) 100vw, 300px\\" /></a></p>
 ",
-      "guid": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg",
+      "guid___NODE": "61ef7ef2-032f-5c90-bba3-99d04c9a1f07",
       "id": "61ef7ef2-032f-5c90-bba3-99d04c9a1f07",
       "internal": Object {
-        "contentDigest": "345cd9205939fd066a98ad92bce14d60",
+        "contentDigest": "bb67f7d3418ce4c5787f6b37aabc9a4b",
         "type": "wordpress__wp_media",
       },
       "link": "http://dev-gatbsyjswp.pantheonsite.io/sample-post-1/pexels-photo-534327/",
       "media_details": Object {
-        "file": "2017/09/pexels-photo-534327.jpeg",
         "height": 4000,
         "image_meta": Object {
           "aperture": "7.1",
@@ -11439,35 +11426,30 @@ Array [
         },
         "sizes": Object {
           "full": Object {
-            "file": "pexels-photo-534327.jpeg",
             "height": 4000,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg",
             "width": 6000,
           },
           "large": Object {
-            "file": "pexels-photo-534327-1024x683.jpeg",
             "height": 683,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-1024x683.jpeg",
             "width": 1024,
           },
           "medium": Object {
-            "file": "pexels-photo-534327-300x200.jpeg",
             "height": 200,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg",
             "width": 300,
           },
           "medium_large": Object {
-            "file": "pexels-photo-534327-768x512.jpeg",
             "height": 512,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-768x512.jpeg",
             "width": 768,
           },
           "thumbnail": Object {
-            "file": "pexels-photo-534327-150x150.jpeg",
             "height": 150,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-150x150.jpeg",
@@ -11532,15 +11514,14 @@ Array [
       "date": "2017-09-02T10:35:16.000Z",
       "description": "<p class=\\"attachment\\"><a href='http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg'><img width=\\"300\\" height=\\"200\\" src=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg\\" class=\\"attachment-medium size-medium\\" alt=\\"\\" srcset=\\"http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg 300w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-768x512.jpeg 768w, http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-1024x683.jpeg 1024w\\" sizes=\\"(max-width: 300px) 100vw, 300px\\" /></a></p>
 ",
-      "guid": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg",
+      "guid___NODE": "950513a1-a720-5588-b262-9533aa598624",
       "id": "950513a1-a720-5588-b262-9533aa598624",
       "internal": Object {
-        "contentDigest": "60e31d4f0302cc6cae5c7021444ff564",
+        "contentDigest": "8cfda0374b40c9c1ea9eef010f5d4d40",
         "type": "wordpress__wp_media",
       },
       "link": "http://dev-gatbsyjswp.pantheonsite.io/gatsby-sample-home-page/pexels-photo-534351/",
       "media_details": Object {
-        "file": "2017/09/pexels-photo-534351.jpeg",
         "height": 4000,
         "image_meta": Object {
           "aperture": "10",
@@ -11558,35 +11539,30 @@ Array [
         },
         "sizes": Object {
           "full": Object {
-            "file": "pexels-photo-534351.jpeg",
             "height": 4000,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg",
             "width": 6000,
           },
           "large": Object {
-            "file": "pexels-photo-534351-1024x683.jpeg",
             "height": 683,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-1024x683.jpeg",
             "width": 1024,
           },
           "medium": Object {
-            "file": "pexels-photo-534351-300x200.jpeg",
             "height": 200,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg",
             "width": 300,
           },
           "medium_large": Object {
-            "file": "pexels-photo-534351-768x512.jpeg",
             "height": 512,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-768x512.jpeg",
             "width": 768,
           },
           "thumbnail": Object {
-            "file": "pexels-photo-534351-150x150.jpeg",
             "height": 150,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-150x150.jpeg",

--- a/packages/gatsby-source-wordpress/src/__tests__/__snapshots__/normalize.js.snap
+++ b/packages/gatsby-source-wordpress/src/__tests__/__snapshots__/normalize.js.snap
@@ -5790,6 +5790,7 @@ Array [
       ],
     },
     "acf": Object {
+      "dummy": true,
       "linked_image___NODE": "950513a1-a720-5588-b262-9533aa598624",
     },
     "author___NODE": "ec1fb3e3-d897-5549-b5f6-72b358fbbe83",
@@ -5862,6 +5863,7 @@ Array [
     "id": "61ef7ef2-032f-5c90-bba3-99d04c9a1f07",
     "link": "http://dev-gatbsyjswp.pantheonsite.io/sample-post-1/pexels-photo-534327/",
     "media_details": Object {
+      "file": "2017/09/pexels-photo-534327.jpeg",
       "height": 4000,
       "image_meta": Object {
         "aperture": "7.1",
@@ -5879,30 +5881,35 @@ Array [
       },
       "sizes": Object {
         "full": Object {
+          "file": "pexels-photo-534327.jpeg",
           "height": 4000,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg",
           "width": 6000,
         },
         "large": Object {
+          "file": "pexels-photo-534327-1024x683.jpeg",
           "height": 683,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-1024x683.jpeg",
           "width": 1024,
         },
         "medium": Object {
+          "file": "pexels-photo-534327-300x200.jpeg",
           "height": 200,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg",
           "width": 300,
         },
         "medium_large": Object {
+          "file": "pexels-photo-534327-768x512.jpeg",
           "height": 512,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-768x512.jpeg",
           "width": 768,
         },
         "thumbnail": Object {
+          "file": "pexels-photo-534327-150x150.jpeg",
           "height": 150,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-150x150.jpeg",
@@ -5968,6 +5975,7 @@ Array [
     "id": "950513a1-a720-5588-b262-9533aa598624",
     "link": "http://dev-gatbsyjswp.pantheonsite.io/gatsby-sample-home-page/pexels-photo-534351/",
     "media_details": Object {
+      "file": "2017/09/pexels-photo-534351.jpeg",
       "height": 4000,
       "image_meta": Object {
         "aperture": "10",
@@ -5985,30 +5993,35 @@ Array [
       },
       "sizes": Object {
         "full": Object {
+          "file": "pexels-photo-534351.jpeg",
           "height": 4000,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg",
           "width": 6000,
         },
         "large": Object {
+          "file": "pexels-photo-534351-1024x683.jpeg",
           "height": 683,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-1024x683.jpeg",
           "width": 1024,
         },
         "medium": Object {
+          "file": "pexels-photo-534351-300x200.jpeg",
           "height": 200,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg",
           "width": 300,
         },
         "medium_large": Object {
+          "file": "pexels-photo-534351-768x512.jpeg",
           "height": 512,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-768x512.jpeg",
           "width": 768,
         },
         "thumbnail": Object {
+          "file": "pexels-photo-534351-150x150.jpeg",
           "height": 150,
           "mime_type": "image/jpeg",
           "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-150x150.jpeg",
@@ -11325,6 +11338,7 @@ Array [
         ],
       },
       "acf": Object {
+        "dummy": true,
         "linked_image___NODE": "950513a1-a720-5588-b262-9533aa598624",
       },
       "author___NODE": "ec1fb3e3-d897-5549-b5f6-72b358fbbe83",
@@ -11343,7 +11357,7 @@ Array [
       "guid": "http://dev-gatbsyjswp.pantheonsite.io/?page_id=5",
       "id": "340ceded-7db7-583c-9486-120758f5d967",
       "internal": Object {
-        "contentDigest": "bf7491f5ede200a6f3ce8db4c28e3eca",
+        "contentDigest": "730b646cd1ae6cd070d74956e5041fd2",
         "type": "wordpress__PAGE",
       },
       "link": "http://dev-gatbsyjswp.pantheonsite.io/",
@@ -11404,11 +11418,12 @@ Array [
       "guid___NODE": "61ef7ef2-032f-5c90-bba3-99d04c9a1f07",
       "id": "61ef7ef2-032f-5c90-bba3-99d04c9a1f07",
       "internal": Object {
-        "contentDigest": "bb67f7d3418ce4c5787f6b37aabc9a4b",
+        "contentDigest": "e34c3e03101d1305788a27f283e90c6b",
         "type": "wordpress__wp_media",
       },
       "link": "http://dev-gatbsyjswp.pantheonsite.io/sample-post-1/pexels-photo-534327/",
       "media_details": Object {
+        "file": "2017/09/pexels-photo-534327.jpeg",
         "height": 4000,
         "image_meta": Object {
           "aperture": "7.1",
@@ -11426,30 +11441,35 @@ Array [
         },
         "sizes": Object {
           "full": Object {
+            "file": "pexels-photo-534327.jpeg",
             "height": 4000,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327.jpeg",
             "width": 6000,
           },
           "large": Object {
+            "file": "pexels-photo-534327-1024x683.jpeg",
             "height": 683,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-1024x683.jpeg",
             "width": 1024,
           },
           "medium": Object {
+            "file": "pexels-photo-534327-300x200.jpeg",
             "height": 200,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-300x200.jpeg",
             "width": 300,
           },
           "medium_large": Object {
+            "file": "pexels-photo-534327-768x512.jpeg",
             "height": 512,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-768x512.jpeg",
             "width": 768,
           },
           "thumbnail": Object {
+            "file": "pexels-photo-534327-150x150.jpeg",
             "height": 150,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534327-150x150.jpeg",
@@ -11517,11 +11537,12 @@ Array [
       "guid___NODE": "950513a1-a720-5588-b262-9533aa598624",
       "id": "950513a1-a720-5588-b262-9533aa598624",
       "internal": Object {
-        "contentDigest": "8cfda0374b40c9c1ea9eef010f5d4d40",
+        "contentDigest": "7bb20caef5bf65715b92b109cbfae7b9",
         "type": "wordpress__wp_media",
       },
       "link": "http://dev-gatbsyjswp.pantheonsite.io/gatsby-sample-home-page/pexels-photo-534351/",
       "media_details": Object {
+        "file": "2017/09/pexels-photo-534351.jpeg",
         "height": 4000,
         "image_meta": Object {
           "aperture": "10",
@@ -11539,30 +11560,35 @@ Array [
         },
         "sizes": Object {
           "full": Object {
+            "file": "pexels-photo-534351.jpeg",
             "height": 4000,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351.jpeg",
             "width": 6000,
           },
           "large": Object {
+            "file": "pexels-photo-534351-1024x683.jpeg",
             "height": 683,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-1024x683.jpeg",
             "width": 1024,
           },
           "medium": Object {
+            "file": "pexels-photo-534351-300x200.jpeg",
             "height": 200,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-300x200.jpeg",
             "width": 300,
           },
           "medium_large": Object {
+            "file": "pexels-photo-534351-768x512.jpeg",
             "height": 512,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-768x512.jpeg",
             "width": 768,
           },
           "thumbnail": Object {
+            "file": "pexels-photo-534351-150x150.jpeg",
             "height": 150,
             "mime_type": "image/jpeg",
             "source_url": "http://dev-gatbsyjswp.pantheonsite.io/wp-content/uploads/2017/09/pexels-photo-534351-150x150.jpeg",

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -240,7 +240,9 @@ exports.mapEntitiesToMedia = entities => {
   return entities.map(e => {
     // Map featured_media to its media node
 
-    const isPhoto = field =>
+    // Check if it's value of ACF Image field, that has 'Return value' set to
+    // 'Image Object' ( https://www.advancedcustomfields.com/resources/image/ )
+    const isPhotoObject = field =>
       _.isObject(field) &&
       field.wordpress_id &&
       field.url &&
@@ -249,45 +251,92 @@ exports.mapEntitiesToMedia = entities => {
         ? true
         : false
 
-    const isPhotoNode = field =>
-      _.isObject(field) && field.id && field.source_url ? true : false
-
     const photoRegex = /\.(gif|jpg|jpeg|tiff|png)$/i
     const isPhotoUrl = filename =>
       _.isString(filename) && photoRegex.test(filename)
+    const isPhotoUrlAlreadyProcessed = key => key == `source_url`
+    const isFeaturedMedia = (value, key) =>
+      (_.isNumber(value) || _.isBoolean(value)) && key === `featured_media`
+    // ACF Gallery and similarly shaped arrays
+    const isArrayOfPhotoObject = field =>
+      _.isArray(field) && field.length > 0 && isPhotoObject(field[0])
+    const getMediaItemID = mediaItem => (mediaItem ? mediaItem.id : null)
+
+    // Try to get media node from value:
+    //  - special case - check if key is featured_media and value is photo ID
+    //  - check if value is photo url
+    //  - check if value is ACF Image Object
+    //  - check if value is ACF Gallery
+    const getMediaFromValue = (value, key) => {
+      if (isFeaturedMedia(value, key)) {
+        return {
+          mediaNodeID: _.isNumber(value)
+            ? getMediaItemID(media.find(m => m.wordpress_id === value))
+            : null,
+          deleteField: true,
+        }
+      } else if (isPhotoUrl(value) && !isPhotoUrlAlreadyProcessed(key)) {
+        const mediaNodeID = getMediaItemID(
+          media.find(m => m.source_url === value)
+        )
+        return {
+          mediaNodeID,
+          deleteField: !!mediaNodeID,
+        }
+      } else if (isPhotoObject(value)) {
+        const mediaNodeID = getMediaItemID(
+          media.find(m => m.source_url === value.url)
+        )
+        return {
+          mediaNodeID,
+          deleteField: !!mediaNodeID,
+        }
+      } else if (isArrayOfPhotoObject(value)) {
+        return {
+          mediaNodeID: value
+            .map(item => getMediaFromValue(item, key).mediaNodeID)
+            .filter(id => id !== null),
+          deleteField: true,
+        }
+      }
+      return {
+        mediaNodeID: null,
+        deleteField: false,
+      }
+    }
 
     const replaceFieldsInObject = object => {
+      let deletedAllFields = true
       _.each(object, (value, key) => {
+        const { mediaNodeID, deleteField } = getMediaFromValue(value, key)
+        if (mediaNodeID) {
+          object[`${key}___NODE`] = mediaNodeID
+        }
+        if (deleteField) {
+          delete object[key]
+          // We found photo node (even if it has no image),
+          // We can end processing this path
+          return
+        } else {
+          deletedAllFields = false
+        }
+
         if (_.isArray(value)) {
           value.forEach(v => replaceFieldsInObject(v))
-        } else if (isPhoto(value)) {
-          const me = media.find(m => m.wordpress_id === value.wordpress_id)
-          if (me) {
-            object[`${key}___NODE`] = me.id
-          }
-          // Always delete even if we can't find a featuredMedia as WordPress' API sets
-          // featured_media to 0 when there isn't one which is useless to us.
-          delete object[key]
-        } else if (isPhotoUrl(value) && key != `source_url`) {
-          const me = media.find(m => m.source_url === value)
-          if (me) {
-            object[`${key}___NODE`] = me.id
-          }
-          delete object[key]
-        } else if (_.isNumber(value) && key == `featured_media`) {
-          const me = media.find(m => m.wordpress_id === value)
-          if (me) {
-            object[`${key}___NODE`] = me.id
-          }
-          delete object[key]
-        } else if (_.isBoolean(value) && key == `featured_media`) {
-          delete object[key]
-        } else if (_.isObject(value) && !isPhotoNode(value)) {
+        } else if (_.isObject(value)) {
           replaceFieldsInObject(value)
         }
       })
-    }
 
+      // Deleting fields and replacing them with links to different nodes
+      // can cause build errors if object will have only linked properites:
+      // https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-input-fields.js#L205
+      // Hacky workaround:
+      // Adding dummy field with concrete value (not link) fixes build
+      if (deletedAllFields && object && _.isObject(object)) {
+        object[`dummy`] = true
+      }
+    }
     replaceFieldsInObject(e)
 
     return e


### PR DESCRIPTION
* Featured medias could be nested at any level
* The most certain way to have photos works with this version on the plugin is to either name the field featured_media or include the image as Post Object.
* Fixed bug where in some case the old featured_media field was not deleted.

Tested with using-wordpress OK.