### PR TITLE
[gatsby-source-filesystem] Add more error handling

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -7,21 +7,28 @@ exports.sourceNodes = (
   { boundActionCreators, getNode, hasNodeChanged, reporter },
   pluginOptions
 ) => {
-  const { createNode, deleteNode } = boundActionCreators
+  if (!(pluginOptions && pluginOptions.path)) {
+    reporter.panic(`
+You should pass 'path' options for gatsby-source-filesystem plugin
 
-  let ready = false
+See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
+    `)
+  }
 
   // Validate that the path exists.
   if (!fs.existsSync(pluginOptions.path)) {
-    console.log(`
+    reporter.panic(`
 The path passed to gatsby-source-filesystem does not exist on your file system:
 
 ${pluginOptions.path}
 
 Please pick a path to an existing directory.
       `)
-    process.exit(1)
   }
+
+  const { createNode, deleteNode } = boundActionCreators
+
+  let ready = false
 
   const watcher = chokidar.watch(pluginOptions.path, {
     ignored: [

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -9,7 +9,7 @@ exports.sourceNodes = (
 ) => {
   if (!(pluginOptions && pluginOptions.path)) {
     reporter.panic(`
-You should pass 'path' options for gatsby-source-filesystem plugin
+"path" is a required option for gatsby-source-filesystem
 
 See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
     `)


### PR DESCRIPTION
Since the `path` option is required for the plugin, thought it'd be good to check it and error out before checking if the path exists. Using `reporter`'s panic to exit the process instead of exiting directly from plugin.

Wonder if we should also check if `path` points to a directory within the project? Or it can be anywhere?