### PR TITLE
Detect if site name passed to `gatsby new` is a URL

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -25,6 +25,7 @@
     "source-map": "^0.5.7",
     "stack-trace": "^0.0.10",
     "update-notifier": "^2.3.0",
+    "url-regex": "^4.1.1",
     "yargs": "^8.0.2",
     "yurnalist": "^0.2.1"
   },

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -25,7 +25,6 @@
     "source-map": "^0.5.7",
     "stack-trace": "^0.0.10",
     "update-notifier": "^2.3.0",
-    "url-regex": "^4.1.1",
     "yargs": "^8.0.2",
     "yurnalist": "^0.2.1"
   },

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -5,7 +5,7 @@ const hostedGitInfo = require(`hosted-git-info`)
 const fs = require(`fs-extra`)
 const sysPath = require(`path`)
 const report = require(`./reporter`)
-const urlRegex = require(`url-regex`)
+const url = require(`url`)
 
 const spawn = (cmd: string) => {
   const [file, ...args] = cmd.split(/\s+/)
@@ -109,7 +109,8 @@ type InitOptions = {
 module.exports = async (starter: string, options: InitOptions = {}) => {
   const rootPath = options.rootPath || process.cwd()
 
-  if (urlRegex({ exact: true }).test(rootPath)) {
+  const urlObject = url.parse(rootPath)
+  if (urlObject.protocol && urlObject.host) {
     report.panic(
       `Path provided to new Gatsby project seems to be an URL. Perhaps you forgot to specify a site name?`
     )

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -112,7 +112,7 @@ module.exports = async (starter: string, options: InitOptions = {}) => {
   const urlObject = url.parse(rootPath)
   if (urlObject.protocol && urlObject.host) {
     report.panic(
-      `Path provided to new Gatsby project seems to be an URL. Perhaps you forgot to specify a site name?`
+      `It looks like you forgot to add the name of your new project. Try running "gatsby new new-gatsby-project ${rootPath}"`
     )
     return
   }

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -5,6 +5,7 @@ const hostedGitInfo = require(`hosted-git-info`)
 const fs = require(`fs-extra`)
 const sysPath = require(`path`)
 const report = require(`./reporter`)
+const urlRegex = require(`url-regex`)
 
 const spawn = (cmd: string) => {
   const [file, ...args] = cmd.split(/\s+/)
@@ -107,6 +108,13 @@ type InitOptions = {
  */
 module.exports = async (starter: string, options: InitOptions = {}) => {
   const rootPath = options.rootPath || process.cwd()
+
+  if (urlRegex({ exact: true }).test(rootPath)) {
+    report.panic(
+      `Path provided to new Gatsby project seems to be an URL. Perhaps you forgot to specify a site name?`
+    )
+    return
+  }
 
   if (fs.existsSync(sysPath.join(rootPath, `package.json`))) {
     report.panic(`Directory ${rootPath} is already an npm project`)


### PR DESCRIPTION
Warn the user, and then proceed to quit prematurely.

I'm using [url-regex](https://github.com/kevva/url-regex) to detect if `rootPath` is indeed a URL. LMK if it's not worth adding a new dependency for such a small use-case. However, I believe the module is pretty small, and serves the exact purpose needed to solve this problem.

I'm not too sure about the error message, tho. 😅

Thanks 💖

<hr />
Closes #4193.