### PR TITLE
Fix positioning of search results at mobile breakpoint on homepage

### DIFF
--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -24,6 +24,10 @@ css.insert(`
     box-shadow: 0 3px 10px 0.05rem ${hex2rgba(colors.lilac, 0.25)} !important;
   }
 
+  .is-homepage .algolia-autocomplete .ds-dropdown-menu {
+    top: ${rhythm(2.5)} !important;
+  }
+
   /* .searchWrap to beat docsearch.css' !important */
   .searchWrap .algolia-autocomplete.algolia-autocomplete-right .ds-dropdown-menu,
   .searchWrap .algolia-autocomplete.algolia-autocomplete-left .ds-dropdown-menu {
@@ -193,6 +197,7 @@ css.insert(`
   }
 
   @media ${presets.tablet} {
+    .is-homepage .algolia-autocomplete .ds-dropdown-menu,
     .algolia-autocomplete .ds-dropdown-menu {
       top: 100% !important;
       position: absolute !important;

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -68,7 +68,7 @@ class DefaultLayout extends React.Component {
     }
 
     return (
-      <div>
+      <div className={isHomepage && `is-homepage`}>
         <Helmet defaultTitle={`GatsbyJS`} titleTemplate={`%s | GatsbyJS`}>
           <meta name="twitter:site" content="@gatsbyjs" />
           <meta name="og:type" content="website" />


### PR DESCRIPTION
The nav on the homepage is slightly lower than the nav on the rest of the site. This was causing the search results to be badly positioned on the home page.

Before

![screen shot 2018-02-05 at 16 52 36](https://user-images.githubusercontent.com/381801/35817458-56afa35e-0a95-11e8-974f-5c92cb80d509.png)

After

![screen shot 2018-02-05 at 16 53 20](https://user-images.githubusercontent.com/381801/35817465-5aea9bcc-0a95-11e8-8bd3-3e1c26c56c15.png)

