### PR TITLE
Prevent search shortcut from breaking other input elements

### DIFF
--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -250,7 +250,10 @@ class SearchForm extends Component {
 
   focusSearchInput(e) {
     if (e.key !== `s`) return
-    if (document.activeElement === this.searchInput) return // eslint-disable-line no-undef
+
+    // ignore this shortcut whenever an <input> has focus
+    if (document.activeElement instanceof window.HTMLInputElement) return // eslint-disable-line no-undef
+
     e.preventDefault()
     this.searchInput.focus()
   }


### PR DESCRIPTION
Fixes the email signup form for people with an 's' in their email address: https://github.com/gatsbyjs/gatsby/pull/3654#issuecomment-361461238