### PR TITLE
set `prettyHost` to `0.0.0.0` instead of `localhost` #2960

### DIFF
--- a/packages/gatsby-source-filesystem/index.js
+++ b/packages/gatsby-source-filesystem/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var fs = require(`fs-extra`);
+const fs = require(`fs-extra`);
 
 function loadNodeContent(fileNode) {
   return fs.readFile(fileNode.absolutePath, `utf-8`);

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -256,7 +256,7 @@ module.exports = async (program: any) => {
     const isUnspecifiedHost = host === `0.0.0.0` || host === `::`
     let prettyHost, lanUrlForConfig, lanUrlForTerminal
     if (isUnspecifiedHost) {
-      prettyHost = `localhost`
+      prettyHost = `0.0.0.0`
       try {
         // This can only return an IPv4 address
         lanUrlForConfig = address.ip()


### PR DESCRIPTION
in /packages/gatsby/src/commands/develop.js
L258-259
```
if (isUnspecifiedHost) {
  prettyHost = `0.0.0.0`
```

This resolves CORS blocking HMR by printing
`Local:            http://0.0.0.0:8000/`
to the terminal after `gatsby develop` is run instead of
`Local:            http://localhost:8000/`

This may not be ideal resolution of the issue and may break
something else. Perhaps a different, deeper fix is needed.
See testing comments in #2960.

Also in packages/gatsby-source-filesystem/index.js
L3
```
var fs = require(`fs-extra`);
```
got transformed to
```
const fs = require(`fs-extra`);
```
I am thinking during `yarn bootstrap` or `gatsby-dev`, still have 100%
tests passing as before and it’s late so gonna commit this and revisit
in the morning.