### PR TITLE
Hidden webpack errors

### DIFF
--- a/packages/gatsby-cli/src/reporter/errors.js
+++ b/packages/gatsby-cli/src/reporter/errors.js
@@ -34,6 +34,10 @@ function getErrorFormatter() {
   })
 
   prettyError.render = err => {
+    if (Array.isArray(err)) {
+      return err.map(this.render).join(`\n`)
+    }
+
     let rendered = baseRender.call(prettyError, err)
     if (err && err.codeFrame) rendered = `\n${err.codeFrame}\n${rendered}`
     return rendered

--- a/packages/gatsby/src/commands/build-javascript.js
+++ b/packages/gatsby/src/commands/build-javascript.js
@@ -20,7 +20,7 @@ module.exports = async program => {
 
       const jsonStats = stats.toJson()
       if (jsonStats.errors && jsonStats.errors.length > 0) {
-        reject(jsonStats.errors[0])
+        reject(jsonStats.errors)
         return
       }
 


### PR DESCRIPTION
Problem:

I have `n` number of webpack generated errors. The 3rd matters really and is cause of the others, just happens to be 3rd. You trim errors so I see only first and I spend hours debugging.

Solution:

I see what webpack is all about