### PR TITLE
remark-prismjs: add aliases for languages

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -34,6 +34,11 @@ plugins: [
             // A suggested value for English speakers is the non-ascii
             // character '›'.
             inlineCodeMarker: null,
+            // This lets you set up language aliases.  For example,
+            // setting this to '{ sh: "bash" }' will let you use
+            // the language "sh" which will highlight using the
+            // bash highlighter.
+            aliases: {},
           },
         },
       ],

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -88,7 +88,63 @@ Object {
 }
 `;
 
-exports[`remark prism plugin generates inline <code> tag with a custom class prefix if configured 1`] = `
+exports[`remark prism plugin generates an inline <code> tag that handles language specifiers 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 29,
+              "line": 1,
+              "offset": 28,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "html",
+          "value": "<code class=\\"language-css\\"><span class=\\"token selector\\">.foo</span> <span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">color</span><span class=\\"token punctuation\\">:</span> red <span class=\\"token punctuation\\">}</span>
+</code>",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 29,
+          "line": 1,
+          "offset": 28,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 29,
+      "line": 1,
+      "offset": 28,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`remark prism plugin generates an inline <code> tag with a custom class prefix if configured 1`] = `
 Object {
   "children": Array [
     Object {
@@ -143,7 +199,7 @@ Object {
 }
 `;
 
-exports[`remark prism plugin generates inline <code> tag with class="language-*" prefix by default 1`] = `
+exports[`remark prism plugin generates an inline <code> tag with class="language-*" prefix by default 1`] = `
 Object {
   "children": Array [
     Object {
@@ -187,62 +243,6 @@ Object {
       "column": 10,
       "line": 1,
       "offset": 9,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-  "type": "root",
-}
-`;
-
-exports[`remark prism plugin inlineCode handles language specifiers 1`] = `
-Object {
-  "children": Array [
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 29,
-              "line": 1,
-              "offset": 28,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "type": "html",
-          "value": "<code class=\\"language-css\\"><span class=\\"token selector\\">.foo</span> <span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">color</span><span class=\\"token punctuation\\">:</span> red <span class=\\"token punctuation\\">}</span>
-</code>",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 29,
-          "line": 1,
-          "offset": 28,
-        },
-        "indent": Array [],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "paragraph",
-    },
-  ],
-  "position": Object {
-    "end": Object {
-      "column": 29,
-      "line": 1,
-      "offset": 28,
     },
     "start": Object {
       "column": 1,

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -44,6 +44,49 @@ Object {
 }
 `;
 
+exports[`remark prism plugin generates a <pre> tag with aliases applied 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "foobar",
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 3,
+          "offset": 21,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight\\">
+      <pre class=\\"language-javascript\\"><code class=\\"language-javascript\\">// Fake</code></pre>
+      </div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 4,
+      "line": 3,
+      "offset": 21,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`remark prism plugin generates a <pre> tag with class="language-*" prefix by default 1`] = `
 Object {
   "children": Array [
@@ -188,6 +231,62 @@ Object {
       "column": 10,
       "line": 1,
       "offset": 9,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`remark prism plugin generates an inline <code> tag with aliases applied 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "html",
+          "value": "<code class=\\"language-javascript\\">Fake
+</code>",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+          "offset": 15,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 16,
+      "line": 1,
+      "offset": 15,
     },
     "start": Object {
       "column": 1,

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -16,6 +16,13 @@ describe(`remark prism plugin`, () => {
       plugin({ markdownAST }, { classPrefix: `custom-` })
       expect(markdownAST).toMatchSnapshot()
     })
+
+    it(`with aliases applied`, () => {
+      const code = `\`\`\`foobar\n// Fake\n\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST }, { aliases: { foobar: `javascript` } })
+      expect(markdownAST).toMatchSnapshot()
+    })
   })
 
   describe(`generates an inline <code> tag`, () => {
@@ -37,6 +44,16 @@ describe(`remark prism plugin`, () => {
       const code = `\`css🍺  .foo { color: red }\``
       const markdownAST = remark.parse(code)
       plugin({ markdownAST }, { inlineCodeMarker: `🍺  ` })
+      expect(markdownAST).toMatchSnapshot()
+    })
+
+    it(`with aliases applied`, () => {
+      const code = `\`foobar : Fake\``
+      const markdownAST = remark.parse(code)
+      plugin(
+        { markdownAST },
+        { inlineCodeMarker: ` : `, aliases: { foobar: `javascript` } }
+      )
       expect(markdownAST).toMatchSnapshot()
     })
   })

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -2,38 +2,42 @@ const remark = require(`remark`)
 const plugin = require(`../index`)
 
 describe(`remark prism plugin`, () => {
-  it(`generates a <pre> tag with class="language-*" prefix by default`, () => {
-    const code = `\`\`\`js\n// Fake\n\`\`\``
-    const markdownAST = remark.parse(code)
-    plugin({ markdownAST })
-    expect(markdownAST).toMatchSnapshot()
+  describe(`generates a <pre> tag`, () => {
+    it(`with class="language-*" prefix by default`, () => {
+      const code = `\`\`\`js\n// Fake\n\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST })
+      expect(markdownAST).toMatchSnapshot()
+    })
+
+    it(`with a custom class prefix if configured`, () => {
+      const code = `\`\`\`js\n// Fake\n\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST }, { classPrefix: `custom-` })
+      expect(markdownAST).toMatchSnapshot()
+    })
   })
 
-  it(`generates a <pre> tag with a custom class prefix if configured`, () => {
-    const code = `\`\`\`js\n// Fake\n\`\`\``
-    const markdownAST = remark.parse(code)
-    plugin({ markdownAST }, { classPrefix: `custom-` })
-    expect(markdownAST).toMatchSnapshot()
-  })
+  describe(`generates an inline <code> tag`, () => {
+    it(`with class="language-*" prefix by default`, () => {
+      const code = `\`foo bar\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST })
+      expect(markdownAST).toMatchSnapshot()
+    })
 
-  it(`generates inline <code> tag with class="language-*" prefix by default`, () => {
-    const code = `\`foo bar\``
-    const markdownAST = remark.parse(code)
-    plugin({ markdownAST })
-    expect(markdownAST).toMatchSnapshot()
-  })
+    it(`with a custom class prefix if configured`, () => {
+      const code = `\`foo bar\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST }, { classPrefix: `custom-` })
+      expect(markdownAST).toMatchSnapshot()
+    })
 
-  it(`generates inline <code> tag with a custom class prefix if configured`, () => {
-    const code = `\`foo bar\``
-    const markdownAST = remark.parse(code)
-    plugin({ markdownAST }, { classPrefix: `custom-` })
-    expect(markdownAST).toMatchSnapshot()
-  })
-
-  it(`inlineCode handles language specifiers`, () => {
-    const code = `\`css🍺  .foo { color: red }\``
-    const markdownAST = remark.parse(code)
-    plugin({ markdownAST }, { inlineCodeMarker: `🍺  ` })
-    expect(markdownAST).toMatchSnapshot()
+    it(`that handles language specifiers`, () => {
+      const code = `\`css🍺  .foo { color: red }\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST }, { inlineCodeMarker: `🍺  ` })
+      expect(markdownAST).toMatchSnapshot()
+    })
   })
 })

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -5,8 +5,13 @@ const highlightCode = require(`./highlight-code`)
 
 module.exports = (
   { markdownAST },
-  { classPrefix = `language-`, inlineCodeMarker = null } = {}
+  { classPrefix = `language-`, inlineCodeMarker = null, aliases = {} } = {}
 ) => {
+  const normalizeLanguage = lang => {
+    const lower = lang.toLowerCase()
+    return aliases[lower] || lower
+  }
+
   visit(markdownAST, `code`, node => {
     let language = node.lang
     let { splitLanguage, highlightLines } = parseLineNumberRange(language)
@@ -20,8 +25,7 @@ module.exports = (
     // @see https://github.com/PrismJS/prism/blob/1d5047df37aacc900f8270b1c6215028f6988eb1/themes/prism.css#L49-L54
     let languageName = `text`
     if (language) {
-      language = language.toLowerCase()
-      languageName = language
+      languageName = normalizeLanguage(language)
     }
 
     // Allow users to specify a custom class prefix to avoid breaking
@@ -49,7 +53,7 @@ module.exports = (
     if (inlineCodeMarker) {
       let [language, restOfValue] = node.value.split(`${inlineCodeMarker}`, 2)
       if (language && restOfValue) {
-        languageName = language.toLowerCase()
+        languageName = normalizeLanguage(language)
         node.value = restOfValue
       }
     }


### PR DESCRIPTION
This allows specifying aliases for languages when using prismjs.

Fixes #4549

I refactored the tests to make things clearer going forward.