### PR TITLE
Add gatsby-wordpress-starter

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -418,3 +418,17 @@ Community:
   * A basic blog, with posts under src/pages/blog
   * A few basic components (Navigation, Layout, Link wrapper around `gatsby-link`))
   * Based on [gatsby-starter-gatsbytheme](https://github.com/saschajullmann/gatsby-starter-gatsbythemes)
+  
+* [gatsby-wordpress-starter](https://github.com/ericwindmill/gatsby-starter-wordpress)
+  [(demo)](https://gatsby-wordpress-starter.netlify.com/)
+
+  Features:
+
+  * All the features from
+    [gatsby-advanced-starter](https://github.com/Vagr9K/gatsby-advanced-starter),
+    plus:
+  * Leverages the [WordPress plugin for Gatsby](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress) for data
+  * Configured to work with WordPress Advanced Custom Fields
+  * Auto generated Navigation for your Wordpress Pages
+  * Minimal UI and Styling -- made to customize.
+  * Styled Components


### PR DESCRIPTION
A simple starter utilizes the WP plug in. Definitely a blog focused starter.

* Auto generates Navigation from your WP pages.
* Blog post template
* Post Listing
* tags pages
* categories pages
* styled-components
* all the features from gatsby-advanced-starter (SEO, Disqus, etc etc etc).

<img width="1362" alt="screen shot 2018-02-03 at 2 09 53 pm" src="https://user-images.githubusercontent.com/21140344/35772526-8f680430-08f5-11e8-9b5c-7d4182e17c30.png">
<img width="1348" alt="screen shot 2018-02-03 at 2 10 06 pm" src="https://user-images.githubusercontent.com/21140344/35772534-eb979266-08f5-11e8-9b7b-857831964924.png">