### PR TITLE
Add note about using Custom Domain with Github Pages

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -8,7 +8,7 @@ The easiest way to push a gatsby app to github pages is using a package called `
 
 ## GitHub repository page
 
-If you want to use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add the pathPrefix as it will cause pathing issues. The site will be at the root of the domain, rather than in a subdirectory like `http://username.github.io/reponame/`, and you will be redirected to a 404.
+If you want to use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add the pathPrefix as it will cause navigation issues. The site will be at the root of the domain, rather than in a subdirectory like `http://username.github.io/reponame/`, and you will be redirected to a 404.
 
 Add a `deploy` script to `package.json`
 

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -8,6 +8,8 @@ The easiest way to push a gatsby app to github pages is using a package called `
 
 ## GitHub repository page
 
+If you want to use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add the pathPrefix as it will cause pathing issues. The site will be at the root of the domain, rather than in a subdirectory like `http://username.github.io/reponame/`, and you will be redirected to a 404.
+
 Add a `deploy` script to `package.json`
 
 ```

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -8,8 +8,6 @@ The easiest way to push a gatsby app to github pages is using a package called `
 
 ## GitHub repository page
 
-If you want to use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add the pathPrefix as it will cause navigation issues. The site will be at the root of the domain, rather than in a subdirectory like `http://username.github.io/reponame/`, and you will be redirected to a 404.
-
 Add a `deploy` script to `package.json`
 
 ```
@@ -46,3 +44,7 @@ In this case we dont need to specify `pathPrefix`, but our website needs to be p
 ```
 
 After running `yarn run deploy` you should see your website at `http://username.github.io`
+
+## Custom domains
+
+If you use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add a `pathPrefix` as it will break navigation on your site. Path prefixing is only necessary when the site is *not* at the root of the domain like with repository sites.


### PR DESCRIPTION
If you want to use a custom domain with a github pages repo, clicking on a link on www.website.com should take you to www.website.com/page, however with a pathPrefix of something like "projectName", you will be taken to this: www.website.com/projectName/page. 