### PR TITLE
simplify tracking root nodes and make sure we try to track only objects

### DIFF
--- a/packages/gatsby/src/redux/index.js
+++ b/packages/gatsby/src/redux/index.js
@@ -122,14 +122,10 @@ exports.getNodeAndSavePathDependency = (id, path) => {
 exports.getRootNodeId = node => rootNodeMap.get(node)
 
 const addParentToSubObjects = (data, parentId) => {
-  _.each(data, (v, k) => {
-    if (_.isArray(v) && _.isObject(v[0])) {
-      _.each(v, o => addParentToSubObjects(o, parentId))
-    } else if (_.isObject(v)) {
-      addParentToSubObjects(v, parentId)
-    }
-  })
-  rootNodeMap.set(data, parentId)
+  if (_.isPlainObject(data) || _.isArray(data)) {
+    _.each(data, o => addParentToSubObjects(o, parentId))
+    rootNodeMap.set(data, parentId)
+  }
 }
 
 const trackSubObjectsToRootNodeId = node => {
@@ -138,11 +134,7 @@ const trackSubObjectsToRootNodeId = node => {
     if (k === `internal`) {
       return
     }
-    if (_.isArray(v) && _.isObject(v[0])) {
-      _.each(v, o => addParentToSubObjects(o, node.parent))
-    } else if (_.isObject(v)) {
-      addParentToSubObjects(v, node.parent)
-    }
+    addParentToSubObjects(v, node.parent)
   })
 }
 exports.trackSubObjectsToRootNodeId = trackSubObjectsToRootNodeId


### PR DESCRIPTION
This is attempt at fixing #2988

Currently we will get build error when creatingNode that have array with 1st element being object and any of the other elements being primitive type (f.e. `null` or `undefined`). This happens because gatsby check only first element in array (propably hoping source plugins would validate/normalize data). There is code snippet to reproduce error in https://github.com/gatsbyjs/gatsby/issues/2988#issuecomment-348021478

This PR simplifies code that keeps track of root nodes (KISS) - we don't really need to have 2 checks (1 for arrays and 1 for objects - array is object) making it easier to follow. It also removes duplicated code (DRY)