### PR TITLE
[www] Add dedicated „How to File an Issue“ page (fix #3923)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,6 +6,7 @@
   Useful Links:
   - Documentation: https://www.gatsbyjs.org/docs/
   - How to Contribute: https://www.gatsbyjs.org/docs/how-to-contribute/
+  - How to File an Issue: https://www.gatsbyjs.org/docs/how-to-file-an-issue/
   - Become a Sponsor: https://opencollective.com/gatsby#sponsor
   
   Before opening a new issue, please search existing issues (https://github.com/gatsbyjs/gatsby/issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,6 @@
 title: How to contribute
 ---
 
-## Filing an issue
-
-If you want your issue to be resolved quickly, please include in your issue:
-
-* Gatsby version, node.js version, OS version
-* The contents of your `gatsby-config.js` and `package.json` as well as your
-  `gatsby-node.js`, `gatsby-browser.js` `gatsby-ssr.js` files depending on
-  changes you've made there.
-
 ## Contributing
 
 We want contributing to Gatsby to be fun, enjoyable, and educational for anyone and everyone. Contributions go far beyond pull requests and commits; we are thrilled to receive a variety of other contributions including the following:
@@ -21,23 +12,14 @@ We want contributing to Gatsby to be fun, enjoyable, and educational for anyone 
 * Submitting documentation updates, enhancements, designs, or bugfixes
 * Submitting spelling or grammar fixes
 * Adding unit or functional tests
-* Triaging GitHub issues -- especially determining whether an issue still persists or is reproducible
+* Triaging [GitHub issues](https://github.com/gatsbyjs/gatsby/issues) -- especially determining whether an issue still persists or is reproducible
+* [Reporting bugs or issues](/docs/how-to-file-an-issue/)
 * Searching for Gatsby on Discord or Spectrum and helping someone else who needs help
 * Teaching others how to contribute to Gatsby's repo!
 
 If you are worried or don't know where to start, you can always reach out to Shannon Soper(@shannonb_ux) on Twitter or simply submit an issue and a maintainer can help give you guidance!
 
 Looking to speak about Gatsby? We'd love to review your talk abstract/CFP! You can email it to shannon [at] gatsbyjs [dot] com and we can give pointers or tips!!!
-
-### Special Note on Issues
-
-If an issue is affecting you, start at the top of this list and complete as many tasks on the list as you can:
-
-1. If there is an issue, +1 the issue to indicate that it's affecting you
-2. If there's an issue and you can add more detail, write a comment describing how the bug is affecting OR if you can, write up a work-around for the bug
-3. If there's not an issue, write the most complete description of what's happening, preferably with link to a Gatsby site that reproduces the problem
-4. Offer to help fix the bug (and it's totally expected that you ask for help; open-source maintainers want to help contributors)
-5. Deliver a well-crafted, tested PR
 
 ### Creating your own plugins and loaders
 

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -17,9 +17,9 @@ and orientation.
 
 The Gatsby community welcomes contributions. Please refer to the guides below on how to make sure your contributions get accepted:
 
-[How to Contribute](/docs/how-to-contribute/)
-
-[Gatsby Style Guide](/docs/gatsby-style-guide/)
+* [How to Contribute](/docs/how-to-contribute/)
+* [How to File an Issue](/docs/how-to-file-an-issue/)
+* [Gatsby Style Guide](/docs/gatsby-style-guide/)
 
 ## Gatsby news
 

--- a/docs/docs/how-to-file-an-issue.md
+++ b/docs/docs/how-to-file-an-issue.md
@@ -1,0 +1,24 @@
+---
+title: How to file an issue
+---
+
+The [issue tracker](https://github.com/gatsbyjs/gatsby/issues) is the preferred channel for bug reports, features requests and submitting pull requests.
+
+If you want your issue to be resolved quickly, please include in your issue:
+
+* Gatsby version, node.js version, OS version
+* The contents of your `gatsby-config.js` and `package.json` as well as your
+  `gatsby-node.js`, `gatsby-browser.js` `gatsby-ssr.js` files depending on
+  changes you've made there.
+
+Please do not use the issue tracker for personal support requests. [Stack Overflow](http://stackoverflow.com/questions/ask?tags=gatsby) (**gatsby** tag) and the [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bZjGY5n) #gatsby channels are better places to get help.
+
+### Special Note on Issues
+
+If an issue is affecting you, start at the top of this list and complete as many tasks on the list as you can:
+
+1. If there is an issue, +1 the issue to indicate that it's affecting you
+2. If there is an issue and you can add more detail, write a comment describing how the bug is affecting OR if you can, write up a work-around for the bug
+3. If there _is not_ an issue, write the most complete description of what's happening, preferably with link to a Gatsby site that reproduces the problem
+4. Offer to help fix the bug (and it is totally expected that you ask for help; open-source maintainers want to help contributors)
+5. Deliver a well-crafted, tested PR

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -92,6 +92,8 @@
   items:
     - title: How to Contribute
       link: /docs/how-to-contribute/
+    - title: How to File an Issue
+      link: /docs/how-to-file-an-issue/
     - title: Gatsby Style Guide
       link: /docs/gatsby-style-guide/
     - title: Design Principles*


### PR DESCRIPTION
* move „Filing an Issue“ and „Special Note on Issues“ from the „How to Contribute“ to the new „How to File an Issue“ page
* add an intro paragraph to the new page linking to the GitHub Gatsby issue tracker
* add a paragraph to the new page informing about personal support requests, pointing to Stack Overflow, Reactiflux Discord
* add a link to the new page to
  * the docs sidebar’s „Contributing“ section
  * the GitHub issue template
  * the „Community“ page
  * the list of ways to contribute on the „How to Contribute“ page
* link „Triaging GitHub issues“ on the „How to Contribute“ page

Fixes #3923