### PR TITLE
Plugin: gatsby-plugin-svg-sprite

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -146,6 +146,7 @@ root.
 * [gatsby-plugin-segment-js](https://github.com/benjaminhoffman/gatsby-plugin-segment-js)
 * [gatsby-plugin-stripe-checkout](https://github.com/njosefbeck/gatsby-plugin-stripe-checkout)
 * [gatsby-plugin-stripe-elements](https://github.com/njosefbeck/gatsby-plugin-stripe-elements)
+* [gatsby-plugin-svg-sprite](https://github.com/marcobiedermann/gatsby-plugin-svg-sprite)
 * [gatsby-plugin-svgr](https://github.com/zabute/gatsby-plugin-svgr)
 * [gatsby-plugin-yandex-metrika](https://github.com/viatsko/gatsby-plugin-yandex-metrika)
 * [gatsby-remark-emoji](https://github.com/Rulikkk/gatsby-remark-emoji)


### PR DESCRIPTION
Add [gatsby-plugin-svg-sprite](https://github.com/marcobiedermann/gatsby-plugin-svg-sprite) to community plugin seciton