### PR TITLE
Develop: use req.path to check for static files

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -114,7 +114,7 @@ async function startServer(program) {
   app.get(`*`, (req, res, next) => {
     // Load file but ignore errors.
     res.sendFile(
-      directoryPath(`/public/${decodeURIComponent(req.url)}`),
+      directoryPath(`/public${decodeURIComponent(req.path)}`),
       err => {
         // No err so a file was sent successfully.
         if (!err || !err.path) {


### PR DESCRIPTION
Allows for query parameters to be passed on to static files.

Fix for #1655