### PR TITLE
Added gatsby-source-dribbble plugin

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -206,6 +206,7 @@ root.
 * [gatsby-source-unsplash](https://github.com/vacas5/gatsby-source-unsplash)
 * [gatsby-source-workable](https://github.com/tumblbug/gatsby-source-workable)
 * [gatsby-transformer-orga](https://github.com/xiaoxinghu/orgajs/tree/master/packages/gatsby-transformer-orga)
+* [gatsby-source-dribbble](https://github.com/smakosh/gatsby-source-dribbble)
 
 ## Community Library
 


### PR DESCRIPTION
Added gatsby-source-dribbble plugin to community plugins.

The plugin allows dribbble users to load their shots easily & free.