### PR TITLE
Change .map to .forEach in part 4 of tutorial.

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -965,7 +965,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         }
       }
     `).then(result => {
-      result.data.allMarkdownRemark.edges.map(({ node }) => {
+      result.data.allMarkdownRemark.edges.forEach(({ node }) => {
         createPage({
           path: node.fields.slug,
           component: path.resolve(`./src/templates/blog-post.js`),


### PR DESCRIPTION
When using `map()` on an array it is customary/expected to return something. In this case nothing is being returned so `forEach` is better in my opinion.

Found this due to the eslint rule [array-callback-return](https://eslint.org/docs/rules/array-callback-return)