### PR TITLE
fix bug: offsetY of autolink-header do not work with encodeURI

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -1,5 +1,5 @@
 const scrollToHash = offsetY => {
-  // Make sure React has had a change to flush to DOM first.
+  // Make sure React has had a chance to flush to DOM first.
   setTimeout(() => {
     const hash = window.decodeURI(window.location.hash.replace(`#`, ``))
     if (hash !== ``) {

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -1,7 +1,7 @@
 const scrollToHash = offsetY => {
   // Make sure React has had a change to flush to DOM first.
   setTimeout(() => {
-    const hash = window.location.hash.replace(`#`, ``)
+    const hash = window.decodeURI(window.location.hash.replace(`#`, ``))
     if (hash !== ``) {
       const element = document.getElementById(hash)
       if (element) {

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -32,7 +32,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 
   const script = `
     document.addEventListener("DOMContentLoaded", function(event) {
-      var hash = location.hash.replace('#', '')
+      var hash = window.decodeURI(location.hash.replace('#', ''))
       if (hash !== '') {
         var element = document.getElementById(hash)
         if (element) {


### PR DESCRIPTION
In package `gatsby-remark-autolink-headers`, once the header text string is encoded as a Uniform Resource Identifier, the `offsetY` does not work well.