### PR TITLE
Remove behance-collection

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -161,7 +161,6 @@ For usage instructions and options, see the plugin repo (linked below).
 * [gatsby-remark-sequence](https://github.com/liudonghua123/gatsby-remark-sequence)
 * [gatsby-source-airtable](https://github.com/kevzettler/gatsby-source-airtable)
 * [gatsby-source-behance](https://github.com/LeKoArts/gatsby-source-behance)
-* [gatsby-source-behance-collection](https://github.com/n370/gatsby-source-behance-collection)
 * [gatsby-source-datocms](https://github.com/datocms/gatsby-source-datocms)
 * [gatsby-source-directus](https://github.com/iKonrad/gatsby-source-directus)
 * [gatsby-source-dribbble](https://github.com/smakosh/gatsby-source-dribbble)


### PR DESCRIPTION
I added the functionalities of this fork to my source-plugin and hence removed it from the list to not confuse people what to use.
My commit: https://github.com/LeKoArts/gatsby-source-behance/commit/8d9b01be6abae0eca7a3d778f1b73b0fc6f85e0d