### PR TITLE
Fix missing argument for providing a custom locale when querying a date

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -127,6 +127,12 @@ function inferGraphQLType({
             measurement years, months, weeks, days, hours, minutes,
             and seconds.`,
         },
+        locale: {
+          type: GraphQLString,
+          description: oneLine`
+            Configures the locale Moment.js will use to format the date.
+          `
+        },
       },
       resolve(object, { fromNow, difference, formatString, locale = `en` }) {
         let date

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -131,7 +131,7 @@ function inferGraphQLType({
           type: GraphQLString,
           description: oneLine`
             Configures the locale Moment.js will use to format the date.
-          `
+          `,
         },
       },
       resolve(object, { fromNow, difference, formatString, locale = `en` }) {


### PR DESCRIPTION
This is a fix for a piece of code that was missing in https://github.com/gatsbyjs/gatsby/pull/2382. It enables the use of a locale argument of type GraphQLString in date queries, as suggested in https://github.com/gatsbyjs/gatsby/pull/2382#issuecomment-339650934. 

Now you can format the date in a query to another locale like this:

```
date(formatString: "DD MMMM YYYY", locale: "de")
```

This will result in a date value of 27 octobre 2017. 