### PR TITLE
WordPress, the open-source project, doesn't come with a hosted option

### DIFF
--- a/docs/features/gatsby-specs.csv
+++ b/docs/features/gatsby-specs.csv
@@ -63,7 +63,7 @@ Developer Experience,Maintenance & Extensibility,Serverless,3,3,2,2,"<p>Serverle
 <li><b>Data structures / types and modularity</b>: Maps, sets, modules, module loading, unicode...</li>
 </ul>"
 Ecosystem,Ecosystem,Component ecosystem,3,0,3,0,"React has several sets of out-of-the-box component libraries, as well as curated sets eg <a href=""https://js.coach/?collection=React"">JSCoach</a>"
-,,Hosted option,2,2,3,3,Gatsby and other static site generators can be plugged into static hosts such as Netlify or surge.sh. Wordpress and Squarespace both come with built-in hosting.
+,,Hosted option,2,2,2,3,Gatsby and other static site generators can be plugged into static hosts such as Netlify or surge.sh. Squarespace comes with built-in hosting.
 ,,Theme ecosystem,2,2,3,3,"Gatsby offers various themes through Typography.js, and Jekyll has themes built on it as well. Wordpress and Squarespace offer support for multiple themes through theme selectors out of the box."
 Design,Faster design iterations,Programmatic Design,2,0,0,0,"Gatsby offers support for programmatic design by being built on <a href=""https://kyleamathews.github.io/typography.js/"">Typography.js</a>."
 ,,Design systems,2,0,0,0,"Gatsby offers native support for design systems through react-sketch, a tool allowing you to export your production React components into Sketch. Other frameworks aren't plugged into the React ecosystem."


### PR DESCRIPTION
There is [WordPress](https://wordpress.org/) (.org) and there is [WordPress.com](https://wordpress.com/). They are very different, for example, WordPress.com doesn't allow custom plugins or themes so most of the items in this table would not apply to it.

The table seems to be comparing Gatsby with WordPress, the open source project, and that doesn't come with any built-in hosting; it's on par with Gatsby in that respect.