### PR TITLE
Upgrade style-loader to fix CSS modules issue

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -102,7 +102,7 @@
     "socket.io": "^2.0.3",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "string-similarity": "^1.2.0",
-    "style-loader": "^0.13.0",
+    "style-loader": "^0.19.0",
     "type-of": "^2.0.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.3",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -102,7 +102,7 @@
     "socket.io": "^2.0.3",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "string-similarity": "^1.2.0",
-    "style-loader": "^0.19.0",
+    "style-loader": "^0.19.1",
     "type-of": "^2.0.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11964,7 +11964,7 @@ strong-log-transformer@^1.0.6:
     moment "^2.6.0"
     through "^2.3.4"
 
-style-loader@^0.19.0:
+style-loader@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.19.1.tgz#591ffc80bcefe268b77c5d9ebc0505d772619f85"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11089,6 +11089,12 @@ sc-simple-broker@~2.1.0:
   dependencies:
     sc-channel "~1.1.0"
 
+schema-utils@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
+  dependencies:
+    ajv "^5.0.0"
+
 scroll-behavior@^0.9.1:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.4.tgz#73b4a0eae3e59c0b8f3b6fc1ff78f054a513e79c"
@@ -11958,11 +11964,12 @@ strong-log-transformer@^1.0.6:
     moment "^2.6.0"
     through "^2.3.4"
 
-style-loader@^0.13.0:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.2.tgz#74533384cf698c7104c7951150b49717adc2f3bb"
+style-loader@^0.19.0:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.19.1.tgz#591ffc80bcefe268b77c5d9ebc0505d772619f85"
   dependencies:
     loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
 
 styled-jsx@^1.0.10:
   version "1.0.11"


### PR DESCRIPTION
Upgrade style-loader in `gatsby` to fix https://github.com/webpack-contrib/style-loader/issues/182

I was running with a weird CSS Modules issue within my gatsby site involving composition. Turns out it was caused by an old version of `style-loader` and was fixed in a more recent version than the one that `gatsby` is using. So this PR just upgrades said package.

I gotta admit I only have one testsite (it's still private for now so I can't share it, sorry!) and I did not see any issues by running this PR on it.