### PR TITLE
use alternative Set concatenation syntax to avoid babel spread bug

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -44,7 +44,7 @@ function convertToInputType(
   if (typeMap.has(type)) {
     return null
   }
-  const nextTypeMap = new Set([...typeMap, type])
+  const nextTypeMap = new Set(Array.from(typeMap).concat([type]))
 
   if (type instanceof GraphQLScalarType || type instanceof GraphQLEnumType) {
     return type


### PR DESCRIPTION
This is a one-line PR to fix an unusual babel issue created by the `Set()` syntax added in https://github.com/gatsbyjs/gatsby/pull/2452

Background: that prior PR worked and tested without issue, and was fine in my local application when running against a source copy of gatsby. But when installing the latest gatsby release normally, the recursion prevention was behaving very differently. 

After much headache, I finally tracked it down to mangled syntax coming out of babel when using the `loose:true` option and creating a Set() using spread syntax. The tests were running fine, as was anything against the `src/`, but the `dist/` created by babel was distorting the line in question.

This line (https://github.com/jasonphillips/gatsby/blob/3e96d498cc42b0268c7aa8e113236e0346eab5b2/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js#L47):

```js
const nextTypeMap = new Set([...typeMap, type])
```

Was being converted by babel to this:

```js
const nextTypeMap = new Set([].concat(typeMap, [type]));
```

-- and the latter does not equate to the former. Since the erroneous code is only in the babel `dist/` output, the `jest` testing wasn't running into it. This mangling only occurs when `loose` mode is set to true. I documented a minimal reproduction of this issue here in a gist: https://gist.github.com/jasonphillips/57c1f8f9dbcd8b489dafcafde4fcdba6

The alternative syntax in this PR survives babel's transformation unchanged, and `Array.from()` should be perfectly safe in all versions of node supported.
