### PR TITLE
Issue template update

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,14 @@
-<!-- 
+<!--
   If you're reading this... it means that you want to contribute to the project! Awesome and thanks!
-  
+
   To make it easier for us to help you — please follow the suggested format below (as it makes sense).
-  
+
   Useful Links:
   - Documentation: https://www.gatsbyjs.org/docs/
   - How to Contribute: https://www.gatsbyjs.org/docs/how-to-contribute/
   - How to File an Issue: https://www.gatsbyjs.org/docs/how-to-file-an-issue/
   - Become a Sponsor: https://opencollective.com/gatsby#sponsor
-  
+
   Before opening a new issue, please search existing issues (https://github.com/gatsbyjs/gatsby/issues)
   to double-check your issue isn't already known.
 -->
@@ -17,12 +17,24 @@
 
 Describe the issue or the enhancement that you want to see.
 
+### Steps to reproduce
+
+Clear steps describing how to reproduce the issue.
+
+### Expected result
+
+What should happen?
+
+### Actual result
+
+What happened.
+
 ### Environment
 
-Gatsby version (`npm list gatsby`):
-gatsby-cli version (`gatsby --version`):
-Node.js version:
-Operating System:
+- Gatsby version (`npm list gatsby`):
+- gatsby-cli version (`gatsby --version`):
+- Node.js version:
+- Operating System:
 
 ### File contents (if changed):
 
@@ -32,20 +44,3 @@ Operating System:
 `gatsby-browser.js`: <!-- code block or not changed -->
 `gatsby-ssr.js`: <!-- code block or not changed -->
 
-### Actual result
-
-What happened.
-
-### Expected behavior
-
-What should happen?
-
-### Steps to reproduce
-
-1\.
-
-2\.
-
-3\.
-
-...

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,7 +19,8 @@ Describe the issue or the enhancement that you want to see.
 
 ### Environment
 
-Gatsby version:
+Gatsby version (`npm list gatsby`):
+gatsby-cli version (`gatsby --version`):
 Node.js version:
 Operating System:
 


### PR DESCRIPTION
Here's a couple of adjustments to the issue template.

### Clearer version instructions

I notice that people often include their version of `gatsby-cli` instead of `gatsby` itself. I suspect this is because `gatsby --version` outputs the version of `gatsby-cli`.

### Reflow issue description steps

I often find myself jumping to the bottom of an issue to fill out the _Steps to reproduce_ section, before going back up to the _Expected result_ and _Actual result_ sections. I've rearranged them into what I think is a more natural order e.g. "I did foo, and I thought bar would happen, but actually baz happened". I guess this change is pretty subjective, feel free to drop it :)