### PR TITLE
 [gatsby] don't run service-workers outside of https or localhost 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,15 +34,11 @@ The usual contributing steps are:
   build of all packages and then watch for changes to packages' source code and
   compile these changes on-the-fly as you work.
 * Install [gatsby-dev-cli](/packages/gatsby-dev-cli/) globally: `yarn global add gatsby-dev-cli`
+* Run `yarn install` in each of the sites you're testing with.
 * For each of your Gatsby test sites, run the `gatsby-dev` command there to copy
   the built files from your cloned copy of Gatsby. It'll watch for your changes
   to Gatsby packages and copy them into the site. For more detailed instructions
   see the [gatsby-dev-cli README](/packages/gatsby-dev-cli/)
-* In each of your test sites' directories, run `yarn install`
-* In your test site(s), run `gatsby develop`
-  - this _may_ cause your `.cache` directory to be reset. if you don't see your
-    changes, editing the source files in your clone will cause them to be copied
-    over to your test site again.
 * Add tests and code for your changes.
 * Once you're done, make sure all tests still pass: `yarn test`
 * Commit and push to your fork.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ The usual contributing steps are:
   the built files from your cloned copy of Gatsby. It'll watch for your changes
   to Gatsby packages and copy them into the site. For more detailed instructions
   see the [gatsby-dev-cli README](/packages/gatsby-dev-cli/)
+* In each of your test sites' directories, run `yarn install`
+* In your test site(s), run `gatsby develop`
+  - this _may_ cause your `.cache` directory to be reset. if you don't see your
+    changes, editing the source files in your clone will cause them to be copied
+    over to your test site again.
 * Add tests and code for your changes.
 * Once you're done, make sure all tests still pass: `yarn test`
 * Commit and push to your fork.

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -105,9 +105,11 @@ git remote add origin git@gitlab.com:examplerepository
 git add .
 git push -u origin master
 ```
+
 You can deploy sites on Gitlab Pages with or without a custom domain. If you choose to use the default setup (without a custom domain), or if you create a project site, you will need to setup your site with path prefixing. If adding a custom domain, you can skip the Path Prefix step, and remove `--prefix-paths` from the gitlab-ci.yml file.
 
 ### Path Prefix
+
 As the site will be hosted under yourname.gitlab.io/examplerepository/, you will need to configure Gatsby to use the Path Prefix plugin.
 
 In the `gatsby-config.js`, set the `pathPrefix` to be added to your site's link
@@ -157,12 +159,12 @@ CI stage. You can have multiple stages, e.g. 'Test', 'Build', 'Deploy' etc.
 `script:` starts the next part of the CI stage, telling it to start running the
 below scripts inside the image selected. We have used the `yarn install` and
 `./node_modules/.bin/gatsby build --prefix-paths` which will install all dependancies, and
-start the static site build, respectively. 
+start the static site build, respectively.
 
 We have used
 `./node_modules/.bin/gatsby build --prefix-paths` because we then don't have to install
 gatsby-cli to build the image, as it has already been included and installed
-with `yarn install`. We have included `--prefix-paths` as when running the command *without* that flag, Gatsby ignores your pathPrefix. `artifacts:` and `paths:` are used to tell GitLab pages
+with `yarn install`. We have included `--prefix-paths` as when running the command _without_ that flag, Gatsby ignores your pathPrefix. `artifacts:` and `paths:` are used to tell GitLab pages
 where the static files are kept. `only:` and `master` tells the CI to only run
 the above instructions when the master branch is deployed.
 

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -24,7 +24,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
    *
    * Let's unregister the service workers in development, and tidy up a few errors.
    */
-  if (`serviceWorker` in navigator) {
+  if (supportsServiceWorkers(location, navigator)) {
     navigator.serviceWorker.getRegistrations().then(registrations => {
       for (let registration of registrations) {
         registration.unregister()
@@ -69,3 +69,10 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     })
   }
 })
+
+function supportsServiceWorkers(location, navigator){
+  if (location.hostname === `localhost` || location.protocol === `https:`){
+    return `serviceWorker` in navigator
+  }
+  return false
+}

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -70,8 +70,8 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   }
 })
 
-function supportsServiceWorkers(location, navigator){
-  if (location.hostname === `localhost` || location.protocol === `https:`){
+function supportsServiceWorkers(location, navigator) {
+  if (location.hostname === `localhost` || location.protocol === `https:`) {
     return `serviceWorker` in navigator
   }
   return false


### PR DESCRIPTION
detail here: https://github.com/gatsbyjs/gatsby/issues/3385

hat-tip to @denster for tracking down the root cause and @KrofDrakula for suggesting the fix :pray::+1: