### PR TITLE
Testing v8-compile-cache

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -105,6 +105,7 @@
     "style-loader": "^0.13.0",
     "type-of": "^2.0.1",
     "url-loader": "^0.5.7",
+    "v8-compile-cache": "^1.1.0",
     "webpack": "^1.13.3",
     "webpack-configurator": "^0.3.0",
     "webpack-dev-middleware": "^1.8.4",

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -393,7 +393,6 @@ module.exports = async (args: BootstrapArgs) => {
     report.log(``)
     report.info(`bootstrap finished - ${process.uptime()} s`)
     report.log(``)
-    process.exit()
     return { graphqlRunner }
   } else {
     return new Promise(resolve => {

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -393,6 +393,7 @@ module.exports = async (args: BootstrapArgs) => {
     report.log(``)
     report.info(`bootstrap finished - ${process.uptime()} s`)
     report.log(``)
+    process.exit()
     return { graphqlRunner }
   } else {
     return new Promise(resolve => {

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -1,3 +1,5 @@
+require(`v8-compile-cache`)
+
 import { uniq, some } from "lodash"
 import fs from "fs"
 import path from "path"


### PR DESCRIPTION
Hi! This PR is related to issue #3306.

I've put `v8-compiler-cache` require in `utils\webpack.config.js` file, ending the process when bootstrap was finished, the result was the follow:

With `v8-compiler-cache`, we have the following bootstrap times(in seconds) with command `gatsby build` using [gatsby-blog-template](https://github.com/gatsbyjs/gatsby-starter-blog):

```
5.612
1.587
1.696
1.589
2.016
1.585
1.683
1.724
1.715
1.596
```

And without:
```
12.337
3.015
1.756
2.174
3.092
1.895
1.872
1.91
1.938
1.749
```

So, disregarding the first builds. We have the follow averages:

With v8-compile-cache: 1.687889

Without: 2.155667

Observation:

Putting dependency only in gatsby, the compilation breaks accusing not finding the v8-compilation-cache. The test was do by installing v8-compile-cache within the gatsby template cited (https://github.com/gatsbyjs/gatsby-starter-blog)