### PR TITLE
add info about org-mode transformer plugin

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -204,6 +204,7 @@ root.
 * [gatsby-source-twitch](https://github.com/jedidiah/gatsby-source-twitch)
 * [gatsby-source-unsplash](https://github.com/vacas5/gatsby-source-unsplash)
 * [gatsby-source-workable](https://github.com/tumblbug/gatsby-source-workable)
+* [gatsby-transformer-orga](https://github.com/xiaoxinghu/orgajs/tree/master/packages/gatsby-transformer-orga)
 
 ## Community Library
 


### PR DESCRIPTION
I created this transformer plugin similar to the offical remark one, that parses org-mode files.