### PR TITLE
improve error message for graphql queries

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -34,7 +34,8 @@ module.exports = async (pageOrLayout, component) => {
   if (result && result.errors) {
     report.log(
       report.stripIndent`
-        The GraphQL query from ${component.componentPath} failed
+        The GraphQL query from ${component.componentPath} failed.
+        See .cache/json/${pageOrLayout.jsonName} if develop mode.
 
         Errors:
           ${result.errors || []}

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -39,6 +39,10 @@ module.exports = async (pageOrLayout, component) => {
 
         Errors:
           ${result.errors || []}
+        Path:
+          ${pageOrLayout.path || `unset`}
+        Plugin:
+          ${pageOrLayout.pluginCreatorId || `none`}
         Query:
           ${component.query}
       `

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -35,12 +35,11 @@ module.exports = async (pageOrLayout, component) => {
     report.log(
       report.stripIndent`
         The GraphQL query from ${component.componentPath} failed.
-        See .cache/json/${pageOrLayout.jsonName} if develop mode.
 
         Errors:
           ${result.errors || []}
-        Path:
-          ${pageOrLayout.path || `unset`}
+        URL path:
+          ${pageOrLayout.path}
         Plugin:
           ${pageOrLayout.pluginCreatorId || `none`}
         Query:


### PR DESCRIPTION
Show where the `.cache` file is to make debugging easier.

I was having problems understanding why I was getting this error:

```
The GraphQL query from /Users/docwhat/Play/WebSites/docwhat/src/templates/page.js failed

        Errors:
          GraphQLError: Variable "$slug" of required type "String!" was not provided.
        Query:
          query currentPageQuery(
  $slug: String!
) {
  markdownRemark(fields: {slug: {eq: $slug}, template: {eq: "page"}}) {
    html
    fields {
      slug
      title
    }
  }
}
```

Listing the template wasn't enough info, because lots of things used it.

This change adds text pointing at the `.cache` file which made fixing the
problem easy.