### PR TITLE
[gatsby-source-drupal] Change URI to URL

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -140,7 +140,7 @@ exports.sourceNodes = async (
       ) {
         try {
           // Resolve w/ baseUrl if node.uri isn't absolute.
-          const url = new URL(node.uri, baseUrl)
+          const url = new URL(node.url, baseUrl)
           fileNode = await createRemoteFileNode({
             url: url.href,
             store,


### PR DESCRIPTION
Internal images use

    uri: Internal URI scheme
    url: external URL (needs baseUrl appended)

External images (references) use

    uri: external URL
    url: external URL

So to cover all bases we need to use url.