### PR TITLE
Add gatsby-link as a peer dependency to gatsby

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -149,5 +149,8 @@
     "prepublish": "cross-env NODE_ENV=production npm run build",
     "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
     "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"
+  },
+  "peerDependencies": {
+    "gatsby-link": "^1.6.30"
   }
 }


### PR DESCRIPTION
This is a first attempt to fix #3069 by making it more obvious that the `gatsby` package relies on `gatsby-link` at this point (see the issue for more information).

I'm new to Yarn and Lerna so please let me know if I did something wrong. I might also add some documentation to ensure users don't accidentally remove `gatsby-link` and to reduce confusion with the peer dependency. Also, can someone help me understand what version constraint to use for `gatsby-link`? Should I just change it to `*` since `gatsby-link` doesn't seem to depend on `gatsby`'s version at all?

Just to be clear, be warned that this could potentially be semver major since technically this could cause breakages where a package depending on `gatsby` but not `gatsby-cli` could not longer be installed by yarn (npm allows this but displays an error).