### PR TITLE
Sitemap route exclusions

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -41,7 +41,10 @@ plugins: [
     resolve: `gatsby-plugin-sitemap`,
     options: {
       output: `/some-other-sitemap.xml`,
-      exclude: [`/path/to/page`, `/another/page`],
+      // Exclude specific pages or groups of pages using glob parameters
+      // See: https://github.com/isaacs/minimatch
+      // The example below will exclude the single `path/to/page` and all routes beginning with `category`
+      exclude: ["/category/*", `/path/to/page`],
       query: `
         {
           site {
@@ -63,4 +66,5 @@ plugins: [
 ]
 ```
 
+If you are using `pathPrefix` in `gatsby-config.js`, you must run `gatsby build --prefix-paths` to build a sitemap with the prefix included. See [path prefix docs](https://www.gatsbyjs.org/docs/path-prefix/#production-build).
 _NOTE: This plugin only generates output when run in `production` mode! To test your sitemap, run: `gatsby build && gatsby serve`_

--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -66,5 +66,4 @@ plugins: [
 ]
 ```
 
-If you are using `pathPrefix` in `gatsby-config.js`, you must run `gatsby build --prefix-paths` to build a sitemap with the prefix included. See [path prefix docs](https://www.gatsbyjs.org/docs/path-prefix/#production-build).
 _NOTE: This plugin only generates output when run in `production` mode! To test your sitemap, run: `gatsby build && gatsby serve`_

--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "minimatch": "^3.0.4",
     "sitemap": "^1.12.0"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -4,7 +4,7 @@ import { defaultOptions, runQuery, writeFile } from "./internals"
 
 const publicPath = `./public`
 
-exports.onPostBuild = async ({ graphql }, pluginOptions) => {
+exports.onPostBuild = async ({ graphql, pathPrefix }, pluginOptions) => {
   const options = { ...pluginOptions }
   delete options.plugins
   delete options.createLinkInHead
@@ -20,7 +20,7 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
   // Paths we're excluding...
   const excludeOptions = exclude.concat(defaultOptions.exclude)
 
-  const queryRecords = await runQuery(graphql, query, excludeOptions)
+  const queryRecords = await runQuery(graphql, query, excludeOptions, pathPrefix)
   serialize(queryRecords).forEach(u => map.add(u))
 
   return await writeFile(saved, map.toString())

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -1,5 +1,7 @@
 import fs from "fs"
 import pify from "pify"
+import minimatch from "minimatch"
+import { withPrefix } from "gatsby-link"
 
 const withoutTrailingSlash = path =>
   path === `/` ? path : path.replace(/\/$/, ``)
@@ -14,7 +16,9 @@ export const runQuery = (handler, query, excludes) =>
 
     // Removing exluded paths
     r.data.allSitePage.edges = r.data.allSitePage.edges.filter(
-      page => !excludes.includes(withoutTrailingSlash(page.node.path))
+      page => !excludes.some(
+        excludedRoute => minimatch(withoutTrailingSlash(page.node.path), excludedRoute)
+      )
     )
 
     return r.data
@@ -48,7 +52,7 @@ export const defaultOptions = {
   serialize: ({ site, allSitePage }) =>
     allSitePage.edges.map(edge => {
       return {
-        url: site.siteMetadata.siteUrl + edge.node.path,
+        url: site.siteMetadata.siteUrl + withPrefix(edge.node.path),
         changefreq: `daily`,
         priority: 0.7,
       }


### PR DESCRIPTION
I would like to add support for excluding multiple routes from the sitemap via globbing, using `minimatch` like in #4538.

I also took a crack at addressing #4723 but it didn't work on my side. I haven't used `pathPrefix` before, maybe someone else can check?