### PR TITLE
Resolves: Object doesn't support this action

### DIFF
--- a/examples/using-page-transitions/gatsby-browser.js
+++ b/examples/using-page-transitions/gatsby-browser.js
@@ -10,7 +10,8 @@ const timeout = 250
 const historyExitingEventType = `history::exiting`
 
 const getUserConfirmation = (pathname, callback) => {
-  const event = new CustomEvent(historyExitingEventType, { detail: { pathname } })
+  const event = document.createEvent("CustomEvent");
+  event.initCustomEvent(historyExitingEventType, false, false, { detail: { pathname } });
   window.dispatchEvent(event)
   setTimeout(() => {
     callback(true)


### PR DESCRIPTION
Resolves the following error in older IE browsers (Tested in IE10 & 11):

SCRIPT445: Object doesn't support this action