### PR TITLE
plugin-google-tagmanager: Adds option to render tag on dev env

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -14,10 +14,9 @@ plugins: [
     resolve: `gatsby-plugin-google-tagmanager`,
     options: {
       id: 'YOUR_GOOGLE_TAGMANAGER_ID',
-      // want GTM to render on dev? (localhost:8000)
-      // very common to have JS snippets specifically for dev env
-      // defaults to false; change this boolean to true to render on dev env
-      renderOnDev: false
+      // This value defaults to false but if you change it to true, 
+      // your GTM snippet will render in your development env.
+      includeInDevelopment: false
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -14,8 +14,8 @@ plugins: [
     resolve: `gatsby-plugin-google-tagmanager`,
     options: {
       id: 'YOUR_GOOGLE_TAGMANAGER_ID',
-      // This value defaults to false but if you change it to true, 
-      // your GTM snippet will render in your development env.
+      // Include GTM in development.
+      // Defaults to false meaning GTM will only be loaded in production.
       includeInDevelopment: false
     },
   },

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -14,6 +14,10 @@ plugins: [
     resolve: `gatsby-plugin-google-tagmanager`,
     options: {
       id: 'YOUR_GOOGLE_TAGMANAGER_ID',
+      // want GTM to render on dev? (localhost:8000)
+      // very common to have JS snippets specifically for dev env
+      // defaults to false; change this boolean to true to render on dev env
+      renderOnDev: false
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -5,7 +5,10 @@ exports.onRenderBody = (
   { setHeadComponents, setPreBodyComponents },
   pluginOptions
 ) => {
-  if (process.env.NODE_ENV === `production` || pluginOptions.renderOnDev) {
+  if (
+    process.env.NODE_ENV === `production` ||
+    pluginOptions.includeInDevelopment
+  ) {
     setHeadComponents([
       <script
         key="plugin-google-tagmanager"

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -5,7 +5,7 @@ exports.onRenderBody = (
   { setHeadComponents, setPreBodyComponents },
   pluginOptions
 ) => {
-  if (process.env.NODE_ENV === `production`) {
+  if (process.env.NODE_ENV === `production` || pluginOptions.renderOnDev) {
     setHeadComponents([
       <script
         key="plugin-google-tagmanager"


### PR DESCRIPTION
This PR adds an option to `gatsby-plugin-google-tagmanager` to allow for the tag manager snippet to render in a development environment.

It's very common for growth engineers to have different analytics environments.  For example:
- I have dev environments within Google Analytics, Mixpanel, etc.  Helps me catch analytics bugs early as well as track developer and QA activity
- sometimes I need to make sure my snippets are firing as expected before deploying to stage (GTM has a "test" mode that can only be activated if the tag is present)
- allows devs to see the GTM snippet in their code while working locally (ie, sanity check)

I have similar logic in my [Segment plugin](https://github.com/benjaminhoffman/gatsby-plugin-segment-js/blob/master/src/gatsby-ssr.js#L14-L16), except there I allow for a different write key.  This extra step is not necessary for GTM bc it's robust enough to allow for hostname filtering within its UI.