### PR TITLE
Fix linter issue in develop command

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -203,7 +203,6 @@ module.exports = async (program: any) => {
     typeof program.port === `string` ? parseInt(program.port, 10) : program.port
 
   let compiler
-  let listener
   await new Promise(resolve => {
     detect(port, (err, _port) => {
       if (err) {
@@ -223,14 +222,12 @@ module.exports = async (program: any) => {
 
           startServer(program).then(([c, l]) => {
             compiler = c
-            listener = l
             resolve()
           })
         })
       } else {
         startServer(program).then(([c, l]) => {
           compiler = c
-          listener = l
           resolve()
         })
       }


### PR DESCRIPTION
# Description

Fix a linting issue (introduced by https://github.com/gatsbyjs/gatsby/commit/c2804726b367f40769e461647e950b8e5e6c1222#diff-346c3005d97c1ca0b5efb170af1b43f6) triggering this error:
```
/home/travis/build/akadop/gatsby/packages/gatsby/src/commands/develop.js
  206:7  error  'listener' is assigned a value but never used  no-unused-vars
```