### PR TITLE
Update downloads badge to point to graph of downloads over time 📈 instead of duplicating link to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Travis CI Build Status](https://travis-ci.org/gatsbyjs/gatsby.svg?branch=master)](https://travis-ci.org/gatsbyjs/gatsby)
 [![npm package](https://img.shields.io/npm/v/gatsby.svg?style=flat-square)](https://www.npmjs.org/package/gatsby)
-[![npm package](https://img.shields.io/npm/dm/gatsby.svg)](https://www.npmjs.org/package/gatsby)
+[![npm package](https://img.shields.io/npm/dm/gatsby.svg)](https://npmcharts.com/compare/gatsby?minimal=true)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/gatsby-js)
 [![gatsby channel on discord](https://img.shields.io/badge/discord-gatsby%40reactiflux-738bd7.svg?style=flat-square)](https://discord.gg/0ZcbPKXt5bVoxkfV)
 [![Open Source Helpers](https://www.codetriage.com/gatsbyjs/gatsby/badges/users.svg)](https://www.codetriage.com/gatsbyjs/gatsby)


### PR DESCRIPTION
Hi! I noticed that your "npm" badge and "downloads" badge currently both point to the same page for the project on npmjs.org  

I was wondering if you might prefer having the download badge point to a [download chart](https://npmcharts.com/compare/redux-form?minimal=true) instead?

If not, feel free to close and apologies for the drive-by PR 😄