### PR TITLE
Add option to disable Google Analytics if Do Not Track is set

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -19,6 +19,8 @@ plugins: [
       head: false,
       // Setting this parameter is optional
       anonymize: true,
+      // Setting this parameter is also optional
+      respectDNT: true,
     },
   },
 ];
@@ -43,3 +45,8 @@ If your visitors should be able to set an Opt-Out-Cookie (No future tracking)
 you can set a link e.g. in your imprint as follows:
 
 `<a href="javascript:gaOptout();">Deactive Google Analytics</a>`
+
+
+## The "respectDNT" option
+
+If you enable this optional option, Google Analytics will not be loaded at all for visitors that have "Do Not Track" enabled. While using Google Analytics does not necessarily constitute Tracking, you might still want to do this to cater to more privacy oriented users.

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -20,17 +20,24 @@ exports.onRenderBody = (
         }',disableStr='ga-disable-'+gaProperty;document.cookie.indexOf(disableStr+'=true')>-1&&(window[disableStr]=!0);`
       : ``
   }
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '${pluginOptions.trackingId}', 'auto');
-  ${
-    typeof pluginOptions.anonymize !== `undefined`
-      ? `ga('set', 'anonymizeIp', 1);`
-      : ``
-  }`,
+  if(${
+    (typeof pluginOptions.respectDNT !== `undefined` && pluginOptions.respectDNT == true)
+    ? `!(navigator.doNotTrack == "1" || window.doNotTrack == "1")`
+    : `true`
+  }) {
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  }
+  if (typeof ga === "function") {
+    ga('create', '${pluginOptions.trackingId}', 'auto');
+      ${
+        typeof pluginOptions.anonymize !== `undefined`
+          ? `ga('set', 'anonymizeIp', 1);`
+          : ``
+      }}
+      `,
         }}
       />,
     ])


### PR DESCRIPTION
This PR adds an optional respectDNT (or is respectDnt better here?) option to the google analytics plugin. If enabled, the google analytics script will not be loaded in browsers that have Do Not Track enabled. While GA is not necessarily tracking, I believe this is what users that enable DNT want. It might also put you a little more in the green in terms of the GDPR.

This change puts the google analytics code in an if clause. If respectDNT is enabled, the condition is: `!(navigator.doNotTrack == '1' || window.doNotTrack == '1')` if its not enabled or not set its just `true`. I did it this way to avoid adding the whole GA code to the $() interpolation.

It also adds a check if the `ga` object exists before doing anything further with it, like the code in gatsby-browser.js does.