### PR TITLE
[DOCS] Links: Remove emphasis from implem stubs

### DIFF
--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -18,7 +18,7 @@
       link: /docs/plugins/
     - title: PRPL Pattern
       link: /docs/prpl-pattern/
-    - title: Querying with GraphQL*
+    - title: Querying with GraphQL
       link: /docs/querying-with-graphql/
 - title: Guides
   items:
@@ -60,9 +60,9 @@
       link: /docs/styled-components/
     - title: Adding Markdown Pages
       link: /docs/adding-markdown-pages/
-    - title: Adding a List of Markdown Blog Posts*
+    - title: Adding a List of Markdown Blog Posts
       link: /docs/adding-a-list-of-markdown-blog-posts/
-    - title: Adding Tags and Categories to Blog Posts*
+    - title: Adding Tags and Categories to Blog Posts
       link: /docs/adding-tags-and-categories-to-blog-posts/
     - title: Creating Dynamically-Rendered Navigation*
       link: /docs/creating-dynamically-rendered-navigation/

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -18,7 +18,7 @@
       link: /docs/plugins/
     - title: PRPL Pattern
       link: /docs/prpl-pattern/
-    - title: Querying with GraphQL
+    - title: Querying with GraphQL*
       link: /docs/querying-with-graphql/
 - title: Guides
   items:


### PR DESCRIPTION
Some docs have been implemented but are still marked as stubs in the navigation drawer