### PR TITLE
Fix hanging `gatsby build`

### DIFF
--- a/packages/gatsby/src/internal-plugins/dev-404-page/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/gatsby-node.js
@@ -27,4 +27,5 @@ exports.createPagesStatefully = async (
       .on(`change`, () => copy())
       .on(`ready`, () => done())
   }
+  done()
 }


### PR DESCRIPTION
Call `done()` when in production mode.

Fixes #3813 