### PR TITLE
Omit undefined attributes from noscript images

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -95,11 +95,22 @@ const noscriptImg = props => {
     sizes = ``,
     title = ``,
     alt = ``,
-    width = ``,
-    height = ``,
+    width,
+    height,
     transitionDelay = `0.5s`,
   } = props
-  return `<img width="${width}" height="${height}" src="${src}" srcset="${srcSet}" alt="${alt}" title="${title}" sizes="${sizes}" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"/>`
+  return `
+    <img 
+      width=${width ? `"${width}"` : null} 
+      height=${height ? `"${height}"` : null}
+      src="${src}" 
+      srcset="${srcSet}" 
+      alt="${alt}" 
+      title="${title}" 
+      sizes="${sizes}" 
+      style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"
+    />
+  `
 }
 
 const Img = props => {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -88,29 +88,19 @@ const isWebpSupported = () => {
 }
 
 const noscriptImg = props => {
-  const {
-    opacity = `1`,
-    src,
-    srcSet,
-    sizes = ``,
-    title = ``,
-    alt = ``,
-    width,
-    height,
-    transitionDelay = `0.5s`,
-  } = props
-  return `
-    <img 
-      width=${width ? `"${width}"` : null} 
-      height=${height ? `"${height}"` : null}
-      src="${src}" 
-      srcset="${srcSet}" 
-      alt="${alt}" 
-      title="${title}" 
-      sizes="${sizes}" 
-      style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"
-    />
-  `
+  // Check if prop exists before adding each attribute to the string output below to prevent
+  // HTML validation issues caused by empty values like width="" and height=""
+  const opacity = `1`
+  const src = props.src ? `src="${props.src}" ` : `src=""` // required attribute
+  const srcSet = props.srcSet ? `srcset="${props.srcSet}" ` : ``
+  const sizes = props.sizes ? `sizes="${props.sizes}" ` : ``
+  const title = props.title ? `title="${props.title}" ` : ``
+  const alt = props.alt ? `alt="${props.alt}" ` : `alt=""` // required attribue
+  const width = props.width ? `width="${props.width}" ` : ``
+  const height = props.height ? `height="${props.height}" ` : ``
+  const transitionDelay = `0.5s`
+
+  return `<img ${width}${height}${src}${srcSet}${alt}${title}${sizes}style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"/>`
 }
 
 const Img = props => {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -90,7 +90,6 @@ const isWebpSupported = () => {
 const noscriptImg = props => {
   // Check if prop exists before adding each attribute to the string output below to prevent
   // HTML validation issues caused by empty values like width="" and height=""
-  const opacity = `1`
   const src = props.src ? `src="${props.src}" ` : `src=""` // required attribute
   const srcSet = props.srcSet ? `srcset="${props.srcSet}" ` : ``
   const sizes = props.sizes ? `sizes="${props.sizes}" ` : ``
@@ -98,7 +97,8 @@ const noscriptImg = props => {
   const alt = props.alt ? `alt="${props.alt}" ` : `alt=""` // required attribute
   const width = props.width ? `width="${props.width}" ` : ``
   const height = props.height ? `height="${props.height}" ` : ``
-  const transitionDelay = `0.5s`
+  const opacity = props.opacity ? props.opacity : `1`
+  const transitionDelay = props.transitionDelay ? props.transitionDelay : `0.5s`
 
   return `<img ${width}${height}${src}${srcSet}${alt}${title}${sizes}style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"/>`
 }

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -95,7 +95,7 @@ const noscriptImg = props => {
   const srcSet = props.srcSet ? `srcset="${props.srcSet}" ` : ``
   const sizes = props.sizes ? `sizes="${props.sizes}" ` : ``
   const title = props.title ? `title="${props.title}" ` : ``
-  const alt = props.alt ? `alt="${props.alt}" ` : `alt=""` // required attribue
+  const alt = props.alt ? `alt="${props.alt}" ` : `alt=""` // required attribute
   const width = props.width ? `width="${props.width}" ` : ``
   const height = props.height ? `height="${props.height}" ` : ``
   const transitionDelay = `0.5s`


### PR DESCRIPTION
To solve issue #4317, this sets the default values of the `<noscript>` image's `height` and `width` attributes to null (rather than `""`). 

The current `width`/`height` defaults of `""` fail HTML validation because these attributes (if present) must be non-negative integers. Omitting these non-required attributes when no width/height is provided (by setting them to null) solves the validation issue.