### PR TITLE
[gatsby-plugin-google-analytics]Wait for the title update

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,7 +1,10 @@
 exports.onRouteUpdate = function({ location }) {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production` && typeof ga === `function`) {
-    window.ga(`set`, `page`, (location || {}).pathname)
-    window.ga(`send`, `pageview`)
+    // Wait for the title update (see #2478)
+    setTimeout(() => {
+      window.ga(`set`, `page`, (location || {}).pathname)
+      window.ga(`send`, `pageview`)
+    }, 0)
   }
 }


### PR DESCRIPTION
As Kyle suggested, we should wrap the Google-Analytics function into a `setTimeout` so it waits until the title is updated.

see #2478 