### PR TITLE
perf(image): reduce svgo precision for tracedSVGs

### DIFF
--- a/examples/gatsbygram/package.json
+++ b/examples/gatsbygram/package.json
@@ -6,7 +6,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "gatsby": "^1.9.52",
-    "gatsby-image": "^1.0.5",
+    "gatsby-image": "^1.0.39",
     "gatsby-link": "^1.6.20",
     "gatsby-plugin-glamor": "^1.6.8",
     "gatsby-plugin-google-analytics": "^1.0.8",

--- a/examples/gatsbygram/src/components/post.js
+++ b/examples/gatsbygram/src/components/post.js
@@ -2,6 +2,7 @@ import * as PropTypes from "prop-types"
 import React from "react"
 import HeartIcon from "react-icons/lib/fa/heart"
 import Link from "gatsby-link"
+import Img from "gatsby-image"
 
 import { rhythm, scale } from "../utils/typography"
 import presets from "../utils/presets"
@@ -42,7 +43,6 @@ class Post extends React.Component {
         }}
         css={{
           display: `block`,
-          backgroundColor: `lightgray`,
           flex: `1 0 0%`,
           marginRight: rhythm(1 / 8),
           width: `100%`,
@@ -61,14 +61,11 @@ class Post extends React.Component {
             flexDirection: `column`,
             flexShrink: 0,
             position: `relative`,
-            paddingBottom: `100%`,
             overflow: `hidden`,
           }}
         >
-          <img
-            src={small.src}
-            srcSet={small.srcSet}
-            sizes="(min-width: 960px) 292px, 33vw"
+          <Img
+            sizes={{ ...small }}
             css={{
               margin: 0,
               height: `100%`,
@@ -133,9 +130,12 @@ export const postFragment = graphql`
     likes
     smallImage: image {
       childImageSharp {
-        small: responsiveSizes(maxWidth: 292, maxHeight: 292) {
+        small: sizes(maxWidth: 292, maxHeight: 292) {
           src
           srcSet
+          aspectRatio
+          sizes
+          tracedSVG
         }
       }
     }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -757,7 +757,7 @@ function encodeOptimizedSVGDataUri(svgString) {
 
 const optimize = svg => {
   const SVGO = require(`svgo`)
-  const svgo = new SVGO({ multipass: true, floatPrecision: 1 })
+  const svgo = new SVGO({ multipass: true, floatPrecision: 0 })
   return new Promise((resolve, reject) => {
     svgo.optimize(svg, ({ data }) => resolve(data))
   })


### PR DESCRIPTION
While comparing initial html rendering results with different techniques, I found out traced SVG sizes can be reduced by the factor of ~2,2. It even increases the compression rate.

I tried several additional svgo settings but the only one with an higher reduction as 0.01% was to reduce the precision from 1 to 0

# Example

My example data is based on [gatsbygram](https://gatsbygram.netlify.com/) which contains 12 traced svg previews.

|Method|Real Size|Gzip Size|Compression Ratio|Size increase gz|
|---|---|---|---|---|
|original |  36.7 kB (36787B) |  10.1kB (10197B) | 360,7% | 100% |
|traced svg | 313.0kB (313018B)| 110.0kB (110078B) | 284,3%  | 1079,5% 😱|
|traced svg pr | 150.8kB (150898B)| 49.6kB (49639B) | 303,9%  | 486,80% 💪|

[Download index.html files of all tests](https://github.com/gatsbyjs/gatsby/files/1764643/gatsbygram-tracedsvg-example.zip)

[Compare to other initial rendering image preview techniques](https://github.com/gatsbyjs/gatsby/pull/4205#issuecomment-368348758)

## Original - 313.0kB
![_users_bene_dev_gatsby_examples_gatsbygram_index-traced-svg-original html ipad pro](https://user-images.githubusercontent.com/1737026/36753506-a61313c2-1c06-11e8-9058-5a6c79298e2b.png)

## Optimized - 150.8kB

![_users_bene_dev_gatsby_examples_gatsbygram_index-traced-svg-precision-0 html-no-option html ipad pro](https://user-images.githubusercontent.com/1737026/36753512-aa3cefea-1c06-11e8-87da-ac84fdf9e385.png)
