### PR TITLE
[gatsby-transformer-react-docgen] Improves docs

### DIFF
--- a/packages/gatsby-transformer-react-docgen/README.md
+++ b/packages/gatsby-transformer-react-docgen/README.md
@@ -1,1 +1,46 @@
 # gatsby-transformer-react-docgen
+
+Parses inline component-documentation using
+[react-docgen](https://github.com/reactjs/react-docgen).
+
+## Install
+
+```
+yarn add gatsby-transformer-react-docgen
+```
+
+## Usage
+
+Add a plugin-entry to your `gatsby-config.js`
+
+```js
+module.exports = {
+  // ...,
+  plugins: [...`gatsby-transformer-react-docgen`],
+}
+```
+
+You'll also need to include a source-plugin, such as [gatsby-source-filesystem],
+so that the transformer has access to source data.
+
+## How to query
+
+An example _graphql_ query to get nodes:
+
+```graphql
+{
+  allComponentMetadata {
+    edges {
+      node {
+        displayName
+        description
+        props {
+          name
+          type
+          required
+        }
+      }
+    }
+  }
+}
+```

--- a/packages/gatsby-transformer-react-docgen/README.md
+++ b/packages/gatsby-transformer-react-docgen/README.md
@@ -20,7 +20,8 @@ module.exports = {
 }
 ```
 
-You'll also need to include a source-plugin, such as [gatsby-source-filesystem],
+You'll also need to include a source-plugin, such as
+[gatsby-source-filesystem](https://www.npmjs.com/package/gatsby-source-filesystem),
 so that the transformer has access to source data.
 
 ## How to query


### PR DESCRIPTION
We're building out a living styleguide a la [react-styleguidist](https://github.com/styleguidist/react-styleguidist) and I worked through this. Pretty self-explanatory if you're familiar with Gatsby concepts, but always good to have.

I'll PR the styleguide as an example when it's in a good place.