### PR TITLE
[gatsby-link] Accept innerRef function

### DIFF
--- a/examples/using-remark/src/pages/2017-04-04---code-and-syntax-highlighting/index.md
+++ b/examples/using-remark/src/pages/2017-04-04---code-and-syntax-highlighting/index.md
@@ -167,7 +167,7 @@ Let's do something crazy and add a list with another code example:
   > version 5 which included the cutting edge,
   > [fault-tolerant](https://en.wikipedia.org/wiki/Fault-tolerant) and highly
   > standards-compliant
-  > [Tasman](<https://en.wikipedia.org/wiki/Tasman_(layout_engine)>)
+  > [Tasman](<https://en.wikipedia.org/wiki/Tasman_(layout_engine)>) >
   > [layout engine](https://en.wikipedia.org/wiki/Layout_engine).
 
   Source: https://en.wikipedia.org/wiki/Internet_Explorer_for_Mac

--- a/packages/gatsby-link/README.md
+++ b/packages/gatsby-link/README.md
@@ -8,17 +8,22 @@ that adds enhancements specific to Gatsby. All props are passed through to React
 Router's Link.
 
 You can set the `activeStyle` or `activeClassName` prop to add styling
-attributes to the rendered element when it matches the current URL. If either of
-these props are set, then
+attributes to the rendered element when it matches the current URL, and Gatsby
+also supports React Router's `exact`, `strict`, `isActive`, and `location`. If
+any of these props are set, then
 [React Router's NavLink component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md)
 will be used instead of Link.
 
 Gatsby does per-route code splitting. This means that when navigating to a new
 page, the code chunks necessary for that page might not be loaded. This is bad.
 Any unnecessary latency when changing pages should be avoided. So to avoid that
-Gatsby preloads code chunks and page data. Preloading is triggered by a link
-entering the viewport so it only prefetchs code/data chunks for pages the user
-is likely to navigate to.
+Gatsby preloads code chunks and page data.
+
+Preloading is triggered by a link entering the viewport; Gatsby uses
+`Link`/`NavLink`'s `innerRef` property to create a new InteractionObserver (on
+supported browsers) to monitor visible links. This way, Gatsby only prefetches
+code/data chunks for pages the user is likely to navigate to. You can still pass
+in your own `innerRef` to be called inside Gatsby's handler.
 
 ## Install
 
@@ -38,6 +43,7 @@ render () {
       activeStyle={{
         color: 'red'
       }}
+      innerRef={(el) => { this.myLink = el }}
     >
     Another page
     </Link>

--- a/packages/gatsby-link/README.md
+++ b/packages/gatsby-link/README.md
@@ -9,10 +9,10 @@ Router's Link.
 
 You can set the `activeStyle` or `activeClassName` prop to add styling
 attributes to the rendered element when it matches the current URL, and Gatsby
-also supports React Router's `exact`, `strict`, `isActive`, and `location`. If
+also supports React Router's props `exact`, `strict`, `isActive`, and `location`. If
 any of these props are set, then
 [React Router's NavLink component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md)
-will be used instead of Link.
+will be used instead of the default `Link`.
 
 Gatsby does per-route code splitting. This means that when navigating to a new
 page, the code chunks necessary for that page might not be loaded. This is bad.
@@ -22,8 +22,8 @@ Gatsby preloads code chunks and page data.
 Preloading is triggered by a link entering the viewport; Gatsby uses
 `Link`/`NavLink`'s `innerRef` property to create a new InteractionObserver (on
 supported browsers) to monitor visible links. This way, Gatsby only prefetches
-code/data chunks for pages the user is likely to navigate to. You can still pass
-in your own `innerRef` to be called inside Gatsby's handler.
+code/data chunks for pages the user is likely to navigate to. You can also get
+access to the link element by passing in a `innerRef` prop.
 
 ## Install
 

--- a/packages/gatsby-link/README.md
+++ b/packages/gatsby-link/README.md
@@ -9,8 +9,8 @@ Router's Link.
 
 You can set the `activeStyle` or `activeClassName` prop to add styling
 attributes to the rendered element when it matches the current URL, and Gatsby
-also supports React Router's props `exact`, `strict`, `isActive`, and `location`. If
-any of these props are set, then
+also supports React Router's props `exact`, `strict`, `isActive`, and
+`location`. If any of these props are set, then
 [React Router's NavLink component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md)
 will be used instead of the default `Link`.
 

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -80,6 +80,8 @@ class GatsbyLink extends React.Component {
   }
 
   handleRef(ref) {
+    this.props.innerRef && this.props.innerRef(ref)
+
     if (this.state.IOSupported && ref) {
       // If IO supported and element reference found, setup Observer functionality
       handleIntersection(ref, () => {
@@ -153,8 +155,9 @@ class GatsbyLink extends React.Component {
 
 GatsbyLink.propTypes = {
   ...NavLinkPropTypes,
-  to: PropTypes.string.isRequired,
+  innerRef: PropTypes.func,
   onClick: PropTypes.func,
+  to: PropTypes.string.isRequired,
 }
 
 GatsbyLink.contextTypes = {

--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -102,18 +102,18 @@ plugins.
 * [x] [ACF](https://www.advancedcustomfields.com/) The option `useACF: true`
       must be activated in your site's `gatsby-config.js`.
 
-      * You must have the plugin
-        [acf-to-rest-api](https://github.com/airesvsg/acf-to-rest-api) installed
-        in WordPress.
-      * Will pull the `acf: { ... }` fields's contents from any entity which has
-        it attached (pages, posts, medias, ... you choose from in WordPress
-        back-end while creating a Group of Fields).
-      * [ACF Pro](https://www.advancedcustomfields.com/pro/) same as ACF :
-      * Will work with
-        [Flexible content](https://www.advancedcustomfields.com/resources/flexible-content/)
-        and premium stuff like that (repeater, gallery, ...).
-      * Will pull the content attached to the
-        [options page](https://www.advancedcustomfields.com/add-ons/options-page/).
+          * You must have the plugin
+            [acf-to-rest-api](https://github.com/airesvsg/acf-to-rest-api) installed
+            in WordPress.
+          * Will pull the `acf: { ... }` fields's contents from any entity which has
+            it attached (pages, posts, medias, ... you choose from in WordPress
+            back-end while creating a Group of Fields).
+          * [ACF Pro](https://www.advancedcustomfields.com/pro/) same as ACF :
+          * Will work with
+            [Flexible content](https://www.advancedcustomfields.com/resources/flexible-content/)
+            and premium stuff like that (repeater, gallery, ...).
+          * Will pull the content attached to the
+            [options page](https://www.advancedcustomfields.com/add-ons/options-page/).
 
 * [x] [WP-API-MENUS](https://wordpress.org/plugins/wp-api-menus/) which gives
       you the menus and menu locations endpoint.


### PR DESCRIPTION
It'd be great if we could pass along an `innerRef` property to `gatsby-link` so we can access the `<a>` tag created by `react-router-dom`.

About my use case: I'm making an accessible menubutton a la http://davidtheclark.github.io/react-aria-menubutton/demo/, but with links. I need the reference to be able to focus the element based on keyboard controls.