### PR TITLE
Fix code highlight in tutorial

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -1019,7 +1019,7 @@ The last step is to link to our new pages from the index page.
 Return to `src/pages/index.js` and let's query for our Markdown slugs and create
 links.
 
-```jsx{3,18-19,29,46-48}
+```jsx{3,18-19,29,47-49}
 import React from "react";
 import g from "glamorous";
 import Link from "gatsby-link";


### PR DESCRIPTION
I think this was missed in the addition of the `id` field in #2864 :joy: