### PR TITLE
Upgrade plugin for styletron to v4.0

### DIFF
--- a/examples/using-styletron/package.json
+++ b/examples/using-styletron/package.json
@@ -13,7 +13,10 @@
     "lodash": "^4.16.4",
     "react-typography": "^0.15.0",
     "slash": "^1.0.0",
-    "styletron-react": "^3.0.0-rc.2",
+    "styletron-engine-atomic": "^1",
+    "styletron-react": "^4",
+    "styletron-react-core": "^1",
+    "styletron-standard": "^1",
     "typography": "^0.15.8",
     "typography-breakpoint-constants": "^0.14.0"
   },

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-styletron",
   "description": "Stub description for gatsby-plugin-styletron",
-  "version": "1.0.15",
+  "version": "2.0.0",
   "author": "Nadiia Dmytrenko &lt;nadiia.dmytrenko@gmail.com&gt;",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -1,16 +1,17 @@
 {
   "name": "gatsby-plugin-styletron",
   "description": "Stub description for gatsby-plugin-styletron",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": "Nadiia Dmytrenko &lt;nadiia.dmytrenko@gmail.com&gt;",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "styletron-client": "^3.0.0-rc.1",
-    "styletron-react": "^3.0.0-rc.2",
-    "styletron-server": "^3.0.0-rc.1"
+    "styletron-engine-atomic": "^1",
+    "styletron-react-core": "^1",
+    "styletron-react": "^4",
+    "styletron-standard": "^1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/gatsby-plugin-styletron/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-styletron/src/gatsby-browser.js
@@ -1,12 +1,12 @@
 const React = require(`react`)
-const Styletron = require(`styletron-client`)
-const { StyletronProvider } = require(`styletron-react`)
+const Styletron = require(`styletron-engine-atomic`).Client
+const StyletronProvider = require(`styletron-react`).Provider
 
 exports.wrapRootComponent = ({ Root }, options) => () => {
   const styleElements = document.getElementsByClassName(`_styletron_hydrate_`)
   const styletron = new Styletron(styleElements, options)
   return (
-    <StyletronProvider styletron={styletron}>
+    <StyletronProvider value={styletron}>
       <Root />
     </StyletronProvider>
   )

--- a/packages/gatsby-plugin-styletron/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-styletron/src/gatsby-ssr.js
@@ -1,6 +1,6 @@
 const React = require(`react`)
-const Styletron = require(`styletron-server`)
-const { StyletronProvider } = require(`styletron-react`)
+const Styletron = require(`styletron-engine-atomic`).Server
+const StyletronProvider = require(`styletron-react`).Provider
 const { renderToString } = require(`react-dom/server`)
 
 exports.replaceRenderer = ({
@@ -11,7 +11,7 @@ exports.replaceRenderer = ({
   const styletron = new Styletron()
 
   const app = (
-    <StyletronProvider styletron={styletron}>{bodyComponent}</StyletronProvider>
+    <StyletronProvider value={styletron}>{bodyComponent}</StyletronProvider>
   )
 
   replaceBodyHTMLString(renderToString(app))


### PR DESCRIPTION
Using the [Styletron v3 to v4 Migration Guide](https://github.com/rtsao/styletron/blob/master/docs/v3-migration-guide.md), this upgrades styletron from v3 to v4. The gatsby example `using-styletron` (aside from updating the dependencies), continues to work without code changes.