### PR TITLE
Fix small typo in index.js

### DIFF
--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -53,7 +53,7 @@ class IndexRoute extends React.Component {
                   Enjoy the power of the latest web technologies –{` `}
                   <TechWithIcon icon={ReactJSIcon}>React.js</TechWithIcon>,{` `}
                   <TechWithIcon icon={WebpackIcon}>Webpack</TechWithIcon>,{` `}
-                  modern JavaScript and CSS and more — all setup and waiting for
+                  modern JavaScript and CSS and more — all set up and waiting for
                   you to start building.
                 </FuturaParagraph>
               </Card>


### PR DESCRIPTION
Hello:

I noticed that there was a small typo in `index.js`: in the first paragraph, `setup` should instead be `set up`.