### PR TITLE
Use `_.isPlainObject` to prevent false Array positives

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -60,7 +60,7 @@ exports.getValidKey = getValidKey
 // Remove the ACF key from the response when it's not an object
 const normalizeACF = entities =>
   entities.map(e => {
-    if (!_.isObject(e[`acf`])) {
+    if (!_.isPlainObject(e[`acf`])) {
       delete e[`acf`]
     }
     return e


### PR DESCRIPTION
`_.isObject` returns true for `Array` instances, preventing this filter from working as intended. It needs to filter out the `acf: []` entries returned by WordPress for posts/pages that do not have acf entries associated with them.