### PR TITLE
limit node tracking to explicitly defined paths

### DIFF
--- a/packages/gatsby/src/schema/__tests__/node-tracking-test.js
+++ b/packages/gatsby/src/schema/__tests__/node-tracking-test.js
@@ -28,7 +28,7 @@ describe(`Track root nodes`, () => {
   require(`fs`).__setMockFiles(MOCK_FILE_INFO)
 
   const { getNode, getNodes } = require(`../../redux`)
-  const { findRootNode } = require(`../node-tracking`)
+  const { findRootNode, registerTrackedPath } = require(`../node-tracking`)
   const runSift = require(`../run-sift`)
   const buildNodeTypes = require(`../build-node-types`)
   const { boundActionCreators: { createNode } } = require(`../../redux/actions`)
@@ -51,6 +51,9 @@ describe(`Track root nodes`, () => {
       name: `test`,
     }
   )
+
+  registerTrackedPath(`TestNode`, `inlineObject.field`)
+  registerTrackedPath(`TestNode`, `inlineArray`)
 
   describe(`Tracks nodes read from redux state cache`, () => {
     it(`Tracks inline objects`, () => {

--- a/packages/gatsby/src/schema/node-tracking.js
+++ b/packages/gatsby/src/schema/node-tracking.js
@@ -8,20 +8,37 @@ const { getNode, getNodes } = require(`../redux`)
  */
 const rootNodeMap = new WeakMap()
 
+const trackedPaths = new Map()
+
+const registerTrackedPath = (type, path) => {
+  if (trackedPaths.has(type)) {
+    trackedPaths.get(type).add(path)
+  } else {
+    trackedPaths.set(type, new Set([path]))
+  }
+
+  getNodes()
+    .filter(node => node.internal.type === type)
+    .forEach(node => trackInlineObjectInRootNodeByPath(node, path))
+}
+
+exports.registerTrackedPath = registerTrackedPath
+
 const getRootNodeId = node => rootNodeMap.get(node)
 
-/**
- * Add link between passed data and Node. This function shouldn't be used
- * directly. Use higher level `trackInlineObjectsInRootNode`
- * @see trackInlineObjectsInRootNode
- * @param {(Object|Array)} data Inline object or array
- * @param {string} nodeId Id of node that contains data passed in first parameter
- */
-const addRootNodeToInlineObject = (data, nodeId) => {
-  if (_.isPlainObject(data) || _.isArray(data)) {
-    _.each(data, o => addRootNodeToInlineObject(o, nodeId))
-    rootNodeMap.set(data, nodeId)
-  }
+const trackInlineObjectInRootNodeByPath = (node, path) => {
+  const selector = path.split(`.`)
+  const parents = new Set()
+  getValuesFromSelector({
+    object: node,
+    selector,
+    parents,
+  })
+  parents.forEach(parent => {
+    if (node !== parent && !rootNodeMap.has(parent)) {
+      rootNodeMap.set(parent, node.id)
+    }
+  })
 }
 
 /**
@@ -29,26 +46,17 @@ const addRootNodeToInlineObject = (data, nodeId) => {
  * and that Node object.
  * @param {Node} node Root Node
  */
-// const nodeDigestTracked = new Set()
 const trackInlineObjectsInRootNode = node => {
-  // const id =
-  // node && node.internal && node.internal.contentDigest
-  // ? node.internal.contentDigest
-  // : node.id
-  // if (nodeDigestTracked.has(id)) {
-  // return node
-  // }
-
-  _.each(node, (v, k) => {
-    // Ignore the node internal object.
-    if (k === `internal`) {
-      return
-    }
-    addRootNodeToInlineObject(v, node.id)
-  })
-
-  // nodeDigestTracked.add(id)
-  return node
+  if (
+    node &&
+    node.internal &&
+    node.internal.type &&
+    trackedPaths.has(node.internal.type)
+  ) {
+    trackedPaths.get(node.internal.type).forEach(path => {
+      trackInlineObjectInRootNodeByPath(node, path)
+    })
+  }
 }
 exports.trackInlineObjectsInRootNode = trackInlineObjectsInRootNode
 
@@ -135,8 +143,3 @@ const getValuesFromSelector = ({
 }
 
 exports.getValuesFromPath = getValuesFromPath
-
-// Track nodes that are already in store
-_.each(getNodes(), node => {
-  trackInlineObjectsInRootNode(node)
-})

--- a/packages/gatsby/src/schema/node-tracking.js
+++ b/packages/gatsby/src/schema/node-tracking.js
@@ -86,6 +86,56 @@ function findRootNode(obj) {
 
 exports.findRootNode = findRootNode
 
+const getValuesFromPath = (object, path) => {
+  const results = []
+  getValuesFromSelector({ object, results, selector: path.split(`.`) })
+  return results
+}
+
+const getValuesFromSelector = ({
+  object,
+  selector,
+  results = null,
+  parents = null,
+  index = 0,
+  value = null,
+}) => {
+  if (!value) {
+    const key = selector[index]
+    value = object[key]
+  }
+
+  if (_.isArray(value)) {
+    value.forEach(item => {
+      getValuesFromSelector({
+        value: item,
+        selector,
+        results,
+        object: value,
+        parents,
+        index,
+      })
+    })
+  } else if (selector.length === index + 1) {
+    if (parents) {
+      parents.add(object)
+    }
+    if (results) {
+      results.push(value)
+    }
+  } else if (_.isPlainObject(value)) {
+    getValuesFromSelector({
+      object: value,
+      selector,
+      results,
+      parents,
+      index: index + 1,
+    })
+  }
+}
+
+exports.getValuesFromPath = getValuesFromPath
+
 // Track nodes that are already in store
 _.each(getNodes(), node => {
   trackInlineObjectsInRootNode(node)

--- a/packages/gatsby/src/schema/types/type-file.js
+++ b/packages/gatsby/src/schema/types/type-file.js
@@ -7,7 +7,11 @@ const normalize = require(`normalize-path`)
 const systemPath = require(`path`)
 
 const { getNodes } = require(`../../redux`)
-const { findRootNode, getValuesFromPath } = require(`../node-tracking`)
+const {
+  findRootNode,
+  getValuesFromPath,
+  registerTrackedPath,
+} = require(`../node-tracking`)
 const {
   createPageDependency,
 } = require(`../../redux/actions/add-page-dependency`)
@@ -59,6 +63,9 @@ function pointsToFile(nodes, key, value) {
   const otherFileExists = getNodes().some(
     n => n.absolutePath === pathToOtherNode
   )
+  if (otherFileExists) {
+    registerTrackedPath(nodes[0].internal.type, key)
+  }
   return otherFileExists
 }
 

--- a/packages/gatsby/src/schema/types/type-file.js
+++ b/packages/gatsby/src/schema/types/type-file.js
@@ -7,7 +7,7 @@ const normalize = require(`normalize-path`)
 const systemPath = require(`path`)
 
 const { getNodes } = require(`../../redux`)
-const { findRootNode } = require(`../node-tracking`)
+const { findRootNode, getValuesFromPath } = require(`../node-tracking`)
 const {
   createPageDependency,
 } = require(`../../redux/actions/add-page-dependency`)
@@ -39,64 +39,12 @@ function pointsToFile(nodes, key, value) {
   }
 
   // Find the node used for this example.
-  let node = nodes.find(n => _.get(n, key) === value)
+  let node = nodes.find(
+    node => getValuesFromPath(node, key).indexOf(value) !== -1
+  )
 
   if (!node) {
-    // Try another search as our "key" isn't always correct e.g.
-    // it doesn't support arrays so the right key could be "a.b[0].c" but
-    // this function will get "a.b.c".
-    //
-    // We loop through every value of nodes until we find
-    // a match.
-    const visit = (current, selector = [], fn) => {
-      for (let i = 0, keys = Object.keys(current); i < keys.length; i++) {
-        const key = keys[i]
-        const value = current[key]
-
-        if (value === undefined || value === null) continue
-
-        if (typeof value === `object` || typeof value === `function`) {
-          visit(current[key], selector.concat([key]), fn)
-          continue
-        }
-
-        let proceed = fn(current[key], key, selector, current)
-
-        if (proceed === false) {
-          break
-        }
-      }
-    }
-
-    const isNormalInteger = str => /^\+?(0|[1-9]\d*)$/.test(str)
-
-    node = nodes.find(n => {
-      let isMatch = false
-      visit(n, [], (v, k, selector, parent) => {
-        if (v === value) {
-          // Remove integers as they're for arrays, which our passed
-          // in object path doesn't have.
-          const normalizedSelector = selector
-            .map(s => (isNormalInteger(s) ? `` : s))
-            .filter(s => s !== ``)
-          const fullSelector = `${normalizedSelector.join(`.`)}.${k}`
-          if (fullSelector === key) {
-            isMatch = true
-            return false
-          }
-        }
-
-        // Not a match so we continue
-        return true
-      })
-
-      return isMatch
-    })
-
-    // Still no node.
-    if (!node) {
-      return false
-    }
+    return false
   }
 
   const rootNode = findRootNode(node)
@@ -123,7 +71,7 @@ export function shouldInfer(nodes, selector, value) {
       (_.isArray(value) &&
         _.isString(value[0]) &&
         !_.isEmpty(value[0]) &&
-        pointsToFile(nodes, `${selector}[0]`, value[0])))
+        pointsToFile(nodes, selector, value[0])))
   )
 }
 


### PR DESCRIPTION
This remove tracking of all objects in nodes by default and add tracking only to objects/arrays that actually need it. This is only used when resolving `File` nodes that were inferred from local paths.

I'm not sure how much performance will be gained from it after previous speedup PRs (if it's worth to complicate code base with it) - any tips on reliable A/B performance testing?

This will need updated/added jsdocs if there will be actual performance gain.