### PR TITLE
[gatsby-plugin-sitemap] - update docs

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -20,8 +20,43 @@ plugins: [
 ]
 ```
 
-Above is the minimal configuration required to have it work, however, note that
-the
-[default query](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js)
-only retrieves nodes of type `MarkdownRemark`. Any parameter in `defaultOptions`
-can be overridden.
+Above is the minimal configuration required to have it work. By default, the
+generated sitemap will include all of your site's pages except the dev 404 page
+(`/dev-404-page/`).
+
+The [default query](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L16)
+as well as any of the other `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L15)
+can be overridden - for example:
+
+```javascript
+// In your gatsby-config.js
+siteMetadata: {
+  siteUrl: `https://www.example.com`,
+},
+plugins: [
+  {
+    resolve: `gatsby-plugin-sitemap`
+    options: {
+      output: `/some-other-sitemap.xml`,
+      query: `
+        {
+          site {
+            siteMetadata {
+              siteUrl
+            }
+          }
+
+          allSitePage {
+            edges {
+              node {
+                path
+              }
+            }
+          }
+      }`
+    }
+  }
+]
+```
+
+_NOTE: This plugin only generates output when run in `production` mode! To test your sitemap, run: `gatsby build && gatsby serve`_


### PR DESCRIPTION
* correct default query description (all pages are included, not just makdown)

* clarify how to override defaultOptions via gatsby-config.js

* add warning: sitemap is not generated when running `gatsby develop`