### PR TITLE
Adds the ability to specify rewrite paths for the API proxy

### DIFF
--- a/docs/docs/api-proxy.md
+++ b/docs/docs/api-proxy.md
@@ -21,7 +21,7 @@ This way, when you `fetch('/api/todos')` in development, the development server
 will recognize that it’s not a static asset, and will proxy your request to
 `http://dev-mysite.com/api/todos` as a fallback.
 
-If you want to configure rewrite rules (say for testing Netlify functions locally), pass a `rewritePaths` object to the proxy config.
+If you want to configure rewrite rules (say for testing Netlify functions locally), pass a `pathRewrite` object to the proxy config.
 
 ```js
 module.exports = {

--- a/docs/docs/api-proxy.md
+++ b/docs/docs/api-proxy.md
@@ -14,12 +14,24 @@ module.exports = {
     prefix: "/api",
     url: "http://dev-mysite.com",
   },
-};
+}
 ```
 
 This way, when you `fetch('/api/todos')` in development, the development server
 will recognize that it’s not a static asset, and will proxy your request to
 `http://dev-mysite.com/api/todos` as a fallback.
+
+If you want to configure rewrite rules (say for testing Netlify functions locally), pass a `rewritePaths` object to the proxy config.
+
+```js
+module.exports = {
+  proxy: {
+    prefix: "/.netlify/functions",
+    url: "http://localhost:9000",
+    pathRewrite: { "/.netlify/functions": "" },
+  },
+}
+```
 
 Keep in mind that `proxy` only has effect in development (with `gatsby develop`), and it is up to you to ensure that URLs like `/api/todos` point to
 the right place in production.

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -140,9 +140,22 @@ async function startServer(program) {
   // Set up API proxy.
   const { proxy } = store.getState().config
   if (proxy) {
-    const { prefix, url } = proxy
+    const { prefix, url, pathRewrite } = proxy
+
     app.use(`${prefix}/*`, (req, res) => {
-      const proxiedUrl = url + req.originalUrl
+      let path = req.originalUrl
+
+      if (pathRewrite) {
+        const matchedPath = Object.keys(pathRewrite).find(k =>
+          req.originalUrl.match(k)
+        )
+
+        if (matchedPath) {
+          path = path.replace(new RegExp(matchedPath), pathRewrite[matchedPath])
+        }
+      }
+
+      const proxiedUrl = url + path
       req.pipe(request(proxiedUrl)).pipe(res)
     })
   }

--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -9,6 +9,7 @@ export const gatsbyConfigSchema = Joi.object().keys({
   proxy: Joi.object().keys({
     prefix: Joi.string().required(),
     url: Joi.string().required(),
+    pathRewrite: Joi.object(),
   }),
 })
 


### PR DESCRIPTION
## Overview
Prior to this change,  there was no way to change the path sent through the API proxy. The reason I needed this was to support Netlify functions, which routes all calls to `/.netlify/functions/functionName` to the correct lamda endpoint.

When you develop the functions locally, the function endpoints are top level (without .netlify/functions). While I could have probably solved this issue with their local lambda server, it seemed like a change that was applicable to other scenarios as well.

I chose `pathRewrite` to keep the API similar to https://github.com/chimurai/http-proxy-middleware. Happy to change that though.

## Changes
- Adds `pathRewrite` to the `proxy` config object