### PR TITLE
Support mapping to fields other than id

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -132,19 +132,21 @@ function inferFromMapping(
   fieldSelector,
   types
 ): ?GraphQLFieldConfig<*, *> {
-  const matchedTypes = types.filter(
-    type => type.name === mapping[fieldSelector]
-  )
+  const linkedType = mapping[fieldSelector].split(`.`)[0]
+  const linkedField =
+    mapping[fieldSelector].slice(linkedType.length + 1) || `id`
+
+  const matchedTypes = types.filter(type => type.name === linkedType)
   if (_.isEmpty(matchedTypes)) {
     console.log(`Couldn't find a matching node type for "${fieldSelector}"`)
     return null
   }
 
   const findNode = (fieldValue, path) => {
-    const linkedType = mapping[fieldSelector]
     const linkedNode = _.find(
       getNodes(),
-      n => n.internal.type === linkedType && n.id === fieldValue
+      n =>
+        n.internal.type === linkedType && _.get(n, linkedField) === fieldValue
     )
     if (linkedNode) {
       createPageDependency({ path, nodeId: linkedNode.id })
@@ -246,7 +248,10 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
     // If there's more than one type, we'll create a union type.
     if (fields.length > 1) {
       type = new GraphQLUnionType({
-        name: `Union_${key}_${fields.map(f => f.name).sort().join(`__`)}`,
+        name: `Union_${key}_${fields
+          .map(f => f.name)
+          .sort()
+          .join(`__`)}`,
         description: `Union interface for the field "${key}" for types [${fields
           .map(f => f.name)
           .sort()


### PR DESCRIPTION
Currently [mapping is hard-coded to id](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L147), so this change is to enable mapping to any field.
e.g. `'MarkdownRemark.frontmatter.author': 'MarkdownRemark.frontmatter.id'`