### PR TITLE
Add name of file above code snippet in docs

### DIFF
--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -39,7 +39,7 @@ e.g. [Sass](/packages/gatsby-plugin-sass/),
 
 ## Example
 
-Here is an example adding support for **flexboxgrid** when processing css files.
+Here is an example that configures **flexboxgrid** when processing css files. Add this in `gatsby-node.js`:
 
 ```js
 exports.modifyWebpackConfig = ({ config, stage }) => {


### PR DESCRIPTION
I noticed that I had to search through the docs to find the name of the file where this snippet needs to go. Now the name of the file is directly above the code.