### PR TITLE
gatsby-remark-custom-blocks gatsby looking for plugin's package.json in dist dir instead of root

### DIFF
--- a/packages/gatsby-remark-custom-blocks/.gitignore
+++ b/packages/gatsby-remark-custom-blocks/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+index.js

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -2,10 +2,10 @@
   "name": "gatsby-remark-custom-blocks",
   "version": "1.0.1",
   "description": "Gatsby remark plugin for adding custom blocks in markdown",
-  "main": "dist/index.js",
+  "main": "index.js",
   "scripts": {
-    "prebuild": "rimraf dist",
-    "build": "yarn prebuild && babel --out-dir dist --ignore __tests__ src",
+    "prebuild": "rimraf index.js",
+    "build": "yarn prebuild && babel --out-dir . --ignore __tests__ src",
     "prepublish": "yarn build"
   },
   "repository": "https://github.com/AlahmadiQ8/gatsby-remark-custom-blocks",
@@ -19,7 +19,7 @@
   "license": "MIT",
   "private": false,
   "files": [
-    "dist",
+    "index.js",
     "README.md"
   ],
   "devDependencies": {

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -4,9 +4,9 @@
   "description": "Gatsby remark plugin for adding custom blocks in markdown",
   "main": "index.js",
   "scripts": {
-    "prebuild": "rimraf index.js",
-    "build": "yarn prebuild && babel --out-dir . --ignore __tests__ src",
-    "prepublish": "yarn build"
+    "build": "babel --out-dir . --ignore __tests__ src",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "repository": "https://github.com/AlahmadiQ8/gatsby-remark-custom-blocks",
   "keywords": [
@@ -25,9 +25,11 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "rimraf": "^2.6.2",
+    "cross-env": "^5.0.5",
     "unist-util-find": "^1.0.1"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "remark-custom-blocks": "^1.0.6"
   }
 }


### PR DESCRIPTION
#3297 

oops, my bad 😞

https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/bootstrap/load-plugins.js#L82

was throwing 
```
Error: ENOENT: no such file or directory, open '/Users/mohammadmohammad/Dev/my-site-2/node_modules/gatsby-remark-custom-blocks/dist/package.json'
```

turned out package  entry point for plugins must be at the root. 

updated `package.json` to change the entry point to `index.js` instead of `dist/index.js`. 

