### PR TITLE
gatsby-remark-prismjs: support inline code (single ticks)

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -27,6 +27,13 @@ plugins: [
             // This is an uncommon use-case though;
             // If you're unsure, it's best to use the default value.
             classPrefix: "language-",
+            // This is used to allow setting a language for inline code
+            // (i.e. single backticks) by creating a separator.
+            // This separator is a string and will do no white-space
+            // stripping.
+            // A suggested value for English speakers is the non-ascii
+            // character '›'.
+            inlineCodeMarker: null,
           },
         },
       ],
@@ -148,6 +155,20 @@ CSS along your PrismJS theme and the styles for `.gatsby-highlight-code-line`:
       }
     ]
     ```
+
+    In addition to fenced code blocks, inline code blocks will be passed through
+    prismjs as well.
+
+    If you set the `inlineCodeMarker`, then you can also specify a format style.
+
+    Here's an example of how to use this if the `inlineCodeMarker` was set to `±`:
+
+    ``` markdown
+    I can highlight `css±.some-class { background-color: red }` with CSS syntax.
+    ```
+
+    This will be rendered in a `<code class=language-css>` with just the (syntax
+    highlighted) text of `.some-class { background-color: red }`
 
 ## Implementation notes
 

--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -188,7 +188,7 @@ Our approach follows the [Pygments-based][2] implementation of the [React
 Tutorial/Documentation][4] for line highlights:
 
 * It uses a wrapper element `<div class="gatsby-highlight">` around the
-  PrismJS-formatted `<pre><code>`-blocks.`.
+  PrismJS-formatted `<pre><code>`-blocks.
 * Highlighted lines are wrapped in `<span class="gatsby-highlight-code-line">`.
 * We insert a linebreak before the closing tag of `.gatsby-highlight-code-line`
   so it ends up at the start of the follwing line.

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -87,3 +87,169 @@ Object {
   "type": "root",
 }
 `;
+
+exports[`remark prism plugin generates inline <code> tag with a custom class prefix if configured 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 10,
+              "line": 1,
+              "offset": 9,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "html",
+          "value": "<code class=\\"custom-none\\">foo bar</code>",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+          "offset": 9,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 10,
+      "line": 1,
+      "offset": 9,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`remark prism plugin generates inline <code> tag with class="language-*" prefix by default 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 10,
+              "line": 1,
+              "offset": 9,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "html",
+          "value": "<code class=\\"language-none\\">foo bar</code>",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+          "offset": 9,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 10,
+      "line": 1,
+      "offset": 9,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`remark prism plugin inlineCode handles language specifiers 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "html",
+          "value": "<code class=\\"language-css\\"><span class=\\"token selector\\">.foo</span> <span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">color</span><span class=\\"token punctuation\\">:</span> red <span class=\\"token punctuation\\">}</span>
+</code>",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 26,
+          "line": 1,
+          "offset": 25,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 26,
+      "line": 1,
+      "offset": 25,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -206,9 +206,9 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 26,
+              "column": 29,
               "line": 1,
-              "offset": 25,
+              "offset": 28,
             },
             "indent": Array [],
             "start": Object {
@@ -224,9 +224,9 @@ Object {
       ],
       "position": Position {
         "end": Object {
-          "column": 26,
+          "column": 29,
           "line": 1,
-          "offset": 25,
+          "offset": 28,
         },
         "indent": Array [],
         "start": Object {
@@ -240,9 +240,9 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 26,
+      "column": 29,
       "line": 1,
-      "offset": 25,
+      "offset": 28,
     },
     "start": Object {
       "column": 1,

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -31,9 +31,9 @@ describe(`remark prism plugin`, () => {
   })
 
   it(`inlineCode handles language specifiers`, () => {
-    const code = `\`css›.foo { color: red }\``
+    const code = `\`css🍺  .foo { color: red }\``
     const markdownAST = remark.parse(code)
-    plugin({ markdownAST })
+    plugin({ markdownAST }, { inlineCodeMarker: `🍺  ` })
     expect(markdownAST).toMatchSnapshot()
   })
 })

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -15,4 +15,25 @@ describe(`remark prism plugin`, () => {
     plugin({ markdownAST }, { classPrefix: `custom-` })
     expect(markdownAST).toMatchSnapshot()
   })
+
+  it(`generates inline <code> tag with class="language-*" prefix by default`, () => {
+    const code = `\`foo bar\``
+    const markdownAST = remark.parse(code)
+    plugin({ markdownAST })
+    expect(markdownAST).toMatchSnapshot()
+  })
+
+  it(`generates inline <code> tag with a custom class prefix if configured`, () => {
+    const code = `\`foo bar\``
+    const markdownAST = remark.parse(code)
+    plugin({ markdownAST }, { classPrefix: `custom-` })
+    expect(markdownAST).toMatchSnapshot()
+  })
+
+  it(`inlineCode handles language specifiers`, () => {
+    const code = `\`css›.foo { color: red }\``
+    const markdownAST = remark.parse(code)
+    plugin({ markdownAST })
+    expect(markdownAST).toMatchSnapshot()
+  })
 })

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -3,7 +3,7 @@ const visit = require(`unist-util-visit`)
 const parseLineNumberRange = require(`./parse-line-number-range`)
 const highlightCode = require(`./highlight-code`)
 
-module.exports = ({ markdownAST }, { classPrefix = `language-` } = {}) => {
+module.exports = ({ markdownAST }, { classPrefix = `language-`, inlineCodeMarker = null } = {}) => {
   visit(markdownAST, `code`, node => {
     let language = node.lang
     let { splitLanguage, highlightLines } = parseLineNumberRange(language)
@@ -43,10 +43,12 @@ module.exports = ({ markdownAST }, { classPrefix = `language-` } = {}) => {
   visit(markdownAST, `inlineCode`, node => {
     let languageName = `none`
 
-    let [ language, restOfValue ] = node.value.split(`›`, 2)
-    if (language && restOfValue) {
-      languageName = language.toLowerCase()
-      node.value = restOfValue
+    if (inlineCodeMarker) {
+      let [ language, restOfValue ] = node.value.split(`${inlineCodeMarker}`, 2)
+      if (language && restOfValue) {
+        languageName = language.toLowerCase()
+        node.value = restOfValue
+      }
     }
 
     const className = `${classPrefix}${languageName}`

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -39,4 +39,22 @@ module.exports = ({ markdownAST }, { classPrefix = `language-` } = {}) => {
     )}</code></pre>
       </div>`
   })
+
+  visit(markdownAST, `inlineCode`, node => {
+    let languageName = `none`
+
+    let [ language, restOfValue ] = node.value.split(`›`, 2)
+    if (language && restOfValue) {
+      languageName = language.toLowerCase()
+      node.value = restOfValue
+    }
+
+    const className = `${classPrefix}${languageName}`
+
+    node.type = `html`
+    node.value = `<code class="${className}">${highlightCode(
+      languageName,
+      node.value
+    )}</code>`
+  })
 }


### PR DESCRIPTION
Currently, the gatsby-remark-prismjs plugin is ignoring inline code markdown
(i.e. text inside single backticks).  This means that most stock prismjs CSS
and even the typography prismjs themes don't work.

The specific CSS selectors to style inline code element usually looks like
`:not(pre) > code[class*="language-"]`

By setting the `inlineCodeMarker` option, you can then do:

``` markdown
Search for the `css›.some-class { color: red }` code and change `red` to
`blue`.
```

Which is converted into this before being passed to prismjs:

``` html
Search for the <code class="language-css">.some-class { color: red }</code>
code and change <code>red</code> to <code>blue</code>.
```