### PR TITLE
[www] Increase main navigation z-index

### DIFF
--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -92,7 +92,7 @@ export default ({ pathname }) => {
         backgroundColor: `rgba(255,255,255,0.975)`,
         position: isHomepage ? `absolute` : false,
         height: presets.headerHeight,
-        zIndex: `1`,
+        zIndex: `2`,
         left: 0,
         right: 0,
         [presets.Tablet]: {


### PR DESCRIPTION
Prevent the author link on blog post cards from showing above the new docsearch dropdown: 

![image](https://user-images.githubusercontent.com/21834/35135500-f4768adc-fcdd-11e7-82b9-2f6a85041e95.png)