### PR TITLE
Adjust inline highlighting

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -546,7 +546,7 @@ export default () => (
 Let's add the same inline `User` component but this time using Glamor's `css`
 prop.
 
-```jsx{5-26,32-40}
+```jsx{5-27,33-40}
 import React from "react"
 
 import Container from "../components/container"


### PR DESCRIPTION
The changed code highlighting is slightly off. This should fix it and should highlight the correct chunks of new code for the Glamor example.

<img width="704" alt="screen shot 2017-12-20 at 12 08 01 am" src="https://user-images.githubusercontent.com/16144158/34192124-13563532-e51a-11e7-8041-cb76ff922c68.png">
The highlighting should extend to the closing `</div>` tag

<img width="693" alt="screen shot 2017-12-20 at 12 08 10 am" src="https://user-images.githubusercontent.com/16144158/34192125-13647f34-e51a-11e7-8e81-c14cc26694b6.png">
The highlighting should not include `<p>Glamor is cool</p>` as that was added in a previous example.