### PR TITLE
[gatsby-transformer-remark] Add `htmlAst` field

### DIFF
--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
+    "graphql-type-json": "^0.1.4",
     "gray-matter": "^3.0.0",
     "hast-util-to-html": "^3.0.0",
     "lodash": "^4.17.4",
@@ -19,6 +20,7 @@
     "sanitize-html": "^1.14.1",
     "underscore.string": "^3.3.4",
     "unified": "^6.1.5",
+    "unist-util-remove-position": "^1.1.1",
     "unist-util-select": "^1.5.0",
     "unist-util-visit": "^1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13469,7 +13469,7 @@ unist-util-position@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.0.tgz#e6e1e03eeeb81c5e1afe553e8d4adfbd7c0d8f82"
 
-unist-util-remove-position@^1.0.0:
+unist-util-remove-position@^1.0.0, unist-util-remove-position@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
   dependencies:


### PR DESCRIPTION
This implements a GraphQL field that presents the rehype AST as JSON, allowing for this information to be consumed from a page template and presented dynamically.

Personally, this will mean being able to write a plugin to render the AST [as React nodes](https://github.com/rhysd/rehype-react) and include [live demos](https://formidable.com/open-source/component-playground/) written as inline code blocks directly in my markdown. It would be possible to implement this by parsing the HTML again on the client side, but I'd prefer to avoid loading a parser if I can. I hope this also enables other cool ideas that other folks might have!