### PR TITLE
Lighter data-explorer command

### DIFF
--- a/packages/gatsby/src/commands/data-explorer.js
+++ b/packages/gatsby/src/commands/data-explorer.js
@@ -3,14 +3,11 @@
 const express = require(`express`)
 const graphqlHTTP = require(`express-graphql`)
 const { store } = require(`../redux`)
-const bootstrap = require(`../bootstrap`)
 
+// Note: the store must exist already. Create it with `gatsby build`.
 module.exports = async (program: any) => {
   let { port, host } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
-
-  // bootstrap to ensure schema is in the store
-  await bootstrap(program)
 
   const app = express()
   app.use(


### PR DESCRIPTION
I've been experimenting with running a Gatsby graphiql instance on Heroku, which has a 60 second limit on app startup time. This isn't a public/documented command so it should be fine to change like this.