### PR TITLE
gatsby-plugin-sharp: Remove incorrect warning when requested width === image width

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -1,6 +1,6 @@
 const path = require(`path`)
 
-const { base64, responsiveSizes } = require(`../`)
+const { base64, responsiveSizes, resolutions } = require(`../`)
 
 describe(`gatsby-plugin-sharp`, () => {
   const args = {
@@ -47,6 +47,42 @@ describe(`gatsby-plugin-sharp`, () => {
       })
 
       expect(args).toEqual({ maxWidth: 400 })
+    })
+  })
+
+  describe(`resolutions`, () => {
+    console.warn = jest.fn()
+
+    beforeEach(() => {
+      console.warn.mockClear()
+    })
+
+    afterAll(() => {
+      console.warn.mockClear()
+    })
+
+    it(`does not warn when the requested width is equal to the image width`, async () => {
+      const args = { width: 1 }
+
+      const result = await resolutions({
+        file,
+        args,
+      })
+
+      expect(result.width).toEqual(1)
+      expect(console.warn).toHaveBeenCalledTimes(0)
+    })
+
+    it(`warns when the requested width is greater than the image width`, async () => {
+      const args = { width: 2 }
+
+      const result = await resolutions({
+        file,
+        args,
+      })
+
+      expect(result.width).toEqual(1)
+      expect(console.warn).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -475,7 +475,7 @@ async function resolutions({ file, args = {} }) {
   sizes.push(options.width * 3)
   const dimensions = imageSize(file.absolutePath)
 
-  const filteredSizes = sizes.filter(size => size < dimensions.width)
+  const filteredSizes = sizes.filter(size => size <= dimensions.width)
 
   // If there's no sizes after filtering (e.g. image is smaller than what's
   // requested, add back the original so there's at least something)


### PR DESCRIPTION
When specifying the width and height of an image in a query using childImageSharp, if the requested width and the image width are equal the plugin yeilds the following console warning:

```
The requested width "348px" for a resolutions field for
                 the file ...cache/gatsby-source-filesystem/565948c15bff82294da798a3bcbbfac8.png
                 was wider than the actual image width of 348px!
                 If possible, replace the current image with a larger one.
```


Example query that triggers this warning:
```
    childImageSharp {
      resolutions(width: 348, height: 348) {
        ...GatsbyImageSharpResolutions_withWebp
      }
    }
```

This change prevents the incorrect warning. 