### PR TITLE
Update dep

### DIFF
--- a/packages/gatsby-source-npm-package-search/package.json
+++ b/packages/gatsby-source-npm-package-search/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.5",
   "author": "james.a.stack@gmail.com",
   "dependencies": {
-    "algoliasearch": "^3.24.9",
+    "algoliasearch": "^3.25.1",
     "babel-runtime": "^6.26.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I was getting an error running gatsbyjs.org locally:

```
AlgoliaSearchError
protocol must be `http:` or `https:` (was `undefined`)
```

This seems to be from a recent algoliasearch release, fixed in 3.25.1: https://github.com/algolia/algoliasearch-client-javascript/blob/develop/CHANGELOG.md