### PR TITLE
Fix typo in gatsby-remark-katex README

### DIFF
--- a/packages/gatsby-remark-katex/README.md
+++ b/packages/gatsby-remark-katex/README.md
@@ -5,7 +5,7 @@
 
 ## Install
 
-`npm install --save gatsby-transformer-remark atsby-remark-katex`
+`npm install --save gatsby-transformer-remark gatsby-remark-katex`
 
 ## How to use
 


### PR DESCRIPTION
Fixed an install typo in `gatsby-remark-katex`