### PR TITLE
Add pathPrefix support to manifest plugin

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -1,11 +1,12 @@
 import React from "react"
+import { withPrefix } from "gatsby-link"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   setHeadComponents([
     <link
       key={`gatsby-plugin-manifest-link`}
       rel="manifest"
-      href="/manifest.json"
+      href={withPrefix(`/manifest.json`)}
     />,
     <meta
       key={`gatsby-plugin-manifest-meta`}


### PR DESCRIPTION
This fixes https://github.com/gatsbyjs/gatsby/issues/2078 adding pathPrefix support to the `gatsby-plugin-manifest`.