### PR TITLE
Add gatsby-starter-redux to gatsby-starters

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -462,3 +462,13 @@ Community:
   * Automatic Favicons
   * Typography.js
   * Part of a german tutorial series on Gatsby. The starter will change over time to use more advanced stuff (feel free to express your ideas)
+  
+* [gatsby-starter-redux](https://github.com/caki0915/gatsby-starter-redux)
+  [(demo)](https://caki0915.github.io/gatsby-starter-redux/)
+
+  Features:
+
+  * [Redux](https://github.com/reactjs/redux) and [Redux-devtools](https://github.com/gaearon/redux-devtools).
+  * [Emotion](https://github.com/emotion-js/emotion) with a basic theme and SSR
+  * [Typography.js](https://kyleamathews.github.io/typography.js/)
+  * Eslint rules based on [Prettier](https://prettier.io/) and [Airbnb](https://www.npmjs.com/package/eslint-config-airbnb)


### PR DESCRIPTION
It can be a little bit tricky to add multiple plugins that's modifying `gatsby-ssr.js`. For example if you want to use both `Redux` and `css-in-js`  
Have been some discussion on, 
https://github.com/gatsbyjs/gatsby/issues/1079

I would like to share my setup for Redux/Redux-Devtools and Emotion. 
I hope this starter can help others as well and save some time :)
