### PR TITLE
[gatsby-plugin-netlify] default HTTP/2 push

### DIFF
--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -10,7 +10,7 @@ export const NETLIFY_HEADERS_FILENAME = `_headers`
 export const DEFAULT_OPTIONS = {
   headers: {},
   mergeSecurityHeaders: true,
-  mergeLinkHeaders: false, // TODO: change this to true when gzip for server push is on netlify
+  mergeLinkHeaders: true,
   mergeCachingHeaders: true,
   transformHeaders: _.identity, // optional transform for manipulating headers for sorting, etc
 }


### PR DESCRIPTION
for #3286 

I ran my page for a few weeks with this option and did not notice any problems, the [netfliy documentation](https://www.netlify.com/docs/headers-and-basic-auth/) does not mention any problems with gzip and server-push