### PR TITLE
Add community source plugin to docs

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -192,6 +192,7 @@ root.
 * [gatsby-remark-sequence](https://github.com/liudonghua123/gatsby-remark-sequence)
 * [gatsby-source-airtable](https://github.com/kevzettler/gatsby-source-airtable)
 * [gatsby-source-behance](https://github.com/LeKoArts/gatsby-source-behance)
+* [gatsby-source-behance-collection](https://github.com/n370/gatsby-source-behance-collection)
 * [gatsby-source-datocms](https://github.com/datocms/gatsby-source-datocms)
 * [gatsby-source-directus](https://github.com/iKonrad/gatsby-source-directus)
 * [gatsby-source-github](https://github.com/mosch/gatsby-source-github)


### PR DESCRIPTION
It turns out Behance has no API endpoint for developers to retrieve team information. The workaround for now is to create a public collection, fill it up with team projects and query the collection API endpoint.

Initially my plan was to use the original https://github.com/LeKoArts/gatsby-source-behance but I quickly found I couldn't query collections with it so I created a new module based on it. I hope to get in contact with @LeKoArts in the future to check if we can collaborate on a merge of the two.

Until then it would be great to have both here side-by-side.

For more info see:
https://stackoverflow.com/questions/39769183/behance-api-endpoint-for-team
https://www.behance.net/dev/api/endpoints/5