### PR TITLE
Remove z-index styles from gatsby-image

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -223,7 +223,6 @@ class Image extends React.Component {
             outerWrapperClassName ? outerWrapperClassName : ``
           } gatsby-image-outer-wrapper`}
           style={{
-            zIndex: 0,
             // Let users set component to be absolutely positioned.
             position: style.position === `absolute` ? `initial` : `relative`,
           }}
@@ -233,7 +232,6 @@ class Image extends React.Component {
             style={{
               position: `relative`,
               overflow: `hidden`,
-              zIndex: 1,
               ...style,
             }}
             ref={this.handleRef}
@@ -316,7 +314,6 @@ class Image extends React.Component {
         position: `relative`,
         overflow: `hidden`,
         display: `inline-block`,
-        zIndex: 1,
         width: image.width,
         height: image.height,
         ...style,
@@ -339,7 +336,6 @@ class Image extends React.Component {
             outerWrapperClassName ? outerWrapperClassName : ``
           } gatsby-image-outer-wrapper`}
           style={{
-            zIndex: 0,
             // Let users set component to be absolutely positioned.
             position: style.position === `absolute` ? `initial` : `relative`,
           }}


### PR DESCRIPTION
In gatsby-image, the z-index of various elements is set to 0 or 1. Is this necessary? If so, in what circumstances is it important?

A z-index of 0 is the same as not setting it at all, and as far as I can see the elements with z-index 1 are always after the 0 elements in DOM order, and so as long as they're positioned (relative for example) they will appear on top anyway.

The reason I ask is that it makes styling the rest of the page a little more difficult: even if later in DOM order and positioned, an element I want to be above a gatsby-image will be below unless I give it a z-index of 1 or more. I wish this weren't necessary.

So in the case that the z-index styles are not actually required, I am proposing via this pull request that they are removed.