### PR TITLE
Add links to the end of the tutorial

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -1087,3 +1087,9 @@ In this part of the tutorial, we've learned the foundations of building with
 Gatsby's data layer. You've learned how to _source_ and _transform_ data using
 plugins. How to use GraphQL to _map_ data to pages. Then how to build _page
 template components_ where you query for data for each page.
+
+## Where next?
+
+Now that you've built a Gatsby site, where do you head to next?
+
+You could take a look at some [example sites](https://github.com/gatsbyjs/gatsby/tree/master/examples#gatsby-example-websites) and [plugins](/docs/plugins/), see what [other people are building with Gatsby](https://github.com/gatsbyjs/gatsby/#showcase), or check out the documentation on [Gatsby's APIs](/docs/api-specification/), [nodes](/docs/node-interface/) or [GraphQL](/docs/graphql-reference/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Example websites sit on one or the other end of the spectrum from very basic
 to complex/complete.
 
-A basic example websites is should be used to demonstrate a specific technology/plugin/technique to help other developers understand how to accomplish task. They should be named `using-*` e.g. `using-sass`.
+A basic example website should demonstrate a specific technology/plugin/technique to help other developers understand how to accomplish task. They should be named `using-*` e.g. `using-sass`.
 
 Complex/complete websites are for studying how to build more complex websites.
 


### PR DESCRIPTION
Link from the tutorial to the Node Interface docs. I added this at the end as my understanding of the tutorial is that it should provide a fairly clear path through, without too many branching offshoots.

Refs #4028