### PR TITLE
Fix bootstrap missing files in gatsby-cli

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,6 @@ install:
         Exit-AppVeyorBuild
       }
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - choco install yarn --ignore-dependencies
   - refreshenv
   - echo we are running on %PLATFORM%
   - node --version

--- a/packages/gatsby-cli/.gitignore
+++ b/packages/gatsby-cli/.gitignore
@@ -1,4 +1,5 @@
 /lib
 /*.js
+!/bin.js
 /reporter
 yarn.lock

--- a/packages/gatsby-cli/bin.js
+++ b/packages/gatsby-cli/bin.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// This file exists to fix a problem lerna has with symlinks on Windows
+// See https://github.com/gatsbyjs/gatsby/pull/2658
+require(`lib/index.js`)

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.11",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {
-    "gatsby": "lib/index.js"
+    "gatsby": "bin.js"
   },
   "dependencies": {
     "babel-code-frame": "^6.26.0",
@@ -32,7 +32,7 @@
     "gatsby"
   ],
   "license": "MIT",
-  "main": "lib/index.js",
+  "main": "bin.js",
   "scripts": {
     "build": "babel src --out-dir lib --ignore __tests__",
     "watch": "babel -w src --out-dir lib --ignore __tests__",

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -34,7 +34,7 @@ describe(`gatsby-remark-copy-linked-files`, () => {
   }
   const getFiles = filePath => [
     {
-      absolutePath: path.normalize(filePath),
+      absolutePath: path.posix.normalize(filePath),
       internal: {},
       extension: filePath
         .split(`.`)

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -24,7 +24,7 @@ module.exports = (
       isRelativeUrl(link.url) &&
       getNode(markdownNode.parent).internal.type === `File`
     ) {
-      const linkPath = path.join(getNode(markdownNode.parent).dir, link.url)
+      const linkPath = path.posix.join(getNode(markdownNode.parent).dir, link.url)
       const linkNode = _.find(files, file => {
         if (file && file.absolutePath) {
           return file.absolutePath === linkPath
@@ -32,7 +32,7 @@ module.exports = (
         return null
       })
       if (linkNode && linkNode.absolutePath) {
-        const newPath = path.join(
+        const newPath = path.posix.join(
           process.cwd(),
           `public`,
           `${linkNode.internal.contentDigest}.${linkNode.extension}`
@@ -43,7 +43,7 @@ module.exports = (
           return
         }
 
-        const relativePath = path.join(
+        const relativePath = path.posix.join(
           `/${linkNode.internal.contentDigest}.${linkNode.extension}`
         )
         link.url = `${relativePath}`
@@ -116,7 +116,7 @@ module.exports = (
       return
     }
 
-    const imagePath = path.join(getNode(markdownNode.parent).dir, image.url)
+    const imagePath = path.posix.join(getNode(markdownNode.parent).dir, image.url)
     const imageNode = _.find(files, file => {
       if (file && file.absolutePath) {
         return file.absolutePath === imagePath


### PR DESCRIPTION
Lerna bootstrap creates symlinks to files that don't yet exist.
Building gatsby-cli separately creates the missing files.
This should solve the error from Appveyor in #2529:
> UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: ENOENT: no such file or directory, stat 'C:\projects\gatsby\packages\gatsby-cli\lib\index.js'.