### PR TITLE
fix: make sure innerGqConfig.type.getFields exists

### DIFF
--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -97,7 +97,9 @@ module.exports = ({
             if (
               _.isObject(innerSift) &&
               v != null &&
-              innerGqConfig.type.getFields
+              innerGqConfig &&
+              innerGqConfig.type &&
+              _.isFunction(innerGqConfig.type.getFields)
             ) {
               return resolveRecursive(
                 v,

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -94,7 +94,11 @@ module.exports = ({
           .then(v => {
             const innerSift = siftFieldsObj[k]
             const innerGqConfig = gqFields[k]
-            if (_.isObject(innerSift) && v != null) {
+            if (
+              _.isObject(innerSift) &&
+              v != null &&
+              innerGqConfig.type.getFields
+            ) {
               return resolveRecursive(
                 v,
                 innerSift,


### PR DESCRIPTION
I'm currently trying to migrate a wordpress frontend to gatsby, but this is impossible as I cannot filter posts by categories. #3401 has more details about the problem.

Not sure this is the best fix as I'm not familiar with internals. :-/

I followed the CONTRIBUTING guide to setup my local fork and test this change. I'm now able to move forward.