### PR TITLE
Consistently use `npm` instead of `yarn` [Docs][Review]

### DIFF
--- a/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
+++ b/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
@@ -181,7 +181,7 @@ Let's fix that. We need to teach Gatsby how to query the file system. Luckily
 this is so common it's been done for you. Install the file system source plugin:
 
 ```
-yarn add gatsby-source-filesystem
+npm i --save gatsby-source-filesystem
 ```
 
 Now modify `gatsby-config.js` to both use the plugin and tell it what directory
@@ -230,7 +230,7 @@ files this is all you will need. But if you want to render markdown files as
 HTML you will need another plugin. Let's add that now:
 
 ```
-yarn add gatsby-transformer-remark
+npm i --save gatsby-transformer-remark
 ```
 
 As before, add it to the `plugins` field in `gatsby-config.js`:

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -166,7 +166,7 @@ cache:
 
 pages:
   script:
-  - yarn install
+  - npm install
   - ./node_modules/.bin/gatsby build --prefix-paths
   artifacts:
     paths:
@@ -181,14 +181,14 @@ in between builds, so subsequent builds should be a lot faster as it doesn't hav
 to reinstall all the dependancies required. `pages:` is the name of the
 CI stage. You can have multiple stages, e.g. 'Test', 'Build', 'Deploy' etc.
 `script:` starts the next part of the CI stage, telling it to start running the
-below scripts inside the image selected. We have used the `yarn install` and
+below scripts inside the image selected. We have used the `npm install` and
 `./node_modules/.bin/gatsby build --prefix-paths` which will install all dependancies, and
 start the static site build, respectively.
 
 We have used
 `./node_modules/.bin/gatsby build --prefix-paths` because we then don't have to install
 gatsby-cli to build the image, as it has already been included and installed
-with `yarn install`. We have included `--prefix-paths` as when running the command _without_ that flag, Gatsby ignores your pathPrefix. `artifacts:` and `paths:` are used to tell GitLab pages
+with `npm install`. We have included `--prefix-paths` as when running the command _without_ that flag, Gatsby ignores your pathPrefix. `artifacts:` and `paths:` are used to tell GitLab pages
 where the static files are kept. `only:` and `master` tells the CI to only run
 the above instructions when the master branch is deployed.
 

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -56,8 +56,7 @@ now to create a new repository on GitHub.
 ### Use the NPM package `gh-pages` for deploying
 
 First add **gh-pages** as a `devDependency` of your site and create an npm
-script to **deploy** your project by running `npm install gh-pages --save-dev`
-or `yarn add gh-pages --dev` (if you have yarn installed).
+script to **deploy** your project by running `npm install gh-pages --save-dev`.
 
 Then add a `deploy` script in your `package.json` file.
 
@@ -84,7 +83,7 @@ repo, set up git in your project with `git init`. Then tell Gatsby where to
 deploy your site by adding the git remote address with https or ssh. Here is how
 to do it with https: `git remote add origin git@github.com:username/project-name.git`.
 
-Now run `yarn deploy` or `npm run deploy`. Preview changes in your GitHub page
+Now run `npm run deploy`. Preview changes in your GitHub page
 `https://username.github.io/project-name/`. You can also find the link to your
 site on GitHub under `Settings` > `GitHub Pages`.
 

--- a/docs/docs/gatsby-style-guide.md
+++ b/docs/docs/gatsby-style-guide.md
@@ -83,7 +83,7 @@ repository.
 
 # Running the Guide locally on your own computer
 
-Finally, if you want to run a version of the guides repository locally, follow
+Finally, if you want to run a version of the Guides repository locally, follow
 these steps:
 
 1. Install the Gatsby command-line tool `npm install --global gatsby-cli`.

--- a/docs/docs/gatsby-style-guide.md
+++ b/docs/docs/gatsby-style-guide.md
@@ -86,10 +86,10 @@ repository.
 Finally, if you want to run a version of the guides repository locally, follow
 these steps:
 
-1. Ensure you have the yarn package manager installed `npm install -g yarn`
-2. Install the Gatsby cli `yarn add --global gatsby-cli`
-3. Follow the steps above to fork and clone the Gatsby repo.
-4. Enter the `www` directory where gatsbyjs.org is and install its dependencies `yarn install` then run `gatsby develop`.
+1. Install the Gatsby command-line tool `npm install --global gatsby-cli`.
+2. Follow the steps above to fork and clone the Gatsby repo.
+3. Enter the `www` directory where gatsbyjs.org is by `cd path-to-gatsby/www` and install its dependencies with `npm install`.
+4. Run `gatsby develop` and view Guides locally.
 
 ## Article style guide
 

--- a/docs/docs/gatsby-style-guide.md
+++ b/docs/docs/gatsby-style-guide.md
@@ -86,10 +86,10 @@ repository.
 Finally, if you want to run a version of the Guides repository locally, follow
 these steps:
 
-1. Install the Gatsby command-line tool `npm install --global gatsby-cli`.
-2. Follow the steps above to fork and clone the Gatsby repo.
-3. Enter the `www` directory where gatsbyjs.org is by `cd path-to-gatsby/www` and install its dependencies with `npm install`.
-4. Run `gatsby develop` and view Guides locally.
+1. Ensure you have the yarn package manager installed `npm install -g yarn`
+2. Install the Gatsby cli `yarn add --global gatsby-cli`
+3. Follow the steps above to fork and clone the Gatsby repo.
+4. Enter the `www` directory where gatsbyjs.org is and install its dependencies `yarn install` then run `gatsby develop`.
 
 ## Article style guide
 

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -4,7 +4,7 @@ title: How Gatsby Works with GitHub Pages
 
 The easiest way to push a gatsby app to GitHub Pages is using a package called `gh-pages`.
 
-`yarn add --dev gh-pages`
+`npm install gh-pages --save-dev`
 
 ## GitHub repository page
 
@@ -26,7 +26,7 @@ We are using prefix paths because our website is inside a folder `http://usernam
 }
 ```
 
-When you run `yarn run deploy` all contents of `public` folder will be moved to your repositorys `gh-pages` branch.
+When you run `npm run deploy` all contents of `public` folder will be moved to your repositorys `gh-pages` branch.
 
 ## GitHub Organization or User page
 
@@ -43,7 +43,7 @@ In this case we dont need to specify `pathPrefix`, but our website needs to be p
     }
 ```
 
-After running `yarn run deploy` you should see your website at `http://username.github.io`
+After running `npm run deploy` you should see your website at `http://username.github.io`
 
 ## Custom domains
 

--- a/packages/gatsby-1-config-css-modules/README.md
+++ b/packages/gatsby-1-config-css-modules/README.md
@@ -4,7 +4,7 @@ CSS Modules configuration for Gatsby v1 plugins
 
 ## Install
 
-`yarn add --dev gatsby-plugin-sass`
+`npm install --save-dev gatsby-plugin-sass`
 
 ## How to use
 

--- a/packages/gatsby-plugin-coffeescript/README.md
+++ b/packages/gatsby-plugin-coffeescript/README.md
@@ -4,7 +4,7 @@ Provides drop-in support for CoffeeScript and CJSX.
 
 ## Install
 
-`yarn add gatsby-plugin-coffeescript`
+`npm install --save gatsby-plugin-coffeescript`
 
 ## How to use
 

--- a/packages/gatsby-plugin-create-client-paths/README.md
+++ b/packages/gatsby-plugin-create-client-paths/README.md
@@ -7,7 +7,7 @@ Use this plugin to simplify creating a “hybrid” Gatsby app with both statica
 Install:
 
 ```
-yarn add gatsby-plugin-create-client-paths
+npm install --save gatsby-plugin-create-client-paths
 ```
 
 Then configure via `gatsby-config.js`:

--- a/packages/gatsby-plugin-postcss-sass/README.md
+++ b/packages/gatsby-plugin-postcss-sass/README.md
@@ -5,7 +5,7 @@ support.
 
 ## Install
 
-`yarn add gatsby-plugin-postcss-sass`
+`npm install --save gatsby-plugin-postcss-sass`
 
 ## How to use
 

--- a/packages/gatsby-plugin-react-css-modules/README.md
+++ b/packages/gatsby-plugin-react-css-modules/README.md
@@ -7,7 +7,7 @@ for details.
 
 ## Install
 
-`yarn add gatsby-plugin-react-css-modules`
+`npm install --save gatsby-plugin-react-css-modules`
 
 ## How to use
 

--- a/packages/gatsby-plugin-remove-trailing-slashes/README.md
+++ b/packages/gatsby-plugin-remove-trailing-slashes/README.md
@@ -8,7 +8,7 @@ example, `yoursite.com/about/` becomes `yoursite.com/about`.
 Install:
 
 ```
-yarn add --dev gatsby-plugin-remove-trailing-slashes
+npm install --save-dev gatsby-plugin-remove-trailing-slashes
 ```
 
 Then configure via `gatsby-config.js`.

--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -4,7 +4,7 @@ Provides drop-in support for SASS/SCSS stylesheets
 
 ## Install
 
-`yarn add gatsby-plugin-sass`
+`npm install --save gatsby-plugin-sass`
 
 ## How to use
 

--- a/packages/gatsby-plugin-styled-components/README.md
+++ b/packages/gatsby-plugin-styled-components/README.md
@@ -6,7 +6,7 @@ built-in server-side rendering support.
 
 ## Install
 
-`yarn add gatsby-plugin-styled-components styled-components --save`
+`npm install --save gatsby-plugin-styled-components styled-components`
 
 ## How to use
 
@@ -25,4 +25,4 @@ module.exports = {
 #### v2.0.1
 
 `styled-components` is moved to a peer dependency. Installing the package
-alongside `gatsby-plugin-styled-components` is now required. Use `yarn add styled-components --save`
+alongside `gatsby-plugin-styled-components` is now required. Use `npm install --save styled-components`

--- a/packages/gatsby-plugin-styled-jsx/README.md
+++ b/packages/gatsby-plugin-styled-jsx/README.md
@@ -4,7 +4,7 @@ Provides drop-in support for [styled-jsx](https://github.com/zeit/styled-jsx).
 
 ## Install
 
-`yarn add styled-jsx gatsby-plugin-styled-jsx`
+`npm install --save styled-jsx gatsby-plugin-styled-jsx`
 
 ## How to use
 

--- a/packages/gatsby-plugin-stylus/README.md
+++ b/packages/gatsby-plugin-stylus/README.md
@@ -4,7 +4,7 @@ Provides drop-in support for Stylus with or without CSS Modules
 
 ## Install
 
-`yarn add gatsby-plugin-stylus`
+`npm install --save gatsby-plugin-stylus`
 
 ## How to use
 

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -4,7 +4,7 @@ Provides drop-in support for TypeScript and TSX.
 
 ## Install
 
-`yarn add gatsby-plugin-typescript typescript`
+`npm install --save gatsby-plugin-typescript typescript`
 
 ## How to use
 

--- a/packages/gatsby-source-faker/README.md
+++ b/packages/gatsby-source-faker/README.md
@@ -7,7 +7,7 @@ This is a plugin that allows you to use [faker.js](https://github.com/marak/Fake
 Install `gatsby-source-faker`
 
 ```
-    yarn add gatsby-source-faker
+    npm install --save gatsby-source-faker
 ```
 
 or

--- a/packages/gatsby-transformer-react-docgen/README.md
+++ b/packages/gatsby-transformer-react-docgen/README.md
@@ -6,7 +6,7 @@ Parses inline component-documentation using
 ## Install
 
 ```
-yarn add gatsby-transformer-react-docgen
+npm install --save gatsby-transformer-react-docgen
 ```
 
 ## Usage


### PR DESCRIPTION
Addresses #4514. @shannonbux @WebRuin feel free to check if I caught all instances.

## TODO

- [x] Go through `docs/`
	- [x] Should [CONTRIBUTING.md]() be changed to `npm`? It says “[it] relies on lerna and yarn to configure the repository...” so I don’t know if it should be touched. [No](https://github.com/gatsbyjs/gatsby/pull/4607#issuecomment-374565536)
	- [x] Should [GitLab deploy instructions](https://www.gatsbyjs.org/docs/deploy-gatsby/#build-and-deploy-with-gitlab-ci) be changed to `npm`? Not sure if GitLab relies on `yarn` or not, since the yml build script mentions `yarn install`. [Yes](https://github.com/gatsbyjs/gatsby/pull/4607#issuecomment-374565536)
- [x] Go through `packages/`
- [x] Go through `blogs/` -- Only one post had `yarn`-only instructions, changed [here](https://github.com/gatsbyjs/gatsby/pull/4607/commits/0985427663e1b9b74e1c2d090781194ae684353e)
- [x] Go through `examples/`
- [x] ~~Go through translated docs?~~ [Nah](https://github.com/gatsbyjs/gatsby/pull/4607#issuecomment-374565536)