### PR TITLE
Set valid defaults for noscript images

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -89,7 +89,7 @@ const isWebpSupported = () => {
 
 const noscriptImg = props => {
   const {
-    opacity = ``,
+    opacity = `1`,
     src,
     srcSet,
     sizes = ``,
@@ -97,9 +97,9 @@ const noscriptImg = props => {
     alt = ``,
     width = ``,
     height = ``,
-    transitionDelay = ``,
+    transitionDelay = `0.5s`,
   } = props
-  return `<img width=${width} height=${height} src="${src}" srcset="${srcSet}" alt="${alt}" title="${title}" sizes="${sizes}" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"/>`
+  return `<img width="${width}" height="${height}" src="${src}" srcset="${srcSet}" alt="${alt}" title="${title}" sizes="${sizes}" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"/>`
 }
 
 const Img = props => {


### PR DESCRIPTION
This should mean the <noscript> output from gatsby-image is valid HTML.

Closes #4317