### PR TITLE
inferring types: sort type names when creating union type name

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -246,9 +246,10 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
     // If there's more than one type, we'll create a union type.
     if (fields.length > 1) {
       type = new GraphQLUnionType({
-        name: `Union_${key}_${fields.map(f => f.name).join(`__`)}`,
+        name: `Union_${key}_${fields.map(f => f.name).sort().join(`__`)}`,
         description: `Union interface for the field "${key}" for types [${fields
           .map(f => f.name)
+          .sort()
           .join(`, `)}]`,
         types: fields.map(f => f.nodeObjectType),
         resolveType: data =>


### PR DESCRIPTION
This makes sure that union names are consistent if order of data is changed. Of course it still will change if node types are added or removed from union.

This ill break builds on websites that rely on current name of union (if order of type names wasn't accidentally naturally sorted)

fixes #4064