### PR TITLE
use basename for router instead of prefixing in link

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -2,7 +2,7 @@
 import React from "react"
 import { Link, NavLink } from "react-router-dom"
 import PropTypes from "prop-types"
-import { createLocation as cL, createPath } from "history"
+import { createLocation, createPath } from "history"
 
 let pathPrefix = `/`
 if (typeof __PREFIX_PATHS__ !== `undefined` && __PREFIX_PATHS__) {
@@ -15,12 +15,6 @@ export function withPrefix(path) {
 
 function normalizePath(path) {
   return path.replace(/^\/\//g, `/`)
-}
-
-function createLocation(path, history) {
-  const location = cL(path, null, null, history.location)
-  location.pathname = withPrefix(location.pathname)
-  return location
 }
 
 const NavLinkPropTypes = {

--- a/packages/gatsby/cache-dir/.eslintrc
+++ b/packages/gatsby/cache-dir/.eslintrc
@@ -1,5 +1,9 @@
 {
   env: {
-    browser: true,
+    browser: true
+  },
+  "globals": {
+    __PREFIX_PATHS__: false,
+    __PATH_PREFIX__: false
   }
 }

--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -37,6 +37,11 @@
 exports.replaceRenderer = true
 
 /**
+ * Allow a plugin to replace the static router component.
+ */
+exports.replaceStaticRouterComponent = true
+
+/**
  * Called after every page Gatsby server renders while building HTML so you can
  * set head and body components to be rendered in your `html.js`.
  *

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -36,11 +36,11 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     Root = Root.default
   }
 
-  domReady(() =>
+  domReady(() => {
     ReactDOM.render(<Root />, rootElement, () => {
       apiRunner(`onInitialClientRender`)
     })
-  )
+  })
 })
 
 function supportsServiceWorkers(location, navigator) {

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -156,15 +156,21 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   const ComponentRendererWithRouter = withRouter(ComponentRenderer)
 
   loader.getResourcesForPathname(window.location.pathname, () => {
+    let pathPrefix = `/`
+    if (__PREFIX_PATHS__) {
+      pathPrefix = `${__PATH_PREFIX__}/`
+    }
+
     const Root = () =>
       createElement(
         AltRouter ? AltRouter : DefaultRouter,
-        null,
+        { basename: pathPrefix },
         createElement(
           ScrollContext,
           { shouldUpdateScroll },
           createElement(ComponentRendererWithRouter, {
             layout: true,
+            // eslint-disable-next-line react/display-name
             children: layoutProps =>
               createElement(Route, {
                 render: routeProps => {

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -122,6 +122,7 @@ const addNotFoundRoute = () => {
   if (noMatch) {
     return createElement(Route, {
       key: `404-page`,
+
       component: props =>
         createElement(syncRequires.components[noMatch.componentChunkName], {
           ...props,
@@ -139,6 +140,11 @@ const navigateTo = to => {
 
 window.___navigateTo = navigateTo
 
+let pathPrefix = `/`
+if (__PREFIX_PATHS__) {
+  pathPrefix = `${__PATH_PREFIX__}/`
+}
+
 const AltRouter = apiRunner(`replaceRouterComponent`, { history })[0]
 const DefaultRouter = ({ children }) => (
   <Router history={history}>{children}</Router>
@@ -154,12 +160,13 @@ const ComponentRendererWithRouter = withRouter(ComponentRenderer)
 const Root = () =>
   createElement(
     AltRouter ? AltRouter : DefaultRouter,
-    null,
+    { basename: pathPrefix },
     createElement(
       ScrollContext,
       { shouldUpdateScroll },
       createElement(ComponentRendererWithRouter, {
         layout: true,
+        // eslint-disable-next-line react/display-name
         children: layoutProps =>
           createElement(Route, {
             render: routeProps => {
@@ -180,6 +187,7 @@ const Root = () =>
                 )
                 return createElement(Route, {
                   key: `404-page`,
+                  // eslint-disable-next-line react/display-name
                   component: props =>
                     createElement(
                       syncRequires.components[dev404Page.componentChunkName],

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -2,7 +2,7 @@ const React = require(`react`)
 const fs = require(`fs`)
 const { renderToString, renderToStaticMarkup } = require(`react-dom/server`)
 const { StaticRouter, Route, withRouter } = require(`react-router-dom`)
-const { kebabCase, get, merge, isArray, isString, flatten } = require(`lodash`)
+const { kebabCase, get, merge, isString, flatten } = require(`lodash`)
 
 const apiRunner = require(`./api-runner-ssr`)
 const pages = require(`./pages.json`)
@@ -97,19 +97,26 @@ export default (locals, callback) => {
     bodyProps = merge({}, bodyProps, props)
   }
 
+  const AltStaticRouter = apiRunner(`replaceStaticRouterComponent`)[0]
+
+  apiRunner(`replaceStaticRouterComponent`)
+
   const bodyComponent = createElement(
-    StaticRouter,
+    AltStaticRouter || StaticRouter,
     {
+      basename: pathPrefix,
       location: {
         pathname: locals.path,
       },
       context: {},
     },
     createElement(Route, {
+      // eslint-disable-next-line react/display-name
       render: routeProps => {
         const page = getPage(routeProps.location.pathname)
         const layout = getLayout(page)
         return createElement(withRouter(layout), {
+          // eslint-disable-next-line react/display-name
           children: layoutProps => {
             const props = layoutProps ? layoutProps : routeProps
             return createElement(


### PR DESCRIPTION
Completely and utterly untested at this point. Is there a reason to not go this direction? Gets you better intro for using thridparty link components like react-router-link-container