### PR TITLE
Webpack commonsChunkPlugin fix for windows dev

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -290,7 +290,7 @@ module.exports = async (
               ]
               const isFramework = some(
                 vendorModuleList.map(vendor => {
-                  const regex = new RegExp(`/node_modules/${vendor}/.*`, `i`)
+                  const regex = new RegExp(`[\\\\/]node_modules[\\\\/]${vendor}[\\\\/].*`, `i`)
                   return regex.test(module.resource)
                 })
               )


### PR DESCRIPTION
Fixes issue [#3937](https://github.com/gatsbyjs/gatsby/issues/3937)

The RegExp pattern in the `isFramework` tester in a parameter-function for `minChunk` option of `commonsChunkPlugin` in `webpack.config.js` does not test positively, as it should, on Windows dev environment (different path separator). 

A small change in the pattern fixes the problem.