### PR TITLE
gatsby-plugin-catch-links: do not catch dynamically created anchor links to hash on IE

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -32,6 +32,11 @@ module.exports = function(root, cb) {
       return true
     }
 
+    // Dynamically created anchor links (href="#my-anchor") do not always have pathname on IE
+    if (anchor.pathname === ``) {
+      return true
+    }
+
     // Don't catch links pointed at what look like file extensions (other than
     // .htm/html extensions).
     if (anchor.pathname.search(/^.*\.((?!htm)[a-z0-9]{1,5})$/i) !== -1) {


### PR DESCRIPTION
Continuation of https://github.com/gatsbyjs/gatsby/pull/2994

IE seems to sometimes miss anchor.pathname if link is dynamically created and points to #fragment.

jsFiddle: https://jsfiddle.net/n6ss7vkn/2/

Chrome:
<img width="1127" alt="screen shot 2017-11-28 at 14 53 20" src="https://user-images.githubusercontent.com/1768778/33320804-13fee3aa-d44c-11e7-828f-aa50b685d7e2.png">

IE11
<img width="993" alt="screen shot 2017-11-28 at 14 52 40" src="https://user-images.githubusercontent.com/1768778/33320809-1660f5b6-d44c-11e7-92b3-b22a1eada57b.png">

