### PR TITLE
Add new React 16.3-style context component to gatsby-plugin-styletron

### DIFF
--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -1,13 +1,14 @@
 {
   "name": "gatsby-plugin-styletron",
   "description": "A Gatsby plugin for styletron with built-in server-side rendering support",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "Nadiia Dmytrenko &lt;nadiia.dmytrenko@gmail.com&gt;",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "create-react-context": "^0.2.1",
     "styletron-engine-atomic": "^1",
     "styletron-react": "^4",
     "styletron-react-core": "^1",

--- a/packages/gatsby-plugin-styletron/src/StyletronContext.js
+++ b/packages/gatsby-plugin-styletron/src/StyletronContext.js
@@ -1,0 +1,17 @@
+/* eslint-env browser */
+
+const Styletron = require(`styletron-engine-atomic`)
+const createReactContext = require(`create-react-context`)
+var instance
+
+module.exports = function(options) {
+  if (!instance) {
+    if (typeof window !== `undefined` && window.document.createElement) {
+      const styles = document.getElementsByClassName(`_styletron_hydrate_`)
+      instance = new Styletron.Client({ hydrate: styles, ... options })
+    } else {
+      instance = new Styletron.Server(options)
+    }
+  }
+  return createReactContext(instance)
+}

--- a/packages/gatsby-plugin-styletron/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-styletron/src/gatsby-browser.js
@@ -1,13 +1,15 @@
 const React = require(`react`)
-const Styletron = require(`styletron-engine-atomic`).Client
 const StyletronProvider = require(`styletron-react`).Provider
 
 exports.wrapRootComponent = ({ Root }, options) => () => {
-  const styleElements = document.getElementsByClassName(`_styletron_hydrate_`)
-  const styletron = new Styletron(styleElements, options)
+  const StyletronContext = require(`./StyletronContext.js`)(options)
   return (
-    <StyletronProvider value={styletron}>
-      <Root />
-    </StyletronProvider>
+    <StyletronContext.Consumer>
+      {value => (
+        <StyletronProvider value={value}>
+          <Root />
+        </StyletronProvider>
+      )}
+    </StyletronContext.Consumer>
   )
 }

--- a/packages/gatsby-plugin-styletron/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-styletron/src/gatsby-ssr.js
@@ -1,5 +1,4 @@
 const React = require(`react`)
-const Styletron = require(`styletron-engine-atomic`).Server
 const StyletronProvider = require(`styletron-react`).Provider
 const { renderToString } = require(`react-dom/server`)
 
@@ -7,26 +6,37 @@ exports.replaceRenderer = ({
   bodyComponent,
   setHeadComponents,
   replaceBodyHTMLString,
-}) => {
-  const styletron = new Styletron()
+}, options) => {
+  const StyletronContext = require(`./StyletronContext.js`)(options)
 
   const app = (
-    <StyletronProvider value={styletron}>{bodyComponent}</StyletronProvider>
+    <StyletronContext.Consumer>
+      {value => (
+        <StyletronProvider value={value}>{bodyComponent}</StyletronProvider>
+      )}
+    </StyletronContext.Consumer>
   )
 
   replaceBodyHTMLString(renderToString(app))
 
-  const stylesheets = styletron.getStylesheets()
-  const headComponents = stylesheets.map((sheet, index) => (
-    <style
-      media={sheet.media}
-      className="_styletron_hydrate_"
-      key={index}
-      dangerouslySetInnerHTML={{
-        __html: sheet.css,
-      }}
-    />
-  ))
+  const headComponents = (
+    <StyletronContext.Consumer>
+      {value => (
+        <StyletronProvider value={value}>
+          {value.getStylesheets().map((sheet, index) => (
+            <style
+              media={sheet.media}
+              className="_styletron_hydrate_"
+              key={index}
+              dangerouslySetInnerHTML={{
+                __html: sheet.css,
+              }}
+            />
+          ))}
+        </StyletronProvider>
+      )}
+    </StyletronContext.Consumer>
+  )
 
   setHeadComponents(headComponents)
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -33,6 +33,7 @@
     "convert-hrtime": "^2.0.0",
     "copyfiles": "^1.2.0",
     "core-js": "^2.5.0",
+    "create-react-context": "^0.2.1",
     "css-loader": "^0.26.1",
     "debug": "^2.6.0",
     "del": "^3.0.0",


### PR DESCRIPTION
This patch creates a new StyletronContext component for gatsby-plugin-styletron. It uses the create-react-context polyfill so it can be used before React 16.3 is released. If React 16.3 becomes a dependency, the create-react-context call should be replaced with React.createContext.

Now, I'm not 100% certain that this is the best way to accomplish this, so I'm open to feedback and/or refusal to accept this pull request. It does solve a problem that I've had and possibly others may have, and it continues to function as a drop in replacement as it does currently, so rather than fork this plugin, I offer these changes for your consideration.