### PR TITLE
Omit localized nodes which are missing required fields

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -224,6 +224,20 @@ exports.createContentTypeNodes = ({
       // Get localized fields.
       const entryItemFields = _.mapValues(entryItem.fields, v => getField(v))
 
+      // Check if all required fields are set on the entry. Required fields can
+      // be null if no values have been added for a locale.
+      // See https://github.com/gatsbyjs/gatsby/issues/4170
+      const requiredFieldsSet = Object.keys(entryItemFields).every(key => {
+        const field = _.find(contentTypeItem.fields, {id: key})
+        if (field && field.required) {
+          return entryItemFields[key] != null
+        }
+        return true
+      })
+      if (!requiredFieldsSet) {
+        return null
+      }
+
       // Prefix any conflicting fields
       // https://github.com/gatsbyjs/gatsby/pull/1084#pullrequestreview-41662888
       conflictFields.forEach(conflictField => {
@@ -364,7 +378,7 @@ exports.createContentTypeNodes = ({
       entryNode.internal.contentDigest = contentDigest
 
       return entryNode
-    })
+    }).filter(entry => entry != null)
 
     // Create a node for each content type
     const contentTypeNode = {

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -228,7 +228,7 @@ exports.createContentTypeNodes = ({
       // be null if no values have been added for a locale.
       // See https://github.com/gatsbyjs/gatsby/issues/4170
       const requiredFieldsSet = Object.keys(entryItemFields).every(key => {
-        const field = _.find(contentTypeItem.fields, {id: key})
+        const field = _.find(contentTypeItem.fields, { id: key })
         if (field && field.required) {
           return entryItemFields[key] != null
         }


### PR DESCRIPTION
⚠️ Unfortunately, this fix does cause issues with nodes pointing to other nodes which have been filtered out by this fix. I would love to discuss with some of the maintainers how to fix this properly.

**Update**: It looks like this is caused by another bug: If a referenced entry has localized fields but the referencing entry has not, a reverse reference is nonetheless created to the localized `id` for the referencing entry, which does not exist.

---

Fixes #4170, at least to the extend possible in a plugin (as far as my understanding goes). The remaining issue is that when data is cached in `.cache`, the `sourceNodes` function (which is the caller of the `createContentTypeNodes` function fixed here) is not called and thus corrupt localised nodes can still produce errors in builds. However, if you delete your cache before applying this fix, the problem should be solved.

The problem being solved being:
* contentful has required fields which cannot be omitted when creating/updating an entry
* this does not apply to non-default locales if a certain setting is not checked; this is useful to progressively translate pages of a large site
* if a page is not (yet) translated (completely), the localised not for this page should be omitted

This fix should be applicable to `v2` branch mutatis mutandis.

I am looking forward to your feedback. 🙂