### PR TITLE
Add endpoint to refresh external data

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -106,6 +106,25 @@ function buildLocalCommands(cli, isLocalSite) {
   })
 
   cli.command({
+    command: `refresh`,
+    desc: `Reload external data sources`,
+    builder: _ =>
+      _.option(`H`, {
+        alias: `host`,
+        type: `string`,
+        default: defaultHost,
+        describe: `Set host. Defaults to ${defaultHost}`,
+      })
+        .option(`p`, {
+          alias: `port`,
+          type: `string`,
+          default: `8000`,
+          describe: `Set port. Defaults to 8000`,
+        }),
+    handler: getCommandHandler(`refresh`),
+  })
+
+  cli.command({
     command: `build`,
     desc: `Build a Gatsby project.`,
     builder: _ =>

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -19,6 +19,7 @@ const launchEditor = require(`react-dev-utils/launchEditor`)
 const formatWebpackMessages = require(`react-dev-utils/formatWebpackMessages`)
 const chalk = require(`chalk`)
 const address = require(`address`)
+const sourceNodes = require(`../utils/source-nodes`)
 
 // const isInteractive = process.stdout.isTTY
 
@@ -91,6 +92,19 @@ async function startServer(program) {
       graphiql: true,
     })
   )
+
+  /**
+   * Refresh external data sources.
+   * If no GATSBY_REFRESH_TOKEN env var is available, then no Authorization header is required
+  **/
+  app.post(`/__refresh`, (req, res) => {
+    if (req.headers.authorization === process.env.GATSBY_REFRESH_TOKEN) {
+      console.log(`Refreshing source data`)
+      sourceNodes()
+    }
+    res.end()
+  })
+
   app.get(`/__open-stack-frame-in-editor`, (req, res) => {
     launchEditor(req.query.fileName, req.query.lineNumber)
     res.end()

--- a/packages/gatsby/src/commands/refresh.js
+++ b/packages/gatsby/src/commands/refresh.js
@@ -1,0 +1,26 @@
+/* @flow */
+
+const http = require(`http`)
+
+module.exports = async (program: { host: string, port: string }) => {
+  const options = {
+    host: program.host,
+    port: program.port,
+    path: `/__refresh`,
+    method: `POST`,
+  }
+
+  const req = http.request(options, (res) => {
+    res.on(`end`, () => {
+      console.log()
+      console.info(`Successfully refreshed external data`)
+    })
+  })
+
+  req.on(`error`, (e) => {
+    console.log()
+    console.error(`Unable to refresh external data: ${e.message}`)
+  })
+
+  req.end()
+}


### PR DESCRIPTION
Fixes #2847 . The external source data can be refreshed by making a POST request to
the __refresh endpoint. If the env var GATSBY_REFRESH_TOKEN is present
there needs to be a matching Authorization header. This post request
is wrapped for convenience with the command gatsby refresh which uses
localhost:8000 by default, but allows for a host and port to be
specified in the same way as gatsby develop.