### PR TITLE
Fix tutorial part one hot reloading

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -68,7 +68,7 @@ tutorial.
 
 ```sh
 cd tutorial-part-one
-gatsby develop
+gatsby develop --host localhost
 ```
 
 You should see shortly some text that says `The development server is listening


### PR DESCRIPTION
Hot reloading wasn't working for me while going through the tutorial and so I searched the issues and came across this: https://github.com/gatsbyjs/gatsby/issues/2989

This issue has been closed by it's author, but it's still valid. Specifying the host on the `gatsby develop` call with `--host localhost` fixed the issue.