### PR TITLE
Update api proxy example

### DIFF
--- a/docs/docs/api-proxy.md
+++ b/docs/docs/api-proxy.md
@@ -12,7 +12,7 @@ in development, add a `proxy` field to your `gatsby-config.js`, for example:
 module.exports = {
   proxy: {
     prefix: "/api",
-    url: "http://dev-mysite.com/api/",
+    url: "http://dev-mysite.com",
   },
 };
 ```


### PR DESCRIPTION
This tackles #4305. Otherwise the sample `fetch('/api/todos')` ends up in hitting dev-mysite.com with the path /api/api/todos.

Thank you.