### PR TITLE
Fix no trailing slashes

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -117,21 +117,20 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
 
   return new Promise((resolve, reject) => {
     // Remove trailing slash
-    const oldPath = page.path
-    // Removing '/' would result in a path that's
-    // an empty string which is invalid
-    page.path = (page.path === `/`) ? page.path : page.path.replace(/\/$/, ``)
-    if (page.path !== oldPath) {
+    const newPage = Object.assign({}, page, {
+      path: page.path === `/` ? page.path : page.path.replace(/\/$/, ``),
+    })
 
+    if (newPage.path !== page.path) {
       // Remove the old page
-      deletePage({ path: oldPath })
-
+      deletePage(page)
       // Add the new page
-      createPage(page)
+      createPage(newPage)
     }
 
     resolve()
   })
+
 }
 ```
 

--- a/examples/no-trailing-slashes/gatsby-node.js
+++ b/examples/no-trailing-slashes/gatsby-node.js
@@ -5,14 +5,14 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
 
   return new Promise((resolve, reject) => {
     // Remove trailing slash
-    const oldPath = page.path
-    page.path = page.path === `/` ? page.path : page.path.replace(/\/$/, ``)
-    if (page.path !== oldPath) {
+    const newPage = Object.assign({}, page, {
+      path: page.path === `/` ? page.path : page.path.replace(/\/$/, ``),
+    })
+    if (newPage.path !== page.path) {
       // Remove the old page
-      deletePage({ path: oldPath })
-
+      deletePage(page)
       // Add the new page
-      createPage(page)
+      createPage(newPage)
     }
 
     resolve()

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -64,7 +64,9 @@ type Plugin = {
 
 /**
  * Delete a page
- * @param {string} page a page object with at least the path set
+ * @param {Object} page a page object with at least the path set
+ * @param {string} page.path The path of the page
+ * @param {string} page.component The absolute path to the page component
  * @example
  * deletePage(page)
  */


### PR DESCRIPTION
Apparently this broke somewhere. We're finally upgrading out of beta - I know 😬  - and noticed the issue. Previously we just needed to pass in an object with `path` into the `deletePage` action-creator, but now `component` needs to be set as well. Otherwise the [components reducer won't be able to normalize the component path](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/redux/reducers/components.js#L20).

Here we...
- Update the usage of `deletePage` to include `component`
- Update the docs for the `deletePage` action creator
- Update the docs outlining removal of trailing slashes