### PR TITLE
Add rel="noopener" to external anchors

### DIFF
--- a/www/src/components/used-by.js
+++ b/www/src/components/used-by.js
@@ -21,6 +21,7 @@ const Icon = ({ icon, alt, href }) => (
     <a
       href={href}
       target="_blank"
+      rel="noopener"
       css={{
         borderBottom: `0 !important`,
         boxShadow: `none !important`,


### PR DESCRIPTION
Add rel="noopener" as a general security good practice to links which open using target="_blank".