### PR TITLE
Improved gatsby-remark-code-repls link HTML generation

### DIFF
--- a/packages/gatsby-remark-code-repls/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-code-repls/src/__tests__/__snapshots__/index.js.snap
@@ -7,15 +7,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "REPL",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -57,15 +49,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "REPL",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -107,15 +91,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "Click me",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >Click me</a>",
         },
       ],
       "position": Position {
@@ -157,15 +133,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "Custom link text",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" >Custom link text</a>",
         },
       ],
       "position": Position {
@@ -207,15 +175,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" target=\\"_blank\\" rel=\\"noreferrer\\">",
-        },
-        Object {
-          "type": "text",
-          "value": "REPL",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"https://babeljs.io/repl/#?presets=react&code_lz=MYewdgzgLgBAZiEMC8MBEAjAhgJzQbiA\\" target=\\"_blank\\" rel=\\"noreferrer\\">REPL</a>",
         },
       ],
       "position": Position {
@@ -257,15 +217,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"/redirect-to-codepen/path/to/nested/file.js\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "REPL",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"/redirect-to-codepen/path/to/nested/file.js\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -307,15 +259,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"/redirect-to-codepen/file.js\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "REPL",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"/redirect-to-codepen/file.js\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -357,15 +301,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"/redirect-to-codepen/file.js\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "Click me",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"/redirect-to-codepen/file.js\\" >Click me</a>",
         },
       ],
       "position": Position {
@@ -407,15 +343,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"/redirect-to-codepen/file.js\\" >",
-        },
-        Object {
-          "type": "text",
-          "value": "Custom link text",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"/redirect-to-codepen/file.js\\" >Custom link text</a>",
         },
       ],
       "position": Position {
@@ -457,15 +385,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"/redirect-to-codepen/file.js\\" target=\\"_blank\\" rel=\\"noreferrer\\">",
-        },
-        Object {
-          "type": "text",
-          "value": "REPL",
-        },
-        Object {
-          "type": "html",
-          "value": "</a>",
+          "value": "<a href=\\"/redirect-to-codepen/file.js\\" target=\\"_blank\\" rel=\\"noreferrer\\">REPL</a>",
         },
       ],
       "position": Position {

--- a/packages/gatsby-remark-code-repls/src/index.js
+++ b/packages/gatsby-remark-code-repls/src/index.js
@@ -19,23 +19,16 @@ const compress = string =>
     .replace(/\//g, `_`) // Convert '/' to '_'
     .replace(/=+$/, ``) // Remove ending '='
 
-function createLinkNodes(text, href, target) {
+function convertNodeToLink(node, text, href, target) {
   target = target ? `target="${target}" rel="noreferrer"` : ``
 
-  return [
-    {
-      type: `html`,
-      value: `<a href="${href}" ${target}>`,
-    },
-    {
-      type: `text`,
-      value: text,
-    },
-    {
-      type: `html`,
-      value: `</a>`,
-    },
-  ]
+  delete node.children
+  delete node.position
+  delete node.title
+  delete node.url
+
+  node.type = `html`
+  node.value = `<a href="${href}" ${target}>${text}</a>`
 }
 
 module.exports = (
@@ -77,7 +70,7 @@ module.exports = (
         const text =
           node.children.length === 0 ? defaultText : node.children[0].value
 
-        parent.children.splice(index, 1, ...createLinkNodes(text, href, target))
+        convertNodeToLink(node, text, href, target)
       } else if (node.url.startsWith(PROTOCOL_CODEPEN)) {
         const filePath = getFilePath(node.url, PROTOCOL_CODEPEN, directory)
 
@@ -87,7 +80,7 @@ module.exports = (
         const text =
           node.children.length === 0 ? defaultText : node.children[0].value
 
-        parent.children.splice(index, 1, ...createLinkNodes(text, href, target))
+        convertNodeToLink(node, text, href, target)
       }
     }
 


### PR DESCRIPTION
Continuation of #2848

I'm not sure why I didn't encounter this when iterating on the plug-in locally, but for some reason when I installed the new plug-in for reactjs.org after it was released, my links didn't work. Looking at the generated HTML, I noticed it looked like `<a href="..."/>{text}`.

Anyway, I decided to change the way the HTML was generated a bit to simplify it and it seems to resolve the issue.