### PR TITLE
Start expanding the GraphQL docs

### DIFF
--- a/docs/docs/querying-with-graphql.md
+++ b/docs/docs/querying-with-graphql.md
@@ -2,23 +2,65 @@
 title: Querying with GraphQL
 ---
 
-Rough outline
+> This page is a work in progress.
 
-* What is GraphQL
-* Why GraphQL? As Gatsby runs on both server (at build time) & client, need way
-  to specify which data is needed.
-* Emphasize this is a _build-time only_ use of GraphQL. You don't need to run a
-  GraphQL server in production. Convenient way to describe data requirements of
-  component.
-* Why query colocation rocks.
-* Some basic terminology
-  * Types based on file type + way data can be transformed
-  * Connections
-  * Shallow intro to how data layer works e.g. source and transformer plugins.
-  * Compare to Webpack loaders — like loaders except create schema that can then
-    be queried.
-* Example queries showing off sorting, filtering, picking fields, programmatic
-  transformations
-* Link to some doc pages on advanced usages of GraphQL.
-* iFrame of graphiql instance for this site running on Heroku so people can run
-  live queries.
+# What is GraphQL?
+
+graphql.org describes it as "...a query language for APIs and a runtime for fulfilling those queries with your existing data".
+
+Gatsby uses GraphQL to create a consistent interface between your static site and your data sources, where data sources can be anything from local markdown files to a remote API.
+
+Gatsby describes your data by creating GraphQL _schemas_ from your data sources.
+
+GraphQL _queries_ can then be associated with your Gatsby pages, ensuring each page receives exactly the data it needs.
+
+
+# Why GraphQL?
+
+* As Gatsby runs on both server (at build time) & client,
+need way to specify which data is needed.
+* This is a *build-time only* use of GraphQL. You don't need to run a
+GraphQL server in production.
+* Convenient way to describe data requirements of component.
+* Why query colocation rocks
+* Uses the Relay Modern compiler behind the scenes
+
+# Basic Terminology
+
+* Types based on file type + way data can be transformed
+* Connections
+* Shallow intro to how data layer works e.g. source and transformer plugins.
+* Compare to webpack loaders — like loaders except create schema that
+can then be queried.
+* Named queries?
+* Using query parameters to manipulate results?
+
+# Example queries
+
+Showing off sorting, filtering, picking fields, programmatic transformations
+
+[Some example queries from Gatsby's tests](https://github.com/gatsbyjs/gatsby/blob/52e36b9994a86fc473cd2f966ab6b6f87ee8eedb/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js#L116-L432) - look for \`template literal blocks\` with `allNode{}` in them.
+
+...
+
+# Further reading
+
+## Getting started with GraphQL
+
+- http://graphql.org/learn/
+- https://services.github.com/on-demand/graphql/
+- https://apis.guru/graphql-voyager/
+- https://www.howtographql.com/
+- https://reactjs.org/blog/2015/05/01/graphql-introduction.html
+- ...
+
+## Advanced usages of GraphQL
+
+- [GraphQL specification](https://facebook.github.io/graphql/October2016/)
+- [Interfaces and Unions](https://medium.com/the-graphqlhub/graphql-tour-interfaces-and-unions-7dd5be35de0d)
+- [Gatsby uses Relay](https://facebook.github.io/relay/docs/en/relay-compiler.html)
+- ...
+
+## Live GraphQL explorer for GatsbyJS.org
+
+* iFrame of graphiql instance for this site running on Heroku so people can run live queries.

--- a/docs/docs/querying-with-graphql.md
+++ b/docs/docs/querying-with-graphql.md
@@ -54,13 +54,13 @@ Showing off sorting, filtering, picking fields, programmatic transformations
 - https://reactjs.org/blog/2015/05/01/graphql-introduction.html
 - ...
 
-## Advanced usages of GraphQL
+## Advanced readings on GraphQL
 
 - [GraphQL specification](https://facebook.github.io/graphql/October2016/)
 - [Interfaces and Unions](https://medium.com/the-graphqlhub/graphql-tour-interfaces-and-unions-7dd5be35de0d)
-- [Gatsby uses Relay](https://facebook.github.io/relay/docs/en/relay-compiler.html)
+- [Gatsby uses the Relay Compiler](https://facebook.github.io/relay/docs/en/relay-compiler.html)
 - ...
 
-## Live GraphQL explorer for GatsbyJS.org
+## TODO — create live GraphQL explorer for GatsbyJS.org
 
 * iFrame of graphiql instance for this site running on Heroku so people can run live queries.


### PR DESCRIPTION
I've restructured the page a bit and expanded on any bullet points where I can, leaving the rest of the points intact. 

The main content additions are:

- Added info to the _What is GraphQL?_ section
- Added a link to some example queries that are used in Gatsby's tests, as I found this quite a useful reference when getting to grips with GraphQL's syntax.
- Added links out to other GraphQL docs, again this is mostly sites that I found useful while building my first Gatsby site.

Please add / edit / delete as you see fit. 