### PR TITLE
Update Deploy Gatsby page - Gitlab Pages

### DIFF
--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -105,6 +105,24 @@ git remote add origin git@gitlab.com:examplerepository
 git add .
 git push -u origin master
 ```
+You can deploy sites on Gitlab Pages with or without a custom domain. If you choose to use the default setup (without a custom domain), or if you create a project site, you will need to setup your site with path prefixing. If adding acustom domain, you can skip the Path Prefix step, and remove `--prefix-paths` from the gitlab-ci.yml file.
+
+### Path Prefix
+As the site will be hosted under yourname.gitlab.io/examplerepository/, you will need to configure Gatsby to use the Path Prefix plugin.
+
+In the `gatsby-config.js`, set the `pathPrefix` to be added to your site's link
+paths. The `pathPrefix` should be the project name in your repository. (ex.
+`https://gitlab.com/yourname/examplerepository/` - your `pathPrefix` should be
+`/examplerepository`). See
+[the docs page on path prefixing for more](/docs/path-prefix/).
+
+```
+module.exports = {
+  pathPrefix: `/examplerepository`,
+}
+```
+
+### Build and deploy with Gitlab CI
 
 To use GitLab's continuous integration (CI), you need to add a `.gitlab-ci.yml`
 configuration file. This can be added into your project folder, or once you have
@@ -123,7 +141,7 @@ cache:
 pages:
   script:
   - yarn install
-  - ./node_modules/.bin/gatsby build
+  - ./node_modules/.bin/gatsby build --prefix-paths
   artifacts:
     paths:
     - public
@@ -138,11 +156,13 @@ to reinstall all the dependancies required. `pages:` is the name of the
 CI stage. You can have multiple stages, e.g. 'Test', 'Build', 'Deploy' etc.
 `script:` starts the next part of the CI stage, telling it to start running the
 below scripts inside the image selected. We have used the `yarn install` and
-`./node_modules/.bin/gatsby build` which will install all dependancies, and
-start the static site build, respectively. We have used
-`./node_modules/.bin/gatsby build` because we then don't have to install
+`./node_modules/.bin/gatsby build --prefix-paths` which will install all dependancies, and
+start the static site build, respectively. 
+
+We have used
+`./node_modules/.bin/gatsby build --prefix-paths` because we then don't have to install
 gatsby-cli to build the image, as it has already been included and installed
-with `yarn install`. `artifacts:` and `paths:` are used to tell GitLab pages
+with `yarn install`. We have included `--prefix-paths` as when running the command *without* that flag, Gatsby ignores your pathPrefix. `artifacts:` and `paths:` are used to tell GitLab pages
 where the static files are kept. `only:` and `master` tells the CI to only run
 the above instructions when the master branch is deployed.
 

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -105,7 +105,7 @@ git remote add origin git@gitlab.com:examplerepository
 git add .
 git push -u origin master
 ```
-You can deploy sites on Gitlab Pages with or without a custom domain. If you choose to use the default setup (without a custom domain), or if you create a project site, you will need to setup your site with path prefixing. If adding acustom domain, you can skip the Path Prefix step, and remove `--prefix-paths` from the gitlab-ci.yml file.
+You can deploy sites on Gitlab Pages with or without a custom domain. If you choose to use the default setup (without a custom domain), or if you create a project site, you will need to setup your site with path prefixing. If adding a custom domain, you can skip the Path Prefix step, and remove `--prefix-paths` from the gitlab-ci.yml file.
 
 ### Path Prefix
 As the site will be hosted under yourname.gitlab.io/examplerepository/, you will need to configure Gatsby to use the Path Prefix plugin.


### PR DESCRIPTION
Have made a few edits, mainly to include the Path Prefix plugin, which is needed when using Gitlab pages without a custom domain. This has basically been shamelessly copied from the Github pages example...
Also did a bit of formatting.

On another note, do you think it would be a good idea to have examples for all of these? For example, I have done a demo repo on Gitlab pages [here](https://gitlab.com/travisreynolds/gatsby--gitlab-pages) with the site [here](https://travisreynolds.gitlab.io/gatsby--gitlab-pages/). Might be useful for people to see the whole setup? But you may also want to set these up under the main Gatsby repo names?