### PR TITLE
Allow Gatsby/Contentful to work offline

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -53,9 +53,10 @@ module.exports = async ({ spaceId, accessToken, host, syncToken, cacheDir }) => 
     console.log(
       `Accessing your Contentful space failed. Perhaps you're offline or the spaceId/accessToken is incorrect.`
     )
-    // TODO perhaps continue if there's cached data? That would let
-    // someone develop a contentful site even if not connected to the internet.
-    // For prod builds though always fail if we can't get the latest data.
+    console.log(
+      `Try running setting GATSBY_CONTENTFUL_OFFLINE=true to see if we can serve from cache.`
+    )
+
     process.exit(1)
   }
 

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -16,6 +16,27 @@ const restrictedNodeFields = [
   `parent`,
 ]
 
+const cmsCacheFilename = `contentful-result.json`
+
+async function writeFetchCache(programDirectory, fetchResult) {
+  try {
+    await fs.writeJson(`${programDirectory}/.cache/${cmsCacheFilename}`, fetchResult)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+async function readFetchCache(programDirectory) {
+  try {
+    console.time(`Fetch Contentful data`)
+    console.log(`Using Contentful Offline cache ⚠️`)
+    return await fs.readJson(`${programDirectory}/.cache/${cmsCacheFilename}`)
+  } catch (err) {
+    console.error(err)
+  }
+  return null
+}
+
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`).extendNodeType
 
 /***
@@ -53,17 +74,27 @@ exports.sourceNodes = async (
     ]
   }
 
+  const programDir = store.getState().program.directory
+  let fetchResult
+
+  if (process.env.GATSBY_CONTENTFUL_OFFLINE === `true`) {
+    fetchResult = await readFetchCache(programDir)
+  } else {
+    fetchResult = await fetchData({
+      syncToken,
+      spaceId,
+      accessToken,
+      host,
+    })
+    writeFetchCache(programDir, fetchResult)
+  }
+
   const {
     currentSyncData,
     contentTypeItems,
     defaultLocale,
     locales,
-  } = await fetchData({
-    syncToken,
-    spaceId,
-    accessToken,
-    host,
-  })
+  } = fetchResult
 
   const entryList = normalize.buildEntryList({
     currentSyncData,

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -32,7 +32,8 @@ async function readFetchCache(programDirectory) {
     console.log(`Using Contentful Offline cache ⚠️`)
     return await fs.readJson(`${programDirectory}/.cache/${cmsCacheFilename}`)
   } catch (err) {
-    console.error(err)
+    console.error(`Sorry, cached CMS data does not exist - unable to run offline`)
+    process.exit(1)
   }
   return null
 }


### PR DESCRIPTION
`GATSBY_CONTENTFUL_OFFLINE` environment variable will make use of a cached fetch results from last successful comms with CMS. Useful if you want to develop/build without an internet connection.

Pretty rudimentary but works. 