### PR TITLE
Set default NODE_ENV for `gatsby develop`

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -99,7 +99,12 @@ function buildLocalCommands(cli, isLocalSite) {
           type: `boolean`,
           describe: `Open the site in your browser for you.`,
         }),
-    handler: getCommandHandler(`develop`),
+    handler: handlerP(
+      getCommandHandler(`develop`, (args, cmd) => {
+        process.env.NODE_ENV = process.env.NODE_ENV || `development`
+        return cmd(args)
+      })
+    ),
   })
 
   cli.command({


### PR DESCRIPTION
During `gatsby develop`, default `NODE_ENV` to be `'development'`.  

Allow overriding with e.g. `NODE_ENV=myCustomEnvName gatsby develop`

Refs #3896