### PR TITLE
[gatsby] Report an error when layout file is missing

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -357,7 +357,11 @@ module.exports = async (args: BootstrapArgs) => {
   // Write out files.
   activity = report.activityTimer(`write out page data`)
   activity.start()
-  await writePages()
+  try {
+    await writePages()
+  } catch (err) {
+    report.panic(`Failed to write out page data`, err)
+  }
   activity.end()
 
   // Write out redirects.

--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -45,7 +45,7 @@ const writePages = async () => {
       let layout = getLayoutById(layouts)(p.layout)
 
       if (!layout) {
-        throw new Error(`Could not find layout '${p.layout}'. Check if such file exists in 'src/layouts'.`)
+        throw new Error(`Could not find layout '${p.layout}'. Check if this file exists in 'src/layouts'.`)
       }
 
       pageLayouts.push(layout)

--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -45,7 +45,11 @@ const writePages = async () => {
       let layout = getLayoutById(layouts)(p.layout)
 
       if (!layout) {
-        throw new Error(`Could not find layout '${p.layout}'. Check if this file exists in 'src/layouts'.`)
+        throw new Error(
+          `Could not find layout '${
+            p.layout
+          }'. Check if this file exists in 'src/layouts'.`
+        )
       }
 
       pageLayouts.push(layout)

--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -43,6 +43,11 @@ const writePages = async () => {
     })
     if (p.layout) {
       let layout = getLayoutById(layouts)(p.layout)
+
+      if (!layout) {
+        throw new Error(`Could not find layout '${p.layout}'. Check if such file exists in 'src/layouts'.`)
+      }
+
       pageLayouts.push(layout)
       json.push({
         jsonName: layout.jsonName,
@@ -122,7 +127,7 @@ const preferDefault = m => m && m.default || m
     .join(`,\n`)}
 }`
 
-  await Promise.all([
+  return await Promise.all([
     fs.writeFile(
       joinPath(program.directory, `.cache/pages.json`),
       JSON.stringify(pagesData, null, 4)
@@ -133,8 +138,6 @@ const preferDefault = m => m && m.default || m
       asyncRequires
     ),
   ])
-
-  return
 }
 
 exports.writePages = writePages


### PR DESCRIPTION
This issue adds better error reporting when a layout file is missing. It's related to https://github.com/gatsbyjs/gatsby/issues/3183.

Before:
```
$ gatsby develop
success delete html files from previous builds — 0.011 s
success open and validate gatsby-config.js — 0.006 s
success copy gatsby files — 0.023 s
success onPreBootstrap — 0.007 s
success source and transform nodes — 4.761 s
success building schema — 4.282 s
success createLayouts — 0.017 s
success createPages — 2.744 s
success createPagesStatefully — 0.049 s
success onPreExtractQueries — 0.000 s
success update schema — 6.861 s
success extract queries from components — 0.271 s
success run graphql queries — 57.004 s
error UNHANDLED REJECTION


  TypeError: Cannot read property 'jsonName' of undefined

  - pages-writer.js:79
    [blog]/[gatsby]/dist/internal-plugins/query-runner/pages-writer.js:79:36

  - Array.forEach

  - pages-writer.js:70 _callee$
    [blog]/[gatsby]/dist/internal-plugins/query-runner/pages-writer.js:70:19

  - pages-writer.js:141 writePages
    [blog]/[gatsby]/dist/internal-plugins/query-runner/pages-writer.js:141:17

  - index.js:459 _callee$
    [blog]/[gatsby]/dist/bootstrap/index.js:459:20


error Command failed with exit code 1.
```

After:
```
$ gatsby develop
success delete html files from previous builds — 0.008 s
success open and validate gatsby-config.js — 0.005 s
success copy gatsby files — 0.026 s
success onPreBootstrap — 0.007 s
success source and transform nodes — 0.912 s
success building schema — 3.641 s
success createLayouts — 0.017 s
success createPages — 2.872 s
success createPagesStatefully — 0.015 s
success onPreExtractQueries — 0.001 s
success update schema — 6.851 s
success extract queries from components — 0.265 s
success run graphql queries — 60.000 s
error Failed to write out page data


  Error: Could not find layout 'de'. Check if such file exists in 'src/layouts'.

  - pages-writer.js:46 pages.forEach.p
    [blog]/[gatsby]/dist/internal-plugins/query-runner/pages-writer.js:46:15

  - Array.forEach

  - pages-writer.js:37 writePages
    [blog]/[gatsby]/dist/internal-plugins/query-runner/pages-writer.js:37:9

  - index.js:325 module.exports
    [blog]/[gatsby]/dist/bootstrap/index.js:325:11



error Command failed with exit code 1.
```