### PR TITLE
Pixel density aware resizing should be optional

### DIFF
--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -85,6 +85,7 @@ plugin for Markdown content as gatsby-remark-images).
 * `maxWidth` (int, default: 800)
 * `maxHeight` (int)
 * `quality` (int, default: 50)
+* `sizeByPixelDensity` (bool, default: false)
 
 #### Returns
 
@@ -160,7 +161,7 @@ responsiveResolution(
 ```
 
 the source image colors will be converted to match a gradient color chosen based
-on each pixel's [relative luminance][4].  
+on each pixel's [relative luminance][4].
 Logic is borrowed from [react-duotone][5].
 
 #### tracedSVG

--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -15,14 +15,30 @@ Object {
   "aspectRatio": 2.0661764705882355,
   "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAYAAAC0VX7mAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAuUlEQVQoz9WRywqCYBCFff9lq6BFLSIQSoIW1UpIulDZ1VKS7GJiapGWl99cnH7sAdy4cTZzmJnzMcwwyDmYYgAHQYBZGKH2cjEOQ7S8d6r3hKS59/HB+0GqNxFB3fXA0hmReqq0ppAYxjfJd0MzSYp0w1yBPn3Idi+j0+2DF4awbCfTdL0ZEEYTlMoVsFwbjSaHqbj4A+M4xlraQZIVXHQdzuOZCbzbNlRNw3y5gnJQcTydYVpW2vsBqlELaS2F/80AAAAASUVORK5CYII=",
   "density": 144,
-  "originalImg": "/static/1234-f54e4.png",
+  "originalImg": "/static/1234-85b96.png",
   "originalName": undefined,
   "presentationHeight": 68,
   "presentationWidth": 141,
   "sizes": "(max-width: 141px) 100vw, 141px",
-  "src": "/static/1234-f54e4.png",
-  "srcSet": "/static/1234-a0d9a.png 200w,
-/static/1234-f54e4.png 281w",
+  "src": "/static/1234-85b96.png",
+  "srcSet": "/static/1234-7c9f5.png 200w,
+/static/1234-85b96.png 281w",
+}
+`;
+
+exports[`gatsby-plugin-sharp responsiveSizes can optionally ignore pixel density 1`] = `
+Object {
+  "aspectRatio": 2.0661764705882355,
+  "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAYAAAC0VX7mAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAuUlEQVQoz9WRywqCYBCFff9lq6BFLSIQSoIW1UpIulDZ1VKS7GJiapGWl99cnH7sAdy4cTZzmJnzMcwwyDmYYgAHQYBZGKH2cjEOQ7S8d6r3hKS59/HB+0GqNxFB3fXA0hmReqq0ppAYxjfJd0MzSYp0w1yBPn3Idi+j0+2DF4awbCfTdL0ZEEYTlMoVsFwbjSaHqbj4A+M4xlraQZIVXHQdzuOZCbzbNlRNw3y5gnJQcTydYVpW2vsBqlELaS2F/80AAAAASUVORK5CYII=",
+  "density": 144,
+  "originalImg": "/static/1234-24ad8.png",
+  "originalName": undefined,
+  "presentationHeight": 136,
+  "presentationWidth": 281,
+  "sizes": "(max-width: 281px) 100vw, 281px",
+  "src": "/static/1234-24ad8.png",
+  "srcSet": "/static/1234-06d78.png 200w,
+/static/1234-24ad8.png 281w",
 }
 `;
 

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -34,6 +34,20 @@ describe(`gatsby-plugin-sharp`, () => {
     it(`accounts for pixel density`, async () => {
       const result = await responsiveSizes({
         file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args: {
+          sizeByPixelDensity: true,
+        },
+      })
+
+      expect(result).toMatchSnapshot()
+    })
+
+    it(`can optionally ignore pixel density`, async () => {
+      const result = await responsiveSizes({
+        file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args: {
+          sizeByPixelDensity: false,
+        },
       })
 
       expect(result).toMatchSnapshot()

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -390,6 +390,7 @@ async function responsiveSizes({ file, args = {} }) {
     duotone: false,
     pathPrefix: ``,
     toFormat: ``,
+    sizeByPixelDensity: false,
   }
   const options = _.defaults({}, args, defaultArgs)
   options.maxWidth = parseInt(options.maxWidth, 10)
@@ -398,7 +399,7 @@ async function responsiveSizes({ file, args = {} }) {
   // images are intended to be displayed at their native resolution.
   const { width, height, density } = await sharp(file.absolutePath).metadata()
   const pixelRatio =
-    typeof density === `number` && density > 0 ? density / 72 : 1
+    options.sizeByPixelDensity && typeof density === `number` && density > 0 ? density / 72 : 1
   const presentationWidth = Math.min(
     options.maxWidth,
     Math.round(width / pixelRatio)

--- a/packages/gatsby-remark-images/README.md
+++ b/packages/gatsby-remark-images/README.md
@@ -46,6 +46,8 @@ plugins: [
             // Example: A screenshot made on a retina screen with a
             // resolution of 144 (e.g. Macbook) and a width of 100px,
             // will be rendered at 50px.
+            //
+            // Defaults to false.
             sizeByPixelDensity: true,
           },
         },

--- a/packages/gatsby-remark-images/README.md
+++ b/packages/gatsby-remark-images/README.md
@@ -36,6 +36,17 @@ plugins: [
             // Remove the default behavior of adding a link to each
             // image.
             linkImagesToOriginal: false,
+            // Analyze images' pixel density to make decisions about
+            // target image size. This is what GitHub is doing when
+            // embedding images in tickets. This is a useful setting
+            // for documentation pages with a lot of screenshots.
+            // It can have unintended side effects on high pixel
+            // density artworks.
+            //
+            // Example: A screenshot made on a retina screen with a
+            // resolution of 144 (e.g. Macbook) and a width of 100px,
+            // will be rendered at 50px.
+            sizeByPixelDensity: true,
           },
         },
       ]


### PR DESCRIPTION
Allow deactivation of pixel density aware resizing so that users can
embed high resolution artworks.

Fixes https://github.com/gatsbyjs/gatsby/issues/2292