### PR TITLE
Updates sitemap example URL

### DIFF
--- a/examples/sitemap/README.md
+++ b/examples/sitemap/README.md
@@ -1,5 +1,5 @@
 # Sitemap
 
-https://sitemap.gatsbyjs.org
+https://www.gatsbyjs.org/sitemap.xml
 
 Gatsby example site explaining how to use the sitemap generator plugin.

--- a/examples/sitemap/src/pages/index.js
+++ b/examples/sitemap/src/pages/index.js
@@ -4,7 +4,9 @@ const IndexRoute = () => (
   <div>
     <p>
       Welcome to the GatsbyJS Sitemap Demo. Visit{` `}
-      <a href="/sitemap.xml">to see the generated sitemap.</a>
+      <a href="https://www.gatsbyjs.org/sitemap.xml">
+        to see the generated sitemap.
+      </a>
     </p>
   </div>
 )


### PR DESCRIPTION
sitemap example URL isn't working.  Updated URL here by recommendation from @calcsam 
 
closes https://github.com/gatsbyjs/gatsby/issues/3014