### PR TITLE
[www] Fix highlighted code block containers in docs/bound-action-creators

### DIFF
--- a/www/src/components/function-list.js
+++ b/www/src/components/function-list.js
@@ -83,14 +83,19 @@ export default ({ functions }) => (
               <h4 css={{ marginTop: rhythm(1) }}>Example</h4>
               {` `}
               {node.examples.map((example, i) => (
-                <pre key={`${node.name} example ${i}`}>
-                  <code
+                <div className="gatsby-highlight">
+                  <pre
                     className="language-javascript"
-                    dangerouslySetInnerHTML={{
-                      __html: example.highlighted,
-                    }}
-                  />
-                </pre>
+                    key={`${node.name} example ${i}`}
+                  >
+                    <code
+                      className="language-javascript"
+                      dangerouslySetInnerHTML={{
+                        __html: example.highlighted,
+                      }}
+                    />
+                  </pre>
+                </div>
               ))}
             </div>
           )}

--- a/www/src/pages/docs/bound-action-creators.js
+++ b/www/src/pages/docs/bound-action-creators.js
@@ -33,16 +33,17 @@ class ActionCreatorsDocs extends React.Component {
           contains the functions and these can be individually extracted by
           using ES6 object destructuring.
         </p>
-        <pre
-          dangerouslySetInnerHTML={{
-            __html: `
-<code class=" language-javascript"><span class="token comment">// For function createNodeField</span>
+        <div className="gatsby-highlight">
+          <pre
+            className="language-javascript"
+            dangerouslySetInnerHTML={{
+              __html: `<code class="language-javascript"><span class="token comment">// For function createNodeField</span>
 exports<span class="token punctuation">.</span><span class="token function-variable function">onCreateNode</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token punctuation">{</span> node<span class="token punctuation">,</span> getNode<span class="token punctuation">,</span> boundActionCreators <span class="token punctuation">}</span><span class="token punctuation">)</span> <span class="token operator">=&gt;</span> <span class="token punctuation">{</span>
   <span class="token keyword">const</span> <span class="token punctuation">{</span> createNodeField <span class="token punctuation">}</span> <span class="token operator">=</span> boundActionCreators
-<span class="token punctuation">}</span></code>
-  `,
-          }}
-        />
+<span class="token punctuation">}</span></code>`,
+            }}
+          />
+        </div>
         <h2 css={{ marginBottom: rhythm(1 / 2) }}>Functions</h2>
         <ul css={{ ...scale(-1 / 5) }}>
           {this.props.data.allDocumentationJs.edges.map(({ node }, i) => (


### PR DESCRIPTION
Fixes all highlighted code blocks by wrapping them in `<div class="gatsby-highlight />` which our CSS is bound to: https://github.com/gatsbyjs/gatsby/blob/a97881ce3c0f93796898eb5b1ccf8ae7e5b67c12/www/src/utils/typography.js#L93-L143

This mimicks what [gatsby-remark-prismjs](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/) adds for code blocks in Markdown/Remark.

Also adds the appropiate `class="language-javascript"` to the `<pre>` element and removes the extraneous whitespace/newline in the first code block.

Before/after:

![image](https://user-images.githubusercontent.com/21834/37250523-032ce99c-24b4-11e8-85f8-5e38b42d3021.png)

![image](https://user-images.githubusercontent.com/21834/37250594-4b58bbdc-24b5-11e8-839d-cdb89523ec1c.png)
