### PR TITLE
[Docs] escape pipe in markdown

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -171,11 +171,11 @@ Pass in the data returned from the `sizes` object in your query via the `sizes` 
 | `fadeIn`                  | `bool`          | Defaults to fading in the image on load  |
 | `title`                   | `string`        | Passed to the `img` element  |
 | `alt`                     | `string`        | Passed to the `img` element   |
-| `className`               | `string|object` | Passed to the wrapper div. Object is needed to support Glamor's css prop |
-| `outerWrapperClassName`   | `string|object` | Passed to the outer wrapper div. Object is needed to support Glamor's css prop |
+| `className`               | `string\|object` | Passed to the wrapper div. Object is needed to support Glamor's css prop |
+| `outerWrapperClassName`   | `string\|object` | Passed to the outer wrapper div. Object is needed to support Glamor's css prop |
 | `style`                   | `object`        | Spread into the default styles in the wrapper div |
 | `position`                | `string`        | Defaults to `relative`. Pass in `absolute` to make the component `absolute` positioned |
-| `backgroundColor`         | `string|bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
+| `backgroundColor`         | `string\|bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
 | `onLoad`                  | `func`          | A callback that is called when the full-size image has loaded.
 
 ## Some other stuff to be aware of


### PR DESCRIPTION
Props on README on gatsby-image were breaking because the |  inside the backticks.  Solution is to escape the character.