### PR TITLE
Move imported css/sass/less before css-in-js styles

### DIFF
--- a/packages/gatsby/cache-dir/default-html.js
+++ b/packages/gatsby/cache-dir/default-html.js
@@ -29,8 +29,8 @@ module.exports = class HTML extends React.Component {
             name="viewport"
             content="width=device-width, initial-scale=1, shrink-to-fit=no"
           />
-          {this.props.headComponents}
           {css}
+          {this.props.headComponents}
         </head>
         <body {...this.props.bodyAttributes}>
           {this.props.preBodyComponents}


### PR DESCRIPTION
I've heard several people asking why they couldn't override their global
styles with their css-in-js styles.

This is a tricky issue because there's not a "right" answer. This could
potentially trip up people who do globals with typography.js (css-in-js)
and then wonder why they can't override the styles with their postcss
setup :shrug:

Thoughts?