### PR TITLE
update `gatsby-source-drupal` to match new json api endpoint

### DIFF
--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -9,6 +9,10 @@ An example site built with the headless Drupal distro
 [ContentaCMS](https://twitter.com/contentacms) is at
 https://using-drupal.gatsbyjs.org/
 
+`apiBase` Option allows changing the API entry point depending on the version of
+jsonapi used by your Drupal instance. The default value is `jsonapi`, which has
+been used since jsonapi version `8.x-1.0-alpha4`.
+
 ## Install
 
 `npm install --save gatsby-source-drupal`
@@ -20,7 +24,10 @@ https://using-drupal.gatsbyjs.org/
 plugins: [
   {
     resolve: `gatsby-source-drupal`,
-    options: { baseUrl: `https://live-contentacms.pantheonsite.io/` },
+    options: {
+      baseUrl: `https://live-contentacms.pantheonsite.io/`,
+      apiBase: `api` // optional, defaults to `jsonapi`
+    },
   },
 ]
 ```

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -13,9 +13,12 @@ const createContentDigest = obj =>
 
 exports.sourceNodes = async (
   { boundActionCreators, getNode, hasNodeChanged, store, cache },
-  { baseUrl }
+  { baseUrl, apiBase }
 ) => {
   const { createNode } = boundActionCreators
+
+  // Default apiBase to `jsonapi`
+  apiBase = apiBase || `jsonapi`
 
   // Touch existing Drupal nodes so Gatsby doesn't garbage collect them.
   // _.values(store.getState().nodes)
@@ -36,7 +39,7 @@ exports.sourceNodes = async (
   // .lastFetched
   // }
 
-  const data = await axios.get(`${baseUrl}/api`)
+  const data = await axios.get(`${baseUrl}/${apiBase}`)
   const allData = await Promise.all(
     _.map(data.data.links, async (url, type) => {
       if (type === `self`) return


### PR DESCRIPTION
Drupal JSON API has changed their endpoint base from `api` to `jsonapi`. This updates `gatsby-source-drupal` to match this, and allows override to old endpoint if necessary.

See https://www.drupal.org/docs/8/modules/json-api/api-overview