### PR TITLE
dont add layout data to json array multiple times

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -52,10 +52,12 @@ const writePages = async () => {
         )
       }
 
-      pageLayouts.push(layout)
-      json.push({
-        jsonName: layout.jsonName,
-      })
+      if (!_.includes(pageLayouts, layout)) {
+        pageLayouts.push(layout)
+        json.push({
+          jsonName: layout.jsonName,
+        })
+      }
     }
     json.push({ path: p.path, jsonName: p.jsonName })
   })


### PR DESCRIPTION
This is a back-port of  a part of #4555 at the suggestion of grajen3 on discord.

Specifically commit f4c92e562018415d83931542ef0798cd248c48b3

I tested it and it helps with the hundreds of lines for `layout-index.json` in
the `.cache/sync-requires.js` during `gatsby develop` sessions.