### PR TITLE
[gatsby-remark-code-repls] Fix validation error saying default template isn't importing React

### DIFF
--- a/packages/gatsby-remark-code-repls/src/default-redirect-template.js
+++ b/packages/gatsby-remark-code-repls/src/default-redirect-template.js
@@ -1,9 +1,9 @@
 "use strict"
 
-import React, { Component } from "react"
+import React from "react"
 import PropTypes from "prop-types"
 
-class GatsbyRemarkCodeReplsRedirect extends Component {
+class GatsbyRemarkCodeReplsRedirect extends React.Component {
   componentDidMount() {
     this.form.submit()
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,7 +549,7 @@ axios@^0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-"axios@github:contentful/axios#fix/https-via-http-proxy":
+axios@contentful/axios#fix/https-via-http-proxy:
   version "0.17.1"
   resolved "https://codeload.github.com/contentful/axios/tar.gz/4b06f4a63db3ac16c99f7c61b584ef0e6d11f1af"
   dependencies:


### PR DESCRIPTION
After a clean install of latest Gatsby I was getting this error

```
The page component at "node_modules/gatsby-remark-code-repls/default-redirect-template.js" didn't pass validation

You must import React at the top of the file for a React component to be valid

Add the following to the top of the component:

    import React from 'react'


The page component must export a React component for it to be valid
```

This PR fixes it.

I'm not sure if that signifies a deeper problem with whatever is doing the validation, but that's beyond my understanding. This was easier to get operational quick :)