### PR TITLE
Add --https option for `gatsby develop`

### DIFF
--- a/docs/docs/local-https.md
+++ b/docs/docs/local-https.md
@@ -1,0 +1,38 @@
+---
+title: "Local HTTPS"
+---
+
+Gatsby provides an easy way to use a local HTTPS server during development, thanks to [devcert](https://github.com/davewasmer/devcert). When you enable the `https` option, a private key and certificate file will be created for your project and used by the development server.
+
+## Usage
+
+Start the development server using `gatsby develop` as usual, and add either the `-S` or `--https` flag.
+
+    $ gatsby develop --https
+
+## Setup
+
+When setting up a development SSL certificate for the first time, you may be asked to type in your password after starting the development environment:
+
+    info setting up SSL certificate (may require sudo)
+
+    Password:
+
+This is *only* required the first time you are using Gatsby's HTTPS feature on your machine. After that, certificates will be created on the fly.
+
+After typing in your password, `devcert` will attempt to install some software necessary to tell Firefox (and Chrome, only on Linux) to trust your development certificates.
+
+    Unable to automatically install SSL certificate - please follow the
+    prompts at http://localhost:52175 in Firefox to trust the root certificate
+    See https://github.com/davewasmer/devcert#how-it-works for more details
+    -- Press <Enter> once you finish the Firefox prompts --
+
+If you wish to support Firefox (or Chrome on Linux), visit [localhost:52175](http://localhost:52175) in Firefox and follow the point-and-click wizard. Otherwise, you may press enter without following the prompts. **Reminder: you'll only need to do this once per machine.**
+
+Now open the development server at [https://localhost:8000](https://localhost:8000) and enjoy the HTTPS goodness ✨. Of course, you may change the port according to your setup.
+
+Find out more about [how devcert works](https://github.com/davewasmer/devcert#how-it-works).
+
+****
+
+Keep in mind that the certificates are explicitly issued to `localhost` and will only be accepted there. Using it together with the `--host` option will likely result in browser warnings.

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -37,6 +37,9 @@ Options
   -S, --https   Use HTTPS?
 ```
 
+Follow the [Local HTTPS guide](https://www.gatsbyjs.org/docs/local-https/)
+to find out how you can set up an HTTPS development server using Gatsby.
+
 ### Build
 
 At the root of a Gatsby site run `gatsby build` to do a production build of a

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -34,7 +34,7 @@ Options
   -H, --host    Set host. Defaults to localhost
   -p, --port    Set port. Defaults to 8000
   -o, --open    Open the site in your browser for you
-  -S, --https   Use HTTPS?
+  -S, --https   Use HTTPS
 ```
 
 Follow the [Local HTTPS guide](https://www.gatsbyjs.org/docs/local-https/)

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -34,6 +34,7 @@ Options
   -H, --host    Set host. Defaults to localhost
   -p, --port    Set port. Defaults to 8000
   -o, --open    Open the site in your browser for you
+  -S, --https   Use HTTPS?
 ```
 
 ### Build

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -98,6 +98,11 @@ function buildLocalCommands(cli, isLocalSite) {
           alias: `open`,
           type: `boolean`,
           describe: `Open the site in your browser for you.`,
+        })
+        .option(`S`, {
+          alias: `https`,
+          type: `boolean`,
+          describe: `Use HTTPS?`,
         }),
     handler: handlerP(
       getCommandHandler(`develop`, (args, cmd) => {

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -102,7 +102,7 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`S`, {
           alias: `https`,
           type: `boolean`,
-          describe: `Use HTTPS?`,
+          describe: `Use HTTPS. See https://www.gatsbyjs.org/docs/local-https/ for an initial setup guide`,
         }),
     handler: handlerP(
       getCommandHandler(`develop`, (args, cmd) => {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -37,6 +37,7 @@
     "debug": "^2.6.0",
     "del": "^3.0.0",
     "detect-port": "^1.2.1",
+    "devcert-san": "^0.3.3",
     "domready": "^1.0.8",
     "dotenv": "^4.0.0",
     "express": "^4.14.0",

--- a/packages/gatsby/src/utils/get-ssl-cert.js
+++ b/packages/gatsby/src/utils/get-ssl-cert.js
@@ -1,0 +1,18 @@
+const getDevelopmentCertificate = require(`devcert-san`).default
+const report = require(`gatsby-cli/lib/reporter`)
+
+module.exports = async name => {
+  report.info(`setting up SSL certificate (may require sudo)`)
+  report.log(``)
+
+  try {
+    return await getDevelopmentCertificate(name, {
+      installCertutil: true,
+    })
+  } catch (err) {
+    report.log(``)
+    report.panic(`Failed to generate dev SSL certificate`, err)
+  }
+
+  return false
+}

--- a/packages/gatsby/src/utils/get-ssl-cert.js
+++ b/packages/gatsby/src/utils/get-ssl-cert.js
@@ -2,16 +2,14 @@ const getDevelopmentCertificate = require(`devcert-san`).default
 const report = require(`gatsby-cli/lib/reporter`)
 
 module.exports = async name => {
-  report.info(`setting up SSL certificate (may require sudo)`)
-  report.log(``)
+  report.info(`setting up SSL certificate (may require sudo)\n`)
 
   try {
     return await getDevelopmentCertificate(name, {
       installCertutil: true,
     })
   } catch (err) {
-    report.log(``)
-    report.panic(`Failed to generate dev SSL certificate`, err)
+    report.panic(`\nFailed to generate dev SSL certificate`, err)
   }
 
   return false

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -96,7 +96,9 @@ module.exports = async (
         return {
           path: directory,
           filename: `[name].js`,
-          publicPath: `http://${program.host}:${webpackPort}/`,
+          publicPath: `${program.ssl ? `https` : `http`}://${
+            program.host
+          }:${webpackPort}/`,
           devtoolModuleFilenameTemplate: info =>
             path.resolve(info.absoluteResourcePath).replace(/\\/g, `/`),
         }
@@ -142,7 +144,9 @@ module.exports = async (
         return {
           commons: [
             require.resolve(`react-hot-loader/patch`),
-            `${require.resolve(`webpack-hot-middleware/client`)}?path=http://${
+            `${require.resolve(`webpack-hot-middleware/client`)}?path=${
+              program.ssl ? `https` : `http`
+            }://${
               program.host
             }:${webpackPort}/__webpack_hmr&reload=true&overlay=false`,
             directoryPath(`.cache/app`),

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -48,6 +48,8 @@
       link: /docs/environment-variables/
     - title: Gatsby on Windows
       link: /docs/gatsby-on-windows/
+    - title: Local HTTPS
+      link: /docs/local-https/
     - title: Managing Content with Netlify CMS
       link: /docs/netlify-cms/
     - title: How Gatsby Works with GitHub Pages


### PR DESCRIPTION
Regarding #1975.

This adds the option of using HTTPS for `gatsby develop`, thanks to [`devcert`](https://github.com/davewasmer/devcert). The implementation is heavily inspired by what [`preact-cli`](https://github.com/developit/preact-cli) has done, minus the fallback to `simplehttp2server`. Wondering if that's necessary?

So using `-S` or `--https` would give you:

![cert](https://user-images.githubusercontent.com/5220692/37376665-ade8213a-2725-11e8-9bd0-8565d9d8724e.png)

It appears that only `localhost` is verified, so it probably won't work well together with `--host`. Same behavior can be seen at `preact-cli`.