### PR TITLE
Add Gatsby Stripe plugins to plugins page

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -139,3 +139,4 @@ you can place the files in a `src` subfolder and build them to the plugin folder
 * [gatsby-remark-external-links](https://github.com/JLongley/gatsby-remark-external-links)
 * [gatsby-source-workable](https://github.com/tumblbug/gatsby-source-workable)
 * [gatsby-source-google-sheets](https://github.com/brandonmp/gatsby-source-google-sheets)
+* [gatsby-source-stripe-products](https://github.com/njosefbeck/gatsby-source-stripe-products)

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -358,7 +358,7 @@ const createACFChildNodes = (
 ) => {
   // Replace any child arrays with pointers to nodes
   _.each(obj, (value, key) => {
-    if (_.isArray(value) && value[0].acf_fc_layout) {
+    if (_.isArray(value) && value[0] && value[0].acf_fc_layout) {
       obj[`${key}___NODE`] = value.map(
         v =>
           createACFChildNodes(
@@ -394,7 +394,7 @@ exports.createNodesFromEntities = ({ entities, createNode }) => {
     let children = []
     if (entity.acf) {
       _.each(entity.acf, (value, key) => {
-        if (_.isArray(value) && value[0].acf_fc_layout) {
+        if (_.isArray(value) && value[0] && value[0].acf_fc_layout) {
           entity.acf[`${key}_${entity.type}___NODE`] = entity.acf[
             key
           ].map((f, i) => {


### PR DESCRIPTION
Hello!

Just creating a pull request to add the three plugins I created for integrating Stripe into a Gatsby site. I could have sworn that the commits from Oct. 26 were merged in yesterday, but Github seems to show otherwise. 

Let me know if there are any issues!

Thanks,
Nathan