### PR TITLE
Run typescript sources through full babel transpiling pipeline

### DIFF
--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -14,12 +14,17 @@ describe(`gatsby-plugin-typescript`, () => {
     expect(resolvableExtensions()).toMatchSnapshot()
   })
 
-  it(`modifies webpack config`, () => {
+  it(`modifies webpack config`, async () => {
+    const stage = ``
+    const program = {
+      directory: `.`,
+      browserslist: [],
+    }
     const config = {
       loader: jest.fn(),
     }
 
-    modifyWebpackConfig({ config }, { compilerOptions: {} })
+    await modifyWebpackConfig({ program, config, stage }, { compilerOptions: {} })
 
     expect(config.loader).toHaveBeenCalledTimes(1)
     const lastCall = config.loader.mock.calls.pop()

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -14,17 +14,13 @@ describe(`gatsby-plugin-typescript`, () => {
     expect(resolvableExtensions()).toMatchSnapshot()
   })
 
-  it(`modifies webpack config`, async () => {
-    const stage = ``
-    const program = {
-      directory: `.`,
-      browserslist: [],
-    }
+  it(`modifies webpack config`, () => {
+    const babelConfig = { "plugins":[``] }
     const config = {
       loader: jest.fn(),
     }
 
-    await modifyWebpackConfig({ program, config, stage }, { compilerOptions: {} })
+    modifyWebpackConfig({ config, babelConfig }, { compilerOptions: {} })
 
     expect(config.loader).toHaveBeenCalledTimes(1)
     const lastCall = config.loader.mock.calls.pop()
@@ -32,12 +28,13 @@ describe(`gatsby-plugin-typescript`, () => {
   })
 
   it(`passes the configuration to the ts-loader plugin`, () => {
+    const babelConfig = { "plugins":[``] }
     const config = {
       loader: jest.fn(),
     }
     const options = { compilerOptions: { foo: `bar` }, transpileOnly: false }
 
-    modifyWebpackConfig({ config }, options)
+    modifyWebpackConfig({ config, babelConfig }, options)
 
     const expectedOptions = {
       compilerOptions: {
@@ -60,10 +57,11 @@ describe(`gatsby-plugin-typescript`, () => {
   })
 
   it(`uses default configuration for the ts-loader plugin when no config is provided`, () => {
+    const babelConfig = { "plugins":[``] }
     const config = {
       loader: jest.fn(),
     }
-    modifyWebpackConfig({ config }, { compilerOptions: {} })
+    modifyWebpackConfig({ config, babelConfig }, { compilerOptions: {} })
 
     const expectedOptions = {
       compilerOptions: {

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -1,4 +1,3 @@
-const genBabelConfig = require(`gatsby/dist/utils/babel-config`)
 const { transpileModule } = require(`typescript`)
 
 const test = /\.tsx?$/
@@ -10,12 +9,10 @@ const compilerDefaults = {
 
 module.exports.resolvableExtensions = () => [`.ts`, `.tsx`]
 
-module.exports.modifyWebpackConfig = async (
-  { program, config, stage },
+module.exports.modifyWebpackConfig = (
+  { config, babelConfig },
   { compilerOptions, transpileOnly = true }
 ) => {
-  const babelConfig = await genBabelConfig(program, stage)
-
   // CommonJS to keep Webpack happy.
   const copts = Object.assign({}, compilerDefaults, compilerOptions, {
     module: `commonjs`,

--- a/packages/gatsby/src/commands/build-javascript.js
+++ b/packages/gatsby/src/commands/build-javascript.js
@@ -11,7 +11,20 @@ module.exports = async program => {
     `build-javascript`
   )
 
-  return new Promise(resolve => {
-    webpack(compilerConfig.resolve()).run(() => resolve())
+  return new Promise((resolve, reject) => {
+    webpack(compilerConfig.resolve()).run((err, stats) => {
+      if (err) {
+        reject(err)
+        return
+      }
+
+      const jsonStats = stats.toJson()
+      if (jsonStats.errors && jsonStats.errors.length > 0) {
+        reject(jsonStats.errors[0])
+        return
+      }
+
+      resolve()
+    })
   })
 }

--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -17,9 +17,9 @@ const validationWhitelist = Joi.object({
   responsiveLoader: Joi.any(),
 })
 
-export default (async function ValidateWebpackConfig(config, stage) {
+export default (async function ValidateWebpackConfig(program, config, stage) {
   // We don't care about the return as plugins just mutate the config directly.
-  await apiRunnerNode(`modifyWebpackConfig`, { config, stage })
+  await apiRunnerNode(`modifyWebpackConfig`, { program, config, stage })
 
   // console.log(JSON.stringify(config, null, 4))
 

--- a/packages/gatsby/src/utils/webpack-modify-validate.js
+++ b/packages/gatsby/src/utils/webpack-modify-validate.js
@@ -17,9 +17,9 @@ const validationWhitelist = Joi.object({
   responsiveLoader: Joi.any(),
 })
 
-export default (async function ValidateWebpackConfig(program, config, stage) {
+export default (async function ValidateWebpackConfig(program, config, babelConfig, stage) {
   // We don't care about the return as plugins just mutate the config directly.
-  await apiRunnerNode(`modifyWebpackConfig`, { program, config, stage })
+  await apiRunnerNode(`modifyWebpackConfig`, { program, config, babelConfig, stage })
 
   // console.log(JSON.stringify(config, null, 4))
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -555,7 +555,7 @@ module.exports = async (
 
   // Use the suppliedStage again to let plugins distinguish between
   // server rendering the html.js and the frontend development config.
-  const validatedConfig = await webpackModifyValidate(program, config, suppliedStage)
+  const validatedConfig = await webpackModifyValidate(program, config, babelConfig, suppliedStage)
 
   return validatedConfig
 }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -37,13 +37,12 @@ module.exports = async (
   webpackPort = 1500,
   pages = []
 ) => {
-  const babelStage = suppliedStage
   const directoryPath = withBasePath(directory)
 
   // We combine develop & develop-html stages for purposes of generating the
   // webpack config.
   const stage = suppliedStage
-  const babelConfig = await genBabelConfig(program, babelStage)
+  const babelConfig = await genBabelConfig(program, suppliedStage)
 
   function processEnv(stage, defaultNodeEnv) {
     debug(`Building env for "${stage}"`)
@@ -556,7 +555,7 @@ module.exports = async (
 
   // Use the suppliedStage again to let plugins distinguish between
   // server rendering the html.js and the frontend development config.
-  const validatedConfig = await webpackModifyValidate(config, suppliedStage)
+  const validatedConfig = await webpackModifyValidate(program, config, suppliedStage)
 
   return validatedConfig
 }


### PR DESCRIPTION
This partially fixes #3356, maybe #3274 (#3274 fails to be minified).

Open issues:
- [x] tests fail. I have no idea how to mock `program` for tests, as it comes from gatsby-cli and I'm not familiar enough with the test framework to try mocking that out.
- [x] async/await syntax works now (as it goes through babel as expected), but fails to be minified.
- [x] `UglifyJsPlugin.js` still fails to bubble up the error / break the build with an error.
- [x] `transpileOnly` seems to be broken badly and is only used in tests.