### PR TITLE
Add BRIIM as showcase website

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Websites built with Gatsby:
   ([source](https://github.com/fabe/site))
 * [Caddy smells like trees - Free-folk band official page](https://caddysmellsliketrees.ru)
   ([source](https://github.com/podabed/caddysmellsliketrees.github.io))
+* [BRIIM](https://bri.im/)
 
 ## Docs
 


### PR DESCRIPTION
Adding one more showcase website built with Gatsby.js. The GitHub repository is still private, but may be going to be public when the website is 100% done.