### PR TITLE
Enable cross-origin requests in development mode

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -93,6 +93,13 @@ async function startServer(program) {
     })
   )
 
+  // Allow requests from any origin. Avoids CORS issues when using the `--host` flag.
+  app.use((req, res, next) => {
+    res.header(`Access-Control-Allow-Origin`, `*`)
+    res.header(`Access-Control-Allow-Headers`, `Origin, X-Requested-With, Content-Type, Accept`)
+    next()
+  })
+
   /**
    * Refresh external data sources.
    * This behavior is disabled by default, but the ENABLE_REFRESH_ENDPOINT env var enables it


### PR DESCRIPTION
Allow cross-origin requests in `gatsby develop`.  This should avoid CORS errors when using the `--host` flag.

Hopefully this helps with working out #2956.