### PR TITLE
Add `update-notifier` as a dependency to gatsby-cli

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -24,6 +24,7 @@
     "resolve-cwd": "^2.0.0",
     "source-map": "^0.5.7",
     "stack-trace": "^0.0.10",
+    "update-notifier": "^2.3.0",
     "yargs": "^8.0.2",
     "yurnalist": "^0.2.1"
   },

--- a/packages/gatsby-cli/src/index.js
+++ b/packages/gatsby-cli/src/index.js
@@ -12,6 +12,11 @@ global.Promise = require(`bluebird`)
 const version = process.version
 const verDigit = Number(version.match(/\d+/)[0])
 
+const pkg = require(`../package.json`)
+const updateNotifier = require(`update-notifier`)
+// Check if update is available
+updateNotifier({ pkg }).notify()
+
 if (verDigit < 4) {
   report.panic(
     `Gatsby 1.0+ requires node.js v4 or higher (you have ${version}). \n` +


### PR DESCRIPTION
This addition will prompt users to update `gatsby-cli` if they are using anything but the latest version.

I tried my best to follow all the guidelines set forth in `CONTRIBUTING.md`, but if for some reason, I've missed something, do let me know and I'll look into it. 😅

Much love. 💖