### PR TITLE
(docs): add gatsby-plugin-mixpanel to plugins list

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -137,6 +137,7 @@ root.
 * [gatsby-plugin-i18n](https://github.com/angeloocana/gatsby-plugin-i18n)
 * [gatsby-plugin-intercom-spa](https://github.com/toriihq/gatsby-plugin-intercom-spa)
 * [gatsby-plugin-klipse](https://github.com/ahmedelgabri/gatsby-plugin-klipse)
+* [gatsby-plugin-mixpanel](https://github.com/thomascarvalho/gatsby-plugin-mixpanel)
 * [gatsby-plugin-protoculture](https://github.com/atrauzzi/gatsby-plugin-protoculture)
 * [gatsby-plugin-purify-css](https://github.com/rongierlach/gatsby-plugin-purify-css)
 * [gatsby-plugin-segment-js](https://github.com/benjaminhoffman/gatsby-plugin-segment-js)


### PR DESCRIPTION
It's a plugin to easily integrate mixpanel in a gatsby project with react-mixpanel package.