### PR TITLE
Adds add'l docs to gatsby-source-filesystem

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -40,6 +40,58 @@ module.exports = {
   ],
 };
 ```
+## API
+
+`gatsby-source-filesystem` reveals two APIs:
+- `createFilePath`
+- `createRemoteFileNode`
+
+### createFilePath
+```javascript
+// In your gatsby-node.js
+createFilePath({
+  // The node you'd like to create into a filepath
+  // Param from `onCreateNode` can be used here
+  // ie: a markdown file, JSON data, etc
+  node:
+  // Method used to get a node
+  // Param from `onCreateNode` can be used here
+  getNode:
+  // the slug structure you'd like to create
+  // Defaults to `src/pages`
+  basePath:
+  // Whether you want your file paths to contain a trailing `/` slash
+  // Defaults to true
+  trailingSlash:
+})
+```
+
+#### Example usage
+The following is taken from [Gatsby Tutorial, Part Four](https://www.gatsbyjs.org/tutorial/part-four/#programmatically-creating-pages-from-data) and is used to create URL slugs from markdown pages.
+
+```javascript
+exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
+    const { createNodeField } = boundActionCreators
+    // Ensures we are processing only markdown files
+    if (node.internal.type === 'MarkdownRemark') {
+        // Use `createFilePath` to turn markdown files in our `data/faqs` directory into `/faqs/slug`
+        const relativeFilePath = createFilePath({ node, getNode, basePath: 'data/faqs/', trailingSlash: false })
+
+        // Creates new query'able field with name of 'slug'
+        createNodeField({
+            node,
+            name: 'slug',
+            value: `/faqs${relativeFilePath}`
+        })
+    }
+};
+```
+
+### createRemoteFileNode
+
+```javascript
+TO DO
+```
 
 ## How to query
 

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -62,8 +62,9 @@ You can query file nodes like the following:
 ## Helper functions
 
 `gatsby-source-filesystem` exports two helper functions:
-- `createFilePath`
-- `createRemoteFileNode`
+
+* `createFilePath`
+* `createRemoteFileNode`
 
 ### createFilePath
 
@@ -87,25 +88,30 @@ createFilePath({
 ```
 
 #### Example usage
+
 The following is taken from [Gatsby Tutorial, Part Four](https://www.gatsbyjs.org/tutorial/part-four/#programmatically-creating-pages-from-data) and is used to create URL slugs for markdown pages.
 
 ```javascript
-const { createFilePath } = require(`gatsby-source-filesystem`)
+const { createFilePath } = require(`gatsby-source-filesystem`);
 
 exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
-    const { createNodeField } = boundActionCreators
-    // Ensures we are processing only markdown files
-    if (node.internal.type === 'MarkdownRemark') {
-        // Use `createFilePath` to turn markdown files in our `data/faqs` directory into `/faqs/slug`
-        const relativeFilePath = createFilePath({ node, getNode, basePath: 'data/faqs/' })
+  const { createNodeField } = boundActionCreators;
+  // Ensures we are processing only markdown files
+  if (node.internal.type === "MarkdownRemark") {
+    // Use `createFilePath` to turn markdown files in our `data/faqs` directory into `/faqs/slug`
+    const relativeFilePath = createFilePath({
+      node,
+      getNode,
+      basePath: "data/faqs/",
+    });
 
-        // Creates new query'able field with name of 'slug'
-        createNodeField({
-            node,
-            name: 'slug',
-            value: `/faqs${relativeFilePath}`
-        })
-    }
+    // Creates new query'able field with name of 'slug'
+    createNodeField({
+      node,
+      name: "slug",
+      value: `/faqs${relativeFilePath}`,
+    });
+  }
 };
 ```
 

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -40,58 +40,6 @@ module.exports = {
   ],
 };
 ```
-## API
-
-`gatsby-source-filesystem` reveals two APIs:
-- `createFilePath`
-- `createRemoteFileNode`
-
-### createFilePath
-```javascript
-// In your gatsby-node.js
-createFilePath({
-  // The node you'd like to create into a filepath
-  // Param from `onCreateNode` can be used here
-  // ie: a markdown file, JSON data, etc
-  node:
-  // Method used to get a node
-  // Param from `onCreateNode` can be used here
-  getNode:
-  // the slug structure you'd like to create
-  // Defaults to `src/pages`
-  basePath:
-  // Whether you want your file paths to contain a trailing `/` slash
-  // Defaults to true
-  trailingSlash:
-})
-```
-
-#### Example usage
-The following is taken from [Gatsby Tutorial, Part Four](https://www.gatsbyjs.org/tutorial/part-four/#programmatically-creating-pages-from-data) and is used to create URL slugs from markdown pages.
-
-```javascript
-exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
-    const { createNodeField } = boundActionCreators
-    // Ensures we are processing only markdown files
-    if (node.internal.type === 'MarkdownRemark') {
-        // Use `createFilePath` to turn markdown files in our `data/faqs` directory into `/faqs/slug`
-        const relativeFilePath = createFilePath({ node, getNode, basePath: 'data/faqs/', trailingSlash: false })
-
-        // Creates new query'able field with name of 'slug'
-        createNodeField({
-            node,
-            name: 'slug',
-            value: `/faqs${relativeFilePath}`
-        })
-    }
-};
-```
-
-### createRemoteFileNode
-
-```javascript
-TO DO
-```
 
 ## How to query
 
@@ -109,4 +57,60 @@ You can query file nodes like the following:
     }
   }
 }
+```
+
+## Helper functions
+
+`gatsby-source-filesystem` exports two helper functions:
+- `createFilePath`
+- `createRemoteFileNode`
+
+### createFilePath
+
+When building pages from files, you often want to create a URL from a file's path on the file system. E.g. if you have a markdown file at `src/content/2018-01-23-an-exploration-of-the-nature-of-reality/index.md`, you might want to turn that into a page on your site at `example.com/2018-01-23-an-exploration-of-the-nature-of-reality/`. `createFilePath` is a helper function to make this task easier.
+
+```javascript
+createFilePath({
+  // The node you'd like to convert to a path
+  // e.g. froom a markdown, JSON, YAML file, etc
+  node:
+  // Method used to get a node
+  // The parameter from `onCreateNode` should be passed in here
+  getNode:
+  // The base path for your files.
+  // Defaults to `src/pages`. For the example above, you'd use `src/contents`.
+  basePath:
+  // Whether you want your file paths to contain a trailing `/` slash
+  // Defaults to true
+  trailingSlash:
+})
+```
+
+#### Example usage
+The following is taken from [Gatsby Tutorial, Part Four](https://www.gatsbyjs.org/tutorial/part-four/#programmatically-creating-pages-from-data) and is used to create URL slugs for markdown pages.
+
+```javascript
+const { createFilePath } = require(`gatsby-source-filesystem`)
+
+exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
+    const { createNodeField } = boundActionCreators
+    // Ensures we are processing only markdown files
+    if (node.internal.type === 'MarkdownRemark') {
+        // Use `createFilePath` to turn markdown files in our `data/faqs` directory into `/faqs/slug`
+        const relativeFilePath = createFilePath({ node, getNode, basePath: 'data/faqs/' })
+
+        // Creates new query'able field with name of 'slug'
+        createNodeField({
+            node,
+            name: 'slug',
+            value: `/faqs${relativeFilePath}`
+        })
+    }
+};
+```
+
+### createRemoteFileNode
+
+```javascript
+TO DO
 ```


### PR DESCRIPTION
Spent some time this week working on markdown pages and GQL.  Wanted to add additional notes do how the `createFilePath` API works.  Not sure if this will be helpful for others but if you'd like me to make additional edits, lemme know!  :)