### PR TITLE
Bugfix for gatsby-remark-embed-snippet

### DIFF
--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-remark-embed-snippet",
   "description": "Gatsby plugin to embed formatted code snippets within markdown",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "dependencies": {
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-remark-embed-snippet/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-embed-snippet/src/__tests__/__snapshots__/index.js.snap
@@ -684,6 +684,72 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-embed-snippet JavaScript files should support multiple highlight directives within a single file 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 23,
+              "line": 1,
+              "offset": 22,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "html",
+          "value": "<div class=\\"gatsby-highlight\\">
+        <pre class=\\"language-jsx\\"><code><span class=\\"token keyword\\">let</span> notHighlighted<span class=\\"token punctuation\\">;</span>
+<span class=\\"gatsby-highlight-code-line\\"><span class=\\"token keyword\\">let</span> highlighted<span class=\\"token punctuation\\">;</span>
+</span>
+notHighlighted <span class=\\"token operator\\">=</span> <span class=\\"token number\\">1</span><span class=\\"token punctuation\\">;</span>
+
+<span class=\\"gatsby-highlight-code-line\\">highlighted <span class=\\"token operator\\">=</span> <span class=\\"token number\\">2</span><span class=\\"token punctuation\\">;</span>
+</span>
+notHighlighted <span class=\\"token operator\\">=</span> <span class=\\"token number\\">3</span><span class=\\"token punctuation\\">;</span>
+<span class=\\"gatsby-highlight-code-line\\">highlighted <span class=\\"token operator\\">=</span> <span class=\\"token number\\">4</span><span class=\\"token punctuation\\">;</span>
+</span></code></pre>
+        </div>",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 23,
+      "line": 1,
+      "offset": 22,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`gatsby-remark-embed-snippet Markdown files should extract the correct Prism language 1`] = `
 Object {
   "children": Array [

--- a/packages/gatsby-remark-embed-snippet/src/__tests__/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/__tests__/index.js
@@ -344,6 +344,37 @@ describe(`gatsby-remark-embed-snippet`, () => {
 
       expect(transformed).toMatchSnapshot()
     })
+
+    it(`should support multiple highlight directives within a single file`, () => {
+      fs.readFileSync.mockReturnValue(
+        `
+        let notHighlighted;
+        // highlight-range{1}
+        let highlighted;
+
+        notHighlighted = 1;
+
+        // highlight-next-line
+        highlighted = 2;
+
+        // highlight-range{2}
+        notHighlighted = 3;
+        highlighted = 4;
+      `
+          .replace(/^ +/gm, ``)
+          .trim()
+      )
+
+      const markdownAST = remark.parse(`\`embed:hello-world.js\``)
+      const transformed = plugin(
+        { markdownAST },
+        {
+          directory: `examples`,
+        }
+      )
+
+      expect(transformed).toMatchSnapshot()
+    })
   })
 
   describe(`Markdown files`, () => {

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -100,9 +100,7 @@ module.exports = (
         .readFileSync(path, `utf8`)
         .split(`\n`)
         .filter((line, index) => {
-          index -= filteredLineOffset
-
-          const returnValue = filterDirectives(line, index)
+          const returnValue = filterDirectives(line, index - filteredLineOffset)
 
           if (!returnValue) {
             filteredLineOffset++

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -53,6 +53,42 @@ module.exports = (
         throw Error(`Invalid snippet specified; no such file "${path}"`)
       }
 
+      // This method removes lines that contain only highlight directives,
+      // eg 'highlight-next-line' or 'highlight-range' comments.
+      function filterDirectives(line, index) {
+        if (line.includes(`highlight-next-line`)) {
+          // Although we're highlighting the next line,
+          // We can use the current index since we also filter this lines.
+          // (Highlight line numbers are 1-based).
+          highlightLines.push(index + 1)
+
+          // Strip lines that contain highlight-next-line comments.
+          return false
+        } else if (line.includes(`highlight-range`)) {
+          const match = line.match(/highlight-range{([^}]+)}/)
+          if (!match) {
+            console.warn(`Invalid match specified: "${line.trim()}"`)
+            return false
+          }
+          const range = match[1]
+
+          // Highlight line numbers are 1-based but so are offsets.
+          // Remember that the current line (index) will be removed.
+          rangeParser.parse(range).forEach(offset => {
+            highlightLines.push(index + offset)
+          })
+
+          // Strip lines that contain highlight-range comments.
+          return false
+        }
+
+        return true
+      }
+
+      // Track the number of lines we've filtered,
+      // So we can adjust the highlighted index accordingly.
+      let filteredLineOffset = 0
+
       // Parse file contents and extract highlight markers:
       // highlight-line, highlight-next-line, highlight-range
       // We support JS, JSX, HTML, CSS, and YAML style comments.
@@ -64,33 +100,15 @@ module.exports = (
         .readFileSync(path, `utf8`)
         .split(`\n`)
         .filter((line, index) => {
-          if (line.includes(`highlight-next-line`)) {
-            // Although we're highlighting the next line,
-            // We can use the current index since we also filter this lines.
-            // (Highlight line numbers are 1-based).
-            highlightLines.push(index + 1)
+          index -= filteredLineOffset
 
-            // Strip lines that contain highlight-next-line comments.
-            return false
-          } else if (line.includes(`highlight-range`)) {
-            const match = line.match(/highlight-range{([^}]+)}/)
-            if (!match) {
-              console.warn(`Invalid match specified: "${line.trim()}"`)
-              return false
-            }
-            const range = match[1]
+          const returnValue = filterDirectives(line, index)
 
-            // Highlight line numbers are 1-based but so are offsets.
-            // Remember that the current line (index) will be removed.
-            rangeParser.parse(range).forEach(offset => {
-              highlightLines.push(index + offset)
-            })
-
-            // Strip lines that contain highlight-range comments.
-            return false
+          if (!returnValue) {
+            filteredLineOffset++
           }
 
-          return true
+          return returnValue
         })
         .map((line, index) => {
           if (line.includes(`highlight-line`)) {


### PR DESCRIPTION
Noticed a possible off-by-N error when integrating the `gatsby-remark-embed-snippet` plug-in into the React website. Fixed and added a test.