### PR TITLE
Fix Styled Components install instructions in docs

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -517,7 +517,7 @@ Styled Components lets you use actual CSS syntax inside your components.
 First, like normal, we'll install the Gatsby plugin for Styled Components.
 
 ```sh
-npm install --save gatsby-plugin-styled-components
+npm install --save gatsby-plugin-styled-components styled-components
 ```
 
 Then modify the `gatsby-config.js`. Before we can use Styled Components however, we'll need to remove the Glamor plugin and delete the Glamor component page we created. The two plugins conflict with each other as both want to take control during server rendering.


### PR DESCRIPTION
Hi!

As I was trying out Gatsby today, I noticed that the install instructions for Styled Components in Part Two of the tutorial were not working out of the box. Indeed, after running `npm install --save gatsby-plugin-styled-components` and restarting the development server, I got the error `Module not found: Error: Cannot resolve module 'styled-components'`.

I dug around a little bit and saw that [a recent breaking change](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components#v201) in `gatsby-plugin-styled-components` moved the `styled-components` package to a peer dependency. Thus, the correct install instruction would now be `npm install --save gatsby-plugin-styled-components styled-components`.

This is my first ever PR on a public project, so I don’t know if I got this right — please tell me otherwise!

