### PR TITLE
Infer nested array GraphQL type

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-type-test.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-type-test.js.snap
@@ -6,6 +6,20 @@ Object {
     "listNode": Array [
       Object {
         "aBoolean": true,
+        "aNestedArray": Array [
+          Array [
+            1,
+            2,
+            3,
+            4,
+          ],
+          Array [
+            5,
+            6,
+            7,
+            8,
+          ],
+        ],
         "anArray": Array [
           1,
           2,
@@ -60,6 +74,14 @@ Object {
       },
       Object {
         "aBoolean": null,
+        "aNestedArray": Array [
+          Array [
+            1,
+            2,
+            3,
+            4,
+          ],
+        ],
         "anArray": Array [
           1,
           2,

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -53,6 +53,7 @@ describe(`GraphQL type inferance`, () => {
       hair: 1,
       date: `1012-11-01`,
       anArray: [1, 2, 3, 4],
+      aNestedArray: [[1, 2, 3, 4], [5, 6, 7, 8]],
       anObjectArray: [
         { aString: `some string`, aNumber: 2, aBoolean: true },
         { aString: `some string`, aNumber: 2, anArray: [1, 2] },
@@ -83,6 +84,7 @@ describe(`GraphQL type inferance`, () => {
       hair: 2,
       date: `1984-10-12`,
       anArray: [1, 2, 5, 4],
+      aNestedArray: [[1, 2, 3, 4]],
       anObjectArray: [{ anotherObjectArray: [{ baz: `quz` }] }],
       frontmatter: {
         date: `1984-10-12`,
@@ -333,6 +335,7 @@ describe(`GraphQL type inferance`, () => {
       `
         hair,
         anArray,
+        aNestedArray,
         anObjectArray {
           aNumber,
           aBoolean,

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -76,9 +76,9 @@ function inferGraphQLType({
     if (exampleValue == null) return null
 
     let headType
-    // If the array contains objects, than treat them as "nodes"
+    // If the array contains non-array objects, than treat them as "nodes"
     // and create an object type.
-    if (_.isObject(exampleValue)) {
+    if (_.isObject(exampleValue) && !_.isArray(exampleValue)) {
       headType = new GraphQLObjectType({
         name: createTypeName(fieldName),
         fields: inferObjectStructureFromNodes({
@@ -87,7 +87,7 @@ function inferGraphQLType({
           selector,
         }),
       })
-      // Else if the values are simple values, just infer their type.
+      // Else if the values are simple values or arrays, just infer their type.
     } else {
       let inferredType = inferGraphQLType({
         ...otherArgs,


### PR DESCRIPTION
I'm using the `gatsby-transformer-json` plugin to parse a raw JSON string into Javascript objects. My JSON is an array of objects and each object contains a nested array.

It would be helpful if a GraphQL query would return a nest array in this situation rather than failing with an error such as `Invariant Violation: Graphql field name (key) is not a string -> 0`.

This PR handles changes how we infer the GraphQL type for arrays - no longer treating them as objects.

I'm new to Gatsby so please do let me know if there is a better way of achieving my goal.