### PR TITLE
Fix Links Redirection

### DIFF
--- a/docs/docs/glamor.md
+++ b/docs/docs/glamor.md
@@ -3,7 +3,7 @@ title: Glamor
 ---
 
 Let's create a page using
-[Glamor](https://github.com/threepointone/glamor). It might be useful for you to explore [CSS Modules](/tutorial/part-two/) and [Styled Components](/styled-components/) to see how Glamor compares as a styling method.
+[Glamor](https://github.com/threepointone/glamor). It might be useful for you to explore [CSS Modules](/tutorial/part-two/#css-modules) and [Styled Components](../styled-components/) to see how Glamor compares as a styling method.
 
 Glamor lets you write _real_ CSS inline in your components using the same Object
 CSS syntax React supports for the `style` prop. Glamor is a variant on "CSS-in-JS"—which solves many of the problems with traditional CSS.

--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -2,7 +2,7 @@
 title: Styled Components
 ---
 
-[Styled Components](https://www.styled-components.com/) is an example of using CSS-in-JS. It might be useful for you to explore [CSS Modules](/tutorial/part-two/) and [Glamor](/glamor/) to see how Styled Components compares as a styling method.
+[Styled Components](https://www.styled-components.com/) is an example of using CSS-in-JS. It might be useful for you to explore [CSS Modules](/tutorial/part-two/) and [Glamor](../glamor/) to see how Styled Components compares as a styling method.
 
 Styled Components lets you use actual CSS syntax inside your components. Like Glamor, Styled Components is a variant on "CSS-in-JS"—which solves many of the problems with traditional CSS.
 


### PR DESCRIPTION
Also, one thing to note is that any link (appended by `#` for visiting certain parts of the same page) like http://localhost:8000/tutorial/part-two/#glamor works on `localhost` but does not work on the actual URL https://www.gatsbyjs.org/tutorial/part-two/#glamor

Also, [the links](https://www.gatsbyjs.org/tutorial/part-two/) on the Sidebar for `Glamor` & `Styled Components` in the `Tutorial` Section `Part Two` is incorrect. So let me know if [these 2 links](https://github.com/gatsbyjs/gatsby/blob/master/www/src/pages/docs/tutorial-links.yml#L33-L36) should be correctly pointed to https://www.gatsbyjs.org/docs/glamor & https://www.gatsbyjs.org/docs/styled-components.