### PR TITLE
[gatsby-plugin-feed] Fix missing colon in Readme

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -10,7 +10,7 @@ Create an RSS feed (or multiple feeds) for your Gatsby site.
 
 ```javascript
 // In your gatsby-config.js
-siteMetadata {
+siteMetadata: {
   title: `GatsbyJS`,
   description: `A fantastic new static site generator.`,
   siteUrl: `https://www.gatsbyjs.org`


### PR DESCRIPTION
This broke my copy paste ><