### PR TITLE
Add gatsby-starter-dimension to Community Starters

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -168,3 +168,11 @@ Community:
   
   Features:
   * Very similar to [gatsby-starter-netlify-cms](https://github.com/AustinGreen/gatsby-starter-netlify-cms), slightly more configurable (eg set site-title in `gatsby-config`) with bootstrap/bootswatch instead of bulma
+
+* [gatsby-starter-dimension](https://github.com/ChangoMan/gatsby-starter-dimension) [(demo)](http://gatsby-dimension.surge.sh/)
+  
+  Features:
+  * Based off of the Dimension site template. Designed by [HTML5 UP](https://html5up.net/dimension)
+  * Simple one page site that's perfect for personal portfolios
+  * Fully Responsive
+  * Styling with SCSS


### PR DESCRIPTION
gatsby-starter-dimension is based off of the Dimension site template, designed by HTML5 UP.