### PR TITLE
adds notes about HOC to handle client routing

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -211,9 +211,10 @@ import { Route } from 'react-router-dom';
 
 // Pass in route config, and the Content component you want rendered
 export default (config, Content) => {
-  const GatsbyClientRoute = () => {
+  const GatsbyClientRoute = (props) => {
     return (
       <Route
+        {...props}
         {...config}
         component={Content}
       />

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -175,7 +175,8 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
   return new Promise((resolve, reject) => {
     if (/view/.test(page.path)) {
       // Gatsby paths have a trailing `/`
-      page.matchPath = `${page.path}:id`;
+      page.path = `${page.path}:id`;
+      page.matchPath = page.path;
     }
 
     createPage(page);

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -160,6 +160,94 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
 };
 ```
 
+### Client Route Params
+
+In order to make a `detail` page at `/widgets/view/ID` and extract the `ID` param, we will need to configure client only routes.
+
+**Build config:**
+
+First configure `gatsby-node.js`:
+
+```javascript
+exports.onCreatePage = async ({ page, boundActionCreators }) => {
+  const { createPage } = boundActionCreators;
+
+  return new Promise((resolve, reject) => {
+    if (/view/.test(page.path)) {
+      // Gatsby paths have a trailing `/`
+      page.matchPath = `${page.path}:id`;
+    }
+
+    createPage(page);
+    resolve();
+  });
+};
+```
+
+**Client:**
+
+Extracting path params from the route on the client requires that you add a `react-router` `<Route>` in your component. 
+
+This can be made simpler by using a HOC:
+
+```javascript
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route } from 'react-router-dom';
+
+// Pass in route config, and the Content component you want rendered
+export default (config, Content) => {
+  const GatsbyClientRoute = () => {
+    return (
+      <Route
+        {...config}
+        component={Content}
+      />
+    )
+  };
+
+  return GatsbyClientRoute;
+};
+```
+
+Use the HOC on the page component you want to access the path params:
+
+```javascript
+export default GatsbyClientRoute({path: '/widgets/view/:id'}, WidgetPage);
+```
+
+Full example page:
+
+```javascript
+import React from 'react';
+
+import GatsbyClientRoute from '<PATH_TO_SRC>/components/hocs/gatsby-client-route';
+
+class WidgetPageContent extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const { match } = this.props;
+    console.log(match.params.id);
+    return (
+      <div>
+        Widget: {match.params.id}
+      </div>
+    );
+  }
+};
+
+export default GatsbyClientRoute(
+	// NOTE this must match path.matchPath
+  {path: '/widgets/view/:id'},
+  WidgetPageContent
+);
+```
+
+Using the URL `http://localhost:8000/wigets/view/10` will console log `10` and the markup will say `Widget: 10`.
+
 ### Choosing the page layout
 
 By default, all pages will use the layout found at `/layouts/index.js`.

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -162,7 +162,7 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
 
 ### Client Route Params
 
-In order to make a `detail` page at `/widgets/view/ID` and extract the `ID` param, we will need to configure client only routes.
+In order to make a "detail" page at `/widgets/view/ID` resolve and extract the `ID` param, we will need to configure client only routes.
 
 **Build config:**
 
@@ -175,8 +175,7 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
   return new Promise((resolve, reject) => {
     if (/view/.test(page.path)) {
       // Gatsby paths have a trailing `/`
-      page.path = `${page.path}:id`;
-      page.matchPath = page.path;
+      page.matchPath = `${page.path}:id`;
     }
 
     createPage(page);
@@ -184,6 +183,20 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
   });
 };
 ```
+
+**Server:**
+
+When creating links to these view/id pages using react router or any pushstate the pages will resolve until the user hard refreshes the page. This is due to your backend server not knowing how to handle the route.
+
+Configuration is going to be required to make these pages work on production. Results may vary depending on deployment but a simple use case for NGINX:
+
+```
+location ~ "([a-z]*)\/view\/(\d*)$" {
+    try_files $uri /$1/view/index.html;
+}
+```
+
+This directive will provide the `widgets/view/index.html` file for any request like (widgets)/view/1. It will also support other pages by matching the first level of the URL, example http://sitename/sprockets/view/1.
 
 **Client:**
 

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -241,7 +241,7 @@ class WidgetPageContent extends React.Component {
 };
 
 export default GatsbyClientRoute(
-	// NOTE this must match path.matchPath
+// NOTE this must match path.matchPath
   {path: '/widgets/view/:id'},
   WidgetPageContent
 );

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -162,7 +162,9 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
 
 ### Client Route Params
 
-In order to make a "detail" page at `/widgets/view/ID` resolve and extract the `ID` param, we will need to configure client only routes.
+Gatsby can create client-only routes which take paramaters. 
+
+We'll walk quickly through how to setup a route on your site like `/widgets/view/ID`.
 
 **Build config:**
 
@@ -173,6 +175,7 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
   const { createPage } = boundActionCreators;
 
   return new Promise((resolve, reject) => {
+    // Add client route for all paths matching `/view/*`
     if (/view/.test(page.path)) {
       // Gatsby paths have a trailing `/`
       page.matchPath = `${page.path}:id`;
@@ -186,9 +189,9 @@ exports.onCreatePage = async ({ page, boundActionCreators }) => {
 
 **Server:**
 
-When creating links to these view/id pages using react router or any pushstate the pages will resolve until the user hard refreshes the page. This is due to your backend server not knowing how to handle the route.
+Links to these pages will work well client-side but fail if a user tries to visit a page directly (i.e. load the page from the server). This is due to your backend server not knowing how to handle the route.
 
-Configuration is going to be required to make these pages work on production. Results may vary depending on deployment but a simple use case for NGINX:
+Some server configuration is required to make these types of pages work in production. This configuration will vary depending on your server environment but here's a simple example configuration for NGINX:
 
 ```
 location ~ "([a-z]*)\/view\/(\d*)$" {
@@ -200,7 +203,7 @@ This directive will provide the `widgets/view/index.html` file for any request l
 
 **Client:**
 
-Extracting path params from the route on the client requires that you add a `react-router` `<Route>` in your component. 
+Extracting path params from the route on the client requires that you use the `react-router` `<Route>` in your component. 
 
 This can be made simpler by using a HOC:
 

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -196,7 +196,7 @@ location ~ "([a-z]*)\/view\/(\d*)$" {
 }
 ```
 
-This directive will provide the `widgets/view/index.html` file for any request like (widgets)/view/1. It will also support other pages by matching the first level of the URL, example http://sitename/sprockets/view/1.
+This directive will provide the `widgets/view/index.html` file for any request like (widgets)/view/1. It will also support other pages by matching the first level of the URL, example `http://sitename/sprockets/view/1`.
 
 **Client:**
 


### PR DESCRIPTION
Hi all,

This is per the convo on Discord this morning about a HOC for client URL params.

I am having some issues testing this in build mode... wanted to mention it here.

When using this config a new page is created in the public output as `/public/widgets/view/index.html` but the the route does not work in the browser. Going to `/widgets/view/10` is a 404, `widgets/view/index.html` works but does not allow one to include the ID.

This feels like something NGINX configs would solve, but it is supposed to work on S3 as well. S3 might work with an additional page setup as a redirect. What would be expected here?

Thanks