### PR TITLE
netlify-cms plugin: include identity widget handlers

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "html-webpack-include-assets-plugin": "^1.0.2",
     "html-webpack-plugin": "^2.30.1",
-    "netlify-cms": "^1.0.1"
+    "netlify-cms": "^1.0.1",
+    "netlify-identity-widget": "^1.4.11"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -1,4 +1,8 @@
 /* eslint-disable no-unused-vars */
-import React from "react"
+/* eslint-env browser */
 import CMS from "netlify-cms"
 import "netlify-cms/dist/cms.css"
+import netlifyIdentityWidget from "netlify-identity-widget"
+
+window.netlifyIdentity = netlifyIdentityWidget
+netlifyIdentityWidget.init()

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-browser.js
@@ -1,0 +1,12 @@
+import netlifyIdentityWidget from "netlify-identity-widget"
+
+exports.onInitialClientRender = () => {
+  netlifyIdentityWidget.on(`init`, user => {
+    if (!user) {
+      netlifyIdentityWidget.on(`login`, () => {
+        document.location.href = `/admin/`
+      })
+    }
+  })
+  netlifyIdentityWidget.init()
+}

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -1,5 +1,4 @@
 const HtmlWebpackPlugin = require(`html-webpack-plugin`)
-const HtmlWebpackIncludeAssetsPlugin = require(`html-webpack-include-assets-plugin`)
 const ExtractTextPlugin = require(`extract-text-webpack-plugin`)
 
 function plugins(stage) {
@@ -9,13 +8,6 @@ function plugins(stage) {
       title: `Content Manager`,
       filename: `admin/index.html`,
       chunks: [`cms`],
-    }),
-
-    // Include the identity widget script in the html file
-    new HtmlWebpackIncludeAssetsPlugin({
-      assets: [`https://identity.netlify.com/v1/netlify-identity-widget.js`],
-      append: false,
-      publicPath: false,
     }),
   ]
 
@@ -68,13 +60,10 @@ function module(config, stage) {
   }
 }
 
-exports.modifyWebpackConfig = (
-  { config, stage },
-  { modulePath = `${__dirname}/cms.js` }
-) => {
+exports.modifyWebpackConfig = ({ config, stage }, { modulePath }) => {
   config.merge({
     entry: {
-      cms: modulePath,
+      cms: [`${__dirname}/cms.js`, modulePath].filter(p => p),
     },
     plugins: plugins(stage),
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8736,6 +8736,10 @@ netlify-cms@^1.0.1:
   optionalDependencies:
     fsevents "^1.0.14"
 
+netlify-identity-widget@^1.4.11:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/netlify-identity-widget/-/netlify-identity-widget-1.4.11.tgz#27fbea5302cd1a360547570ddc855fd0cb528e5a"
+
 netrc@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"


### PR DESCRIPTION
This updates the plugin to handle git-gateway/Netlify Identity auth handling across the site.

Fixes the confusion exemplified in https://github.com/netlify/netlify-cms/issues/1108.