### PR TITLE
Fix hardcoded link path

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -153,7 +153,8 @@ describe(`gatsby-remark-copy-linked-files`, () => {
           destinationDir: validDestinationDir,
         }
       ).then(v => {
-        expect(v).toBeDefined()
+        const newPath = v[0]
+        expect(newPath).toContain(validDestinationDir)
       })
     })
   })

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -10,7 +10,7 @@ const pathIsInside = require(`path-is-inside`)
 const DEPLOY_DIR = `public`
 
 const invalidDestinationDirMessage = destinationDir =>
-  `[gatsby-remark-copy-linked-files You have supplied an invalid destination directory. The destination directory must be within the '${
+  `[gatsby-remark-copy-linked-files] You have supplied an invalid destination directory. The destination directory must be within the '${
     DEPLOY_DIR
   }' directory, but was: '${destinationDir}'`
 

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -7,15 +7,15 @@ const cheerio = require(`cheerio`)
 const sizeOf = require(`image-size`)
 const pathIsInside = require(`path-is-inside`)
 
-const DEFAULT_DESTINATION_DIR = `public`
+const DEPLOY_DIR = `public`
 
-const invalidDestinationDirMessage = dir =>
+const invalidDestinationDirMessage = destinationDir =>
   `[gatsby-remark-copy-linked-files You have supplied an invalid destination directory. The destination directory must be within the '${
-    DEFAULT_DESTINATION_DIR
-  }' directory, but was: ${dir}`
+    DEPLOY_DIR
+  }' directory, but was: '${destinationDir}'`
 
-const destinationDirIsValid = dir =>
-  pathIsInside(path.join(DEFAULT_DESTINATION_DIR, dir), DEFAULT_DESTINATION_DIR)
+const destinationDirIsValid = destinationDir =>
+  pathIsInside(path.join(DEPLOY_DIR, destinationDir), DEPLOY_DIR)
 
 module.exports = (
   { files, markdownNode, markdownAST, getNode },
@@ -23,20 +23,13 @@ module.exports = (
 ) => {
   const defaults = {
     ignoreFileExtensions: [`png`, `jpg`, `jpeg`, `bmp`, `tiff`],
-    destinationDir: DEFAULT_DESTINATION_DIR,
+    destinationDir: `/`,
   }
 
   // Validate supplied destination directory
   const { destinationDir } = pluginOptions
-  if (destinationDir) {
-    if (destinationDirIsValid(destinationDir)) {
-      pluginOptions.destinationDir = path.join(
-        DEFAULT_DESTINATION_DIR,
-        destinationDir
-      )
-    } else {
-      return Promise.reject(invalidDestinationDirMessage(destinationDir))
-    }
+  if (destinationDir && !destinationDirIsValid(destinationDir)) {
+    return Promise.reject(invalidDestinationDirMessage(destinationDir))
   }
 
   const options = _.defaults(pluginOptions, defaults)
@@ -62,17 +55,18 @@ module.exports = (
       if (linkNode && linkNode.absolutePath) {
         const newPath = path.posix.join(
           process.cwd(),
+          DEPLOY_DIR,
           options.destinationDir,
           `${linkNode.internal.contentDigest}.${linkNode.extension}`
         )
-
         // Prevent uneeded copying
         if (linkPath === newPath) {
           return
         }
 
         const relativePath = path.posix.join(
-          `/${linkNode.internal.contentDigest}.${linkNode.extension}`
+          options.destinationDir,
+          `${linkNode.internal.contentDigest}.${linkNode.extension}`
         )
         link.url = `${relativePath}`
 
@@ -270,6 +264,7 @@ module.exports = (
           console.error(`error copying file`, err)
         }
       }
+      return newPath
     })
   )
 }


### PR DESCRIPTION
- Fixes issue with hardcoded path in links
- Returns new path from resolved promises to allow for better testing

I would have caught this issue if I had been able to use this package locally with an active project, but not sure how to do that with a Lerna repo as each package needs to be built.

Also, it is hard to debug issues with plugins in projects because of the cache - changing logging within a plugin only gets picked up when the cache is deleted and the site rebuilt. Is there a way of disabling the cache? 