### PR TITLE
[gatsby-source-contentful] Delete original link regardless of ID validity

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -238,7 +238,6 @@ exports.createContentTypeNodes = ({
       Object.keys(entryItemFields).forEach(entryItemFieldKey => {
         if (entryItemFields[entryItemFieldKey]) {
           const entryItemFieldValue = entryItemFields[entryItemFieldKey]
-
           if (Array.isArray(entryItemFieldValue)) {
             if (
               entryItemFieldValue[0].sys &&
@@ -257,18 +256,13 @@ exports.createContentTypeNodes = ({
             entryItemFieldValue &&
             entryItemFieldValue.sys &&
             entryItemFieldValue.sys.type &&
-            entryItemFieldValue.sys.id &&
-            resolvable.has(entryItemFieldValue.sys.id)
+            entryItemFieldValue.sys.id
           ) {
-            entryItemFields[`${entryItemFieldKey}___NODE`] = mId(
-              entryItemFieldValue.sys.id
-            )
-            delete entryItemFields[entryItemFieldKey]
-          } else if (
-            entryItemFieldValue &&
-            entryItemFieldValue.sys &&
-            entryItemFieldValue.sys.type === `Link`
-          ) {
+            if (resolvable.has(entryItemFieldValue.sys.id)) {
+              entryItemFields[`${entryItemFieldKey}___NODE`] = mId(
+                entryItemFieldValue.sys.id
+              )
+            }
             delete entryItemFields[entryItemFieldKey]
           }
         }

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -238,6 +238,7 @@ exports.createContentTypeNodes = ({
       Object.keys(entryItemFields).forEach(entryItemFieldKey => {
         if (entryItemFields[entryItemFieldKey]) {
           const entryItemFieldValue = entryItemFields[entryItemFieldKey]
+
           if (Array.isArray(entryItemFieldValue)) {
             if (
               entryItemFieldValue[0].sys &&
@@ -262,6 +263,12 @@ exports.createContentTypeNodes = ({
             entryItemFields[`${entryItemFieldKey}___NODE`] = mId(
               entryItemFieldValue.sys.id
             )
+            delete entryItemFields[entryItemFieldKey]
+          } else if (
+            entryItemFieldValue &&
+            entryItemFieldValue.sys &&
+            entryItemFieldValue.sys.type === `Link`
+          ) {
             delete entryItemFields[entryItemFieldKey]
           }
         }


### PR DESCRIPTION
This change is resolves an issue I see frequently in my Contentful project where entries linking to drafted or deleted content would trigger a GraphQL Error.

Drafted content link
![screenshot 2018-01-18 14 35 16](https://user-images.githubusercontent.com/11855531/35125362-5be35716-fc77-11e7-9d8b-faa5219dce10.png)

Deleted content link
![screenshot 2018-01-18 17 43 26](https://user-images.githubusercontent.com/11855531/35125353-53ac3914-fc77-11e7-9d68-44f7fd6fb026.png)

Typical graphql error
<img width="714" alt="screenshot 2018-01-18 14 06 25" src="https://user-images.githubusercontent.com/11855531/35125356-57695488-fc77-11e7-8593-e698c50b1dee.png">

Since `resolvable.has(entryItemFieldValue.sys.id)` is false, the original field linking to the invalid does not get deleted from `entryItemFields` on master. This leads to an invalid schema.

Ideally editors would never link to deleted/drafted content, but it's a really easy mistake to make in Contentful; when you're deleting an entry, you have no way to see what other entries might be linking to it.

Let me know your thoughts!