### PR TITLE
Move inlined webpack manifest to the end of body element

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -137,19 +137,6 @@ module.exports = (locals, callback) => {
     bodyHtml,
   })
 
-  // Add the chunk-manifest as a head component.
-  const chunkManifest = require(`!raw!../public/chunk-manifest.json`)
-
-  headComponents.unshift(
-    <script
-      id="webpack-manifest"
-      key="webpack-manifest"
-      dangerouslySetInnerHTML={{
-        __html: `/*<![CDATA[*/window.webpackManifest=${chunkManifest}/*]]>*/`,
-      }}
-    />
-  )
-
   let stats
   try {
     stats = require(`../public/stats.json`)
@@ -204,6 +191,19 @@ module.exports = (locals, callback) => {
       key={`script-loader`}
       dangerouslySetInnerHTML={{
         __html: `/*<![CDATA[*/!function(e,t,r){function n(){for(;d[0]&&"loaded"==d[0][f];)c=d.shift(),c[o]=!i.parentNode.insertBefore(c,i)}for(var s,a,c,d=[],i=e.scripts[0],o="onreadystatechange",f="readyState";s=r.shift();)a=e.createElement(t),"async"in i?(a.async=!1,e.head.appendChild(a)):i[f]?(d.push(a),a[o]=n):e.write("<"+t+' src="'+s+'" defer></'+t+">"),a.src=s}(document,"script",[${scriptsString}])/*]]>*/`,
+      }}
+    />
+  )
+
+  // Add the chunk-manifest at the end of body element.
+  const chunkManifest = require(`!raw!../public/chunk-manifest.json`)
+
+  postBodyComponents.unshift(
+    <script
+      id="webpack-manifest"
+      key="webpack-manifest"
+      dangerouslySetInnerHTML={{
+        __html: `/*<![CDATA[*/window.webpackManifest=${chunkManifest}/*]]>*/`,
       }}
     />
   )


### PR DESCRIPTION
This is a simple change to move inlined webpack manifest from the head element to the end of body element that was requested in https://github.com/gatsbyjs/gatsby/issues/2541.

Everything seems to still work, though I'm not sure if it will in all cases ¯\_(ツ)_/¯.