### PR TITLE
[gatsby-remark-katex/www] Add plugin README and plugin to docs/plugins

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -99,6 +99,7 @@ root.
 * [gatsby-remark-autolink-headers](/packages/gatsby-remark-autolink-headers/)
 * [gatsby-remark-copy-linked-files](/packages/gatsby-remark-copy-linked-files/)
 * [gatsby-remark-images](/packages/gatsby-remark-images/)
+* [gatsby-remark-katex](/packages/gatsby-remark-katex/)
 * [gatsby-remark-prismjs](/packages/gatsby-remark-prismjs/)
 * [gatsby-remark-responsive-iframe](/packages/gatsby-remark-responsive-iframe/)
 * [gatsby-remark-smartypants](/packages/gatsby-remark-smartypants/)

--- a/packages/gatsby-remark-katex/README.md
+++ b/packages/gatsby-remark-katex/README.md
@@ -1,0 +1,58 @@
+# gatsby-remark-katex
+
+[gatsby-remark-katex][1] adds math equation support to gatsby using
+[remark-math][2] and [katex][3]. Live example at [using-remark.gatsbyjs.org/katex/](https://using-remark.gatsbyjs.org/katex/).
+
+## Install
+
+`npm install --save gatsby-transformer-remark atsby-remark-katex`
+
+## How to use
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      plugins: [
+        `gatsby-remark-katex`,
+      ],
+    },
+  },
+],
+```
+
+**Add Katex CSS to your template:** Katex's CSS file is required to render the formulas correctly. Include the CSS file in your template ([example][4]):
+
+```
+require(`katex/dist/katex.min.css`)
+```
+
+### Math Equations in Inline Mode
+
+Surround your equation with `$` to generate a math equation in inline mode.
+
+**Example markdown:**
+
+```
+$a^2 + b^2 = c^2$
+```
+
+### Math Equations in Display Mode
+
+Surround your equation with `$$` and new-lines to generate a math equation in
+display mode.
+
+**Example markdown:**
+
+```
+$$
+a^2 + b^2 = c^2
+$$
+```
+
+[1]: https://www.gatsbyjs.org/packages/gatsby-remark-katex/
+[2]: https://github.com/Rokt33r/remark-math
+[3]: https://github.com/Khan/KaTeX
+[4]: https://github.com/gatsbyjs/gatsby/blob/master/examples/using-remark/src/templates/template-blog-post.js


### PR DESCRIPTION
README content is based on the using-remark example page by @jeffrey-xiao (https://using-remark.gatsbyjs.org/katex/).

Ref. #1524, #1731