### PR TITLE
Revert "Use HTTPS over git:// when cloning starters (#3820)"

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -82,7 +82,7 @@ const clone = async (hostInfo: any, rootPath: string) => {
     url = hostInfo.ssh({ noCommittish: true })
     // Otherwise default to normal git syntax.
   } else {
-    url = hostInfo.https({ noCommittish: true })
+    url = hostInfo.git({ noCommittish: true })
   }
 
   const branch = hostInfo.committish ? `-b ${hostInfo.committish}` : ``


### PR DESCRIPTION
This reverts commit 8261ac36f16915d06bd7d79a568bc0f77118dca2.