### PR TITLE
fix(dev-404-page): route to 404 fails when using plugin-remove-trailing-slashes

### DIFF
--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -111,7 +111,7 @@ function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
 
 let noMatch
 for (let i = 0; i < pages.length; i++) {
-  if (pages[i].path === `/dev-404-page/`) {
+  if (/^\/dev-404-page/.test(pages[i].path)) {
     noMatch = pages[i]
     break
   }

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -174,7 +174,7 @@ const Root = () =>
                   pageResources,
                 })
               } else {
-                const dev404Page = pages.find(p => p.path.match(/^\/dev-404-page/))
+                const dev404Page = pages.find(p => /^\/dev-404-page/.test(p.path))
                 return createElement(Route, {
                   key: `404-page`,
                   component: props =>

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -174,7 +174,7 @@ const Root = () =>
                   pageResources,
                 })
               } else {
-                const dev404Page = pages.find(p => p.path === `/dev-404-page/`)
+                const dev404Page = pages.find(p => p.path.match(/^\/dev-404-page/))
                 return createElement(Route, {
                   key: `404-page`,
                   component: props =>


### PR DESCRIPTION
Fixes: #3521