### PR TITLE
[gatsby-transformer-remark] Add `pathPrefix` to relative links

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -119,8 +119,7 @@ module.exports = (
                 if (
                   node.url &&
                   node.url.startsWith(`/`) &&
-                  !node.url.startsWith(`//`) &&
-                  !node.url.startsWith(pathPrefix)
+                  !node.url.startsWith(`//`)
                 ) {
                   node.url = withPathPrefix(node.url, pathPrefix)
                 }

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -25,26 +25,27 @@ const stripPosition = require(`unist-util-remove-position`)
 const hastReparseRaw = require(`hast-util-raw`)
 
 let pluginsCacheStr = ``
+let pathPrefixCacheStr = ``
 const astCacheKey = node =>
   `transformer-remark-markdown-ast-${
     node.internal.contentDigest
-  }-${pluginsCacheStr}`
+  }-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const htmlCacheKey = node =>
   `transformer-remark-markdown-html-${
     node.internal.contentDigest
-  }-${pluginsCacheStr}`
+  }-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const htmlAstCacheKey = node =>
   `transformer-remark-markdown-html-ast-${
     node.internal.contentDigest
-  }-${pluginsCacheStr}`
+  }-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const headingsCacheKey = node =>
   `transformer-remark-markdown-headings-${
     node.internal.contentDigest
-  }-${pluginsCacheStr}`
+  }-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const tableOfContentsCacheKey = node =>
   `transformer-remark-markdown-toc-${
     node.internal.contentDigest
-  }-${pluginsCacheStr}`
+  }-${pluginsCacheStr}-${pathPrefixCacheStr}`
 
 // ensure only one `/` in new url
 const withPathPrefix = (url, pathPrefix) =>
@@ -59,6 +60,7 @@ module.exports = (
   }
 
   pluginsCacheStr = pluginOptions.plugins.map(p => p.name).join(``)
+  pathPrefixCacheStr = pathPrefix || ``
 
   return new Promise((resolve, reject) => {
     // Setup Remark.
@@ -119,7 +121,7 @@ module.exports = (
                   node.url.startsWith(`/`) &&
                   !node.url.startsWith(`//`) &&
                   !node.url.startsWith(pathPrefix)
-              ) {
+                ) {
                   node.url = withPathPrefix(node.url, pathPrefix)
                 }
               })

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -46,6 +46,7 @@ const tableOfContentsCacheKey = node =>
     node.internal.contentDigest
   }-${pluginsCacheStr}`
 
+// ensure only one `/` in new url
 const withPathPrefix = (url, pathPrefix) =>
   (pathPrefix + url).replace(/\/\//, `/`)
 

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -46,6 +46,9 @@ const tableOfContentsCacheKey = node =>
     node.internal.contentDigest
   }-${pluginsCacheStr}`
 
+const withPathPrefix = (url, pathPrefix) =>
+  (pathPrefix + url).replace(/\/\//, `/`)
+
 module.exports = (
   { type, store, pathPrefix, getNode, cache },
   pluginOptions
@@ -106,6 +109,20 @@ module.exports = (
             }
           }).then(() => {
             const markdownAST = remark.parse(markdownNode.internal.content)
+
+            if (pathPrefix) {
+              // Ensure relative links include `pathPrefix`
+              visit(markdownAST, `link`, node => {
+                if (
+                  node.url &&
+                  node.url.startsWith(`/`) &&
+                  !node.url.startsWith(`//`) &&
+                  !node.url.startsWith(pathPrefix)
+              ) {
+                  node.url = withPathPrefix(node.url, pathPrefix)
+                }
+              })
+            }
 
             // source => parse (can order parsing for dependencies) => typegen
             //


### PR DESCRIPTION
Ensure markdown relative links include `pathPrefix`.
Fixes #3316