### PR TITLE
clean old css files when starting a build – fixes #4166

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -57,15 +57,15 @@ module.exports = async (args: BootstrapArgs) => {
     payload: program,
   })
 
-  // Delete html files from the public directory as we don't want deleted
-  // pages from previous builds to stick around.
-  let activity = report.activityTimer(`delete html files from previous builds`)
+  // Delete html and css files from the public directory as we don't want
+  // deleted pages and styles from previous builds to stick around.
+  let activity = report.activityTimer(`delete html and css files from previous builds`)
   activity.start()
   await del([
-    `public/*.html`,
-    `public/**/*.html`,
+    `public/*.{html,css}`,
+    `public/**/*.{html,css}`,
     `!public/static`,
-    `!public/static/**/*.html`,
+    `!public/static/**/*.{html,css}`,
   ])
   activity.end()
 


### PR DESCRIPTION
I'm treating them the say way that html files are treated. I.e. remove them from the `public/` folder, but keep them within `public/static/`