### PR TITLE
Add Container as a styled div to styled-components doc

### DIFF
--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -38,7 +38,12 @@ Now let's create a sample Styled Components page at `src/pages/index.js`:
 import React from "react";
 import styled from "styled-components";
 
-import Container from "../components/container";
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
 
 const UserWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/gatsbyjs/gatsby/issues/3973)
