### PR TITLE
correct key behavior

### DIFF
--- a/packages/gatsby-react-router-scroll/src/StateStorage.js
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.js
@@ -46,8 +46,7 @@ export default class SessionStorage {
   }
 
   getStateKey(location, key) {
-    const locationPath = location.pathname
-    const stateKeyBase = `${STATE_KEY_PREFIX}${locationPath}`
+    const stateKeyBase = `${STATE_KEY_PREFIX}${location.pathname}`
     return key === null || typeof key === `undefined`
       ? stateKeyBase
       : `${stateKeyBase}|${key}`

--- a/packages/gatsby-react-router-scroll/src/StateStorage.js
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.js
@@ -47,8 +47,7 @@ export default class SessionStorage {
 
   getStateKey(location, key) {
     const locationPath = location.pathname
-    const strippedLocationPath = locationPath.endsWith(`/`) ? locationPath.slice(0, -1) : locationPath
-    const stateKeyBase = `${STATE_KEY_PREFIX}${strippedLocationPath}`
+    const stateKeyBase = `${STATE_KEY_PREFIX}${locationPath}`
     return key === null || typeof key === `undefined`
       ? stateKeyBase
       : `${stateKeyBase}|${key}`

--- a/packages/gatsby-react-router-scroll/src/StateStorage.js
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.js
@@ -6,7 +6,7 @@ export default class SessionStorage {
     const stateKey = this.getStateKey(location, key)
 
     try {
-      const value = sessionStorage.getItem(stateKey)
+      const value = window.sessionStorage.getItem(stateKey)
       return JSON.parse(value)
     } catch (e) {
       console.warn(
@@ -30,7 +30,7 @@ export default class SessionStorage {
     const storedValue = JSON.stringify(value)
 
     try {
-      sessionStorage.setItem(stateKey, storedValue)
+      window.sessionStorage.setItem(stateKey, storedValue)
     } catch (e) {
       if (window && window[GATSBY_ROUTER_SCROLL_STATE]) {
         window[GATSBY_ROUTER_SCROLL_STATE][stateKey] = JSON.parse(storedValue)
@@ -46,8 +46,9 @@ export default class SessionStorage {
   }
 
   getStateKey(location, key) {
-    const locationKey = location.key
-    const stateKeyBase = `${STATE_KEY_PREFIX}${locationKey}`
+    const locationPath = location.pathname
+    const strippedLocationPath = locationPath.endsWith(`/`) ? locationPath.slice(0, -1) : locationPath
+    const stateKeyBase = `${STATE_KEY_PREFIX}${strippedLocationPath}`
     return key === null || typeof key === `undefined`
       ? stateKeyBase
       : `${stateKeyBase}|${key}`


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/3249. The problem was that `location.key` was evaluating to `undefined` since `key` is not a key of the Location object. 

As a result, Gatsby was sending window.sessionStorage only one scroll position for all Gatsby routes, so scroll position leaked across routes when you used the browser URL to navigate between pages (rather than links or the Back button). 