### PR TITLE
Use a red background for the errors

### DIFF
--- a/packages/gatsby-cli/src/reporter/errors.js
+++ b/packages/gatsby-cli/src/reporter/errors.js
@@ -24,6 +24,10 @@ function getErrorFormatter() {
   prettyError.appendStyle({
     "pretty-error": {
       marginTop: 1,
+      background: `red`,
+    },
+    "pretty-error > trace > item > footer > addr": {
+      color: `cyan`,
     },
   })
 


### PR DESCRIPTION
Related to: gatsbyjs/gatsby#2645

I set the background color of the errors to red.
There is a screenshot to show the changes.

![screenshot at 2018-01-27 17 56 12](https://user-images.githubusercontent.com/16168447/35474444-a0785ca0-038e-11e8-8f1a-783897a079b4.png)
