### PR TITLE
add config avoid_meta for gatsby-plugin-manifest

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -5,6 +5,7 @@ exports.onPostBuild = (args, pluginOptions) =>
   new Promise(resolve => {
     const manifest = { ...pluginOptions }
     delete manifest.plugins
+    delete manifest.avoid_meta
     fs.writeFileSync(`./public/manifest.json`, JSON.stringify(manifest))
     resolve()
   })

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -2,16 +2,23 @@ import React from "react"
 import { withPrefix } from "gatsby-link"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-  setHeadComponents([
+  const headComponents = [
     <link
       key={`gatsby-plugin-manifest-link`}
       rel="manifest"
       href={withPrefix(`/manifest.json`)}
     />,
-    <meta
-      key={`gatsby-plugin-manifest-meta`}
-      name="theme-color"
-      content={pluginOptions.theme_color}
-    />,
-  ])
+  ]
+
+  if (!pluginOptions.avoid_meta) {
+    headComponents.push(
+      <meta
+        key={`gatsby-plugin-manifest-meta`}
+        name="theme-color"
+        content={pluginOptions.theme_color}
+      />
+    )
+  }
+
+  setHeadComponents(headComponents)
 }


### PR DESCRIPTION
Add the configuration `avoid_meta` to remove the default meta for "theme-color" to handle it with Helmet.

In this way is possible to change the browser bar color with a client side logic.