### PR TITLE
[gastby-plugin-sitemap] Add addLinkToHead option

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -25,7 +25,7 @@ generated sitemap will include all of your site's pages, except the ones you exc
 
 ## Options
 
-The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L15) can be overridden.
+The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L20) can be overridden.
 
 We _ALWAYS_ exclude the following pages: `/dev-404-page/`,`/404` &`/offline-plugin-app-shell-fallback/`, this cannot be changed.
 

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -5,11 +5,13 @@ import { defaultOptions, runQuery, writeFile } from "./internals"
 const publicPath = `./public`
 
 exports.onPostBuild = async ({ graphql }, pluginOptions) => {
-  delete pluginOptions.plugins
+  const options = { ...pluginOptions }
+  delete options.plugins
+  delete options.addLinkToHead
 
   const { query, serialize, output, exclude, ...rest } = {
     ...defaultOptions,
-    ...pluginOptions,
+    ...options,
   }
 
   const map = sitemap.createSitemap(rest)

--- a/packages/gatsby-plugin-sitemap/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-ssr.js
@@ -3,7 +3,12 @@ import { withPrefix } from "gatsby-link"
 import { defaultOptions } from "./internals"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-  let { output } = { ...defaultOptions, ...pluginOptions }
+  let { output, addLinkToHead } = { ...defaultOptions, ...pluginOptions }
+
+  if (!addLinkToHead) {
+    return
+  }
+
   if (output.charAt(0) !== `/`) {
     output = `/` + output
   }

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -36,6 +36,7 @@ export const defaultOptions = {
   }`,
   output: `/sitemap.xml`,
   exclude: [`/dev-404-page`, `/404`, `/offline-plugin-app-shell-fallback`],
+  addLinkToHead: true,
   serialize: ({ site, allSitePage }) =>
     allSitePage.edges.map(edge => {
       return {


### PR DESCRIPTION
I'm generating sitemaps for a search service provider (one sitemap per language with post pages only) and then separate sitemaps with various index pages. All these sitemaps will be linked in yet another sitemap and finally this sitemap will be linked to in generated pages ;)

I needed a way to prevent sitemap plugin from trying to add every generated sitemap to generated html files (which doesn't work correctly anyway, because they all have the same key, so only the first one is added), so now there's an option for that.

I'm not sure if `addLinkToHead` name is ok, so feel free to suggest something that makes more sense.