### PR TITLE
Only warn about passing duplicate data to context if the data is the same as on the page object

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
@@ -7,7 +7,7 @@ exports[`Add pages Fails if path is missing 1`] = `"The plugin \\"test\\" must s
 exports[`Add pages Fails if the component path isn't absolute 1`] = `"The plugin \\"test\\" must set the absolute path to the page component when create creating a page"`;
 
 exports[`Add pages Fails if use a reserved field in the context object 1`] = `
-"You used reserved field names in the context object when creating a page:
+"The plugin \\"test\\" used reserved field names in the context object when creating a page:
 
   * \\"path\\"
   * \\"matchPath\\"

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
@@ -25,13 +25,15 @@ Data in \\"context\\" is passed to GraphQL as potential arguments when running t
 page query.
 
 When arguments for GraphQL are constructed, the context object is combined with
-the page object so both page object and context data are available as
-arguments. If a context field duplicates a field already used by the page
-object, this can break functionality within Gatsby so must be avoided.
+the page object so *both* page object and context data are available as
+arguments. So you don't need to add the page \\"path\\" to the context as it's
+already available in GraphQL. If a context field duplicates a field already
+used by the page object, this can break functionality within Gatsby so must be
+avoided.
 
 Please choose another name for the conflicting fields.
 
-The following fields are used by the page object and must be avoided.
+The following fields are used by the page object and should be avoided.
 
   * \\"path\\"
   * \\"matchPath\\"

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -101,6 +101,7 @@ const pascalCase = _.flow(_.camelCase, _.upperFirst)
  *   },
  * })
  */
+const hasWarnedForPageComponent = new Set()
 actions.createPage = (page: PageInput, plugin?: Plugin, traceId?: string) => {
   let noPageOrComponent = false
   let name = `The plugin "${plugin.name}"`
@@ -148,21 +149,31 @@ Data in "context" is passed to GraphQL as potential arguments when running the
 page query.
 
 When arguments for GraphQL are constructed, the context object is combined with
-the page object so both page object and context data are available as
-arguments. If a context field duplicates a field already used by the page
-object, this can break functionality within Gatsby so must be avoided.
+the page object so *both* page object and context data are available as
+arguments. So you don't need to add the page "path" to the context as it's
+already available in GraphQL. If a context field duplicates a field already
+used by the page object, this can break functionality within Gatsby so must be
+avoided.
 
 Please choose another name for the conflicting fields.
 
-The following fields are used by the page object and must be avoided.
+The following fields are used by the page object and should be avoided.
 
 ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
 
             `
       if (process.env.NODE_ENV === `test`) {
         return error
-      } else {
+        // Only error if the context version is different than the page
+        // version.  People in v1 often thought that they needed to also pass
+        // the path to context for it to be available in GraphQL
+      } else if (invalidFields.some(f => page.context[f] !== page[f])) {
         report.panic(error)
+      } else {
+        if (!hasWarnedForPageComponent.has(page.component)) {
+          report.warn(error)
+          hasWarnedForPageComponent.add(page.component)
+        }
       }
     }
   }

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -134,8 +134,8 @@ actions.createPage = (page: PageInput, plugin?: Plugin, traceId?: string) => {
     ]
     const invalidFields = Object.keys(_.pick(page.context, reservedFields))
 
-    const singularMessage = `You used a reserved field name in the context object when creating a page:`
-    const pluralMessage = `You used reserved field names in the context object when creating a page:`
+    const singularMessage = `${name} used a reserved field name in the context object when creating a page:`
+    const pluralMessage = `${name} used reserved field names in the context object when creating a page:`
     if (invalidFields.length > 0) {
       const error = `${
         invalidFields.length === 1 ? singularMessage : pluralMessage


### PR DESCRIPTION
Passing "path" in the context is for some reason way more common than I thought so
erroring on this validation is causing confusion e.g. https://spectrum.chat/thread/37d73127-6577-4758-9462-581c2af6cdb8