### PR TITLE
Add [chunkhash] to the output filename when emitting css assets

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -210,7 +210,7 @@ module.exports = async (
             __PATH_PREFIX__: JSON.stringify(store.getState().config.pathPrefix),
             __POLYFILL__: store.getState().config.polyfill,
           }),
-          new ExtractTextPlugin(`styles.css`, { allChunks: true }),
+          new ExtractTextPlugin(`styles-[chunkhash].css`, { allChunks: true }),
         ]
       case `build-html`:
         return [


### PR DESCRIPTION
Add `[chunkhash]` to the css output filename, just like for JavaScript assets:
https://github.com/gatsbyjs/gatsby/blob/7572e0d64be38f2c6ab4831be80824be91baae0b/packages/gatsby/src/utils/webpack.config.js#L116-L118
for predictable long term caching.