### PR TITLE
[gatsby-plugin-styletron] pass options to styletron constructor

### DIFF
--- a/packages/gatsby-plugin-styletron/README.md
+++ b/packages/gatsby-plugin-styletron/README.md
@@ -18,6 +18,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-styletron',
       options: {
+        // You can pass options to Styletron.
         prefix: '_',
       },
     },

--- a/packages/gatsby-plugin-styletron/README.md
+++ b/packages/gatsby-plugin-styletron/README.md
@@ -13,5 +13,12 @@ rendering support.
 Edit `gatsby-config.js`
 
 ```javascript
-plugins: [`gatsby-plugin-styletron`];
+plugins: [
+  {
+    resolve: 'gatsby-plugin-styletron',
+    options: {
+      prefix: '_',
+    },
+  },
+];
 ```

--- a/packages/gatsby-plugin-styletron/README.md
+++ b/packages/gatsby-plugin-styletron/README.md
@@ -13,12 +13,14 @@ rendering support.
 Edit `gatsby-config.js`
 
 ```javascript
-plugins: [
-  {
-    resolve: 'gatsby-plugin-styletron',
-    options: {
-      prefix: '_',
+module.exports = {
+  plugins: [ 
+    {
+      resolve: 'gatsby-plugin-styletron',
+      options: {
+        prefix: '_',
+      },
     },
-  },
-];
+  ],
+};
 ```

--- a/packages/gatsby-plugin-styletron/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-styletron/src/gatsby-browser.js
@@ -2,9 +2,9 @@ const React = require(`react`)
 const Styletron = require(`styletron-client`)
 const { StyletronProvider } = require(`styletron-react`)
 
-exports.wrapRootComponent = ({ Root }) => () => {
+exports.wrapRootComponent = ({ Root }, options) => () => {
   const styleElements = document.getElementsByClassName(`_styletron_hydrate_`)
-  const styletron = new Styletron(styleElements)
+  const styletron = new Styletron(styleElements, options)
   return (
     <StyletronProvider styletron={styletron}>
       <Root />


### PR DESCRIPTION
hiya,

I stumbled upon this issue in Styletron, where after so many selectors are keyed, it eventually uses the string `ad` as a class name, which become subject to removal by ad blockers:

https://github.com/rtsao/styletron/issues/139

A decent solution which I wanted to implement, as suggested by rtsao, was to pass the `prefix` option with a value of `_`, to prefix keys with an underscore, therefore it wouldn't get removed by the ad blocker.

However, the gatsby plugin doesn't pass `options`. This PR lets you pass it now, so `prefix` can be used. I feel like maybe this should also be the default. Thoughts?