### PR TITLE
[gatsby-plugin-google-analytics] Allow passing extra code.

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -19,6 +19,9 @@ exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
   ${typeof pluginOptions.anonymize !== `undefined`
     ? `ga('set', 'anonymizeIp', 1);`
     : ``}
+  ${typeof pluginOptions.extraCode !== `undefined`
+    ? pluginOptions.extraCode
+    : ``}
   ga('send', 'pageview');
       `,
         }}


### PR DESCRIPTION
I'm trying to use Google Optimize and it tells you to place the Optimize call before the pageView event like this: 

```
<script>
  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
  ga('create', 'TRACKING', 'auto');
  ga('require', 'GTM-CODE'); <----- This line
  ga('send', 'pageview');
</script>
```

This allows injecting random commands.