### PR TITLE
Log type conflics when inferring graphql types

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -39,6 +39,7 @@ exports.createFileNode = async (pathToFile, pluginOptions = {}) => {
     internal = {
       contentDigest,
       type: `Directory`,
+      nodeDescription: `Directory "${path.relative(process.cwd(), slashed)}"`,
     }
   } else {
     const contentDigest = await md5File(slashedFile.absolutePath)
@@ -46,6 +47,7 @@ exports.createFileNode = async (pathToFile, pluginOptions = {}) => {
       contentDigest,
       mediaType: mime.lookup(slashedFile.ext),
       type: `File`,
+      nodeDescription: `File "${path.relative(process.cwd(), slashed)}"`,
     }
   }
 

--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -39,7 +39,7 @@ exports.createFileNode = async (pathToFile, pluginOptions = {}) => {
     internal = {
       contentDigest,
       type: `Directory`,
-      nodeDescription: `Directory "${path.relative(process.cwd(), slashed)}"`,
+      description: `Directory "${path.relative(process.cwd(), slashed)}"`,
     }
   } else {
     const contentDigest = await md5File(slashedFile.absolutePath)
@@ -47,7 +47,7 @@ exports.createFileNode = async (pathToFile, pluginOptions = {}) => {
       contentDigest,
       mediaType: mime.lookup(slashedFile.ext),
       type: `File`,
-      nodeDescription: `File "${path.relative(process.cwd(), slashed)}"`,
+      description: `File "${path.relative(process.cwd(), slashed)}"`,
     }
   }
 

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -206,7 +206,7 @@ async function processRemoteNode({ url, store, cache, createNode, auth = {} }) {
 
     // Create the file node.
     const fileNode = await createFileNode(filename, {})
-    fileNode.internal.nodeDescription = `File "${url}"`
+    fileNode.internal.description = `File "${url}"`
     // Override the default plugin as gatsby-source-filesystem needs to
     // be the owner of File nodes or there'll be conflicts if any other
     // File nodes are created through normal usages of

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -206,7 +206,7 @@ async function processRemoteNode({ url, store, cache, createNode, auth = {} }) {
 
     // Create the file node.
     const fileNode = await createFileNode(filename, {})
-
+    fileNode.internal.nodeDescription = `File "${url}"`
     // Override the default plugin as gatsby-source-filesystem needs to
     // be the owner of File nodes or there'll be conflicts if any other
     // File nodes are created through normal usages of

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -340,6 +340,8 @@ module.exports = async (args: BootstrapArgs) => {
   await require(`../schema`)()
   activity.end()
 
+  require(`../schema/type-conflict-reporter`).printConflicts()
+
   // Extract queries
   activity = report.activityTimer(`extract queries from components`)
   activity.start()

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -156,6 +156,10 @@ exports.onCreatePage = ({ page, boundActionCreators }) => {
         .createHash(`md5`)
         .update(JSON.stringify(page))
         .digest(`hex`),
+      description:
+        page.pluginCreatorId === `Plugin default-site-plugin`
+          ? `Your site's "gatsby-node.js"`
+          : page.pluginCreatorId,
     },
   })
 }

--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -57,6 +57,7 @@ export const nodeSchema = Joi.object()
       owner: Joi.string().required(),
       fieldOwners: Joi.array(),
       content: Joi.string().allow(``),
+      nodeDescription: Joi.string(),
     }),
   })
   .unknown()

--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -57,7 +57,7 @@ export const nodeSchema = Joi.object()
       owner: Joi.string().required(),
       fieldOwners: Joi.array(),
       content: Joi.string().allow(``),
-      nodeDescription: Joi.string(),
+      description: Joi.string(),
     }),
   })
   .unknown()

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -505,6 +505,10 @@ const typeOwners = {}
  * @param {string} node.internal.contentDigest the digest for the content
  * of this node. Helps Gatsby avoid doing extra work on data that hasn't
  * changed.
+ * @param {string} node.internal.nodeDescription An optional field. Human
+ * readable description of what this node represent / its source. It will
+ * be displayed when type conflicts are found, making it easier to find
+ * and correct type conflicts.
  * @example
  * createNode({
  *   // Data for the node.
@@ -525,6 +529,7 @@ const typeOwners = {}
  *       .digest(`hex`),
  *     mediaType: `text/markdown`, // optional
  *     content: JSON.stringify(fieldData), // optional
+ *     nodeDescription: `Cool Service: "Title of entry"`, // optional
  *   }
  * })
  */

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -505,7 +505,7 @@ const typeOwners = {}
  * @param {string} node.internal.contentDigest the digest for the content
  * of this node. Helps Gatsby avoid doing extra work on data that hasn't
  * changed.
- * @param {string} node.internal.nodeDescription An optional field. Human
+ * @param {string} node.internal.description An optional field. Human
  * readable description of what this node represent / its source. It will
  * be displayed when type conflicts are found, making it easier to find
  * and correct type conflicts.
@@ -529,7 +529,7 @@ const typeOwners = {}
  *       .digest(`hex`),
  *     mediaType: `text/markdown`, // optional
  *     content: JSON.stringify(fieldData), // optional
- *     nodeDescription: `Cool Service: "Title of entry"`, // optional
+ *     description: `Cool Service: "Title of entry"`, // optional
  *   }
  * })
  */

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
@@ -35,6 +35,12 @@ Object {
   "name": Object {
     "field": "name",
   },
+  "nestedArrays": Object {
+    "field": "nestedArrays",
+  },
+  "objectsInArray": Object {
+    "field": "objectsInArray",
+  },
 }
 `;
 
@@ -61,5 +67,17 @@ Object {
   "iAmNull": null,
   "key-with..unsupported-values": true,
   "name": "The Mad Max",
+  "nestedArrays": Array [
+    Array [
+      1,
+    ],
+  ],
+  "objectsInArray": Array [
+    Object {
+      "field1": true,
+      "field2": 1,
+      "field3": "foo",
+    },
+  ],
 }
 `;

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
@@ -45,21 +45,21 @@ Object {
   ],
   "context": Object {
     "nestedObject": Object {
-      "someOtherProperty": 3,
+      "someOtherProperty": 1,
     },
   },
   "date": "2006-07-22T22:39:53.000Z",
   "emptyArray": null,
   "frontmatter": Object {
-    "blue": 10010,
+    "blue": 100,
     "circle": "happy",
     "date": "2006-07-22T22:39:53.000Z",
     "draft": false,
-    "title": "The world of slash and adventure",
+    "title": "The world of dash and adventure",
   },
-  "hair": 4,
+  "hair": 1,
   "iAmNull": null,
   "key-with..unsupported-values": true,
-  "name": "The Mad Wax",
+  "name": "The Mad Max",
 }
 `;

--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -10,6 +10,10 @@ const {
 } = require(`../type-conflict-reporter`)
 
 describe(`Gatsby data tree utils`, () => {
+  beforeEach(() => {
+    clearTypeExampleValues()
+  })
+
   const nodes = [
     {
       name: `The Mad Max`,

--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -1,5 +1,5 @@
 const {
-  extractFieldExamples,
+  getExampleValue,
   buildFieldEnumValues,
   INVALID_VALUE,
 } = require(`../data-tree-utils`)
@@ -83,15 +83,15 @@ describe(`Gatsby data tree utils`, () => {
   ]
 
   it(`builds field examples from an array of nodes`, () => {
-    expect(extractFieldExamples(nodes)).toMatchSnapshot()
+    expect(getExampleValue(nodes)).toMatchSnapshot()
   })
 
   it(`null fields should have a null value`, () => {
-    expect(extractFieldExamples(nodes).iAmNull).toBeNull()
+    expect(getExampleValue(nodes).iAmNull).toBeNull()
   })
 
   it(`should not mutate the nodes`, () => {
-    extractFieldExamples(nodes)
+    getExampleValue(nodes)
     expect(nodes[0].context.nestedObject).toBeNull()
     expect(nodes[1].context.nestedObject.someOtherProperty).toEqual(1)
     expect(nodes[2].context.nestedObject.someOtherProperty).toEqual(2)
@@ -99,8 +99,8 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`turns empty or sparse arrays to null`, () => {
-    expect(extractFieldExamples(nodes).emptyArray).toBeNull()
-    expect(extractFieldExamples(nodes).hair).toBeDefined()
+    expect(getExampleValue(nodes).emptyArray).toBeNull()
+    expect(getExampleValue(nodes).hair).toBeDefined()
   })
 
   it(`build enum values for fields from array on nodes`, () => {
@@ -108,7 +108,7 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`turns polymorphic fields null`, () => {
-    let example = extractFieldExamples([
+    let example = getExampleValue([
       { foo: null },
       { foo: [1] },
       { foo: { field: 1 } },
@@ -117,7 +117,7 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`handles polymorphic arrays`, () => {
-    let example = extractFieldExamples([
+    let example = getExampleValue([
       { foo: [[`foo`, `bar`]] },
       { foo: [{ field: 1 }] },
     ])
@@ -125,14 +125,14 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`doesn't confuse empty fields for polymorhpic ones`, () => {
-    let example = extractFieldExamples([
+    let example = getExampleValue([
       { foo: { bar: 1 } },
       { foo: null },
       { foo: { field: 1 } },
     ])
     expect(example.foo).toEqual({ field: 1, bar: 1 })
 
-    example = extractFieldExamples([
+    example = getExampleValue([
       { foo: [{ bar: 1 }] },
       { foo: null },
       { foo: [{ field: 1 }, { baz: 1 }] },

--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -1,5 +1,5 @@
 const {
-  getExampleValue,
+  getExampleValues,
   buildFieldEnumValues,
   clearTypeExampleValues,
   INVALID_VALUE,
@@ -96,15 +96,15 @@ describe(`Gatsby data tree utils`, () => {
   ]
 
   it(`builds field examples from an array of nodes`, () => {
-    expect(getExampleValue(nodes)).toMatchSnapshot()
+    expect(getExampleValues(nodes)).toMatchSnapshot()
   })
 
   it(`null fields should have a null value`, () => {
-    expect(getExampleValue(nodes).iAmNull).toBeNull()
+    expect(getExampleValues(nodes).iAmNull).toBeNull()
   })
 
   it(`should not mutate the nodes`, () => {
-    getExampleValue(nodes)
+    getExampleValues(nodes)
     expect(nodes[0].context.nestedObject).toBeNull()
     expect(nodes[1].context.nestedObject.someOtherProperty).toEqual(1)
     expect(nodes[2].context.nestedObject.someOtherProperty).toEqual(2)
@@ -112,8 +112,8 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`turns empty or sparse arrays to null`, () => {
-    expect(getExampleValue(nodes).emptyArray).toBeNull()
-    expect(getExampleValue(nodes).hair).toBeDefined()
+    expect(getExampleValues(nodes).emptyArray).toBeNull()
+    expect(getExampleValues(nodes).hair).toBeDefined()
   })
 
   it(`build enum values for fields from array on nodes`, () => {
@@ -121,7 +121,7 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`turns polymorphic fields null`, () => {
-    let example = getExampleValue([
+    let example = getExampleValues([
       { foo: null },
       { foo: [1] },
       { foo: { field: 1 } },
@@ -130,7 +130,7 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`handles polymorphic arrays`, () => {
-    let example = getExampleValue([
+    let example = getExampleValues([
       { foo: [[`foo`, `bar`]] },
       { foo: [{ field: 1 }] },
     ])
@@ -138,14 +138,14 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`doesn't confuse empty fields for polymorhpic ones`, () => {
-    let example = getExampleValue([
+    let example = getExampleValues([
       { foo: { bar: 1 } },
       { foo: null },
       { foo: { field: 1 } },
     ])
     expect(example.foo).toEqual({ field: 1, bar: 1 })
 
-    example = getExampleValue([
+    example = getExampleValues([
       { foo: [{ bar: 1 }] },
       { foo: null },
       { foo: [{ field: 1 }, { baz: 1 }] },
@@ -189,7 +189,7 @@ describe(`Type conflicts`, () => {
       },
     ]
 
-    getExampleValue({ nodes, type: `NoConflict` })
+    getExampleValues({ nodes, type: `NoConflict` })
 
     expect(addConflictExampleSpy).not.toBeCalled()
   })
@@ -212,7 +212,7 @@ describe(`Type conflicts`, () => {
       },
     ]
 
-    getExampleValue({ nodes, type: `Conflict_1` })
+    getExampleValues({ nodes, type: `Conflict_1` })
 
     expect(addConflictSpy).toBeCalled()
     expect(addConflictSpy).toBeCalledWith(
@@ -246,7 +246,7 @@ describe(`Type conflicts`, () => {
       },
     ]
 
-    getExampleValue({ nodes, type: `Conflict_2` })
+    getExampleValues({ nodes, type: `Conflict_2` })
     expect(addConflictSpy).toBeCalled()
     expect(addConflictSpy).toBeCalledWith(
       `Conflict_2.arrayOfMixedType`,

--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -13,6 +13,8 @@ describe(`Gatsby data tree utils`, () => {
       "key-with..unsupported-values": true,
       emptyArray: [],
       anArray: [1, 2, 3, 4],
+      nestedArrays: [[1, 2, 3], [4, 5, 6]],
+      objectsInArray: [{ field1: true }, { field2: 1 }],
       frontmatter: {
         date: `2006-07-22T22:39:53.000Z`,
         title: `The world of dash and adventure`,
@@ -29,6 +31,8 @@ describe(`Gatsby data tree utils`, () => {
       emptyArray: [undefined, null],
       anArray: [1, 2, 5, 4],
       iAmNull: null,
+      nestedArrays: [[1, 2, 3]],
+      objectsInArray: [{ field3: `foo` }],
       frontmatter: {
         date: `2006-07-22T22:39:53.000Z`,
         title: `The world of slash and adventure`,

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -15,6 +15,7 @@ const {
   inferInputObjectStructureFromNodes,
 } = require(`../infer-graphql-input-fields`)
 const createSortField = require(`../create-sort-field`)
+const { clearTypeExampleValues } = require(`../data-tree-utils`)
 
 function queryResult(nodes, query, { types = [] } = {}) {
   const nodeType = new GraphQLObjectType({
@@ -29,7 +30,7 @@ function queryResult(nodes, query, { types = [] } = {}) {
     nodeType,
     connectionFields: () =>
       buildConnectionFields({
-        name: `Test`,
+        name,
         nodes,
         nodeObjectType: nodeType,
       }),
@@ -74,6 +75,10 @@ function queryResult(nodes, query, { types = [] } = {}) {
 
   return graphql(schema, query)
 }
+
+beforeEach(() => {
+  clearTypeExampleValues()
+})
 
 describe(`GraphQL Input args`, () => {
   const nodes = [

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -6,7 +6,7 @@ const {
 } = require(`graphql`)
 const path = require(`path`)
 const normalizePath = require(`normalize-path`)
-
+const { clearTypeExampleValues } = require(`../data-tree-utils`)
 const { inferObjectStructureFromNodes } = require(`../infer-graphql-type`)
 
 function queryResult(nodes, fragment, { types = [] } = {}) {
@@ -47,6 +47,10 @@ function queryResult(nodes, fragment, { types = [] } = {}) {
     { path: `/` }
   )
 }
+
+beforeEach(() => {
+  clearTypeExampleValues()
+})
 
 describe(`GraphQL type inferance`, () => {
   const nodes = [

--- a/packages/gatsby/src/schema/__tests__/node-tracking-test.js
+++ b/packages/gatsby/src/schema/__tests__/node-tracking-test.js
@@ -28,7 +28,7 @@ describe(`Track root nodes`, () => {
   require(`fs`).__setMockFiles(MOCK_FILE_INFO)
 
   const { getNode, getNodes } = require(`../../redux`)
-  const { findRootNode } = require(`../node-tracking`)
+  const { findRootNodeAncestor } = require(`../node-tracking`)
   const runSift = require(`../run-sift`)
   const buildNodeTypes = require(`../build-node-types`)
   const { boundActionCreators: { createNode } } = require(`../../redux/actions`)
@@ -56,7 +56,7 @@ describe(`Track root nodes`, () => {
     it(`Tracks inline objects`, () => {
       const node = getNode(`id1`)
       const inlineObject = node.inlineObject
-      const trackedRootNode = findRootNode(inlineObject)
+      const trackedRootNode = findRootNodeAncestor(inlineObject)
 
       expect(trackedRootNode).toEqual(node)
     })
@@ -64,7 +64,7 @@ describe(`Track root nodes`, () => {
     it(`Tracks inline arrays`, () => {
       const node = getNode(`id1`)
       const inlineObject = node.inlineArray
-      const trackedRootNode = findRootNode(inlineObject)
+      const trackedRootNode = findRootNodeAncestor(inlineObject)
 
       expect(trackedRootNode).toEqual(node)
     })
@@ -72,7 +72,7 @@ describe(`Track root nodes`, () => {
     it(`Doesn't track copied objects`, () => {
       const node = getNode(`id1`)
       const copiedInlineObject = { ...node.inlineObject }
-      const trackedRootNode = findRootNode(copiedInlineObject)
+      const trackedRootNode = findRootNodeAncestor(copiedInlineObject)
 
       expect(trackedRootNode).not.toEqual(node)
     })
@@ -82,7 +82,7 @@ describe(`Track root nodes`, () => {
     it(`Tracks inline objects`, () => {
       const node = getNode(`id2`)
       const inlineObject = node.inlineObject
-      const trackedRootNode = findRootNode(inlineObject)
+      const trackedRootNode = findRootNodeAncestor(inlineObject)
 
       expect(trackedRootNode).toEqual(node)
     })
@@ -105,10 +105,10 @@ describe(`Track root nodes`, () => {
       })
 
       expect(result.edges.length).toEqual(2)
-      expect(findRootNode(result.edges[0].node.inlineObject)).toEqual(
+      expect(findRootNodeAncestor(result.edges[0].node.inlineObject)).toEqual(
         result.edges[0].node
       )
-      expect(findRootNode(result.edges[1].node.inlineObject)).toEqual(
+      expect(findRootNodeAncestor(result.edges[1].node.inlineObject)).toEqual(
         result.edges[1].node
       )
     })
@@ -130,7 +130,7 @@ describe(`Track root nodes`, () => {
       })
 
       expect(result.edges.length).toEqual(1)
-      expect(findRootNode(result.edges[0].node.inlineObject)).toEqual(
+      expect(findRootNodeAncestor(result.edges[0].node.inlineObject)).toEqual(
         result.edges[0].node
       )
     })

--- a/packages/gatsby/src/schema/build-connection-fields.js
+++ b/packages/gatsby/src/schema/build-connection-fields.js
@@ -15,7 +15,10 @@ const {
 const { buildFieldEnumValues } = require(`./data-tree-utils`)
 
 module.exports = type => {
-  const enumValues = buildFieldEnumValues(type.nodes)
+  const enumValues = buildFieldEnumValues({
+    nodes: type.nodes,
+    type: type.name,
+  })
   const { connectionType: groupConnection } = connectionDefinitions({
     name: _.camelCase(`${type.name} groupConnection`),
     nodeType: type.nodeObjectType,

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -19,7 +19,10 @@ const { nodeInterface } = require(`./node-interface`)
 const { getNodes, getNode, getNodeAndSavePathDependency } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const { setFileNodeRootType } = require(`./types/type-file`)
-const { clearTypeExampleValues, getExampleValue } = require(`./data-tree-utils`)
+const {
+  clearTypeExampleValues,
+  getExampleValues,
+} = require(`./data-tree-utils`)
 
 import type { ProcessedNodeType } from "./infer-graphql-type"
 
@@ -115,7 +118,7 @@ module.exports = async () => {
     const inferredFields = inferObjectStructureFromNodes({
       nodes: type.nodes,
       types: _.values(processedTypes),
-      exampleValue: getExampleValue({ type: type.name, nodes: type.nodes }),
+      exampleValue: getExampleValues({ type: type.name, nodes: type.nodes }),
     })
 
     return {

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -19,6 +19,7 @@ const { nodeInterface } = require(`./node-interface`)
 const { getNodes, getNode, getNodeAndSavePathDependency } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const { setFileNodeRootType } = require(`./types/type-file`)
+const { clearTypeExampleValues, getExampleValue } = require(`./data-tree-utils`)
 
 import type { ProcessedNodeType } from "./infer-graphql-type"
 
@@ -27,6 +28,8 @@ type TypeMap = { [typeName: string]: ProcessedNodeType }
 module.exports = async () => {
   const types = _.groupBy(getNodes(), node => node.internal.type)
   const processedTypes: TypeMap = {}
+
+  clearTypeExampleValues()
 
   // Reset stored File type to not point to outdated type definition
   setFileNodeRootType(null)
@@ -112,7 +115,7 @@ module.exports = async () => {
     const inferredFields = inferObjectStructureFromNodes({
       nodes: type.nodes,
       types: _.values(processedTypes),
-      allNodes: getNodes(),
+      exampleValue: getExampleValue({ type: type.name, nodes: type.nodes }),
     })
 
     return {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -181,7 +181,7 @@ const extractFieldExamples = (nodes: object[], selector: string) => {
 
 const buildFieldEnumValues = arg => {
   const enumValues = {}
-  const values = flatten(getExampleValue(arg), {
+  const values = flatten(getExampleValues(arg), {
     maxDepth: 3,
     safe: true, // don't flatten arrays.
     delimiter: `___`,
@@ -198,7 +198,7 @@ const buildFieldEnumValues = arg => {
 // nested objects get flattened to "outer___inner" which will be converted back to
 // "outer.inner" by run-sift
 const extractFieldNames = arg => {
-  const values = flatten(getExampleValue(arg), {
+  const values = flatten(getExampleValues(arg), {
     maxDepth: 3,
     safe: true, // don't flatten arrays.
     delimiter: `___`,
@@ -232,7 +232,7 @@ const getNodesAndTypeFromArg = arg => {
   return { type, nodes }
 }
 
-const getExampleValue = arg => {
+const getExampleValues = arg => {
   const { type, nodes } = getNodesAndTypeFromArg(arg)
 
   // if type is defined and is in example value cache return it
@@ -259,5 +259,5 @@ module.exports = {
   extractFieldNames,
   isEmptyObjectOrArray,
   clearTypeExampleValues,
-  getExampleValue,
+  getExampleValues,
 }

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -79,7 +79,7 @@ const extractFromEntries = (entries, selector, key = null) => {
   ) {
     // there is multiple types or array of multiple types
     if (selector) {
-      typeConflictReporter.addConflict(selector, ...entriesOfUniqueType)
+      typeConflictReporter.addConflict(selector, entriesOfUniqueType)
     }
     return INVALID_VALUE
   }

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -8,13 +8,6 @@ const createKey = require(`./create-key`)
 const INVALID_VALUE = Symbol(`INVALID_VALUE`)
 const isDefined = v => v != null
 
-const isSameType = (a, b) => a == null || b == null || typeOf(a) === typeOf(b)
-const areAllSameType = list =>
-  list.every((current, i) => {
-    let prev = i ? list[i - 1] : undefined
-    return isSameType(prev, current)
-  })
-
 const isEmptyObjectOrArray = (obj: any): boolean => {
   if (obj === INVALID_VALUE) {
     return true
@@ -37,6 +30,104 @@ const isEmptyObjectOrArray = (obj: any): boolean => {
   return false
 }
 
+const isScalar = val => !_.isObject(val) || val instanceof Date
+
+const extractTypes = value => {
+  if (_.isArray(value)) {
+    const uniqueTypes = _.uniq(
+      value.filter(isDefined).map(item => extractTypes(item).type)
+    ).sort()
+    return {
+      type: `array<${uniqueTypes.join(`|`)}>`,
+      arrayTypes: uniqueTypes,
+    }
+  } else {
+    const type = typeOf(value)
+    return {
+      type,
+      arrayTypes: [],
+    }
+  }
+}
+
+const getExampleScalarFromArray = values =>
+  _.reduce(
+    values,
+    (value, nextValue) => {
+      // Prefer floats over ints as they're more specific.
+      if (value && _.isNumber(value) && !_.isInteger(value)) {
+        return value
+      } else if (value === null) {
+        return nextValue
+      } else {
+        return value
+      }
+    },
+    null
+  )
+
+const extractFromEntries = (entries, selector, key = null) => {
+  const entriesOfUniqueType = _.uniqBy(entries, entry => entry.type)
+
+  if (entriesOfUniqueType.length == 0) {
+    // skip if no defined types
+    return null
+  } else if (
+    entriesOfUniqueType.length > 1 ||
+    entriesOfUniqueType[0].arrayTypes.length > 1
+  ) {
+    // there is multiple types or array of multiple types
+    return INVALID_VALUE
+  }
+
+  // Now we have entries of single type, we can merge them
+  const values = entries.map(entry => entry.value)
+
+  const exampleValue = entriesOfUniqueType[0].value
+  if (isScalar(exampleValue)) {
+    return getExampleScalarFromArray(values)
+  } else if (_.isObject(exampleValue)) {
+    if (_.isArray(exampleValue)) {
+      const concatanedItems = _.concat(...values)
+      // Linked node arrays don't get reduced further as we
+      // want to preserve all the linked node types.
+      if (_.includes(key, `___NODE`)) {
+        return concatanedItems
+      }
+
+      return extractFromArrays(concatanedItems, entries, selector)
+    } else if (_.isPlainObject(exampleValue)) {
+      return extractFieldExamples(values, selector)
+    }
+  }
+  // unsuported object
+  return INVALID_VALUE
+}
+
+const extractFromArrays = (values, entries, selector) => {
+  const filteredItems = values.filter(isDefined)
+  if (filteredItems.length === 0) {
+    return null
+  }
+  if (isScalar(filteredItems[0])) {
+    return [getExampleScalarFromArray(filteredItems)]
+  }
+
+  const flattenEntries = _.flatten(
+    entries.map(entry =>
+      entry.value.map(value => {
+        return {
+          value,
+          parent: entry.parent,
+          ...extractTypes(value),
+        }
+      })
+    )
+  )
+
+  return [extractFromEntries(flattenEntries, `${selector}[]`)]
+}
+
 /**
  * Takes an array of source nodes and returns a pristine
  * example that can be used to infer types.
@@ -49,48 +140,40 @@ const isEmptyObjectOrArray = (obj: any): boolean => {
  *
  * @param {*Nodes} args
  */
-const extractFieldExamples = (nodes: any[]) =>
-  // $FlowFixMe
-  _.mergeWith(
-    _.isArray(nodes[0]) ? [] : {},
-    ..._.cloneDeep(nodes),
-    (obj, next, key, po, pn, stack) => {
-      if (obj === INVALID_VALUE) return obj
+const extractFieldExamples = (nodes: object[], selector: string) => {
+  // get list of keys in all nodes
+  const allKeys = _.uniq(_.flatten(nodes.map(_.keys)))
 
-      // TODO: if you want to support infering Union types this should be handled
-      // differently. Maybe merge all like types into examples for each type?
-      // e.g. union: [1, { foo: true }, ['brown']] -> Union Int|Object|List
-      if (!isSameType(obj, next)) {
-        return INVALID_VALUE
-      }
+  return _.zipObject(
+    allKeys,
+    allKeys.map(key => {
+      const nextSelector = selector && `${selector}.${key}`
 
-      if (!_.isArray(obj || next)) {
-        // Prefer floats over ints as they're more specific.
-        if (obj && _.isNumber(obj) && !_.isInteger(obj)) return obj
-        if (obj === null) return next
-        if (next === null) return obj
-        return undefined
-      }
+      const nodeWithValues = nodes.filter(node => {
+        if (!node) return false
 
-      let array = [].concat(obj, next).filter(isDefined)
+        const value = node[key]
+        if (_.isObject(value)) {
+          return !isEmptyObjectOrArray(value)
+        } else {
+          return isDefined(value)
+        }
+      })
 
-      if (!array.length) return null
-      if (!areAllSameType(array)) return INVALID_VALUE
+      // we want to keep track of nodes as we need it to get origin of data
+      const entries = nodeWithValues.map(node => {
+        const value = node[key]
+        return {
+          value,
+          parent: node,
+          ...extractTypes(value),
+        }
+      })
 
-      // Linked node arrays don't get reduced further as we
-      // want to preserve all the linked node types.
-      if (_.includes(key, `___NODE`)) {
-        return array
-      }
-
-      // primitive values and dates don't get merged further, just take the first item
-      if (!_.isObject(array[0]) || array[0] instanceof Date) {
-        return array.slice(0, 1)
-      }
-      let merged = extractFieldExamples(array)
-      return isDefined(merged) ? [merged] : null
-    }
+      return extractFromEntries(entries, nextSelector, key)
+    })
   )
+}
 
 const buildFieldEnumValues = arg => {
   const enumValues = {}
@@ -154,7 +237,7 @@ const getExampleValue = arg => {
 
   // if nodes were passed extract field example from it
   if (nodes && nodes.length > 0) {
-    const exampleValue = extractFieldExamples(nodes)
+    const exampleValue = extractFieldExamples(nodes, type)
     // if type is set - cache results
     if (type) {
       typeExampleValues[type] = exampleValue

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -4,6 +4,7 @@ const flatten = require(`flat`)
 const typeOf = require(`type-of`)
 
 const createKey = require(`./create-key`)
+const { typeConflictReporter } = require(`./type-conflict-reporter`)
 
 const INVALID_VALUE = Symbol(`INVALID_VALUE`)
 const isDefined = v => v != null
@@ -77,6 +78,9 @@ const extractFromEntries = (entries, selector, key = null) => {
     entriesOfUniqueType[0].arrayTypes.length > 1
   ) {
     // there is multiple types or array of multiple types
+    if (selector) {
+      typeConflictReporter.addConflict(selector, ...entriesOfUniqueType)
+    }
     return INVALID_VALUE
   }
 
@@ -207,6 +211,7 @@ let typeExampleValues = {}
 
 const clearTypeExampleValues = () => {
   typeExampleValues = {}
+  typeConflictReporter.clearConflicts()
 }
 
 const getNodesAndTypeFromArg = arg => {

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -14,7 +14,7 @@ const typeOf = require(`type-of`)
 const createTypeName = require(`./create-type-name`)
 const createKey = require(`./create-key`)
 const {
-  extractFieldExamples,
+  getExampleValue,
   extractFieldNames,
   isEmptyObjectOrArray,
 } = require(`./data-tree-utils`)
@@ -212,12 +212,15 @@ export function inferInputObjectStructureFromNodes({
   nodes,
   typeName = ``,
   prefix = ``,
-  exampleValue = extractFieldExamples(nodes),
+  exampleValue = null,
 }: InferInputOptions): Object {
   const inferredFields = {}
   const isRoot = !prefix
 
   prefix = isRoot ? typeName : prefix
+  if (exampleValue === null) {
+    exampleValue = getExampleValue(nodes)
+  }
 
   _.each(exampleValue, (v, k) => {
     let value = v
@@ -238,7 +241,10 @@ export function inferInputObjectStructureFromNodes({
         const relatedNodes = getNodes().filter(
           node => node.internal.type === linkedNode.internal.type
         )
-        value = extractFieldExamples(relatedNodes)
+        value = getExampleValue({
+          nodes: relatedNodes,
+          type: linkedNode.internal.type,
+        })
         value = recursiveOmitBy(value, (_v, _k) => _.includes(_k, `___NODE`))
         linkedNodeCache[linkedNode.internal.type] = value
       }

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -14,7 +14,7 @@ const typeOf = require(`type-of`)
 const createTypeName = require(`./create-type-name`)
 const createKey = require(`./create-key`)
 const {
-  getExampleValue,
+  getExampleValues,
   extractFieldNames,
   isEmptyObjectOrArray,
 } = require(`./data-tree-utils`)
@@ -219,7 +219,7 @@ export function inferInputObjectStructureFromNodes({
 
   prefix = isRoot ? typeName : prefix
   if (exampleValue === null) {
-    exampleValue = getExampleValue(nodes)
+    exampleValue = getExampleValues(nodes)
   }
 
   _.each(exampleValue, (v, k) => {
@@ -241,7 +241,7 @@ export function inferInputObjectStructureFromNodes({
         const relatedNodes = getNodes().filter(
           node => node.internal.type === linkedNode.internal.type
         )
-        value = getExampleValue({
+        value = getExampleValues({
           nodes: relatedNodes,
           type: linkedNode.internal.type,
         })

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -16,7 +16,7 @@ const { store, getNode, getNodes } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const createTypeName = require(`./create-type-name`)
 const createKey = require(`./create-key`)
-const { getExampleValue, isEmptyObjectOrArray } = require(`./data-tree-utils`)
+const { getExampleValues, isEmptyObjectOrArray } = require(`./data-tree-utils`)
 const DateType = require(`./types/type-date`)
 const FileType = require(`./types/type-file`)
 
@@ -324,7 +324,7 @@ export function inferObjectStructureFromNodes({
 
   const nodeTypeName = nodes[0].internal.type
   if (exampleValue === null) {
-    exampleValue = getExampleValue({ type: nodeTypeName, nodes })
+    exampleValue = getExampleValues({ type: nodeTypeName, nodes })
   }
 
   const inferredFields = {}

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -16,10 +16,7 @@ const { store, getNode, getNodes } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const createTypeName = require(`./create-type-name`)
 const createKey = require(`./create-key`)
-const {
-  extractFieldExamples,
-  isEmptyObjectOrArray,
-} = require(`./data-tree-utils`)
+const { getExampleValue, isEmptyObjectOrArray } = require(`./data-tree-utils`)
 const DateType = require(`./types/type-date`)
 const FileType = require(`./types/type-file`)
 
@@ -316,7 +313,7 @@ export function inferObjectStructureFromNodes({
   nodes,
   types,
   selector,
-  exampleValue = extractFieldExamples(nodes),
+  exampleValue = null,
 }: inferTypeOptions): GraphQLFieldConfigMap<*, *> {
   const config = store.getState().config
   const isRoot = !selector
@@ -324,6 +321,11 @@ export function inferObjectStructureFromNodes({
 
   // Ensure nodes have internal key with object.
   nodes = nodes.map(n => (n.internal ? n : { ...n, internal: {} }))
+
+  const nodeTypeName = nodes[0].internal.type
+  if (exampleValue === null) {
+    exampleValue = getExampleValue({ type: nodeTypeName, nodes })
+  }
 
   const inferredFields = {}
   _.each(exampleValue, (value, key) => {
@@ -334,7 +336,7 @@ export function inferObjectStructureFromNodes({
     // Several checks to see if a field is pointing to custom type
     // before we try automatic inference.
     const nextSelector = selector ? `${selector}.${key}` : key
-    const fieldSelector = `${nodes[0].internal.type}.${nextSelector}`
+    const fieldSelector = `${nodeTypeName}.${nextSelector}`
 
     let fieldName = key
     let inferredField

--- a/packages/gatsby/src/schema/node-tracking.js
+++ b/packages/gatsby/src/schema/node-tracking.js
@@ -55,14 +55,17 @@ exports.trackInlineObjectsInRootNode = trackInlineObjectsInRootNode
 /**
  * Finds top most ancestor of node that contains passed Object or Array
  * @param {(Object|Array)} obj Object/Array belonging to Node object or Node object
- * @returns {Node} Top most ancestor
+ * @param {nodePredicate} [predicate] Optional callback to check if ancestor meets defined conditions
+ * @returns {Node} Top most ancestor if predicate is not specified
+ * or first node that meet predicate conditions if predicate is specified
  */
-function findRootNode(obj) {
+const findRootNodeAncestor = (obj, predicate = null) => {
   // Find the root node.
   let rootNode = obj
   let whileCount = 0
   let rootNodeId
   while (
+    (!predicate || !predicate(rootNode)) &&
     (rootNodeId = getRootNodeId(rootNode) || rootNode.parent) &&
     (getNode(rootNode.parent) !== undefined || getNode(rootNodeId)) &&
     whileCount < 101
@@ -81,10 +84,15 @@ function findRootNode(obj) {
     }
   }
 
-  return rootNode
+  return !predicate || predicate(rootNode) ? rootNode : null
 }
 
-exports.findRootNode = findRootNode
+/**
+ * @callback nodePredicate
+ * @param {Node} node Node that is examined
+ */
+
+exports.findRootNodeAncestor = findRootNodeAncestor
 
 // Track nodes that are already in store
 _.each(getNodes(), node => {

--- a/packages/gatsby/src/schema/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/type-conflict-reporter.js
@@ -5,14 +5,14 @@ const typeOf = require(`type-of`)
 const util = require(`util`)
 const { findRootNodeAncestor } = require(`./node-tracking`)
 
-const isNodeWithNodeDescription = node =>
-  node && node.internal && node.internal.nodeDescription
+const isNodeWithDescription = node =>
+  node && node.internal && node.internal.description
 
 const findNodeDescription = obj => {
   if (obj) {
-    const node = findRootNodeAncestor(obj, isNodeWithNodeDescription)
-    if (isNodeWithNodeDescription(node)) {
-      return node.internal.nodeDescription
+    const node = findRootNodeAncestor(obj, isNodeWithDescription)
+    if (isNodeWithDescription(node)) {
+      return node.internal.description
     }
   }
   return ``
@@ -57,7 +57,7 @@ class TypeConflictEntry {
   addExample({ value, type, parent }) {
     this.types[type] = {
       value,
-      nodeDescription: findNodeDescription(parent),
+      description: findNodeDescription(parent),
     }
   }
 
@@ -70,9 +70,9 @@ class TypeConflictEntry {
     report.log(
       `${this.selector}:${sortedByTypeName
         .map(
-          ([typeName, { value, nodeDescription }]) =>
-            `\n - ${typeName}: ${formatValue(value)}${nodeDescription &&
-              ` (${nodeDescription})`}`
+          ([typeName, { value, description }]) =>
+            `\n - ${typeName}: ${formatValue(value)}${description &&
+              ` (${description})`}`
         )
         .join(``)}`
     )

--- a/packages/gatsby/src/schema/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/type-conflict-reporter.js
@@ -1,0 +1,125 @@
+// @flow
+const _ = require(`lodash`)
+const report = require(`gatsby-cli/lib/reporter`)
+const typeOf = require(`type-of`)
+const util = require(`util`)
+const { findRootNodeAncestor } = require(`./node-tracking`)
+
+const isNodeWithNodeDescription = node =>
+  node && node.internal && node.internal.nodeDescription
+
+const findNodeDescription = obj => {
+  if (obj) {
+    const node = findRootNodeAncestor(obj, isNodeWithNodeDescription)
+    if (isNodeWithNodeDescription(node)) {
+      return node.internal.nodeDescription
+    }
+  }
+  return ``
+}
+
+const formatValue = value => {
+  if (!_.isArray(value)) {
+    return util.inspect(value, {
+      colors: true,
+      depth: 0,
+      breakLength: Infinity,
+    })
+  }
+
+  let wasElipsisLast = false
+  const usedTypes = []
+  const output = []
+
+  value.forEach(item => {
+    const type = typeOf(item)
+    if (usedTypes.indexOf(type) !== -1) {
+      if (!wasElipsisLast) {
+        output.push(`...`)
+        wasElipsisLast = true
+      }
+    } else {
+      output.push(formatValue(item))
+      wasElipsisLast = false
+      usedTypes.push(type)
+    }
+  })
+
+  return `[ ${output.join(`, `)} ]`
+}
+
+class TypeConflictEntry {
+  constructor(selector) {
+    this.selector = selector
+    this.types = {}
+  }
+
+  addExample({ value, type, parent }) {
+    this.types[type] = {
+      value,
+      nodeDescription: findNodeDescription(parent),
+    }
+  }
+
+  printEntry() {
+    const sortedByTypeName = _.sortBy(
+      _.entries(this.types),
+      ([typeName, value]) => typeName
+    )
+
+    report.log(
+      `${this.selector}:${sortedByTypeName
+        .map(
+          ([typeName, { value, nodeDescription }]) =>
+            `\n - ${typeName}: ${formatValue(value)}${nodeDescription &&
+              ` (${nodeDescription})`}`
+        )
+        .join(``)}`
+    )
+  }
+}
+
+class TypeConflictReporter {
+  constructor() {
+    this.clearConflicts()
+  }
+
+  clearConflicts() {
+    this.entries = {}
+  }
+
+  getFromSelector(selector) {
+    if (this.entries[selector]) {
+      return this.entries[selector]
+    }
+
+    const dataEntry = new TypeConflictEntry(selector)
+    this.entries[selector] = dataEntry
+    return dataEntry
+  }
+
+  addConflict(selector, ...examples) {
+    const entry = this.getFromSelector(selector)
+    examples
+      .filter(example => example.value != null)
+      .forEach(example => entry.addExample(example))
+  }
+
+  printConflicts() {
+    const entries = _.values(this.entries)
+    if (entries.length > 0) {
+      report.warn(
+        `There are conflicting field types in your data. GraphQL schema will omit those fields.`
+      )
+      entries.forEach(entry => entry.printEntry())
+    }
+  }
+}
+
+const typeConflictReporter = new TypeConflictReporter()
+
+const printConflicts = () => {
+  typeConflictReporter.printConflicts()
+}
+
+module.exports = { typeConflictReporter, printConflicts }

--- a/packages/gatsby/src/schema/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/type-conflict-reporter.js
@@ -71,8 +71,9 @@ class TypeConflictEntry {
       `${this.selector}:${sortedByTypeName
         .map(
           ([typeName, { value, description }]) =>
-            `\n - ${typeName}: ${formatValue(value)}${description &&
-              ` (${description})`}`
+            `\n - type: ${typeName}\n   value: ${formatValue(
+              value
+            )}${description && `\n   source: ${description}`}`
         )
         .join(``)}`
     )

--- a/packages/gatsby/src/schema/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/type-conflict-reporter.js
@@ -98,7 +98,7 @@ class TypeConflictReporter {
     return dataEntry
   }
 
-  addConflict(selector, ...examples) {
+  addConflict(selector, examples) {
     const entry = this.getFromSelector(selector)
     examples
       .filter(example => example.value != null)
@@ -122,4 +122,4 @@ const printConflicts = () => {
   typeConflictReporter.printConflicts()
 }
 
-module.exports = { typeConflictReporter, printConflicts }
+module.exports = { typeConflictReporter, printConflicts, TypeConflictEntry }

--- a/packages/gatsby/src/schema/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/type-conflict-reporter.js
@@ -100,6 +100,13 @@ class TypeConflictReporter {
   }
 
   addConflict(selector, examples) {
+    if (selector.substring(0, 11) === `SitePlugin.`) {
+      // Don't store and print out type conflicts in plugins.
+      // This is out of user control so he can't do anything
+      // to hide those.
+      return
+    }
+
     const entry = this.getFromSelector(selector)
     examples
       .filter(example => example.value != null)

--- a/packages/gatsby/src/schema/types/type-file.js
+++ b/packages/gatsby/src/schema/types/type-file.js
@@ -7,7 +7,7 @@ const normalize = require(`normalize-path`)
 const systemPath = require(`path`)
 
 const { getNodes } = require(`../../redux`)
-const { findRootNode } = require(`../node-tracking`)
+const { findRootNodeAncestor } = require(`../node-tracking`)
 const {
   createPageDependency,
 } = require(`../../redux/actions/add-page-dependency`)
@@ -99,7 +99,7 @@ function pointsToFile(nodes, key, value) {
     }
   }
 
-  const rootNode = findRootNode(node)
+  const rootNode = findRootNodeAncestor(node)
 
   // Only nodes transformed (ultimately) from a File
   // can link to another File.
@@ -164,7 +164,7 @@ function createType(fileNodeRootType, isArray) {
 
       // Find the File node for this node (we assume the node is something
       // like markdown which would be a child node of a File node).
-      const parentFileNode = findRootNode(node)
+      const parentFileNode = findRootNodeAncestor(node)
 
       // Find the linked File node(s)
       if (isArray) {

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -125,9 +125,9 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
 
         // Create blog pages.
         blogPosts.forEach((edge, index) => {
-          const next = index === 0 ? false : blogPosts[index - 1].node
+          const next = index === 0 ? null : blogPosts[index - 1].node
           const prev =
-            index === blogPosts.length - 1 ? false : blogPosts[index + 1].node
+            index === blogPosts.length - 1 ? null : blogPosts[index + 1].node
 
           createPage({
             path: `${edge.node.fields.slug}`, // required


### PR DESCRIPTION
This adds logging discarded/omitted fields that have conflicting types.

Example of output:
```
success update schema — 0.152 s
warning There are conflicting field types in your data. GraphQL schema will omit those fields.
SitePage.context.previous:
 - boolean: false
 - object: { fields: [Object], frontmatter: [Object] }
SitePage.context.next:
 - boolean: false
 - object: { fields: [Object], frontmatter: [Object] }
MarkdownRemark.frontmatter.scalarTest:
 - boolean: true (File "src\pages\my-second-post\index.md")
 - number: 5 (File "src\pages\hi-folks\index.md")
 - string: 'string' (File "src\pages\hello-world\index.md")
MarkdownRemark.frontmatter.scalarObjectTest:
 - object: { prop: true, a3: true } (File "src\pages\hello-world\index.md")
 - string: 'string' (File "src\pages\my-second-post\index.md")
MarkdownRemark.frontmatter.objectArrayTest:
 - array<number>: [ 5 ] (File "src\pages\hello-world\index.md")
 - object: { prop: true } (File "src\pages\hi-folks\index.md")
MarkdownRemark.frontmatter.mixedArrayInSingleNodeTest:
 - array<number|string>: [ 5, ..., 'string', ... ] (File "src\pages\hello-world\index.md")
MarkdownRemark.frontmatter.mixedArrayInDifferentNodesTest:
 - array<number>: [ 5 ] (File "src\pages\hello-world\index.md")
 - array<string>: [ 'string' ] (File "src\pages\hi-folks\index.md")
MarkdownRemark.frontmatter.objectsInArray[].scalarTest:
 - boolean: true (File "src\pages\hello-world\index.md")
 - string: 'test' (File "src\pages\my-second-post\index.md")
success extract queries from components — 0.080 s
```

Above was generated using this demo - https://github.com/pieh/gatsby-conflicting-types-demo with prepared conflicts in frontmatter:

page 1 (hello-world - https://github.com/pieh/gatsby-conflicting-types-demo/blob/master/src/pages/hello-world/index.md ):
```yaml
scalarTest: 'string'
scalarObjectTest:
  prop: true
  a3: true
objectArrayTest:
  - 5
mixedArrayInSingleNodeTest:
  - 5
  - 8
  - 9
  - 'string'
  - 'anotherString'
mixedArrayInDifferentNodesTest:
  - 5
objectsInArray:
  - scalarTest: true
    correct: true
```

page 2 (hi-folks - https://github.com/pieh/gatsby-conflicting-types-demo/blob/master/src/pages/hi-folks/index.md ):
```yaml
scalarTest: 5
scalarObjectTest:
  prop: true
  a2: true
objectArrayTest:
  prop: true
mixedArrayInDifferentNodesTest:
  - 'string'
```

page 3 (my second post - https://github.com/pieh/gatsby-conflicting-types-demo/blob/master/src/pages/my-second-post/index.md ):
```yaml
scalarTest: true
scalarObjectTest: 'string'
objectsInArray:
  - scalarTest: "test"
    correct: true
```

Closes #3856

Btw: funny side gain for finding conflicts in `gatsby-starter-blog` in passed context ( if anyone would ever want to query that :) ). Would need to use `null` instead of false here - https://github.com/gatsbyjs/gatsby-starter-blog/blob/master/gatsby-node.js#L39-L40