### PR TITLE
Remove "gatsby-plugin" keyword from gatsby-react-router-scroll as it's not a plugin

### DIFF
--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -19,8 +19,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll#readme",
   "keywords": [
-    "gatsby",
-    "gatsby-plugin"
+    "gatsby"
   ],
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
It's a direct dependency of `gatsby`, not something people optionally add to their site.