### PR TITLE
Fix remark copy linked files

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -5,7 +5,6 @@ const path = require(`path`)
 const _ = require(`lodash`)
 const cheerio = require(`cheerio`)
 const sizeOf = require(`image-size`)
-const pathIsInside = require(`path-is-inside`)
 
 const DEPLOY_DIR = `public`
 

--- a/packages/gatsby-source-filesystem/index.js
+++ b/packages/gatsby-source-filesystem/index.js
@@ -1,12 +1,12 @@
-"use strict";
+"use strict"
 
-var fs = require(`fs-extra`);
+const fs = require(`fs-extra`)
 
 function loadNodeContent(fileNode) {
-  return fs.readFile(fileNode.absolutePath, `utf-8`);
+  return fs.readFile(fileNode.absolutePath, `utf-8`)
 }
 
-exports.createFilePath = require(`./create-file-path`);
-exports.createRemoteFileNode = require(`./create-remote-file-node`);
+exports.createFilePath = require(`./create-file-path`)
+exports.createRemoteFileNode = require(`./create-remote-file-node`)
 
-exports.loadNodeContent = loadNodeContent;
+exports.loadNodeContent = loadNodeContent


### PR DESCRIPTION
The ongoing saga of adding `destinationDir` option to `gatsby-copy-linked-files` The third in a trilogy, but unlike Robocop 3, this is the best of the bunch.

- Fixes another issue with invalid path
- Adds more and better tests
- Fixes an unrelated formatting issue in `gatsby-source-filesystem` (had been checked in with semicolons and single-quotes instead of backticks.

@KyleAMathews Using the `gatsby-dev-cli` has been really helpful. Not sure how I missed it before, but I've noticed that all logging within plugins (when run in an app/site) is suppressed. Is there a way to enable logging in plugins when running them?