### PR TITLE
Revert "define webpack loader.exclude with array for extensibility"

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -384,7 +384,7 @@ module.exports = async (
     // Common config for every env.
     config.loader(`js`, {
       test: /\.jsx?$/, // Accept either .js or .jsx files.
-      exclude: [/(node_modules|bower_components)/],
+      exclude: /(node_modules|bower_components)/,
       loader: `babel`,
       query: babelConfig,
     })
@@ -421,7 +421,7 @@ module.exports = async (
       case `develop`:
         config.loader(`css`, {
           test: /\.css$/,
-          exclude: [/\.module\.css$/],
+          exclude: /\.module\.css$/,
           loaders: [`style`, `css`, `postcss`],
         })
 
@@ -446,7 +446,7 @@ module.exports = async (
       case `build-css`:
         config.loader(`css`, {
           test: /\.css$/,
-          exclude: [/\.module\.css$/],
+          exclude: /\.module\.css$/,
           loader: extractBuildCss.extract([`css?minimize`, `postcss`]),
         })
 
@@ -476,7 +476,7 @@ module.exports = async (
 
         config.loader(`css`, {
           test: /\.css$/,
-          exclude: [/\.module\.css$/],
+          exclude: /\.module\.css$/,
           loader: `null`,
         })
 
@@ -501,7 +501,7 @@ module.exports = async (
 
         config.loader(`css`, {
           test: /\.css$/,
-          exclude: [/\.module\.css$/],
+          exclude: /\.module\.css$/,
           // loader: `null`,
           loader: extractBuildJavascript.extract([`css`]),
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,7 +549,7 @@ axios@^0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-"axios@github:contentful/axios#fix/https-via-http-proxy":
+axios@contentful/axios#fix/https-via-http-proxy:
   version "0.17.1"
   resolved "https://codeload.github.com/contentful/axios/tar.gz/4b06f4a63db3ac16c99f7c61b584ef0e6d11f1af"
   dependencies:
@@ -11307,9 +11307,9 @@ remark-html@6.0.1:
     mdast-util-to-hast "^2.1.1"
     xtend "^4.0.1"
 
-remark-math@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-0.2.4.tgz#f027cf7f984108777c23425905bf0cbfeeeddda1"
+remark-math@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-1.0.3.tgz#e8cda5af8cd8a85fc7782ccbecf0261943c29b9a"
   dependencies:
     trim-trailing-lines "^1.1.0"
 


### PR DESCRIPTION
This reverts commit 50b0a47b20ae4a5e07b3b9bc9f4b87cc3bb509d1, which was an unintentional breaking change.

Closes #4044.