### PR TITLE
Fix crash by rounding auto-calculated height in resize

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -1,6 +1,6 @@
 const path = require(`path`)
 
-const { base64, responsiveSizes, resolutions } = require(`../`)
+const { base64, responsiveSizes, resolutions, queueImageResizing } = require(`../`)
 
 describe(`gatsby-plugin-sharp`, () => {
   const args = {
@@ -10,6 +10,20 @@ describe(`gatsby-plugin-sharp`, () => {
   }
   const absolutePath = path.join(__dirname, `images/test.png`)
   const file = getFileObject(absolutePath)
+
+  describe(`queueImageResizing`, () => {
+    it(`should round height when auto-calculated`, () => {
+      // Resize 144-density.png (281x136) with a 3px width
+      const result = queueImageResizing({
+        file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args: { width: 3 },
+      })
+
+      // Width should be: w = (3 * 136) / 281 = 1.451957295
+      // We expect value to be rounded to 1
+      expect(result.height).toBe(1)
+    })
+  })
 
   describe(`responsiveSizes`, () => {
     it(`includes responsive image properties, e.g. sizes, srcset, etc.`, async () => {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -299,7 +299,7 @@ function queueImageResizing({ file, args = {} }) {
     // Use the aspect ratio of the image to calculate what will be the resulting
     // height.
     width = options.width
-    height = options.width / aspectRatio
+    height = Math.round(options.width / aspectRatio)
   }
 
   // Create job and process.


### PR DESCRIPTION
Fix #4156 