### PR TITLE
Allow same network connections

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -13,7 +13,7 @@ const handlerP = fn => (...args) => {
 }
 
 function buildLocalCommands(cli, isLocalSite) {
-  const defaultHost = `localhost`
+  const defaultHost = `0.0.0.0`
   const directory = path.resolve(`.`)
 
   let siteInfo = { directory, browserslist: DEFAULT_BROWSERS }

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -1,8 +1,8 @@
 /* @flow weak */
-import detect from "detect-port"
-import Hapi from "hapi"
-import opn from "opn"
-import rl from "readline"
+import detect from 'detect-port'
+import Hapi from 'hapi'
+import opn from 'opn'
+import rl from 'readline'
 
 const rlInterface = rl.createInterface({
   input: process.stdin,
@@ -21,6 +21,7 @@ function startServer(program, launchPort) {
   server.connection({
     host: program.host,
     port: serverPort,
+    address: '0.0.0.0',
   })
 
   server.route({

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -21,7 +21,7 @@ function startServer(program, launchPort) {
   server.connection({
     host: program.host,
     port: serverPort,
-    address: '0.0.0.0',
+    address: `0.0.0.0`,
   })
 
   server.route({


### PR DESCRIPTION
This lets people on the same network view a Gatsby site running on your machine.

For example, `{local_ip}:8000` with `gatsby develop` or `{local_ip:9000}` with `gatsby serve`.

This does not affect the usual `localhost:8000` or `localhost:9000` behavior.