### PR TITLE
Revert "Enable filtering on linked nodes"

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -482,33 +482,4 @@ describe(`GraphQL Input args`, () => {
 
     expect(result).toMatchSnapshot()
   })
-
-  it(`filters on linked fields`, async () => {
-    const { store, getNodes } = require(`../../redux`)
-    const linkedNodeType = new GraphQLObjectType({
-      name: `Bar`,
-      fields: {
-        id: { type: GraphQLString },
-      },
-    })
-    let types = [{ name: `Bar`, nodeObjectType: linkedNodeType }]
-
-    store.dispatch({
-      type: `CREATE_NODE`,
-      payload: { id: `baz`, internal: { type: `Bar` } },
-    })
-
-    let result = await queryResult(
-      [...getNodes(), { linked___NODE: `baz`, foo: `bar` }],
-      `
-        {
-          allNode(filter: { linked: { id: { eq: "baz" } } }) {
-            edges { node { linked { id } } }
-          }
-        }
-      `,
-      { types }
-    )
-    expect(result.data.allNode.edges[0].node.linked.id).toEqual(`baz`)
-  })
 })

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -19,8 +19,6 @@ const {
   isEmptyObjectOrArray,
 } = require(`./data-tree-utils`)
 
-const { findLinkedNode } = require(`./infer-graphql-type`)
-
 import type {
   GraphQLInputFieldConfig,
   GraphQLInputFieldConfigMap,
@@ -204,10 +202,7 @@ export function inferInputObjectStructureFromNodes({
     if (isRoot && EXCLUDE_KEYS[key]) return
 
     // Input arguments on linked fields aren't currently supported
-    if (_.includes(key, `___NODE`)) {
-      value = findLinkedNode(value)
-      ;[key] = key.split(`___`)
-    }
+    if (_.includes(key, `___NODE`)) return
 
     let field = inferGraphQLInputFields({
       nodes,

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -252,7 +252,7 @@ function inferFromMapping(
   }
 }
 
-export function findLinkedNode(value, linkedField, path) {
+function findLinkedNode(value, linkedField, path) {
   let linkedNode
   // If the field doesn't link to the id, use that for searching.
   if (linkedField) {


### PR DESCRIPTION
Reverts gatsbyjs/gatsby#3600

@alvinthen so the test proved too simplistic :-) I ran this against the using-wordpress example and it caused an infinite loop as the code added a new linked node as the value which the inferring would recurse into and would find new links returning to the original source :-)