### PR TITLE
Update SitePage schema before onPreExtractQueries

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -331,6 +331,12 @@ module.exports = async (args: BootstrapArgs) => {
   await apiRunnerNode(`onPreExtractQueries`)
   activity.end()
 
+  // Update Schema for SitePage.
+  activity = report.activityTimer(`update schema`)
+  activity.start()
+  await require(`../schema`)()
+  activity.end()
+
   // Extract queries
   activity = report.activityTimer(`extract queries from components`)
   activity.start()
@@ -358,12 +364,6 @@ module.exports = async (args: BootstrapArgs) => {
   activity = report.activityTimer(`write out redirect data`)
   activity.start()
   await writeRedirects()
-  activity.end()
-
-  // Update Schema for SitePage.
-  activity = report.activityTimer(`update schema`)
-  activity.start()
-  await require(`../schema`)()
   activity.end()
 
   const checkJobsDone = _.debounce(resolve => {


### PR DESCRIPTION
Addresses #2685.

It looks like there was an attempt to fix this problem before judging by these lines:
https://github.com/gatsbyjs/gatsby/blob/3691d65bccc0ccb5ca487c36adf13416ee7993cc/packages/gatsby/src/bootstrap/index.js#L363-L367

This PR simply moves that second `require('../schema')()` call to before `onPreExtractQueries`. And that seems to fix it.

Of course, I tried this *after* attempting to update the old schema in this [branch](https://github.com/fusepilot/gatsby/tree/topics/site-page-querying). So thats started in case I've missed something and we need that in between "SitePage schema only" update.
