### PR TITLE
Remove call to delete page when path is modified.

### DIFF
--- a/packages/gatsby-plugin-remove-trailing-slashes/gatsby-node.js
+++ b/packages/gatsby-plugin-remove-trailing-slashes/gatsby-node.js
@@ -8,7 +8,6 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
     const oldPage = Object.assign({}, page)
     page.path = replacePath(page.path)
     if (page.path !== oldPage.path) {
-      deletePage(oldPage)
       createPage(page)
     }
     resolve()


### PR DESCRIPTION
When running the `gatsby-plugin-remove-trailing-slashes` plugin in development mode, whenever I made a change to a page, an infinite loop would be caused. It appeared as if `deletePage()` and/or `createPage()` were triggering the 'onCreatePage()` over and over. 

After simply removing the call to first delete the old page, this looping issue was resolved. 

This change also seems to be more consistent with the example in the documentation on how to set a custom layout, which does not include a call to delete the old page after modifying it. 

https://www.gatsbyjs.org/docs/creating-and-modifying-pages/