### PR TITLE
updated canonical plugin to not overwrite configured domain name with…

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Adds canonical link to head correctly creates a canonical link if siteUrl is set 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        <link
+          data-basehost="someurl.com"
+          data-baseprotocol="http:"
+          href="http://someurl.com/somepost"
+          rel="canonical"
+        />,
+      ],
+    ],
+  ],
+}
+`;
+
+exports[`Adds canonical link to head correctly does not create a canonical link if siteUrl is not set 1`] = `[MockFunction]`;

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-ssr.js
@@ -1,0 +1,33 @@
+const { onRenderBody } = require(`../gatsby-ssr`)
+
+describe(`Adds canonical link to head correctly`, () => {
+  it(`creates a canonical link if siteUrl is set`, async () => {
+    const pluginOptions = {
+      siteUrl: `http://someurl.com`,
+    }
+    const setHeadComponents = jest.fn()
+    const pathname = `/somepost`
+
+    await onRenderBody({
+      setHeadComponents,
+      pathname,
+    }, pluginOptions )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(1)
+  })
+
+  it(`does not create a canonical link if siteUrl is not set`, async () => {
+    const pluginOptions = {}
+    const setHeadComponents = jest.fn()
+    const pathname = `/somepost`
+
+    await onRenderBody({
+      setHeadComponents,
+      pathname,
+    }, pluginOptions )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,4 +1,9 @@
 exports.onRouteUpdate = ({ location }) => {
   const domElem = document.querySelector(`link[rel='canonical']`)
-  domElem.setAttribute(`href`, `${window.location.origin}${location.pathname}`)
+  var existingValue = domElem.getAttribute(`href`)
+  var baseProtocol = domElem.getAttribute(`data-baseProtocol`)
+  var baseHost = domElem.getAttribute(`data-baseHost`)
+  if ( existingValue && baseProtocol && baseHost ) {
+    domElem.setAttribute(`href`, `${baseProtocol}//${baseHost}${location.pathname}${location.search}${location.hash}`)
+  }
 }

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -1,9 +1,13 @@
 import React from "react"
+import url from "url"
 
 exports.onRenderBody = (
   { setHeadComponents, pathname = `/` },
   pluginOptions
 ) => {
-  const url = `${pluginOptions.siteUrl}${pathname}`
-  setHeadComponents([<link rel="canonical" key={url} href={url} />])
+  if ( pluginOptions && pluginOptions.siteUrl ) {
+    const parsedUrl = url.parse(pluginOptions.siteUrl)
+    const myUrl = `${pluginOptions.siteUrl}${pathname}`
+    setHeadComponents([<link rel="canonical" key={myUrl} href={myUrl} data-baseprotocol={parsedUrl.protocol} data-basehost={parsedUrl.host} />])
+  }
 }


### PR DESCRIPTION
… current domain name

updated gatsby-ssr.js to only write canonical link if siteUrl option is
specified
added tests for gatsby-ssr.js
updated gatsby-browser.js to
- use the existing domain name from the canonical link, which is the
one set in the siteUrl option, rather than overwrite it with the
current domain name
- include search and hash in the canonical url