### PR TITLE
Fix tracking nodes with filtering/running sift

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -11,7 +11,7 @@ const { joinPath } = require(`../utils/path`)
 const {
   getNode,
   hasNodeChanged,
-  trackSubObjectsToRootNodeId,
+  trackInlineObjectsInRootNode,
 } = require(`./index`)
 const { store } = require(`./index`)
 import * as joiSchemas from "../joi-schemas/joi"
@@ -484,7 +484,7 @@ actions.createNode = (node: any, plugin?: Plugin, traceId?: string) => {
     )
   }
 
-  trackSubObjectsToRootNodeId(node)
+  trackInlineObjectsInRootNode(node)
 
   const oldNode = getNode(node.id)
 

--- a/packages/gatsby/src/redux/index.js
+++ b/packages/gatsby/src/redux/index.js
@@ -48,6 +48,7 @@ const trackInlineObjectsInRootNode = node => {
     }
     addRootNodeToInlineObject(v, node.id)
   })
+  return node
 }
 exports.trackInlineObjectsInRootNode = trackInlineObjectsInRootNode
 

--- a/packages/gatsby/src/redux/index.js
+++ b/packages/gatsby/src/redux/index.js
@@ -12,25 +12,44 @@ const emitter = mitt()
 // Reducers
 const reducers = require(`./reducers`)
 
-// Parent node tracking
+// Root node tracking
+
+/**
+ * Map containing links between inline objects or arrays
+ * and Node that contains them
+ * @type {Object.<(Object|Array),string>}
+ */
 const rootNodeMap = new WeakMap()
-const addParentToSubObjects = (data, parentId) => {
+
+/**
+ * Add link between passed data and Node. This function shouldn't be used
+ * directly. Use higher level `trackInlineObjectsInRootNode`
+ * @see trackInlineObjectsInRootNode
+ * @param {(Object|Array)} data Inline object or array
+ * @param {string} nodeId Id of node that contains data passed in first parameter
+ */
+const addRootNodeToInlineObject = (data, nodeId) => {
   if (_.isPlainObject(data) || _.isArray(data)) {
-    _.each(data, o => addParentToSubObjects(o, parentId))
-    rootNodeMap.set(data, parentId)
+    _.each(data, o => addRootNodeToInlineObject(o, nodeId))
+    rootNodeMap.set(data, nodeId)
   }
 }
 
-const trackSubObjectsToRootNodeId = node => {
+/**
+ * Adds link between inline objects/arrays contained in Node object
+ * and that Node object.
+ * @param {Node} node Root Node
+ */
+const trackInlineObjectsInRootNode = node => {
   _.each(node, (v, k) => {
     // Ignore the node internal object.
     if (k === `internal`) {
       return
     }
-    addParentToSubObjects(v, node.parent)
+    addRootNodeToInlineObject(v, node.id)
   })
 }
-exports.trackSubObjectsToRootNodeId = trackSubObjectsToRootNodeId
+exports.trackInlineObjectsInRootNode = trackInlineObjectsInRootNode
 
 // Read from cache the old node data.
 let initialState = {}
@@ -40,7 +59,7 @@ try {
   )
 
   _.each(initialState.nodes, node => {
-    trackSubObjectsToRootNodeId(node)
+    trackInlineObjectsInRootNode(node)
   })
 } catch (e) {
   // ignore errors.

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -5,6 +5,7 @@ const { connectionFromArray } = require(`graphql-skip-limit`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const prepareRegex = require(`./prepare-regex`)
 const Promise = require(`bluebird`)
+const { trackInlineObjectsInRootNode } = require(`../redux`)
 
 function awaitSiftField(fields, node, k) {
   const field = fields[k]
@@ -109,6 +110,7 @@ module.exports = ({
   return Promise.all(
     nodes.map(node => resolveRecursive(node, fieldsToSift, type.getFields()))
   ).then(myNodes => {
+    myNodes = myNodes.map(trackInlineObjectsInRootNode)
     if (!connection) {
       const index = _.isEmpty(siftArgs)
         ? 0


### PR DESCRIPTION
Only second commit is actual fix. When filtering we create copies of nodes to add fields added by plugins with `setFieldsOnGraphQLNodeType` and not mutate original nodes (fields are added only if they would be filtered on).

First commit just add some jsdoc in tracking related code and change function names to hopefully be less confusing about what they actually do (still pretty confusing tho). That was supposed to be part of PR that add tests for this but it might as well go in earlier.

Fixes #2929 (again)