### PR TITLE
Correct line highlighting

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -197,7 +197,7 @@ Let's make a quick improvement. Many sites have a single column of text centered
 in the middle of the page. To create this, add the following styles to the
 `<div>` in `src/pages/index.js`.
 
-```jsx{4,23}
+```jsx{4,25}
 import React from "react";
 
 export default () =>


### PR DESCRIPTION
Line 25 should be highlighted, as it corresponds with the opening div tag.

The problem can be seen here https://www.gatsbyjs.org/tutorial/part-two/