### PR TITLE
Add head option to gatsby-plugin-google-analytics

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -15,6 +15,8 @@ plugins: [
     resolve: `gatsby-plugin-google-analytics`,
     options: {
       trackingId: "YOUR_GOOGLE_ANALYTICS_TRACKING_ID",
+      // Puts tracking script in the head instead of the body
+      head: false,
       // Setting this parameter is optional
       anonymize: true,
     },

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -1,8 +1,14 @@
 import React from "react"
 
-exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
+exports.onRenderBody = (
+  { setHeadComponents, setPostBodyComponents },
+  pluginOptions
+) => {
   if (process.env.NODE_ENV === `production`) {
-    return setPostBodyComponents([
+    const setComponents = pluginOptions.head
+      ? setHeadComponents
+      : setPostBodyComponents
+    return setComponents([
       <script
         key={`gatsby-plugin-google-analytics`}
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
Add head option to configure whether scrip tag should be put in the
body (by default, same as previously) or inside of the head.
closes #2894