### PR TITLE
Use layout if exist for dev 404 page

### DIFF
--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -23,7 +23,7 @@ class ComponentRenderer extends React.Component {
 
     this.state = {
       location,
-      pageResources: loader.getResourcesForPathname(props.location.pathname),
+      pageResources: loader.getResourcesForPathname(location.pathname),
     }
   }
 


### PR DESCRIPTION
This fix is about utilising layout if exist for 404 dev page.

Initially, it looks like this:
![404 dev page without layout](https://user-images.githubusercontent.com/22838512/33076176-1b9c619a-cf20-11e7-85a0-a0dea0112af7.png)

With the fix, it should be looking like this:
![404 dev page with layout](https://user-images.githubusercontent.com/22838512/33076222-4194fbf0-cf20-11e7-98ca-c00060854d3f.png)