### PR TITLE
[gatsby-source-wordpress] Link Parent pages to pages

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -96,6 +96,9 @@ exports.sourceNodes = async (
     _auth,
   })
 
+  // Creates links between pages and parent pages.
+  entities = normalize.mapPagesToParentPages(entities)
+
   // Search and replace Content Urls
   entities = normalize.searchReplaceContentUrls({
     entities,

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -97,7 +97,7 @@ exports.sourceNodes = async (
   })
 
   // Creates links between pages and parent pages.
-  entities = normalize.mapPagesToParentPages(entities)
+  entities = normalize.mapElementsToParent(entities)
 
   // Search and replace Content Urls
   entities = normalize.searchReplaceContentUrls({

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -96,7 +96,7 @@ exports.sourceNodes = async (
     _auth,
   })
 
-  // Creates links between pages and parent pages.
+  // Creates links between elements and parent element.
   entities = normalize.mapElementsToParent(entities)
 
   // Search and replace Content Urls

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -225,11 +225,9 @@ exports.mapTagsCategoriesToTaxonomies = entities =>
 
 exports.mapElementsToParent = entities => entities.map(e => {
     if (e.wordpress_parent) {
-      // Replace wordpress_parent with a link to the parent node of type.
+      // Create parent_element with a link to the parent node of type.
       e.parent_element___NODE = entities
-        .filter(el => el.__type === e.__type)
-        .find(t => t.wordpress_id === e.wordpress_parent).id
-      delete e.wordpress_parent
+        .find(t => t.wordpress_id === e.wordpress_parent && t.__type === e.__type).id
     }
     return e
   })

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -223,18 +223,16 @@ exports.mapTagsCategoriesToTaxonomies = entities =>
     return e
   })
 
-exports.mapPagesToParentPages = entities => {
-  const pages = entities.filter(e => e.__type === `wordpress__PAGE`)
-  return entities.map(e => {
-    if (e.wordpress_parent && e.__type === `wordpress__PAGE`) {
-      // Replace wordpress_parent with a link to the parent page node.
-      e.parent_page___NODE = pages.find(
-        t => t.wordpress_id === e.wordpress_parent
-      ).id
+exports.mapElementsToParent = entities => entities.map(e => {
+    if (e.wordpress_parent) {
+      // Replace wordpress_parent with a link to the parent node of type.
+      e.parent_element___NODE = entities
+        .filter(el => el.__type === e.__type)
+        .find(t => t.wordpress_id === e.wordpress_parent).id
+      delete e.wordpress_parent
     }
     return e
   })
-}
 
 exports.searchReplaceContentUrls = function({
   entities,

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -223,6 +223,19 @@ exports.mapTagsCategoriesToTaxonomies = entities =>
     return e
   })
 
+exports.mapPagesToParentPages = entities => {
+  const pages = entities.filter(e => e.__type === `wordpress__PAGE`)
+  return entities.map(e => {
+    if (e.wordpress_parent && e.__type === `wordpress__PAGE`) {
+      // Replace wordpress_parent with a link to the parent page node.
+      e.parent_page___NODE = pages.find(
+        t => t.wordpress_id === e.wordpress_parent
+      ).id
+    }
+    return e
+  })
+}
+
 exports.searchReplaceContentUrls = function({
   entities,
   searchAndReplaceContentUrls,


### PR DESCRIPTION
Hi Team! 

With this PR you can use the WordPress Page's attributes to link a page to another one.

![image](https://user-images.githubusercontent.com/5808108/38046283-9751eeec-32bf-11e8-82bc-94645eea4e1c.png)

Your GraphQL query may now include : 

```gql
{
  allWordpressPage {
    edges {
      node {
        slug
        parent_element {
          slug
        }
      }
    }
  }
}
```

So let's say you would like to include the parent's page slug in the child page slug, in your site's `gatsby-node.js` : 

```js         
 createPage({
            // Each page is required to have a `path` as well
            // as a template component. The `context` is
            // optional but is often necessary so the template
            // can query data specific to each page.
            path: `${edge.node.slug.parent_element ? `/${edge.node.slug.parent_element .slug}`: ''}/${edge.node.slug}/`,
            component: slash(pageTemplate),
            context: {
              id: edge.node.id,
            },
          });

```
#