### PR TITLE
responsiveResolution is deprecated

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -87,7 +87,7 @@ allContentfulProduct {
         id
         productName
         image {
-          responsiveResolution(width: 100) {
+          resolutions(width: 100) {
             width
             height
             src


### PR DESCRIPTION
According to https://github.com/gatsbyjs/gatsby/pull/2320/ "responsive" is dropped in favor of resolutions. 