### PR TITLE
[using-contentful][examples] Fix three links

### DIFF
--- a/examples/using-css-modules/src/pages/index.js
+++ b/examples/using-css-modules/src/pages/index.js
@@ -24,7 +24,7 @@ class IndexComponent extends React.Component {
         <p>
           <a
             className={indexStyles.link}
-            href="https://github.com/gatsbyjs/gatsby/tree/1.0/examples/using-css-modules"
+            href="https://github.com/gatsbyjs/gatsby/tree/master/examples/using-css-modules"
           >
             cODe for eXAMple sIte on GiTHUb
           </a>

--- a/examples/using-sass/src/pages/index.js
+++ b/examples/using-sass/src/pages/index.js
@@ -18,7 +18,7 @@ class Index extends React.Component {
               <a href="#">Logout</a>
             </li>
             <li>
-              <a href="https://github.com/gatsbyjs/gatsby/tree/1.0/examples/using-sass">
+              <a href="https://github.com/gatsbyjs/gatsby/tree/master/examples/using-sass">
                 Code for site on GitHub
               </a>
             </li>

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -3,7 +3,7 @@
 Source plugin for pulling content types, entries, and assets into Gatsby from Contentful spaces. It creates links between entry types and asset so they can be queried in Gatsby using GraphQL.
 
 An example site for using this plugin is at
-https://using-contentful.netlify.com/
+https://using-contentful.gatsbyjs.org/
 
 ## Install
 


### PR DESCRIPTION
* Update `using-contentful.netlify.com` -> `using-contentful.gatsbyjs.org` in the `using-contentful` README.
* Fix two broken links in the examples for `using-css-modules` and `using-sass` that still pointed to  `tree/v1` instead of `tree/master`.