### PR TITLE
Exclude Netlify CMS styles from main bundle

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -35,8 +35,15 @@ function plugins(stage) {
  * target loader key being named "css" in Gatsby's webpack config.
  */
 function excludeFromLoader(key, config) {
-  config.loader(key, {
-    exclude: [/\/node_modules\/netlify-cms\//],
+  config.loader(key, ({ exclude, ...configRest }) => {
+    const regex = /\/node_modules\/netlify-cms\//
+    if (!exclude) {
+      return { ...configRest, exclude: regex }
+    }
+    if (Array.isArray(exclude)) {
+      return { ...configRest, exclude: [...exclude, regex] }
+    }
+    return { ...configRest, exclude: [exclude, regex] }
   })
 }
 


### PR DESCRIPTION
Proper, per-plugin approach to achieving the goal of reverted commit https://github.com/gatsbyjs/gatsby/pull/3611/commits/50b0a47b20ae4a5e07b3b9bc9f4b87cc3bb509d1, passes a function to webpack-configurator method `config.loader` to augment and return a loader's entire configuration object rather than passing an object and relying on merging. Necessary in this case because the value being extended is a string, which would be overwritten.

Closes #4047.