### PR TITLE
Added community plugin: gatsby-plugin-pathdata

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -156,6 +156,7 @@ root.
 * [gatsby-plugin-svgr](https://github.com/zabute/gatsby-plugin-svgr)
 * [gatsby-plugin-typescript-css-modules](https://github.com/jcreamer898/gatsby-plugin-typescript-css-modules)
 * [gatsby-plugin-yandex-metrika](https://github.com/viatsko/gatsby-plugin-yandex-metrika)
+* [gatsby-plugin-pathdata](https://github.com/barskern/gatsby-plugin-pathdata)
 * [gatsby-remark-emoji](https://github.com/Rulikkk/gatsby-remark-emoji)
 * [gatsby-remark-external-links](https://github.com/JLongley/gatsby-remark-external-links)
 * [gatsby-remark-flowchart](https://github.com/liudonghua123/gatsby-remark-flowchart)


### PR DESCRIPTION
Added a new community plugin which converts data from the path of a file to the graphql database. 