### PR TITLE
[gatsby-cli] Bugfix : 'Cannot find module lib/index.js'

### DIFF
--- a/packages/gatsby-cli/bin.js
+++ b/packages/gatsby-cli/bin.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 // This file exists to fix a problem lerna has with symlinks on Windows
 // See https://github.com/gatsbyjs/gatsby/pull/2658
-require(`lib/index.js`)
+require(`./lib/index.js`)


### PR DESCRIPTION
Referencing the module using a relative path fixes the following error which appeared with v1.1.12

![image](https://user-images.githubusercontent.com/5808108/32201168-b9198dbe-bdd5-11e7-840d-d9c67a163b2b.png)
