### PR TITLE
[WIP][json-loader] keep results of last few queries in memory to avoid excessive file reads

### DIFF
--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -21,10 +21,52 @@ const getCachedPageData = (jsonName, directory) => {
   }
 }
 
+/**
+ * Specialized result buffer that will keep in memory results
+ * of last N queries needed to render pages in browser
+ */
+class ResultBuffer {
+  constructor(capacity) {
+    this.history = new Array(capacity)
+    this.first = 0
+    this.size = 0
+    this.results = new Map()
+  }
+
+  get(path) {
+    return this.results.get(path)
+  }
+
+  set(data, updateOnly) {
+    if (!this.results.has(data.path)) {
+      if (updateOnly) {
+        return
+      }
+
+      // if we don't have result for this path in buffer - need to add history tracking
+      const end = (this.first + this.size) % this.history.length
+      const isFull = this.size === this.history.length
+
+      if (isFull) {
+        const pathOfResultTodelete = this.history[end].path
+        this.results.delete(pathOfResultTodelete)
+
+        this.first = (this.first + 1) % this.results.length
+      } else {
+        this.size++
+      }
+
+      this.history[end] = data.path
+    }
+
+    this.results.set(data.path, data)
+  }
+}
+
 class WebsocketManager {
   constructor() {
     this.isInitialised = false
-    this.results = {}
+    this.results = new ResultBuffer(15)
     this.activePaths = new Map()
     this.websocket
     this.programDir
@@ -60,16 +102,27 @@ class WebsocketManager {
   getPageData(path, clientId) {
     // track the active path for each connected client
     this.activePaths.set(clientId, path)
+
+    const dataInBuffer = this.results.get(path)
+    if (dataInBuffer) {
+      // If we have data in buffer emit that instead of reading json file
+      this.emitData({
+        data: dataInBuffer,
+      })
+      return
+    }
+
     const data = getCachedPageData(path, this.programDir)
-    this.emitData({ data, forceEmit: true })
+    this.emitData({ data })
   }
 
-  emitData({ data, forceEmit = false }) {
+  emitData({ data }) {
     const isActivePath =
       data.path && Array.from(this.activePaths.values()).includes(data.path)
 
+    this.results.set(data, !isActivePath)
     // push results if this path is active on a client
-    if (isActivePath || forceEmit) {
+    if (isActivePath) {
       this.websocket.emit(`queryResult`, data)
     }
   }


### PR DESCRIPTION
this is still work in progress, not sure where is best place to keep results of queries in memory

this keep track of active pages and will keep in memory results of last 15 queries that were needed to render pages