### PR TITLE
Complete missing instruction for glamor and style components tutorials

### DIFF
--- a/docs/docs/glamor.md
+++ b/docs/docs/glamor.md
@@ -33,7 +33,19 @@ module.exports = {
 
 Then in your terminal run `gatsby develop` to start the Gatsby development server.
 
-Now let's create a sample Glamor page at `src/pages/index.js`
+Now let's create a new `Container` component.
+Create a `components` directory at `src/components` and then, in this directory,
+create a file named `container.js` and paste the following:
+
+```javascript
+import React from "react";
+
+export default ({ children }) => (
+  <div style={{ margin: "3rem auto", maxWidth: 600 }}>{children}</div>
+);
+```
+
+Then let's create a sample Glamor page at `src/pages/index.js`
 
 ```jsx
 import React from "react";

--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -32,7 +32,19 @@ module.exports = {
 
 Then in your terminal run `gatsby develop` to start the Gatsby development server.
 
-Now let's create a sample Styled Components page at `src/pages/index.js`:
+Now let's create a new `Container` component.
+Create a `components` directory at `src/components` and then, in this directory,
+create a file named `container.js` and paste the following:
+
+```javascript
+import React from "react";
+
+export default ({ children }) => (
+  <div style={{ margin: "3rem auto", maxWidth: 600 }}>{children}</div>
+);
+```
+
+Then let's create a sample Styled Components page at `src/pages/index.js`:
 
 ```jsx
 import React from "react";
@@ -103,3 +115,7 @@ export default () => (
   </Container>
 );
 ```
+
+### Final result
+
+![glamor page](../tutorial/part-two/glamor-example.png)


### PR DESCRIPTION
There are missing instructions for creating `Container` components if you try to follow step by step the [glamor](https://www.gatsbyjs.org/docs/glamor/) and [style-components](https://www.gatsbyjs.org/docs/styled-components/) tutorials:

### Before
![image](https://user-images.githubusercontent.com/26092508/36915034-887a909c-1e4f-11e8-8597-5c9cac49962c.png)

### After
![image](https://user-images.githubusercontent.com/26092508/36915084-b3d6c396-1e4f-11e8-9be3-0508b91ba13a.png)

These instruction are clear on the [tutorial part 2](https://www.gatsbyjs.org/tutorial/part-two/#component-css), but if you follow the `Glamor` or `Style-components` mini tutorial as a standalone, the `Container` components are nos detailed.