### PR TITLE
fix(cli): Console errors should have a background color

### DIFF
--- a/packages/gatsby-cli/src/reporter/errors.js
+++ b/packages/gatsby-cli/src/reporter/errors.js
@@ -25,6 +25,12 @@ function getErrorFormatter() {
     "pretty-error": {
       marginTop: 1,
     },
+    'pretty-error > header': {
+      background: `red`,
+    },
+    'pretty-error > header > colon': {
+      color: `white`,
+    },
   })
 
   prettyError.render = err => {


### PR DESCRIPTION
Fixes #2645 

# Before

<img width="529" alt="screen shot 2018-03-19 at 11 53 38" src="https://user-images.githubusercontent.com/135674/37594116-39b447c6-2b6c-11e8-9779-d4e73b6f25a6.png">
<img width="540" alt="screen shot 2018-03-19 at 11 53 49" src="https://user-images.githubusercontent.com/135674/37594119-3b3d05ce-2b6c-11e8-8c7d-ed35d75452d3.png">


# After

<img width="530" alt="screen shot 2018-03-19 at 11 50 34" src="https://user-images.githubusercontent.com/135674/37593984-db113580-2b6b-11e8-8e5f-11065a21c313.png">
<img width="551" alt="screen shot 2018-03-19 at 11 51 00" src="https://user-images.githubusercontent.com/135674/37593985-db260410-2b6b-11e8-9296-fb0e134cbbd8.png">
