### PR TITLE
check markdown images, ensure parent is File before referencing dir

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -149,6 +149,11 @@ module.exports = (
       return
     }
 
+    // since dir will be undefined on non-files
+    if (getNode(markdownNode.parent).internal.type !== `File`) {
+      return
+    }
+
     const imagePath = path.posix.join(
       getNode(markdownNode.parent).dir,
       image.url

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -150,7 +150,10 @@ module.exports = (
     }
 
     // since dir will be undefined on non-files
-    if (getNode(markdownNode.parent).internal.type !== `File`) {
+    if (
+      markdownNode.parent &&
+      getNode(markdownNode.parent).internal.type !== `File`
+    ) {
       return
     }
 


### PR DESCRIPTION
`visitor` code only operates on Files, so this doesn't change behavior

it does however stop `path.posix.join` from blowing up when it is called with `undefined` as the first argument.

Fixes https://github.com/gatsbyjs/gatsby/issues/3811