### PR TITLE
Permit user to skip path existence check

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -58,3 +58,18 @@ You can query file nodes like the following:
   }
 }
 ```
+
+## Advanced usage
+
+If you wish to prevent `gatsby-source-filesystem` from ensuring that the given directory exists, you may set `skipPathCheck: true` to pass a glob or array of globs:
+
+```javascript
+{
+  resolve: `gatsby-source-filesystem`,
+  options: {
+    name: `pages`,
+    path: [`${__dirname}/README.md`, `${__dirname}/docs`],
+    skipPathCheck: true,
+  },
+},
+```

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -12,7 +12,7 @@ exports.sourceNodes = (
   let ready = false
 
   // Validate that the path exists.
-  if (!fs.existsSync(pluginOptions.path)) {
+  if (!fs.existsSync(pluginOptions.path) && pluginOptions.skipPathCheck !== true) {
     console.log(`
 The path passed to gatsby-source-filesystem does not exist on your file system:
 


### PR DESCRIPTION
This permits the user to pass as a path anything that `chokidar` accepts, including globs and array of globs.

Use case: generate documentation for a repository from its markdown:

```js
{
  resolve: `gatsby-source-filesystem`,
  options: {
    name: `pages`,
    path: [`${__dirname}/README.md`, `${__dirname}/docs`],
    skipPathCheck: true,
  },
},
```