### PR TITLE
Add section about deploying with now to the docs

### DIFF
--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -250,7 +250,12 @@ Finally, add a `static.json` file in the root of your project to define the dire
 
 In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can do the following:
 
-1. Install a node server package (such as `serve`, or `http-server`) locally
+1. Install a node server package (such as `serve`, or `http-server`)
+
+```
+npm install --save serve
+```
+
 2. Add a `start` script to your `package.json` file, this is what Now will use to run your application:
 
 ```

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -250,19 +250,20 @@ Finally, add a `static.json` file in the root of your project to define the dire
 
 In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can do the following:
 
-1. Install a node server package (such as `serve`, or `http-server`)
+1. Install the Now CLI
 
-```
-npm install --save serve
-```
+`npm install -g now`
 
-2. Add a `start` script to your `package.json` file, this is what Now will use to run your application:
+2. Install a node server package (such as `serve`, or `http-server`)
 
-```
-"start": "serve public/"
-```
+`npm install --save serve`
 
-3. Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
+3. Add a `start` script to your `package.json` file, this is what Now will use to run your application:
+
+
+`"start": "serve public/"`
+
+4. Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
 ## Debugging tips
 

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -9,6 +9,7 @@ title: "Deploying Gatsby"
 * [GitHub Pages](/docs/deploy-gatsby/#github-pages)
 * [GitLab Pages](/docs/deploy-gatsby/#gitlab-pages)
 * [Heroku](/docs/deploy-gatsby/#heroku)
+* [Now](/docs/deploy-gatsby/#now)
 
 ## Netlify
 
@@ -244,6 +245,19 @@ Finally, add a `static.json` file in the root of your project to define the dire
   "root": "public/"
 }
 ```
+
+## Now
+
+In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can do the following:
+
+1. Install a node server package (such as `serve`, or `http-server`) locally
+2. Add a `start` script to your `package.json` file, this is what Now will use to run your application:
+
+```
+"start": "serve public/"
+```
+
+3. Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
 ## Debugging tips
 

--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -358,3 +358,22 @@ Community:
   * Baseline grid built in with modular scale across viewports.
   * Abstract measurements utilize REM for spacing.
   * One font to rule them all: Helvetica.
+
+* [gatsby-starter-lumen](https://github.com/alxshelepenok/gatsby-starter-lumen)
+  [(demo)](https://lumen.netlify.com/)
+
+  Features:
+
+  * Lost Grid.
+  * Beautiful typography inspired by [matejlatin/Gutenberg](https://github.com/matejlatin/Gutenberg).
+  * [Mobile-First](https://medium.com/@mrmrs_/mobile-first-css-48bc4cc3f60f) approach in development.
+  * Stylesheet built using SASS and [BEM](http://getbem.com/naming/)-Style naming.
+  * Syntax highlighting in code blocks.
+  * Sidebar menu built using a configuration block.
+  * Archive organized by tags and categories.
+  * Automatic RSS generation.
+  * Automatic Sitemap generation.
+  * Offline support.
+  * Google Analytics support.
+  * Disqus Comments support.
+  


### PR DESCRIPTION
This should close https://github.com/gatsbyjs/gatsby/issues/3635.
