### PR TITLE
Add documentation for createRemoteFileNode

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -117,30 +117,33 @@ exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
 
 ### createRemoteFileNode
 
-When working with remote files from a source such as headless CMS, you download them and create `File` nodes using `createRemoteFileNode`
+When building source plugins for remote data sources such as headless CMSs, their data will often link to files stored remotely that are often convenient to download so you can work with locally.
+
+The `createRemoteFileNode` helper makes it easy to download remote files and add them to your site's GraphQL schema.
 
 ```javascript
 createRemoteFileNode({
   // The source url of the remote file
-  url:
-  // The redux store
-  // The parameter from `downloadMediaFiles` should be passed in here
-  store:
-  // The cache passed in to check if there's response headers for this url from previous request
-  // The parameter from `downloadMediaFiles` should be passed in here
-  cache:
-  // Method used to create a node
-  // The parameter from `downloadMediaFiles` should be passed in here
-  createNode:
+  url: `https://example.com/a-file.jpg`,
+  
+  // The redux store which is passed to all Node APIs.
+  store,
+  
+  // Gatsby's cache which the helper uses to check if the file has been downloaded already. It's passed to all Node APIs.
+  cache,
+  
+  // The boundActionCreator used to create nodes
+  createNode,
+  
   // OPTIONAL
-  // Adds htaccess authentication if passed in
-  auth:
+  // Adds htaccess authentication to the download request if passed in.
+  auth: { user: `USER`, password: `PASSWORD` },
 })
 ```
 
 #### Example usage
 
-The following is what's done in [gatsby-source-wordpress](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). Downloaded files are created as `File` nodes and then linked to the Media File node, so it can be queried both as a regular `File` node and from the `localFile` field in the Media File node.
+The following example is pulled from [gatsby-source-wordpress](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). Downloaded files are created as `File` nodes and then linked to the WordPress Media node, so it can be queried both as a regular `File` node and from the `localFile` field in the Media node.
 
 ```javascript
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
@@ -165,7 +168,7 @@ exports.downloadMediaFiles = ({ nodes, store, cache, createNode, _auth }) => {
       }
 
       // Adds a field `localFile` to the node
-      // ___NODE appendix tells gatsby that this field will link to another node
+      // ___NODE appendix tells Gatsby that this field will link to another node
       if (fileNode) {
         node.localFile___NODE = fileNode.id
       }

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -117,29 +117,30 @@ exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
 
 ### createRemoteFileNode
 
-When working with remote files from a source such as headless CMS, you download the files and create `File` nodes. 
+When working with remote files from a source such as headless CMS, you download them and create `File` nodes using `createRemoteFileNode`
 
 ```javascript
 createRemoteFileNode({
   // The source url of the remote file
   url:
-  // The redux store.
+  // The redux store
   // The parameter from `downloadMediaFiles` should be passed in here
   store:
-  // The Gatsby cache
+  // The cache passed in to check if there's response headers for this url from previous request
   // The parameter from `downloadMediaFiles` should be passed in here
   cache:
   // Method used to create a node
+  // The parameter from `downloadMediaFiles` should be passed in here
   createNode:
   // OPTIONAL
-  // Adds htaccess authentication if passed in.
+  // Adds htaccess authentication if passed in
   auth:
 })
 ```
 
 #### Example usage
 
-The following is what's done in [gatsby-source-wordpress](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). Downloaded files are created as `File` nodes.  
+The following is what's done in [gatsby-source-wordpress](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). Downloaded files are created as `File` nodes and then linked to the Media File node, so it can be queried both as a regular `File` node and from the `localFile` field in the Media File node.
 
 ```javascript
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
@@ -147,11 +148,11 @@ const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
 exports.downloadMediaFiles = ({ nodes, store, cache, createNode, _auth }) => {
   nodes.map(async node => {
     let fileNode
-    // Ensures we are only process Media Files
+    // Ensures we are only processing Media Files
     // `wordpress__wp_media` is the media file type name for Wordpress
     if (node.__type === `wordpress__wp_media`) {
-        try {
-          fileNode = await createRemoteFileNode({
+      try {
+        fileNode = await createRemoteFileNode({
             url: node.source_url,
             store,
             cache,
@@ -163,6 +164,8 @@ exports.downloadMediaFiles = ({ nodes, store, cache, createNode, _auth }) => {
         }
       }
 
+      // Adds a field `localFile` to the node
+      // ___NODE appendix tells gatsby that this field will link to another node
       if (fileNode) {
         node.localFile___NODE = fileNode.id
       }

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -117,6 +117,55 @@ exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
 
 ### createRemoteFileNode
 
+When working with remote files from a source such as headless CMS, you download the files and create `File` nodes. 
+
 ```javascript
-TO DO
+createRemoteFileNode({
+  // The source url of the remote file
+  url:
+  // The redux store.
+  // The parameter from `downloadMediaFiles` should be passed in here
+  store:
+  // The Gatsby cache
+  // The parameter from `downloadMediaFiles` should be passed in here
+  cache:
+  // Method used to create a node
+  createNode:
+  // OPTIONAL
+  // Adds htaccess authentication if passed in.
+  auth:
+})
+```
+
+#### Example usage
+
+The following is what's done in [gatsby-source-wordpress](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). Downloaded files are created as `File` nodes.  
+
+```javascript
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
+
+exports.downloadMediaFiles = ({ nodes, store, cache, createNode, _auth }) => {
+  nodes.map(async node => {
+    let fileNode
+    // Ensures we are only process Media Files
+    // `wordpress__wp_media` is the media file type name for Wordpress
+    if (node.__type === `wordpress__wp_media`) {
+        try {
+          fileNode = await createRemoteFileNode({
+            url: node.source_url,
+            store,
+            cache,
+            createNode,
+            auth: _auth,
+          })
+        } catch (e) {
+          // Ignore
+        }
+      }
+
+      if (fileNode) {
+        node.localFile___NODE = fileNode.id
+      }
+  })
+};
 ```


### PR DESCRIPTION
Addresses #4302 

I've added rough documentation for `createRemoteFileNode`. As you can see it's still needs a lot of improvement. Any guidance would be appreciated. 

What's to be added/improved:
* Add better descriptions for what each parameter of `createRemoteFileNode` does. For instance the `store` and `cache` that's passed in.
* Add a hint on what `node.localFile___NODE = fileNode.id` does
* Write a bit about how these File nodes can be queried in GraphQL in the end of doc.

@m-allanson @KyleAMathews @pieh 