### PR TITLE
Use non-interactive docker login

### DIFF
--- a/scripts/www-graphql-docker-push.sh
+++ b/scripts/www-graphql-docker-push.sh
@@ -3,8 +3,6 @@
 # Path to here
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-docker version
-
 # Prepare
 echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 export REPO=mikeallanson/gatsby-graphql

--- a/scripts/www-graphql-docker-push.sh
+++ b/scripts/www-graphql-docker-push.sh
@@ -3,8 +3,10 @@
 # Path to here
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+docker version
+
 # Prepare
-docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 export REPO=mikeallanson/gatsby-graphql
 export TAG=latest
 


### PR DESCRIPTION
I'm not sure why this stopped working, but according to the docs this is the right way to do a non-interactive docker login. 

Refs #4263 