### PR TITLE
Don't throw error if query not in page/layout component fixes #2030

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -15,7 +15,6 @@ const { store } = require(`../../redux/`)
 const { boundActionCreators } = require(`../../redux/actions`)
 const queryCompiler = require(`./query-compiler`).default
 const queue = require(`./query-queue`)
-const invariant = require(`invariant`)
 const normalize = require(`normalize-path`)
 
 exports.extractQueries = () => {

--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -88,14 +88,12 @@ const watch = rootDir => {
     queryCompiler().then(queries => {
       const components = store.getState().components
       queries.forEach(({ text }, id) => {
-        invariant(
-          components[id],
-          `${id} not found in the store components: ${JSON.stringify(
-            components
-          )}`
-        )
-
-        if (text !== components[id].query) {
+        // Queries can be parsed from non page/layout components e.g. components
+        // with fragments so ignore those.
+        //
+        // If the query has changed, set the new query in the store and run
+        // its queries.
+        if (components[id] && text !== components[id].query) {
           boundActionCreators.replaceComponentQuery({
             query: text,
             componentPath: id,


### PR DESCRIPTION
We were throwing errors for what actually wasn't an error. Which is
confusing enough but also, to add insult to injury, the error message is
inscrutable.

This PR removes the invalid check.