### PR TITLE
[Docs] Fix "Adding Markdown Pages" url

### DIFF
--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -49,7 +49,7 @@
     - title: Adding Tags and Categories to Blog Posts*
       link: /docs/adding-tags-and-categories-to-blog-posts/
     - title: Adding Markdown Pages*
-      link: /adding-markdown-pages/
+      link: /docs/adding-markdown-pages/
     - title: Creating Dynamically-Rendered Navigation*
       link: /docs/creating-dynamically-rendered-navigation/
     - title: Dropping Images into Static Folders*


### PR DESCRIPTION
In *Guides* section *Adding Markdown Pages* url is https://www.gatsbyjs.org/adding-markdown-pages/, which is  currently 404. it should be https://www.gatsbyjs.org/docs/adding-markdown-pages/