### PR TITLE
[v2] add support for `text/jsx` in `gatsby-transformer-javascript-frontmatter`

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
+++ b/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
@@ -12,7 +12,8 @@ async function onCreateNode({
   const { createNode, createParentChildLink } = boundActionCreators
 
   // This only processes javascript files.
-  if (node.internal.mediaType !== `application/javascript`) {
+  if (node.internal.mediaType !== `application/javascript` &&
+    node.internal.mediaType !== `text/jsx`) {
     return
   }
 


### PR DESCRIPTION
and my second pr :D

as done [here](https://github.com/gatsbyjs/gatsby/pull/3169/commits) for `gatsby-transformer-react-docgen`