### PR TITLE
🐞 💥  Sitemap excludes should ignore trailing slashes

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -1,6 +1,9 @@
 import fs from "fs"
 import pify from "pify"
 
+const withoutTrailingSlash = path =>
+  path === `/` ? path : path.replace(/\/$/, ``)
+
 export const writeFile = pify(fs.writeFile)
 
 export const runQuery = (handler, query, excludes) =>
@@ -11,7 +14,7 @@ export const runQuery = (handler, query, excludes) =>
 
     // Removing exluded paths
     r.data.allSitePage.edges = r.data.allSitePage.edges.filter(
-      page => !excludes.includes(page.node.path)
+      page => !excludes.includes(withoutTrailingSlash(page.node.path))
     )
 
     return r.data

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -38,7 +38,12 @@ export const defaultOptions = {
       }
   }`,
   output: `/sitemap.xml`,
-  exclude: [`/dev-404-page`, `/404`, `/offline-plugin-app-shell-fallback`],
+  exclude: [
+    `/dev-404-page`,
+    `/404`,
+    `/404.html`,
+    `/offline-plugin-app-shell-fallback`,
+  ],
   createLinkInHead: true,
   serialize: ({ site, allSitePage }) =>
     allSitePage.edges.map(edge => {


### PR DESCRIPTION
I ran into #4621 on my project and wanted to fix this. I first thought that adding the slashes to the default excludes would be enough, but thinking a bit more about this, I actually think it's nicer if it just ignores the trailing slash, as this would also bite users for their custom exclude paths.

Alternatively one could install the [gatsby-plugin-remove-trailing-slashes](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes) plugin, but I wanted this to work out of the box without dependencies to another module.

Let me know what you think about this, happy to adapt where it's needed.