### PR TITLE
Updating gatsby-plugin-manifest

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -21,11 +21,17 @@ the created manifest.json.
 
 ## How to use
 
-There are three configs in which this plugin will function: manual, hybrid, and auto. These three configuration options are explained below. The plugin functions differently depending on which of the three you choose.
+This plugin configures Gatsby to create a `manifest.json` file on every site build.
 
-### Auto config
+## Generating icons
 
-In the auto config you are responsible for defining the entire web app manifest except for the icons portion. You only provide a high resolution source icon. The icons themselves and the needed config will be generated at build time. See the example below:
+It can be tedious creating the multitude of icon sizes required by different devices and browsers. This plugin includes code to auto-generate smaller icons from a larger src image.
+
+There are three modes in which icon generation can function: manual, hybrid, and auto. These three modes are explained below. Icon generation functions differently depending on which of the three you choose.
+
+### Automatic mode
+
+In the automatic mode, you are responsible for defining the entire web app manifest except for the icons portion. You only provide a high resolution source icon. The icons themselves and the needed config will be generated at build time. See the example below:
 
 ```javascript
 // In your gatsby-config.js
@@ -39,13 +45,17 @@ plugins: [
       background_color: "#f7f0eb",
       theme_color: "#a2466c",
       display: "minimal-ui",
-      icon: src/images/icon.png
+      icon: src/images/icon.png // This path is relative to the root of the site.
     },
   },
 ];
 ```
 
-The auto config will be the easiest option for most people. If you're looking to customize the icon set included in your web app manifest, then the hybrid option is for you. For your reference the default icons config used is as follows:
+### Hybrid mode
+
+The auto config is the easiest option for most people. However, if need to use different icons for different targets, then the hybrid option is for you. Like Automatic mode, you should include a high-res icon to generate smaller icons from. But unlike Automatic mode, you can include manually created icons for some sizes.
+
+The following are all the icon sizes we create.
 
 ```js
 [
@@ -92,9 +102,9 @@ The auto config will be the easiest option for most people. If you're looking to
 ]
 ```
 
-### Hybrid config
+To override any of these, include an `icons` array with a link to the image file you've added to the "static" directory. It should be an absolute path e.g. if you add a file a `static/favicons/android-chrome-192x192.png` then the `src` should be `/favicons/android-chrome-192x192.png`.
 
-In the hybrid config you are responsible for defining the entire web app manifest, including the icons portion. Including the icons config will override the default config and only the icons you have defined will be generated. See the example below:
+Here's an example:
 
 ```javascript
 // In your gatsby-config.js
@@ -108,7 +118,7 @@ plugins: [
       background_color: "#f7f0eb",
       theme_color: "#a2466c",
       display: "minimal-ui",
-      icon: src/images/icon.png
+      icon: src/images/icon.png // This path is relative to the root of the site.
       icons: [
         {
           src: `/favicons/android-chrome-192x192.png`,
@@ -125,10 +135,11 @@ plugins: [
   },
 ];
 ```
-The hybrid option allows the most flexibility while still not requiring you to create the variety of icon sizes manually. However, if the auto icon resize is not up to you standards the manual config is for you.
+
+The hybrid option allows the most flexibility while still not requiring you to create most icons sizes manually.
 
 ### Manual config
-In the manual config you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. See the example below:
+In the manual config, you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. Only icons you provide will be added. See the example below:
 
 ```javascript
 // In your gatsby-config.js
@@ -162,7 +173,3 @@ plugins: [
   },
 ];
 ```
-
-To create `manifest.json`, you need to run `gatsby build`.
-
-

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -23,6 +23,110 @@ the created manifest.json.
 
 There are three configs in which this plugin will function: manual, hybrid, and auto. These three configuration options are explained below. The plugin functions differently depending on which of the three you choose.
 
+### Auto config
+
+In the auto config you are responsible for defining the entire web app manifest except for the icons portion. You only provide a high resolution source icon. The icons themselves and the needed config will be generated at build time. See the example below:
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-manifest`,
+    options: {
+      name: "GatsbyJS",
+      short_name: "GatsbyJS",
+      start_url: "/",
+      background_color: "#f7f0eb",
+      theme_color: "#a2466c",
+      display: "minimal-ui",
+      icon: src/images/icon.png
+    },
+  },
+];
+```
+
+The auto config will be the easiest option for most people. If you're looking to customize the icon set included in your web app manifest, then the hybrid option is for you. For your reference the default icons config used is as follows:
+
+```js
+[
+  {
+      "src": `icons/icon-48x48.png`,
+      "sizes": `48x48`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-72x72.png`,
+      "sizes": `72x72`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-96x96.png`,
+      "sizes": `96x96`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-144x144.png`,
+      "sizes": `144x144`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-192x192.png`,
+      "sizes": `192x192`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-256x256.png`,
+      "sizes": `256x256`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-384x384.png`,
+      "sizes": `384x384`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-512x512.png`,
+      "sizes": `512x512`,
+      "type": `image/png`,
+  },
+]
+```
+
+### Hybrid config
+
+In the hybrid config you are responsible for defining the entire web app manifest, including the icons portion. Including the icons config will override the default config and only the icons you have defined will be generated. See the example below:
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-manifest`,
+    options: {
+      name: "GatsbyJS",
+      short_name: "GatsbyJS",
+      start_url: "/",
+      background_color: "#f7f0eb",
+      theme_color: "#a2466c",
+      display: "minimal-ui",
+      icon: src/images/icon.png
+      icons: [
+        {
+          src: `/favicons/android-chrome-192x192.png`,
+          sizes: `192x192`,
+          type: `image/png`,
+        },
+        {
+          src: `/favicons/android-chrome-512x512.png`,
+          sizes: `512x512`,
+          type: `image/png`,
+        },
+      ],
+    },
+  },
+];
+```
+The hybrid option allows the most flexibility while still not requiring you to create the variety of icon sizes manually. However, if the auto icon resize is not up to you standards the manual config is for you.
+
 ### Manual config
 In the manual config you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. See the example below:
 
@@ -54,62 +158,6 @@ plugins: [
           type: `image/png`,
         },
       ],
-    },
-  },
-];
-```
-
-### Hybrid config
-
-In the hybrid config you are responsible for defining the entire web app manifest but instead of manually generating the defined icons you provide a high resolution source icon to be used to auto generate your defined icons. See the example below:
-
-```javascript
-// In your gatsby-config.js
-plugins: [
-  {
-    resolve: `gatsby-plugin-manifest`,
-    options: {
-      name: "GatsbyJS",
-      short_name: "GatsbyJS",
-      start_url: "/",
-      background_color: "#f7f0eb",
-      theme_color: "#a2466c",
-      display: "minimal-ui",
-      icon: src/images/icon.png
-      icons: [
-        {
-          src: `/favicons/android-chrome-192x192.png`,
-          sizes: `192x192`,
-          type: `image/png`,
-        },
-        {
-          src: `/favicons/android-chrome-512x512.png`,
-          sizes: `512x512`,
-          type: `image/png`,
-        },
-      ],
-    },
-  },
-];
-```
-
-### Auto config
-
-In the auto config you are responsible for defining the entire web app manifest except for the icons. You only provide a high resolution source icon. The icons themselves and the needed config will be generated. See the example below:
-
-```javascript
-// In your gatsby-config.js
-plugins: [
-  {
-    resolve: `gatsby-plugin-manifest`,
-    options: {
-      name: "GatsbyJS",
-      short_name: "GatsbyJS",
-      start_url: "/",
-      background_color: "#f7f0eb",
-      theme_color: "#a2466c",
-      display: "minimal-ui",
-      icon: src/images/icon.png
     },
   },
 ];

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -19,6 +19,11 @@ the created manifest.json.
 
 ## How to use
 
+There are three configurations in which this plugin will function: manual, hybrid, and auto. What config options you include will determine how the plugin functions.
+
+### Manual configuration
+In the manual configuration you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. See the example below:
+
 ```javascript
 // In your gatsby-config.js
 plugins: [
@@ -52,4 +57,62 @@ plugins: [
 ];
 ```
 
+### Hybrid configuration
+
+In the hybrid configuration you are responsible for defining the entire web app manifest but instead of manually generating the defined icons you provide a hi-res source icon to be used to auto generate your defined icons. See the example below:
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-manifest`,
+    options: {
+      name: "GatsbyJS",
+      short_name: "GatsbyJS",
+      start_url: "/",
+      background_color: "#f7f0eb",
+      theme_color: "#a2466c",
+      display: "minimal-ui",
+      icon: src/images/icon.png
+      icons: [
+        {
+          src: `/favicons/android-chrome-192x192.png`,
+          sizes: `192x192`,
+          type: `image/png`,
+        },
+        {
+          src: `/favicons/android-chrome-512x512.png`,
+          sizes: `512x512`,
+          type: `image/png`,
+        },
+      ],
+    },
+  },
+];
+```
+
+### Automatic configuration
+
+In the automatic configuration you are responsible for defining the entire web app manifest ecept for the icons, you only provide a hi-res source icon to be used to auto generate the default set of icons. See the example below:
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-manifest`,
+    options: {
+      name: "GatsbyJS",
+      short_name: "GatsbyJS",
+      start_url: "/",
+      background_color: "#f7f0eb",
+      theme_color: "#a2466c",
+      display: "minimal-ui",
+      icon: src/images/icon.png
+    },
+  },
+];
+```
+
 To create `manifest.json`, you need to run `gatsby build`.
+
+

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -93,7 +93,7 @@ plugins: [
 
 ### Automatic configuration
 
-In the automatic configuration you are responsible for defining the entire web app manifest ecept for the icons, you only provide a hi-res source icon to be used to auto generate the default set of icons. See the example below:
+In the automatic configuration you are responsible for defining the entire web app manifest except for the icons. You only provide a hi-res source icon. The icons themselves and the needed configuration will be generated. See the example below:
 
 ```javascript
 // In your gatsby-config.js

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -1,13 +1,15 @@
 # gatsby-plugin-manifest
 
 Adds support for shipping a manifest.json with your site. The web application
-manifest is a JSON file that lets users (on Android Chrome —
-[support in MS Edge & Firefox is under development](http://caniuse.com/#feat=web-app-manifest))
+manifest is a JSON file that lets users (on Android Chrome, Firefox, and Opera —
+[support in MS Edge & Safari is under development](http://caniuse.com/#feat=web-app-manifest))
 save your web application to their smartphone home screen so it behaves similar
 to native apps.
 
 This article from the Chrome DevRel team is a good intro to the web app
 manifest—https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+
+For more information see the w3 spec https://www.w3.org/TR/appmanifest/ or Mozilla Docs https://developer.mozilla.org/en-US/docs/Web/Manifest.
 
 If you're using this plugin together with `gatsby-plugin-offline` (recommended),
 this plugin should be listed _before_ the offline plugin so that it can cache
@@ -19,10 +21,10 @@ the created manifest.json.
 
 ## How to use
 
-There are three configurations in which this plugin will function: manual, hybrid, and auto. What config options you include will determine how the plugin functions.
+There are three configs in which this plugin will function: manual, hybrid, and auto. These three configuration options are explained below. The plugin functions differently depending on which of the three you choose.
 
-### Manual configuration
-In the manual configuration you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. See the example below:
+### Manual config
+In the manual config you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. See the example below:
 
 ```javascript
 // In your gatsby-config.js
@@ -57,9 +59,9 @@ plugins: [
 ];
 ```
 
-### Hybrid configuration
+### Hybrid config
 
-In the hybrid configuration you are responsible for defining the entire web app manifest but instead of manually generating the defined icons you provide a hi-res source icon to be used to auto generate your defined icons. See the example below:
+In the hybrid config you are responsible for defining the entire web app manifest but instead of manually generating the defined icons you provide a high resolution source icon to be used to auto generate your defined icons. See the example below:
 
 ```javascript
 // In your gatsby-config.js
@@ -91,9 +93,9 @@ plugins: [
 ];
 ```
 
-### Automatic configuration
+### Auto config
 
-In the automatic configuration you are responsible for defining the entire web app manifest except for the icons. You only provide a hi-res source icon. The icons themselves and the needed configuration will be generated. See the example below:
+In the auto config you are responsible for defining the entire web app manifest except for the icons. You only provide a high resolution source icon. The icons themselves and the needed config will be generated. See the example below:
 
 ```javascript
 // In your gatsby-config.js

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -27,7 +27,7 @@ This plugin configures Gatsby to create a `manifest.json` file on every site bui
 
 It can be tedious creating the multitude of icon sizes required by different devices and browsers. This plugin includes code to auto-generate smaller icons from a larger src image.
 
-There are three modes in which icon generation can function: manual, hybrid, and auto. These three modes are explained below. Icon generation functions differently depending on which of the three you choose.
+There are three modes in which icon generation can function: automatic, hybrid, and manual. These three modes are explained below. Icon generation functions differently depending on which of the three you choose.
 
 ### Automatic mode
 
@@ -51,13 +51,9 @@ plugins: [
 ];
 ```
 
-### Hybrid mode
+When in automatic mode the following json array is injected into the manifest configuration you provide and the icons are generated from it. The source icon you provide should be at least as big as the largest icon being generated.
 
-The auto config is the easiest option for most people. However, if need to use different icons for different targets, then the hybrid option is for you. Like Automatic mode, you should include a high-res icon to generate smaller icons from. But unlike Automatic mode, you can include manually created icons for some sizes.
-
-The following are all the icon sizes we create.
-
-```js
+```javascript
 [
   {
       "src": `icons/icon-48x48.png`,
@@ -102,9 +98,11 @@ The following are all the icon sizes we create.
 ]
 ```
 
-To override any of these, include an `icons` array with a link to the image file you've added to the "static" directory. It should be an absolute path e.g. if you add a file a `static/favicons/android-chrome-192x192.png` then the `src` should be `/favicons/android-chrome-192x192.png`.
+The automatic mode is the easiest option for most people.
 
-Here's an example:
+### Hybrid mode
+
+ However, if you want to include more or fewer sizes, then the hybrid option is for you. Like automatic mode, you should include a high resolution icon to generate smaller icons from. But unlike automatic mode, you provide the `icons` array config and icons are generated based on the sizes defined in your config. Here's an example:
 
 ```javascript
 // In your gatsby-config.js
@@ -138,8 +136,8 @@ plugins: [
 
 The hybrid option allows the most flexibility while still not requiring you to create most icons sizes manually.
 
-### Manual config
-In the manual config, you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. Only icons you provide will be added. See the example below:
+### Manual mode
+In the manual mode, you are responsible for defining the entire web app manifest and providing the defined icons in the static directory. Only icons you provide will be available. There is no automatic resizing done for you. See the example below:
 
 ```javascript
 // In your gatsby-config.js

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -19,6 +19,8 @@
   "keywords": [
     "gatsby",
     "gatsby-plugin",
+    "favicon",
+    "icons",
     "manifest.json",
     "progressive-web-app",
     "pwa"

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "bluebird": "^3.5.0"
+    "bluebird": "^3.5.0",
+    "sharp": "^0.20.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -66,16 +66,16 @@ exports.onPostBuild = (args, pluginOptions) =>
     const { icon } = pluginOptions
     const manifest = { ...pluginOptions }
   
-    //cleanup non manifest config from manifest
+    // Delete options we won't pass to the manifest.json.
     delete manifest.plugins
     delete manifest.icon
 
-    //if icons are not manually defined use default icon set
+    // If icons are not manually defined, use the default icon set.
     if (!manifest.icons) {
       manifest.icons = defaultIcons
     }
 
-    //determine destination path for icons and 
+    // Determine destination path for icons.
     const iconPath = `./public/` + manifest.icons[0].src.substring(0, manifest.icons[0].src.lastIndexOf(`/`))
 
     //create destination directory if it doesn't exist
@@ -85,7 +85,7 @@ exports.onPostBuild = (args, pluginOptions) =>
 
     fs.writeFileSync(`${iconPath}/manifest.json`, JSON.stringify(manifest))
     
-    // only auto-generate if a src icon is defined
+    // Only auto-generate icons if a src icon is defined.
     if (icon !== undefined) {
         generateIcons(manifest.icons, icon).then(() => {
             //images have been generated

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -1,10 +1,98 @@
 const fs = require(`fs`)
 const Promise = require(`bluebird`)
+const sharp = require(`sharp`)
+
+// default icons for generating icons
+const defaultIcons = [
+  {
+      "src": `icons/icon-48x48.png`,
+      "sizes": `48x48`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-72x72.png`,
+      "sizes": `72x72`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-96x96.png`,
+      "sizes": `96x96`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-144x144.png`,
+      "sizes": `144x144`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-192x192.png`,
+      "sizes": `192x192`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-256x256.png`,
+      "sizes": `256x256`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-384x384.png`,
+      "sizes": `384x384`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-512x512.png`,
+      "sizes": `512x512`,
+      "type": `image/png`,
+  },
+]
+
+sharp.simd(true)
+
+function generateIcons(icons, srcIcon) {
+  return Promise.map(icons, icon => {
+    const size = parseInt(icon.sizes.substring(0, icon.sizes.lastIndexOf(`x`)))
+    const imgPath = `./public/` + icon.src
+    
+    return sharp(srcIcon)
+      .resize(size)
+      .toFile(imgPath)
+      .then(() => {
+      })
+  })
+}
 
 exports.onPostBuild = (args, pluginOptions) =>
   new Promise(resolve => {
+    const { icon } = pluginOptions
     const manifest = { ...pluginOptions }
+  
+    //cleanup non manifest config from manifest
     delete manifest.plugins
-    fs.writeFileSync(`./public/manifest.json`, JSON.stringify(manifest))
-    resolve()
+    delete manifest.icon
+
+    //if icons are not manually defined use default icon set
+    if (!manifest.icons) {
+      manifest.icons = defaultIcons
+    }
+
+    //determine destination path for icons and 
+    const iconPath = `./public/` + manifest.icons[0].src.substring(0, manifest.icons[0].src.lastIndexOf(`/`))
+
+    //create destination directory if it doesn't exist
+    if (!fs.existsSync(iconPath)){
+      fs.mkdirSync(iconPath)
+    }
+
+    fs.writeFileSync(`${iconPath}/manifest.json`, JSON.stringify(manifest))
+    
+    // only auto-generate if a src icon is defined
+    if (icon !== undefined) {
+        generateIcons(manifest.icons, icon).then(() => {
+            //images have been generated
+            console.log(`done`)
+            resolve()
+        })
+    } else {
+        resolve()
+    }
   })

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -2,11 +2,15 @@ import React from "react"
 import { withPrefix } from "gatsby-link"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
+
+  const { icons } = pluginOptions
+  const iconPath = icons[0].src.substring(0, icons[0].src.lastIndexOf(`/`))
+
   setHeadComponents([
     <link
       key={`gatsby-plugin-manifest-link`}
       rel="manifest"
-      href={withPrefix(`/manifest.json`)}
+      href={withPrefix(`${iconPath}/manifest.json`)}
     />,
     <meta
       key={`gatsby-plugin-manifest-meta`}


### PR DESCRIPTION
# The problem
There are currently two plugins in the Gatsby eco system that deal with the web app manifest, favicons,
 and apple icons (`gatsby-plugin-manifest` and `gatsby-plugin-favicon`). The latter auto generates these images but allows no customization of the other manifest properties. The former allows complete customization while not providing auto generation of the various icons.

# The goal
In short the goal of this PR is to update the existing `gatsby-plugin-manifest` to include auto generation of images and maintain it's great flexibility in configuring all aspects of the web app manifest.

# The challenges
While I was hoping to "simply" combined the two plugins it's not going to be so easy (of course not, how naive of me). The [gatsby-plugin-favicon](https://github.com/Creatiwity/gatsby-plugin-favicon) relies on another npm module that acts as a plugin to webpack [favicons-webpack-plugin](https://github.com/jantimon/favicons-webpack-plugin). That module in turn relies on the [favicons](https://github.com/evilebottnawi/favicons). 

The biggest problem is the `favicons-webpack-plugin` doesn't support the web app manifest configs for anything other that `name` and `background-color`. You can't configure any other parameters. The underlying `favicons` plugin does support more, if not all the various web app manifest parameters, it's quite out of date. For Firefox, it's still generating what's now [defunct spec](https://developer.mozilla.org/en-US/docs/Archive/B2G_OS/Firefox_OS_apps/Building_apps_for_Firefox_OS/Manifest). There's a couple other weir quirks I won't get into.

# The solution

## Theory
Now that the Chrome spec is becoming standardized by [W3](https://www.w3.org/TR/appmanifest/, this plugin should reflect that standard. 

I love how the current `gatsby-plugin-manifest` simply passes the plugin config on to be the webapp manifest. This means our plugin will maintain compatability to the spec without modification...people simply have to update their config. Obviously, if we want to add new fields to have default values we can do that. 

This will need to be augmented by some boolean values that determine what images are created and what part of the `icons` config is added.

```
webapp: true,
ie: true.
apple: true,
favicon: true,
```
### The backwards compatibility issue
Currently only Edge [maybe](https://blogs.windows.com/msedgedev/2018/02/06/welcoming-progressive-web-apps-edge-windows-10/#czMkH4bVX9fB1aUi.97), Firefox, Opera, and Chrome support the web app manifest standard. We have to account for that...

What's up with the ie, apple, favicons boolean values above? This controls weather our web app includes support for these non-standard standards. [IE](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85)) and [Safari/Apple](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html) don't support the web app manifest standard. Favicons are still a thing though (this is total speculation) may be eclipsed by the web app manifest standard. But for now we should probably keep generating them.

## Reality
IMO, basically nothing from the `gatsby-plugin-favicons` plugin is useful moving forward. Given that `gatsby-plugin-sharp` exists I'm thinking that we could leverage that to generate the needed images from a single source file. The plugin would auto populate the `icons` attribute of the `manifest.json` and all other attributes in the `manifest.json` would be passed through from the plugin config. Any other files, headers, icons for IE, Apple, and the favicon would also be generate automatically. Any data in IE's `browserconfig.xml` would be derived from the web app manifest fields.

# In conclusion...
## So what code did you just submit?

Basically, I modified to `gatsby-plugin-manifest` to be `gatsby-plugin-favicon` and then tried to modify the code to be able to configure the `manifest.json`. But, due to the previously mentioned issues the only thing this code adds is the ability to modify the `name` and `background-color` fields. So, this code is functionally worthless and should never see release, it was useful in that I learned everything above...fun times.

## Feedback:
Please give me feed back on any thoughts on how this plugin should function in it's v2 state. The one question I specifically have is:

* Should v2 of this plugin be backwards compatible? It'd be difficult, probably not impossible. If we're concerned about backwards compatibility a better option might be a different plugin name (this comes with it's own confusion though).

## Resources
Are lots of resources and reference guides for the various specs mentioned in this PR. While [this](https://caniuse.com/#feat=web-app-manifest) exists I don't believe it's entirely accurate... I could be wrong though.

### Specs
Web app Manifest W3 Spec: https://www.w3.org/TR/appmanifest/
Favicon: https://www.w3.org/2005/10/howto-favicon

### Individual Browser Reference
Chrome: https://developers.google.com/web/fundamentals/web-app-manifest/
Apple: https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html
Internet Explore: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85)
FireFox: https://developer.mozilla.org/en-US/docs/Web/Manifest
Opera: https://dev.opera.com/articles/installable-web-apps/
