### PR TITLE
Add typings for 'to' property of Gatsby Link

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -5,7 +5,7 @@ export interface GatsbyLinkProps extends NavLinkProps {
   onClick?: (event: any) => void
   className?: string
   style?: any
-  to: string
+  to: any
 }
 
 export const navigateTo: (path: string) => void

--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,14 +1,15 @@
-import * as React from "react";
-import { NavLinkProps } from "react-router-dom";
+import * as React from "react"
+import { NavLinkProps } from "react-router-dom"
 
 export interface GatsbyLinkProps extends NavLinkProps {
   onClick?: (event: any) => void
   className?: string
-  style?:any;
+  style?: any
+  to: string
 }
 
-export const navigateTo: (path: string) => void;
+export const navigateTo: (path: string) => void
 
-export const withPrefix: (path: string) => string;
+export const withPrefix: (path: string) => string
 
-export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> { }
+export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> {}


### PR DESCRIPTION
This should fix https://github.com/gatsbyjs/gatsby/issues/3525#issuecomment-357740713 

Based on documentation 'to' property always takes a string. I also prettified the file to be more consistent as certain lines had semicolons, some didn't etc. 