### PR TITLE
Use HTTPS over git:// when cloning starters

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -82,7 +82,7 @@ const clone = async (hostInfo: any, rootPath: string) => {
     url = hostInfo.ssh({ noCommittish: true })
     // Otherwise default to normal git syntax.
   } else {
-    url = hostInfo.git({ noCommittish: true })
+    url = hostInfo.https({ noCommittish: true })
   }
 
   const branch = hostInfo.committish ? `-b ${hostInfo.committish}` : ``


### PR DESCRIPTION
`git://` (which is what `hostInfo.git(...)` gets you) uses unencrypted transport and thus isn't recommended as a way to clone GitHub repositories (https://help.github.com/articles/which-remote-url-should-i-use/).  This PR uses HTTPS instead.

I've tried for several years to get GitHub to _explicitly_ mention "don't use git://" on their documentation without success but the best I've had is a quote from their support team:

> There are several problems with the git:// protocol (completely unencrypted and open to man in the middle attacks for instance). HTTPS should be beneficial in every way for your uses (it's actually just as efficient as git:// since the SmartHTTP update 3 years ago). For the security reasons, we've decided to stop promoting the protocol. That being said, we will still support it — but you'll have to manually type in the URLs.

Fwiw, it's also mentioned in `hosted-git-info`'s comments (https://github.com/npm/hosted-git-info/blob/master/git-host-info.js#L5).