### PR TITLE
Remove unused const config from example

### DIFF
--- a/docs/docs/building-with-components.md
+++ b/docs/docs/building-with-components.md
@@ -65,7 +65,6 @@ import React, { Component } from "react";
 
 class AboutPage extends Component {
   render() {
-    const config = this.props.data.site.siteMetadata;
     return (
       <div className="about-container">
         <p>About me.</p>


### PR DESCRIPTION
When I pasted the example `src/pages/about.jsx` from https://www.gatsbyjs.org/docs/building-with-components/#page-components into a newly generated "my-gatsby-site" and tried to view the new page at http://localhost:8000/about, I was met with an error:

TypeError: Cannot read property 'site' of undefined

Removing the `const config = this.props.data.site.siteMetadata;` line seems to fix it.  The `config` variable isn't used in the example.