### PR TITLE
Respect remark plugins order, process them serially

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -82,6 +82,7 @@ module.exports = (
           n => n.internal.type === `File`
         )
         const ast = await new Promise((resolve, reject) => {
+          // Use Bluebird's Promise function "each" to run remark plugins serially.
           Promise.each(pluginOptions.plugins, plugin => {
             const requiredPlugin = require(plugin.resolve)
             if (_.isFunction(requiredPlugin.mutateSource)) {
@@ -132,6 +133,7 @@ module.exports = (
             const files = _.values(store.getState().nodes).filter(
               n => n.internal.type === `File`
             )
+            // Use Bluebird's Promise function "each" to run remark plugins serially.
             Promise.each(pluginOptions.plugins, plugin => {
               const requiredPlugin = require(plugin.resolve)
               if (_.isFunction(requiredPlugin)) {

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -82,23 +82,21 @@ module.exports = (
           n => n.internal.type === `File`
         )
         const ast = await new Promise((resolve, reject) => {
-          Promise.all(
-            pluginOptions.plugins.map(plugin => {
-              const requiredPlugin = require(plugin.resolve)
-              if (_.isFunction(requiredPlugin.mutateSource)) {
-                return requiredPlugin.mutateSource(
-                  {
-                    markdownNode,
-                    files,
-                    getNode,
-                  },
-                  plugin.pluginOptions
-                )
-              } else {
-                return Promise.resolve()
-              }
-            })
-          ).then(() => {
+          Promise.each(pluginOptions.plugins, plugin => {
+            const requiredPlugin = require(plugin.resolve)
+            if (_.isFunction(requiredPlugin.mutateSource)) {
+              return requiredPlugin.mutateSource(
+                {
+                  markdownNode,
+                  files,
+                  getNode,
+                },
+                plugin.pluginOptions
+              )
+            } else {
+              return Promise.resolve()
+            }
+          }).then(() => {
             const markdownAST = remark.parse(markdownNode.internal.content)
 
             // source => parse (can order parsing for dependencies) => typegen
@@ -134,25 +132,23 @@ module.exports = (
             const files = _.values(store.getState().nodes).filter(
               n => n.internal.type === `File`
             )
-            Promise.all(
-              pluginOptions.plugins.map(plugin => {
-                const requiredPlugin = require(plugin.resolve)
-                if (_.isFunction(requiredPlugin)) {
-                  return requiredPlugin(
-                    {
-                      markdownAST,
-                      markdownNode,
-                      getNode,
-                      files,
-                      pathPrefix,
-                    },
-                    plugin.pluginOptions
-                  )
-                } else {
-                  return Promise.resolve()
-                }
-              })
-            ).then(() => {
+            Promise.each(pluginOptions.plugins, plugin => {
+              const requiredPlugin = require(plugin.resolve)
+              if (_.isFunction(requiredPlugin)) {
+                return requiredPlugin(
+                  {
+                    markdownAST,
+                    markdownNode,
+                    getNode,
+                    files,
+                    pathPrefix,
+                  },
+                  plugin.pluginOptions
+                )
+              } else {
+                return Promise.resolve()
+              }
+            }).then(() => {
               resolve(markdownAST)
             })
           })


### PR DESCRIPTION
I needed this for a plugin that fetched code snippets from github and inserts them in the markdown AST. The problem was that I wanted those code snippets to be processed by remark prismjs plugin, but there was a race condition between the two plugins.