### PR TITLE
Add the freeCodeCamp Guide to Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Websites built with Gatsby:
 * [React](https://reactjs.org/) ([source](https://github.com/reactjs/reactjs.org))
 * [Sourcegraph](https://about.sourcegraph.com)
 * [Simply](https://simply.co.za)
+* [The freeCodeCamp Guide](https://guide.freecodecamp.org)
 * [FloydHub's Blog](https://blog.floydhub.com)
 * [mParticle's Documentation](https://docs.mparticle.com)
 * [Segment's Blog](https://segment.com/blog/)


### PR DESCRIPTION
We are proud to have built the freeCodeCamp Guide using Gatsby. It is now serving thousands of articles to thousands of visitors a month. Gatsby was instrumental in helping us build this static website, which has hundreds of contributors and auto-deploys through Netlify with each accepted PR.