### PR TITLE
fix(search): filter out deprecated packages

### DIFF
--- a/www/src/components/searchbar-body.js
+++ b/www/src/components/searchbar-body.js
@@ -200,7 +200,12 @@ class Search extends Component {
             attributeName="keywords"
             defaultRefinement={[`gatsby-component`, `gatsby-plugin`]}
           />
-          <Toggle attributeName="deprecated" defaultRefinement={false} />
+          <Toggle
+            attributeName="deprecated"
+            value={false}
+            label="No deprecated plugins"
+            defaultRefinement={true}
+          />
         </div>
 
         <div
@@ -278,10 +283,9 @@ class Search extends Component {
                 overflow: `hidden`,
                 textIndent: `-9000px`,
                 padding: `0!important`,
-                width: `100%`,
+                width: 110,
                 height: `100%`,
                 display: `block`,
-                width: 110,
                 marginLeft: `auto`,
                 "&:hover": {
                   background: `url(${AlgoliaLogo})`,


### PR DESCRIPTION
This was my fault, I got confused when explaining how to do this.

Both this toggle and the refinementList can also be done with Configure (no need to hide then), or with "virtual widgets" (also no need to hide).

If needed I can make a PR for a change like that :)