### PR TITLE
[transformer-react-docgen] add missing description for method

### DIFF
--- a/packages/gatsby-transformer-react-docgen/src/extend-node-type.js
+++ b/packages/gatsby-transformer-react-docgen/src/extend-node-type.js
@@ -34,6 +34,7 @@ const Method = new GraphQLObjectType({
   fields: () => {
     return {
       name: { type: new GraphQLNonNull(GraphQLString) },
+      description: { type: GraphQLString },
       docblock: {
         type: GraphQLString,
         description: oneLine`


### PR DESCRIPTION
Although it's seldom being used, but it'a available from `react-docgen`, and I need it 😉 