### PR TITLE
[gatsby-link] scrollToTop on click to same site

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -145,8 +145,8 @@ class GatsbyLink extends React.Component {
               if (element !== null) {
                 element.scrollIntoView()
                 return true
-              }else{
-                window.scrollTo(0,0)
+              } else {
+                window.scrollTo(0, 0)
                 return true
               }
             }

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -132,6 +132,9 @@ class GatsbyLink extends React.Component {
               if (element !== null) {
                 element.scrollIntoView()
                 return true
+              }else{
+                window.scrollTo(0,0)
+                return true
               }
             }
 

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -146,6 +146,8 @@ class GatsbyLink extends React.Component {
                 element.scrollIntoView()
                 return true
               } else {
+                // This is just a normal link to the current page so let's emulate default
+                // browser behavior by scrolling now to the top of the page.
                 window.scrollTo(0, 0)
                 return true
               }


### PR DESCRIPTION
If the user clicks a gatsby-link to the current site (eg. he is on `/contact/` and clicks on a link to `/contact/`) nothing is happening. 

From "normal" links he would expect that the page will scroll to the top. 


#### Changes
The page scrolls to the top
using JS [`window.scrollTo`](https://www.w3schools.com/jsref/met_win_scrollto.asp) 