### PR TITLE
Fix building on windows

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -181,8 +181,8 @@ module.exports = async (args: BootstrapArgs) => {
     if (env === `ssr` && plugin.skipSSR === true) return undefined
 
     const envAPIs = plugin[`${env}APIs`]
-    if (envAPIs && Array.isArray(envAPIs) && envAPIs.length > 0 ) {
-      return path.join(plugin.resolve, `gatsby-${env}.js`)
+    if (envAPIs && Array.isArray(envAPIs) && envAPIs.length > 0) {
+      return slash(path.join(plugin.resolve, `gatsby-${env}.js`))
     }
     return undefined
   }


### PR DESCRIPTION
This is fix for gatsby not building on windows after #3889 :

```
Error: Module not found: Error: Cannot resolve module 'E:LennartDocumentsGitHubgatsby-starter-portfolio-emma
  ode_modulesgatsby-plugin-react-helmetgatsby-ssr.js' in E:\Lennart\Documents\GitHub\gatsby-starter-portfolio-emma\.cache
  resolve module E:LennartDocumentsGitHubgatsby-starter-portfolio-emma
  ode_modulesgatsby-plugin-react-helmetgatsby-ssr.js in E:\Lennart\Documents\GitHub\gatsby-starter-portfolio-emma\.cache
    looking for modules in E:\Lennart\Documents\GitHub\gatsby-starter-portfolio-emma\node_modules
      E:\Lennart\Documents\GitHub\gatsby-starter-portfolio-emma\node_modules\E:LennartDocumentsGitHubgatsby-starter-portfolio-emma
  ode_modulesgatsby-plugin-react-helmetgatsby-ssr.js doesn't exist (module as directory)
```

Previous method ( this is change for context https://github.com/gatsbyjs/gatsby/pull/3889/files#diff-8c8b888e741f1c31e97d4bf05894f50dL178 ) would use path with `/` separators but `path` methods defaults to use `\` separator on windows and as we write path to a file with unescaped `\` this cause above problem.

Solution - use `slash` function/package on to convert backslashes to slashes - thanks @m-allanson for hint