### PR TITLE
[gatsby-plugin-sitemap] exclude gatsby-plugin-offline app shell from sitemap

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/index.js
@@ -1,8 +1,8 @@
-const { regexExclude404 } = require(`../internals`)
+const { regexExclude404AndOfflineShell } = require(`../internals`)
 
 describe(`gatsby-plugin-sitemap`, () => {
   it(`regex for filtering out 404 pages`, () => {
-    const regex = new RegExp(regexExclude404)
+    const regex = new RegExp(regexExclude404AndOfflineShell)
 
     // 404 pages
     expect(regex.exec(`/404`)).toBeNull()
@@ -11,9 +11,13 @@ describe(`gatsby-plugin-sitemap`, () => {
     expect(regex.exec(`/404page`)).toBeNull()
     expect(regex.exec(`/404-and-now-anything`)).toBeNull()
 
+    // gatsby-plugin-offline app shell fallback
+    expect(regex.exec(`/offline-plugin-app-shell-fallback`)).toBeNull()
+
     // Generic valid pages
     expect(regex.exec(`/my-page`)).not.toBeNull()
     expect(regex.exec(`/my-page-404123`)).not.toBeNull()
     expect(regex.exec(`/my-page-404`)).not.toBeNull()
+    expect(regex.exec(`/my-offline-plugin-app-shell-fallback`)).not.toBeNull()
   })
 })

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -12,7 +12,7 @@ export const runQuery = (handler, query) =>
     return r.data
   })
 
-export const regexExclude404 = /^(?!\/(dev-404-page|404)).*$/
+export const regexExclude404AndOfflineShell = /^(?!\/(dev-404-page|404|offline-plugin-app-shell-fallback)).*$/
 
 export const defaultOptions = {
   query: `
@@ -26,7 +26,7 @@ export const defaultOptions = {
       allSitePage(
         filter: {
           path: {
-            regex: "${regexExclude404}"
+            regex: "${regexExclude404AndOfflineShell}"
           }
         }
       ) {


### PR DESCRIPTION
Remove `/offline-plugin-app-shell-fallback/` created by `gatsby-plugin-offline` from sitemap, as this may lead to duplicate content problems when app shell fallback is indexed by search engines.