### PR TITLE
Do not cache js bundle when deploying on heroku

### DIFF
--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -248,7 +248,12 @@ Finally, add a `static.json` file in the root of your project to define the dire
 
 ```
 {
-  "root": "public/"
+  "root": "public/",
+  "headers": {
+    "/**.js": {
+      "Cache-Control": "public, max-age=0, must-revalidate"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
JS files should note be cached. Configure heroku-buildpack-static
to prevent that. See
https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/caching.md#javascript