### PR TITLE
data-explorer command - revert #3676

### DIFF
--- a/packages/gatsby/src/commands/data-explorer.js
+++ b/packages/gatsby/src/commands/data-explorer.js
@@ -3,17 +3,28 @@
 const express = require(`express`)
 const graphqlHTTP = require(`express-graphql`)
 const { store } = require(`../redux`)
+const bootstrap = require(`../bootstrap`)
+const { GraphQLSchema } = require(`graphql`)
 
-// Note: the store must exist already. Create it with `gatsby build`.
 module.exports = async (program: any) => {
   let { port, host } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
+
+  // bootstrap to ensure schema is in the store
+  await bootstrap(program)
+
+  const schema = store.getState().schema
+
+  console.log(
+    `Schema is instance of GraphQLSchema?`,
+    schema instanceof GraphQLSchema
+  )
 
   const app = express()
   app.use(
     `/`,
     graphqlHTTP({
-      schema: store.getState().schema,
+      schema,
       graphiql: true,
     })
   )


### PR DESCRIPTION
Experimenting with getting this running for inside Heroku's startup time limits for `www`. This basically reverts #3676. 

My previous approach doesn't work as reading in a pre-generated schema from `.cache/redux-state.json` doesn't leave you with an instance of `GraphQLSchema`, which GraphiQL needs to start.