### PR TITLE
Fix createPage action ignoring matchPath

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
@@ -9,6 +9,7 @@ Array [
     "internalComponentName": "ComponentHi",
     "jsonName": "hi.json",
     "layout": null,
+    "matchPath": undefined,
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
@@ -21,6 +22,7 @@ Array [
     "internalComponentName": "ComponentHiPizza",
     "jsonName": "hi-pizza.json",
     "layout": null,
+    "matchPath": undefined,
     "path": "/hi/pizza/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
@@ -38,6 +40,7 @@ Object {
     "internalComponentName": "ComponentHi",
     "jsonName": "hi.json",
     "layout": null,
+    "matchPath": undefined,
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
@@ -61,6 +64,7 @@ Array [
     "internalComponentName": "ComponentHi",
     "jsonName": "hi.json",
     "layout": null,
+    "matchPath": undefined,
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
@@ -80,6 +84,7 @@ Object {
     "internalComponentName": "ComponentHi",
     "jsonName": "hi.json",
     "layout": null,
+    "matchPath": undefined,
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
@@ -105,6 +110,49 @@ Array [
     "internalComponentName": "ComponentHi",
     "jsonName": "hi.json",
     "layout": null,
+    "matchPath": undefined,
+    "path": "/hi/",
+    "pluginCreatorId": "test",
+    "pluginCreator___NODE": "test",
+    "updatedAt": 1482363367071,
+  },
+]
+`;
+
+exports[`Add pages allows you to add pages with matchPath 1`] = `
+Object {
+  "payload": Object {
+    "component": "/whatever/index.js",
+    "componentChunkName": "component---whatever-index-js",
+    "context": Object {},
+    "internalComponentName": "ComponentHi",
+    "jsonName": "hi.json",
+    "layout": null,
+    "matchPath": "/hi-from-somewhere-else/",
+    "path": "/hi/",
+    "pluginCreatorId": "test",
+    "pluginCreator___NODE": "test",
+    "updatedAt": 1482363367071,
+  },
+  "plugin": Object {
+    "id": "test",
+    "name": "test",
+  },
+  "traceId": undefined,
+  "type": "CREATE_PAGE",
+}
+`;
+
+exports[`Add pages allows you to add pages with matchPath 2`] = `
+Array [
+  Object {
+    "component": "/whatever/index.js",
+    "componentChunkName": "component---whatever-index-js",
+    "context": Object {},
+    "internalComponentName": "ComponentHi",
+    "jsonName": "hi.json",
+    "layout": null,
+    "matchPath": "/hi-from-somewhere-else/",
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",
@@ -124,6 +172,7 @@ Array [
     "internalComponentName": "ComponentHi",
     "jsonName": "hi.json",
     "layout": null,
+    "matchPath": undefined,
     "path": "/hi/",
     "pluginCreatorId": "test",
     "pluginCreator___NODE": "test",

--- a/packages/gatsby/src/redux/__tests__/pages.js
+++ b/packages/gatsby/src/redux/__tests__/pages.js
@@ -37,6 +37,20 @@ describe(`Add pages`, () => {
     expect(state).toMatchSnapshot()
   })
 
+  it(`allows you to add pages with matchPath`, () => {
+    const action = actions.createPage(
+      {
+        path: `/hi/`,
+        component: `/whatever/index.js`,
+        matchPath: `/hi-from-somewhere-else/`,
+      },
+      { id: `test`, name: `test` }
+    )
+    const state = reducer(undefined, action)
+    expect(action).toMatchSnapshot()
+    expect(state).toMatchSnapshot()
+  })
+
   it(`allows you to add multiple pages`, () => {
     const action = actions.createPage(
       {

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -33,6 +33,7 @@ type LayoutInput = {
 
 type Page = {
   path: string,
+  matchPath: ?string,
   component: string,
   context: Object,
   internalComponentName: string,
@@ -117,6 +118,7 @@ actions.createPage = (page: PageInput, plugin?: Plugin, traceId?: string) => {
     jsonName,
     internalComponentName,
     path: page.path,
+    matchPath: page.matchPath,
     component: page.component,
     componentChunkName: generateComponentChunkName(page.component),
     // Ensure the page has a context object


### PR DESCRIPTION
I did an upgrade in the gatsby version and in `1.9.97` `matchPath` is not working anymore, because the created/updated pages didn't have the`matchPath` key. This PR fixes it 😃 