### PR TITLE
add package json metadata for better display on npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,17 +40,20 @@
   "engines": {
     "yarn": "^1.2.1"
   },
+  "eslintIgnore": [
+    "interfaces",
+    "**/__tests__/fixtures/"
+  ],
   "private": true,
   "scripts": {
     "bootstrap": "npm-run-all -s check-versions lerna-prepublish",
-    "prebootstrap": "yarn",
     "check-versions": "babel-node scripts/check-versions.js",
     "format": "npm-run-all -p format-packages format-cache-dir format-www format-examples format-scripts format-markdown",
     "format-cache-dir": "prettier-eslint --write \"packages/gatsby/cache-dir/*.js\"",
     "format-examples": "prettier-eslint --write \"examples/**/gatsby-node.js\" \"examples/**/gatsby-config.js\" \"examples/**/src/**/*.js\"",
+    "format-markdown": "prettier --write \"**/*.md\" --semi",
     "format-packages": "prettier-eslint --write \"packages/*/src/**/*.js\"",
     "format-scripts": "prettier-eslint --write \"scripts/**/*.js\"",
-    "format-markdown": "prettier --write \"**/*.md\" --semi",
     "format-www": "prettier-eslint --write \"www/*.js\" \"www/src/**/*.js\"",
     "jest": "jest",
     "lerna": "lerna",
@@ -58,6 +61,7 @@
     "lint": "eslint --ext .js,.jsx packages/**/src",
     "lint:flow": "babel-node scripts/flow-check.js",
     "plop": "plop",
+    "prebootstrap": "yarn",
     "publish": "lerna publish",
     "publish-canary": "lerna publish --canary --yes",
     "publish-next": "lerna publish --npm-tag=next",
@@ -70,9 +74,5 @@
   },
   "workspaces": [
     "packages/*"
-  ],
-  "eslintIgnore": [
-    "interfaces",
-    "**/__tests__/fixtures/"
   ]
 }

--- a/packages/gatsby-1-config-css-modules/package.json
+++ b/packages/gatsby-1-config-css-modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-1-config-css-modules",
-  "version": "1.0.8",
   "description": "CSS Modules configuration for Gatsby v1 plugins",
+  "version": "1.0.8",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Ming Aldrich-Gan <mingaldrichgan@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-1-config-css-modules#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0"
   },

--- a/packages/gatsby-1-config-css-modules/package.json
+++ b/packages/gatsby-1-config-css-modules/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-1-config-css-modules",
   "description": "CSS Modules configuration for Gatsby v1 plugins",
   "version": "1.0.8",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Ming Aldrich-Gan <mingaldrichgan@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-1-config-css-modules#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"
@@ -27,5 +12,20 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-1-config-css-modules#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -2,7 +2,25 @@
   "name": "gatsby-cli",
   "description": "Gatsby command-line interface for creating new sites and running Gatsby commands",
   "version": "1.1.39",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "babel src --out-dir lib --ignore __tests__",
+    "watch": "babel -w src --out-dir lib --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "bin": {
     "gatsby": "lib/index.js"
   },
@@ -31,16 +49,6 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "scripts": {
-    "build": "babel src --out-dir lib --ignore __tests__",
-    "watch": "babel -w src --out-dir lib --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "yargs": {
     "boolean-negation": false

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -2,30 +2,12 @@
   "name": "gatsby-cli",
   "description": "Gatsby command-line interface for creating new sites and running Gatsby commands",
   "version": "1.1.39",
-  "main": "lib/index.js",
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {
     "gatsby": "lib/index.js"
   },
-  "files": [
-    "lib"
-  ],
-  "scripts": {
-    "build": "babel src --out-dir lib --ignore __tests__",
-    "watch": "babel -w src --out-dir lib --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-code-frame": "^6.26.0",
@@ -49,6 +31,24 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "files": [
+    "lib"
+  ],
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir lib --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir lib --ignore __tests__"
   },
   "yargs": {
     "boolean-negation": false

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -3,6 +3,12 @@
   "description": "Gatsby command-line interface for creating new sites and running Gatsby commands",
   "version": "1.1.39",
   "main": "lib/index.js",
+  "bin": {
+    "gatsby": "lib/index.js"
+  },
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "babel src --out-dir lib --ignore __tests__",
     "watch": "babel -w src --out-dir lib --ignore __tests__",
@@ -21,12 +27,6 @@
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git"
   },
-  "bin": {
-    "gatsby": "lib/index.js"
-  },
-  "files": [
-    "lib"
-  ],
   "dependencies": {
     "babel-code-frame": "^6.26.0",
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -1,24 +1,8 @@
 {
-  "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "chokidar": "^1.7.0",
-    "configstore": "^3.1.0",
-    "fs-extra": "^4.0.1",
-    "is-absolute": "^0.2.6",
-    "lodash": "^4.17.4",
-    "yargs": "^8.0.2"
-  },
   "name": "gatsby-dev-cli",
-  "version": "1.2.10",
   "description": "CLI helpers for contributors working on Gatsby",
+  "version": "1.2.10",
   "main": "index.js",
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
-  },
-  "bin": {
-    "gatsby-dev": "./dist/index.js"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel src --out-dir dist",
@@ -29,5 +13,29 @@
     "gatsby"
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "chokidar": "^1.7.0",
+    "configstore": "^3.1.0",
+    "fs-extra": "^4.0.1",
+    "is-absolute": "^0.2.6",
+    "lodash": "^4.17.4",
+    "yargs": "^8.0.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "bin": {
+    "gatsby-dev": "./dist/index.js"
+  }
 }

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -2,28 +2,12 @@
   "name": "gatsby-dev-cli",
   "description": "CLI helpers for contributors working on Gatsby",
   "version": "1.2.10",
-  "main": "index.js",
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {
     "gatsby-dev": "./dist/index.js"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "babel src --out-dir dist",
-    "watch": "babel -w src --out-dir dist",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -37,5 +21,21 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir dist",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "watch": "babel -w src --out-dir dist"
   }
 }

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -3,6 +3,9 @@
   "description": "CLI helpers for contributors working on Gatsby",
   "version": "1.2.10",
   "main": "index.js",
+  "bin": {
+    "gatsby-dev": "./dist/index.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel src --out-dir dist",
@@ -34,8 +37,5 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
-  },
-  "bin": {
-    "gatsby-dev": "./dist/index.js"
   }
 }

--- a/packages/gatsby-image/package.json
+++ b/packages/gatsby-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-image",
-  "version": "1.0.35",
   "description": "Lazy-loading React image component with optional support for the blur-up effect.",
+  "version": "1.0.35",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.6.0"

--- a/packages/gatsby-image/package.json
+++ b/packages/gatsby-image/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-image",
   "description": "Lazy-loading React image component with optional support for the blur-up effect.",
   "version": "1.0.35",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-component",
-    "react-component"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -30,5 +13,22 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-component",
+    "react-component"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-link",
-  "version": "1.6.36",
   "description": "An enhanced Link component for Gatsby sites with support for resource prefetching",
+  "version": "1.6.36",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
@@ -15,6 +15,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -2,33 +2,9 @@
   "name": "gatsby-link",
   "description": "An enhanced Link component for Gatsby sites with support for resource prefetching",
   "version": "1.6.36",
-  "main": "index.js",
-  "types": "index.d.ts",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-component"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
-  },
-  "peerDependencies": {
-    "gatsby": "^1.0.0"
   },
   "dependencies": {
     "@types/history": "^4.6.2",
@@ -36,5 +12,29 @@
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.5.8",
     "ric": "^1.3.0"
-  }
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-component"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "peerDependencies": {
+    "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  },
+  "types": "index.d.ts"
 }

--- a/packages/gatsby-module-loader/package.json
+++ b/packages/gatsby-module-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-module-loader",
-  "version": "1.0.9",
   "description": "_Based on https://github.com/webpack/bundle-loader and https://github.com/NekR/async-module-loader_",
+  "version": "1.0.9",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -11,6 +11,14 @@
   },
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-module-loader#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "loader-utils": "^0.2.16"

--- a/packages/gatsby-module-loader/package.json
+++ b/packages/gatsby-module-loader/package.json
@@ -2,22 +2,9 @@
   "name": "gatsby-module-loader",
   "description": "_Based on https://github.com/webpack/bundle-loader and https://github.com/NekR/async-module-loader_",
   "version": "1.0.9",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-module-loader#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -26,5 +13,18 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-module-loader#readme",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-aphrodite/package.json
+++ b/packages/gatsby-plugin-aphrodite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-aphrodite",
-  "version": "1.0.6",
   "description": "Stub description for gatsby-plugin-aphrodite",
+  "version": "1.0.6",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-aphrodite#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-aphrodite/package.json
+++ b/packages/gatsby-plugin-aphrodite/package.json
@@ -2,33 +2,33 @@
   "name": "gatsby-plugin-aphrodite",
   "description": "Stub description for gatsby-plugin-aphrodite",
   "version": "1.0.6",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-aphrodite#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-aphrodite#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-aphrodite/package.json
+++ b/packages/gatsby-plugin-aphrodite/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-canonical-urls",
-  "version": "1.0.12",
   "description": "Stub description for gatsby-plugin-canonical-urls",
+  "version": "1.0.12",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -2,33 +2,33 @@
   "name": "gatsby-plugin-canonical-urls",
   "description": "Stub description for gatsby-plugin-canonical-urls",
   "version": "1.0.12",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-catch-links/package.json
+++ b/packages/gatsby-plugin-catch-links/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-catch-links",
-  "version": "1.0.15",
   "description": "Intercepts local links from markdown and other non-react pages and does a client-side pushState to avoid the browser having to refresh the page.",
+  "version": "1.0.15",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-catch-links/package.json
+++ b/packages/gatsby-plugin-catch-links/package.json
@@ -2,34 +2,34 @@
   "name": "gatsby-plugin-catch-links",
   "description": "Intercepts local links from markdown and other non-react pages and does a client-side pushState to avoid the browser having to refresh the page.",
   "version": "1.0.15",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-coffeescript/package.json
+++ b/packages/gatsby-plugin-coffeescript/package.json
@@ -2,7 +2,26 @@
   "name": "gatsby-plugin-coffeescript",
   "description": "Adds CoffeeScript support for Gatsby layouts and pages.",
   "version": "1.4.9",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "coffeescript"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "contributors": [
     "Noah Lange <noahrlange@gmail.com>"
   ],
@@ -18,16 +37,5 @@
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "keywords": [
-    "gatsby",
-    "coffeescript"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "readme": "README.md",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  }
+  "readme": "README.md"
 }

--- a/packages/gatsby-plugin-coffeescript/package.json
+++ b/packages/gatsby-plugin-coffeescript/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-plugin-coffeescript",
   "description": "Adds CoffeeScript support for Gatsby layouts and pages.",
   "version": "1.4.9",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "coffeescript"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "contributors": [
     "Noah Lange <noahrlange@gmail.com>"
@@ -34,8 +18,24 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript#readme",
+  "keywords": [
+    "coffeescript",
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "readme": "README.md"
+  "readme": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  }
 }

--- a/packages/gatsby-plugin-create-client-paths/package.json
+++ b/packages/gatsby-plugin-create-client-paths/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-create-client-paths",
-  "version": "1.0.4",
   "description": "Gatsby-plugin for creating paths that exist only on the client",
+  "version": "1.0.4",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "scott.eckenthal@gmail.com",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0"
   },

--- a/packages/gatsby-plugin-create-client-paths/package.json
+++ b/packages/gatsby-plugin-create-client-paths/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-plugin-create-client-paths",
   "description": "Gatsby-plugin for creating paths that exist only on the client",
   "version": "1.0.4",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "scott.eckenthal@gmail.com",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"
@@ -28,7 +13,22 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-cxs",
-  "version": "1.0.6",
   "description": "Stub description for gatsby-plugin-cxs",
+  "version": "1.0.6",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -2,33 +2,33 @@
   "name": "gatsby-plugin-cxs",
   "description": "Stub description for gatsby-plugin-cxs",
   "version": "1.0.6",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-emotion",
-  "version": "1.1.11",
   "description": "Gatsby plugin to add support for Emotion",
+  "version": "1.1.11",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Tegan Churchill <churchill.tegan@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -2,36 +2,36 @@
   "name": "gatsby-plugin-emotion",
   "description": "Gatsby plugin to add support for Emotion",
   "version": "1.1.11",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "emotion"
-  ],
   "author": "Tegan Churchill <churchill.tegan@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion#readme",
+  "keywords": [
+    "emotion",
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "emotion": "7 || 8 ",
     "emotion-server": "7 || 8",
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-feed",
-  "version": "1.3.17",
   "description": "Creates an RSS feed for your Gatsby site.",
+  "version": "1.3.17",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -17,6 +17,14 @@
   ],
   "author": "Nicholas Young <nicholas@nicholaswyoung.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -2,32 +2,9 @@
   "name": "gatsby-plugin-feed",
   "description": "Creates an RSS feed for your Gatsby site.",
   "version": "1.3.17",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "rss",
-    "atom",
-    "feed"
-  ],
   "author": "Nicholas Young <nicholas@nicholaswyoung.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -35,7 +12,30 @@
     "pify": "^3.0.0",
     "rss": "^1.2.2"
   },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed#readme",
+  "keywords": [
+    "atom",
+    "feed",
+    "gatsby",
+    "gatsby-plugin",
+    "rss"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-glamor/package.json
+++ b/packages/gatsby-plugin-glamor/package.json
@@ -2,7 +2,27 @@
   "name": "gatsby-plugin-glamor",
   "description": "Gatsby plugin to add support for Glamor",
   "version": "1.6.11",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "glamor"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "glamor": "^2.20.29"
@@ -13,17 +33,5 @@
   },
   "peerDependencies": {
     "gatsby": "^1.0.0"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "glamor"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-plugin-glamor/package.json
+++ b/packages/gatsby-plugin-glamor/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-plugin-glamor",
   "description": "Gatsby plugin to add support for Glamor",
   "version": "1.6.11",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "glamor"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -31,7 +14,24 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "glamor"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-glamorous/package.json
+++ b/packages/gatsby-plugin-glamorous/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-glamorous",
-  "version": "1.0.6",
   "description": "Stub description for gatsby-plugin-glamorous",
+  "version": "1.0.6",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamorous#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-glamorous/package.json
+++ b/packages/gatsby-plugin-glamorous/package.json
@@ -2,33 +2,33 @@
   "name": "gatsby-plugin-glamorous",
   "description": "Stub description for gatsby-plugin-glamorous",
   "version": "1.0.6",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamorous#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamorous#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-glamorous/package.json
+++ b/packages/gatsby-plugin-glamorous/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -2,22 +2,30 @@
   "name": "gatsby-plugin-google-analytics",
   "description": "Gatsby plugin to add google analytics onto a site",
   "version": "1.0.17",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "keywords": [
     "gatsby",
     "gatsby-plugin",
     "google analytics"
   ],
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -1,41 +1,36 @@
 {
   "name": "gatsby-plugin-google-analytics",
   "description": "Gatsby plugin to add google analytics onto a site",
-  "main": "index.js",
   "version": "1.0.18",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics#readme",
   "keywords": [
     "gatsby",
     "gatsby-plugin",
     "google analytics"
   ],
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  "main": "index.js",
+  "peerDependencies": {
+    "gatsby": "^1.0.0"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git"
   },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
-  },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
-  "peerDependencies": {
-    "gatsby": "^1.0.0"
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -2,10 +2,11 @@
   "name": "gatsby-plugin-google-tagmanager",
   "description": "Gatsby plugin to add google tagmanager onto a site",
   "version": "1.0.13",
-  "author": "Thijs Koerselman <thijs@vauxlab.com>",
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "keywords": [
     "gatsby",
@@ -13,12 +14,19 @@
     "google analytics",
     "google tagmanager"
   ],
+  "author": "Thijs Koerselman <thijs@vauxlab.com>",
   "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"

--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -2,36 +2,36 @@
   "name": "gatsby-plugin-google-tagmanager",
   "description": "Gatsby plugin to add google tagmanager onto a site",
   "version": "1.0.13",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+  "author": "Thijs Koerselman <thijs@vauxlab.com>",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager#readme",
   "keywords": [
     "gatsby",
     "gatsby-plugin",
     "google analytics",
     "google tagmanager"
   ],
-  "author": "Thijs Koerselman <thijs@vauxlab.com>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  "main": "index.js",
+  "peerDependencies": {
+    "gatsby": "^1.0.0"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git"
   },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
-  },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
-  "peerDependencies": {
-    "gatsby": "^1.0.0"
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-jss/package.json
+++ b/packages/gatsby-plugin-jss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-jss",
-  "version": "1.5.10",
   "description": "Gatsby plugin that adds SSR support for JSS",
+  "version": "1.5.10",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -16,6 +16,14 @@
   ],
   "author": "Vladimir Guguiev <wizardzloy@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "react-jss": "^7.0.2"

--- a/packages/gatsby-plugin-jss/package.json
+++ b/packages/gatsby-plugin-jss/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-plugin-jss",
   "description": "Gatsby plugin that adds SSR support for JSS",
   "version": "1.5.10",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "jss",
-    "react-jss"
-  ],
   "author": "Vladimir Guguiev <wizardzloy@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -31,7 +13,25 @@
   "devDependencies": {
     "babel-cli": "^6.26.0"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "jss",
+    "react-jss"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-less/package.json
+++ b/packages/gatsby-plugin-less/package.json
@@ -2,7 +2,26 @@
   "name": "gatsby-plugin-less",
   "description": "Adds the ability to load and parse less-files to include in project your",
   "version": "1.1.4",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__,theme-test.js",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__,theme-test.js"
+  },
+  "keywords": [
+    "gatsby",
+    "less"
+  ],
   "author": "Ming Aldrich-Gan <mingaldrichgan@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "contributors": [
     "Ole Martin Ruud <barskern@outlook.com> (barskern.github.io)"
   ],
@@ -20,16 +39,5 @@
   },
   "peerDependencies": {
     "gatsby": "^1.0.0"
-  },
-  "keywords": [
-    "gatsby",
-    "less"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__,theme-test.js",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__,theme-test.js"
   }
 }

--- a/packages/gatsby-plugin-less/package.json
+++ b/packages/gatsby-plugin-less/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-plugin-less",
   "description": "Adds the ability to load and parse less-files to include in project your",
   "version": "1.1.4",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__,theme-test.js",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__,theme-test.js"
-  },
-  "keywords": [
-    "gatsby",
-    "less"
-  ],
   "author": "Ming Aldrich-Gan <mingaldrichgan@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "contributors": [
     "Ole Martin Ruud <barskern@outlook.com> (barskern.github.io)"
@@ -37,7 +21,23 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less#readme",
+  "keywords": [
+    "gatsby",
+    "less"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__,theme-test.js",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__,theme-test.js"
   }
 }

--- a/packages/gatsby-plugin-lodash/package.json
+++ b/packages/gatsby-plugin-lodash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-lodash",
-  "version": "1.0.8",
   "description": "Easy modular Lodash builds. Adds the Lodash webpack & Babel plugins to your Gatsby build",
+  "version": "1.0.8",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-plugin-lodash": "^3.2.11",
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-plugin-lodash/package.json
+++ b/packages/gatsby-plugin-lodash/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-plugin-lodash",
   "description": "Easy modular Lodash builds. Adds the Lodash webpack & Babel plugins to your Gatsby build",
   "version": "1.0.8",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-plugin-lodash": "^3.2.11",
@@ -31,7 +16,22 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-manifest",
-  "version": "1.0.13",
   "description": "Gatsby plugin which adds a manifest.json to make sites progressive web apps",
+  "version": "1.0.13",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -17,6 +17,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -2,38 +2,38 @@
   "name": "gatsby-plugin-manifest",
   "description": "Gatsby plugin which adds a manifest.json to make sites progressive web apps",
   "version": "1.0.13",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "manifest.json",
-    "pwa",
-    "progressive-web-app"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0"
   },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "manifest.json",
+    "progressive-web-app",
+    "pwa"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -1,9 +1,8 @@
 {
   "name": "gatsby-plugin-netlify-cms",
-  "version": "1.0.6",
   "description": "A Gatsby plugin which generates the Netlify CMS single page app",
+  "version": "1.0.6",
   "main": "index.js",
-  "author": "Shawn Erquhart <shawn@erquh.art>",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -15,7 +14,16 @@
     "netlify",
     "netlify-cms"
   ],
+  "author": "Shawn Erquhart <shawn@erquh.art>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "html-webpack-include-assets-plugin": "^1.0.2",
     "html-webpack-plugin": "^2.30.1",

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-plugin-netlify-cms",
   "description": "A Gatsby plugin which generates the Netlify CMS single page app",
   "version": "1.0.6",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "netlify",
-    "netlify-cms"
-  ],
   "author": "Shawn Erquhart <shawn@erquh.art>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "html-webpack-include-assets-plugin": "^1.0.2",
@@ -33,7 +15,25 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.1.3"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "netlify",
+    "netlify-cms"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -1,15 +1,8 @@
 {
   "name": "gatsby-plugin-netlify",
-  "version": "1.0.17",
   "description": "A Gatsby plugin which generates a _headers file for netlify",
+  "version": "1.0.17",
   "main": "index.js",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "contributors": [
-    {
-      "name": "Nathanael Beisiegel",
-      "email": "pknb.dev@gmail.com"
-    }
-  ],
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -21,7 +14,22 @@
     "netlify",
     "http/2-server-push"
   ],
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "contributors": [
+    {
+      "name": "Nathanael Beisiegel",
+      "email": "pknb.dev@gmail.com"
+    }
+  ],
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "fs-extra": "^4.0.2",

--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-plugin-netlify",
   "description": "A Gatsby plugin which generates a _headers file for netlify",
   "version": "1.0.17",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "netlify",
-    "http/2-server-push"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "contributors": [
     {
@@ -40,7 +22,25 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "http/2-server-push",
+    "netlify"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-no-sourcemaps/package.json
+++ b/packages/gatsby-plugin-no-sourcemaps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-no-sourcemaps",
-  "version": "1.0.2",
   "description": "Disable sourcemaps when building javascript",
+  "version": "1.0.2",
   "main": "index.js",
   "keywords": [
     "gatsby",
@@ -9,5 +9,13 @@
     "sourcemaps"
   ],
   "author": "Stuart Taylor <stuart@freecodecamp.org>",
-  "license": "MIT"
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  }
 }

--- a/packages/gatsby-plugin-no-sourcemaps/package.json
+++ b/packages/gatsby-plugin-no-sourcemaps/package.json
@@ -2,18 +2,18 @@
   "name": "gatsby-plugin-no-sourcemaps",
   "description": "Disable sourcemaps when building javascript",
   "version": "1.0.2",
-  "main": "index.js",
-  "keywords": [
-    "gatsby",
-    "webpack",
-    "sourcemaps"
-  ],
   "author": "Stuart Taylor <stuart@freecodecamp.org>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps#readme",
+  "keywords": [
+    "gatsby",
+    "sourcemaps",
+    "webpack"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git"

--- a/packages/gatsby-plugin-nprogress/package.json
+++ b/packages/gatsby-plugin-nprogress/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-nprogress",
-  "version": "1.0.11",
   "description": "Shows page loading indicator when loading page resources is delayed",
+  "version": "1.0.11",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews<mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-nprogress/package.json
+++ b/packages/gatsby-plugin-nprogress/package.json
@@ -2,34 +2,34 @@
   "name": "gatsby-plugin-nprogress",
   "description": "Shows page loading indicator when loading page resources is delayed",
   "version": "1.0.11",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews<mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "nprogress": "^0.2.0"
   },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -2,10 +2,11 @@
   "name": "gatsby-plugin-offline",
   "description": "Gatsby plugin which sets up a site to be able to run offline",
   "version": "1.0.13",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "keywords": [
     "gatsby",
@@ -14,12 +15,19 @@
     "precache",
     "service-worker"
   ],
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -2,12 +2,19 @@
   "name": "gatsby-plugin-offline",
   "description": "Gatsby plugin which sets up a site to be able to run offline",
   "version": "1.0.13",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "sw-precache": "^5.0.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline#readme",
   "keywords": [
     "gatsby",
     "gatsby-plugin",
@@ -15,25 +22,18 @@
     "precache",
     "service-worker"
   ],
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  "main": "index.js",
+  "peerDependencies": {
+    "gatsby": "^1.0.0"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git"
   },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
-  },
-  "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "sw-precache": "^5.0.0"
-  },
-  "peerDependencies": {
-    "gatsby": "^1.0.0"
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-postcss-sass/package.json
+++ b/packages/gatsby-plugin-postcss-sass/package.json
@@ -2,7 +2,29 @@
   "name": "gatsby-plugin-postcss-sass",
   "description": "Gatsby plugin to handle scss/sass files with integrated support for also processing with Postcss plugins",
   "version": "1.0.16",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "postcss",
+    "sass",
+    "scss"
+  ],
   "author": "Scotty Eckenthal <scotty@meetfabric.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss-sass#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "extract-text-webpack-plugin": "^1.0.1",
@@ -17,19 +39,5 @@
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "postcss",
-    "sass",
-    "scss"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "readme": "README.md",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  }
+  "readme": "README.md"
 }

--- a/packages/gatsby-plugin-postcss-sass/package.json
+++ b/packages/gatsby-plugin-postcss-sass/package.json
@@ -2,28 +2,9 @@
   "name": "gatsby-plugin-postcss-sass",
   "description": "Gatsby plugin to handle scss/sass files with integrated support for also processing with Postcss plugins",
   "version": "1.0.16",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "postcss",
-    "sass",
-    "scss"
-  ],
   "author": "Scotty Eckenthal <scotty@meetfabric.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss-sass#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -36,8 +17,27 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss-sass#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "postcss",
+    "sass",
+    "scss"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "readme": "README.md"
+  "readme": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  }
 }

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-preact",
-  "version": "1.0.15",
   "description": "A Gatsby plugin which replaces React with Preact",
+  "version": "1.0.15",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "preact": "^8.2.5",

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-plugin-preact",
   "description": "A Gatsby plugin which replaces React with Preact",
   "version": "1.0.15",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "preact"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -32,7 +15,24 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "preact"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-react-css-modules/package.json
+++ b/packages/gatsby-plugin-react-css-modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-react-css-modules",
-  "version": "1.0.12",
   "description": "Gatsby plugin that transforms styleName to className using compile time CSS module resolution",
+  "version": "1.0.12",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -20,6 +20,14 @@
   ],
   "author": "Ming Aldrich-Gan <mingaldrichgan@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-plugin-react-css-modules": "^3.2.1",
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-plugin-react-css-modules/package.json
+++ b/packages/gatsby-plugin-react-css-modules/package.json
@@ -2,31 +2,9 @@
   "name": "gatsby-plugin-react-css-modules",
   "description": "Gatsby plugin that transforms styleName to className using compile time CSS module resolution",
   "version": "1.0.12",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "babel",
-    "babel-plugin",
-    "react",
-    "css modules",
-    "styleName",
-    "className"
-  ],
   "author": "Ming Aldrich-Gan <mingaldrichgan@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-plugin-react-css-modules": "^3.2.1",
@@ -37,7 +15,29 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules#readme",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "className",
+    "css modules",
+    "gatsby",
+    "gatsby-plugin",
+    "react",
+    "styleName"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-react-helmet",
-  "version": "2.0.4",
   "description": "Stub description for gatsby-plugin-react-helmet",
+  "version": "2.0.4",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -2,34 +2,34 @@
   "name": "gatsby-plugin-react-helmet",
   "description": "Stub description for gatsby-plugin-react-helmet",
   "version": "2.0.4",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0",
     "react-helmet": ">=5.1.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-react-next/package.json
+++ b/packages/gatsby-plugin-react-next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-react-next",
-  "version": "1.0.8",
   "description": "Use React 16 with your Gatsby v1 site",
+  "version": "1.0.8",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-next#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "core-js": "^2.5.1",

--- a/packages/gatsby-plugin-react-next/package.json
+++ b/packages/gatsby-plugin-react-next/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-plugin-react-next",
   "description": "Use React 16 with your Gatsby v1 site",
   "version": "1.0.8",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-next#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -31,7 +16,22 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-next#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-remove-trailing-slashes/package.json
+++ b/packages/gatsby-plugin-remove-trailing-slashes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-remove-trailing-slashes",
-  "version": "1.0.4",
   "description": "Stub description for gatsby-plugin-remove-trailing-slashes",
+  "version": "1.0.4",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "scott.eckenthal@gmail.com",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0"
   },

--- a/packages/gatsby-plugin-remove-trailing-slashes/package.json
+++ b/packages/gatsby-plugin-remove-trailing-slashes/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-plugin-remove-trailing-slashes",
   "description": "Stub description for gatsby-plugin-remove-trailing-slashes",
   "version": "1.0.4",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "scott.eckenthal@gmail.com",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"
@@ -28,7 +13,22 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -2,7 +2,27 @@
   "name": "gatsby-plugin-sass",
   "description": "Gatsby plugin to handle scss/sass files",
   "version": "1.0.16",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "sass",
+    "scss"
+  ],
   "author": "Daniel Farrell <daniel@mobelux.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "extract-text-webpack-plugin": "^1.0.1",
@@ -18,17 +38,5 @@
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "keywords": [
-    "gatsby",
-    "sass",
-    "scss"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "readme": "README.md",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  }
+  "readme": "README.md"
 }

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-plugin-sass",
   "description": "Gatsby plugin to handle scss/sass files",
   "version": "1.0.16",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "sass",
-    "scss"
-  ],
   "author": "Daniel Farrell <daniel@mobelux.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -35,8 +18,25 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass#readme",
+  "keywords": [
+    "gatsby",
+    "sass",
+    "scss"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "readme": "README.md"
+  "readme": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  }
 }

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -2,7 +2,27 @@
   "name": "gatsby-plugin-sharp",
   "description": "Wrapper of the Sharp image manipulation library for Gatsby plugins",
   "version": "1.6.27",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "image",
+    "sharp"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "async": "^2.1.2",
     "babel-runtime": "^6.26.0",
@@ -23,17 +43,5 @@
   },
   "peerDependencies": {
     "gatsby": "^1.0.0"
-  },
-  "keywords": [
-    "gatsby",
-    "image",
-    "sharp"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-plugin-sharp",
   "description": "Wrapper of the Sharp image manipulation library for Gatsby plugins",
   "version": "1.6.27",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "image",
-    "sharp"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "async": "^2.1.2",
@@ -41,7 +24,24 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp#readme",
+  "keywords": [
+    "gatsby",
+    "image",
+    "sharp"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-sitemap",
-  "version": "1.2.12",
   "description": "Stub description for gatsby-plugin-sitemap",
+  "version": "1.2.12",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Nicholas Young &lt;nicholas@nicholaswyoung.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -2,34 +2,34 @@
   "name": "gatsby-plugin-sitemap",
   "description": "Stub description for gatsby-plugin-sitemap",
   "version": "1.2.12",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Nicholas Young &lt;nicholas@nicholaswyoung.com&gt;",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "sitemap": "^1.12.0"
   },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -2,7 +2,26 @@
   "name": "gatsby-plugin-styled-components",
   "description": "Gatsby plugin to add support for styled components",
   "version": "2.0.5",
+  "main": "index.js",
+  "scripts": {
+    "prepublish": "npm run build",
+    "build": "babel src --out-dir ."
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "styled-components"
+  ],
   "author": "Guten Ye <ywzhaifei@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0"
   },
@@ -12,16 +31,5 @@
   "peerDependencies": {
     "gatsby": "^1.0.0",
     "styled-components": ">= 2.0.0"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "prepublish": "npm run build",
-    "build": "babel src --out-dir ."
   }
 }

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-plugin-styled-components",
   "description": "Gatsby plugin to add support for styled components",
   "version": "2.0.5",
-  "main": "index.js",
-  "scripts": {
-    "prepublish": "npm run build",
-    "build": "babel src --out-dir ."
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "styled-components"
-  ],
   "author": "Guten Ye <ywzhaifei@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"
@@ -28,8 +12,24 @@
   "devDependencies": {
     "babel-cli": "^6.26.0"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "styled-components"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0",
     "styled-components": ">= 2.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir .",
+    "prepublish": "npm run build"
   }
 }

--- a/packages/gatsby-plugin-styled-jsx/package.json
+++ b/packages/gatsby-plugin-styled-jsx/package.json
@@ -1,8 +1,7 @@
 {
   "name": "gatsby-plugin-styled-jsx",
-  "version": "2.0.2",
   "description": "Adds SSR support for styled-jsx",
-  "author": "Tim Suchanek <tim.suchanek@gmail.com>",
+  "version": "2.0.2",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,7 +12,16 @@
     "gatsby",
     "styled-jsx"
   ],
+  "author": "Tim Suchanek <tim.suchanek@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0"
   },

--- a/packages/gatsby-plugin-styled-jsx/package.json
+++ b/packages/gatsby-plugin-styled-jsx/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-plugin-styled-jsx",
   "description": "Adds SSR support for styled-jsx",
   "version": "2.0.2",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "styled-jsx"
-  ],
   "author": "Tim Suchanek <tim.suchanek@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"
@@ -28,8 +12,24 @@
   "devDependencies": {
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx#readme",
+  "keywords": [
+    "gatsby",
+    "styled-jsx"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0",
     "styled-jsx": "^2.2.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-styletron",
-  "version": "1.0.11",
   "description": "Stub description for gatsby-plugin-styletron",
+  "version": "1.0.11",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Nadiia Dmytrenko &lt;nadiia.dmytrenko@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -2,28 +2,9 @@
   "name": "gatsby-plugin-styletron",
   "description": "Stub description for gatsby-plugin-styletron",
   "version": "1.0.11",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Nadiia Dmytrenko &lt;nadiia.dmytrenko@gmail.com&gt;",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -31,7 +12,26 @@
     "styletron-react": "^3.0.0-rc.2",
     "styletron-server": "^3.0.0-rc.1"
   },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -2,7 +2,27 @@
   "name": "gatsby-plugin-stylus",
   "description": "Gatsby support for Stylus",
   "version": "1.1.14",
+  "main": "./gatsby-node.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "stylus"
+  ],
   "author": "Ian Sinnott <ian@iansinnott.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "extract-text-webpack-plugin": "^1.0.1",
@@ -17,17 +37,5 @@
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "stylus"
-  ],
-  "license": "MIT",
-  "main": "./gatsby-node.js",
-  "readme": "README.md",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  }
+  "readme": "README.md"
 }

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-plugin-stylus",
   "description": "Gatsby support for Stylus",
   "version": "1.1.14",
-  "main": "./gatsby-node.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "stylus"
-  ],
   "author": "Ian Sinnott <ian@iansinnott.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -34,8 +17,25 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "stylus"
+  ],
+  "license": "MIT",
+  "main": "./gatsby-node.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
   },
-  "readme": "README.md"
+  "readme": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  }
 }

--- a/packages/gatsby-plugin-twitter/package.json
+++ b/packages/gatsby-plugin-twitter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-twitter",
-  "version": "1.0.16",
   "description": "Stub description for gatsby-plugin-twitter",
+  "version": "1.0.16",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-plugin-twitter/package.json
+++ b/packages/gatsby-plugin-twitter/package.json
@@ -2,33 +2,33 @@
   "name": "gatsby-plugin-twitter",
   "description": "Stub description for gatsby-plugin-twitter",
   "version": "1.0.16",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
-  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -1,8 +1,27 @@
 {
   "name": "gatsby-plugin-typescript",
-  "version": "1.4.15",
   "description": "Adds TypeScript support for Gatsby layouts and pages.",
+  "version": "1.4.15",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir .",
+    "watch": "babel -w src --out-dir .",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "typescript"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "contributors": [
     "Noah Lange <noahrlange@gmail.com>"
   ],
@@ -17,16 +36,5 @@
   },
   "peerDependencies": {
     "gatsby": "^1.0.0"
-  },
-  "keywords": [
-    "gatsby",
-    "typescript"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir .",
-    "watch": "babel -w src --out-dir .",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-plugin-typescript",
   "description": "Adds TypeScript support for Gatsby layouts and pages.",
   "version": "1.4.15",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir .",
-    "watch": "babel -w src --out-dir .",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "typescript"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "contributors": [
     "Noah Lange <noahrlange@gmail.com>"
@@ -34,7 +18,23 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript#readme",
+  "keywords": [
+    "gatsby",
+    "typescript"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir .",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir ."
   }
 }

--- a/packages/gatsby-plugin-typography/package.json
+++ b/packages/gatsby-plugin-typography/package.json
@@ -1,13 +1,8 @@
 {
   "name": "gatsby-plugin-typography",
-  "version": "1.7.13",
   "description": "Gatsby plugin to setup server rendering of Typography.js' CSS",
+  "version": "1.7.13",
   "main": "index.js",
-  "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "react-typography": "^0.16.1",
-    "typography": "^0.16.0"
-  },
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -21,6 +16,19 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "react-typography": "^0.16.1",
+    "typography": "^0.16.0"
+  },
   "devDependencies": {
     "cross-env": "^5.0.5"
   },

--- a/packages/gatsby-plugin-typography/package.json
+++ b/packages/gatsby-plugin-typography/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-plugin-typography",
   "description": "Gatsby plugin to setup server rendering of Typography.js' CSS",
   "version": "1.7.13",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "typography",
-    "typography.js"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -32,7 +14,25 @@
   "devDependencies": {
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "typography",
+    "typography.js"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "gatsby": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -2,7 +2,25 @@
   "name": "gatsby-react-router-scroll",
   "description": "React Router scroll management forked from https://github.com/ytase/react-router-scroll for Gatsby",
   "version": "1.0.10",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  },
+  "keywords": [
+    "gatsby"
+  ],
   "author": "Jimmy Jia",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "scroll-behavior": "^0.9.9",
@@ -14,19 +32,9 @@
     "babel-preset-stage-1": "^6.24.1",
     "cross-env": "^5.0.5"
   },
-  "keywords": [
-    "gatsby"
-  ],
-  "license": "MIT",
-  "main": "index.js",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-router-dom": "^4.0"
-  },
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-react-router-scroll",
   "description": "React Router scroll management forked from https://github.com/ytase/react-router-scroll for Gatsby",
   "version": "1.0.10",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Jimmy Jia",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -32,9 +17,24 @@
     "babel-preset-stage-1": "^6.24.1",
     "cross-env": "^5.0.5"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-router-dom": "^4.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-autolink-headers/package.json
+++ b/packages/gatsby-remark-autolink-headers/package.json
@@ -2,7 +2,27 @@
   "name": "gatsby-remark-autolink-headers",
   "description": "Gatsby plugin to autolink headers in markdown processed by Remark",
   "version": "1.4.11",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "remark"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "github-slugger": "^1.1.1",
@@ -12,17 +32,5 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-remark-autolink-headers/package.json
+++ b/packages/gatsby-remark-autolink-headers/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-remark-autolink-headers",
   "description": "Gatsby plugin to autolink headers in markdown processed by Remark",
   "version": "1.4.11",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -32,5 +15,22 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "remark"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-code-repls/package.json
+++ b/packages/gatsby-remark-code-repls/package.json
@@ -2,7 +2,30 @@
   "name": "gatsby-remark-code-repls",
   "description": "Gatsby plugin to auto-generate links to popular REPLs like Babel and Codepen",
   "version": "1.0.8",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "remark",
+    "babel",
+    "codepen",
+    "repl"
+  ],
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "lz-string": "^1.4.4",
@@ -14,20 +37,5 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark",
-    "babel",
-    "codepen",
-    "repl"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-remark-code-repls/package.json
+++ b/packages/gatsby-remark-code-repls/package.json
@@ -2,29 +2,9 @@
   "name": "gatsby-remark-code-repls",
   "description": "Gatsby plugin to auto-generate links to popular REPLs like Babel and Codepen",
   "version": "1.0.8",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark",
-    "babel",
-    "codepen",
-    "repl"
-  ],
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -37,5 +17,25 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls#readme",
+  "keywords": [
+    "babel",
+    "codepen",
+    "gatsby",
+    "gatsby-plugin",
+    "remark",
+    "repl"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -2,7 +2,28 @@
   "name": "gatsby-remark-copy-linked-files",
   "description": "Find files which are linked to from markdown and copy them to the public directory",
   "version": "1.5.26",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "prismjs",
+    "remark"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "cheerio": "^1.0.0-rc.2",
@@ -16,18 +37,5 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "prismjs",
-    "remark"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-remark-copy-linked-files",
   "description": "Find files which are linked to from markdown and copy them to the public directory",
   "version": "1.5.26",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "prismjs",
-    "remark"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -37,5 +19,23 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "prismjs",
+    "remark"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -1,14 +1,13 @@
 {
   "name": "gatsby-remark-custom-blocks",
-  "version": "1.0.2",
   "description": "Gatsby remark plugin for adding custom blocks in markdown",
+  "version": "1.0.2",
   "main": "index.js",
   "scripts": {
     "build": "babel --out-dir . --ignore __tests__ src",
     "watch": "babel -w src --out-dir . --ignore __tests__",
     "prepublish": "cross-env NODE_ENV=production npm run build"
   },
-  "repository": "https://github.com/AlahmadiQ8/gatsby-remark-custom-blocks",
   "keywords": [
     "gatsby",
     "gatsby-plugin",
@@ -17,6 +16,11 @@
   ],
   "author": "Mohammad Asad Mohammad <m91.alahmadi@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks#readme",
+  "repository": "https://github.com/AlahmadiQ8/gatsby-remark-custom-blocks",
   "private": false,
   "files": [
     "index.js",

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -3,6 +3,10 @@
   "description": "Gatsby remark plugin for adding custom blocks in markdown",
   "version": "1.0.2",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
   "scripts": {
     "build": "babel --out-dir . --ignore __tests__ src",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -22,10 +26,6 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks#readme",
   "repository": "https://github.com/AlahmadiQ8/gatsby-remark-custom-blocks",
   "private": false,
-  "files": [
-    "index.js",
-    "README.md"
-  ],
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5",

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -2,38 +2,38 @@
   "name": "gatsby-remark-custom-blocks",
   "description": "Gatsby remark plugin for adding custom blocks in markdown",
   "version": "1.0.2",
-  "main": "index.js",
-  "files": [
-    "index.js",
-    "README.md"
-  ],
-  "scripts": {
-    "build": "babel --out-dir . --ignore __tests__ src",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "markdown",
-    "remark"
-  ],
   "author": "Mohammad Asad Mohammad <m91.alahmadi@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks#readme",
-  "repository": "https://github.com/AlahmadiQ8/gatsby-remark-custom-blocks",
-  "private": false,
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "remark-custom-blocks": "^1.0.6"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5",
     "rimraf": "^2.6.2",
     "unist-util-find": "^1.0.1"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "remark-custom-blocks": "^1.0.6"
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "markdown",
+    "remark"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "private": false,
+  "repository": "https://github.com/AlahmadiQ8/gatsby-remark-custom-blocks",
+  "scripts": {
+    "build": "babel --out-dir . --ignore __tests__ src",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -2,7 +2,28 @@
   "name": "gatsby-remark-embed-snippet",
   "description": "Gatsby plugin to embed formatted code snippets within markdown",
   "version": "1.0.8",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "remark",
+    "prism"
+  ],
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "gatsby-remark-prismjs": "^1.2.14",
@@ -13,18 +34,5 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark",
-    "prism"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-remark-embed-snippet",
   "description": "Gatsby plugin to embed formatted code snippets within markdown",
   "version": "1.0.8",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark",
-    "prism"
-  ],
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -34,5 +16,23 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "prism",
+    "remark"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -1,8 +1,13 @@
 {
   "name": "gatsby-remark-images",
-  "version": "1.5.43",
   "description": "Processes images in markdown so they can be used in the production build.",
+  "version": "1.5.43",
   "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
   "keywords": [
     "gatsby",
     "gatsby-plugin",
@@ -13,6 +18,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
@@ -25,10 +38,5 @@
     "lodash": "^4.17.4",
     "slash": "^1.0.0",
     "unist-util-select": "^1.5.0"
-  },
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -2,33 +2,9 @@
   "name": "gatsby-remark-images",
   "description": "Processes images in markdown so they can be used in the production build.",
   "version": "1.5.43",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "markdown",
-    "remark",
-    "image",
-    "responsive images"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -38,5 +14,29 @@
     "lodash": "^4.17.4",
     "slash": "^1.0.0",
     "unist-util-select": "^1.5.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "image",
+    "markdown",
+    "remark",
+    "responsive images"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-katex/package.json
+++ b/packages/gatsby-remark-katex/package.json
@@ -2,12 +2,11 @@
   "name": "gatsby-remark-katex",
   "description": "Transform math nodes to html markup",
   "version": "1.0.10",
-  "author": "Jeffrey Xiao <jeffrey.xiao1998@gmail.com>",
-  "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "katex": "^0.8.3",
-    "remark-math": "^0.2.4",
-    "unist-util-visit": "^1.1.1"
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "keywords": [
     "gatsby",
@@ -15,12 +14,21 @@
     "remark",
     "katex"
   ],
+  "author": "Jeffrey Xiao <jeffrey.xiao1998@gmail.com>",
   "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "katex": "^0.8.3",
+    "remark-math": "^0.2.4",
+    "unist-util-visit": "^1.1.1"
   },
   "devDependencies": {
     "cross-env": "^5.0.5"

--- a/packages/gatsby-remark-katex/package.json
+++ b/packages/gatsby-remark-katex/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-remark-katex",
   "description": "Transform math nodes to html markup",
   "version": "1.0.10",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark",
-    "katex"
-  ],
   "author": "Jeffrey Xiao <jeffrey.xiao1998@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -32,5 +14,23 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "katex",
+    "remark"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -2,7 +2,28 @@
   "name": "gatsby-remark-prismjs",
   "description": "Adds syntax highlighting to code blocks at build time using PrismJS",
   "version": "1.2.14",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "prismjs",
+    "remark"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "parse-numeric-range": "0.0.2",
@@ -13,18 +34,5 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.1.3",
     "remark": "^7.0.1"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "prismjs",
-    "remark"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-remark-prismjs",
   "description": "Adds syntax highlighting to code blocks at build time using PrismJS",
   "version": "1.2.14",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "prismjs",
-    "remark"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -34,5 +16,23 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.1.3",
     "remark": "^7.0.1"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "prismjs",
+    "remark"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-remark-responsive-iframe",
-  "version": "1.4.16",
   "description": "Make iframes in Markdown processed by Remark responsive",
+  "version": "1.4.16",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5",

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -2,32 +2,9 @@
   "name": "gatsby-remark-responsive-iframe",
   "description": "Make iframes in Markdown processed by Remark responsive",
   "version": "1.4.16",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "remark"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5",
-    "remark": "^7.0.0",
-    "unist-util-find": "^1.0.1"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -35,5 +12,28 @@
     "cheerio": "^1.0.0-rc.2",
     "lodash": "^4.17.4",
     "unist-util-visit": "^1.1.1"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5",
+    "remark": "^7.0.0",
+    "unist-util-find": "^1.0.1"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "remark"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-remark-smartypants/package.json
+++ b/packages/gatsby-remark-smartypants/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-remark-smartypants",
-  "version": "1.4.10",
   "description": "Use retext-smartypants to auto-enhance typography of markdown",
+  "version": "1.4.10",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "retext": "^4.0.0",

--- a/packages/gatsby-remark-smartypants/package.json
+++ b/packages/gatsby-remark-smartypants/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-remark-smartypants",
   "description": "Use retext-smartypants to auto-enhance typography of markdown",
   "version": "1.4.10",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "smartypants"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -32,5 +15,22 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "smartypants"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-contentful",
-  "version": "1.3.37",
   "description": "Gatsby source plugin for building websites using the Contentful CMS as a data source",
+  "version": "1.3.37",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Marcus Ericsson <mericsson@gmail.com> (mericsson.com)",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "axios": "^0.16.1",
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-source-contentful",
   "description": "Gatsby source plugin for building websites using the Contentful CMS as a data source",
   "version": "1.3.37",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
   "author": "Marcus Ericsson <mericsson@gmail.com> (mericsson.com)",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "axios": "^0.16.1",
@@ -36,5 +20,21 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-drupal",
-  "version": "2.0.19",
   "description": "Gatsby source plugin for building websites using the Drupal CMS as a data source",
+  "version": "2.0.19",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "axios": "^0.16.1",
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-source-drupal",
   "description": "Gatsby source plugin for building websites using the Drupal CMS as a data source",
   "version": "2.0.19",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "axios": "^0.16.1",
@@ -31,5 +15,21 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-faker/package.json
+++ b/packages/gatsby-source-faker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-faker",
-  "version": "1.0.1",
   "description": "A gatsby plugin to get fake data for testing",
+  "version": "1.0.1",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "Pavithra Kodmad<pavithra.kodmad@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "faker": "^4.1.0"

--- a/packages/gatsby-source-faker/package.json
+++ b/packages/gatsby-source-faker/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-source-faker",
   "description": "A gatsby plugin to get fake data for testing",
   "version": "1.0.1",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
   "author": "Pavithra Kodmad<pavithra.kodmad@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -29,5 +12,22 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -1,8 +1,7 @@
 {
   "name": "gatsby-source-filesystem",
-  "version": "1.5.18",
   "description": "Gatsby plugin which parses files within a directory for further parsing by other plugins",
-  "license": "MIT",
+  "version": "1.5.18",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -13,6 +12,15 @@
     "gatsby-plugin"
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-source-filesystem",
   "description": "Gatsby plugin which parses files within a directory for further parsing by other plugins",
   "version": "1.5.18",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-cli": "^6.26.0",
@@ -36,5 +21,20 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-hacker-news",
-  "version": "1.0.9",
   "description": "Gatsby source plugin for building websites using Hacker News as a data source",
+  "version": "1.0.9",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "axios": "^0.16.1",
     "babel-runtime": "^6.26.0",

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-source-hacker-news",
   "description": "Gatsby source plugin for building websites using Hacker News as a data source",
   "version": "1.0.9",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "axios": "^0.16.1",
@@ -29,5 +13,21 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -1,5 +1,27 @@
 {
+  "name": "gatsby-source-lever",
+  "description": "Gatsby source plugin for building websites using the Lever.co Recruitment Software as a data source.",
+  "version": "1.0.7",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
   "author": "Sebastien Fichot <fichot.sebastien@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "bundleDependencies": false,
   "dependencies": {
     "axios": "^0.16.1",
@@ -11,20 +33,6 @@
     "lodash": "^4.17.4"
   },
   "deprecated": false,
-  "description": "Gatsby source plugin for building websites using the Lever.co Recruitment Software as a data source.",
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
-  "license": "MIT",
-  "name": "gatsby-source-lever",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "version": "1.0.7",
   "devDependencies": {
     "cross-env": "^5.0.5"
   }

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-source-lever",
   "description": "Gatsby source plugin for building websites using the Lever.co Recruitment Software as a data source.",
   "version": "1.0.7",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
   "author": "Sebastien Fichot <fichot.sebastien@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "bundleDependencies": false,
   "dependencies": {
@@ -35,5 +19,21 @@
   "deprecated": false,
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-medium/package.json
+++ b/packages/gatsby-source-medium/package.json
@@ -2,7 +2,25 @@
   "name": "gatsby-source-medium",
   "description": "Gatsby source plugin for building websites using Medium as a data source",
   "version": "1.0.11",
+  "main": "index.js",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  },
+  "keywords": [
+    "gatsby"
+  ],
   "author": "Robert Vogt <robert@smartive.ch>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "axios": "^0.16.2",
     "babel-runtime": "^6.26.0"
@@ -10,15 +28,5 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-medium/package.json
+++ b/packages/gatsby-source-medium/package.json
@@ -2,24 +2,9 @@
   "name": "gatsby-source-medium",
   "description": "Gatsby source plugin for building websites using Medium as a data source",
   "version": "1.0.11",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Robert Vogt <robert@smartive.ch>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "axios": "^0.16.2",
@@ -28,5 +13,20 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-mongodb",
-  "version": "1.5.13",
   "description": "Stub description for gatsby-source-mongodb",
+  "version": "1.5.13",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "jhermans85@hotmail.com",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -2,32 +2,32 @@
   "name": "gatsby-source-mongodb",
   "description": "Stub description for gatsby-source-mongodb",
   "version": "1.5.13",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "jhermans85@hotmail.com",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "lodash": "^4.17.4",
     "mongodb": "^2.2.30"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-wordpress-com/package.json
+++ b/packages/gatsby-source-wordpress-com/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-wordpress-com",
-  "version": "1.0.5",
   "description": "Stub description for gatsby-source-wordpress-com",
+  "version": "1.0.5",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress-com#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-source-wordpress-com/package.json
+++ b/packages/gatsby-source-wordpress-com/package.json
@@ -2,30 +2,30 @@
   "name": "gatsby-source-wordpress-com",
   "description": "Stub description for gatsby-source-wordpress-com",
   "version": "1.0.5",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress-com#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress-com#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-wordpress-com/package.json
+++ b/packages/gatsby-source-wordpress-com/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -2,7 +2,26 @@
   "name": "gatsby-source-wordpress",
   "description": "Gatsby source plugin for building websites using the Wordpress CMS as a data source.",
   "version": "2.0.54",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
   "author": "Sebastien Fichot <fichot.sebastien@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "bundleDependencies": false,
   "dependencies": {
     "axios": "^0.16.1",
@@ -18,16 +37,5 @@
   "deprecated": false,
   "devDependencies": {
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
-  "license": "MIT",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-source-wordpress",
   "description": "Gatsby source plugin for building websites using the Wordpress CMS as a data source.",
   "version": "2.0.54",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore __tests__"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-source-plugin"
-  ],
   "author": "Sebastien Fichot <fichot.sebastien@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "bundleDependencies": false,
   "dependencies": {
@@ -37,5 +21,21 @@
   "deprecated": false,
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-csv/package.json
+++ b/packages/gatsby-transformer-csv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-csv",
-  "version": "1.3.7",
   "description": "Gatsby transformer plugin for CSV files",
+  "version": "1.3.7",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "Sonal Saldanha <sonal.saldanha@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5",

--- a/packages/gatsby-transformer-csv/package.json
+++ b/packages/gatsby-transformer-csv/package.json
@@ -2,35 +2,35 @@
   "name": "gatsby-transformer-csv",
   "description": "Gatsby transformer plugin for CSV files",
   "version": "1.3.7",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "csv",
-    "gatsby-plugin"
-  ],
   "author": "Sonal Saldanha <sonal.saldanha@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "bluebird": "^3.5.0",
+    "csvtojson": "^1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5",
     "json2csv": "^3.7"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "bluebird": "^3.5.0",
-    "csvtojson": "^1.1"
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv#readme",
+  "keywords": [
+    "csv",
+    "gatsby",
+    "gatsby-plugin"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-documentationjs/package.json
+++ b/packages/gatsby-transformer-documentationjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-documentationjs",
-  "version": "1.4.8",
   "description": "Gatsby transformer plugin which uses Documentation.js to extract JavaScript documentation",
+  "version": "1.4.8",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -16,6 +16,14 @@
   ],
   "author": "Kyle Mathews",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "documentation": "^4.0.0-rc.1"

--- a/packages/gatsby-transformer-documentationjs/package.json
+++ b/packages/gatsby-transformer-documentationjs/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-transformer-documentationjs",
   "description": "Gatsby transformer plugin which uses Documentation.js to extract JavaScript documentation",
   "version": "1.4.8",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "gatsby-transformer",
-    "documentation.js"
-  ],
   "author": "Kyle Mathews",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -31,5 +13,23 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs#readme",
+  "keywords": [
+    "documentation.js",
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-transformer"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-docx/package.json
+++ b/packages/gatsby-transformer-docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-docx",
-  "version": "1.0.5",
   "description": "Stub description for gatsby-transformer-docx",
+  "version": "1.0.5",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-docx#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-transformer-docx/package.json
+++ b/packages/gatsby-transformer-docx/package.json
@@ -2,30 +2,30 @@
   "name": "gatsby-transformer-docx",
   "description": "Stub description for gatsby-transformer-docx",
   "version": "1.0.5",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-docx#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-docx#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-docx/package.json
+++ b/packages/gatsby-transformer-docx/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-transformer-excel/package.json
+++ b/packages/gatsby-transformer-excel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-excel",
-  "version": "1.0.3",
   "description": "Gatsby transformer plugin for Excel spreadsheets",
+  "version": "1.0.3",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "SheetJS <dev@sheetjs.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "xlsx": "^0.11.5"

--- a/packages/gatsby-transformer-excel/package.json
+++ b/packages/gatsby-transformer-excel/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-transformer-excel",
   "description": "Gatsby transformer plugin for Excel spreadsheets",
   "version": "1.0.3",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "excel",
-    "gatsby-plugin"
-  ],
   "author": "SheetJS <dev@sheetjs.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -30,5 +13,22 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel#readme",
+  "keywords": [
+    "excel",
+    "gatsby",
+    "gatsby-plugin"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-hjson/package.json
+++ b/packages/gatsby-transformer-hjson/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-hjson",
-  "version": "1.0.2",
   "description": "Gatsby transformer plugin for HJSON files",
+  "version": "1.0.2",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Remi Barraquand <dev@remibarraquand.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",

--- a/packages/gatsby-transformer-hjson/package.json
+++ b/packages/gatsby-transformer-hjson/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-transformer-hjson",
   "description": "Gatsby transformer plugin for HJSON files",
   "version": "1.0.2",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "hjson"
-  ],
   "author": "Remi Barraquand <dev@remibarraquand.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -30,5 +14,21 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "hjson"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-javascript-static-exports/package.json
+++ b/packages/gatsby-transformer-javascript-static-exports/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-javascript-static-exports",
-  "version": "1.3.8",
   "description": "Gatsby transformer plugin for JavaScript to extract exports.data statically.",
+  "version": "1.3.8",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Jacob Bolda <me@jacobbolda.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "babel-traverse": "^6.24.1",

--- a/packages/gatsby-transformer-javascript-static-exports/package.json
+++ b/packages/gatsby-transformer-javascript-static-exports/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-transformer-javascript-static-exports",
   "description": "Gatsby transformer plugin for JavaScript to extract exports.data statically.",
   "version": "1.3.8",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "js"
-  ],
   "author": "Jacob Bolda <me@jacobbolda.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -30,5 +14,21 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "js"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-json/package.json
+++ b/packages/gatsby-transformer-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-json",
-  "version": "1.0.14",
   "description": "Gatsby transformer plugin for JSON files",
+  "version": "1.0.14",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0"

--- a/packages/gatsby-transformer-json/package.json
+++ b/packages/gatsby-transformer-json/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-transformer-json",
   "description": "Gatsby transformer plugin for JSON files",
   "version": "1.0.14",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "json"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -29,5 +13,21 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "json"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-pdf/package.json
+++ b/packages/gatsby-transformer-pdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-pdf",
-  "version": "1.0.5",
   "description": "Stub description for gatsby-transformer-pdf",
+  "version": "1.0.5",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-transformer-pdf/package.json
+++ b/packages/gatsby-transformer-pdf/package.json
@@ -2,30 +2,30 @@
   "name": "gatsby-transformer-pdf",
   "description": "Stub description for gatsby-transformer-pdf",
   "version": "1.0.5",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-pdf/package.json
+++ b/packages/gatsby-transformer-pdf/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-transformer-pdfimages/package.json
+++ b/packages/gatsby-transformer-pdfimages/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-pdfimages",
-  "version": "1.0.4",
   "description": "Gatsby transformer plugin for extracting images from PDFs",
+  "version": "1.0.4",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -14,6 +14,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdfimages#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0"
   }

--- a/packages/gatsby-transformer-pdfimages/package.json
+++ b/packages/gatsby-transformer-pdfimages/package.json
@@ -2,27 +2,27 @@
   "name": "gatsby-transformer-pdfimages",
   "description": "Gatsby transformer plugin for extracting images from PDFs",
   "version": "1.0.4",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdfimages#readme",
   "keywords": [
     "gatsby",
     "gatsby-plugin",
     "gatsby-transformer",
     "pdfimage"
   ],
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdfimages#readme",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0"
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-react-docgen",
-  "version": "1.0.12",
   "description": "Expose React component metadata and prop information as GraphQL types",
+  "version": "1.0.12",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -16,6 +16,14 @@
   ],
   "author": "Jason Quense <monastic.panic@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "babel-types": "^6.24.1",

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -2,27 +2,9 @@
   "name": "gatsby-transformer-react-docgen",
   "description": "Expose React component metadata and prop information as GraphQL types",
   "version": "1.0.12",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "react",
-    "react-docgen"
-  ],
   "author": "Jason Quense <monastic.panic@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -35,5 +17,23 @@
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5",
     "lodash": "^4.17.4"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "react",
+    "react-docgen"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -2,7 +2,27 @@
   "name": "gatsby-transformer-remark",
   "description": "Gatsby transformer plugin for Markdown using the Remark library and ecosystem",
   "version": "1.7.31",
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "markdown",
+    "remark"
+  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
@@ -29,17 +49,5 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "cross-env": "^5.0.5"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "markdown",
-    "remark"
-  ],
-  "license": "MIT",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
   }
 }

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-transformer-remark",
   "description": "Gatsby transformer plugin for Markdown using the Remark library and ecosystem",
   "version": "1.7.31",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "markdown",
-    "remark"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -49,5 +32,22 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "markdown",
+    "remark"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-screenshot/package.json
+++ b/packages/gatsby-transformer-screenshot/package.json
@@ -1,15 +1,8 @@
 {
   "name": "gatsby-transformer-screenshot",
-  "version": "1.0.1",
   "description": "Gatsby transformer plugin that uses AWS Lambda to take screenshots of websites",
+  "version": "1.0.1",
   "main": "index.js",
-  "dependencies": {
-    "axios": "^0.17.1"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.1.3"
-  },
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -23,5 +16,20 @@
     "screenshot"
   ],
   "author": "David Beckley <beckl.ds@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "dependencies": {
+    "axios": "^0.17.1"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.1.3"
+  }
 }

--- a/packages/gatsby-transformer-screenshot/package.json
+++ b/packages/gatsby-transformer-screenshot/package.json
@@ -2,28 +2,9 @@
   "name": "gatsby-transformer-screenshot",
   "description": "Gatsby transformer plugin that uses AWS Lambda to take screenshots of websites",
   "version": "1.0.1",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "build-lambda-package": "npm run prepare-lambda-package && cp chrome/headless_shell.tar.gz lambda-dist && cd lambda-dist && zip -rq ../lambda-package.zip .",
-    "prepare-lambda-package": "babel lambda --out-dir lambda-dist && cp lambda/package.json lambda-dist/package.json && cd lambda-dist && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install --production"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "screenshot"
-  ],
   "author": "David Beckley <beckl.ds@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "axios": "^0.17.1"
@@ -31,5 +12,24 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.1.3"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "screenshot"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "build-lambda-package": "npm run prepare-lambda-package && cp chrome/headless_shell.tar.gz lambda-dist && cd lambda-dist && zip -rq ../lambda-package.zip .",
+    "prepare-lambda-package": "babel lambda --out-dir lambda-dist && cp lambda/package.json lambda-dist/package.json && cd lambda-dist && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install --production",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-sharp",
-  "version": "1.6.18",
   "description": "Gatsby transformer plugin for images using Sharp",
+  "version": "1.6.18",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -15,6 +15,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -2,26 +2,9 @@
   "name": "gatsby-transformer-sharp",
   "description": "Gatsby transformer plugin for images using Sharp",
   "version": "1.6.18",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "sharp",
-    "image"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -32,5 +15,22 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "image",
+    "sharp"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-toml/package.json
+++ b/packages/gatsby-transformer-toml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-toml",
-  "version": "1.1.7",
   "description": "Gatsby transformer plugin for toml",
+  "version": "1.1.7",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Ruben Harutyunyan <vagr9k@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",

--- a/packages/gatsby-transformer-toml/package.json
+++ b/packages/gatsby-transformer-toml/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-transformer-toml",
   "description": "Gatsby transformer plugin for toml",
   "version": "1.1.7",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "toml"
-  ],
   "author": "Ruben Harutyunyan <vagr9k@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -30,5 +14,21 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "toml"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-xml",
-  "version": "1.0.11",
   "description": "Stub description for gatsby-transformer-xml",
+  "version": "1.0.11",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
@@ -13,6 +13,14 @@
   ],
   "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -2,33 +2,33 @@
   "name": "gatsby-transformer-xml",
   "description": "Stub description for gatsby-transformer-xml",
   "version": "1.0.11",
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby"
-  ],
   "author": "Kyle Mathews <matthews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
     "lodash": "^4.17.4",
     "xml-parser": "^1.2.1"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -11,7 +11,7 @@
   "keywords": [
     "gatsby"
   ],
-  "author": "Kyle Mathews &lt;mathews.kyle@gmail.com&gt;",
+  "author": "Kyle Mathews <matthews.kyle@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-transformer-yaml",
-  "version": "1.5.14",
   "description": "Gatsby transformer plugin for yaml",
+  "version": "1.5.14",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
@@ -14,6 +14,14 @@
   ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "js-yaml": "3.7.0",

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -2,25 +2,9 @@
   "name": "gatsby-transformer-yaml",
   "description": "Gatsby transformer plugin for yaml",
   "version": "1.5.14",
-  "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin",
-    "yaml"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
@@ -31,5 +15,21 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "yaml"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore __tests__",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -2,12 +2,38 @@
   "name": "gatsby",
   "description": "React.js Static Site Generator",
   "version": "1.9.192",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "bin": {
-    "gatsby": "./dist/bin/gatsby.js"
+  "main": "index.js",
+  "scripts": {
+    "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles",
+    "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
+    "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
+    "build:src": "babel src --out-dir dist --source-maps --ignore gatsby-cli.js,raw_*,__tests__",
+    "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
+    "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"
   },
+  "keywords": [
+    "blog",
+    "generator",
+    "jekyll",
+    "markdown",
+    "react",
+    "ssg",
+    "website"
+  ],
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gatsbyjs/gatsby.git"
+  },
+  "bin": {
+    "gatsby": "./dist/bin/gatsby.js"
   },
   "dependencies": {
     "async": "^2.1.2",
@@ -129,31 +155,5 @@
   },
   "resolutions": {
     "graphql": "^0.11.7"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby#readme",
-  "keywords": [
-    "blog",
-    "generator",
-    "jekyll",
-    "markdown",
-    "react",
-    "ssg",
-    "website"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/gatsbyjs/gatsby.git"
-  },
-  "scripts": {
-    "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles",
-    "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
-    "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
-    "build:src": "babel src --out-dir dist --source-maps --ignore gatsby-cli.js,raw_*,__tests__",
-    "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
-    "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -3,6 +3,9 @@
   "description": "React.js Static Site Generator",
   "version": "1.9.192",
   "main": "index.js",
+  "bin": {
+    "gatsby": "./dist/bin/gatsby.js"
+  },
   "scripts": {
     "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles",
     "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
@@ -31,9 +34,6 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gatsbyjs/gatsby.git"
-  },
-  "bin": {
-    "gatsby": "./dist/bin/gatsby.js"
   },
   "dependencies": {
     "async": "^2.1.2",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -1,40 +1,13 @@
 {
   "name": "gatsby",
   "description": "React.js Static Site Generator",
-  "main": "index.js",
   "version": "1.9.193",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {
     "gatsby": "./dist/bin/gatsby.js"
   },
-  "scripts": {
-    "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles",
-    "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
-    "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
-    "build:src": "babel src --out-dir dist --source-maps --ignore gatsby-cli.js,raw_*,__tests__",
-    "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
-    "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
-    "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"
-  },
-  "keywords": [
-    "blog",
-    "generator",
-    "jekyll",
-    "markdown",
-    "react",
-    "ssg",
-    "website"
-  ],
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
-  },
-  "homepage": "https://github.com/gatsbyjs/gatsby#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/gatsbyjs/gatsby.git"
   },
   "dependencies": {
     "async": "^2.1.2",
@@ -154,7 +127,33 @@
   "engines": {
     "node": ">4.0.0"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby#readme",
+  "keywords": [
+    "blog",
+    "generator",
+    "jekyll",
+    "markdown",
+    "react",
+    "ssg",
+    "website"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gatsbyjs/gatsby.git"
+  },
   "resolutions": {
     "graphql": "^0.11.7"
+  },
+  "scripts": {
+    "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles",
+    "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
+    "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
+    "build:src": "babel src --out-dir dist --source-maps --ignore gatsby-cli.js,raw_*,__tests__",
+    "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
+    "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"
   }
 }

--- a/packages/graphql-skip-limit/package.json
+++ b/packages/graphql-skip-limit/package.json
@@ -2,22 +2,30 @@
   "name": "graphql-skip-limit",
   "description": "A library to help construct a graphql-js server supporting skip/relay style pagination. Built for Gatsby but perhaps useful elsewhere.",
   "version": "1.0.9",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5",
-    "graphql": "^0.10.3"
-  },
-  "keywords": [
-    "gatsby",
-    "graphql"
-  ],
-  "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
     "build": "babel src --out-dir dist",
     "watch": "babel -w src --out-dir dist",
     "prepublish": "cross-env NODE_ENV=production npm run build"
+  },
+  "keywords": [
+    "gatsby",
+    "graphql"
+  ],
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "cross-env": "^5.0.5",
+    "graphql": "^0.10.3"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",

--- a/packages/graphql-skip-limit/package.json
+++ b/packages/graphql-skip-limit/package.json
@@ -2,33 +2,33 @@
   "name": "graphql-skip-limit",
   "description": "A library to help construct a graphql-js server supporting skip/relay style pagination. Built for Gatsby but perhaps useful elsewhere.",
   "version": "1.0.9",
-  "main": "dist/index.js",
-  "scripts": {
-    "build": "babel src --out-dir dist",
-    "watch": "babel -w src --out-dir dist",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "keywords": [
-    "gatsby",
-    "graphql"
-  ],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+  "dependencies": {
+    "babel-runtime": "^6.26.0",
+    "graphql": "^0.11.7"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "cross-env": "^5.0.5",
     "graphql": "^0.10.3"
   },
-  "dependencies": {
-    "babel-runtime": "^6.26.0",
-    "graphql": "^0.11.7"
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit#readme",
+  "keywords": [
+    "gatsby",
+    "graphql"
+  ],
+  "license": "MIT",
+  "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
+  "scripts": {
+    "build": "babel src --out-dir dist",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir dist"
   }
 }

--- a/plop-templates/package/package.json.hbs
+++ b/plop-templates/package/package.json.hbs
@@ -12,6 +12,14 @@
     "gatsby"
   ],
   "author": "{{{author}}}",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/{{name}}#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git"
+  },
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^6.26.0"


### PR DESCRIPTION
I oftentimes find myself navigating to package READMEs on npmjs.org, e.g. [gatsby-transformer-yaml](https://www.npmjs.com/package/gatsby-transformer-yaml) (and in fact, npmjs is usually the first result when I'm searching for Gatsby packages).

Once there, it'd be nice to be able to navigate to other applicable, helpful links such as the package source or gatsbyjs.org (I'm unsure which is better currently, so advice appreciated with `homepage`; we could also make the homepage the gatsbyjs package homepage, e.g. `https://www.gatsbyjs.org/packages/gatsby-transformer-yaml/`).

(This was generated with a simple script, so hopefully there aren't any weird issues; I've attempted to re-order keys only when necessary and when it makes sense!)

