### PR TITLE
Update the part three of the tutorial

### DIFF
--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -29,7 +29,7 @@ import fairyGateTheme from "typography-theme-fairy-gates"
 
 const typography = new Typography(fairyGateTheme)
 
-module.exports = typography
+export default typography
 ```
 
 Then our site's `gatsby-config.js`
@@ -114,6 +114,8 @@ export default ({ children }) =>
     {children()}
   </div>
 ```
+
+_Notice that unlike the `children` that is received on other React components, this `children` is a function and needs to be executed_
 
 Stop `gatsby develop` and start it again for the new layout to take effect.
 

--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -115,7 +115,7 @@ export default ({ children }) =>
   </div>
 ```
 
-_Notice that unlike the `children` that is received on other React components, this `children` is a function and needs to be executed_
+_Notice that unlike most `children` props, the `children` prop passed to layout components is a function and needs to be executed_
 
 Stop `gatsby develop` and start it again for the new layout to take effect.
 


### PR DESCRIPTION
Changed the export statement on "src/utils/typography.js" to be the ES6 way of exporting modules. Also added a note about using `children` as a function, since it may be confusing for people who have used React before with `children` not being a function.