### PR TITLE
sass plugin: use existing extract plugin for current stage

### DIFF
--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -1,10 +1,7 @@
 describe(`gatsby-plugin-sass`, () => {
-  jest.mock(`extract-text-webpack-plugin`, () => class {
-    extract(...args) {
-      return { extractTextCalledWithArgs: args }
-    }
+  jest.mock(`extract-text-webpack-plugin`, function ExtractTextPlugin() {
+    this.extract = (...args) => {return { extractTextCalledWithArgs: args }}
   })
-
   const { modifyWebpackConfig } = require(`../gatsby-node`)
   const cssLoader = expect.stringMatching(/^css/)
   ;[
@@ -75,7 +72,19 @@ describe(`gatsby-plugin-sass`, () => {
           const stringified = JSON.stringify(options)
 
           it(`modifies webpack config for ${stringified}`, () => {
-            const config = { loader: jest.fn(), merge: jest.fn() }
+            const config = {
+              loader: jest.fn(),
+              merge: jest.fn(),
+              resolve: jest.fn(() => {return {
+                plugins: [
+                  new function ExtractTextPlugin() {
+                    this.extract = (...args) => {return {
+                      extractTextCalledWithArgs: args,
+                    }}
+                  }(),
+                ],
+              }}),
+            }
             const modified = modifyWebpackConfig({ config, stage }, options)
 
             expect(modified).toBe(config)

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -1,12 +1,21 @@
-const ExtractTextPlugin = require(`extract-text-webpack-plugin`)
 const { cssModulesConfig } = require(`gatsby-1-config-css-modules`)
-
-const extractSass = new ExtractTextPlugin(`styles.css`, { allChunks: true })
 
 exports.modifyWebpackConfig = ({ config, stage }, options) => {
   const sassFiles = /\.s[ac]ss$/
   const sassModulesFiles = /\.module\.s[ac]ss$/
   const sassLoader = `sass?${JSON.stringify(options)}`
+
+  /**
+   * Get the first instance of `ExtractTextPlugin` from the plugins array. This
+   * relies on other plugins not intentionally inserting their own instance of
+   * `ExtractTextPlugin` before Gatsby's own.
+   */
+  const extractPlugin = config
+    .resolve()
+    .plugins.find(
+      plugin =>
+        plugin.constructor && plugin.constructor.name === `ExtractTextPlugin`
+    )
 
   switch (stage) {
     case `develop`: {
@@ -26,19 +35,15 @@ exports.modifyWebpackConfig = ({ config, stage }, options) => {
       config.loader(`sass`, {
         test: sassFiles,
         exclude: sassModulesFiles,
-        loader: extractSass.extract([`css?minimize`, sassLoader]),
+        loader: extractPlugin.extract([`css?minimize`, sassLoader]),
       })
 
       config.loader(`sassModules`, {
         test: sassModulesFiles,
-        loader: extractSass.extract(`style`, [
+        loader: extractPlugin.extract(`style`, [
           cssModulesConfig(stage),
           sassLoader,
         ]),
-      })
-
-      config.merge({
-        plugins: [extractSass],
       })
 
       return config
@@ -54,14 +59,10 @@ exports.modifyWebpackConfig = ({ config, stage }, options) => {
 
       config.loader(`sassModules`, {
         test: sassModulesFiles,
-        loader: extractSass.extract(`style`, [
+        loader: extractPlugin.extract(`style`, [
           cssModulesConfig(stage),
           sassLoader,
         ]),
-      })
-
-      config.merge({
-        plugins: [extractSass],
       })
 
       return config


### PR DESCRIPTION
For styles affecting the main chunk, we need to reuse the extract plugin instance created in Gatsby's webpack config, otherwise the new instance will overwrite the output of Gatsby's instance.

Fixes #4457 