### PR TITLE
Make transpileOnly configurable in gatsby-plugin-typescript

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -16,6 +16,22 @@ plugins: [
   `gatsby-plugin-typescript`,
 ]
 ```
+Or with optional configuration:
+```javascript
+plugins: [
+  {
+    resolve: 'gatsby-plugin-typescript',
+    options: {
+      transpileOnly: true, // default
+      compilerOptions: {
+        target: `esnext`,
+        experimentalDecorators: true,
+        jsx: `react`,
+      }, // default
+    }
+  },
+]
+```
 
 `tsconfig.json`
 ```json

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -26,6 +26,62 @@ describe(`gatsby-plugin-typescript`, () => {
     expect(lastCall).toMatchSnapshot()
   })
 
+  it(`passes the configuration to the ts-loader plugin`, () => {
+    const config = {
+      loader: jest.fn(),
+    }
+    const options = { compilerOptions: { foo: `bar` }, transpileOnly: false }
+
+    modifyWebpackConfig(
+      { config },
+      options
+    )
+
+    const expectedOptions = {
+      compilerOptions: {
+        target: `esnext`,
+        experimentalDecorators: true,
+        jsx: `react`,
+        foo: `bar`,
+        module: `commonjs`,
+      },
+      transpileOnly: false,
+    }
+
+    expect(config.loader).toHaveBeenCalledWith(`typescript`, {
+      test: /\.tsx?$/,
+      loaders: [
+        `babel?${JSON.stringify({ plugins: [``] })}`,
+        `ts-loader?${JSON.stringify(expectedOptions)}`,
+      ],
+    })
+  })
+
+  it(`uses default configuration for the ts-loader plugin when no config is provided`, () => {
+    const config = {
+      loader: jest.fn(),
+    }
+    modifyWebpackConfig({ config }, { compilerOptions: {} })
+
+    const expectedOptions = {
+      compilerOptions: {
+        target: `esnext`,
+        experimentalDecorators: true,
+        jsx: `react`,
+        module: `commonjs`,
+      },
+      transpileOnly: true,
+    }
+
+    expect(config.loader).toHaveBeenCalledWith(`typescript`, {
+      test: /\.tsx?$/,
+      loaders: [
+        `babel?${JSON.stringify({ plugins: [``] })}`,
+        `ts-loader?${JSON.stringify(expectedOptions)}`,
+      ],
+    })
+  })
+
   describe(`pre-processing`, () => {
     const opts = { compilerOptions: {} }
     it(`leaves non-tsx? files alone`, () => {

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -10,7 +10,7 @@ const compilerDefaults = {
 
 module.exports.resolvableExtensions = () => [`.ts`, `.tsx`]
 
-module.exports.modifyWebpackConfig = ({ config }, { compilerOptions }) => {
+module.exports.modifyWebpackConfig = ({ config }, { compilerOptions, transpileOnly = true }) => {
   // CommonJS to keep Webpack happy.
   const copts = Object.assign({}, compilerDefaults, compilerOptions, {
     module: `commonjs`,
@@ -18,7 +18,7 @@ module.exports.modifyWebpackConfig = ({ config }, { compilerOptions }) => {
 
   // React-land is rather undertyped; nontrivial TS projects will most likely
   // error (i.e., not build) at something or other.
-  const opts = { compilerOptions: copts, transpileOnly: true }
+  const opts = { compilerOptions: copts, transpileOnly }
 
   // Load gatsby babel plugin to extract graphql query
   const extractQueryPlugin = path.resolve(


### PR DESCRIPTION
Keeps the default config of `transpileOnly: true`, but now it is
configurable in the options passed to the plugin. Resolves #2749 

@KyleAMathews @noahlange 👀  please