### PR TITLE
Make the 'navigateTo' of 'gatsby-link' accept options defining if the pathPrefix should be added to a path

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -163,6 +163,6 @@ GatsbyLink.contextTypes = {
 
 export default GatsbyLink
 
-export const navigateTo = pathname => {
-  window.___navigateTo(withPrefix(pathname))
+export const navigateTo = {pathname, options = {}} => {
+  window.___navigateTo(options.prefixed ? pathname : withPrefix(pathname))
 }

--- a/packages/gatsby-plugin-catch-links/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-catch-links/src/gatsby-browser.js
@@ -3,5 +3,5 @@ import { navigateTo } from "gatsby-link"
 import catchLinks from "./catch-links"
 
 catchLinks(window, href => {
-  navigateTo(href)
+  navigateTo(href, {prefixed: true})
 })


### PR DESCRIPTION
The hrefs of links caught by 'gatsby-plugin-catch-links' should already contain a pathPrefix in it if the links are rendered correctly. So the pathPrefix shouldn't be added to these links during navigation handling.