### PR TITLE
Update part four of tutorial to be consistent.

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -172,7 +172,7 @@ import kirkhamTheme from "typography-theme-kirkham";
 
 const typography = new Typography(kirkhamTheme);
 
-module.exports = typography;
+export default typography;
 ```
 
 `gatsby-config.js` (must be in the root of your project, not under src)


### PR DESCRIPTION
The previous tutorials used `export default typography;`, so do the same in part four.