### PR TITLE
Fix usage instructions for remark-embed-snippet

### DIFF
--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -114,25 +114,47 @@ quz: "highlighted"
 
 `npm install --save gatsby-remark-embed-snippet`
 
-## Usage
+## How to use
 
 ```javascript
 // In your gatsby-config.js
-{
-  resolve: 'gatsby-remark-embed-snippet',
-  options: {
-    // Class prefix for <pre> tags containing syntax highlighting;
-    // defaults to 'language-' (eg <pre class="language-js">).
-    // If your site loads Prism into the browser at runtime,
-    // (eg for use with libraries like react-live),
-    // you may use this to prevent Prism from re-processing syntax.
-    // This is an uncommon use-case though;
-    // If you're unsure, it's best to use the default value.
-    classPrefix: 'language-',
+plugins: [
+  {
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      plugins: [
+        {
+          resolve: `gatsby-remark-prismjs`,
+          options: {
+            // Class prefix for <pre> tags containing syntax highlighting;
+            // defaults to 'language-' (eg <pre class="language-js">).
+            // If your site loads Prism into the browser at runtime,
+            // (eg for use with libraries like react-live),
+            // you may use this to prevent Prism from re-processing syntax.
+            // This is an uncommon use-case though;
+            // If you're unsure, it's best to use the default value.
+            classPrefix: "language-",
+          },
+        },
+        {
+          resolve: 'gatsby-remark-embed-snippet',
+          options: {
+            // Class prefix for <pre> tags containing syntax highlighting;
+            // defaults to 'language-' (eg <pre class="language-js">).
+            // If your site loads Prism into the browser at runtime,
+            // (eg for use with libraries like react-live),
+            // you may use this to prevent Prism from re-processing syntax.
+            // This is an uncommon use-case though;
+            // If you're unsure, it's best to use the default value.
+            classPrefix: 'language-',
 
-    // Example code links are relative to this dir.
-    // eg examples/path/to/file.js
-    directory: `${__dirname}/examples/`,
+            // Example code links are relative to this dir.
+            // eg examples/path/to/file.js
+            directory: `${__dirname}/examples/`,
+          },
+        },
+      ],
+    },
   },
-},
+};
 ```

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -118,43 +118,45 @@ quz: "highlighted"
 
 ```javascript
 // In your gatsby-config.js
-plugins: [
-  {
-    resolve: `gatsby-transformer-remark`,
-    options: {
-      plugins: [
-        {
-          resolve: `gatsby-remark-prismjs`,
-          options: {
-            // Class prefix for <pre> tags containing syntax highlighting;
-            // defaults to 'language-' (eg <pre class="language-js">).
-            // If your site loads Prism into the browser at runtime,
-            // (eg for use with libraries like react-live),
-            // you may use this to prevent Prism from re-processing syntax.
-            // This is an uncommon use-case though;
-            // If you're unsure, it's best to use the default value.
-            classPrefix: "language-",
+module.exports = {
+  plugins: [ 
+    {
+      resolve: `gatsby-transformer-remark`,
+      options: {
+        plugins: [
+          {
+            resolve: `gatsby-remark-prismjs`,
+            options: {
+              // Class prefix for <pre> tags containing syntax highlighting;
+              // defaults to 'language-' (eg <pre class="language-js">).
+              // If your site loads Prism into the browser at runtime,
+              // (eg for use with libraries like react-live),
+              // you may use this to prevent Prism from re-processing syntax.
+              // This is an uncommon use-case though;
+              // If you're unsure, it's best to use the default value.
+              classPrefix: "language-",
+            },
           },
-        },
-        {
-          resolve: 'gatsby-remark-embed-snippet',
-          options: {
-            // Class prefix for <pre> tags containing syntax highlighting;
-            // defaults to 'language-' (eg <pre class="language-js">).
-            // If your site loads Prism into the browser at runtime,
-            // (eg for use with libraries like react-live),
-            // you may use this to prevent Prism from re-processing syntax.
-            // This is an uncommon use-case though;
-            // If you're unsure, it's best to use the default value.
-            classPrefix: 'language-',
+          {
+            resolve: 'gatsby-remark-embed-snippet',
+            options: {
+              // Class prefix for <pre> tags containing syntax highlighting;
+              // defaults to 'language-' (eg <pre class="language-js">).
+              // If your site loads Prism into the browser at runtime,
+              // (eg for use with libraries like react-live),
+              // you may use this to prevent Prism from re-processing syntax.
+              // This is an uncommon use-case though;
+              // If you're unsure, it's best to use the default value.
+              classPrefix: 'language-',
 
-            // Example code links are relative to this dir.
-            // eg examples/path/to/file.js
-            directory: `${__dirname}/examples/`,
+              // Example code links are relative to this dir.
+              // eg examples/path/to/file.js
+              directory: `${__dirname}/examples/`,
+            },
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-};
+  ]
+}
 ```


### PR DESCRIPTION
It didn't mention that it needed to be in the `gatsby-transformer-remak`
plugins section.