### PR TITLE
Remove render-page.js.map from public folder

### DIFF
--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -44,6 +44,7 @@ module.exports = async (program: any) => {
       // Remove the temp JS bundle file built for the static-site-generator-plugin
       try {
         fs.unlinkSync(outputFile)
+        fs.unlinkSync(`${outputFile}.map`)
       } catch (e) {
         // This function will fail on Windows with no further consequences.
       }


### PR DESCRIPTION
This file is not required in production and it may leak too much information
about the folder structure and/or user name

Addresses #3324 