### PR TITLE
[gatsby-plugin-feed] Document slug fields creation

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -22,6 +22,28 @@ plugins: [
 ]
 ```
 
+You also need to make sure that slugs for your markdown nodes are created.
+
+```javascript
+// In your gatsby-node.js
+const { createFilePath } = require('gatsby-source-filesystem')
+
+// ...
+
+exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
+  const { createNodeField } = boundActionCreators
+
+  if (node.internal.type === `MarkdownRemark`) {
+    const value = createFilePath({ node, getNode })
+    createNodeField({
+      name: `slug`,
+      node,
+      value,
+    })
+  }
+}
+```
+
 Above is the minimal configuration required to begin working. If you wish to
 customize the query being executed to retrieve nodes, try this:
 


### PR DESCRIPTION
I noticed that without configuration to create the slug fields, it will result in the following error:

```
error Plugin gatsby-plugin-feed returned an error


  Error: GraphQLError: Cannot query field "fields" on type "  MarkdownRemark".

  - internals.js:29
    [jiahaog.com]/[gatsby-plugin-feed]/internals.js:29:13

  - es6-promise.js:409 tryCatch
    [jiahaog.com]/[es6-promise]/dist/es6-promise.js:409:12

  - es6-promise.js:424 invokeCallback
    [jiahaog.com]/[es6-promise]/dist/es6-promise.js:424:13

  - es6-promise.js:176
    [jiahaog.com]/[es6-promise]/dist/es6-promise.js:176:14

  - es6-promise.js:128 flush
    [jiahaog.com]/[es6-promise]/dist/es6-promise.js:128:5

  - next_tick.js:131 _combinedTickCallback
    internal/process/next_tick.js:131:7

  - next_tick.js:180 process._tickCallback
    internal/process/next_tick.js:180:9
```

This has already been implemented in https://github.com/gatsbyjs/gatsby-starter-blog/pull/70 but it's not immediately obvious when starting afresh on a new project, so I just copied the implementation over to the docs.

Cheers!