### PR TITLE
Replace image-size with probe-image-size

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -10,7 +10,7 @@
     "async": "^2.1.2",
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
-    "image-size": "^0.5.1",
+    "probe-image-size": "^3.2.0",
     "imagemin": "^5.2.2",
     "imagemin-pngquant": "^5.0.0",
     "imagemin-webp": "^4.0.0",

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -12,9 +12,9 @@ describe(`gatsby-plugin-sharp`, () => {
   const file = getFileObject(absolutePath)
 
   describe(`queueImageResizing`, () => {
-    it(`should round height when auto-calculated`, () => {
+    it(`should round height when auto-calculated`, async () => {
       // Resize 144-density.png (281x136) with a 3px width
-      const result = queueImageResizing({
+      const result = await queueImageResizing({
         file: getFileObject(path.join(__dirname, `images/144-density.png`)),
         args: { width: 3 },
       })

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -12,9 +12,9 @@ describe(`gatsby-plugin-sharp`, () => {
   const file = getFileObject(absolutePath)
 
   describe(`queueImageResizing`, () => {
-    it(`should round height when auto-calculated`, async () => {
+    it(`should round height when auto-calculated`, () => {
       // Resize 144-density.png (281x136) with a 3px width
-      const result = await queueImageResizing({
+      const result = queueImageResizing({
         file: getFileObject(path.join(__dirname, `images/144-density.png`)),
         args: { width: 3 },
       })

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -1,6 +1,6 @@
 const sharp = require(`sharp`)
 const crypto = require(`crypto`)
-const imageSize = require(`image-size`)
+const imageSize = require(`probe-image-size`)
 const _ = require(`lodash`)
 const Promise = require(`bluebird`)
 const fs = require(`fs`)
@@ -300,7 +300,7 @@ function queueImageResizing({ file, args = {}, reporter }) {
   let width
   let height
   // Calculate the eventual width/height of the image.
-  const dimensions = imageSize(file.absolutePath)
+  const dimensions = imageSize.sync(toArray(fs.readFileSync(file.absolutePath)))
   let aspectRatio = dimensions.width / dimensions.height
   const originalName = file.base
 
@@ -555,7 +555,7 @@ async function resolutions({ file, args = {}, reporter }) {
   sizes.push(options.width * 1.5)
   sizes.push(options.width * 2)
   sizes.push(options.width * 3)
-  const dimensions = imageSize(file.absolutePath)
+  const dimensions = imageSize.sync(toArray(fs.readFileSync(file.absolutePath)))
 
   const filteredSizes = sizes.filter(size => size <= dimensions.width)
 
@@ -745,6 +745,16 @@ const optimize = svg => {
   return new Promise((resolve, reject) => {
     svgo.optimize(svg, ({ data }) => resolve(data))
   })
+}
+
+function toArray(buf) {
+  var arr = new Array(buf.length)
+
+  for (var i = 0; i < buf.length; i++) {
+    arr[i] = buf[i]
+  }
+
+  return arr
 }
 
 exports.queueImageResizing = queueImageResizing

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -247,7 +247,7 @@ const queueJob = (job, reporter) => {
   }
 }
 
-async function queueImageResizing({ file, args = {}, reporter }) {
+function queueImageResizing({ file, args = {}, reporter }) {
   const defaultArgs = {
     width: 400,
     quality: 50,
@@ -300,7 +300,7 @@ async function queueImageResizing({ file, args = {}, reporter }) {
   let width
   let height
   // Calculate the eventual width/height of the image.
-  const dimensions = await getImageSize(file.absolutePath)
+  const dimensions = imageSize.sync(toArray(fs.readFileSync(file.absolutePath)))
   let aspectRatio = dimensions.width / dimensions.height
   const originalName = file.base
 
@@ -481,7 +481,7 @@ async function responsiveSizes({ file, args = {}, reporter }) {
   const sortedSizes = _.sortBy(filteredSizes)
 
   // Queue sizes for processing.
-  const images = await Promise.all(sortedSizes.map(async size => {
+  const images = sortedSizes.map(size => {
     const arrrgs = {
       ...options,
       width: Math.round(size),
@@ -496,7 +496,7 @@ async function responsiveSizes({ file, args = {}, reporter }) {
       args: arrrgs, // matey
       reporter,
     })
-  }))
+  })
 
   const base64Width = 20
   const base64Height = Math.max(1, Math.round(base64Width * height / width))
@@ -555,7 +555,7 @@ async function resolutions({ file, args = {}, reporter }) {
   sizes.push(options.width * 1.5)
   sizes.push(options.width * 2)
   sizes.push(options.width * 3)
-  const dimensions = await getImageSize(file.absolutePath)
+  const dimensions = imageSize.sync(toArray(fs.readFileSync(file.absolutePath)))
 
   const filteredSizes = sizes.filter(size => size <= dimensions.width)
 
@@ -578,7 +578,7 @@ async function resolutions({ file, args = {}, reporter }) {
   // Sort sizes for prettiness.
   const sortedSizes = _.sortBy(filteredSizes)
 
-  const images = await Promise.all(sortedSizes.map(async size => {
+  const images = sortedSizes.map(size => {
     const arrrgs = {
       ...options,
       width: Math.round(size),
@@ -593,7 +593,7 @@ async function resolutions({ file, args = {}, reporter }) {
       args: arrrgs,
       reporter,
     })
-  }))
+  })
 
   const base64Args = {
     duotone: options.duotone,
@@ -747,14 +747,14 @@ const optimize = svg => {
   })
 }
 
-async function getImageSize(fileName) {
-  const input = fs.createReadStream(fileName)
-  try {
-    const { width, height } = await imageSize(input)
-    return { width, height }
-  } finally {
-    input.destroy()
+function toArray(buf) {
+  var arr = new Array(buf.length)
+
+  for (var i = 0; i < buf.length; i++) {
+    arr[i] = buf[i]
   }
+
+  return arr
 }
 
 exports.queueImageResizing = queueImageResizing

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -10,7 +10,7 @@
     "babel-runtime": "^6.26.0",
     "cheerio": "^1.0.0-rc.2",
     "fs-extra": "^4.0.1",
-    "image-size": "^0.6.1",
+    "probe-image-size": "^3.2.0",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",
     "path-is-inside": "^1.0.2",

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -1,10 +1,11 @@
 const visit = require(`unist-util-visit`)
 const isRelativeUrl = require(`is-relative-url`)
+const fs = require(`fs`)
 const fsExtra = require(`fs-extra`)
 const path = require(`path`)
 const _ = require(`lodash`)
 const cheerio = require(`cheerio`)
-const sizeOf = require(`image-size`)
+const imageSize = require(`probe-image-size`)
 
 const DEPLOY_DIR = `public`
 
@@ -37,6 +38,16 @@ const newLinkURL = (linkNode, destinationDir) => {
     return path.posix.join(`/`, destinationDir, newFileName(linkNode))
   }
   return path.posix.join(`/`, newFileName(linkNode))
+}
+
+function toArray(buf) {
+  var arr = new Array(buf.length)
+
+  for (var i = 0; i < buf.length; i++) {
+    arr[i] = buf[i]
+  }
+
+  return arr
 }
 
 module.exports = (
@@ -113,7 +124,7 @@ module.exports = (
     let dimensions
 
     if (!image.attr(`width`) || !image.attr(`height`)) {
-      dimensions = sizeOf(imageNode.absolutePath)
+      dimensions = imageSize.sync(toArray(fs.readFileSync(imageNode.absolutePath)))
     }
 
     // Generate default alt tag

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -10,7 +10,7 @@
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
     "fs-extra": "^4.0.2",
-    "image-size": "^0.6.0"
+    "probe-image-size": "^3.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -17,8 +17,9 @@ const {
 } = require(`gatsby-plugin-sharp`)
 
 const sharp = require(`sharp`)
+const fs = require(`fs`)
 const fsExtra = require(`fs-extra`)
-const sizeOf = require(`image-size`)
+const imageSize = require(`probe-image-size`)
 const path = require(`path`)
 const Potrace = require(`potrace`).Potrace
 
@@ -89,6 +90,16 @@ const PotraceType = new GraphQLInputObjectType({
   },
 })
 
+function toArray(buf) {
+  var arr = new Array(buf.length)
+
+  for (var i = 0; i < buf.length; i++) {
+    arr[i] = buf[i]
+  }
+
+  return arr
+}
+
 module.exports = ({
   type,
   pathPrefix,
@@ -119,7 +130,7 @@ module.exports = ({
       args: {},
       async resolve(image, fieldArgs, context) {
         const details = getNodeAndSavePathDependency(image.parent, context.path)
-        const dimensions = sizeOf(details.absolutePath)
+        const dimensions = imageSize.sync(toArray(fs.readFileSync(details.absolutePath)))
         const imageName = `${details.name}-${image.internal.contentDigest}${
           details.ext
         }`

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -90,14 +90,14 @@ const PotraceType = new GraphQLInputObjectType({
   },
 })
 
-function toArray(buf) {
-  var arr = new Array(buf.length)
-
-  for (var i = 0; i < buf.length; i++) {
-    arr[i] = buf[i]
+async function getImageSize(fileName) {
+  const input = fs.createReadStream(fileName)
+  try {
+    const { width, height } = await imageSize(input)
+    return { width, height }
+  } finally {
+    input.destroy()
   }
-
-  return arr
 }
 
 module.exports = ({
@@ -130,7 +130,7 @@ module.exports = ({
       args: {},
       async resolve(image, fieldArgs, context) {
         const details = getNodeAndSavePathDependency(image.parent, context.path)
-        const dimensions = imageSize.sync(toArray(fs.readFileSync(details.absolutePath)))
+        const dimensions = await getImageSize(details.absolutePath)
         const imageName = `${details.name}-${image.internal.contentDigest}${
           details.ext
         }`
@@ -584,7 +584,7 @@ module.exports = ({
       resolve: (image, fieldArgs, context) => {
         const file = getNodeAndSavePathDependency(image.parent, context.path)
         const args = { ...fieldArgs, pathPrefix }
-        return new Promise(resolve => {
+        return new Promise(async resolve => {
           if (fieldArgs.base64) {
             resolve(
               base64({
@@ -592,7 +592,7 @@ module.exports = ({
               })
             )
           } else {
-            const o = queueImageResizing({
+            const o = await queueImageResizing({
               file,
               args,
             })

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,6 +266,10 @@ any-promise@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-0.1.0.tgz#830b680aa7e56f33451d4b049f3bd8044498ee27"
 
+any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
@@ -3330,7 +3334,7 @@ debug@*, debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.2, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6, debug@~2.6.7, debug@~2.6.9:
+debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.2, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6, debug@~2.6.7, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -3436,6 +3440,10 @@ deep-map@^1.5.0:
     es6-weak-map "^2.0.2"
     lodash "^4.17.4"
     tslib "^1.6.0"
+
+deepmerge@^1.3.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -6053,13 +6061,9 @@ ignore@^3.2.7, ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
-image-size@^0.5.1, image-size@~0.5.0:
+image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
-
-image-size@^0.6.0, image-size@^0.6.1:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.2.tgz#8ee316d4298b028b965091b673d5f1537adee5b4"
 
 imagemin-pngquant@^5.0.0:
   version "5.0.1"
@@ -8736,6 +8740,10 @@ netrc@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
+next-tick@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+
 nlcst-to-string@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nlcst-to-string/-/nlcst-to-string-2.0.1.tgz#f90f3cf905c137dc8edd8727fbcde73e73c2a1d9"
@@ -10394,6 +10402,17 @@ private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
+probe-image-size@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-3.2.0.tgz#0b8d7cd6e8dce8356bec732a1d9e793bcc8aed44"
+  dependencies:
+    any-promise "^1.3.0"
+    deepmerge "^1.3.0"
+    got "^6.7.1"
+    inherits "^2.0.3"
+    next-tick "^1.0.0"
+    stream-parser "~0.3.1"
+
 process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -11259,7 +11278,7 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
-relay-compiler@^1.4.1:
+relay-compiler@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-1.4.1.tgz#10e83f0f5de8db3d000851a4c0e435e7dd1deb95"
   dependencies:
@@ -12881,6 +12900,12 @@ stream-http@^2.3.1, stream-http@^2.7.2:
     readable-stream "^2.3.3"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-parser@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/stream-parser/-/stream-parser-0.3.1.tgz#1618548694420021a1182ff0af1911c129761773"
+  dependencies:
+    debug "2"
 
 stream-shift@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #3423 

The `image-size` package was already using a synchronous function call, so I have maintained that instead of trying to update to an asynchronous function call.

I saw the tests for `gatsby-plugin-sharp` turn red and then green, but not for `gatsby-remark-copy-linked-files` or `gatsby-transformer-sharp`, so I suspect there may be some issues with the tests for those. I don't know where to begin adding tests for those other packages.

All existing tests pass and my site builds fine.

It appears that image-size@0.5.0 is still installed by yarn because it is an optional dependency of `less` from `gatsby-plugin-less`.