### PR TITLE
add javascriptstuff.com to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Websites built with Gatsby:
 * [Hallingdata](http://hallingdata.no/)
 * [@swyx](http://swyx.io) [(source)](https://github.com/sw-yx/swyxdotio)
 * [Portfolio of Piotr Fedorczyk](https://piotrf.pl)
+* [JavaScript Stuff](https://www.javascriptstuff.com)
 
 ## Docs
 


### PR DESCRIPTION
Are you taking any Gatsby sites for the showcase list? I just built a new site and it is 100% Gatsby: https://www.javascriptstuff.com/
