### PR TITLE
[gatsby-link] Fallback to using intersectionRatio for MSEdge support for link preloading.

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -31,7 +31,8 @@ const handleIntersection = (el, cb) => {
     entries.forEach(entry => {
       if (el === entry.target) {
         // Check if element is within viewport, remove listener, destroy observer, and run link callback.
-        if (entry.isIntersecting) {
+        // MSEdge doesn't currently support isIntersecting, so also test for  an intersectionRatio > 0
+        if (entry.isIntersecting || entry.intersectionRatio > 0) {
           io.unobserve(el)
           io.disconnect()
           cb()


### PR DESCRIPTION
A quick fix for gatsby-link to also fallback to using intersectionRatio when isIntersecting() is falsy (it's undefined in MSEdge).

Similar to https://github.com/gatsbyjs/gatsby/pull/2853.

(I probably should've grok'd the codebase for this before the last pull request.)

