### PR TITLE
Fix Contentful property internal of null on build

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -242,11 +242,21 @@ exports.createContentTypeNodes = ({
               entryItemFieldValue[0].sys.type &&
               entryItemFieldValue[0].sys.id
             ) {
-              entryItemFields[
-                `${entryItemFieldKey}___NODE`
-              ] = entryItemFieldValue
-                .filter(v => resolvable.has(v.sys.id))
-                .map(v => mId(v.sys.id))
+              // Check if there are any values in entryItemFieldValue to prevent
+              // creating an empty node field in case when original key field value
+              // is empty due to links to missing entities
+              const resolvableEntryItemFieldValue = entryItemFieldValue
+                .filter(function(v) {
+                  return resolvable.has(v.sys.id)
+                })
+                .map(function(v) {
+                  return mId(v.sys.id)
+                })
+              if (resolvableEntryItemFieldValue.length !== 0) {
+                entryItemFields[
+                  `${entryItemFieldKey}___NODE`
+                ] = resolvableEntryItemFieldValue
+              }
 
               delete entryItemFields[entryItemFieldKey]
             }


### PR DESCRIPTION
Fix for #4479 

Check whether there are any resolvable values in the entryItemFieldValue before adding `fieldkey___NODE`, otherwise it will map an empty array.

Alternative fix would be to fetch entities from ContentAPI and add values to unresolvable based on error values returned in response, but plugin uses sync.