### PR TITLE
[DOCS] Adding Markdown pages: Remove useless fields

### DIFF
--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -141,13 +141,9 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
       ) {
         edges {
           node {
-            excerpt(pruneLength: 250)
-            html
-            id
             frontmatter {
               date
               path
-              title
             }
           }
         }

--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -142,7 +142,6 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
         edges {
           node {
             frontmatter {
-              date
               path
             }
           }


### PR DESCRIPTION
I left `date` because it is used in the sort, not sure if it is mandatory though?