### PR TITLE
fix: fix issue with misnamed raw-loader

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -184,7 +184,7 @@ module.exports = (locals, callback) => {
   })
 
   // Add the chunk-manifest at the end of body element.
-  const chunkManifest = require(`!raw!../public/chunk-manifest.json`)
+  const chunkManifest = require(`!raw-loader!../public/chunk-manifest.json`)
   postBodyComponents.unshift(
     <script
       id="webpack-manifest"


### PR DESCRIPTION
> BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                   You need to specify 'raw-loader' instead of 'raw',
                   see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed