### PR TITLE
Validate that page context fields don't conflict with core page fields fixes #4163

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
@@ -6,6 +6,26 @@ exports[`Add pages Fails if path is missing 1`] = `"The plugin \\"test\\" must s
 
 exports[`Add pages Fails if the component path isn't absolute 1`] = `"The plugin \\"test\\" must set the absolute path to the page component when create creating a page"`;
 
+exports[`Add pages Fails if use a reserved field in the context object 1`] = `
+"You used reserved field names in the context object when creating a page:
+
+\\"path\\", \\"matchPath\\"
+
+{
+    \\"component\\": \\"/path/to/file1.js\\",
+    \\"path\\": \\"/yo/\\",
+    \\"context\\": {
+        \\"path\\": \\"/yo/\\",
+        \\"matchPath\\": \\"/pizz*\\"
+    }
+}
+
+Replace your invalid field names with ones not on the list of reserved field names:
+
+\\"path\\", \\"matchPath\\", \\"component\\", \\"componentChunkName\\", \\"pluginCreator___NODE\\", \\"pluginCreatorName\\"
+            "
+`;
+
 exports[`Add pages allows you to add multiple pages 1`] = `
 Array [
   Object {

--- a/packages/gatsby/src/redux/__tests__/pages.js
+++ b/packages/gatsby/src/redux/__tests__/pages.js
@@ -70,6 +70,22 @@ describe(`Add pages`, () => {
     expect(action).toMatchSnapshot()
   })
 
+  it(`Fails if use a reserved field in the context object`, () => {
+    const { actions } = require(`../actions`)
+    const action = actions.createPage(
+      {
+        component: `/path/to/file1.js`,
+        path: `/yo/`,
+        context: {
+          path: `/yo/`,
+          matchPath: `/pizz*`,
+        },
+      },
+      { id: `test`, name: `test` }
+    )
+    expect(action).toMatchSnapshot()
+  })
+
   it(`adds an initial forward slash if the user doesn't`, () => {
     const { actions } = require(`../actions`)
     const action = actions.createPage(

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -4,6 +4,7 @@ import chalk from "chalk"
 const _ = require(`lodash`)
 const { bindActionCreators } = require(`redux`)
 const { stripIndent } = require(`common-tags`)
+const report = require(`gatsby-cli/lib/reporter`)
 const glob = require(`glob`)
 const path = require(`path`)
 const fs = require(`fs`)
@@ -117,6 +118,37 @@ actions.createPage = (page: PageInput, plugin?: Plugin, traceId?: string) => {
       return message
     }
     noPageOrComponent = true
+  }
+
+  // Validate that the context object doesn't overlap with any core page fields
+  // as this will cause trouble when running graphql queries.
+  if (_.isObject(page.context)) {
+    const reservedFields = [
+      `path`,
+      `matchPath`,
+      `component`,
+      `componentChunkName`,
+      `pluginCreator___NODE`,
+      `pluginCreatorName`,
+    ]
+    const invalidFields = Object.keys(_.pick(page.context, reservedFields))
+
+    const singularMessage = `You used a reserved field name in the context object when creating a page:`
+    const pluralMessage = `You used reserved field names in the context object when creating a page:`
+    if (invalidFields.length > 0) {
+      report.panic(`${
+        invalidFields.length === 1 ? singularMessage : pluralMessage
+      }
+
+${invalidFields.map(f => `"${f}"`).join(`, `)}
+
+${JSON.stringify(page, null, 4)}
+
+Replace your invalid field names with ones not on the list of reserved field names:
+
+${reservedFields.map(f => `"${f}"`).join(`, `)}
+            `)
+    }
   }
 
   // Don't check if the component exists during tests as we use a lot of fake

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -136,7 +136,7 @@ actions.createPage = (page: PageInput, plugin?: Plugin, traceId?: string) => {
     const singularMessage = `You used a reserved field name in the context object when creating a page:`
     const pluralMessage = `You used reserved field names in the context object when creating a page:`
     if (invalidFields.length > 0) {
-      report.panic(`${
+      const error = `${
         invalidFields.length === 1 ? singularMessage : pluralMessage
       }
 
@@ -147,7 +147,12 @@ ${JSON.stringify(page, null, 4)}
 Replace your invalid field names with ones not on the list of reserved field names:
 
 ${reservedFields.map(f => `"${f}"`).join(`, `)}
-            `)
+            `
+      if (process.env.NODE_ENV === `test`) {
+        return error
+      } else {
+        report.panic(error)
+      }
     }
   }
 


### PR DESCRIPTION
We merge the page object and the page.context object as the "context" when running graphql queries.

If a user sets a context field that matches a core one, this can cause subtle & weird bugs e.g. #4163 where it broke hot reloading of a markdown file.

This PR adds validation for the field names in a page context and panics if there's a conflict.