### PR TITLE
Fix page hot loading fixes #3255

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -152,6 +152,18 @@ const debouncedWritePages = _.debounce(
   500,
   { leading: true }
 )
+emitter.on(`CREATE_PAGE`, () => {
+  // Ignore CREATE_PAGE until bootstrap is finished
+  // as this is called many many times during bootstrap and
+  // we can ignore them until CREATE_PAGE_END is called.
+  //
+  // After bootstrap, we need to listen for this as stateful page
+  // creators e.g. the internal plugin "component-page-creator"
+  // calls createPage directly so CREATE_PAGE_END won't get fired.
+  if (bootstrapFinished) {
+    debouncedWritePages()
+  }
+})
 
 emitter.on(`CREATE_PAGE_END`, () => {
   debouncedWritePages()


### PR DESCRIPTION
In https://github.com/gatsbyjs/gatsby/pull/3237 I added `CREATE_PAGE_END` as cleaner way to know when pages are finished being added and stopped listening to `CREATE_PAGE` as it's really noisy and sometimes leads to extra writes.

But I forgot that `CREATE_PAGE_END` won't always be called as plugins implementing `createPagesStagefully` can create pages whenever so we still need to listen to `CREATE_PAGES`. 

This PR restores listening to `CREATE_PAGE` but only after bootstrap is finished.