### PR TITLE
Add a no-color option to disable the colors

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -41,5 +41,8 @@
     "build": "babel src --out-dir lib --ignore __tests__",
     "watch": "babel -w src --out-dir lib --ignore __tests__",
     "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "yargs": {
+    "boolean-negation": false
   }
 }

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -60,7 +60,8 @@ function buildLocalCommands(cli, isLocalSite) {
   function getCommandHandler(command, handler) {
     return argv => {
       report.setVerbose(!!argv.verbose)
-
+      report.setNoColor(!!argv.noColor)
+      
       process.env.gatsby_log_level = argv.verbose ? `verbose` : `normal`
       report.verbose(`set gatsby_log_level: "${process.env.gatsby_log_level}"`)
 
@@ -173,6 +174,12 @@ module.exports = (argv, handlers) => {
       default: false,
       type: `boolean`,
       describe: `Turn on verbose output`,
+      global: true,
+    })
+    .option(`no-color`,{
+      default: false,
+      type: `boolean`,
+      describe: `Turn off the color in output`,
       global: true,
     })
 

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -17,7 +17,11 @@ module.exports = Object.assign(reporter, {
   setVerbose(isVerbose = true) {
     this.isVerbose = !!isVerbose
   },
-
+  setNoColor(isNoColor = false){
+    if(isNoColor){
+      errorFormatter.withoutColors()
+    }
+  },
   panic(...args) {
     this.error(...args)
     process.exit(1)


### PR DESCRIPTION
Related to: #3736 and #2645 

I had an issue with yargs when I had the option no-color. By default, when using a --no-something option yargs does a boolean negation on the something option.
I disable this feature of yargs as I don't think that it's breaking something.

You can find more info on the boolean-negation [there]( https://github.com/yargs/yargs-parser#boolean-negation)
