### PR TITLE
[gatsby-source-mongodb] create children nodes after parent node was created

### DIFF
--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -1,6 +1,6 @@
 const MongoClient = require(`mongodb`).MongoClient
 const crypto = require(`crypto`)
-const createMappingChildNodes = require(`./mapping`)
+const prepareMappingChildNode = require(`./mapping`)
 const _ = require(`lodash`)
 
 exports.sourceNodes = (
@@ -78,6 +78,7 @@ function createNodes(
             .digest(`hex`),
         },
       }
+      const childrenNodes = []
       if (pluginOptions.map) {
         let mapObj = pluginOptions.map
         if (pluginOptions.map[collectionName]) {
@@ -90,7 +91,7 @@ function createNodes(
             (typeof mapObj[mediaItemFieldKey] === `string` ||
               mapObj[mediaItemFieldKey] instanceof String)
           ) {
-            node[`${mediaItemFieldKey}___NODE`] = createMappingChildNodes(
+            const mappingChildNode = prepareMappingChildNode(
               node,
               mediaItemFieldKey,
               node[mediaItemFieldKey],
@@ -98,11 +99,17 @@ function createNodes(
               createNode
             )
 
+            node[`${mediaItemFieldKey}___NODE`] = mappingChildNode.id
+            childrenNodes.push(mappingChildNode)
+
             delete node[mediaItemFieldKey]
           }
         })
       }
       createNode(node)
+      childrenNodes.forEach(node => {
+        createNode(node)
+      })
     }
   })
 }

--- a/packages/gatsby-source-mongodb/src/mapping.js
+++ b/packages/gatsby-source-mongodb/src/mapping.js
@@ -21,7 +21,6 @@ module.exports = function(node, key, text, mediaType, createNode) {
   }
 
   node.children = node.children.concat([mappingNode.id])
-  createNode(mappingNode)
 
-  return mappingNode.id
+  return mappingNode
 }


### PR DESCRIPTION
Fix for last from official source plugins that was affected by parent/children changes.

| Source plugin | Status |
| --- | --- |
| gatsby-source-contentful | Fixed in #4429 |
| gatsby-source-drupal | Not used |
| gatsby-source-faker | Not used |
| gatsby-source-filesystem | Not used |
| gatsby-source-hacker-news | Correct order |
| gatsby-source-lever | Not used |
| gatsby-source-medium | Not used |
| gatsby-source-mongodb | Fix in this PR |
| gatsby-source-npm-package-search | Not used |
| gatsby-source-wordpress | Fixed in #4501 |
| gatsby-source-wordpress-com | Just a stub |

Next steps:
- update docs about parent/children
- remove parent/children in v2 where it shouldn't be used (https://github.com/gatsbyjs/gatsby/pull/4429#issuecomment-371651142)