### PR TITLE
Adds closing </iframe> tag to google-tag-manager plugin

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -35,7 +35,7 @@ exports.onRenderBody = (
               height="0"
               width="0"
               style="display: none; visibility: hidden"
-            />`,
+            ></iframe>`,
         }}
       />,
     ])


### PR DESCRIPTION
This fixes a bug where disabling JS from a page makes the page unrenderable.  This is because there is a missing `</iframe>`, which is required for the page to compile the HTML correctly.

Steps to repro:
1. load a page that uses this plugin
2. confirm that page loads correctly and the HTML is rendered
3. disable JS
4. notice page doesn't render anything
