### PR TITLE
Updates debugging-html instructions

### DIFF
--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -11,8 +11,10 @@ Errors while building static HTML files generally happen for two reasons.
    is building (see code sample below) or b) if the code is in the render
    function of a React.js component, move that code into "componentDidMount"
    which ensures the code doesn't run unless it's in the browser.
+   
+2. Check that each of your JS files listed in your `pages` directory (and any sub-directories) are exporting either a React component or string.  Gatsby treats any JS file listed under the pages dir as a page component, so it must have a default export that's a component or string.
 
-2. Some other reason :-) #1 is the most common reason building static files
+3. Some other reason :-) #1 is the most common reason building static files
    fail. If it's another reason, you have to be a bit more creative in figuring
    out the problem.
 


### PR DESCRIPTION
includes note about how Gatsby treats all JS files listed in pages directory as page component so the file must export a string or react component