### PR TITLE
Add iContract blog to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Websites built with Gatsby:
 * [VisitGemer](https://visitgemer.sk/)
 * [Nexit](https://nexit.sk/)
 * [ERC dEX](https://ercdex.com)
+* [iContract Blog](https://blog.icontract.co.uk)
 
 ## Docs
 


### PR DESCRIPTION
This has been up for a while now but I've finally got round to adding iContract blog to readme.
