### PR TITLE
[gatsby-image] Fallback to intersectionRatio for Edge compatibility.

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -42,7 +42,8 @@ if (typeof window !== `undefined` && window.IntersectionObserver) {
       entries.forEach(entry => {
         listeners.forEach(l => {
           if (l[0] === entry.target) {
-            if (entry.isIntersecting) {
+            // Edge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
+            if (entry.isIntersecting || entry.intersectionRatio > 0) {
               io.unobserve(l[0])
               l[1]()
             }


### PR DESCRIPTION
This pull request causes the intersection check to fallback to using intersectionRatio when isIntersecting() is falsy (it's undefined in MSEdge). This does mean that MSEdge will never be able to detect an intersection on an element of 0px in size.

**Context** 
While testing a new site in MSEdge (lucky me) I've discovered that _gatsby-image_ never triggers the lazy loading of images when they become visible in the viewport, instead only displaying the fallback image. This is reproducable by loading the [gatsby-image demo site](https://using-gatsby-image.gatsbyjs.org/) in MSEdge v15 or older.

After investigation, the cause is that the MSEdge IntersectionObserver implementation does not currently support isIntersecting(). See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/. This appears to on the roadmap to be fixed in a future release.

