### PR TITLE
Issues with windows-build-tools getting hung up

### DIFF
--- a/docs/docs/gatsby-on-windows.md
+++ b/docs/docs/gatsby-on-windows.md
@@ -17,7 +17,7 @@ Build Tools 2015, provided free of charge by Microsoft. These tools are required
 to compile popular native modules. It will also install Python 2.7, configuring
 your machine and npm appropriately.
 
-If - when attempting to install `windows-buld-tools` - the installation gets stuck after installing visual studio build tools, you may find [this remedy](https://github.com/felixrieseberg/windows-build-tools/issues/47#issuecomment-296881488) handy.
+If your `windows-buld-tools` installation gets stuck after Visual Studio Build Tools, [this remedy](https://github.com/felixrieseberg/windows-build-tools/issues/47#issuecomment-296881488) might help.
 
 ### If `npm install` still fails...
 

--- a/docs/docs/gatsby-on-windows.md
+++ b/docs/docs/gatsby-on-windows.md
@@ -17,6 +17,8 @@ Build Tools 2015, provided free of charge by Microsoft. These tools are required
 to compile popular native modules. It will also install Python 2.7, configuring
 your machine and npm appropriately.
 
+If - when attempting to install `windows-buld-tools` - the installation gets stuck after installing visual studio build tools, you may find [this remedy](https://github.com/felixrieseberg/windows-build-tools/issues/47#issuecomment-296881488) handy.
+
 ### If `npm install` still fails...
 
 Sometimes the `windows-build-tools` won't properly install the required

--- a/docs/docs/gatsby-on-windows.md
+++ b/docs/docs/gatsby-on-windows.md
@@ -17,7 +17,7 @@ Build Tools 2015, provided free of charge by Microsoft. These tools are required
 to compile popular native modules. It will also install Python 2.7, configuring
 your machine and npm appropriately.
 
-If your `windows-buld-tools` installation gets stuck after Visual Studio Build Tools, [this remedy](https://github.com/felixrieseberg/windows-build-tools/issues/47#issuecomment-296881488) might help.
+If your `windows-buld-tools` installation stalls after Visual Studio Build Tools finishes, [this remedy](https://github.com/felixrieseberg/windows-build-tools/issues/47#issuecomment-296881488) might help.
 
 ### If `npm install` still fails...
 


### PR DESCRIPTION
After Visual Studio Build Tools are installed, the `windows-build-tools` gets hung up.