### PR TITLE
Update package.json

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -10,6 +10,7 @@
     "image-size": "^0.6.1",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",
+    "path": "^0.12.7",
     "path-is-inside": "^1.0.2",
     "unist-util-visit": "^1.1.1"
   },


### PR DESCRIPTION
Hmm, it looks like the `gatsby-remark-copy-linked-files` plugin depends on `path` without explicitly requiring it in its `package.json`: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-copy-linked-files/src/index.js#L4