### PR TITLE
[www] Use algolia's config for search box keyboard shortcut

### DIFF
--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -238,7 +238,6 @@ class SearchForm extends Component {
     super()
     this.state = { enabled: true, focussed: false }
     this.autocompleteSelected = this.autocompleteSelected.bind(this)
-    this.focusSearchInput = this.focusSearchInput.bind(this)
   }
 
   /**
@@ -257,16 +256,6 @@ class SearchForm extends Component {
     navigateTo(`${a.pathname}${a.hash}`)
   }
 
-  focusSearchInput(e) {
-    if (e.key !== `s`) return
-
-    // ignore this shortcut whenever an <input> has focus
-    if (document.activeElement instanceof window.HTMLInputElement) return // eslint-disable-line no-undef
-
-    e.preventDefault()
-    this.searchInput.focus()
-  }
-
   componentDidMount() {
     if (
       typeof window === `undefined` || // eslint-disable-line no-undef
@@ -276,9 +265,6 @@ class SearchForm extends Component {
       this.setState({ enabled: false })
       return
     }
-
-    // eslint-disable-next-line no-undef
-    window.addEventListener(`keydown`, this.focusSearchInput)
 
     // eslint-disable-next-line no-undef
     window.addEventListener(
@@ -297,13 +283,9 @@ class SearchForm extends Component {
         openOnFocus: true,
         autoselect: true,
         hint: false,
+        keyboardShortcuts: ['s']
       },
     })
-  }
-
-  componentWillUnmount() {
-    // eslint-disable-next-line no-undef
-    window.removeEventListener(`keydown`, this.focusSearchInput)
   }
 
   render() {


### PR DESCRIPTION
Looks like the keyboard shortcut ('s') for search box isn't working now. While trying to fix this, found Algolia autocomplete lib has a config option to specify the keyboard shortcut and it works well. It also takes care of the issue mentioned in https://github.com/gatsbyjs/gatsby/pull/3654#issuecomment-361461238