### PR TITLE
Add babelrc to gatsby-plugin-netlify-cms to stop Uglify failure

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/.babelrc
+++ b/packages/gatsby-plugin-netlify-cms/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    ["../../.babelrc.js", { "browser": true }]
+  ]
+}
+


### PR DESCRIPTION
Stops UglifyJS failing at build

As per https://github.com/gatsbyjs/gatsby/issues/4227