### PR TITLE
test "exports.default" when validating page component

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -204,7 +204,8 @@ actions.createPage = (page: PageInput, plugin?: Plugin, traceId?: string) => {
     }
     if (
       !fileContent.includes(`export default`) &&
-      !fileContent.includes(`module.exports`)
+      !fileContent.includes(`module.exports`) &&
+      !fileContent.includes(`exports.default`)
     ) {
       includesDefaultExport = false
     }


### PR DESCRIPTION
Fixes #3939

gatsby-plugin-offline create page with app-shell transpiled component:
```
"use strict";

exports.__esModule = true;

var _classCallCheck2 = require("babel-runtime/helpers/classCallCheck");

var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);

var _possibleConstructorReturn2 = require("babel-runtime/helpers/possibleConstructorReturn");

var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);

var _inherits2 = require("babel-runtime/helpers/inherits");

var _inherits3 = _interopRequireDefault(_inherits2);

var _react = require("react");

var _react2 = _interopRequireDefault(_react);

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var AppShell = function (_React$Component) {
  (0, _inherits3.default)(AppShell, _React$Component);

  function AppShell() {
    (0, _classCallCheck3.default)(this, AppShell);
    return (0, _possibleConstructorReturn3.default)(this, _React$Component.apply(this, arguments));
  }

  AppShell.prototype.render = function render() {
    return _react2.default.createElement("div", null);
  };

  return AppShell;
}(_react2.default.Component);

exports.default = AppShell;
```

This won't pass current export test.