### PR TITLE
Allow emotion@9 as a peer dependency

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -21,8 +21,8 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "emotion": "7 || 8 ",
-    "emotion-server": "7 || 8",
+    "emotion": "7 || 8 || 9",
+    "emotion-server": "7 || 8 || 9",
     "gatsby": "^1.0.0"
   },
   "repository": {


### PR DESCRIPTION
`emotion` version 9 is out and the APIs that `gatsby-plugin-emotion` uses haven't changed at all. I verified that this plugin still works correctly in my own site. This update just removes the warning about incompatible versions, since they're not actually incompatible.