### PR TITLE
Only link to the Gatsby room of Reactiflux directly

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -40,6 +40,6 @@ tagged with **gatsby** or
 ### Reactiflux Chat
 
 If you need an answer right away, check out the
-[Reactiflux Discord](https://discord.gg/0ZcbPKXt5bZjGY5n) #gatsby channel. There
+[Reactiflux Discord](https://discord.gg/0ZcbPKXt5bVoxkfV) #gatsby channel. There
 are usually a number of Gatsby experts there who can help out or point you to
 useful resources.

--- a/docs/docs/how-to-file-an-issue.md
+++ b/docs/docs/how-to-file-an-issue.md
@@ -11,7 +11,7 @@ If you want your issue to be resolved quickly, please include in your issue:
   `gatsby-node.js`, `gatsby-browser.js` `gatsby-ssr.js` files depending on
   changes you've made there.
 
-Please do not use the issue tracker for personal support requests. [Stack Overflow](http://stackoverflow.com/questions/ask?tags=gatsby) (**gatsby** tag) and the [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bZjGY5n) #gatsby channels are better places to get help.
+Please do not use the issue tracker for personal support requests. [Stack Overflow](http://stackoverflow.com/questions/ask?tags=gatsby) (**gatsby** tag) and the [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bVoxkfV) #gatsby channels are better places to get help.
 
 ### Special Note on Issues
 

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -186,7 +186,7 @@ export default ({ pathname }) => {
             }}
           >
             <a
-              href="https://discord.gg/0ZcbPKXt5bZjGY5n"
+              href="https://discord.gg/0ZcbPKXt5bVoxkfV"
               title="Discord"
               css={{
                 ...navItemStyles,


### PR DESCRIPTION
Right now there are two Discord invite links in the Gatsby docs, and only https://discord.gg/0ZcbPKXt5bVoxkfV links directly to the Gatsby room. I got confused because one of the links actually went to the `#react-native` channel on Reactiflux, so this should keep the invite consistent everywhere.