### PR TITLE
Removes hrefs from homepage logos

### DIFF
--- a/www/src/components/used-by.js
+++ b/www/src/components/used-by.js
@@ -133,14 +133,12 @@ const UsedBy = () => (
       >
         <Icon
           icon={FabricIcon}
-          alt="Fabric"
-          href="https://meetfabric.com/careers"
+          alt="Fabric logo"
         />
-        <Icon icon={SegmentIcon} alt="Segment" href="https://segment.com" />
+        <Icon icon={SegmentIcon} alt="Segment logo" />
         <Icon
           icon={FormidableIcon}
-          alt="Formidable"
-          href="https://formidable.com"
+          alt="Formidable logo"
         />
       </ul>
     </div>


### PR DESCRIPTION
I absolutely love the idea of using logos as social proof but not super keen on sending our hard-earned traffic immediately away, especially since these are above the fold on the homepage.  

This PR may be controversial so feel free to close & not merge.  My theory and experience shows that having partner logos that are clickable does lead to a loss of at least _some_ traffic loss.