### PR TITLE
[gatsby-source-medium] fetch users and publications

### DIFF
--- a/packages/gatsby-source-medium/README.md
+++ b/packages/gatsby-source-medium/README.md
@@ -23,6 +23,8 @@ plugins: [
   },
 ];
 ```
+###### Note
+Remember that if you are fetching a user, prepend your username with `@`.
 
 ## How to query
 

--- a/packages/gatsby-source-medium/src/gatsby-node.js
+++ b/packages/gatsby-source-medium/src/gatsby-node.js
@@ -66,7 +66,7 @@ exports.sourceNodes = async ({ boundActionCreators }, { username }) => {
         .digest(`hex`)
 
       const links =
-        resource.type === `Post` || resource.type === `Collection`
+        resource.type === `Post`
           ? {
               author___NODE: resource.creatorId,
             }

--- a/packages/gatsby-source-medium/src/gatsby-node.js
+++ b/packages/gatsby-source-medium/src/gatsby-node.js
@@ -32,15 +32,29 @@ exports.sourceNodes = async ({ boundActionCreators }, { username }) => {
     const result = await fetch(username)
     const json = JSON.parse(strip(result.data))
 
-    const { posts } = json.payload
-    const collectionKeys = Object.keys(json.payload.references.Collection)
-    const userKeys = Object.keys(json.payload.references.User)
+    let importableResources = []
+    let posts = {} // because `posts` needs to be in a scope accessible by `links` below
 
-    const importableResources = [
-      userKeys.map(key => json.payload.references.User[key]),
-      posts,
-      collectionKeys.map(key => json.payload.references.Collection[key]),
-    ]
+    const users = Object.keys(json.payload.references.User)
+      .map(key => json.payload.references.User[key])
+    importableResources = importableResources.concat(users)
+
+    if (json.payload.posts) {
+      posts = json.payload.posts
+      importableResources = importableResources.concat(posts)
+    }
+
+    if (json.payload.references.Post) {
+      posts = Object.keys(json.payload.references.Post)
+        .map(key => json.payload.references.Post[key])
+      importableResources = importableResources.concat(posts)
+    }
+
+    if (json.payload.references.Collection) {
+      const collections = Object.keys(json.payload.references.Collection)
+        .map(key => json.payload.references.Collection[key])
+      importableResources = importableResources.concat(collections)
+    }
 
     const resources = Array.prototype.concat(...importableResources)
     resources.map(resource => {
@@ -52,7 +66,7 @@ exports.sourceNodes = async ({ boundActionCreators }, { username }) => {
         .digest(`hex`)
 
       const links =
-        resource.type === `Post`
+        resource.type === `Post` || resource.type === `Collection`
           ? {
               author___NODE: resource.creatorId,
             }


### PR DESCRIPTION
Add support for fetching a users payload along with publications from Medium. 

Should fix issue #2291. 
Very similar idea to #2515 but it checks whether the values exist in the payload rather than checking if there is a '@' before the username, since some users can also have Collections.  And it leaves the node `links` variable alone.