### PR TITLE
Add new Tools-section and mention Gatsby-Docker

### DIFF
--- a/docs/docs/awesome-gatsby.md
+++ b/docs/docs/awesome-gatsby.md
@@ -16,6 +16,10 @@ See the [list of official and community starters](/docs/gatsby-starters/)
 
 See the [list of official and community plugins](/docs/plugins/)
 
+## Tools
+
+* [Develop & Build GatsbyJS static sites within Docker](https://github.com/aripalo/gatsby-docker/)
+
 ## Videos
 
 * [Static Site Generation with Gatsby.js v0 — Scott Nonnenberg](https://blog.scottnonnenberg.com/static-site-generation-with-gatsby-js/)


### PR DESCRIPTION
Adds new “Tools”-section after “Plugins”-section [as suggested here](https://twitter.com/gatsbyjs/status/964531323606986752) and add a link to [Gatsby-Docker](https://github.com/aripalo/gatsby-docker/) which enables Gatsby site development & build completely within Docker container environment.

The Tools-section would be a good place to list various tooling around Gatsby that doesn't necessarily fall within starters or plugins.

