### PR TITLE
Update JS frontmatter README to match data object name

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/README.md
+++ b/packages/gatsby-transformer-javascript-frontmatter/README.md
@@ -57,7 +57,7 @@ You'd be able to query your data like:
   allJavascriptFrontmatter {
     edges {
       node {
-        data {
+        frontmatter {
           error
           path
           title
@@ -81,7 +81,7 @@ Which would return something like:
       "edges": [
         {
           "node": {
-            "data": {
+            "frontmatter": {
               "error": false,
               "path": "choropleth-on-d3v4",
               "title": "Choropleth on d3v4",
@@ -98,7 +98,7 @@ Which would return something like:
 }
 ```
 
-Any attribute on "data" across your js files will be exported. If a file is
+Any attribute on "frontmatter" across your js files will be exported. If a file is
 missing it, the value will be null.
 
 The error field will contain `false` or an object with error information just to


### PR DESCRIPTION
The **Parsing algorithm** examples use `frontmatter` as the data object name, but **How to query** examples used `data` as the data object name.

To avoid confusion, all data objects in examples are named `frontmatter`.