### PR TITLE
fix(transformer-remark): resolve htmlAst correctly

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -290,9 +290,10 @@ module.exports = (
       htmlAst: {
         type: GraphQlJson,
         resolve(markdownNode) {
-          const ast = _.clone(getHTMLAst(markdownNode))
-          stripPosition(ast, true)
-          return ast
+          return getHTMLAst(markdownNode).then(ast => {
+            const strippedAst = stripPosition(_.clone(ast), true)
+            return strippedAst
+          })
         },
       },
       excerpt: {


### PR DESCRIPTION
The resolve function must return a promise, which breaks when cloned with lodash. The fix resolves the value before modifying it.

closes #3711 
