### PR TITLE
fix(gatsby-link): correct dependency declaration

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -19,11 +19,13 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "peerDependencies": {
+    "gatsby": "^1.0.0"
+  },
   "dependencies": {
     "@types/react-router-dom": "^4.2.2",
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.5.8",
-    "react-router-dom": "^4.2.2",
     "ric": "^1.3.0"
   }
 }

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -17,12 +17,13 @@
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5",
-    "react-router-dom": "^4.2.2"
+    "cross-env": "^5.0.5"
   },
   "dependencies": {
+    "@types/react-router-dom": "^4.2.2",
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.5.8",
+    "react-router-dom": "^4.2.2",
     "ric": "^1.3.0"
   }
 }


### PR DESCRIPTION
The code depends on `react-router-dom`, and therefore it should be declared as a
direct dependency, not a dev one. Also, it needs `@types/react-router-dom` for
index.d.ts.