### PR TITLE
Revert #2571

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -39,6 +39,7 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
 
       if (options.query) {
         f.query = merge(options.query, f.query)
+        delete options.query
       }
     }
 
@@ -56,8 +57,5 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
     await writeFile(path.join(publicPath, f.output), feed.xml())
   }
 
-  if (options.query) {
-    delete options.query
-  }
   return Promise.resolve()
 }


### PR DESCRIPTION
As mentioned in the [related PR thread (#2571)](https://github.com/gatsbyjs/gatsby/pull/2571) fff40f365ae1dc6c73c5f5962836d625e8e91ee1 actually introduced a bug, rather than resolving one.

This bug wasn't evident on sites that only generate a single RSS feed, which is probably why it wasn't caught on GatsbyJS.org. However, I use a much more complex configuration, designed to push this plugin to the limits, on my site, which is where the havoc was caused.

@KyleAMathews: if you could take a look and get this merged and released, I'd appreciate it. I have enough wrangling to do, cleaning up the issues this bug has caused.

@briced: Since this PR reverts your change, I'd like to talk more about what you hope to get from the feed plugin. It obviously wasn't meeting your needs, so there are changes to be made. But this, unfortunately, isn't one of them.