### PR TITLE
Fix issue that Gatsby can't sometimes find layout and page files on Windows

### DIFF
--- a/packages/gatsby/src/internal-plugins/component-layout-creator/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/component-layout-creator/gatsby-node.js
@@ -19,19 +19,20 @@ exports.createLayouts = async (
 ) => {
   const { createLayout, deleteLayout } = boundActionCreators
   const program = store.getState().program
+  const exts = program.extensions.map(e => `${e.slice(1)}`).join(`,`)
   const layoutDirectory = systemPath.posix.join(
     program.directory,
     `/src/layouts`
   )
-  const exts = program.extensions.map(e => `${e.slice(1)}`).join(`,`)
+  const layoutGlob = `${layoutDirectory}/**/*.{${exts}}`
 
   // Get initial list of files.
-  let files = await glob(`${layoutDirectory}/**/?(${exts})`)
+  let files = await glob(layoutGlob)
   files.forEach(file => _createLayout(file, layoutDirectory, createLayout))
 
   // Listen for new layouts to be added or removed.
   chokidar
-    .watch(`${layoutDirectory}/**/*.{${exts}}`)
+    .watch(layoutGlob)
     .on(`add`, path => {
       if (!_.includes(files, path)) {
         _createLayout(path, layoutDirectory, createLayout)

--- a/packages/gatsby/src/internal-plugins/component-page-creator/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/component-page-creator/gatsby-node.js
@@ -21,16 +21,17 @@ exports.createPagesStatefully = async (
 ) => {
   const { createPage, deletePage } = boundActionCreators
   const program = store.getState().program
-  const pagesDirectory = systemPath.posix.join(program.directory, `/src/pages`)
   const exts = program.extensions.map(e => `${e.slice(1)}`).join(`,`)
+  const pagesDirectory = systemPath.posix.join(program.directory, `/src/pages`)
+  const pagesGlob = `${pagesDirectory}/**/*.{${exts}}`
 
   // Get initial list of files.
-  let files = await glob(`${pagesDirectory}/**/?(${exts})`)
+  let files = await glob(pagesGlob)
   files.forEach(file => _createPage(file, pagesDirectory, createPage))
 
   // Listen for new component pages to be added or removed.
   chokidar
-    .watch(`${pagesDirectory}/**/*.{${exts}}`)
+    .watch(pagesGlob)
     .on(`add`, path => {
       if (!_.includes(files, path)) {
         _createPage(path, pagesDirectory, createPage)


### PR DESCRIPTION
This should fix the issue (reported in https://github.com/gatsbyjs/gatsby/issues/3183) that Gatsby can't sometimes find layout and page files on Windows, e.g. when the project is created in `C:\Program Files (x86)` folder, even though it works fine in `C:\Program Files` 🤷‍♂️ .

It simply changes this strange glob: `${layoutDirectory}/**/?(${exts})` to the same one that is used a few lines lower by `chokidar`: `${layoutDirectory}/**/*.{${exts}}`. I'm not sure how it worked before, but this change fixes this issue:

<img width="718" alt="gatsby-windows-layout-issue" src="https://user-images.githubusercontent.com/9873/35640842-b99dc0f2-06be-11e8-9fba-e201c661808b.png">

BTW. Speaking of layouts - if anyone could suggest some solution to https://github.com/gatsbyjs/gatsby/issues/3792 I'd be really grateful ;)
