### PR TITLE
test-require-error escape backslashes in module name/path

### DIFF
--- a/packages/gatsby/src/utils/__tests__/test-require-error.js
+++ b/packages/gatsby/src/utils/__tests__/test-require-error.js
@@ -10,6 +10,15 @@ describe(`test-require-error`, () => {
       )
     }
   })
+  it(`detects require errors when using windows path`, () => {
+    try {
+      require(`.\\fixtures\\module-does-not-exist`)
+    } catch (err) {
+      expect(
+        testRequireError(`.\\fixtures\\module-does-not-exist`, err)
+      ).toEqual(true)
+    }
+  })
   it(`Only returns true on not found errors for actual module not "not found" errors of requires inside the module`, () => {
     try {
       require(`./fixtures/bad-module-require`)

--- a/packages/gatsby/src/utils/test-require-error.js
+++ b/packages/gatsby/src/utils/test-require-error.js
@@ -1,7 +1,9 @@
 // This module is also copied into the .cache directory some modules copied there
 // from cache-dir can also use this module.
 module.exports = (moduleName, err) => {
-  const regex = new RegExp(`Error: Cannot find module\\s.${moduleName}`)
+  const regex = new RegExp(
+    `Error: Cannot find module\\s.${moduleName.replace(/\\/g, `\\\\`)}`
+  )
   const firstLine = err.toString().split(`\n`)[0]
   return regex.test(firstLine)
 }


### PR DESCRIPTION
It doesn't currently work as expected on windows when testing for `gatsby-config.js` (full path is passed). 

It cause https://github.com/gatsbyjs/gatsby-starter-hello-world (without gatsby-config.js) to be unusable on windows and this is bad because this starter is used in tutorial.