### PR TITLE
Revert #2573

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -76,8 +76,7 @@ plugins: [
               }
             }
           `,
-          output: '/rss.xml',
-          feedTitle: 'My feed title'
+          output: '/rss.xml'
         }
       ]
     }

--- a/packages/gatsby-plugin-feed/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-ssr.js
@@ -7,7 +7,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     ...pluginOptions,
   }
 
-  const links = feeds.map(({ output, feedTitle = `` }, i) => {
+  const links = feeds.map(({ output }, i) => {
     if (output.charAt(0) !== `/`) {
       output = `/` + output
     }
@@ -17,7 +17,6 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
         key={`gatsby-plugin-feed-${i}`}
         rel="alternate"
         type="application/rss+xml"
-        title={feedTitle}
         href={output}
       />
     )


### PR DESCRIPTION
This reverts commit aae508f1a57e72c702637c7d3613b9e26b294d44, which introduced unclear markup to the feed plugin.

As stated in [the PR](https://github.com/gatsbyjs/gatsby/pull/2573), I have questions about whether `title` will be parsed correctly by clients running feed discovery. The entire purpose of the `application/xml` tag is feed discovery, and if we confuse the browser, then I expect more problems than utility. (Do browsers read out the titles of all alternate feeds? Documentation that I've seen doesn't seem to support this line of reasoning.)

I'd like a way to merge this in, but the API doesn't match convention even if I were sure of support. This PR, #2573, needs more research before it can be safely implemented.