### PR TITLE
Bump version remark-math to latest 

### DIFF
--- a/packages/gatsby-remark-katex/package.json
+++ b/packages/gatsby-remark-katex/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "katex": "^0.8.3",
-    "remark-math": "^0.2.4",
+    "remark-math": "^1.0.3",
     "unist-util-visit": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `remark-math` to the latest version in order to fix an issue where equations surrounded by `$$` with new lines are not displayed in `displayMode`.  This can be witnessed at: https://using-remark.gatsbyjs.org/katex/ where both examples are rendered as inline equations.