### PR TITLE
Field inferring changes and cleanup

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-type-test.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/infer-graphql-type-test.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GraphQL type inferance Handles dates Date type inference 1`] = `
+Object {
+  "data": Object {
+    "listNode": Array [
+      Object {
+        "dateObject": "2012-11-05T00:00:00.000Z",
+      },
+      Object {
+        "dateObject": "2012-11-05T00:00:00.000Z",
+      },
+    ],
+  },
+}
+`;
+
 exports[`GraphQL type inferance Infers graphql type from array of nodes 1`] = `
 Object {
   "data": Object {
@@ -110,21 +125,6 @@ Object {
           "title": "The world of slash and adventure",
         },
         "hair": 2,
-      },
-    ],
-  },
-}
-`;
-
-exports[`GraphQL type inferance handles date objects 1`] = `
-Object {
-  "data": Object {
-    "listNode": Array [
-      Object {
-        "dateObject": "2012-11-05T00:00:00.000Z",
-      },
-      Object {
-        "dateObject": "2012-11-05T00:00:00.000Z",
       },
     ],
   },

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -78,6 +78,7 @@ function queryResult(nodes, query, { types = [] } = {}) {
 describe(`GraphQL Input args`, () => {
   const nodes = [
     {
+      index: 0,
       name: `The Mad Max`,
       hair: 1,
       date: `2006-07-22T22:39:53.000Z`,
@@ -103,9 +104,9 @@ describe(`GraphQL Input args`, () => {
       boolean: true,
     },
     {
+      index: 1,
       name: `The Mad Wax`,
       hair: 2,
-      date: `2006-07-22T22:39:53.000Z`,
       anArray: [1, 2, 5, 4],
       frontmatter: {
         date: `2006-07-22T22:39:53.000Z`,
@@ -116,9 +117,10 @@ describe(`GraphQL Input args`, () => {
       boolean: false,
     },
     {
+      index: 2,
       name: `The Mad Wax`,
       hair: 0,
-      date: `2006-07-22T22:39:53.000Z`,
+      date: `2006-07-29T22:39:53.000Z`,
       frontmatter: {
         date: `2006-07-22T22:39:53.000Z`,
         title: `The world of shave and adventure`,
@@ -373,6 +375,23 @@ describe(`GraphQL Input args`, () => {
     expect(result.errors).not.toBeDefined()
     expect(result.data.allNode.edges.length).toEqual(2)
     expect(result.data.allNode.edges[0].node.name).toEqual(`The Mad Wax`)
+  })
+
+  it(`filters date fields`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: {date: { ne: null }}) {
+            edges { node { index }}
+          }
+        }
+      `
+    )
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(2)
+    expect(result.data.allNode.edges[0].node.index).toEqual(0)
+    expect(result.data.allNode.edges[1].node.index).toEqual(2)
   })
 
   it(`sorts results`, async () => {

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -4,6 +4,9 @@ const {
   GraphQLList,
   GraphQLSchema,
 } = require(`graphql`)
+const path = require(`path`)
+const normalizePath = require(`normalize-path`)
+
 const { inferObjectStructureFromNodes } = require(`../infer-graphql-type`)
 
 function queryResult(nodes, fragment, { types = [] } = {}) {
@@ -39,7 +42,9 @@ function queryResult(nodes, fragment, { types = [] } = {}) {
         ${fragment}
       }
     }
-    `
+    `,
+    null,
+    { path: `/` }
   )
 }
 
@@ -207,7 +212,97 @@ describe(`GraphQL type inferance`, () => {
   })
 
   xdescribe(`Linked inference from config mappings`)
-  xdescribe(`Linked inference from file URIs`)
+
+  describe(`Linked inference from file URIs`, () => {
+    let store, types, dir
+
+    beforeEach(() => {
+      ;({ store } = require(`../../redux`))
+
+      const { setFileNodeRootType } = require(`../types/type-file`)
+      const fileType = {
+        name: `File`,
+        nodeObjectType: new GraphQLObjectType({
+          name: `File`,
+          fields: inferObjectStructureFromNodes({
+            nodes: [{ id: `file_1`, absolutePath: `path`, dir: `path` }],
+            types: [{ name: `File` }],
+          }),
+        }),
+      }
+
+      types = [fileType]
+      setFileNodeRootType(fileType.nodeObjectType)
+
+      dir = normalizePath(path.resolve(`/path/`))
+
+      store.dispatch({
+        type: `CREATE_NODE`,
+        payload: {
+          id: `parent`,
+          internal: { type: `File` },
+          absolutePath: normalizePath(path.resolve(dir, `index.md`)),
+          dir: dir,
+        },
+      })
+      store.dispatch({
+        type: `CREATE_NODE`,
+        payload: {
+          id: `file_1`,
+          internal: { type: `File` },
+          absolutePath: normalizePath(path.resolve(dir, `file_1.jpg`)),
+          dir,
+        },
+      })
+      store.dispatch({
+        type: `CREATE_NODE`,
+        payload: {
+          id: `file_2`,
+          internal: { type: `File` },
+          absolutePath: normalizePath(path.resolve(dir, `file_2.txt`)),
+          dir,
+        },
+      })
+    })
+
+    it(`Links to file node`, async () => {
+      let result = await queryResult(
+        [{ file: `./file_1.jpg`, parent: `parent` }],
+        `
+          file {
+            absolutePath
+          }
+        `,
+        { types }
+      )
+
+      expect(result.errors).not.toBeDefined()
+      expect(result.data.listNode[0].file.absolutePath).toEqual(
+        normalizePath(path.resolve(dir, `file_1.jpg`))
+      )
+    })
+
+    it(`Links to array of file nodes`, async () => {
+      let result = await queryResult(
+        [{ files: [`./file_1.jpg`, `./file_2.txt`], parent: `parent` }],
+        `
+          files {
+            absolutePath
+          }
+        `,
+        { types }
+      )
+
+      expect(result.errors).not.toBeDefined()
+      expect(result.data.listNode[0].files.length).toEqual(2)
+      expect(result.data.listNode[0].files[0].absolutePath).toEqual(
+        normalizePath(path.resolve(dir, `file_1.jpg`))
+      )
+      expect(result.data.listNode[0].files[1].absolutePath).toEqual(
+        normalizePath(path.resolve(dir, `file_2.txt`))
+      )
+    })
+  })
 
   describe(`Linked inference by __NODE convention`, () => {
     let store, types

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -18,6 +18,7 @@ const {
 const { nodeInterface } = require(`./node-interface`)
 const { getNodes, getNode, getNodeAndSavePathDependency } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
+const { setFileNodeRootType } = require(`./types/type-file`)
 
 import type { ProcessedNodeType } from "./infer-graphql-type"
 
@@ -26,6 +27,9 @@ type TypeMap = { [typeName: string]: ProcessedNodeType }
 module.exports = async () => {
   const types = _.groupBy(getNodes(), node => node.internal.type)
   const processedTypes: TypeMap = {}
+
+  // Reset stored File type to not point to outdated type definition
+  setFileNodeRootType(null)
 
   function createNodeFields(type: ProcessedNodeType) {
     const defaultNodeFields = {
@@ -183,6 +187,11 @@ module.exports = async () => {
     }
 
     processedTypes[_.camelCase(typeName)] = proccesedType
+
+    // Special case to construct linked file type used by type inferring
+    if (typeName === `File`) {
+      setFileNodeRootType(gqlType)
+    }
   }
 
   // Create node types and node fields for nodes that have a resolve function.

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -527,7 +527,7 @@ export function inferObjectStructureFromNodes({
         nodes,
         types,
         exampleValue: value,
-        selector: selector ? `${selector}.${key}` : key,
+        selector: nextSelector,
       })
     }
 

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -75,33 +75,17 @@ function inferGraphQLType({
 
     if (exampleValue == null) return null
 
-    let headType
-    // If the array contains non-array objects, than treat them as "nodes"
-    // and create an object type.
-    if (_.isObject(exampleValue) && !_.isArray(exampleValue)) {
-      headType = new GraphQLObjectType({
-        name: createTypeName(fieldName),
-        fields: inferObjectStructureFromNodes({
-          ...otherArgs,
-          exampleValue,
-          selector,
-        }),
-      })
-      // Else if the values are simple values or arrays, just infer their type.
-    } else {
-      let inferredType = inferGraphQLType({
-        ...otherArgs,
-        exampleValue,
-        selector,
-      })
-      invariant(
-        inferredType,
-        `Could not infer graphQL type for value: ${exampleValue}`
-      )
+    let inferredType = inferGraphQLType({
+      ...otherArgs,
+      exampleValue,
+      selector,
+    })
+    invariant(
+      inferredType,
+      `Could not infer graphQL type for value: ${exampleValue}`
+    )
 
-      headType = inferredType.type
-    }
-    return { type: new GraphQLList(headType) }
+    return { type: new GraphQLList(inferredType.type) }
   }
 
   // Check if this is a date.

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -89,7 +89,7 @@ function inferGraphQLType({
   }
 
   if (DateType.shouldInfer(exampleValue)) {
-    return DateType.getType(fieldName)
+    return DateType.getType()
   }
 
   switch (typeof exampleValue) {

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -85,7 +85,27 @@ function inferGraphQLType({
       `Could not infer graphQL type for value: ${exampleValue}`
     )
 
-    return { type: new GraphQLList(inferredType.type) }
+    const { type, args = null, resolve = null } = inferredType
+
+    const listType = { type: new GraphQLList(type), args }
+
+    if (resolve) {
+      // If inferredType has resolve function wrap it with Array.map
+      listType.resolve = (object, args, context, resolveInfo) => {
+        const fieldValue = object[fieldName]
+        if (!fieldValue) {
+          return null
+        }
+
+        // Field resolver expects first parameter to be plain object
+        // containing key with name of field we want to resolve.
+        return fieldValue.map(value =>
+          resolve({ [fieldName]: value }, args, context, resolveInfo)
+        )
+      }
+    }
+
+    return listType
   }
 
   // Check if this is a date.

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -10,15 +10,9 @@ const {
 } = require(`graphql`)
 const _ = require(`lodash`)
 const invariant = require(`invariant`)
-const mime = require(`mime`)
-const isRelative = require(`is-relative`)
-const isRelativeUrl = require(`is-relative-url`)
-const normalize = require(`normalize-path`)
-const systemPath = require(`path`)
 const { oneLine } = require(`common-tags`)
 
-const { store, getNode, getNodes, getRootNodeId } = require(`../redux`)
-const { joinPath } = require(`../utils/path`)
+const { store, getNode, getNodes } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const createTypeName = require(`./create-type-name`)
 const createKey = require(`./create-key`)
@@ -27,6 +21,7 @@ const {
   isEmptyObjectOrArray,
 } = require(`./data-tree-utils`)
 const DateType = require(`./types/type-date`)
+const FileType = require(`./types/type-file`)
 
 import type { GraphQLOutputType } from "graphql"
 import type {
@@ -282,177 +277,6 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
   }
 }
 
-function findRootNode(node) {
-  // Find the root node.
-  let rootNode = node
-  let whileCount = 0
-  let rootNodeId
-  while (
-    (rootNodeId = getRootNodeId(rootNode) || rootNode.parent) &&
-    (getNode(rootNode.parent) !== undefined || getNode(rootNodeId)) &&
-    whileCount < 101
-  ) {
-    if (rootNodeId) {
-      rootNode = getNode(rootNodeId)
-    } else {
-      rootNode = getNode(rootNode.parent)
-    }
-    whileCount += 1
-    if (whileCount > 100) {
-      console.log(
-        `It looks like you have a node that's set its parent as itself`,
-        rootNode
-      )
-    }
-  }
-
-  return rootNode
-}
-
-function shouldInferFile(nodes, key, value) {
-  const looksLikeFile =
-    _.isString(value) &&
-    mime.lookup(value) !== `application/octet-stream` &&
-    // domains ending with .com
-    mime.lookup(value) !== `application/x-msdownload` &&
-    isRelative(value) &&
-    isRelativeUrl(value)
-
-  if (!looksLikeFile) {
-    return false
-  }
-
-  // Find the node used for this example.
-  let node = nodes.find(n => _.get(n, key) === value)
-
-  if (!node) {
-    // Try another search as our "key" isn't always correct e.g.
-    // it doesn't support arrays so the right key could be "a.b[0].c" but
-    // this function will get "a.b.c".
-    //
-    // We loop through every value of nodes until we find
-    // a match.
-    const visit = (current, selector = [], fn) => {
-      for (let i = 0, keys = Object.keys(current); i < keys.length; i++) {
-        const key = keys[i]
-        const value = current[key]
-
-        if (value === undefined || value === null) continue
-
-        if (typeof value === `object` || typeof value === `function`) {
-          visit(current[key], selector.concat([key]), fn)
-          continue
-        }
-
-        let proceed = fn(current[key], key, selector, current)
-
-        if (proceed === false) {
-          break
-        }
-      }
-    }
-
-    const isNormalInteger = str => /^\+?(0|[1-9]\d*)$/.test(str)
-
-    node = nodes.find(n => {
-      let isMatch = false
-      visit(n, [], (v, k, selector, parent) => {
-        if (v === value) {
-          // Remove integers as they're for arrays, which our passed
-          // in object path doesn't have.
-          const normalizedSelector = selector
-            .map(s => (isNormalInteger(s) ? `` : s))
-            .filter(s => s !== ``)
-          const fullSelector = `${normalizedSelector.join(`.`)}.${k}`
-          if (fullSelector === key) {
-            isMatch = true
-            return false
-          }
-        }
-
-        // Not a match so we continue
-        return true
-      })
-
-      return isMatch
-    })
-
-    // Still no node.
-    if (!node) {
-      return false
-    }
-  }
-
-  const rootNode = findRootNode(node)
-
-  // Only nodes transformed (ultimately) from a File
-  // can link to another File.
-  if (rootNode.internal.type !== `File`) {
-    return false
-  }
-
-  const pathToOtherNode = normalize(joinPath(rootNode.dir, value))
-  const otherFileExists = getNodes().some(
-    n => n.absolutePath === pathToOtherNode
-  )
-  return otherFileExists
-}
-
-// Look for fields that are pointing at a file — if the field has a known
-// extension then assume it should be a file field.
-function inferFromUri(key, types, isArray) {
-  const fileField = types.find(type => type.name === `File`)
-
-  if (!fileField) return null
-
-  return {
-    type: isArray
-      ? new GraphQLList(fileField.nodeObjectType)
-      : fileField.nodeObjectType,
-    resolve: (node, a, { path }) => {
-      const fieldValue = node[key]
-
-      if (!fieldValue) {
-        return null
-      }
-
-      const findLinkedFileNode = relativePath => {
-        // Use the parent File node to create the absolute path to
-        // the linked file.
-        const fileLinkPath = normalize(
-          systemPath.resolve(parentFileNode.dir, relativePath)
-        )
-
-        // Use that path to find the linked File node.
-        const linkedFileNode = _.find(
-          getNodes(),
-          n => n.internal.type === `File` && n.absolutePath === fileLinkPath
-        )
-        if (linkedFileNode) {
-          createPageDependency({
-            path,
-            nodeId: linkedFileNode.id,
-          })
-          return linkedFileNode
-        } else {
-          return null
-        }
-      }
-
-      // Find the File node for this node (we assume the node is something
-      // like markdown which would be a child node of a File node).
-      const parentFileNode = findRootNode(node)
-
-      // Find the linked File node(s)
-      if (isArray) {
-        return fieldValue.map(relativePath => findLinkedFileNode(relativePath))
-      } else {
-        return findLinkedFileNode(fieldValue)
-      }
-    },
-  }
-}
-
 type inferTypeOptions = {
   nodes: Object[],
   types: ProcessedNodeType[],
@@ -508,17 +332,8 @@ export function inferObjectStructureFromNodes({
 
       // Third if the field (whether a string or array of string(s)) is
       // pointing to a file (from another file).
-    } else if (
-      nodes[0].internal.type !== `File` &&
-      ((_.isString(value) &&
-        !_.isEmpty(value) &&
-        shouldInferFile(nodes, nextSelector, value)) ||
-        (_.isArray(value) &&
-          _.isString(value[0]) &&
-          !_.isEmpty(value[0]) &&
-          shouldInferFile(nodes, `${nextSelector}[0]`, value[0])))
-    ) {
-      inferredField = inferFromUri(key, types, _.isArray(value))
+    } else if (FileType.shouldInfer(nodes, nextSelector, value)) {
+      inferredField = FileType.inferFromUri(key, types, _.isArray(value))
     }
 
     // Finally our automatic inference of field value type.

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -333,7 +333,9 @@ export function inferObjectStructureFromNodes({
       // Third if the field (whether a string or array of string(s)) is
       // pointing to a file (from another file).
     } else if (FileType.shouldInfer(nodes, nextSelector, value)) {
-      inferredField = FileType.inferFromUri(key, types, _.isArray(value))
+      inferredField = _.isArray(value)
+        ? FileType.getListType()
+        : FileType.getType()
     }
 
     // Finally our automatic inference of field value type.

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -9,7 +9,7 @@ const Promise = require(`bluebird`)
 function awaitSiftField(fields, node, k) {
   const field = fields[k]
   if (field.resolve) {
-    return field.resolve(node)
+    return field.resolve(node, {}, {}, { fieldName: k })
   } else if (node[k] !== undefined) {
     return node[k]
   }

--- a/packages/gatsby/src/schema/types/type-date.js
+++ b/packages/gatsby/src/schema/types/type-date.js
@@ -30,66 +30,68 @@ export function shouldInfer(value) {
   return momentDate.isValid() && typeof value !== `number`
 }
 
-export function getType(fieldName) {
-  return {
-    type: GraphQLString,
-    args: {
-      formatString: {
-        type: GraphQLString,
-        description: oneLine`
-          Format the date using Moment.js' date tokens e.g.
+const type = Object.freeze({
+  type: GraphQLString,
+  args: {
+    formatString: {
+      type: GraphQLString,
+      description: oneLine`
+        Format the date using Moment.js' date tokens e.g.
         "date(formatString: "YYYY MMMM DD)"
         See https://momentjs.com/docs/#/displaying/format/
         for documentation for different tokens`,
-      },
-      fromNow: {
-        type: GraphQLBoolean,
-        description: oneLine`
-          Returns a string generated with Moment.js' fromNow function`,
-      },
-      difference: {
-        type: GraphQLString,
-        description: oneLine`
-          Returns the difference between this date and the current time.
-          Defaults to miliseconds but you can also pass in as the
-          measurement years, months, weeks, days, hours, minutes,
-          and seconds.`,
-      },
-      locale: {
-        type: GraphQLString,
-        description: oneLine`
-          Configures the locale Moment.js will use to format the date.
-        `,
-      },
     },
-    resolve(object, args) {
-      let date
-      if (object[fieldName]) {
-        date = JSON.parse(JSON.stringify(object[fieldName]))
-      } else {
-        return null
-      }
-      if (_.isPlainObject(args)) {
-        const { fromNow, difference, formatString, locale = `en` } = args
-        if (formatString) {
-          return moment
-            .utc(date, ISO_8601_FORMAT, true)
-            .locale(locale)
-            .format(formatString)
-        } else if (fromNow) {
-          return moment
-            .utc(date, ISO_8601_FORMAT, true)
-            .locale(locale)
-            .fromNow()
-        } else if (difference) {
-          return moment().diff(
-            moment.utc(date, ISO_8601_FORMAT, true).locale(locale),
-            difference
-          )
-        }
-      }
+    fromNow: {
+      type: GraphQLBoolean,
+      description: oneLine`
+        Returns a string generated with Moment.js' fromNow function`,
+    },
+    difference: {
+      type: GraphQLString,
+      description: oneLine`
+        Returns the difference between this date and the current time.
+        Defaults to miliseconds but you can also pass in as the
+        measurement years, months, weeks, days, hours, minutes,
+        and seconds.`,
+    },
+    locale: {
+      type: GraphQLString,
+      description: oneLine`
+        Configures the locale Moment.js will use to format the date.`,
+    },
+  },
+  resolve(source, args, context, { fieldName }) {
+    let date
+    if (source[fieldName]) {
+      date = JSON.parse(JSON.stringify(source[fieldName]))
+    } else {
+      return null
+    }
 
-      return date
-    },
-  }
+    if (_.isPlainObject(args)) {
+      const { fromNow, difference, formatString, locale = `en` } = args
+      if (formatString) {
+        return moment
+          .utc(date, ISO_8601_FORMAT, true)
+          .locale(locale)
+          .format(formatString)
+      } else if (fromNow) {
+        return moment
+          .utc(date, ISO_8601_FORMAT, true)
+          .locale(locale)
+          .fromNow()
+      } else if (difference) {
+        return moment().diff(
+          moment.utc(date, ISO_8601_FORMAT, true).locale(locale),
+          difference
+        )
+      }
+    }
+
+    return date
+  },
+})
+
+export function getType() {
+  return type
 }

--- a/packages/gatsby/src/schema/types/type-date.js
+++ b/packages/gatsby/src/schema/types/type-date.js
@@ -1,5 +1,10 @@
 const moment = require(`moment`)
-const { GraphQLString, GraphQLBoolean } = require(`graphql`)
+const {
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLScalarType,
+  Kind,
+} = require(`graphql`)
 const _ = require(`lodash`)
 const { oneLine } = require(`common-tags`)
 
@@ -30,8 +35,20 @@ export function shouldInfer(value) {
   return momentDate.isValid() && typeof value !== `number`
 }
 
+export const GraphQLDate = new GraphQLScalarType({
+  name: `Date`,
+  description: oneLine`
+    A date string, such as 2007-12-03, compliant with the ISO 8601 standard 
+    for representation of dates and times using the Gregorian calendar.`,
+  serialize: String,
+  parseValue: String,
+  parseLiteral(ast) {
+    return ast.kind === Kind.STRING ? ast.value : undefined
+  },
+})
+
 const type = Object.freeze({
-  type: GraphQLString,
+  type: GraphQLDate,
   args: {
     formatString: {
       type: GraphQLString,

--- a/packages/gatsby/src/schema/types/type-date.js
+++ b/packages/gatsby/src/schema/types/type-date.js
@@ -1,0 +1,95 @@
+const moment = require(`moment`)
+const { GraphQLString, GraphQLBoolean } = require(`graphql`)
+const _ = require(`lodash`)
+const { oneLine } = require(`common-tags`)
+
+const ISO_8601_FORMAT = [
+  `YYYY`,
+  `YYYY-MM`,
+  `YYYY-MM-DD`,
+  `YYYYMMDD`,
+  `YYYY-MM-DDTHHZ`,
+  `YYYY-MM-DDTHH:mmZ`,
+  `YYYY-MM-DDTHHmmZ`,
+  `YYYY-MM-DDTHH:mm:ssZ`,
+  `YYYY-MM-DDTHHmmssZ`,
+  `YYYY-MM-DDTHH:mm:ss.SSSZ`,
+  `YYYY-MM-DDTHHmmss.SSSZ`,
+  `YYYY-[W]WW`,
+  `YYYY[W]WW`,
+  `YYYY-[W]WW-E`,
+  `YYYY[W]WWE`,
+  `YYYY-DDDD`,
+  `YYYYDDDD`,
+]
+
+// Check if this is a date.
+// All the allowed ISO 8601 date-time formats used.
+export function shouldInfer(value) {
+  const momentDate = moment.utc(value, ISO_8601_FORMAT, true)
+  return momentDate.isValid() && typeof value !== `number`
+}
+
+export function getType(fieldName) {
+  return {
+    type: GraphQLString,
+    args: {
+      formatString: {
+        type: GraphQLString,
+        description: oneLine`
+          Format the date using Moment.js' date tokens e.g.
+        "date(formatString: "YYYY MMMM DD)"
+        See https://momentjs.com/docs/#/displaying/format/
+        for documentation for different tokens`,
+      },
+      fromNow: {
+        type: GraphQLBoolean,
+        description: oneLine`
+          Returns a string generated with Moment.js' fromNow function`,
+      },
+      difference: {
+        type: GraphQLString,
+        description: oneLine`
+          Returns the difference between this date and the current time.
+          Defaults to miliseconds but you can also pass in as the
+          measurement years, months, weeks, days, hours, minutes,
+          and seconds.`,
+      },
+      locale: {
+        type: GraphQLString,
+        description: oneLine`
+          Configures the locale Moment.js will use to format the date.
+        `,
+      },
+    },
+    resolve(object, args) {
+      let date
+      if (object[fieldName]) {
+        date = JSON.parse(JSON.stringify(object[fieldName]))
+      } else {
+        return null
+      }
+      if (_.isPlainObject(args)) {
+        const { fromNow, difference, formatString, locale = `en` } = args
+        if (formatString) {
+          return moment
+            .utc(date, ISO_8601_FORMAT, true)
+            .locale(locale)
+            .format(formatString)
+        } else if (fromNow) {
+          return moment
+            .utc(date, ISO_8601_FORMAT, true)
+            .locale(locale)
+            .fromNow()
+        } else if (difference) {
+          return moment().diff(
+            moment.utc(date, ISO_8601_FORMAT, true).locale(locale),
+            difference
+          )
+        }
+      }
+
+      return date
+    },
+  }
+}

--- a/packages/gatsby/src/schema/types/type-file.js
+++ b/packages/gatsby/src/schema/types/type-file.js
@@ -1,0 +1,197 @@
+const { GraphQLList } = require(`graphql`)
+const _ = require(`lodash`)
+const mime = require(`mime`)
+const isRelative = require(`is-relative`)
+const isRelativeUrl = require(`is-relative-url`)
+const normalize = require(`normalize-path`)
+const systemPath = require(`path`)
+
+const { getNode, getNodes, getRootNodeId } = require(`../../redux`)
+const {
+  createPageDependency,
+} = require(`../../redux/actions/add-page-dependency`)
+const { joinPath } = require(`../../utils/path`)
+
+function findRootNode(node) {
+  // Find the root node.
+  let rootNode = node
+  let whileCount = 0
+  let rootNodeId
+  while (
+    (rootNodeId = getRootNodeId(rootNode) || rootNode.parent) &&
+    (getNode(rootNode.parent) !== undefined || getNode(rootNodeId)) &&
+    whileCount < 101
+  ) {
+    if (rootNodeId) {
+      rootNode = getNode(rootNodeId)
+    } else {
+      rootNode = getNode(rootNode.parent)
+    }
+    whileCount += 1
+    if (whileCount > 100) {
+      console.log(
+        `It looks like you have a node that's set its parent as itself`,
+        rootNode
+      )
+    }
+  }
+
+  return rootNode
+}
+
+function pointsToFile(nodes, key, value) {
+  const looksLikeFile =
+    _.isString(value) &&
+    mime.lookup(value) !== `application/octet-stream` &&
+    // domains ending with .com
+    mime.lookup(value) !== `application/x-msdownload` &&
+    isRelative(value) &&
+    isRelativeUrl(value)
+
+  if (!looksLikeFile) {
+    return false
+  }
+
+  // Find the node used for this example.
+  let node = nodes.find(n => _.get(n, key) === value)
+
+  if (!node) {
+    // Try another search as our "key" isn't always correct e.g.
+    // it doesn't support arrays so the right key could be "a.b[0].c" but
+    // this function will get "a.b.c".
+    //
+    // We loop through every value of nodes until we find
+    // a match.
+    const visit = (current, selector = [], fn) => {
+      for (let i = 0, keys = Object.keys(current); i < keys.length; i++) {
+        const key = keys[i]
+        const value = current[key]
+
+        if (value === undefined || value === null) continue
+
+        if (typeof value === `object` || typeof value === `function`) {
+          visit(current[key], selector.concat([key]), fn)
+          continue
+        }
+
+        let proceed = fn(current[key], key, selector, current)
+
+        if (proceed === false) {
+          break
+        }
+      }
+    }
+
+    const isNormalInteger = str => /^\+?(0|[1-9]\d*)$/.test(str)
+
+    node = nodes.find(n => {
+      let isMatch = false
+      visit(n, [], (v, k, selector, parent) => {
+        if (v === value) {
+          // Remove integers as they're for arrays, which our passed
+          // in object path doesn't have.
+          const normalizedSelector = selector
+            .map(s => (isNormalInteger(s) ? `` : s))
+            .filter(s => s !== ``)
+          const fullSelector = `${normalizedSelector.join(`.`)}.${k}`
+          if (fullSelector === key) {
+            isMatch = true
+            return false
+          }
+        }
+
+        // Not a match so we continue
+        return true
+      })
+
+      return isMatch
+    })
+
+    // Still no node.
+    if (!node) {
+      return false
+    }
+  }
+
+  const rootNode = findRootNode(node)
+
+  // Only nodes transformed (ultimately) from a File
+  // can link to another File.
+  if (rootNode.internal.type !== `File`) {
+    return false
+  }
+
+  const pathToOtherNode = normalize(joinPath(rootNode.dir, value))
+  const otherFileExists = getNodes().some(
+    n => n.absolutePath === pathToOtherNode
+  )
+  return otherFileExists
+}
+
+export function shouldInfer(nodes, selector, value) {
+  return (
+    nodes[0].internal.type !== `File` &&
+    ((_.isString(value) &&
+      !_.isEmpty(value) &&
+      pointsToFile(nodes, selector, value)) ||
+      (_.isArray(value) &&
+        _.isString(value[0]) &&
+        !_.isEmpty(value[0]) &&
+        pointsToFile(nodes, `${selector}[0]`, value[0])))
+  )
+}
+
+// Look for fields that are pointing at a file — if the field has a known
+// extension then assume it should be a file field.
+export function inferFromUri(key, types, isArray) {
+  const fileField = types.find(type => type.name === `File`)
+
+  if (!fileField) return null
+
+  return {
+    type: isArray
+      ? new GraphQLList(fileField.nodeObjectType)
+      : fileField.nodeObjectType,
+    resolve: (node, a, { path }) => {
+      const fieldValue = node[key]
+
+      if (!fieldValue) {
+        return null
+      }
+
+      const findLinkedFileNode = relativePath => {
+        // Use the parent File node to create the absolute path to
+        // the linked file.
+        const fileLinkPath = normalize(
+          systemPath.resolve(parentFileNode.dir, relativePath)
+        )
+
+        // Use that path to find the linked File node.
+        const linkedFileNode = _.find(
+          getNodes(),
+          n => n.internal.type === `File` && n.absolutePath === fileLinkPath
+        )
+        if (linkedFileNode) {
+          createPageDependency({
+            path,
+            nodeId: linkedFileNode.id,
+          })
+          return linkedFileNode
+        } else {
+          return null
+        }
+      }
+
+      // Find the File node for this node (we assume the node is something
+      // like markdown which would be a child node of a File node).
+      const parentFileNode = findRootNode(node)
+
+      // Find the linked File node(s)
+      if (isArray) {
+        return fieldValue.map(relativePath => findLinkedFileNode(relativePath))
+      } else {
+        return findLinkedFileNode(fieldValue)
+      }
+    },
+  }
+}

--- a/packages/gatsby/src/schema/types/type-file.js
+++ b/packages/gatsby/src/schema/types/type-file.js
@@ -12,6 +12,18 @@ const {
 } = require(`../../redux/actions/add-page-dependency`)
 const { joinPath } = require(`../../utils/path`)
 
+let type, listType
+
+export function setFileNodeRootType(fileNodeRootType) {
+  if (fileNodeRootType) {
+    type = createType(fileNodeRootType, false)
+    listType = createType(fileNodeRootType, true)
+  } else {
+    type = null
+    listType = null
+  }
+}
+
 function findRootNode(node) {
   // Find the root node.
   let rootNode = node
@@ -141,19 +153,13 @@ export function shouldInfer(nodes, selector, value) {
   )
 }
 
-// Look for fields that are pointing at a file — if the field has a known
-// extension then assume it should be a file field.
-export function inferFromUri(key, types, isArray) {
-  const fileField = types.find(type => type.name === `File`)
-
-  if (!fileField) return null
+function createType(fileNodeRootType, isArray) {
+  if (!fileNodeRootType) return null
 
   return {
-    type: isArray
-      ? new GraphQLList(fileField.nodeObjectType)
-      : fileField.nodeObjectType,
-    resolve: (node, a, { path }) => {
-      const fieldValue = node[key]
+    type: isArray ? new GraphQLList(fileNodeRootType) : fileNodeRootType,
+    resolve: (node, args, { path }, { fieldName }) => {
+      let fieldValue = node[fieldName]
 
       if (!fieldValue) {
         return null
@@ -194,4 +200,12 @@ export function inferFromUri(key, types, isArray) {
       }
     },
   }
+}
+
+export function getType() {
+  return type
+}
+
+export function getListType() {
+  return listType
 }


### PR DESCRIPTION
1. Remove special case for inferring array of objects - it seems to not be needed and removing not needed special cases improves code readability.
2. Currently when inferring arrays gatsby takes just type of array items discarding field args and resolve function. Adding them back allows to use date formatting function in array of dates (so this one closes #3556)
3. Code organization - move date and file related code to separate file to make type inferring file more readable.
4. Add tests for linking fields to file nodes

Probably more changes will come soon.