### PR TITLE
Add starter repo for i18n from Contentful CMS.

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -175,6 +175,13 @@ Community:
 
   * localization (Multilanguage)
 
+* [gatsby-starter-contentful-i18n](https://github.com/mccrodp/gatsby-starter-contentful-i18n) [(demo)](https://gatsby-starter-contentful-i18n.netlify.com/)
+
+  Features:
+  * Localization (Multilanguage)
+  * Dynamic content from Contentful CMS
+  * Integrates [i18n plugin starter](https://github.com/angeloocana/gatsby-starter-default-i18n) and [using-contentful](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful) repos
+
 * [gatsby-starter-gatsbythemes](https://github.com/saschajullmann/gatsby-starter-gatsbythemes)
   [(demo)](https://themes.gatsbythemes.com/gatsby-starter/)
 
@@ -451,7 +458,7 @@ Community:
   Features:
 
   * Parses [org-mode](http://orgmode.org) files with [Orga](https://github.com/xiaoxinghu/orgajs).
-  
+
 * [gatsby-starter-minimal-blog](https://github.com/LeKoArts/gatsby-starter-minimal-blog)
   [(demo)](https://minimal-blog.netlify.com/)
 
@@ -462,7 +469,7 @@ Community:
   * Automatic Favicons
   * Typography.js
   * Part of a german tutorial series on Gatsby. The starter will change over time to use more advanced stuff (feel free to express your ideas)
-  
+
 * [gatsby-starter-redux](https://github.com/caki0915/gatsby-starter-redux)
   [(demo)](https://caki0915.github.io/gatsby-starter-redux/)
 


### PR DESCRIPTION
It took me quite a while to get this working, so much so that I think it's useful for others. I focused on creating a starter repo on it before starting my own work. So, just making the docs update below.

---

* [gatsby-starter-contentful-i18n](https://github.com/mccrodp/gatsby-starter-contentful-i18n) [(demo)](https://gatsby-starter-contentful-i18n.netlify.com/)

  Features:
  * Localization (Multilanguage)
  * Dynamic content from Contentful CMS
  * Integrates [i18n plugin starter](https://github.com/angeloocana/gatsby-starter-default-i18n) and [using-contentful](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful) repos

---

It basically integrates the community `i18n` plugin with `using-contentful` repo. i.e. - uses the `en-US` and `de` content from Using Contenful example and displays either of the content depending on lang selected using the lang selector.

I also have a i18n with transformer remark plugin, but that's perhaps better in the i18n plugin repo itself rather than here. Not sure though, if you want here, I can clean it up w.r.t naming, code comments, repo name, live demo on netlify, etc. https://github.com/mccrodp/gatsby-transformer-remark-i18n