### PR TITLE
[BREAKING] Move react-helmet to peerDependencies

### DIFF
--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -18,7 +18,9 @@
     "cross-env": "^5.0.5"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "react-helmet": "^5.1.3"
+    "babel-runtime": "^6.26.0"
+  },
+  "peerDependencies": {
+    "react-helmet": ">=5.1.3"
   }
 }


### PR DESCRIPTION
- Remove `react-helmet` from `dependencies`
- Add `react-helmet` from `peerDependencies`

This fixes the problem described in #2446 where using `gatsby-plugin-react-helmet` triggers the `import/no-extraneous-dependencies` ESLint rule.

BREAKING CHANGE: Requires that `react-helmet` is installed alongside `gatsby-plugin-react-helmet`.

re gatsbyjs/gatsby#2446