### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ RUN cd www && yarn run build
 FROM node:8 as dist
 
 COPY --from=build /usr/src/app /usr/src/app
-WORKDIR /usr/src/app
+
+# Set cwd to www so that Gatsby's bootstrap can find www/gatsby-node.js
+WORKDIR /usr/src/app/www
+CMD [ "node","../scripts/www-data-explorer.js" ]
 
 # To run this image, set the port as an env var with `-e PORT=xxxx` e.g.
 # docker run -p 8080:8080 --rm -it -e PORT=8080 <registryUsername>/<imageName>
-CMD [ "node","./scripts/www-data-explorer.js" ]

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -331,7 +331,7 @@ module.exports = (
           await fsExtra.ensureDir(path.dirname(newFilePath))
           await fsExtra.copy(linkPath, newFilePath)
         } catch (err) {
-          console.error(`error copy ing file`, err)
+          console.error(`error copying file`, err)
         }
       }
     })


### PR DESCRIPTION
The makeshift bootstrap process in `scripts/www-data-explorer.js` needs the cwd to be the root of the Gatsby website.