### PR TITLE
[query-runner] Prevent empty error message for GraphQL errors

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
@@ -64,6 +64,7 @@ function extractError(error: Error): { message: string, docName: string } {
     if (matches.index === docRegex.lastIndex) docRegex.lastIndex++
     ;[, message, docName] = matches
   }
+  if (!message) message = error.toString()
   return { message, docName }
 }
 


### PR DESCRIPTION
A raw solution to prevent GraphQL queries from having any error messages. Better an ugly error message than no error message, isn't it?
Probably a more suitable solution would be to modify this function so that it accepts more input formatting. I don't have time to do that this month, I hope someone else will have time to focus on it.