### PR TITLE
[gatsby-link] add `className` prop to TypeScript declarations

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -4,6 +4,7 @@ import { NavLinkProps } from "react-router-dom";
 export interface GatsbyLinkProps extends NavLinkProps {
   to: string;
   onClick?: (event: any) => void
+  className?: string
 }
 
 export const navigateTo: (path: string) => void;


### PR DESCRIPTION
Fixes #3197.