### PR TITLE
fix: prevent invalid graphql field names from being created

### DIFF
--- a/packages/gatsby/src/schema/__tests__/create-key.js
+++ b/packages/gatsby/src/schema/__tests__/create-key.js
@@ -2,12 +2,8 @@ const createKey = require(`../create-key`)
 
 describe(`createKey`, () => {
   it(`leaves valid strings as is`, () => {
-    ;[
-      [`01234`, `01234`],
-      [`description`, `description`],
-      [`_hello`, `_hello`],
-    ].forEach(([input, output]) => {
-      expect(createKey(input)).toBe(output)
+    ;[`01234`, `validstring`, `_hello`, `_`].forEach(input => {
+      expect(createKey(input)).toBe(input)
     })
   })
 

--- a/packages/gatsby/src/schema/__tests__/create-key.js
+++ b/packages/gatsby/src/schema/__tests__/create-key.js
@@ -10,11 +10,17 @@ describe(`createKey`, () => {
   it(`replaces invalid characters`, () => {
     ;[
       [`/hello`, `_hello`],
-      [`~/path/to/some/module`, `_path_to_some_module`],
-      [`/*`, `_`],
-      [`/*.js`, `_js`],
+      [`~/path/to/some/module`, `_-path-to-some-module`],
+      [`/*`, `_-`],
+      [`/*.js`, `_--js`],
     ].forEach(([input, output]) => {
       expect(createKey(input)).toBe(output)
+    })
+  })
+
+  it(`does not generate same key for different input`, () => {
+    ;[[`/*.js`, `*js`]].forEach(([one, two]) => {
+      expect(createKey(one)).not.toBe(createKey(two))
     })
   })
 })

--- a/packages/gatsby/src/schema/__tests__/create-key.js
+++ b/packages/gatsby/src/schema/__tests__/create-key.js
@@ -1,0 +1,24 @@
+const createKey = require(`../create-key`)
+
+describe(`createKey`, () => {
+  it(`leaves valid strings as is`, () => {
+    ;[
+      [`01234`, `01234`],
+      [`description`, `description`],
+      [`_hello`, `_hello`],
+    ].forEach(([input, output]) => {
+      expect(createKey(input)).toBe(output)
+    })
+  })
+
+  it(`replaces invalid characters`, () => {
+    ;[
+      [`/hello`, `_hello`],
+      [`~/path/to/some/module`, `_path_to_some_module`],
+      [`/*`, `_`],
+      [`/*.js`, `_js`],
+    ].forEach(([input, output]) => {
+      expect(createKey(input)).toBe(output)
+    })
+  })
+})

--- a/packages/gatsby/src/schema/create-key.js
+++ b/packages/gatsby/src/schema/create-key.js
@@ -1,6 +1,6 @@
 // @flow
 const invariant = require(`invariant`)
-const regex = new RegExp(`[^a-zA-Z0-9_]`, `g`)
+const nonAlphaNumericExpr = new RegExp(`[^a-zA-Z0-9_]`, `g`)
 
 /**
  * GraphQL field names must be a string and cannot contain anything other than
@@ -14,5 +14,12 @@ module.exports = (key: string): string => {
     `Graphql field name (key) is not a string -> ${key}`
   )
 
-  return key.replace(regex, `_`)
+  const replaced = key.replace(nonAlphaNumericExpr, `_`)
+
+  // TODO: figure out what to replace this with _OR_ change the expr
+  if (replaced.match(/^__/)) {
+    return replaced.replace(/^_{2,}/, `_`)
+  }
+
+  return replaced
 }

--- a/packages/gatsby/src/schema/create-key.js
+++ b/packages/gatsby/src/schema/create-key.js
@@ -16,9 +16,9 @@ module.exports = (key: string): string => {
 
   const replaced = key.replace(nonAlphaNumericExpr, `_`)
 
-  // TODO: figure out what to replace this with _OR_ change the expr
+  // key is invalid; normalize with a leading underscore and dasherize rest
   if (replaced.match(/^__/)) {
-    return replaced.replace(/^_{2,}/, `_`)
+    return replaced.replace(/_/g, (char, index) => (index === 0 ? `_` : `-`))
   }
 
   return replaced

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,7 +549,7 @@ axios@^0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-axios@contentful/axios#fix/https-via-http-proxy:
+"axios@github:contentful/axios#fix/https-via-http-proxy":
   version "0.17.1"
   resolved "https://codeload.github.com/contentful/axios/tar.gz/4b06f4a63db3ac16c99f7c61b584ef0e6d11f1af"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,7 +549,7 @@ axios@^0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-"axios@github:contentful/axios#fix/https-via-http-proxy":
+axios@contentful/axios#fix/https-via-http-proxy:
   version "0.17.1"
   resolved "https://codeload.github.com/contentful/axios/tar.gz/4b06f4a63db3ac16c99f7c61b584ef0e6d11f1af"
   dependencies:


### PR DESCRIPTION
This PR prevents invalid GraphQL field names from being created, at least in certain circumstances. Field names that were _only_ invalid characters were being translated into `_{STR_LENGTH}`, e.g. `/*` was being translated to `__`, `/*.js` was translated to `___js`, etc.

Note: This will currently transform (for example) `/*` into `_` so I'm not quite sure what the best course of action is to replace that, or what's preferred there.

Fixes #3487; Fixes #2925