### PR TITLE
Support `text/jsx` mediaType in `gatsby-transformer-react-docgen`

### DIFF
--- a/packages/gatsby-transformer-react-docgen/src/__tests__/on-node-create.js
+++ b/packages/gatsby-transformer-react-docgen/src/__tests__/on-node-create.js
@@ -42,15 +42,18 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
     }
   })
 
-  it(`should only process javascript nodes`, () => {
+  it(`should only process javascript and jsx nodes`, () => {
     loadNodeContent = jest.fn(() => new Promise(() => {}))
 
     expect(run({ internal: { mediaType: `text/x-foo` } })).toBeNull()
     expect(
       run({ internal: { mediaType: `application/javascript` } })
     ).toBeDefined()
+    expect(
+      run({ internal: { mediaType: `text/jsx` } })
+    ).toBeDefined()
 
-    expect(loadNodeContent.mock.calls).toHaveLength(1)
+    expect(loadNodeContent.mock.calls).toHaveLength(2)
   })
 
   it(`should extract all components in a file`, async () => {

--- a/packages/gatsby-transformer-react-docgen/src/on-node-create.js
+++ b/packages/gatsby-transformer-react-docgen/src/on-node-create.js
@@ -69,7 +69,7 @@ export default function onCreateNode(
 ) {
   const { createNode, createParentChildLink } = boundActionCreators
 
-  if (node.internal.mediaType !== `application/javascript`) return null
+  if (node.internal.mediaType !== `application/javascript` && node.internal.mediaType !== `text/jsx`) return null
 
   return loadNodeContent(node)
     .then(content => {


### PR DESCRIPTION
This fixes #2941, adding support for the `text/jsx` MIME types within the `react-docgen` transformer.

`text/jsx` [seems to be the correct MIME type](https://github.com/jshttp/mime-types/issues/4#issuecomment-46132049) for `.jsx` files.