### PR TITLE
[gatsby-plugin-sharp] fix bluebird.js warning...

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -160,8 +160,7 @@ const processFile = (file, jobs, cb, reporter) => {
     ) {
       clonedPipeline
         .toBuffer()
-        .then(sharpBuffer => {
-          imagemin
+        .then(sharpBuffer => imagemin
             .buffer(sharpBuffer, {
               plugins: [
                 imageminPngquant({
@@ -175,8 +174,7 @@ const processFile = (file, jobs, cb, reporter) => {
             .then(imageminBuffer => {
               fs.writeFile(job.outputPath, imageminBuffer, onFinish)
             })
-            .catch(onFinish)
-        })
+            .catch(onFinish))
         .catch(onFinish)
       // Compress webp
     } else if (
@@ -185,16 +183,14 @@ const processFile = (file, jobs, cb, reporter) => {
     ) {
       clonedPipeline
         .toBuffer()
-        .then(sharpBuffer => {
-          imagemin
+        .then(sharpBuffer => imagemin
             .buffer(sharpBuffer, {
               plugins: [imageminWebp({ quality: args.quality })],
             })
             .then(imageminBuffer => {
               fs.writeFile(job.outputPath, imageminBuffer, onFinish)
             })
-            .catch(onFinish)
-        })
+            .catch(onFinish))
         .catch(onFinish)
       // any other format (jpeg, tiff) - don't compress it just handle output
     } else {


### PR DESCRIPTION
after upgrading to gatsby-plugin-sharp v1.6.37 (from v1.6.25), i started seeing a ton of warnings from the bluebird promise lib:

```
Generating image thumbnails [============================--] 521/568 44.8 secs 92%
(node:45054) Warning: a promise was created in a handler at /path/to/my/project/node_modules/gatsby-plugin-sharp/index.js:727:28 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (/path/to/my/project/node_modules/bluebird/js/release/promise.js:79:10)
```

this PR fixes the underlying issue and eliminates the warning for me. I'm not sure if there are other places where the promise isn't being returned that my site code simply doesn't hit. If you are aware of any, I'd be happy to address them as well 👍 
