### PR TITLE
Encrypt env var correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
           if: (NOT type = pull_request) AND branch = master
           env:
             - DOCKER_USER=mikeallanson
-            - secure: J8daWiar248dPWwrutZd83CeSif/+rMjB9hSOjq0pQDNj7QcOKjUwLsv6yMDJAcQCAAyobwRQTNYANGXmvQsi5ZppZe/P/enDPD/ZEPz3XkvxYYbXC7TNKVp8bnvYTWu6qO9ljkMsKGttsqaz+MyTx2MjV9pJhkmw2rfQ5iVn/80bORaCCMDcSB2ud/jLN+AVBFNMDUVEL9RnAXTq+CyQmSLvlvmJNCu9CXnb/Kt+IcbqswTjre/V2lVkzcXEvUYd0F9la3bsGVVQ9vBd3IumSIGnSOxD91DLUOeuh5K7FJxPoqqwM+bCn4zZWtQMOGpPDoYYllVejFHC16g/FBa6uC455OvqeS6fSCRXr9bqDxDLPhn7IyDAuG2jXps++sbd2RA8eXq8IGA4AqtTf4smiIXbOu3p3d2n9ww4Z/NgRpLHYRFcVwjG92okVN4by7n1+kr7wGx+alCkHTMDrLkkeZ0AEJphaxAH+TxP+SvCFY1z/OyNM0YzICrLXjf2w60Xz4wE563yUM8OLFm4GbeM33eQYRErTLADG9JtGDev+L5tS/Vo8+KGkL3creY7f9BgsNyfxbQbv84X7f+vSPlzl6u8V9EuVA80+5hE7artRtM+BxiT5pGM1983+QK2CPv4EptMYRa0EjlVbxyrfVYF22lsAqqgVApZGGneUxB0cQ= # DOCKER_PASS
+            - secure: "oF3OuabOsUtqf1IIo/YQA/FzVzZOQFlNqGbnu7/KO5LugtMBkxDcrT9FA33LHn1kX2TsblOaMviY5ukTVIQIAFTcaqPmYzt8phCi3x6tugcT0bfYmTWIQZ/KsZFFufB8MiLFAgILpfhpooDPFhiRZMdv/NLlTPO50iAth6/WqfgMffvtU3xpWrqxLzvAJLw1Dgx0cDsw515FcMjy2QJHmwob3eb7/PTfd0qmpQlzrspvf7PxTfGd6mZDfXsaOnqHAH36oiXe5Hwhnfoz0oePeb7d36RY1/SUX7kYBhf/gWNcFMzERGGnFjbT5RtQPAViMjCpPuPI3RsytA1DdH/I/ykobQ0fx94Vr+R3xe4+gujYDkTRek6JvnS1gj2BxJ6J8rZHOJyI0WpGNORwkOwDla2KRuJZLWBaZ6MvDH+uWeRuEDZnSlqgNERWztLpCAjx8V+MdHbI/rG4OC2AanrgD3BabGm/YwBptfc0x+23ibSlez4LtJmozx6wOzYDXhqfvRk6pD4YhXc0XXUlwBqAymFszZY7yyDkdeN+2SgBBye+dSbDqS7X26r/tyT+0NrjQH+oUM5EeHL8mH2I5Tvwx3fgaK5d3Uuvaet49CROMKb+IcDnK5qZnaD3Oq6glDgAfINPXPT3ptVjQSCDenrUbRkNR3x3bgETCPRak4/x1nw=" # DOCKER_PASS
           before_install:
             - chmod +x scripts/www-graphql-docker-push.sh
           script:


### PR DESCRIPTION
This should fix the failing builds on master.

Travis' encrypted env vars are tied to individual repos. This env var
was originally encrypted through my forked copy of the Gatsby repo. The
test builds on my fork worked, but would then fail in the main Gatsby
repo.

See the [Travis docs encrypting env vars](https://docs.travis-ci.com/user/environment-variables#Defining-encrypted-variables-in-.travis.yml) for more info.

Closes #4263 