### PR TITLE
[gatsby-source-contentful] Retrieve falsey field values

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -110,6 +110,31 @@ describe(`Gets field value based on current locale`, () => {
       })
     ).toBe(field[`de`])
   })
+  it(`Gets the specified locale if the field is falsey`, () => {
+    const falseyField = {
+      de: 0,
+      "en-US": false,
+    }
+    expect(
+      normalize.getLocalizedField({
+        field: falseyField,
+        defaultLocale: `en-US`,
+        locale: {
+          code: `en-US`,
+        },
+      })
+    ).toBe(falseyField[`en-US`])
+
+    expect(
+      normalize.getLocalizedField({
+        field: falseyField,
+        defaultLocale: `en-US`,
+        locale: {
+          code: `de`,
+        },
+      })
+    ).toBe(falseyField[`de`])
+  })
   it(`falls back to the locale's fallback locale if passed a locale that doesn't have a localized field`, () => {
     expect(
       normalize.getLocalizedField({

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -12,9 +12,9 @@ const typePrefix = `Contentful`
 const makeTypeName = type => _.upperFirst(_.camelCase(`${typePrefix} ${type}`))
 
 const getLocalizedField = ({ field, defaultLocale, locale }) => {
-  if (field[locale.code]) {
+  if (!_.isUndefined(field[locale.code])) {
     return field[locale.code]
-  } else if (field[locale.fallbackCode]) {
+  } else if (!_.isUndefined(field[locale.fallbackCode])) {
     return field[locale.fallbackCode]
   } else {
     return null


### PR DESCRIPTION
Since contentful can retrieve boolean and number fields, falsey values `0` and `false` should be retrieved from a locale.