### PR TITLE
Load layouts before pages

### DIFF
--- a/packages/gatsby-transformer-react-docgen/README.md
+++ b/packages/gatsby-transformer-react-docgen/README.md
@@ -17,7 +17,7 @@ Add a plugin-entry to your `gatsby-config.js`
 module.exports = {
   // ...,
   plugins: [...`gatsby-transformer-react-docgen`],
-}
+};
 ```
 
 You'll also need to include a source-plugin, such as

--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -58,14 +58,14 @@ const writePages = async () => {
   let syncRequires = `// prefer default export if available
 const preferDefault = m => m && m.default || m
 \n\n`
-syncRequires += `exports.layouts = {\n${pageLayouts
-  .map(
-    l =>
-      `  "${l.machineId}": preferDefault(require("${
-        l.componentWrapperPath
-      }"))`
-  )
-  .join(`,\n`)}
+  syncRequires += `exports.layouts = {\n${pageLayouts
+    .map(
+      l =>
+        `  "${l.machineId}": preferDefault(require("${
+          l.componentWrapperPath
+        }"))`
+    )
+    .join(`,\n`)}
 }\n\n`
   syncRequires += `exports.components = {\n${components
     .map(
@@ -87,7 +87,6 @@ syncRequires += `exports.layouts = {\n${pageLayouts
     )
     .join(`,\n`)}
 }`
-
 
   // Create file with async requires of layouts/components/json files.
   let asyncRequires = `// prefer default export if available

--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -58,6 +58,15 @@ const writePages = async () => {
   let syncRequires = `// prefer default export if available
 const preferDefault = m => m && m.default || m
 \n\n`
+syncRequires += `exports.layouts = {\n${pageLayouts
+  .map(
+    l =>
+      `  "${l.machineId}": preferDefault(require("${
+        l.componentWrapperPath
+      }"))`
+  )
+  .join(`,\n`)}
+}\n\n`
   syncRequires += `exports.components = {\n${components
     .map(
       c =>
@@ -77,16 +86,8 @@ const preferDefault = m => m && m.default || m
         )}")`
     )
     .join(`,\n`)}
-}\n\n`
-  syncRequires += `exports.layouts = {\n${pageLayouts
-    .map(
-      l =>
-        `  "${l.machineId}": preferDefault(require("${
-          l.componentWrapperPath
-        }"))`
-    )
-    .join(`,\n`)}
 }`
+
 
   // Create file with async requires of layouts/components/json files.
   let asyncRequires = `// prefer default export if available


### PR DESCRIPTION
Resolves the issue https://github.com/gatsbyjs/gatsby/issues/1994

Gatsby loaded the css from pages before loading it from layouts.
This meant that page specific css could be overwritten by layout wide css (bootstrap, font-awesome).

Normally you'd want bootstrap & font-awesome load before page specific css.