### PR TITLE
Add `gatsby-transformer-remark` to `npm install` in `gatsby-remark-prismjs` README

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -5,7 +5,7 @@ Adds syntax highlighting to code blocks in markdown files using
 
 ## Install
 
-`npm install --save gatsby-remark-prismjs`
+`npm install --save gatsby-transformer-remark gatsby-remark-prismjs`
 
 ## How to use
 


### PR DESCRIPTION
This may be totally intuitive to some, but if you add `gatsby-remark-prismjs` as shown above without having added `gatsby-transformer-remark`, you get a build failure:

```
prichey@BE7700 ~/g/prichey-gatsby (master)> yarn deploy
yarn run v1.2.1
$ gatsby build --prefix-paths && gh-pages -d public
success delete html files from previous builds — 0.046 s
success open and validate gatsby-config.js — 0.007 s
error Unable to find plugin "gatsby-transformer-remark"


  Error: Unable to find plugin "gatsby-transformer-remark"

  - load-plugins.js:96 resolvePlugin
    [prichey-gatsby]/[gatsby]/dist/bootstrap/load-plugins.js:96:11

  - load-plugins.js:147 processPlugin
    [prichey-gatsby]/[gatsby]/dist/bootstrap/load-plugins.js:147:27

  - load-plugins.js:168
    [prichey-gatsby]/[gatsby]/dist/bootstrap/load-plugins.js:168:28

  - Array.forEach

  - load-plugins.js:167 _callee$
    [prichey-gatsby]/[gatsby]/dist/bootstrap/load-plugins.js:167:28

  - index.js:122 _callee$
    [prichey-gatsby]/[gatsby]/dist/bootstrap/index.js:122:20


error Command failed with exit code 1.
```

Small change, but it would save beginners from running into the same error I just hit.