### PR TITLE
Do not parse numbers as dates in ambiguous cases

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-type-test.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-type-test.js.snap
@@ -109,7 +109,7 @@ Object {
           "date": "1984",
           "title": "The world of slash and adventure",
         },
-        "hair": 2,
+        "hair": 2048,
       },
     ],
   },

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -81,7 +81,7 @@ describe(`GraphQL type inferance`, () => {
       id: `boo`,
       name: `The Mad Wax`,
       type: `Test`,
-      hair: 2,
+      hair: 2048,
       date: `1984-10-12`,
       anArray: [1, 2, 5, 4],
       aNestedArray: [[1, 2, 3, 4]],

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -43,10 +43,8 @@ export type ProcessedNodeType = {
 }
 
 const ISO_8601_FORMAT = [
-  `YYYY`,
   `YYYY-MM`,
   `YYYY-MM-DD`,
-  `YYYYMMDD`,
   `YYYY-MM-DDTHHZ`,
   `YYYY-MM-DDTHH:mmZ`,
   `YYYY-MM-DDTHHmmZ`,
@@ -59,7 +57,6 @@ const ISO_8601_FORMAT = [
   `YYYY-[W]WW-E`,
   `YYYY[W]WWE`,
   `YYYY-DDDD`,
-  `YYYYDDDD`,
 ]
 
 function inferGraphQLType({


### PR DESCRIPTION
I'm using the `gatsby-transformer-json` plugin to parse a raw JSON string into Javascript objects. Some of the values are numbers but some (not all) are coming through as strings after a GraphQL query.

I believe this is due to them being treated as dates. In particular, a number with four or eight digits is treated as a date if it matched one of the following date formats: YYYY, YYYYMMDD or YYYYMMDD.

This PR removes these date formats from the matching criteria when inferring the GraphQL type. I think this is more in line with what a user would expect and still allows data which is more obviously a date to be parsed as expected.