### PR TITLE
Check if a node is found when running query

### DIFF
--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -114,13 +114,18 @@ module.exports = ({
         ? 0
         : sift.indexOf({ $and: siftArgs }, myNodes)
 
-      // Create dependency between resulting node and the path.
-      createPageDependency({
-        path,
-        nodeId: myNodes[index].id,
-      })
+      // If a node is found, create a dependency between the resulting node and
+      // the path.
+      if (index !== -1) {
+        createPageDependency({
+          path,
+          nodeId: myNodes[index].id,
+        })
 
-      return myNodes[index]
+        return myNodes[index]
+      } else {
+        return null
+      }
     }
 
     let result = _.isEmpty(siftArgs)


### PR DESCRIPTION
Without this, people would sometimes see a mysterious graphql error:
"GraphQLError: Cannot read property 'id' of undefined".

It happened because we didn't check if a query has a result before
trying to use the result.

It seems this error often occurs because people put a page component
template into src/pages which results in Gatsby trying to run it as a
normal page causing the component's graphql query to fail. We should
error when people put page templates into src/pages to prevent problems.