### PR TITLE
add support for `text/jsx` in `gatsby-transformer-javascript-frontmatter`

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
+++ b/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
@@ -11,8 +11,9 @@ async function onCreateNode({
 }) {
   const { createNode, createParentChildLink } = boundActionCreators
 
-  // This only processes javascript files.
-  if (node.internal.mediaType !== `application/javascript`) {
+  // This only processes javascript & jsx files.
+  if (node.internal.mediaType !== `application/javascript` && 
+    node.internal.mediaType !== `text/jsx`) {
     return
   }
 


### PR DESCRIPTION
as done [here](https://github.com/gatsbyjs/gatsby/pull/3169/commits) for `gatsby-transformer-react-docgen`

this my first pr at all so please let me know if i could/should improve anything ;-)