### PR TITLE
Expose GraphQL errors

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
@@ -55,7 +55,7 @@ function formatError(message: string, filePath: string, codeFrame: string) {
 }
 
 function extractError(error: Error): { message: string, docName: string } {
-  const docRegex = /Invariant Violation: RelayParser: (.*). Source: document `(.*)` file:/g
+  const docRegex = /Invariant Violation: (RelayParser|GraphQLParser): (.*). Source: document `(.*)` file:/g
   let matches
   let message = ``,
     docName = ``


### PR DESCRIPTION
While working with amazing Gatsby I found frustrating that I saw line 

```
GraphQL Error There was an error while compiling your site's GraphQL queries.
```

but no details.

I know I have some bugs, but I had to debug gatsby to figure out what. After the change not only `Relay` but also `GraphQL` errors are being exposed and I see what I did wrong:

```
  GraphQLParser
  GraphQLParser: Unknown field `image` on type `frontmatter_2`. Source: document `PageBlog` file: `GraphQL request`.
````