### PR TITLE
Fix out-of-memory error when building hundreds of pages

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -6,7 +6,7 @@
  */
 
 const _ = require(`lodash`)
-const Promise = require(`bluebird`)
+const async = require(`async`)
 
 const { store, emitter } = require(`../../redux`)
 const queryRunner = require(`./query-runner`)
@@ -90,18 +90,30 @@ const runQueriesForIds = ids => {
     return Promise.resolve()
   }
   const state = store.getState()
-  return Promise.all(
-    ids.map(id => {
-      const pagesAndLayouts = [...state.pages, ...state.layouts]
-      const plObj = pagesAndLayouts.find(
-        pl => pl.path === id || `LAYOUT___${pl.id}` === id
-      )
-      if (plObj) {
-        return queryRunner(plObj, state.components[plObj.component])
+
+  return new Promise((resolve, reject) => {
+    async.mapLimit(
+      ids,
+      4,
+      (id, callback) => {
+        const pagesAndLayouts = [...state.pages, ...state.layouts]
+        const plObj = pagesAndLayouts.find(
+          pl => pl.path === id || `LAYOUT___${pl.id}` === id
+        )
+        if (plObj) {
+          return queryRunner(plObj, state.components[plObj.component])
+            .then(
+              result => callback(null, result),
+              error => callback(error)
+            )
+        }
+        return callback(null, null)
+      },
+      (error, result) => {
+        error ? reject(error) : resolve(result)
       }
-      return null
-    })
-  )
+    )
+  })
 }
 
 const findDirtyIds = actions => {

--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -10,6 +10,7 @@
 
 const _ = require(`lodash`)
 const chokidar = require(`chokidar`)
+const async = require(`async`)
 
 const { store } = require(`../../redux/`)
 const { boundActionCreators } = require(`../../redux/actions`)
@@ -57,7 +58,22 @@ const runQueriesForComponent = componentPath => {
     pages.map(p => p.path || p.id)
   )
   const component = store.getState().components[componentPath]
-  return Promise.all(pages.map(p => queryRunner(p, component)))
+  return new Promise((resolve, reject) => {
+    async.mapLimit(
+      pages,
+      4,
+      (page, callback) => {
+        queryRunner(page, component)
+          .then(
+            result => callback(null, result),
+            error => callback(error)
+          )
+      },
+      (error, result) => {
+        error ? reject(error) : resolve(result)
+      }
+    )
+  })
 }
 
 const getPagesForComponent = componentPath => {


### PR DESCRIPTION
The latest version of Gatsby crashes when trying to build ~500 pages using filesystem source plugin and json transformer plugin. The same error has been reported in https://github.com/gatsbyjs/gatsby/issues/2796. The issue was most likely introduced in https://github.com/gatsbyjs/gatsby/commit/7dd5f3b39b2231c91b7d0f410693267cf5575a40, though I haven't been able to figure out where exactly. However, the time to finish `run graphql queries` step is significantly longer in 1.9.33 than in 1.9.32 (for a number of pages that doesn't cause 1.9.33 to crash). It looks like it's caused by `queryRunner` function, which is called for every page, but if there are too many pages, it never gets resolved.

This is probably more of a workaround rather than a real fix, because whatever Gatsby is doing there, it probably shouldn't use up to 1.5GB memory to process 500 JSON files, even if it's processing them all in parallel. At least now the build finishes! :) Also, it takes ~16-20s to run the `run graphql queries` for these 500 pages in 1.9.118 with this fix, while in 1.9.32 it takes ~2s. However, as I mentioned earlier, it's (mostly) caused by changes introduced in 1.9.33, not by this fix.