### PR TITLE
fix: ensure graphql key is a valid graphql key value

### DIFF
--- a/packages/gatsby/src/schema/__tests__/create-key.js
+++ b/packages/gatsby/src/schema/__tests__/create-key.js
@@ -10,9 +10,9 @@ describe(`createKey`, () => {
   it(`replaces invalid characters`, () => {
     ;[
       [`/hello`, `_hello`],
-      [`~/path/to/some/module`, `_-path-to-some-module`],
-      [`/*`, `_-`],
-      [`/*.js`, `_--js`],
+      [`~/path/to/some/module`, `_xpathxtoxsomexmodule`],
+      [`/*`, `_x`],
+      [`/*.js`, `_xxjs`],
     ].forEach(([input, output]) => {
       expect(createKey(input)).toBe(output)
     })

--- a/packages/gatsby/src/schema/create-key.js
+++ b/packages/gatsby/src/schema/create-key.js
@@ -16,7 +16,7 @@ module.exports = (key: string): string => {
 
   const replaced = key.replace(nonAlphaNumericExpr, `_`)
 
-  // key is invalid; normalize with a leading underscore and dasherize rest
+  // key is invalid; normalize with leading underscore and rest with x
   if (replaced.match(/^__/)) {
     return replaced.replace(/_/g, (char, index) => (index === 0 ? `_` : `x`))
   }

--- a/packages/gatsby/src/schema/create-key.js
+++ b/packages/gatsby/src/schema/create-key.js
@@ -18,7 +18,7 @@ module.exports = (key: string): string => {
 
   // key is invalid; normalize with a leading underscore and dasherize rest
   if (replaced.match(/^__/)) {
-    return replaced.replace(/_/g, (char, index) => (index === 0 ? `_` : `-`))
+    return replaced.replace(/_/g, (char, index) => (index === 0 ? `_` : `x`))
   }
 
   return replaced


### PR DESCRIPTION
Fixes error introduced in merging #3994

> error Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "_--html" does not.

Validated locally, shouldn't have any issues with this one.