### PR TITLE
[gatsby-plugin-preact] Fix Preact URL in readme

### DIFF
--- a/packages/gatsby-plugin-preact/README.md
+++ b/packages/gatsby-plugin-preact/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-preact
 
-Provides drop-in support for replacing React with [Preact]().
+Provides drop-in support for replacing React with [Preact](https://preactjs.com/).
 
 While Preact doesn't provide full support for the React ecosystem, it is an
 intriguing option for Gatsby sites as it saves ~30kb of Javascript vs. using


### PR DESCRIPTION
Empty link updated with link to Preact.