### PR TITLE
fix missing `path` dependency in exemple (docs/adding-tags-and-categories-to-blog-posts)

### DIFF
--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -157,6 +157,8 @@ export const pageQuery = graphql`
 Now we've got a template. Great! I'll assume you followed the tutorial for [Adding Markdown Pages](/docs/adding-tags-and-categories-to-blog-posts/) and provide a sample `createPages` that generates post pages as well as tag pages. In the site's `gatsby-node.js` file, include `lodash` (`const _ = require('lodash')`) and then make sure your [`createPages`](/docs/node-apis/#createPages) looks something like this:
 
 ```js
+const path = require("path");
+
 exports.createPages = ({ boundActionCreators, graphql }) => {
   const { createPage } = boundActionCreators;
 


### PR DESCRIPTION
Following the guide I had an error with the `path`.

It seems that requiring it at the top of the file solves the issue: `const path = require("path");`

Is there something else I was missing?

If this is correct, maybe this page [docs/node-apis/#createPages](https://www.gatsbyjs.org/docs/node-apis/#createPages) could benefit from the same 

Cheers