### PR TITLE
Standalone GraphiQL using www's data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+**/node_modules
+**/public
+npm-debug.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Create a standalone instance of GraphiQL populated with gatsbyjs.org's data
+# ---
+# libvips needed for image manipulation
+FROM marcbachmann/libvips:8.4.1 as build
+
+# Node.js version 8 and build tools for sharp
+RUN apt-get update && apt-get install -y build-essential g++ curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g yarn@1.3.2
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN yarn && cd www && yarn
+RUN cd www && yarn run build
+
+# Start again and just copy across the built files (+ node_modules)
+# TODO: Can we do this all on Alpine for a much smaller image? This node:8 image is ~600MB
+FROM node:8 as dist
+
+COPY --from=build /usr/src/app /usr/src/app
+WORKDIR /usr/src/app
+
+# To run this image, set the port as an env var with `-e PORT=xxxx` e.g.
+# docker run -p 8080:8080 --rm -it -e PORT=8080 <registryUsername>/<imageName>
+CMD [ "node","./scripts/www-data-explorer.js" ]

--- a/packages/gatsby/src/commands/data-explorer.js
+++ b/packages/gatsby/src/commands/data-explorer.js
@@ -4,7 +4,6 @@ const express = require(`express`)
 const graphqlHTTP = require(`express-graphql`)
 const { store } = require(`../redux`)
 const bootstrap = require(`../bootstrap`)
-const { GraphQLSchema } = require(`graphql`)
 
 module.exports = async (program: any) => {
   let { port, host } = program
@@ -14,11 +13,6 @@ module.exports = async (program: any) => {
   await bootstrap(program)
 
   const schema = store.getState().schema
-
-  console.log(
-    `Schema is instance of GraphQLSchema?`,
-    schema instanceof GraphQLSchema
-  )
 
   const app = express()
   app.use(

--- a/scripts/www-data-explorer.js
+++ b/scripts/www-data-explorer.js
@@ -1,0 +1,26 @@
+const path = require(`path`)
+const gatsbyPath = path.resolve(
+  __dirname,
+  `..`,
+  `www`,
+  `node_modules`,
+  `gatsby`,
+  `dist`
+)
+const explorer = require(path.resolve(
+  gatsbyPath,
+  `commands`,
+  `data-explorer.js`
+))
+
+const port = process.env.PORT || 8080
+const host = `0.0.0.0`
+const directory = path.join(__dirname, `..`, `www`)
+const sitePackageJson = require(path.join(directory, `package.json`))
+
+explorer({
+  port,
+  host,
+  directory,
+  sitePackageJson,
+})


### PR DESCRIPTION
This Dockerfile will create an image that runs an instance of GraphiQL loaded with www's data.

[Click to see a demo instance of this running](https://gatsbygraphql.sloppy.zone/?query=%23%20Hello!%20This%20is%20a%20live%20copy%20of%20the%20data%20powering%20gatsbyjs.org.%0A%23%0A%23%20Here%27s%20an%20example%20query%20to%20get%20you%20started%20-%20hit%20the%20%27play%27%20button%20to%20run%20it%3A%0A%0A%7B%20%0A%20allMarkdownRemark%20%0A%20%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%20%20publishedAt%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%20%0A) (this is just manually deployed for now).