### PR TITLE
Adds ERC dEX website to Showcase, built with Gatsby

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Websites built with Gatsby:
 * [Nortcast](https://nortcast.com/)
 * [VisitGemer](https://visitgemer.sk/)
 * [Nexit](https://nexit.sk/)
+* [ERC dEX](https://ercdex.com)
 
 ## Docs
 


### PR DESCRIPTION
I built this in a weekend (2 weekends back) using Gatsby for the first time, and thoroughly enjoyed it. 

* [ERC dEX](https://ercdex.com)