### PR TITLE
[dev-404-page] suppress EPERM errors on Windows

### DIFF
--- a/packages/gatsby/src/internal-plugins/dev-404-page/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/gatsby-node.js
@@ -8,7 +8,8 @@ exports.createPages = async ({ store, boundActionCreators }) => {
     const currentPath = path.join(__dirname, `./raw_dev-404-page.js`)
     const newPath = path.join(program.directory, `.cache`, `dev-404-page.js`)
 
-    fs.copySync(currentPath, newPath)
+    fs.copy(currentPath, newPath)
+      .catch(err => console.error(err))
 
     createPage({
       component: newPath,


### PR DESCRIPTION
Addresses issue #2819. Note that this doesn't entirely fix it, however it is a much-needed mitigation until we figure out a better way to fix this.

Thanks to @op3d and @kripod for their efforts in investigating this issue.