### PR TITLE
prevent duplicate json entries in sync-requires.js

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -64,6 +64,7 @@ const writePages = async () => {
 
   pageLayouts = _.uniq(pageLayouts)
   components = _.uniqBy(components, c => c.componentChunkName)
+  json = _.uniqBy(json, x => x.jsonName)
 
   // Create file with sync requires of layouts/components/json files.
   let syncRequires = `// prefer default export if available


### PR DESCRIPTION
This mitigates the dreaded "deoptimised" message from babel by
preventing the `sync-requires.js` file creating duplicates in the
`exports.json` hash.

```
[BABEL] Note: The code generator has deoptimised the styling of
"/Users/docwhat/Play/WebSites/docwhat/.cache/sync-requires.js" as it
exceeds the max of "500KB".
```

This does not fix the problems with the queue of `*.js.<seconds-since-epoch>` being created.