### PR TITLE
Add endpoint for refresh

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -19,6 +19,7 @@ const launchEditor = require(`react-dev-utils/launchEditor`)
 const formatWebpackMessages = require(`react-dev-utils/formatWebpackMessages`)
 const chalk = require(`chalk`)
 const address = require(`address`)
+const sourceNodes = require(`../utils/source-nodes`)
 
 // const isInteractive = process.stdout.isTTY
 
@@ -91,6 +92,24 @@ async function startServer(program) {
       graphiql: true,
     })
   )
+
+  /**
+   * Refresh external data sources.
+   * This behavior is disabled by default, but the ENABLE_REFRESH_ENDPOINT env var enables it
+   * If no GATSBY_REFRESH_TOKEN env var is available, then no Authorization header is required
+  **/
+  app.post(`/__refresh`, (req, res) => {
+    const enableRefresh = process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
+    const refreshToken = process.env.GATSBY_REFRESH_TOKEN
+    const authorizedRefresh = (!refreshToken || req.headers.authorization === refreshToken)
+
+    if (enableRefresh && authorizedRefresh) {
+      console.log(`Refreshing source data`)
+      sourceNodes()
+    }
+    res.end()
+  })
+
   app.get(`/__open-stack-frame-in-editor`, (req, res) => {
     launchEditor(req.query.fileName, req.query.lineNumber)
     res.end()


### PR DESCRIPTION
This is only active if you actively enable via an environment variable. This is following up on #3054 per @KyleAMathews 's idea for a #dark-deploy
