### PR TITLE
[www] Fix search box

### DIFF
--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -293,6 +293,11 @@ class SearchForm extends Component {
       indexName: `gatsbyjs`,
       inputSelector: `#doc-search`,
       debug: false,
+      autocompleteOptions: {
+        openOnFocus: true,
+        autoselect: true,
+        hint: false,
+      },
     })
   }
 


### PR DESCRIPTION
Closes #4431 

Replaying the repro steps mentioned in the issue with this fix:

![gatsby-search-fix](https://user-images.githubusercontent.com/450559/37533679-835a63f2-2968-11e8-92e0-98c61fcf4527.gif)
