### PR TITLE
Support pathPrefix in sitemap and feed plugins

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-ssr.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { withPrefix } from "gatsby-link"
 import { defaultOptions } from "./internals"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
@@ -17,7 +18,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
         key={`gatsby-plugin-feed-${i}`}
         rel="alternate"
         type="application/rss+xml"
-        href={output}
+        href={withPrefix(output)}
       />
     )
   })

--- a/packages/gatsby-plugin-sitemap/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-ssr.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { withPrefix } from "gatsby-link"
 import { defaultOptions } from "./internals"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
@@ -12,7 +13,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       key={`gatsby-plugin-sitemap`}
       rel="sitemap"
       type="application/xml"
-      href={output}
+      href={withPrefix(output)}
     />,
   ])
 }


### PR DESCRIPTION
This fixes #4449 by adding pathPrefix support to sitemap and feed plugins