### PR TITLE
Add WebGazer to Showcase sites on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Websites built with Gatsby:
 * [Hapticmedia](https://hapticmedia.fr/en/)
 * [Philipp Czernitzki - Blog/Website](http://philippczernitzki.me)
 * [CodeBushi](https://codebushi.com/)
+* [WebGazer](https://www.webgazer.io)
 
 ## Docs
 


### PR DESCRIPTION
Hi,

Thanks to all contributors! At WebGazer we are using Gatsby on our website and I wanted to add our website to the Showcase list.