### PR TITLE
Properly use `withPrefix` in adding-images-fonts-files docs

### DIFF
--- a/docs/docs/adding-images-fonts-files.md
+++ b/docs/docs/adding-images-fonts-files.md
@@ -86,7 +86,7 @@ render() {
   // Note: this is an escape hatch and should be used sparingly!
   // Normally we recommend using `import` for getting asset URLs
   // as described in “Adding Images and Fonts” above this section.
-  return <img src={__PATH_PREFIX__ + '/img/logo.png'} alt="Logo" />;
+  return <img src={withPrefix('/img/logo.png')} alt="Logo" />;
 }
 ```
 


### PR DESCRIPTION
I came across this while browsing through the documentation. The `withPrefix` import was left unused in the "escape hatch" example, which I'm pretty sure is not intentional.