### PR TITLE
GatsbyLink: typescript definition update

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -5,10 +5,11 @@ export interface GatsbyLinkProps extends NavLinkProps {
   to: string;
   onClick?: (event: any) => void
   className?: string
+  style?:any;
 }
 
 export const navigateTo: (path: string) => void;
 
 export const withPrefix: (path: string) => string;
 
-export default class GatsbyLink extends React.Component<GatsbyLinkProps> { }
+export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> { }


### PR DESCRIPTION
Updates to pass typescript compiler(tsc) type checks, given the Gatsby's default layout in src/layouts/index.js.