### PR TITLE
Check exports.frontmatter before creating javascriptFrontmatter nodes

### DIFF
--- a/examples/using-javascript-transforms/gatsby-node.js
+++ b/examples/using-javascript-transforms/gatsby-node.js
@@ -119,14 +119,6 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
                 slug: edge.node.fields.slug,
               },
             })
-          } else if (edge.node.fields.slug === `/index/`) {
-            createPage({
-              path: `/`, // required, we don't have frontmatter for this page hence separate if()
-              component: path.resolve(edge.node.fileAbsolutePath),
-              context: {
-                slug: edge.node.fields.slug,
-              },
-            })
           }
         })
 

--- a/examples/using-javascript-transforms/src/mainPages/index.js
+++ b/examples/using-javascript-transforms/src/mainPages/index.js
@@ -5,6 +5,11 @@ import sortBy from "lodash/sortBy"
 import moment from "moment"
 import InsetPageLayout from "../components/Layouts/insetPage"
 
+exports.frontmatter = {
+  layoutType: `page`,
+  path: `/`,
+}
+
 class SiteIndex extends React.Component {
   render() {
     const pageLinks = []


### PR DESCRIPTION
Closes #4095.

This breaks the [using-javascript-transforms example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-javascript-transforms), which actually expected a js file without frontmatter to be included with `allJavascriptFrontmatter` during page creation.

I've included a simple fix for that as well—adding frontmatter to that file—but now I wonder if this is a more significant change than I'd previously thought.

That said, I still think it makes the most sense that the javascript frontmatter plugin only create nodes from files that actually export frontmatter.

