### PR TITLE
fix(plugin-feed): remove `draft: true` query restriction

### DIFF
--- a/packages/gatsby-plugin-feed/src/internals.js
+++ b/packages/gatsby-plugin-feed/src/internals.js
@@ -48,11 +48,6 @@ export const defaultOptions = {
           sort: {
             order: DESC,
             fields: [frontmatter___date]
-          },
-          filter: {
-            frontmatter: {
-              draft: { ne: true }
-            }
           }
         ) {
           edges {


### PR DESCRIPTION
Remove the `draft: true` restriction from the default query, as discussed in gatsbyjs/gatsby-starter-blog#68.