### PR TITLE
Minimize HTML as much as possible by default

### DIFF
--- a/packages/gatsby/cache-dir/develop-static-entry.js
+++ b/packages/gatsby/cache-dir/develop-static-entry.js
@@ -71,7 +71,7 @@ module.exports = (locals, callback) => {
     ]),
   })
   htmlStr = renderToStaticMarkup(htmlElement)
-  htmlStr = `<!DOCTYPE html>\n${htmlStr}`
+  htmlStr = `<!DOCTYPE html>${htmlStr}`
 
   callback(null, htmlStr)
 }

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -145,11 +145,7 @@ module.exports = (locals, callback) => {
       id="webpack-manifest"
       key="webpack-manifest"
       dangerouslySetInnerHTML={{
-        __html: `
-            //<![CDATA[
-            window.webpackManifest = ${chunkManifest}
-            //]]>
-            `,
+        __html: `/*<![CDATA[*/window.webpackManifest=${chunkManifest}/*]]>*/`,
       }}
     />
   )
@@ -207,16 +203,12 @@ module.exports = (locals, callback) => {
     <script
       key={`script-loader`}
       dangerouslySetInnerHTML={{
-        __html: `
-  !function(e,t,r){function n(){for(;d[0]&&"loaded"==d[0][f];)c=d.shift(),c[o]=!i.parentNode.insertBefore(c,i)}for(var s,a,c,d=[],i=e.scripts[0],o="onreadystatechange",f="readyState";s=r.shift();)a=e.createElement(t),"async"in i?(a.async=!1,e.head.appendChild(a)):i[f]?(d.push(a),a[o]=n):e.write("<"+t+' src="'+s+'" defer></'+t+">"),a.src=s}(document,"script",[
-  ${scriptsString}
-])
-  `,
+        __html: `/*<![CDATA[*/!function(e,t,r){function n(){for(;d[0]&&"loaded"==d[0][f];)c=d.shift(),c[o]=!i.parentNode.insertBefore(c,i)}for(var s,a,c,d=[],i=e.scripts[0],o="onreadystatechange",f="readyState";s=r.shift();)a=e.createElement(t),"async"in i?(a.async=!1,e.head.appendChild(a)):i[f]?(d.push(a),a[o]=n):e.write("<"+t+' src="'+s+'" defer></'+t+">"),a.src=s}(document,"script",[${scriptsString}])/*]]>*/`,
       }}
     />
   )
 
-  const html = `<!DOCTYPE html>\n ${renderToStaticMarkup(
+  const html = `<!DOCTYPE html>${renderToStaticMarkup(
     <Html
       {...bodyProps}
       headComponents={headComponents}


### PR DESCRIPTION
When I first saw the HTML output from `gatsby build` I wondered why the HTML wasn't completely minimized. With these handful of changes, something like html-minifier wouldn't actually have anything to do.