### PR TITLE
added inlineCode nodes to gatsby-transformer-remark excerpt

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -257,9 +257,16 @@ module.exports = (
         },
         resolve(markdownNode, { pruneLength }) {
           return getAST(markdownNode).then(ast => {
-            const textNodes = []
-            visit(ast, `text`, textNode => textNodes.push(textNode.value))
-            return prune(textNodes.join(` `), pruneLength, `…`)
+            const excerptNodes = []
+
+            visit(ast, node => {
+              if (node.type === `text` || node.type === `inlineCode`) {
+                excerptNodes.push(node.value)
+              }
+              return
+            })
+
+            return prune(excerptNodes.join(` `), pruneLength, `…`)
           })
         },
       },


### PR DESCRIPTION
As discussed in issue #2694  (Markdown Node excerpt does not have text within \<code\> tags), this pull request changes the gatsby-transformer-remark excerpt field to include values of `inlineCode` nodes from the abstract syntax tree.

Notes:
- There may be other abstract syntax tree nodes that should be included here as well, besides `text` and `inlineCode`.
- There are currently no tests for the `extend-node-type` file, which defines the new fields on the markdown file type, such as `html` and `excerpt`. I wasn't sure what kind of tests are desired for this code (snapshots? assert equals?), and there's a whole lot going on in `extend-node-type` that I don't understand, so I didn't add any myself. 