### PR TITLE
[www] Minor: change dev name & description of gatsbyjs.org

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-starter-default",
-  "description": "Gatsby default starter",
+  "name": "gatsbyjs.org",
+  "description": "Gatsby's Website",
   "version": "1.0.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {


### PR DESCRIPTION
Instead of:
> You can now view `gatsby-starter-default` in the browser.
<img width="762" alt="screen shot 2018-03-26 at 08 14 10" src="https://user-images.githubusercontent.com/2069737/37915522-920415fc-30ce-11e8-949f-1263040d4b15.png">

It’s now:
> You can now view `gatsbyjs.org` in the browser.
<img width="762" alt="screen shot 2018-03-26 at 08 17 51" src="https://user-images.githubusercontent.com/2069737/37915527-94d8e2da-30ce-11e8-824f-b15be7799ffe.png">

I like that more when doing development on the website. Feel free to edit to something more descriptive, or discard altogether if I misunderstood what name and description are supposed to be.