### PR TITLE
[gatsby-plugin-sharp] add missing gatsby-cli dependency

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -7,6 +7,7 @@
     "async": "^2.1.2",
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
+    "gatsby-cli": "^1.1.39",
     "image-size": "^0.5.1",
     "imagemin": "^5.2.2",
     "imagemin-pngquant": "^5.0.0",


### PR DESCRIPTION
Please don't merge without review! 

In #4076 I added implicit dependency on `gatsby-cli/lib/reporter` to `gatsby-plugin-sharp`, which would works fine when installing dependencies with yarn and not with npm. 

`gatsby` package has listed `gatsby-cli` as dependency and yarn will install both `gatsby` and `gatsby-cli` in project node_modules and npm will install `gatsby-cli` in `gatsby`s node_modules.

Propably better way would be exporting `reporter` from `gatsby` (similar to `gatsby-link` exported from gatsby in v2), but this would cause another conflict to resolve when merging master into v2 which I'd like to avoid.
