### PR TITLE
Don't create pages for test files

### DIFF
--- a/packages/gatsby/src/internal-plugins/component-page-creator/__tests__/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/component-page-creator/__tests__/gatsby-node.js
@@ -53,6 +53,28 @@ describe(`JavaScript page creator`, () => {
     expect(files.filter(file => validatePath(file.path)).length).toEqual(2)
   })
 
+  it(`filters out test files`, () => {
+    const files = [
+      {
+        path: `__tests__/something.test.js`,
+      },
+      {
+        path: `foo.spec.js`,
+      },
+      {
+        path: `bar.test.js`,
+      },
+      {
+        path: `page.js`,
+      },
+      {
+        path: `page.jsx`,
+      },
+    ]
+
+    expect(files.filter(file => validatePath(file.path)).length).toEqual(2)
+  })
+
   describe(`create-path`, () => {
     it(`should create unix paths`, () => {
       const basePath = `/a/`

--- a/packages/gatsby/src/internal-plugins/component-page-creator/validate-path.js
+++ b/packages/gatsby/src/internal-plugins/component-page-creator/validate-path.js
@@ -2,6 +2,11 @@ const systemPath = require(`path`)
 
 const tsDeclarationExtTest = /\.d\.tsx?$/
 
+function isTestFile(path) {
+  const testFileTest = new RegExp(`(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$`)
+  return path.match(testFileTest)
+}
+
 module.exports = path => {
   // Disallow paths starting with an underscore
   // and template-.
@@ -10,6 +15,7 @@ module.exports = path => {
   return (
     parsedPath.name.slice(0, 1) !== `_` &&
     parsedPath.name.slice(0, 9) !== `template-` &&
-    !tsDeclarationExtTest.test(parsedPath.base)
+    !tsDeclarationExtTest.test(parsedPath.base) &&
+    !isTestFile(path)
   )
 }

--- a/packages/gatsby/src/internal-plugins/component-page-creator/validate-path.js
+++ b/packages/gatsby/src/internal-plugins/component-page-creator/validate-path.js
@@ -16,6 +16,6 @@ module.exports = path => {
     parsedPath.name.slice(0, 1) !== `_` &&
     parsedPath.name.slice(0, 9) !== `template-` &&
     !tsDeclarationExtTest.test(parsedPath.base) &&
-    !isTestFile(path)
+    !isTestFile(parsedPath.base)
   )
 }


### PR DESCRIPTION
Currently, Gatsby will attempt to create pages for any tests that might exist in the `pages/` directory. This introduces problems with module name collision, test globals (e.g. Jest's `it`) being undefined, etc and breaks the site build. 

This is using Jest's default [test regex](https://facebook.github.io/jest/docs/en/configuration.html#testregex-string) right now. Should this be more generic to account for other test environments?