### PR TITLE
use ssh git urls for starters

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -66,7 +66,7 @@ const copy = async (starterPath: string, rootPath: string) => {
 
 // Clones starter from URI.
 const clone = async (hostInfo: any, rootPath: string) => {
-  const url = hostInfo.git({ noCommittish: true })
+  const url = hostInfo.ssh({ noCommittish: true })
   const branch = hostInfo.committish ? `-b ${hostInfo.committish}` : ``
 
   report.info(`Creating new site from git: ${url}`)

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -66,7 +66,7 @@ const copy = async (starterPath: string, rootPath: string) => {
 
 // Clones starter from URI.
 const clone = async (hostInfo: any, rootPath: string) => {
-  const url = hostInfo.ssh({ noCommittish: true })
+  const url = hostInfo.getDefaultRepresentation({ noCommittish: true })
   const branch = hostInfo.committish ? `-b ${hostInfo.committish}` : ``
 
   report.info(`Creating new site from git: ${url}`)


### PR DESCRIPTION
use `hosted-git-info`'s ssh url. This allows starters from private repos
to work while still supporting the defaults and public starters.