### PR TITLE
Add gatsby-node-helpers description to create-source-plugin.md

### DIFF
--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -93,3 +93,10 @@ But at a high-level, these are the jobs of a source plugin:
   Gatsby when you're done sourcing nodes. Otherwise either Gatsby will continue
   on before you're done sourcing or hang while waiting for you to indicate
   you're finished.
+
+[`gatsby-node-helpers`](https://github.com/angeloashmore/gatsby-node-helpers),
+a community-made NPM package, can help when writing source plugins. This
+package provides a set of helper functions to generate Node objects with the
+required fields. This includes automatically generating fields like node IDs
+and the `contentDigest` MD5 hash, keeping your code focused on data gathering,
+not boilerplate.


### PR DESCRIPTION
Adds `gatsby-node-helpers` description to `create-source-plugin.md` per https://github.com/gatsbyjs/gatsby/issues/1199#issuecomment-352582133.