### PR TITLE
[v2] Fix deleteNodes deprecation

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -33,7 +33,7 @@ exports.sourceNodes = async (
   { actions, getNodes, createNodeId, hasNodeChanged, store },
   { spaceId, accessToken, host }
 ) => {
-  const { createNode, deleteNodes, touchNode, setPluginStatus } = actions
+  const { createNode, deleteNode, touchNode, setPluginStatus } = actions
 
   host = host || `cdn.contentful.com`
   // Get sync token if it exists.
@@ -68,8 +68,8 @@ exports.sourceNodes = async (
   // Remove deleted entries & assets.
   // TODO figure out if entries referencing now deleted entries/assets
   // are "updated" so will get the now deleted reference removed.
-  deleteNodes(currentSyncData.deletedEntries.map(e => e.sys.id))
-  deleteNodes(currentSyncData.deletedAssets.map(e => e.sys.id))
+  currentSyncData.deletedEntries.forEach(e => deleteNode(e.sys.id, e.sys))
+  currentSyncData.deletedAssets.forEach(e => deleteNode(e.sys.id, e.sys))
 
   const existingNodes = getNodes().filter(
     n => n.internal.owner === `gatsby-source-contentful`

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -415,7 +415,9 @@ actions.deleteNodes = (nodes: any[], plugin: Plugin) => {
   console.log(
     `The "deleteNodes" is now deprecated and will be removed in Gatsby v3. Please use "deleteNode" instead`
   )
-  console.log(`"deleteNodes" was called by ${plugin.name}`)
+  if (plugin && plugin.name) {
+    console.log(`"deleteNodes" was called by ${plugin.name}`)
+  }
 
   return {
     type: `DELETE_NODES`,

--- a/packages/gatsby/src/utils/source-nodes.js
+++ b/packages/gatsby/src/utils/source-nodes.js
@@ -4,7 +4,7 @@ const report = require(`gatsby-cli/lib/reporter`)
 const apiRunner = require(`./api-runner-node`)
 const { store, getNode } = require(`../redux`)
 const { boundActionCreators } = require(`../redux/actions`)
-const { deleteNodes } = boundActionCreators
+const { deleteNode } = boundActionCreators
 
 /**
  * Finds the name of all plugins which implement Gatsby APIs that
@@ -67,6 +67,6 @@ module.exports = async () => {
   })
 
   if (staleNodes.length > 0) {
-    deleteNodes(staleNodes.map(n => n.id))
+    staleNodes.forEach(n => deleteNode(n.id, n))
   }
 }


### PR DESCRIPTION
When Gatsby prunes stale nodes, it uses the deprecated `deleteNodes` method, but outside of the context of a plugin, which results in an error when the deprecation warnings are printed.

This PR is divided into two commits; the first fixes the deprecation warning to support this particular scenario, while the second attempts to replace `deleteNodes` wherever it is used in core.

I'm not sure that the second commit does the right thing, so if it seems wrong, let me know and i can fix or remove it!