### PR TITLE
fix infinity loop when inferring input fields for linked nodes

### DIFF
--- a/examples/using-drupal/gatsby-config.js
+++ b/examples/using-drupal/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: [
     {
       resolve: `gatsby-source-drupal`,
-      options: { baseUrl: `https://live-contentacms.pantheonsite.io/` },
+      options: { baseUrl: `https://live-contentacms.pantheonsite.io/`, apiBase: `api` },
     },
     {
       resolve: `gatsby-plugin-google-analytics`,

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -190,6 +190,22 @@ type InferInputOptions = {
   exampleValue?: Object,
 }
 
+const recursiveOmitBy = (value, fn) => {
+  if (_.isObject(value)) {
+    if (_.isPlainObject(value)) {
+      value = _.omitBy(value, fn)
+    }
+    _.each(value, (v, k) => {
+      value[k] = recursiveOmitBy(v, fn)
+    })
+    if (_.isEmpty(value)) {
+      // don't return empty objects - gatsby doesn't support these
+      return null
+    }
+  }
+  return value
+}
+
 const linkedNodeCache = {}
 
 export function inferInputObjectStructureFromNodes({
@@ -223,7 +239,7 @@ export function inferInputObjectStructureFromNodes({
           node => node.internal.type === linkedNode.internal.type
         )
         value = extractFieldExamples(relatedNodes)
-        value = _.omitBy(value, (_v, _k) => _.includes(_k, `___NODE`))
+        value = recursiveOmitBy(value, (_v, _k) => _.includes(_k, `___NODE`))
         linkedNodeCache[linkedNode.internal.type] = value
       }
 


### PR DESCRIPTION
This fixes #4206

Gatsby was omitting `___NODE` fields only from first level of node object, but it kept all `___NODE`s that were deeper. This caused infinite loop / circular dep with drupal data ( `node.relationships.relationship_name___NODE` ).