### PR TITLE
Update sharp and revert smartcrop bug workaround

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -17,7 +17,7 @@
     "potrace": "^2.1.1",
     "probe-image-size": "^3.2.0",
     "progress": "^1.1.8",
-    "sharp": "^0.19.0",
+    "sharp": "^0.19.1",
     "svgo": "^0.7.2"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -60,18 +60,6 @@ const reportError = (message, err, reporter) => {
   }
 }
 
-// Sharp sometimes will throw error when image is just scaled (not cropped)
-// and using crop "attention" or "entropy" strategy.
-// https://github.com/lovell/sharp/issues/1134
-// As a workaround use "center" crop strategy if we are scaling and one of
-// propblematic crop strategy is used.
-const validateCropFocus = options =>
-  (!options.width || !options.height) &&
-  (options.cropFocus === sharp.strategy.entropy ||
-    options.cropFocus === sharp.strategy.attention)
-    ? sharp.gravity.center
-    : options.cropFocus
-
 let totalJobs = 0
 const processFile = (file, jobs, cb, reporter) => {
   // console.log("totalJobs", totalJobs)
@@ -108,7 +96,7 @@ const processFile = (file, jobs, cb, reporter) => {
     const roundedWidth = Math.round(args.width)
     clonedPipeline
       .resize(roundedWidth, roundedHeight)
-      .crop(validateCropFocus(args))
+      .crop(args.cropFocus)
       .png({
         compressionLevel: args.pngCompressionLevel,
         adaptiveFiltering: false,
@@ -394,7 +382,7 @@ async function notMemoizedbase64({ file, args = {}, reporter }) {
 
   pipeline
     .resize(options.width, options.height)
-    .crop(validateCropFocus(options))
+    .crop(options.cropFocus)
     .png({
       compressionLevel: options.pngCompressionLevel,
       adaptiveFiltering: false,
@@ -699,7 +687,7 @@ async function notMemoizedtraceSVG({ file, args, fileArgs, reporter }) {
 
   pipeline
     .resize(options.width, options.height)
-    .crop(validateCropFocus(options))
+    .crop(options.cropFocus)
     .png({
       compressionLevel: options.pngCompressionLevel,
       adaptiveFiltering: false,


### PR DESCRIPTION
Bug that we worked around was fixed upstream ( https://github.com/lovell/sharp/issues/1134 ) and we can remove that workaround ( https://github.com/gatsbyjs/gatsby/pull/4174 ) and bump sharp version