### PR TITLE
update CONTRIBUTING documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,7 @@ The usual contributing steps are:
 * setup up repo and Install dependencies: `yarn run bootstrap`
 * Make sure tests are passing for you: `yarn test`
 * Create a topic branch: `git checkout -b topics/new-feature-name`
-* Run `npm run watch` from the root of the repo to first do an initial Babel
-  build of all packages and then watch for changes to packages' source code and
-  compile these changes on-the-fly as you work.
+* Run `npm run watch` from the root of the repo to watch for changes to packages' source code and compile these changes on-the-fly as you work. Note that the watch command can be resource intensive. To limit it to the packages you're working on, add a scope flag, like `npm run watch -- --scope={gatsby,gatsby-cli}`. To watch just one package, run `npm run watch -- --scope=gatsby`.
 * Install [gatsby-dev-cli](/packages/gatsby-dev-cli/) globally: `yarn global add gatsby-dev-cli`
 * Run `yarn install` in each of the sites you're testing with.
 * For each of your Gatsby test sites, run the `gatsby-dev` command there to copy


### PR DESCRIPTION
Update CONTRIBUTING documentation to mention that npm run watch can be resource intensive, and suggest watching select packages at a time.