### PR TITLE
[gatsby-plugin-netlify] create rewrite rules for pages that use matchPath

### DIFF
--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -42,6 +42,7 @@ plugins: [
       mergeLinkHeaders: false, // boolean to turn off the default gatsby js headers (disabled by default, until gzip is fixed for server push)
       mergeCachingHeaders: true, // boolean to turn off the default caching headers
       transformHeaders: (headers, path) => headers, // optional transform for manipulating headers under each path (e.g.sorting), etc.
+      generateMatchPathRewrites: true, // boolean to turn off automatic creation of redirect rules for client only paths
     },
   },
 ];
@@ -127,3 +128,5 @@ You can also create a `_redirects` file in the `static` folder for the same affe
 
 You can validate the `_redirects` config through the
 [Netlify playground app](https://play.netlify.com/redirects).
+
+Redirect rules are automaticly added for [client only paths](/docs/building-apps-with-gatsby/#client-only-routes). If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -129,4 +129,4 @@ You can also create a `_redirects` file in the `static` folder for the same affe
 You can validate the `_redirects` config through the
 [Netlify playground app](https://play.netlify.com/redirects).
 
-Redirect rules are automaticly added for [client only paths](/docs/building-apps-with-gatsby/#client-only-routes). If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.
+Redirect rules are automatically added for [client only paths](/docs/building-apps-with-gatsby/#client-only-routes). If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.

--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -13,6 +13,7 @@ export const DEFAULT_OPTIONS = {
   mergeLinkHeaders: true,
   mergeCachingHeaders: true,
   transformHeaders: _.identity, // optional transform for manipulating headers for sorting, etc
+  generateMatchPathRewrites: true, // generate rewrites for client only paths
 }
 
 export const SECURITY_HEADERS = {

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -1,10 +1,14 @@
 import { HEADER_COMMENT } from "./constants"
 import { appendFile, exists, readFile, writeFile } from "fs-extra"
 
-export default async function writeRedirectsFile(pluginData, redirects) {
+export default async function writeRedirectsFile(
+  pluginData,
+  redirects,
+  rewrites
+) {
   const { publicFolder } = pluginData
 
-  if (!redirects.length) return null
+  if (!redirects.length && !rewrites.length) return null
 
   const FILE_PATH = publicFolder(`_redirects`)
 
@@ -43,6 +47,8 @@ export default async function writeRedirectsFile(pluginData, redirects) {
     return pieces.join(`  `)
   })
 
+  rewrites = rewrites.map(({ fromPath, toPath }) => `${fromPath}  ${toPath}  200`)
+
   let appendToFile = false
 
   // Websites may also have statically defined redirects
@@ -56,7 +62,7 @@ export default async function writeRedirectsFile(pluginData, redirects) {
     }
   }
 
-  const data = `${HEADER_COMMENT}\n\n${redirects.join(`\n`)}`
+  const data = `${HEADER_COMMENT}\n\n${[...redirects, ...rewrites].join(`\n`)}`
 
   return appendToFile
     ? appendFile(FILE_PATH, `\n\n${data}`)

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -35,8 +35,21 @@ exports.onPostBuild = async ({ store, pathPrefix }, userPluginOptions) => {
 
   const { redirects } = store.getState()
 
+  let rewrites = []
+  if (pluginOptions.generateMatchPathRewrites) {
+    const { pages } = store.getState()
+    rewrites = pages
+      .filter(page => page.matchPath && page.matchPath !== page.path)
+      .map(page => {
+        return {
+          fromPath: page.matchPath,
+          toPath: page.path,
+        }
+      })
+  }
+
   await Promise.all([
     buildHeadersProgram(pluginData, pluginOptions),
-    createRedirects(pluginData, redirects),
+    createRedirects(pluginData, redirects, rewrites),
   ])
 }


### PR DESCRIPTION
This adds feature to `gatsby-plugin-netlify` that automaticly generate `_redirects` entries for pages that use `matchPath`. It's implementation of idea from https://github.com/gatsbyjs/gatsby/pull/3168#issuecomment-351257197

It seems that react router path parameters are compatible with netlify so I just write them as they are. Not sure if they need to be prefixed (in case of `pathPrefix`)?

This will propably need updated `readme`, I'll add that when code is agreed on (in case if this would feature would be changed to opt-in).