### PR TITLE
Replace absolute links with relative links for docs features on gatsbyjs.org

### DIFF
--- a/docs/blog/2017-09-26-embracing-graphql/index.md
+++ b/docs/blog/2017-09-26-embracing-graphql/index.md
@@ -81,7 +81,7 @@ works, but I have it working, so cool”. Easy to update — check.
 
 I'm not the type of person to settle on “It's working so don't touch anything”.
 So I started digging into how Gatsby 1.x works—particular the
-[data layer](https://www.gatsbyjs.org/tutorial/part-four/#data-in-gatsby).
+[data layer](/tutorial/part-four/#data-in-gatsby).
 
 Things really clicked when I read this part about the GraphiQL IDE and watched
 how to drill down on the data.

--- a/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
+++ b/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
@@ -36,7 +36,7 @@ Let's jump in.
 
 **NOTE:** If you _don't_ already have a blog or want to create one from scratch
 there's a
-[tutorial for exactly that right here](https://www.gatsbyjs.org/blog/2017-07-19-creating-a-blog-with-gatsby/).
+[tutorial for exactly that right here](/blog/2017-07-19-creating-a-blog-with-gatsby/).
 
 Let's move some files around. Gatsby gives you a good amount of flexibility when
 it comes to file structure, but for consistency with the docs I'm going to use

--- a/docs/blog/2017-10-03-smartive-goes-gatsby/index.md
+++ b/docs/blog/2017-10-03-smartive-goes-gatsby/index.md
@@ -52,7 +52,7 @@ the content. Although this felt right at first but, as all of us are developers,
 working around the constraints of it just didn’t feel right.
 
 Luckily at that time Gatsby version 1.0
-[just got released](https://www.gatsbyjs.org/blog/gatsby-v1/) and we decided to
+[just got released](/blog/gatsby-v1/) and we decided to
 give it a try during one of our so-called Hackdays. We instantly fell in love
 with the simplicity of the system. Our first approach was to just use all the
 components which we already had created for Next.js and backed it by simple JSON

--- a/docs/blog/2017-10-05-portfolio-site-gatsby-wordpress/index.md
+++ b/docs/blog/2017-10-05-portfolio-site-gatsby-wordpress/index.md
@@ -54,7 +54,7 @@ will I query it?
 
 The answer... [GraphQL](http://graphql.org/). Gatsby ships with it and through
 an npm install of a
-[gatsby-source plugin](https://www.gatsbyjs.org/docs/plugins/) of your choice
+[gatsby-source plugin](/docs/plugins/) of your choice
 and a tiny bit of a config, you can start querying in no time. I was amazed with
 how simple queries are using GraphQL. You look at them and you go "Huh, that's
 it? Really?". Gatsby even ships with an in-browser query tester so you can see
@@ -109,7 +109,7 @@ export const postQuery = graphql`
 ## Wrap up and future
 
 In just a few weekends I managed to rebuild my portfolio site with the blog I
-wanted. I'd highly recommend [Gatsby](https://www.gatsbyjs.org/tutorial/) for
+wanted. I'd highly recommend [Gatsby](/tutorial/) for
 anyone who has started getting acquainted with React. Before I started this
 project I didn't know a lot about:
 

--- a/docs/blog/2017-10-20-from-wordpress-to-developing-in-react-starting-to-see-it/index.md
+++ b/docs/blog/2017-10-20-from-wordpress-to-developing-in-react-starting-to-see-it/index.md
@@ -20,7 +20,7 @@ developer on a project.
 
 So I decided to dive into learning React with a few courses and some
 experimentation. I had the aim of building a site in
-[Gatsby.js](https://www.gatsbyjs.org/ "Blazing-fast static site generator for React")
+[Gatsby.js](/ "Blazing-fast static site generator for React")
 as a test for doing projects built entirely in React.
 
 ## Letting Go
@@ -129,7 +129,7 @@ focus on context without having to grok SCSS again, reducing mental friction.
 
 ## My Project
 
-Following the [tutorial on Gatsbyjs](https://www.gatsbyjs.org/tutorial/) I built
+Following the [tutorial on Gatsbyjs](/tutorial/) I built
 up my project from scratch, breaking things profusely at first, but it honestly
 didn’t take long to gain confidence enough so that I launched my first site at
 [freebabylon5.com](https://freebabylon5.com "Our last, best hope of getting back on the air")
@@ -137,7 +137,7 @@ recently.
 
 Be warned: the tutorial isn’t quite finished yet, you might be better off
 starting with
-[one of the starter kits already available](https://www.gatsbyjs.org/docs/gatsby-starters/),
+[one of the starter kits already available](/docs/gatsby-starters/),
 so that you get `react-helmet` and active links implemented, the 2 things I had
 to learn independently.
 
@@ -163,7 +163,7 @@ hacked.
 
 Using GatsbyJS with its “Bring Your Own Data” strategy makes perfect sense, and
 we’re about to start building our first Gatsby client site using the plugin
-[`gatsby-source-wordpress`](https://www.gatsbyjs.org/packages/gatsby-source-wordpress/ "WordPress content into Gatsby")
+[`gatsby-source-wordpress`](/packages/gatsby-source-wordpress/ "WordPress content into Gatsby")
 to pull in our data and build a totally secure website with some pretty
 impressive gains on loading time. We’ll also sleep better at night knowing
 insecurities in WordPress are no longer putting our clients at risk.

--- a/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
+++ b/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
@@ -87,12 +87,12 @@ programatic creation of pages explained in the next section.
 ### Programatic page creation
 
 This is the official
-[documentation](https://www.gatsbyjs.org/docs/creating-and-modifying-pages/),
+[documentation](/docs/creating-and-modifying-pages/),
 plus there is a
-[tutorial](https://www.gatsbyjs.org/tutorial/part-four/#data-in-gatsby) which
+[tutorial](/tutorial/part-four/#data-in-gatsby) which
 gives examples. Basically, I had to create a `gatsby-node.js` file which exports
 `createPages` method using the `createPage` action from
-[`boundActionCreators`](https://www.gatsbyjs.org/docs/bound-action-creators/).
+[`boundActionCreators`](/docs/bound-action-creators/).
 
 This might sound way more complicated than what it is:
 
@@ -155,13 +155,13 @@ keep my previous URLs of existing content the same in the new system.
 
 The display of the data is handled by a React component acting as a template. My
 case is nothing different than the
-[official documentation](https://www.gatsbyjs.org/docs/building-with-components/#page-template-components).
+[official documentation](/docs/building-with-components/#page-template-components).
 
 ### Adding styles
 
 Now that the system displays the content, it's time to style it. I decided to go
 for the
-[`typography.js` route](https://www.gatsbyjs.org/tutorial/part-two/#typographyjs).
+[`typography.js` route](/tutorial/part-two/#typographyjs).
 The approach is well documented and you can also see
 [previews of the themes online](http://kyleamathews.github.io/typography.js/).
 

--- a/docs/blog/2017-12-06-gatsby-plus-contentful-plus-netlify/index.md
+++ b/docs/blog/2017-12-06-gatsby-plus-contentful-plus-netlify/index.md
@@ -57,7 +57,7 @@ make content changes or add a markdown file then fire off a site rebuild
 command, and finally redeploy. Even though static site generators have solved
 this in many clever ways, I feel Gatsby solves this problem in a particularly
 elegant fashion via it’s GraphQL data layer (more on that later) and its vast
-ecosystem of data [source plugins](https://www.gatsbyjs.org/docs/plugins/).
+ecosystem of data [source plugins](/docs/plugins/).
 
 Before I jump into the topic of content and “data”, I want to briefly say that
 building a static site template with React-based architecture and hot module
@@ -78,7 +78,7 @@ experience couldn’t rely on creating a file and committing changes to a git
 repo.
 
 > Sidebar: There is
-> [Gatsby-Source-Wordpress](https://www.gatsbyjs.org/packages/gatsby-source-wordpress/)
+> [Gatsby-Source-Wordpress](/packages/gatsby-source-wordpress/)
 > plugin that pulls in content via a Wordpress API. However, to me, this was not
 > appealing because I was trying to avoid hosting a traditional CMS entirely.
 
@@ -122,7 +122,7 @@ for grabbing content as well, but how you deal with actually pulling it into
 your React components/pages with GraphQL is beautiful.
 
 After you install the `gatsby-source-contentful`
-[plugin](https://www.gatsbyjs.org/packages/gatsby-source-contentful/) with NPM
+[plugin](/packages/gatsby-source-contentful/) with NPM
 and add your Contentful API credentials to the gatsby-config file, the fun
 begins.
 

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -161,7 +161,7 @@ format, use the `withWebp` fragments. If the browser doesn't support WebP,
 `gatsby-image` will fall back to the default image format.
 
 _Please see the
-[gatsby-plugin-sharp](https://www.gatsbyjs.org/packages/gatsby-plugin-sharp/#tracedsvg)
+[gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/#tracedsvg)
 documentation for more information on `tracedSVG` and its configuration
 options._
 

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -108,7 +108,7 @@ You can validate the `_headers` config through the
 
 ### Redirects
 
-You can create redirects using the [`createRedirect`](https://www.gatsbyjs.org/docs/bound-action-creators/#createRedirect) action.
+You can create redirects using the [`createRedirect`](/docs/bound-action-creators/#createRedirect) action.
 
 An example:
 

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -196,7 +196,7 @@ quoting the Sharp documentation:
 
 Generates a traced SVG of the image (see [the original GitHub issue][9]) and
 returns the SVG as "[optimized URL-encoded][10]" `data:` URI. It it used in
-[gatsby-image](https://www.gatsbyjs.org/packages/gatsby-image/) to provide an
+[gatsby-image](/packages/gatsby-image/) to provide an
 alternative to the default inline base64 placeholder image.
 
 Uses [node-potrace][11] and [SVGO][12] under the hood. Default settings for


### PR DESCRIPTION
Per discussion on #3204, replaced absolute paths with relative paths in markdown files for docs that are featured on gatsbyjs.org. That included anything in `/docs/blog/` and some files in `/packages`.