### PR TITLE
[json-loader] develop - run queries on demand

### DIFF
--- a/packages/gatsby-link/.eslintrc
+++ b/packages/gatsby-link/.eslintrc
@@ -1,4 +1,4 @@
 env:
   browser: true
 globals:
-  ___loader: false
+  ___emitter: false

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -55,7 +55,7 @@ class GatsbyLink extends React.Component {
     }
 
     const { history } = context.router
-    const to = createLocation(props.to, history)
+    const to = createLocation(props.to, null, null, history.location)
 
     this.state = {
       path: createPath(to),
@@ -67,7 +67,7 @@ class GatsbyLink extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.to !== nextProps.to) {
-      const to = createLocation(nextProps.to, history)
+      const to = createLocation(nextProps.to, null, null, history.location)
       this.setState({
         path: createPath(to),
         to,

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -68,13 +68,18 @@ class GatsbyLink extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.to !== nextProps.to) {
       const to = createLocation(nextProps.to, null, null, history.location)
+
+      if (!this.state.IOSupported) {
+        ___emitter.emit(`UNPREFETCH_PATH`, this.state.path)
+      }
+
       this.setState({
         path: createPath(to),
         to,
       })
       // Preserve non IO functionality if no support
       if (!this.state.IOSupported) {
-        ___loader.enqueue(this.state.path)
+        ___emitter.emit(`PREFETCH_PATH`, this.state.path.toString())
       }
     }
   }
@@ -82,8 +87,12 @@ class GatsbyLink extends React.Component {
   componentDidMount() {
     // Preserve non IO functionality if no support
     if (!this.state.IOSupported) {
-      ___loader.enqueue(this.state.path)
+      ___emitter.emit(`PREFETCH_PATH`, this.state.path.toString())
     }
+  }
+
+  componentWillUnmount() {
+    ___emitter.emit(`UNPREFETCH_PATH`, this.state.path.toString())
   }
 
   handleRef(ref) {
@@ -92,7 +101,7 @@ class GatsbyLink extends React.Component {
     if (this.state.IOSupported && ref) {
       // If IO supported and element reference found, setup Observer functionality
       handleIntersection(ref, () => {
-        ___loader.enqueue(this.state.path)
+        ___emitter.emit(`PREFETCH_PATH`, this.state.path.toString())
       })
     }
   }

--- a/packages/gatsby/cache-dir/json-store.js
+++ b/packages/gatsby/cache-dir/json-store.js
@@ -6,81 +6,87 @@ import socketIo from "./socketIo"
 import omit from "lodash/omit"
 import get from "lodash/get"
 
+const getPathFromProps = props => {
+  if (props.isPage) {
+    return get(props.pageResources, `page.path`)
+  } else {
+    return `/dev-404-page/`
+  }
+}
+
 class JSONStore extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      data: {},
+      data: null,
+      path: null,
     }
 
-    this.socket = socketIo()
-
     this.setPageData = this.setPageData.bind(this)
-    this.getPageData = this.getPageData.bind(this)
-  }
 
-  componentDidMount() {
+    this.socket = socketIo()
     this.socket.on(`queryResult`, this.setPageData)
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    if (nextProps !== this.props) return true
-
-    // if json for nextState is not available
-    const nextJsonId = get(nextProps.pageResources, `page.jsonName`)
-    if (!nextState.data[nextJsonId]) return false
-
-    // if nextState json is the same as current state json
-    const sameDataPath =
-      get(nextState, `data[${nextJsonId}].dataPath`) ===
-      get(this, `state.data[${nextJsonId}].dataPath`)
-
-    if (sameDataPath) return false
-
-    return true
+  componentWillMount() {
+    this.registerPath(getPathFromProps(this.props))
   }
 
-  setPageData(newData) {
-    this.setState({
-      data: { [newData.path]: newData },
-    })
+  componentWillReceiveProps(nextProps) {
+    const { path } = this.state
+    const newPath = getPathFromProps(nextProps)
+
+    if (path !== newPath) {
+      this.unregisterPath(path)
+      this.registerPath(newPath)
+    }
   }
 
-  getPageData(path) {
-    const res = this.state.data[path]
+  registerPath(path) {
+    this.setState({ path })
+    this.socket.emit(`registerPath`, path)
+  }
 
-    // always check for fresh data
-    this.socket.emit(`getPageData`, path)
+  unregisterPath(path) {
+    this.setState({ data: null, path: null })
+    this.socket.emit(`unregisterPath`, path)
+  }
 
-    if (!res || !res.data) return false
-    return JSON.parse(res.data)
+  componentWillUnmount() {
+    this.unregisterPath(this.state.path)
+  }
+
+  setPageData({ path, result }) {
+    if (this.state.path === path)
+      this.setState({
+        data: result,
+      })
   }
 
   render() {
     const { isPage, pages, pageResources } = this.props
+    const { data } = this.state
     const propsWithoutPages = omit(this.props, `pages`)
 
-    if (isPage) {
-      const jsonId = get(pageResources, `page.jsonName`)
-      const pageData = this.getPageData(jsonId)
-      if (pageData === false) return ``
+    if (!data) {
+      return null
+    } else if (isPage) {
       return createElement(ComponentRenderer, {
         key: `normal-page`,
         ...propsWithoutPages,
-        ...pageData,
+        ...data,
       })
     } else {
       const dev404Page = pages.find(p => /^\/dev-404-page/.test(p.path))
-      const dev404Props = {
-        ...propsWithoutPages,
-        ...this.getPageData(dev404Page.jsonName),
-      }
       return createElement(Route, {
         key: `404-page`,
         component: props =>
           createElement(
             syncRequires.components[dev404Page.componentChunkName],
-            dev404Props
+            {
+              ...propsWithoutPages,
+              ...data,
+            }
           ),
       })
     }

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -354,6 +354,10 @@ const queue = {
   ___resources: () => resourcesArray.slice().reverse(),
 }
 
+emitter.on(`PREFETCH_PATH`, rawPath => {
+  queue.enqueue(rawPath)
+})
+
 export const publicLoader = {
   getResourcesForPathname: queue.getResourcesForPathname,
 }

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -49,7 +49,12 @@ function urlJoin(...parts) {
   }, ``)
 }
 
-const getPage = path => pages.find(page => page.path === path)
+const getPage = path => {
+  const pathWithStartingSlash =
+    path.length > 0 && path[0] === `/` ? path : `/${path}`
+
+  return pages.find(page => page.path === pathWithStartingSlash)
+}
 const defaultLayout = props => <div>{props.children()}</div>
 
 const getLayout = page => {

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -354,11 +354,14 @@ module.exports = async (args: BootstrapArgs) => {
     require(`./page-hot-reloader`)(graphqlRunner)
   }
 
-  // Run queries
-  activity = report.activityTimer(`run graphql queries`)
-  activity.start()
-  await runQueries()
-  activity.end()
+  // Run queries only for build. In develop we run queries on demand.
+  if (process.env.NODE_ENV === `production`) {
+    // Run queries
+    activity = report.activityTimer(`run graphql queries`)
+    activity.start()
+    await runQueries()
+    activity.end()
+  }
 
   // Write out files.
   activity = report.activityTimer(`write out page data`)

--- a/packages/gatsby/src/internal-plugins/query-runner/query-queue.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-queue.js
@@ -27,7 +27,8 @@ const queue = new Queue(
     concurrent: 4,
     // Merge duplicate jobs.
     merge: (oldTask, newTask, cb) => {
-      cb(null, newTask)
+      // Use task with higher priority
+      cb(null, newTask.priority > oldTask.priority ? newTask : oldTask)
     },
     // Filter out new query jobs if that query is already running.  When the
     // query finshes, it checks the waiting map and pushes another job to
@@ -39,6 +40,9 @@ const queue = new Queue(
       } else {
         cb(null, job)
       }
+    },
+    priority: (task, cb) => {
+      cb(null, task.priority)
     },
   }
 )

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -57,44 +57,40 @@ module.exports = async (pageOrLayout, component) => {
   } else {
     result[`pageContext`] = pageOrLayout.context
   }
-  const resultJSON = JSON.stringify(result)
-  const resultHash = md5(resultJSON)
 
-  if (resultHashes[pageOrLayout.jsonName] !== resultHash) {
-    resultHashes[pageOrLayout.jsonName] = resultHash
-
-    // Always write file to public/static/d/ folder.
-    const dataPath = `${generatePathChunkName(
-      pageOrLayout.jsonName
-    )}-${resultHash}`
-
-    const programType = program._[0]
-
-    if (programType === `develop`) {
-      const data = {
-        dataPath,
-        data: resultJSON,
-        path: pageOrLayout.jsonName,
-      }
-      websocketManager.emitData({ data })
-    }
-
-    const resultPath = path.join(
-      program.directory,
-      `public`,
-      `static`,
-      `d`,
-      `${dataPath}.json`
-    )
-    await fs.writeFile(resultPath, resultJSON)
-
-    store.dispatch({
-      type: `SET_JSON_DATA_PATH`,
-      payload: {
-        [pageOrLayout.jsonName]: dataPath,
-      },
+  const programType = program._[0]
+  if (programType === `develop`) {
+    websocketManager.emitData({
+      result,
+      path: pageOrLayout.path,
     })
+  } else {
+    const resultJSON = JSON.stringify(result)
+    const resultHash = md5(resultJSON)
 
-    return
+    if (resultHashes[pageOrLayout.jsonName] !== resultHash) {
+      resultHashes[pageOrLayout.jsonName] = resultHash
+
+      // Write file to public/static/d/ folder.
+      const dataPath = `${generatePathChunkName(
+        pageOrLayout.jsonName
+      )}-${resultHash}`
+
+      const resultPath = path.join(
+        program.directory,
+        `public`,
+        `static`,
+        `d`,
+        `${dataPath}.json`
+      )
+      await fs.writeFile(resultPath, resultJSON)
+
+      store.dispatch({
+        type: `SET_JSON_DATA_PATH`,
+        payload: {
+          [pageOrLayout.jsonName]: dataPath,
+        },
+      })
+    }
   }
 }

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -18,47 +18,97 @@ class WebsocketManager {
     this.programDir = directory
     this.websocket = require(`socket.io`)(server)
 
-    const isRoomEmpty = roomName => {
-      const clientsInRoom = this.websocket.sockets.adapter.rooms[roomName]
-      return !clientsInRoom || clientsInRoom.length === 0
-    }
+    emitter.on(`INVALIDATE_QUERY_RESULTS`, path => {
+      this.results.delete(path)
+    })
 
     this.websocket.on(`connection`, s => {
-      const activePaths = new Set()
+      /**
+       * Ref counting map for paths
+       * differentiate between active path and linked path, because
+       * queries will have different priorities for each type
+       */
+      const pathRefCount = {
+        ACTIVE_PATH: new Map(),
+        LINKED_PATH: new Map(),
+      }
 
-      const leaveRoom = path => {
+      const leaveRoom = ({ path, mode, forceRemove = false }) => {
         const roomName = getRoomNameFromPath(path)
-        s.leave(roomName)
-        activePaths.delete(path)
 
-        if (isRoomEmpty(roomName)) {
-          emitter.emit(`STOP_RUNNING_QUERIES_FOR_PATH`, path)
+        let removeQueryListener = forceRemove
+
+        if (!forceRemove) {
+          let refCount = pathRefCount[mode].get(path)
+          if (typeof refCount !== `undefined`) {
+            refCount--
+            if (refCount <= 0) {
+              removeQueryListener = true
+            } else {
+              pathRefCount[mode].set(path, refCount)
+            }
+          } else {
+            // If we have not ref counts, remove listener just in case
+            removeQueryListener = true
+          }
+        }
+
+        if (removeQueryListener) {
+          pathRefCount[mode].delete(path)
+
+          if (
+            !pathRefCount.ACTIVE_PATH.has(path) &&
+            !pathRefCount.LINKED_PATH.has(path)
+          ) {
+            // Leave room if both ACTIVE and LINKED paths don't have
+            s.leave(roomName)
+          }
+
+          emitter.emit(`REMOVE_QUERY_RESULTS_LISTENER`, {
+            path,
+            mode,
+            listenerID: s.id,
+          })
         }
       }
 
-      s.on(`disconnect`, s => {
-        activePaths.forEach(path => {
-          leaveRoom(path)
+      s.on(`disconnect`, () => {
+        ;[`ACTIVE_PATH`, `LINKED_PATH`].forEach(mode => {
+          pathRefCount[mode].forEach((refCount, path) => {
+            leaveRoom({ path, mode, forceRemove: true })
+          })
         })
       })
 
-      s.on(`registerPath`, path => {
-        const roomName = getRoomNameFromPath(path)
+      s.on(`registerPath`, ({ path, mode }) => {
+        const refCount = pathRefCount[mode].get(path)
+        if (typeof refCount !== `undefined`) {
+          pathRefCount[mode].set(path, refCount + 1)
+        } else {
+          const roomName = getRoomNameFromPath(path)
 
-        if (isRoomEmpty(roomName)) {
-          emitter.emit(`RUN_QUERIES_FOR_PATH`, path)
-        }
+          emitter.emit(`ADD_QUERY_RESULTS_LISTENER`, {
+            path,
+            mode,
+            listenerID: s.id,
+          })
 
-        s.join(roomName)
-        activePaths.add(path)
+          s.join(roomName)
 
-        if (this.results.has(path)) {
-          s.emit(`queryResult`, this.results.get(path))
+          pathRefCount[mode].set(path, 1)
+
+          if (this.results.has(path)) {
+            s.emit(`queryResult`, this.results.get(path))
+          }
         }
       })
 
-      s.on(`unregisterPath`, path => {
-        leaveRoom(path)
+      s.on(`unregisterPath`, args => {
+        // Add small delay before leaving room, to allow page to change
+        // so we first add new listeners before removing old ones
+        setTimeout(() => {
+          leaveRoom(args)
+        }, 500)
       })
     })
 

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -33,13 +33,6 @@ class WebsocketManager {
 
         if (isRoomEmpty(roomName)) {
           emitter.emit(`STOP_RUNNING_QUERIES_FOR_PATH`, path)
-
-          // keep results in memory for few seconds
-          setTimeout(() => {
-            if (isRoomEmpty(roomName)) {
-              this.results.delete(path)
-            }
-          }, 5000)
         }
       }
 


### PR DESCRIPTION
initial work

- doesn't save query results to json files
- track active paths in browsers and run queries just for active paths (run query when we register active path and later when node dependency of that path changes)
- it keeps results of queries for active paths in memory on server, so when user open another tab/browser we can send him stored results instead of running query again (it also keep results in memory for few secs so if user go back to previous page quickly (within ~5s) results are sent from memory)
- utilise socket.io rooms to send query results only to clients that listen for results for given path

TODO:
- [ ] prerun queries for pages linked with `gatsby-link`

posibble TODO (need feedback on that)
- prerun query for `/` index path by default (so first first load is quick)
- display loader and/or info 'running query' while waiting for results (this could be either overlay or just instead of page component)