### PR TITLE
fix(gatsby-cli): Clone using https instead of git

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -66,7 +66,7 @@ const copy = async (starterPath: string, rootPath: string) => {
 
 // Clones starter from URI.
 const clone = async (hostInfo: any, rootPath: string) => {
-  const url = hostInfo.git({ noCommittish: true })
+  const url = hostInfo.https({ noCommittish: true })
   const branch = hostInfo.committish ? `-b ${hostInfo.committish}` : ``
 
   report.info(`Creating new site from git: ${url}`)


### PR DESCRIPTION
Fixes #3399