### PR TITLE
[Docs] Explicitly reference config file

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -200,7 +200,7 @@ const typography = new Typography({ baseFontSize: '18px' })
 export default typography
 ```
 
-Then set this module to be used by `gatsby-plugin-typography` as its config.
+Then set this module to be used by `gatsby-plugin-typography` as its config in our `gatsby-config.js` file.
 
 ```javascript{2..9}
 module.exports = {


### PR DESCRIPTION
Small, perhaps nitpicky, change but not explicitly stating which file this config was referencing tripped up the flow for me for a bit when running through step-by-step.