### PR TITLE
[gatsby] Compare location object instead of just pathname

### DIFF
--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -12,7 +12,7 @@ import history from "./history"
 window.___history = history
 import emitter from "./emitter"
 window.___emitter = emitter
-import { isEqual } from "lodash"
+import shallowCompare from "shallow-compare"
 import pages from "./pages.json"
 import redirects from "./redirects.json"
 import ComponentRenderer from "./component-renderer"
@@ -64,7 +64,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     }
 
     // If we're already at this location, do nothing.
-    if (isEqual(window.location, location)) {
+    if (shallowCompare(window.location, location)) {
       return
     }
 

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -12,6 +12,7 @@ import history from "./history"
 window.___history = history
 import emitter from "./emitter"
 window.___emitter = emitter
+import { isEqual } from "lodash"
 import pages from "./pages.json"
 import redirects from "./redirects.json"
 import ComponentRenderer from "./component-renderer"
@@ -62,8 +63,8 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       pathname = redirect.toPath
     }
 
-    // If we're already at this path, do nothing.
-    if (window.location.pathname === pathname) {
+    // If we're already at this location, do nothing.
+    if (isEqual(window.location, location)) {
       return
     }
 


### PR DESCRIPTION
re: https://github.com/gatsbyjs/gatsby/pull/3802 

This PR compares `window.location` and `location` objects instead of just their pathnames. 

Let me know if there is a better approach. Thanks!