### PR TITLE
Note about GTM history change triggers

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -22,3 +22,6 @@ plugins: [
   },
 ];
 ```
+
+#### Note
+Out of the box this plugin will simply load Google Tag Manager on the initial page/app load. It's up to you to fire tags based on changes in your app. To automatically track page changes, in GA for instance, you can configure your tags in GTM to trigger on [History Change](https://support.google.com/tagmanager/topic/7679384?hl=en&rd=1#HistoryChange). 


### PR DESCRIPTION
The installation instructions for this plugin make it seem like it just works out of the box. For many users switching to Gatsby from other static or CMS based sites, they may be expecting GTM and GA to work as normal, but they'll need to trigger state changes, this can be done pretty easily with the history change trigger in GTM.