### PR TITLE
[www] Add gatsby-plugin-postcss-sass to /docs/plugins/

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -90,6 +90,7 @@ root.
 * [gatsby-plugin-netlify-cms](/packages/gatsby-plugin-netlify-cms/)
 * [gatsby-plugin-nprogress](/packages/gatsby-plugin-nprogress/)
 * [gatsby-plugin-offline](/packages/gatsby-plugin-offline/)
+* [gatsby-plugin-postcss-sass](/packages/gatsby-plugin-postcss-sass)
 * [gatsby-plugin-preact](/packages/gatsby-plugin-preact/)
 * [gatsby-plugin-react-helmet](/packages/gatsby-plugin-react-helmet/)
 * [gatsby-plugin-remove-trailing-slashes](/packages/gatsby-plugin-remove-trailing-slashes/)


### PR DESCRIPTION
Noticed that gatsby-plugin-postcss-sass is missing from https://www.gatsbyjs.org/docs/plugins/ (thanks to https://github.com/gatsbyjs/gatsby/issues/3581#issuecomment-358740376).