### PR TITLE
Update build-html.js

### DIFF
--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -30,9 +30,14 @@ module.exports = async (program: any) => {
       }
       const outputFile = `${directory}/public/render-page.js`
       if (stats.hasErrors()) {
-        let webpackErrors = stats.compilation.errors.filter(e => e)
+        let webpackErrors = stats.toJson().errors.filter(Boolean)
         return reject(
-          createErrorFromString(webpackErrors[0], `${outputFile}.map`)
+          webpackErrors.length ?
+            createErrorFromString(webpackErrors[0], `${outputFile}.map`) :
+            new Error(
+              `There was an issue while building the site: ` +
+              `\n\n${stats.toString()}`
+            )
         )
       }
 


### PR DESCRIPTION
This should hopefully cover any weird edge cases. We should be using `toJson()` though as that is what the webpack docs suggest for error handling