### PR TITLE
[using-page-transitions] fixes #2669

### DIFF
--- a/examples/using-page-transitions/src/pages/cat.js
+++ b/examples/using-page-transitions/src/pages/cat.js
@@ -3,7 +3,7 @@ import React from "react"
 import Link from "gatsby-link"
 
 const Cat = ({ transition }) => (
-  <div style={transition.style}>
+  <div style={transition && transition.style}>
     <h1>meow</h1>
     <div>
       <Link to="/">Go to home</Link>

--- a/examples/using-page-transitions/src/pages/dog.js
+++ b/examples/using-page-transitions/src/pages/dog.js
@@ -3,7 +3,7 @@ import React from "react"
 import Link from "gatsby-link"
 
 const Dog = ({ transition }) => (
-  <div style={transition.style}>
+  <div style={transition && transition.style}>
     <h1>ruff</h1>
     <div>
       <Link to="/">Go to home</Link>

--- a/examples/using-page-transitions/src/pages/index.js
+++ b/examples/using-page-transitions/src/pages/index.js
@@ -3,7 +3,7 @@ import React from "react"
 import Link from "gatsby-link"
 
 const Index = ({ transition }) => (
-  <div style={transition.style}>
+  <div style={transition && transition.style}>
     <h1>animals</h1>
     <div>
       <Link to="/cat/">Go to cat</Link>

--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -104,7 +104,7 @@ class ComponentRenderer extends React.Component {
 
   render() {
     const pluginResponses = apiRunner(`replaceComponentRenderer`, {
-      props: this.props,
+      props: { ...this.props, pageResources: { ...this.state.pageResources } },
     })
     const replacementComponent = pluginResponses[0]
     // If page.

--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -104,7 +104,7 @@ class ComponentRenderer extends React.Component {
 
   render() {
     const pluginResponses = apiRunner(`replaceComponentRenderer`, {
-      props: { ...this.props, pageResources: { ...this.state.pageResources } },
+      props: { ...this.props, pageResources: this.state.pageResources },
     })
     const replacementComponent = pluginResponses[0]
     // If page.


### PR DESCRIPTION
On a production build `pageResources` werent being passed through as a prop if you `replaceComponentRenderer` in`gatsby-browser.js`