### PR TITLE
[FOR DISCUSSION] Expose GQL Union possibilities 

### DIFF
--- a/packages/gatsby-source-filesystem/index.js
+++ b/packages/gatsby-source-filesystem/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var fs = require(`fs-extra`);
+const fs = require(`fs-extra`);
 
 function loadNodeContent(fileNode) {
   return fs.readFile(fileNode.absolutePath, `utf-8`);

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -1,60 +1,37 @@
 /* @flow */
 const _ = require(`lodash`)
-const { GraphQLSchema, GraphQLObjectType, GraphQLUnionType, GraphQLList } = require(`graphql`)
+const { GraphQLSchema, GraphQLObjectType } = require(`graphql`)
 
+const apiRunner = require(`../utils/api-runner-node`)
 const buildNodeTypes = require(`./build-node-types`)
 const buildNodeConnections = require(`./build-node-connections`)
 const { store, getNodes } = require(`../redux`)
 const invariant = require(`invariant`)
 
-/**
- * The GraphQL definition of our shape union type
- */
-const defineShapesType = (CircleGql, SquareGql) => (
-  new GraphQLUnionType({
-    name: `AllShapesType`,
-    description: `All shapes under one roof`,
-    types: [ CircleGql, SquareGql ],
-    resolveType: (data) => {
-      const { type } = data.internal
-      switch (type) {
-        case `ContentfulCircle`:
-          return CircleGql
-        case `ContentfulSquare`:
-          return SquareGql
-        default:
-          return null
-      }
-    },
+async function getEnhancedGqlFields(typesGQL) {
+  const enhancedFields = await apiRunner(`enhanceSchema`, {
+    types: typesGQL,
+    allNodes: getNodes(),
+    traceId: `initial-enhanceSchema`,
   })
-)
-
-/**
- * TODO:
- * TODO: resolve
- * TODO: args
- */
-const genExtra = (CircleGql, SquareGql) => {
-  return {
-    allShapes: {
-      type: new GraphQLList(defineShapesType(CircleGql, SquareGql)),
-      args: {},
-      resolve(root, args) {
-        const latestNodes = _.filter(
-          getNodes(),
-          n => (n.internal.type === `ContentfulCircle`) ||
-                (n.internal.type === `ContentfulSquare`)
-        )
-        return latestNodes
-      },
-    },
-  }
+  return enhancedFields
 }
 
 module.exports = async () => {
   const typesGQL = await buildNodeTypes()
-  const connections = buildNodeConnections(_.values(typesGQL))
+  let enhancedFields = {}
+  const enhancedFieldResults = await getEnhancedGqlFields(typesGQL)
+  Object.keys(enhancedFieldResults).forEach(key => {
+    enhancedFields = {
+      ...enhancedFields,
+      ...enhancedFieldResults[key],
+    }
+  })
 
+  // console.log(`got enhanced fields`, Object.keys(enhancedFields))
+  // console.log(`delme`, Object.keys(enhancedFields[0]))
+
+  const connections = buildNodeConnections(_.values(typesGQL))
 
   // Pull off just the graphql node from each type object.
   const nodes = _.mapValues(typesGQL, `node`)
@@ -62,14 +39,10 @@ module.exports = async () => {
   invariant(!_.isEmpty(nodes), `There are no available GQL nodes`)
   invariant(!_.isEmpty(connections), `There are no available GQL connections`)
 
-  const CircleType = typesGQL[`contentfulCircle`].nodeObjectType
-  const SqaureType = typesGQL[`contentfulSquare`].nodeObjectType
-  const extra = genExtra(CircleType, SqaureType)
-
   const schema = new GraphQLSchema({
     query: new GraphQLObjectType({
       name: `RootQueryType`,
-      fields: { ...connections, ...nodes, ...extra },
+      fields: { ...connections, ...nodes, ...enhancedFields },
     }),
   })
 

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -1,57 +1,11 @@
 /* @flow */
 const _ = require(`lodash`)
-const { GraphQLSchema, GraphQLObjectType, GraphQLUnionType, GraphQLString, GraphQLNonNull, GraphQLList } = require(`graphql`)
+const { GraphQLSchema, GraphQLObjectType, GraphQLUnionType, GraphQLList } = require(`graphql`)
 
 const buildNodeTypes = require(`./build-node-types`)
 const buildNodeConnections = require(`./build-node-connections`)
 const { store, getNodes } = require(`../redux`)
 const invariant = require(`invariant`)
-
-const DATA = [
-  { username : `catherine` },
-  { director : `catherine hardwicke` },
-  { author : `catherine cookson` },
-]
-
-const UserType = new GraphQLObjectType({
-  name : `User`,
-  fields : {
-    username : { type : GraphQLString },
-  },
-})
-
-const MovieType = new GraphQLObjectType({
-  name : `Movie`,
-  fields : {
-    director : { type : GraphQLString },
-  },
-})
-
-const BookType = new GraphQLObjectType({
-  name : `Book`,
-  fields : {
-    author : { type : GraphQLString },
-  },
-})
-
-const resolveType = (data) => {
-  if (data.username) {
-    return UserType
-  }
-  if (data.director) {
-    return MovieType
-  }
-  if (data.author) {
-    return BookType
-  }
-  return null
-}
-
-const SearchableType = new GraphQLUnionType({
-  name: `SearchableType`,
-  types: [ UserType, MovieType, BookType ],
-  resolveType: resolveType,
-})
 
 /**
  * The GraphQL definition of our shape union type
@@ -75,21 +29,10 @@ const defineShapesType = (CircleGql, SquareGql) => (
   })
 )
 
-// const latestNodes = _.filter(
-//   getNodes(),
-//   n => n.internal.type === `ContentfulCircle`
-// )
-//
-// console.log(JSON.stringify(latestNodes, null, 2))
-
 /**
- * TODO: get the gql for the Square
- * TODO: get the gql for the Circle
- * TODO: resolve type
+ * TODO:
  * TODO: resolve
  * TODO: args
- *
- * TODO add a circle and sqaure to the results
  */
 const genExtra = (CircleGql, SquareGql) => {
   return {
@@ -103,19 +46,6 @@ const genExtra = (CircleGql, SquareGql) => {
                 (n.internal.type === `ContentfulSquare`)
         )
         return latestNodes
-      },
-    },
-    search: {
-      type: new GraphQLList(SearchableType),
-      args:  {
-        text: { type : new GraphQLNonNull(GraphQLString) },
-      },
-      resolve(root, args) {
-        const text = args.text
-        return DATA.filter((d) => {
-          const searchableProperty = d.username || d.director || d.author
-          return searchableProperty.indexOf(text) !== -1
-        })
       },
     },
   }

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -1,11 +1,26 @@
 /* @flow */
 const _ = require(`lodash`)
-const { GraphQLSchema, GraphQLObjectType } = require(`graphql`)
+const { GraphQLSchema, GraphQLObjectType, GraphQLString, GraphQLNonNull } = require(`graphql`)
 
 const buildNodeTypes = require(`./build-node-types`)
 const buildNodeConnections = require(`./build-node-connections`)
 const { store } = require(`../redux`)
 const invariant = require(`invariant`)
+
+const genExtra = () => {
+  console.log(`in the mixer`)
+  return {
+    search: {
+      type: GraphQLString,
+      args: {
+        text: { type : new GraphQLNonNull(GraphQLString) },
+      },
+      resolve(root, args) {
+        return args.text
+      },
+    },
+  }
+}
 
 module.exports = async () => {
   const typesGQL = await buildNodeTypes()
@@ -17,10 +32,12 @@ module.exports = async () => {
   invariant(!_.isEmpty(nodes), `There are no available GQL nodes`)
   invariant(!_.isEmpty(connections), `There are no available GQL connections`)
 
+  const extra = genExtra()
+
   const schema = new GraphQLSchema({
     query: new GraphQLObjectType({
       name: `RootQueryType`,
-      fields: { ...connections, ...nodes },
+      fields: { ...connections, ...nodes, ...extra },
     }),
   })
 

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -1,22 +1,121 @@
 /* @flow */
 const _ = require(`lodash`)
-const { GraphQLSchema, GraphQLObjectType, GraphQLString, GraphQLNonNull } = require(`graphql`)
+const { GraphQLSchema, GraphQLObjectType, GraphQLUnionType, GraphQLString, GraphQLNonNull, GraphQLList } = require(`graphql`)
 
 const buildNodeTypes = require(`./build-node-types`)
 const buildNodeConnections = require(`./build-node-connections`)
-const { store } = require(`../redux`)
+const { store, getNodes } = require(`../redux`)
 const invariant = require(`invariant`)
 
-const genExtra = () => {
-  console.log(`in the mixer`)
+const DATA = [
+  { username : `catherine` },
+  { director : `catherine hardwicke` },
+  { author : `catherine cookson` },
+]
+
+const UserType = new GraphQLObjectType({
+  name : `User`,
+  fields : {
+    username : { type : GraphQLString },
+  },
+})
+
+const MovieType = new GraphQLObjectType({
+  name : `Movie`,
+  fields : {
+    director : { type : GraphQLString },
+  },
+})
+
+const BookType = new GraphQLObjectType({
+  name : `Book`,
+  fields : {
+    author : { type : GraphQLString },
+  },
+})
+
+const resolveType = (data) => {
+  if (data.username) {
+    return UserType
+  }
+  if (data.director) {
+    return MovieType
+  }
+  if (data.author) {
+    return BookType
+  }
+  return null
+}
+
+const SearchableType = new GraphQLUnionType({
+  name: `SearchableType`,
+  types: [ UserType, MovieType, BookType ],
+  resolveType: resolveType,
+})
+
+/**
+ * The GraphQL definition of our shape union type
+ */
+const defineShapesType = (CircleGql, SquareGql) => (
+  new GraphQLUnionType({
+    name: `AllShapesType`,
+    description: `All shapes under one roof`,
+    types: [ CircleGql, SquareGql ],
+    resolveType: (data) => {
+      const { type } = data.internal
+      switch (type) {
+        case `ContentfulCircle`:
+          return CircleGql
+        case `ContentfulSquare`:
+          return SquareGql
+        default:
+          return null
+      }
+    },
+  })
+)
+
+// const latestNodes = _.filter(
+//   getNodes(),
+//   n => n.internal.type === `ContentfulCircle`
+// )
+//
+// console.log(JSON.stringify(latestNodes, null, 2))
+
+/**
+ * TODO: get the gql for the Square
+ * TODO: get the gql for the Circle
+ * TODO: resolve type
+ * TODO: resolve
+ * TODO: args
+ *
+ * TODO add a circle and sqaure to the results
+ */
+const genExtra = (CircleGql, SquareGql) => {
   return {
+    allShapes: {
+      type: new GraphQLList(defineShapesType(CircleGql, SquareGql)),
+      args: {},
+      resolve(root, args) {
+        const latestNodes = _.filter(
+          getNodes(),
+          n => (n.internal.type === `ContentfulCircle`) ||
+                (n.internal.type === `ContentfulSquare`)
+        )
+        return latestNodes
+      },
+    },
     search: {
-      type: GraphQLString,
-      args: {
+      type: new GraphQLList(SearchableType),
+      args:  {
         text: { type : new GraphQLNonNull(GraphQLString) },
       },
       resolve(root, args) {
-        return args.text
+        const text = args.text
+        return DATA.filter((d) => {
+          const searchableProperty = d.username || d.director || d.author
+          return searchableProperty.indexOf(text) !== -1
+        })
       },
     },
   }
@@ -26,13 +125,16 @@ module.exports = async () => {
   const typesGQL = await buildNodeTypes()
   const connections = buildNodeConnections(_.values(typesGQL))
 
+
   // Pull off just the graphql node from each type object.
   const nodes = _.mapValues(typesGQL, `node`)
 
   invariant(!_.isEmpty(nodes), `There are no available GQL nodes`)
   invariant(!_.isEmpty(connections), `There are no available GQL connections`)
 
-  const extra = genExtra()
+  const CircleType = typesGQL[`contentfulCircle`].nodeObjectType
+  const SqaureType = typesGQL[`contentfulSquare`].nodeObjectType
+  const extra = genExtra(CircleType, SqaureType)
 
   const schema = new GraphQLSchema({
     query: new GraphQLObjectType({

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -202,4 +202,10 @@ exports.onPostBuild = true
  *
  * See gatsby-transformer-remark and gatsby-source-contentful for examples.
  */
-exports.onPreExtractQueries = true
+exports.onPreExtractQueries =
+
+/**
+ * Run after the schema has been created but before it's dispatched allowing you
+ * to do cool enhancements e.g. union / interface stuff
+ */
+exports.enhanceSchema = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,10 +3307,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
-deep-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -4236,10 +4232,6 @@ executable@^1.0.0:
   resolved "https://registry.yarnpkg.com/executable/-/executable-1.1.0.tgz#877980e9112f3391066da37265de7ad8434ab4d9"
   dependencies:
     meow "^3.1.0"
-
-exenv@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
 
 exif-parser@^0.1.9:
   version "0.1.12"
@@ -10009,15 +10001,6 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
-react-helmet@^5.1.3:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
-  dependencies:
-    deep-equal "^1.0.1"
-    object-assign "^4.1.1"
-    prop-types "^15.5.4"
-    react-side-effect "^1.1.0"
-
 react-hot-loader@^3.0.0-beta.6:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.1.1.tgz#e06db8cd0841c41e3ab0b395b2b774126fc8914e"
@@ -10066,13 +10049,6 @@ react-router@^4.1.1, react-router@^4.2.0:
     path-to-regexp "^1.7.0"
     prop-types "^15.5.4"
     warning "^3.0.0"
-
-react-side-effect@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.3.tgz#512c25abe0dec172834c4001ec5c51e04d41bc5c"
-  dependencies:
-    exenv "^1.2.1"
-    shallowequal "^1.0.1"
 
 react-typography@^0.16.1:
   version "0.16.5"
@@ -11288,10 +11264,6 @@ shallow-clone@^0.1.2:
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
-
-shallowequal@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 sharp@^0.17.3:
   version "0.17.3"


### PR DESCRIPTION
Raising a super rough PR to get early feedback. 

Following on from the discussion here https://github.com/gatsbyjs/gatsby/issues/2775 I've proposed a new API to allow sites/plugins to manipulate the GQL schema to do cool stuff. In my case I wanted to add a Union type which would allow me to query for 2 types at the same time. This has been achieved (very roughly) over here https://github.com/uttrasey/gatsby-union-demo/pull/2

Assuming a path exists forward I'm keen to hear thoughts if it's possible to make use of some of the awesome stuff available in build-node-connections for filtering, paging, sorting etc.

What do folks think?