### PR TITLE
Adds Google Tag Manager (GTM) to /www

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -112,6 +112,13 @@ module.exports = {
         trackingId: `UA-93349937-1`,
       },
     },
+    {
+      resolve: `gatsby-plugin-google-tagmanager`,
+      options: {
+        id: `GTM-NWW5NJL`,
+        includeInDevelopment: true,
+      },
+    },
     `gatsby-plugin-sitemap`,
     {
       resolve: `gatsby-plugin-feed`,

--- a/www/package.json
+++ b/www/package.json
@@ -14,6 +14,7 @@
     "gatsby-plugin-feed": "^1.3.10",
     "gatsby-plugin-glamor": "^1.6.7",
     "gatsby-plugin-google-analytics": "^1.0.7",
+    "gatsby-plugin-google-tagmanager": "^1.0.13",
     "gatsby-plugin-lodash": "^1.0.0",
     "gatsby-plugin-manifest": "^1.0.7",
     "gatsby-plugin-netlify": "^1.0.0",


### PR DESCRIPTION
apologies on the delay with this one.  work's been intense recently.

addresses https://github.com/gatsbyjs/gatsby/issues/3542

Steps:
- [ ] deploy GTM for www
- [ ] create new GA account to track alongside old GA account
- [ ] setup GTM tag & trigger for Google Analytics; click publish

@calcsam @KyleAMathews not sure if I have the correct account privilege within GA.  I tried to make a new property but the "Add" option isn't showing up.  Specifically, I'd like to create a _new_ GA account to track alongside our current one.  I'll update it with all the correct settings and we can compare traffic numbers (old vs. new).  In the new GA property, I'll create three views:
- all traffic
- internal / dev traffic only
- external traffic (excludes internal/dev)

(GA allows us to [exclude local traffic via an IP address filter](https://support.google.com/analytics/answer/1034840?hl=en).  If you can share with me the IP address of the places where you hack (via twitter DM?), I can block out our own traffic.  (Simple google query: _what is my IP address?_ will suffice).