### PR TITLE
Use IntersectionObserver when polyfilled after gatsby-image first load

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -36,27 +36,32 @@ const inImageCache = props => {
 
 let io
 const listeners = []
-if (typeof window !== `undefined` && window.IntersectionObserver) {
-  io = new window.IntersectionObserver(
-    entries => {
-      entries.forEach(entry => {
-        listeners.forEach(l => {
-          if (l[0] === entry.target) {
-            // Edge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
-            if (entry.isIntersecting || entry.intersectionRatio > 0) {
-              io.unobserve(l[0])
-              l[1]()
+
+function getIO() {
+  if (typeof io === `undefined` && typeof window !== `undefined` && window.IntersectionObserver) {
+    io = new window.IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          listeners.forEach(l => {
+            if (l[0] === entry.target) {
+              // Edge doesn't currently support isIntersecting, so also test for an intersectionRatio > 0
+              if (entry.isIntersecting || entry.intersectionRatio > 0) {
+                io.unobserve(l[0])
+                l[1]()
+              }
             }
-          }
+          })
         })
-      })
-    },
-    { rootMargin: `200px` }
-  )
+      },
+      { rootMargin: `200px` }
+    )
+  }
+
+  return io
 }
 
 const listenToIntersections = (el, cb) => {
-  io.observe(el)
+  getIO().observe(el)
   listeners.push([el, cb])
 }
 


### PR DESCRIPTION
Scenario:

If a browser lacks `IntersectionObserver` support, and later becomes polyfilled with support, gatsby-image would throw the error `TypeError: undefined is not an object (evaluating 'io.observe')`.

Explanation:

The `<Image>` component checks for IntersectionObserver support [upon instantiation](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-image/src/index.js#L130), but `io` would only attempt to be defined once, [upon initial load of gatsby-image](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-image/src/index.js#L39-L56). This resulted in an attempt to use the undefined `io` variable.

This change attempts to initialize `io` if not already defined whenever it is requested.
