### PR TITLE
Topic/remark copy linked files destination dir

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/README.md
+++ b/packages/gatsby-remark-copy-linked-files/README.md
@@ -24,6 +24,30 @@ plugins: [
 ]
 ```
 
+### How to change the directory the files are added to.
+
+By default, all files will be added to the root of the `public` dir, but you can choose a different location using the `destinationDir` option. Provide a path, relative to the `public` directory. The path must be within the public directory, so `path/to/dir` is fine, but `../../dir` is not.
+
+```
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      plugins: [
+        { 
+          resolve: 'gatsby-remark-copy-linked-files',
+          options: {
+            destinationDir: 'path/to/dir',
+          }
+        }
+      }
+    }
+  }
+]
+```
+
+
 ### How to override which file types are ignored
 
 ```javascript

--- a/packages/gatsby-remark-copy-linked-files/README.md
+++ b/packages/gatsby-remark-copy-linked-files/README.md
@@ -26,7 +26,7 @@ plugins: [
 
 ### How to change the directory the files are added to.
 
-By default, all files will be added to the root of the `public` dir, but you can choose a different location using the `destinationDir` option. Provide a path, relative to the `public` directory. The path must be within the public directory, so `path/to/dir` is fine, but `../../dir` is not.
+By default, all files will be copied to the root of the `public` dir, but you can choose a different location using the `destinationDir` option. Provide a path, relative to the `public` directory. The path must be within the public directory, so `path/to/dir` is fine, but `../../dir` is not.
 
 ```
 // In your gatsby-config.js

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -10,6 +10,7 @@
     "image-size": "^0.6.1",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",
+    "path-is-inside": "^1.0.2",
     "unist-util-visit": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -132,7 +132,7 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
 
     it(`throws an error if the destination directory is not within 'public'`, async () => {
-      const invalidDestinationDir = `../../../../destination`
+      const invalidDestinationDir = `../destination`
       expect.assertions(1)
       return plugin(
         { files: getFiles(imagePath), markdownAST, markdownNode, getNode },

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -126,4 +126,35 @@ describe(`gatsby-remark-copy-linked-files`, () => {
 
     expect(fsExtra.copy).not.toHaveBeenCalled()
   })
+
+  describe(`options.destinationDir`, () => {
+    const imagePath = `images/sample-image.gif`
+    const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+
+    it(`throws an error if the destination directory is not within 'public'`, async () => {
+      const invalidDestinationDir = `../../../../destination`
+      expect.assertions(1)
+      return plugin(
+        { files: getFiles(imagePath), markdownAST, markdownNode, getNode },
+        {
+          destinationDir: invalidDestinationDir,
+        }
+      ).catch(e => {
+        expect(e).toEqual(expect.stringContaining(invalidDestinationDir))
+      })
+    })
+
+    it(`doesn't throw an error if the destination directory is within 'public'`, async () => {
+      const validDestinationDir = `path/to/dir`
+      expect.assertions(1)
+      return plugin(
+        { files: getFiles(imagePath), markdownAST, markdownNode, getNode },
+        {
+          destinationDir: validDestinationDir,
+        }
+      ).then(v => {
+        expect(v).toBeDefined()
+      })
+    })
+  })
 })

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -12,13 +12,14 @@ module.exports = (
 ) => {
   const defaults = {
     ignoreFileExtensions: [`png`, `jpg`, `jpeg`, `bmp`, `tiff`],
+    destinationDir: `public`,
   }
 
   const options = _.defaults(pluginOptions, defaults)
 
   const filesToCopy = new Map()
-  // Copy linked files to the public directory and modify the AST to point to
-  // new location of the files.
+  // Copy linked files to the destination directory and modify the AST to point
+  // to new location of the files.
   const visitor = link => {
     if (
       isRelativeUrl(link.url) &&
@@ -37,7 +38,7 @@ module.exports = (
       if (linkNode && linkNode.absolutePath) {
         const newPath = path.posix.join(
           process.cwd(),
-          `public`,
+          options.destinationDir,
           `${linkNode.internal.contentDigest}.${linkNode.extension}`
         )
 

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -5,14 +5,38 @@ const path = require(`path`)
 const _ = require(`lodash`)
 const cheerio = require(`cheerio`)
 const sizeOf = require(`image-size`)
+const pathIsInside = require(`path-is-inside`)
+
+const DEFAULT_DESTINATION_DIR = `public`
+
+const invalidDestinationDirMessage = dir =>
+  `[gatsby-remark-copy-linked-files You have supplied an invalid destination directory. The destination directory must be within the '${
+    DEFAULT_DESTINATION_DIR
+  }' directory, but resolved to: ${dir}`
+
+const destinationDirIsValid = dir =>
+  pathIsInside(path.join(DEFAULT_DESTINATION_DIR, dir), DEFAULT_DESTINATION_DIR)
 
 module.exports = (
   { files, markdownNode, markdownAST, getNode },
-  pluginOptions
+  pluginOptions = {}
 ) => {
   const defaults = {
     ignoreFileExtensions: [`png`, `jpg`, `jpeg`, `bmp`, `tiff`],
-    destinationDir: `public`,
+    destinationDir: DEFAULT_DESTINATION_DIR,
+  }
+
+  // Validate supplied destination directory
+  const { destinationDir } = pluginOptions
+  if (destinationDir) {
+    if (destinationDirIsValid(destinationDir)) {
+      pluginOptions.destinationDir = path.join(
+        DEFAULT_DESTINATION_DIR,
+        destinationDir
+      )
+    } else {
+      return Promise.reject(invalidDestinationDirMessage(destinationDir))
+    }
   }
 
   const options = _.defaults(pluginOptions, defaults)

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -12,7 +12,7 @@ const DEFAULT_DESTINATION_DIR = `public`
 const invalidDestinationDirMessage = dir =>
   `[gatsby-remark-copy-linked-files You have supplied an invalid destination directory. The destination directory must be within the '${
     DEFAULT_DESTINATION_DIR
-  }' directory, but resolved to: ${dir}`
+  }' directory, but was: ${dir}`
 
 const destinationDirIsValid = dir =>
   pathIsInside(path.join(DEFAULT_DESTINATION_DIR, dir), DEFAULT_DESTINATION_DIR)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,13 +1893,6 @@ buffer@^4.3.0, buffer@^4.9.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.3:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.8.tgz#84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24"
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -3007,10 +3000,6 @@ css-color-function@^1.2.0:
     debug "^3.1.0"
     rgb "~0.1.0"
 
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -3073,14 +3062,6 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
-
-css-to-react-native@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.0.4.tgz#cf4cc407558b3474d4ba8be1a2cd3b6ce713101b"
-  dependencies:
-    css-color-keywords "^1.0.0"
-    fbjs "^0.8.5"
-    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha17:
   version "1.0.0-alpha17"
@@ -4459,7 +4440,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -11941,20 +11922,6 @@ style-loader@^0.13.0:
   dependencies:
     loader-utils "^1.0.2"
 
-styled-components@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.2.2.tgz#a00c4b7a432ff77e5fb962ec1fbc030248d27171"
-  dependencies:
-    buffer "^5.0.3"
-    css-to-react-native "^2.0.3"
-    fbjs "^0.8.9"
-    hoist-non-react-statics "^1.2.0"
-    is-function "^1.0.1"
-    is-plain-object "^2.0.1"
-    prop-types "^15.5.4"
-    stylis "3.x"
-    supports-color "^3.2.3"
-
 styled-jsx@^1.0.10:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-1.0.11.tgz#8454f06916d9d57a2e9aed6a9c2e695177822045"
@@ -12005,10 +11972,6 @@ styletron-utils@^3.0.0-rc.1:
 stylis@3.2.18:
   version "3.2.18"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.18.tgz#211661f13b636e9e451456a1aadcec31248edf0e"
-
-stylis@3.x:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.0.tgz#55c6530ebceeca5976d54fb4adc67578afee828d"
 
 stylus-loader@webpack1:
   version "2.5.1"


### PR DESCRIPTION
Add an option to `gatsby-remark-copy-linked-files` config to allow the destination directory of linked files to be specified. 

- Paths are valid as long as they resolve to inside the `public` directory. Otherwise an the plugin returns `Promise.reject` with an error message. 
- Added tests for valid and invalid dirs.

See: #2779