### PR TITLE
Add gatsby-plugin-hotjar to docs

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -136,6 +136,7 @@ you can place the files in a `src` subfolder and build them to the plugin folder
 * [gatsby-plugin-klipse](https://github.com/ahmedelgabri/gatsby-plugin-klipse)
 * [gatsby-plugin-stripe-checkout](https://github.com/njosefbeck/gatsby-plugin-stripe-checkout)
 * [gatsby-plugin-stripe-elements](https://github.com/njosefbeck/gatsby-plugin-stripe-elements)
+* [gatsby-plugin-hotjar](https://github.com/pavloko/gatsby-plugin-hotjar)
 * [gatsby-remark-emoji](https://github.com/Rulikkk/gatsby-remark-emoji)
 * [gatsby-remark-external-links](https://github.com/JLongley/gatsby-remark-external-links)
 * [gatsby-source-workable](https://github.com/tumblbug/gatsby-source-workable)


### PR DESCRIPTION
Little plugin to add [Hotjar analytics](https://www.hotjar.com/) to gatsby sites.