### PR TITLE
Preserve the Drupal JSONApi ID on Gatsby node.

### DIFF
--- a/packages/gatsby-source-drupal/.gitignore
+++ b/packages/gatsby-source-drupal/.gitignore
@@ -1,1 +1,2 @@
 /gatsby-node.js
+/normalize.js

--- a/packages/gatsby-source-drupal/src/__tests__/data.json
+++ b/packages/gatsby-source-drupal/src/__tests__/data.json
@@ -1,0 +1,14 @@
+{
+    "idOverlayExample": {
+        "type": "menu_link_content--menu_link_content",
+        "id": "bae879ec-42da-4b79-9341-006623d4a9cc",
+        "attributes": {
+            "id": 1,
+            "uuid": "bae879ec-42da-4b79-9341-006623d4a9cc",
+            "bundle": "menu_link_content"
+        },
+        "links": {
+            "self": "https://cms.eidentity.cz/cs/jsonapi/menu_link_content/menu_link_content/bae879ec-42da-4b79-9341-006623d4a9cc"
+        }
+    }
+}

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -1,0 +1,11 @@
+const { nodeFromData } = require(`../normalize`)
+const { idOverlayExample } = require(`./data.json`)
+
+describe(`node completion`, () => {
+  it(`should preserve the node ID from jsonapi`, () => {
+    const node = nodeFromData(idOverlayExample)
+    expect(node.id).toEqual(idOverlayExample.id)
+    expect(node.bundle).toEqual(idOverlayExample.attributes.bundle)
+    expect(node._attributes_id).toEqual(idOverlayExample.attributes.id)
+  })
+})

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -3,6 +3,7 @@ const crypto = require(`crypto`)
 const _ = require(`lodash`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 const { URL } = require(`url`)
+const { nodeFromData } = require(`./normalize`)
 
 // Get content digest of node.
 const createContentDigest = obj =>
@@ -102,15 +103,7 @@ exports.sourceNodes = async (
     if (!contentType) return
 
     _.each(contentType.data, datum => {
-      const node = {
-        id: datum.id,
-        parent: null,
-        children: [],
-        ...datum.attributes,
-        internal: {
-          type: datum.type.replace(/-|__|:|\.|\s/g, `_`),
-        },
-      }
+      const node = nodeFromData(datum)
 
       // Add relationships
       if (datum.relationships) {

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -1,0 +1,17 @@
+const nodeFromData = datum => {
+  const { attributes: { id: _attributes_id, ...attributes } = {} } = datum
+  const preservedId = typeof _attributes_id !== `undefined` ? { _attributes_id } : {}
+  return {
+    id: datum.id,
+    parent: null,
+    children: [],
+    ...attributes,
+    ...preservedId,
+    internal: {
+      type: datum.type.replace(/-|__|:|\.|\s/g, `_`),
+    },
+  }
+}
+
+exports.nodeFromData = nodeFromData
+


### PR DESCRIPTION
Conversion from Drupal's response to Gatsby Node structure overlays attributes.id over the top-level id. The ID in attributes might be numeric, while Node's ID is string.

The patch updates the drupal source plugin to preserve original ID, moving the attributes.id to _attributes_id prop.