### PR TITLE
[gatsby] Pass location state to history

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { NavLinkProps } from "react-router-dom";
+import { LocationDescriptor } from "history";
 
 export interface GatsbyLinkProps extends NavLinkProps {
   onClick?: (event: any) => void
@@ -7,7 +8,7 @@ export interface GatsbyLinkProps extends NavLinkProps {
   style?:any;
 }
 
-export const navigateTo: (path: string) => void;
+export const navigateTo: (to: LocationDescriptor) => void;
 
 export const withPrefix: (path: string) => string;
 

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -23,6 +23,7 @@
     "gatsby": "^1.0.0"
   },
   "dependencies": {
+    "@types/history": "^4.6.2",
     "@types/react-router-dom": "^4.2.2",
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.5.8",

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -184,6 +184,6 @@ GatsbyLink.contextTypes = {
 
 export default GatsbyLink
 
-export const navigateTo = pathname => {
-  window.___navigateTo(pathname)
+export const navigateTo = to => {
+  window.___navigateTo(to)
 }

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -157,7 +157,7 @@ class GatsbyLink extends React.Component {
             // loaded before continuing.
             if (process.env.NODE_ENV === `production`) {
               e.preventDefault()
-              window.___navigateTo(this.state.path)
+              window.___navigateTo(this.state.to)
             }
           }
 

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -7,6 +7,7 @@ import ReactDOM from "react-dom"
 import { Router, Route, withRouter, matchPath } from "react-router-dom"
 import { ScrollContext } from "gatsby-react-router-scroll"
 import domReady from "domready"
+import { createLocation } from "history"
 import history from "./history"
 window.___history = history
 import emitter from "./emitter"
@@ -50,7 +51,9 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     require(`./register-service-worker`)
   }
 
-  const navigateTo = pathname => {
+  const navigateTo = to => {
+    const location = createLocation(to, null, null, history.location)
+    let { pathname } = location
     const redirect = redirectMap[pathname]
 
     // If we're redirecting, just replace the passed in pathname
@@ -70,7 +73,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       if (e.page.path === loader.getPage(pathname).path) {
         emitter.off(`onPostLoadPageResources`, eventHandler)
         clearTimeout(timeoutId)
-        window.___history.push(pathname)
+        window.___history.push(location)
       }
     }
 
@@ -79,13 +82,13 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     const timeoutId = setTimeout(() => {
       emitter.off(`onPostLoadPageResources`, eventHandler)
       emitter.emit(`onDelayedLoadPageResources`, { pathname })
-      window.___history.push(pathname)
+      window.___history.push(location)
     }, 1000)
 
     if (loader.getResourcesForPathname(pathname)) {
       // The resources are already loaded so off we go.
       clearTimeout(timeoutId)
-      window.___history.push(pathname)
+      window.___history.push(location)
     } else {
       // They're not loaded yet so let's add a listener for when
       // they finish loading.

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -132,8 +132,8 @@ const addNotFoundRoute = () => {
   }
 }
 
-const navigateTo = pathname => {
-  window.___history.push(pathname)
+const navigateTo = to => {
+  window.___history.push(to)
 }
 
 window.___navigateTo = navigateTo

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/history@*", "@types/history@^4.6.2":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
+
 "@types/inline-style-prefixer@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
@@ -13,6 +17,21 @@
 "@types/node@^6.0.46":
   version "6.0.90"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.90.tgz#0ed74833fa1b73dcdb9409dcb1c97ec0a8b13b02"
+
+"@types/react-router-dom@^4.2.2":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.2.3.tgz#06e0b67ff536adc0681dffdbe592ae91fb85887d"
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "4.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.0.21.tgz#d6c7ea3b45dba02eb8f869629f3b7d7b6e9a7938"
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react@*":
   version "16.0.18"
@@ -11969,6 +11988,10 @@ shallow-clone@^0.1.2:
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
+
+shallow-compare@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/shallow-compare/-/shallow-compare-1.2.2.tgz#fa4794627bf455a47c4f56881d8a6132d581ffdb"
 
 shallow-equal@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Adds support for passing history state by making a location object a valid param for `navigateTo`.
It also updates `gatby-link` to pass history state on production.

Fixes: #3728 