### PR TITLE
Small fix to Drupal source

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -133,10 +133,10 @@ exports.sourceNodes = async (
   await Promise.all(
     nodes.map(async node => {
       let fileNode
-      if (node.internal.type === `files`) {
+      if (node.internal.type === `files` || node.internal.type === `file__file`) {
         try {
           fileNode = await createRemoteFileNode({
-            url: node.uri,
+            url: baseUrl + node.url,
             store,
             cache,
             createNode,


### PR DESCRIPTION
`file--file` is the normal name of the file type in Drupal, files is what contenta renames it. So let's have both get checked.
I also added baseUrl and changed it to node.url from node.uri as it was not working for me.