### PR TITLE
Add PrismJS classname to <pre> and <code> tags

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -23,7 +23,7 @@ Object {
       },
       "type": "html",
       "value": "<div class=\\"gatsby-highlight\\">
-      <pre class=\\"custom-js\\"><code><span class=\\"token comment\\">// Fake</span>
+      <pre class=\\"custom-js\\"><code class=\\"custom-js\\"><span class=\\"token comment\\">// Fake</span>
 </code></pre>
       </div>",
     },
@@ -67,7 +67,7 @@ Object {
       },
       "type": "html",
       "value": "<div class=\\"gatsby-highlight\\">
-      <pre class=\\"language-js\\"><code><span class=\\"token comment\\">// Fake</span>
+      <pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// Fake</span>
 </code></pre>
       </div>",
     },

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -32,7 +32,7 @@ module.exports = ({ markdownAST }, { classPrefix = `language-` } = {}) => {
     // 100% width highlighted code lines work
     node.type = `html`
     node.value = `<div class="gatsby-highlight">
-      <pre class="${className}"><code>${highlightCode(
+      <pre class="${className}"><code class="${className}">${highlightCode(
       language,
       node.value,
       highlightLines


### PR DESCRIPTION
Looking at [Prism's demo](http://prismjs.com/test.html), it seems that the language class is expected to exist on the `<pre>` and `<code>` tags. Gatsby was only adding it to the `<pre>` tag, which meant Prism's _Coy_ theme rendered incorrectly.

Closes #4325