### PR TITLE
fix CSS-in-JS Container component/Glamor & Styled Components tutorial

### DIFF
--- a/docs/docs/glamor.md
+++ b/docs/docs/glamor.md
@@ -33,24 +33,14 @@ module.exports = {
 
 Then in your terminal run `gatsby develop` to start the Gatsby development server.
 
-Now let's create a new `Container` component.
-Create a `components` directory at `src/components` and then, in this directory,
-create a file named `container.js` and paste the following:
-
-```javascript
-import React from "react";
-
-export default ({ children }) => (
-  <div style={{ margin: "3rem auto", maxWidth: 600 }}>{children}</div>
-);
-```
-
-Then let's create a sample Glamor page at `src/pages/index.js`
+Now let's create a sample Glamor page at `src/pages/index.js`
 
 ```jsx
 import React from "react";
 
-import Container from "../components/container";
+const Container = ({ children }) => (
+  <div>{children}</div>
+);
 
 export default () => (
   <Container>
@@ -60,12 +50,14 @@ export default () => (
 );
 ```
 
-Let's add a inline `User` component using Glamor's `css` prop.
+Let's add css styles to `Container` and add a inline `User` component using Glamor's `css` prop.
 
-```jsx{5-27,33-40}
+```jsx{4,7-29,35-42}
 import React from "react"
 
-import Container from "../components/container"
+const Container = ({ children }) => (
+  <div css={{ margin: `3rem auto`, maxWidth: 600 }}>{children}</div>
+);
 
 const User = props =>
   <div

--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -32,25 +32,15 @@ module.exports = {
 
 Then in your terminal run `gatsby develop` to start the Gatsby development server.
 
-Now let's create a new `Container` component.
-Create a `components` directory at `src/components` and then, in this directory,
-create a file named `container.js` and paste the following:
-
-```javascript
-import React from "react";
-
-export default ({ children }) => (
-  <div style={{ margin: "3rem auto", maxWidth: 600 }}>{children}</div>
-);
-```
-
-Then let's create a sample Styled Components page at `src/pages/index.js`:
+Now let's create a sample Styled Components page at `src/pages/index.js`:
 
 ```jsx
 import React from "react";
 import styled from "styled-components";
 
 const Container = styled.div`
+  margin: 3rem auto;
+  max-width: 600px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -115,7 +105,3 @@ export default () => (
   </Container>
 );
 ```
-
-### Final result
-
-![glamor page](../tutorial/part-two/glamor-example.png)


### PR DESCRIPTION
>This PR is following the premature merge of #4338 

## `/docs/docs/glamor.md`:
I decided to create the `Container` component as inline component in `index.js`. Otherwise we should have introduce Glamor's `css` prop before the `User` component.

![image](https://user-images.githubusercontent.com/26092508/36924771-40822f0e-1e70-11e8-95c2-05f45be9acf6.png)


## `/docs/docs/styled-components.md`:
I removed my previous addition of the `Container` components as it is created by:

```
const Container = styled.div``;
```
I just added the css properties to better match the style of the main tutorial.
![image](https://user-images.githubusercontent.com/26092508/36925161-a4cf329e-1e71-11e8-9a83-088cc8f099cd.png)


I hope everything is well this time :)