### PR TITLE
Auto-deploy GraphQL docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,40 @@
-language: node_js
-node_js:
-  - "6"
-  - "8"
+sudo: required
 
-os: [linux]
+services:
+  - docker
+
+os:
+  - linux
+
 dist: trusty
 sudo: required
-cache:
-  yarn: true
 
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
+jobs:
+    include:
+        - stage: build and test
+          if: type = pull_request
+          language: node_js
+          node_js:
+            - '6'
+            - '8'
+          cache:
+            yarn: true
+          before_install:
+          - curl -o- -L https://yarnpkg.com/install.sh | bash
+          - export PATH=$HOME/.yarn/bin:$PATH
+          install:
+          - yarn run bootstrap
+          script:
+          - yarn test
 
-install:
-  - yarn run bootstrap
+        - stage: www graphql docker image build and push
+          if: tag =~ ^gatsby@.*
+          env:
+            - DOCKER_USER=mikeallanson
+            - secure: J8daWiar248dPWwrutZd83CeSif/+rMjB9hSOjq0pQDNj7QcOKjUwLsv6yMDJAcQCAAyobwRQTNYANGXmvQsi5ZppZe/P/enDPD/ZEPz3XkvxYYbXC7TNKVp8bnvYTWu6qO9ljkMsKGttsqaz+MyTx2MjV9pJhkmw2rfQ5iVn/80bORaCCMDcSB2ud/jLN+AVBFNMDUVEL9RnAXTq+CyQmSLvlvmJNCu9CXnb/Kt+IcbqswTjre/V2lVkzcXEvUYd0F9la3bsGVVQ9vBd3IumSIGnSOxD91DLUOeuh5K7FJxPoqqwM+bCn4zZWtQMOGpPDoYYllVejFHC16g/FBa6uC455OvqeS6fSCRXr9bqDxDLPhn7IyDAuG2jXps++sbd2RA8eXq8IGA4AqtTf4smiIXbOu3p3d2n9ww4Z/NgRpLHYRFcVwjG92okVN4by7n1+kr7wGx+alCkHTMDrLkkeZ0AEJphaxAH+TxP+SvCFY1z/OyNM0YzICrLXjf2w60Xz4wE563yUM8OLFm4GbeM33eQYRErTLADG9JtGDev+L5tS/Vo8+KGkL3creY7f9BgsNyfxbQbv84X7f+vSPlzl6u8V9EuVA80+5hE7artRtM+BxiT5pGM1983+QK2CPv4EptMYRa0EjlVbxyrfVYF22lsAqqgVApZGGneUxB0cQ= # DOCKER_PASS
+          before_install:
+            - chmod +x scripts/www-graphql-docker-push.sh
+          script:
+            - ./scripts/www-graphql-docker-push.sh
 
-script:
-  - yarn test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
           - yarn test
 
         - stage: www graphql docker image build and push
-          if: tag =~ ^gatsby@.*
+          if: (NOT type = pull_request) AND branch = master
           env:
             - DOCKER_USER=mikeallanson
             - secure: J8daWiar248dPWwrutZd83CeSif/+rMjB9hSOjq0pQDNj7QcOKjUwLsv6yMDJAcQCAAyobwRQTNYANGXmvQsi5ZppZe/P/enDPD/ZEPz3XkvxYYbXC7TNKVp8bnvYTWu6qO9ljkMsKGttsqaz+MyTx2MjV9pJhkmw2rfQ5iVn/80bORaCCMDcSB2ud/jLN+AVBFNMDUVEL9RnAXTq+CyQmSLvlvmJNCu9CXnb/Kt+IcbqswTjre/V2lVkzcXEvUYd0F9la3bsGVVQ9vBd3IumSIGnSOxD91DLUOeuh5K7FJxPoqqwM+bCn4zZWtQMOGpPDoYYllVejFHC16g/FBa6uC455OvqeS6fSCRXr9bqDxDLPhn7IyDAuG2jXps++sbd2RA8eXq8IGA4AqtTf4smiIXbOu3p3d2n9ww4Z/NgRpLHYRFcVwjG92okVN4by7n1+kr7wGx+alCkHTMDrLkkeZ0AEJphaxAH+TxP+SvCFY1z/OyNM0YzICrLXjf2w60Xz4wE563yUM8OLFm4GbeM33eQYRErTLADG9JtGDev+L5tS/Vo8+KGkL3creY7f9BgsNyfxbQbv84X7f+vSPlzl6u8V9EuVA80+5hE7artRtM+BxiT5pGM1983+QK2CPv4EptMYRa0EjlVbxyrfVYF22lsAqqgVApZGGneUxB0cQ= # DOCKER_PASS

--- a/scripts/www-graphql-docker-push.sh
+++ b/scripts/www-graphql-docker-push.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Path to here
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# Prepare
+docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+export REPO=mikeallanson/gatsby-graphql
+export TAG=latest
+
+# Build
+# Build the Dockerfile located at ../, using ../ as the context directory
+docker build -t "$REPO":"$TRAVIS_COMMIT" -f "$DIR"/../Dockerfile "$DIR"/../
+
+docker tag "$REPO":"$TRAVIS_COMMIT" "$REPO":"$TAG"
+docker tag "$REPO":"$TRAVIS_COMMIT" "$REPO":travis-"$TRAVIS_BUILD_NUMBER"
+
+# Push
+docker push "$REPO"


### PR DESCRIPTION
This should deploy the www GraphQL docker image whenever a tag starts with `gatsby@`. PR builds will remain unchanged.

We'll need to set 'Build pushed branches' to ON in Travis' settings:
 
![screen shot 2018-02-16 at 16 28 23](https://user-images.githubusercontent.com/381801/36318022-91741944-1336-11e8-91c0-7605f1622ccc.png)

The `if:` conditionals in `travis.yml` mean that pushed branches will only build when a `gatsby@` tag is present.

The images get pushed to https://hub.docker.com/r/mikeallanson/gatsby-graphql/tags/, which fires a webhook to sloppy.io, automatically updating the [hosted GraphiQL instance](https://gatsbygraphql.sloppy.zone/?query=%23%20Hello!%20This%20is%20a%20live%20copy%20of%20the%20data%20powering%20gatsbyjs.org.%0A%23%0A%23%20Here%27s%20an%20example%20query%20to%20get%20you%20started%20-%20hit%20the%20%27play%27%20button%20to%20run%20it%3A%0A%0A%7B%20%0A%20allMarkdownRemark%20%0A%20%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20_PARENT%0A%20%20%20%20%20%20%20%20%20%20parent%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%20%20imageAuthor%0A%20%20%20%20%20%20%20%20%20%20imageAuthorLink%0A%20%20%20%20%20%20%20%20%20%20imageTitle%0A%20%20%20%20%20%20%20%20%20%20excerpt%0A%20%20%20%20%20%20%20%20%20%20showImageInArticle%0A%20%20%20%20%20%20%20%20%20%20draft%0A%20%20%20%20%20%20%20%20%20%20canonicalLink%0A%20%20%20%20%20%20%20%20%20%20publishedAt%0A%20%20%20%20%20%20%20%20%20%20typora_copy_images_to%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%20%0A)
