### PR TITLE
Next page context for page transitions

### DIFF
--- a/examples/using-page-transitions/gatsby-browser.js
+++ b/examples/using-page-transitions/gatsby-browser.js
@@ -9,8 +9,8 @@ import getTransitionStyle from "./src/utils/getTransitionStyle"
 const timeout = 250
 const historyExitingEventType = `history::exiting`
 
-const getUserConfirmation = (message, callback) => {
-  const event = new CustomEvent(historyExitingEventType, { detail: { message } })
+const getUserConfirmation = (pathname, callback) => {
+  const event = new CustomEvent(historyExitingEventType, { detail: { pathname } })
   window.dispatchEvent(event)
   setTimeout(() => {
     callback(true)
@@ -18,18 +18,19 @@ const getUserConfirmation = (message, callback) => {
 }
 const history = createHistory({ getUserConfirmation })
 // block must return a string to conform
-history.block((location, action) => location.key)
+history.block((location, action) => location.pathname)
 exports.replaceHistory = () => history
 
 class ReplaceComponentRenderer extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { exiting: false }
+    this.state = { exiting: false, nextPageResources: {} }
     this.listenerHandler = this.listenerHandler.bind(this)
   }
 
   listenerHandler(event) {
-    this.setState({ exiting: true })
+    const nextPageResources = this.props.loader.getResourcesForPathname(event.detail.pathname)
+    this.setState({ exiting: true, nextPageResources })
   }
 
   componentDidMount() {
@@ -42,7 +43,7 @@ class ReplaceComponentRenderer extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.location.key !== nextProps.location.key) {
-      this.setState({ exiting: false })
+      this.setState({ exiting: false, nextPageResources: {} })
     }
   }
 
@@ -66,6 +67,7 @@ class ReplaceComponentRenderer extends React.Component {
             status,
             timeout,
             style: getTransitionStyle({ status, timeout }),
+            nextPageResources: this.state.nextPageResources,
           },
         })
       }
@@ -75,9 +77,9 @@ class ReplaceComponentRenderer extends React.Component {
 }
 
 // eslint-disable-next-line react/display-name
-exports.replaceComponentRenderer = ({ props }) => {
+exports.replaceComponentRenderer = ({ props, loader }) => {
   if (props.layout) {
     return undefined
   }
-  return createElement(ReplaceComponentRenderer, props)
+  return createElement(ReplaceComponentRenderer, { ...props, loader })
 }

--- a/examples/using-page-transitions/gatsby-browser.js
+++ b/examples/using-page-transitions/gatsby-browser.js
@@ -29,7 +29,10 @@ class ReplaceComponentRenderer extends React.Component {
   }
 
   listenerHandler(event) {
-    const nextPageResources = this.props.loader.getResourcesForPathname(event.detail.pathname)
+    const nextPageResources = this.props.loader.getResourcesForPathname(
+      event.detail.pathname,
+      nextPageResources => this.setState({ nextPageResources })
+    ) || {}
     this.setState({ exiting: true, nextPageResources })
   }
 

--- a/examples/using-page-transitions/package.json
+++ b/examples/using-page-transitions/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Steven Surgnier <stevensurgnier@gmail.com>",
   "dependencies": {
-    "gatsby": "^1.9.73",
+    "gatsby": "^1.9.102",
     "gatsby-link": "^1.6.22",
     "gatsby-plugin-react-helmet": "^1.0.8",
     "react-transition-group": "^2.2.1"

--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -105,6 +105,7 @@ class ComponentRenderer extends React.Component {
   render() {
     const pluginResponses = apiRunner(`replaceComponentRenderer`, {
       props: { ...this.props, pageResources: this.state.pageResources },
+      loader,
     })
     const replacementComponent = pluginResponses[0]
     // If page.

--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -1,6 +1,6 @@
 import React, { createElement } from "react"
 import PropTypes from "prop-types"
-import loader from "./loader"
+import loader, { publicLoader } from "./loader"
 import emitter from "./emitter"
 import { apiRunner } from "./api-runner-browser"
 
@@ -105,7 +105,7 @@ class ComponentRenderer extends React.Component {
   render() {
     const pluginResponses = apiRunner(`replaceComponentRenderer`, {
       props: { ...this.props, pageResources: this.state.pageResources },
-      loader,
+      loader: publicLoader,
     })
     const replacementComponent = pluginResponses[0]
     // If page.

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -319,4 +319,8 @@ const queue = {
   indexOf: path => pathArray.length - pathArray.indexOf(path) - 1,
 }
 
-module.exports = queue
+export const publicLoader = {
+  getResourcesForPathname: queue.getResourcesForPathname,
+}
+
+export default queue

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -50,6 +50,7 @@ exports.replaceRouterComponent = true
  * implement page transitions. See https://github.com/gatsbyjs/gatsby/tree/master/examples/using-page-transitions for an example of this.
  * @param {object} $0
  * @param {object} $0.props The props of the page or layout.
+ * @param {object} $0.loader The gatsby loader.
  */
 exports.replaceComponentRenderer = true
 


### PR DESCRIPTION
Exit animations that are conditional on the following page will likely want more expressive data than the `location`. We're considering static fields on the component to be entered.

I'm not sure what the best way to globally expose the `loader` module to gatsby clients is. This PR simply exposes it locally to the `replaceComponentRenderer` api.