### PR TITLE
docs: improve documentation for plugin authors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Looking to speak about Gatsby? We'd love to review your talk abstract/CFP! You c
 
 ### Creating your own plugins and loaders
 
-If you create a loader or plugin, we would <3 for you to open source it, and put it on npm.
+If you create a loader or plugin, we would <3 for you to open source it, and put it on npm. For more information on creating custom plugins, please see the documentation for [plugins](/docs/plugins/) and the [API specification](/docs/api-specification/).
 
 ### Contributing to the repo
 

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -6,7 +6,7 @@ Creating custom plugins in Gatsby is a breeze with our straightforward authoring
 
 ## Core Concepts
 
-- Each Gatsby plugin can installed as an npm package or as a [local plugin](#local-plugins)
+- Each Gatsby plugin can be installed as an npm package or as a [local plugin](#local-plugins)
 - At minimum, a `package.json` is required
 - A plugin has access to the the Gatsby [Node](/docs/node-apis/), [SSR](/docs/ssr-apis/), and [browser](/docs/browser-apis/) APIs
 

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -17,6 +17,7 @@ There are four standard plugin naming conventions for Gatsby:
 
 - **`gatsby-source-*`** — a source plugin loads data from a given source (e.g. WordPress, MongoDB, the file system). Use this plugin type if you are connecting a new source of data to Gatsby.
   - Example: `gatsby-source-contentful`
+  - Docs: [create a source plugin](/docs/create-source-plugin/)
 - **`gatsby-transformer-*`** — a transformer plugin converts data from one format to another (e.g. CSV to JSON). Use this naming convention
   - Example: `gatsby-transformer-yaml`
 - **`gatsby-[plugin-name]-*`** — if a plugin is a plugin for another plugin 😅, it should be prefixed with the name of the plugin it extends (e.g. if it adds emoji to the output of `gatsby-transformer-remark`, call it `gatsby-remark-add-emoji`). Use this naming convention whenever your plugin will be included as a plugin in the `options` object of another plugin.
@@ -26,8 +27,14 @@ There are four standard plugin naming conventions for Gatsby:
 
 ## What files does Gatsby look for in a plugin?
 
-- `package.json` — [required] used to find the `name` and `version` fields (both optional)
-  - this can be an empty object (`{}`) for local plugins
+All files are optional unless specifically marked as required.
+
+- `package.json` — [required] this can be an empty object (`{}`) for local plugins
+    - `name` is used to identify the plugin when it mutates Gatsby’s GraphQL data structure
+        - if `name` isn’t set, the folder name for the plugin is used
+    - `version` is used to manage the cache — if it changes, the cache is cleared
+        - if `version` isn’t set, an MD5 hash of the `gatsby-*` file contents is used to invalidate the cache
+        - omitting the `version` field is recommended for local plugins
 - `gatsby-browser.js` — usage details are in the [browser API reference](/docs/browser-apis/)
 - `gatsby-node.js` — usage details are in the [Node API reference](/docs/node-apis/)
 - `gatsby-ssr.js` — usage details are in the [SSR API reference](/docs/ssr-apis/)
@@ -47,20 +54,7 @@ plugins
     └── package.json
 ```
 
-**NOTE:** You still need to add the plugin to your `gatsby-config.js` like for plugins
-installed from NPM.
-
-At a minimum, each plugin requires a package.json file, but the minimum content is just an
-empty object `{}`. The `name` and `version` fields are read from the package
-file. The name is used to identify the plugin when it mutates the GraphQL data
-structure. The version is used to clear the cache when it changes.
-
-For local plugins it is best to leave the version field empty. Gatsby will
-generate an md5-hash from all `gatsby-*` file contents and use that as the
-version. This way the cache is automatically flushed when you change the code of
-your plugin.
-
-If the name is empty it is inferred from the plugin folder name.
+**NOTE:** You still need to add the plugin to your `gatsby-config.js`. There is no auto-detection of local plugins.
 
 Like all `gatsby-*` files, the code is not being processed by Babel. If you want
 to use JavaScript syntax which isn't supported by your version of Node.js, you

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -2,7 +2,7 @@
 title: Plugin Authoring
 ---
 
-One of the best ways to add functionality to Gatsby is through our plugin system. Gatsby is designed to be extensible, which means plugins are able to modify and extend just about everything Gatsby does.
+One of the best ways to add functionality to Gatsby is through our plugin system. Gatsby is designed to be extensible, which means plugins are able to extend and modify just about everything Gatsby does.
 
 Of the many possibilities, plugins can:
 

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -14,22 +14,22 @@ Of the many possibilities, plugins can:
 ## Core Concepts
 
 - Each Gatsby plugin can be installed as an npm package or as a [local plugin](#local-plugins)
-- At minimum, a `package.json` is required
-- A plugin has access to the the Gatsby [Node](/docs/node-apis/), [SSR](/docs/ssr-apis/), and [browser](/docs/browser-apis/) APIs
+- A `package.json` is required
+- Plugin implement the Gatsby APIs for [Node](/docs/node-apis/), [server-side rendering](/docs/ssr-apis/), and the [browser](/docs/browser-apis/)
 
 ## Plugin naming conventions
 
 There are four standard plugin naming conventions for Gatsby:
 
 - **`gatsby-source-*`** — a source plugin loads data from a given source (e.g. WordPress, MongoDB, the file system). Use this plugin type if you are connecting a new source of data to Gatsby.
-  - Example: `gatsby-source-contentful`
+  - Example: [`gatsby-source-contentful`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful)
   - Docs: [create a source plugin](/docs/create-source-plugin/)
-- **`gatsby-transformer-*`** — a transformer plugin converts data from one format to another (e.g. CSV to JSON). Use this naming convention
-  - Example: `gatsby-transformer-yaml`
+- **`gatsby-transformer-*`** — a transformer plugin converts data from one format (e.g. CSV, YAML) to a JavaScript object. Use this naming convention if your plugin will be transforming data from one format to another.
+  - Example: [`gatsby-transformer-yaml`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml)
 - **`gatsby-[plugin-name]-*`** — if a plugin is a plugin for another plugin 😅, it should be prefixed with the name of the plugin it extends (e.g. if it adds emoji to the output of `gatsby-transformer-remark`, call it `gatsby-remark-add-emoji`). Use this naming convention whenever your plugin will be included as a plugin in the `options` object of another plugin.
-  - Example: `gatsby-remark-images`
+  - Example: [`gatsby-remark-images`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images)
 - **`gatsby-plugin-*`** — this is the most general plugin type. Use this naming convention if your plugin doesn’t meet the requirements of any other plugin types.
-  - Example: `gatsby-plugin-sass`
+  - Example: [`gatsby-plugin-sharp`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp)
 
 ## What files does Gatsby look for in a plugin?
 
@@ -47,12 +47,9 @@ All files are optional unless specifically marked as required.
 
 ## Local plugins
 
-When you want to work on a new plugin, or maybe write one that is only relevant
-to your specific use-case, a locally defined plugin is more convenient than
-having to create an NPM package for it.
+If a plugin is only relevant to your specific use-case, or if you’re developing a plugin and want a simpler workflow, a locally defined plugin is a convenient way to create and manage your plugin code.
 
-You can place the code in the `plugins` folder in the root of your project like
-this:
+Place the code in the `plugins` folder in the root of your project like this:
 
 ```
 plugins

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -1,0 +1,5 @@
+---
+title: Plugin Authoring
+---
+
+TKTK

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -2,7 +2,14 @@
 title: Plugin Authoring
 ---
 
-Creating custom plugins in Gatsby is a breeze with our straightforward authoring process.
+One of the best ways to add functionality to Gatsby is through our plugin system. Gatsby is designed to be extensible, which means plugins are able to modify and extend just about everything Gatsby does.
+
+Of the many possibilities, plugins can:
+
+- add external data or content (e.g. your CMS, static files, a REST API) to your Gatsby GraphQL data
+- transform data from other formats (e.g. YAML, CSV) to JSON objects
+- add third-party services (e.g. Google Analytics, Instagram) to your site
+- anything you can dream up!
 
 ## Core Concepts
 

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -6,9 +6,8 @@ Creating custom plugins in Gatsby is a breeze with our straightforward authoring
 
 ## Core Concepts
 
-- Every Gatsby plugin is a standalone npm package
+- Each Gatsby plugin can installed as an npm package or as a [local plugin](#local-plugins)
 - At minimum, a `package.json` is required
-- Plugins can be used locally (see [local plugins](#local-plugins) below) or published to npm as packages
 - A plugin has access to the the Gatsby [Node](/docs/node-apis/), [SSR](/docs/ssr-apis/), and [browser](/docs/browser-apis/) APIs
 
 ## Plugin naming conventions

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -13,7 +13,7 @@ Of the many possibilities, plugins can:
 
 ## Core Concepts
 
-- Each Gatsby plugin can be installed as an npm package or as a [local plugin](#local-plugins)
+- Each Gatsby plugin can be created as an npm package or as a [local plugin](#local-plugins)
 - A `package.json` is required
 - Plugin implement the Gatsby APIs for [Node](/docs/node-apis/), [server-side rendering](/docs/ssr-apis/), and the [browser](/docs/browser-apis/)
 
@@ -59,7 +59,7 @@ plugins
 
 **NOTE:** You still need to add the plugin to your `gatsby-config.js`. There is no auto-detection of local plugins.
 
-Like all `gatsby-*` files, the code is not being processed by Babel. If you want
+Like all `gatsby-*` files, the code is not processed by Babel. If you want
 to use JavaScript syntax which isn't supported by your version of Node.js, you
 can place the files in a `src` subfolder and build them to the plugin folder
 root.

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -2,4 +2,67 @@
 title: Plugin Authoring
 ---
 
-TKTK
+Creating custom plugins in Gatsby is a breeze with our straightforward authoring process.
+
+## Core Concepts
+
+- Every Gatsby plugin is a standalone npm package
+- At minimum, a `package.json` is required
+- Plugins can be used locally (see [local plugins](#local-plugins) below) or published to npm as packages
+- A plugin has access to the the Gatsby [Node](/docs/node-apis/), [SSR](/docs/ssr-apis/), and [browser](/docs/browser-apis/) APIs
+
+## Plugin naming conventions
+
+There are four standard plugin naming conventions for Gatsby:
+
+- **`gatsby-source-*`** — a source plugin loads data from a given source (e.g. WordPress, MongoDB, the file system). Use this plugin type if you are connecting a new source of data to Gatsby.
+  - Example: `gatsby-source-contentful`
+- **`gatsby-transformer-*`** — a transformer plugin converts data from one format to another (e.g. CSV to JSON). Use this naming convention
+  - Example: `gatsby-transformer-yaml`
+- **`gatsby-[plugin-name]-*`** — if a plugin is a plugin for another plugin 😅, it should be prefixed with the name of the plugin it extends (e.g. if it adds emoji to the output of `gatsby-transformer-remark`, call it `gatsby-remark-add-emoji`). Use this naming convention whenever your plugin will be included as a plugin in the `options` object of another plugin.
+  - Example: `gatsby-remark-images`
+- **`gatsby-plugin-*`** — this is the most general plugin type. Use this naming convention if your plugin doesn’t meet the requirements of any other plugin types.
+  - Example: `gatsby-plugin-sass`
+
+## What files does Gatsby look for in a plugin?
+
+- `package.json` — [required] used to find the `name` and `version` fields (both optional)
+  - this can be an empty object (`{}`) for local plugins
+- `gatsby-browser.js` — usage details are in the [browser API reference](/docs/browser-apis/)
+- `gatsby-node.js` — usage details are in the [Node API reference](/docs/node-apis/)
+- `gatsby-ssr.js` — usage details are in the [SSR API reference](/docs/ssr-apis/)
+
+## Local plugins
+
+When you want to work on a new plugin, or maybe write one that is only relevant
+to your specific use-case, a locally defined plugin is more convenient than
+having to create an NPM package for it.
+
+You can place the code in the `plugins` folder in the root of your project like
+this:
+
+```
+plugins
+└── my-own-plugin
+    └── package.json
+```
+
+**NOTE:** You still need to add the plugin to your `gatsby-config.js` like for plugins
+installed from NPM.
+
+At a minimum, each plugin requires a package.json file, but the minimum content is just an
+empty object `{}`. The `name` and `version` fields are read from the package
+file. The name is used to identify the plugin when it mutates the GraphQL data
+structure. The version is used to clear the cache when it changes.
+
+For local plugins it is best to leave the version field empty. Gatsby will
+generate an md5-hash from all `gatsby-*` file contents and use that as the
+version. This way the cache is automatically flushed when you change the code of
+your plugin.
+
+If the name is empty it is inferred from the plugin folder name.
+
+Like all `gatsby-*` files, the code is not being processed by Babel. If you want
+to use JavaScript syntax which isn't supported by your version of Node.js, you
+can place the files in a `src` subfolder and build them to the plugin folder
+root.

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -40,41 +40,9 @@ Plugins can take options. Note that plugin options will be stringified by Gatsby
 See each plugin page below for more detailed
 documentation on using each plugin.
 
-## Locally defined plugins
+## Creating your own plugins
 
-When you want to work on a new plugin, or maybe write one that is only relevant
-to your specific use-case, a locally defined plugin is more convenient than
-having to create an NPM package for it.
-
-You can place the code in the `plugins` folder in the root of your project like
-this:
-
-```
-plugins
-└── my-own-plugin
-    ├── gatsby-node.js
-    └── package.json
-```
-
-You still need to add the plugin to your `gatsby-config.js` like for plugins
-installed from NPM.
-
-Each plugin requires a package.json file, but the minimum content is just an
-empty object `{}`. The `name` and `version` fields are read from the package
-file. The name is used to identify the plugin when it mutates the GraphQL data
-structure. The version is used to clear the cache when it changes.
-
-For local plugins it is best to leave the version field empty. Gatsby will
-generate an md5-hash from all gatsby-\* file contents and use that as the
-version. This way the cache is automatically flushed when you change the code of
-your plugin.
-
-If the name is empty it is inferred from the plugin folder name.
-
-Like all gatsby-\* files, the code is not being processed by Babel. If you want
-to use JavaScript syntax which isn't supported by your version of Node.js, you
-can place the files in a `src` subfolder and build them to the plugin folder
-root.
+If you’d like to create a custom Gatsby plugin, check out the [plugin authoring guide](/docs/plugin-authoring/).
 
 ## Official plugins
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -37,14 +37,13 @@ module.exports = {
 
 Plugins can take options. Note that plugin options will be stringified by Gatsby, so they cannot be functions.
 
-See each plugin page below for more detailed
-documentation on using each plugin.
-
 ## Creating your own plugins
 
 If you’d like to create a custom Gatsby plugin, check out the [plugin authoring guide](/docs/plugin-authoring/).
 
 ## Official plugins
+
+For usage instructions and options, see the plugin repo (linked below).
 
 * [gatsby-plugin-aphrodite](/packages/gatsby-plugin-aphrodite/)
 * [gatsby-plugin-canonical-urls](/packages/gatsby-plugin-canonical-urls/)

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -54,6 +54,8 @@
       link: /docs/migrating-from-v0-to-v1/
     - title: Path Prefix
       link: /docs/path-prefix/
+    - title: Plugin Authoring
+      link: /docs/plugin-authoring/
     - title: Proxying API Requests
       link: /docs/api-proxy/
     - title: Using CSS-in-JS library Glamor


### PR DESCRIPTION
Opening a PR early to allow feedback early and often.

## Goals for this PR:

- [x] Link to plugin docs from the "how to contribute" page
- [x] Link to API spec from the "how to contribute" page
- [x] Add a "Plugin authoring" page to the "Guides" section of the docs
- [x] Move local plugin info from core concepts to plugin authoring
- [x] Add link to core concepts plugin page to plugin authoring
- [x] Add naming convention docs to authoring page
- [x] Add a list of all files Gatsby looks for in a plugin (e.g. `gatsby-node.js`) to the authoring page
~- [ ] Add a boilerplate README for a Gatsby plugin to the authoring page~ (this was moved to #4284)

re #4266