### PR TITLE
Update to markdown formatting

### DIFF
--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -133,7 +133,7 @@ pages:
 ```
 
 The CI platform uses Docker images/containers, so `image: node:latest` tells the
-CI to use the latest node image. `cache:` caches the node_modules folder
+CI to use the latest node image. `cache:` caches the `node_modules` folder
 inbetween builds, so subsequent builds should be a lot faster as it doesn't have
 to reinstall all the dependancies required. `pages:` Is simply the name of the
 CI stage. You can have multiple stages, e.g. 'Test', 'Build', 'Deploy' etc.


### PR DESCRIPTION
one of the node_modules wasn't wrapped with ``, so with _ in markdown it changed subsequent text to italics - see https://www.gatsbyjs.org/docs/deploy-gatsby/#gitlab-pages