### PR TITLE
Add gatsby-plugin-meta-redirect to community plugins

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -172,6 +172,7 @@ root.
 * [gatsby-plugin-i18n](https://github.com/angeloocana/gatsby-plugin-i18n)
 * [gatsby-plugin-intercom-spa](https://github.com/toriihq/gatsby-plugin-intercom-spa)
 * [gatsby-plugin-klipse](https://github.com/ahmedelgabri/gatsby-plugin-klipse)
+* [gatsby-plugin-meta-redirect](https://github.com/getchalk/gatsby-plugin-meta-redirect)
 * [gatsby-plugin-mixpanel](https://github.com/thomascarvalho/gatsby-plugin-mixpanel)
 * [gatsby-plugin-protoculture](https://github.com/atrauzzi/gatsby-plugin-protoculture)
 * [gatsby-plugin-purify-css](https://github.com/rongierlach/gatsby-plugin-purify-css)


### PR DESCRIPTION
[`gatsby-plugin-meta-redirect`](https://github.com/getchalk/gatsby-plugin-meta-redirect) is a small plugin that handles redirects by writing html files containing `<meta refresh>` at the redirect fromPath location. Useful for simple static hosts that don't support redirects natively. 