### PR TITLE
make ComponentRenderer shouldUpdateComponent return true when props c…

### DIFF
--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import loader, { publicLoader } from "./loader"
 import emitter from "./emitter"
 import { apiRunner } from "./api-runner-browser"
-import _ from "lodash"
+import shallowCompare from "shallow-compare"
 
 const DefaultLayout = ({ children }) => <div>{children()}</div>
 
@@ -91,21 +91,21 @@ class ComponentRenderer extends React.Component {
     if (!nextState.pageResources) {
       return true
     }
-
     // Check if the component or json have changed.
     if (!this.state.pageResources && nextState.pageResources) {
       return true
     }
-
     if (
       this.state.pageResources.component !== nextState.pageResources.component
     ) {
       return true
     }
 
+
     if (this.state.pageResources.json !== nextState.pageResources.json) {
       return true
     }
+
 
     // Check if location has changed on a page using internal routing
     // via matchPath configuration.
@@ -118,28 +118,11 @@ class ComponentRenderer extends React.Component {
       return true
     }
 
-    if (Object.keys(this.props).length !== Object.keys(nextProps).length) {
-      return true;
-    }
-
-    // shallow object comparison, assume child object equality
-    const differentProps = Object.keys(this.props).filter(key => (
-      typeof this.props[key] !== "object" &&
-      this.props[key] !== nextProps[key]
-    ))
-
-    if (differentProps.length) {
-      return true
-    }
-
-    if (!_.isEqual(this.props.location, nextProps.location)) {
-      return true;
-    }
-
-    return false
+    return shallowCompare(this, nextProps, nextState)
   }
 
   render() {
+    console.log("222")
     const pluginResponses = apiRunner(`replaceComponentRenderer`, {
       props: { ...this.props, pageResources: this.state.pageResources },
       loader: publicLoader,

--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -122,7 +122,6 @@ class ComponentRenderer extends React.Component {
   }
 
   render() {
-    console.log("222")
     const pluginResponses = apiRunner(`replaceComponentRenderer`, {
       props: { ...this.props, pageResources: this.state.pageResources },
       loader: publicLoader,

--- a/packages/gatsby/cache-dir/component-renderer.js
+++ b/packages/gatsby/cache-dir/component-renderer.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import loader, { publicLoader } from "./loader"
 import emitter from "./emitter"
 import { apiRunner } from "./api-runner-browser"
+import _ from "lodash"
 
 const DefaultLayout = ({ children }) => <div>{children()}</div>
 
@@ -115,6 +116,24 @@ class ComponentRenderer extends React.Component {
         nextState.pageResources.page.path)
     ) {
       return true
+    }
+
+    if (Object.keys(this.props).length !== Object.keys(nextProps).length) {
+      return true;
+    }
+
+    // shallow object comparison, assume child object equality
+    const differentProps = Object.keys(this.props).filter(key => (
+      typeof this.props[key] !== "object" &&
+      this.props[key] !== nextProps[key]
+    ))
+
+    if (differentProps.length) {
+      return true
+    }
+
+    if (!_.isEqual(this.props.location, nextProps.location)) {
+      return true;
     }
 
     return false

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -96,6 +96,7 @@
     "relay-compiler": "^1.4.1",
     "remote-redux-devtools": "^0.5.7",
     "serve": "^6.4.0",
+    "shallow-compare": "^1.2.2",
     "sift": "^3.2.6",
     "signal-exit": "^3.0.2",
     "slash": "^1.0.0",


### PR DESCRIPTION
…hange

Fixes https://github.com/gatsbyjs/gatsby/issues/3412

I added a timer in the DefaultLayout of www (similar to what @busticated did in his example gist ^) and this code took 1.5ms (Chrome on a 2yr old MacBook) to execute per prop update. Is not called if Layout doesn't send diff props. 