### PR TITLE
update docs for modifyWebpackConfig

### DIFF
--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -14,7 +14,7 @@ function called `modifyWebpackConfig`.
 
 When Gatsby creates its webpack config, this function will be called allowing
 you to modify the default webpack config using
-[webpack-configurator](https://github.com/lewie9021/webpack-configurator).
+[webpack-merge](https://github.com/survivejs/webpack-merge).
 
 Gatsby does multiple webpack builds with somewhat different configuration. We
 call each build type a "stage". The following stages exist:

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -47,12 +47,18 @@ rendering.
 `gatsby-node.js` in the project root:
 
 ```js
-exports.modifyWebpackConfig = ({ config, stage }) => {
+exports.modifyWebpackConfig = ({ stage, loaders, actions }) => {
   if (stage === "build-html") {
-    config.loader("null", {
-      test: /bad-module/,
-      loader: "null-loader",
-    });
+    actions.setWebpackConfig({
+      module: {
+        rules: [
+          {
+            test: /bad-module/,
+            use: loaders.null(),
+          }
+        ]
+      }
+    })
   }
 };
 ```

--- a/packages/gatsby-plugin-no-sourcemaps/gatsby-node.js
+++ b/packages/gatsby-plugin-no-sourcemaps/gatsby-node.js
@@ -1,5 +1,7 @@
-exports.modifyWebpackConfig = ({ config, stage }) => {
-  if (stage === 'build-javascript') {
-    config._config.devtool = false;
+exports.modifyWebpackConfig = ({ stage, actions }) => {
+  if (stage === `build-javascript`) {
+    actions.setWebpackConfig({
+      devtool: false,
+    })
   }
-};
+}

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -179,8 +179,8 @@ exports.modifyBabelrc = true
  * @param {object} $0.plugins A set of preconfigured webpack config plugins
  * @param {object} $0.actions
  * @example
- * exports.modifyBabelrc = ({
- *  getConfig, stage, loaders, actions
+ * exports.modifyWebpackConfig = ({
+ *  stage, getConfig, rules, loaders, actions
  * }) => {
  *   actions.setWebpackConfig({
  *     module: {


### PR DESCRIPTION
`gatsby-plugin-netlify-cms` is still using the v1 way, because of #4179, I have no idea how to add `exclude` to existing rules, so I just leave it there