### PR TITLE
Coalesce field values to ensure no broken production build on no content

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -274,7 +274,8 @@ exports.createContentTypeNodes = ({
           return
         }
 
-        entryItemFields[entryItemFieldKey] = entryItemFields[entryItemFieldKey]
+        // Ensure contentful empty value is not undefined (to get past graphql schema errors)
+        entryItemFields[entryItemFieldKey] = entryItemFields[entryItemFieldKey] || ``
       })
 
       // Replace text fields with text nodes so we can process their markdown


### PR DESCRIPTION
Added one line check to ensure fields that are sent from contentful are not treated as null and then stripped from graphql available schemas.

Caused by behaviour described in #2881 