### PR TITLE
Update canonical url when navigating to another page

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,0 +1,4 @@
+exports.onRouteUpdate = ({ location }) => {
+  const domElem = document.querySelector(`link[rel='canonical']`)
+  domElem.setAttribute(`href`, `${window.location.origin}${location.pathname}`)
+}


### PR DESCRIPTION
Update the `href` attribute of the `<link rel="canonical">` tag when navigating to another page.

Should fix https://github.com/gatsbyjs/gatsby/issues/2699