### PR TITLE
Update minimum Node.js versions

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -28,7 +28,7 @@ You should see something like:
 
 ![Check if node.js/npm is installed](check-versions.png)
 
-Gatsby supports versions of Node back to v4 and npm to v3.
+Gatsby supports versions of Node back to v6 and npm to v3.
 
 If you don't have Node.js installed, go to https://nodejs.org/ and install the
 recommended version for your operating system.

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -126,7 +126,7 @@
     "rimraf": "^2.6.1"
   },
   "engines": {
-    "node": ">4.0.0"
+    "node": ">6.0.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby#readme",
   "keywords": [


### PR DESCRIPTION
Updating minimum Node.js versions, as Gatsby doesn't currently work with Node.js v4.

Refs #4072 