### PR TITLE
Tweaked capitalization in docs for consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-title: How to contribute
+title: How to Contribute
 ---
 
 ## Contributing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,8 @@ The usual contributing steps are:
 Gatsby, unsurprisingly, uses Gatsby for its documentation website.
 
 If you want to add/modify any Gatsby documentation, go to the
-[docs folder on Github](https://github.com/gatsbyjs/gatsby/tree/master/docs) and
-use the file editor to edit and then preview your changes. Github then allows
+[docs folder on GitHub](https://github.com/gatsbyjs/gatsby/tree/master/docs) and
+use the file editor to edit and then preview your changes. GitHub then allows
 you to commit the change and raise a PR right in the UI. This is the _easiest_
 way you can contribute to the project!
 

--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -1,5 +1,5 @@
 ---
-title: "Add Custom webpack config"
+title: "Add Custom webpack Config"
 ---
 
 _Before creating custom webpack configuration, check to see if there's a Gatsby

--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -1,5 +1,5 @@
 ---
-title: "Add custom webpack config"
+title: "Add Custom webpack config"
 ---
 
 _Before creating custom webpack configuration, check to see if there's a Gatsby

--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -1,5 +1,5 @@
 ---
-title: Creating tags pages for blog posts
+title: Creating Tags Pages for Blog Posts
 ---
 
 Creating tag pages for your blog post is a way to let visitors browse related content.

--- a/docs/docs/api-specification.md
+++ b/docs/docs/api-specification.md
@@ -1,5 +1,5 @@
 ---
-title: API specification
+title: API Specification
 ---
 
 Gatsby's APIs are tailored conceptually to some extent after React.js to improve

--- a/docs/docs/building-apps-with-gatsby.md
+++ b/docs/docs/building-apps-with-gatsby.md
@@ -1,5 +1,5 @@
 ---
-title: "Building apps with Gatsby"
+title: "Building Apps with Gatsby"
 ---
 
 Gatsby is an excellent framework for building web apps. You can use Gatsby to create personalized, logged-in experiences with two different methods.

--- a/docs/docs/caching.md
+++ b/docs/docs/caching.md
@@ -1,5 +1,5 @@
 ---
-title: "Caching static sites"
+title: "Caching Static Sites"
 ---
 
 An important part of creating a very fast website is setting up proper HTTP caching. HTTP caching allows browsers to cache resources from a website so that when the user returns to a site, very few parts of the website have to be downloaded.

--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "Create a source plugin"
+title: "Create a Source Plugin"
 ---
 
 There are two types of plugins that work within Gatsby's data system, "source"

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating and modifying pages"
+title: "Creating and Modifying Pages"
 ---
 
 Gatsby makes it easy to programmatically control your pages.

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -48,10 +48,10 @@ choose to use the default setup (without a custom domain), or if you create a
 project site, you will need to setup your site with
 [path prefixing](/docs/path-prefix/).
 
-On Github, you get one site per GitHub account and organization, and unlimited
+On GitHub, you get one site per GitHub account and organization, and unlimited
 project sites. So it is most likely you will be creating a project site. If you
-do not have an existing repository on Github that you plan to use, take the time
-now to create a new repository on Github.
+do not have an existing repository on GitHub that you plan to use, take the time
+now to create a new repository on GitHub.
 
 ### Use the NPM package `gh-pages` for deploying
 
@@ -114,9 +114,9 @@ custom domain url inside, like so:
 your-custom-domain.com
 ```
 
-## Gitlab Pages
+## GitLab Pages
 
-Gitlab Pages are similar to GitHub pages, perhaps even easier to setup. It also
+GitLab Pages are similar to GitHub Pages, perhaps even easier to setup. It also
 supports custom domain names and SSL certificates. The process of setting GitLab
 pages up is made a lot easier with GitLab's included continuous integration
 platform.
@@ -131,7 +131,7 @@ git add .
 git push -u origin master
 ```
 
-You can deploy sites on Gitlab Pages with or without a custom domain. If you choose to use the default setup (without a custom domain), or if you create a project site, you will need to setup your site with path prefixing. If adding a custom domain, you can skip the Path Prefix step, and remove `--prefix-paths` from the gitlab-ci.yml file.
+You can deploy sites on GitLab Pages with or without a custom domain. If you choose to use the default setup (without a custom domain), or if you create a project site, you will need to setup your site with path prefixing. If adding a custom domain, you can skip the Path Prefix step, and remove `--prefix-paths` from the gitlab-ci.yml file.
 
 ### Path Prefix
 
@@ -149,7 +149,7 @@ module.exports = {
 }
 ```
 
-### Build and deploy with Gitlab CI
+### Build and deploy with GitLab CI
 
 To use GitLab's continuous integration (CI), you need to add a `.gitlab-ci.yml`
 configuration file. This can be added into your project folder, or once you have

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -149,7 +149,7 @@ module.exports = {
 }
 ```
 
-### Build and deploy with GitLab CI
+### Build and Deploy with GitLab CI
 
 To use GitLab's continuous integration (CI), you need to add a `.gitlab-ci.yml`
 configuration file. This can be added into your project folder, or once you have

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -2,7 +2,7 @@
 title: How Gatsby Works with GitHub Pages
 ---
 
-The easiest way to push a gatsby app to github pages is using a package called `gh-pages`.
+The easiest way to push a gatsby app to GitHub Pages is using a package called `gh-pages`.
 
 `yarn add --dev gh-pages`
 

--- a/docs/docs/how-to-file-an-issue.md
+++ b/docs/docs/how-to-file-an-issue.md
@@ -1,5 +1,5 @@
 ---
-title: How to file an issue
+title: How to File an Issue
 ---
 
 The [issue tracker](https://github.com/gatsbyjs/gatsby/issues) is the preferred channel for bug reports, features requests and submitting pull requests.

--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -5,7 +5,7 @@ title: Adding a Path Prefix
 Many sites are hosted at something other than the root of their domain.
 
 E.g. a Gatsby blog could live at `example.com/blog/` or a site could be hosted
-on GitHub pages at `example.github.io/my-gatsby-site/`
+on GitHub Pages at `example.github.io/my-gatsby-site/`
 
 Each of these sites need a prefix added to all paths on the site. So a link to
 `/my-sweet-blog-post/` should be rewritten to `/blog/my-sweet-blog-post`.

--- a/docs/docs/querying-with-graphql.md
+++ b/docs/docs/querying-with-graphql.md
@@ -1,5 +1,5 @@
 ---
-title: Querying data with GraphQL
+title: Querying Data with GraphQL
 ---
 
 There are many options for loading data into React components. One of the most

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -20,7 +20,7 @@
       link: /docs/plugins/
     - title: PRPL Pattern
       link: /docs/prpl-pattern/
-    - title: Querying data with GraphQL
+    - title: Querying Data with GraphQL
       link: /docs/querying-with-graphql/
 - title: Guides
   items:
@@ -30,13 +30,13 @@
       link: /docs/adding-images-fonts-files/
     - title: Browser Support
       link: /docs/browser-support/
-    - title: Building apps with Gatsby
+    - title: Building Apps with Gatsby
       link: /docs/building-apps-with-gatsby/
     - title: Caching
       link: /docs/caching/
     - title: Creating and Modifying Pages
       link: /docs/creating-and-modifying-pages/
-    - title: Create a source plugin
+    - title: Create a Source Plugin
       link: /docs/create-source-plugin/
     - title: Custom webpack config
       link: /docs/add-custom-webpack-config/
@@ -62,9 +62,9 @@
       link: /docs/plugin-authoring/
     - title: Proxying API Requests
       link: /docs/api-proxy/
-    - title: Using CSS-in-JS library Glamor
+    - title: Using CSS-in-JS Library Glamor
       link: /docs/glamor/
-    - title: Using CSS-in-JS library Styled Components
+    - title: Using CSS-in-JS Library Styled Components
       link: /docs/styled-components/
     - title: Adding Markdown Pages
       link: /docs/adding-markdown-pages/

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -15,7 +15,7 @@ class IndexRoute extends React.Component {
           <title>Docs</title>
         </Helmet>
         <h1 id="get-started" css={{ marginTop: 0 }}>
-          Get started
+          Get Started
         </h1>
         <p>Gatsby is a blazing-fast static site generator for React.</p>
         <p>


### PR DESCRIPTION
Heya folks, 
I noticed some inconsistent capitalization in the docs, specifically the titles of articles and GitHub vs. Github. I changed them to all conform to MLA title casing, which I think is what’s being currently used for most doc titles. 
Feel free to merge, discuss, or reject.