### PR TITLE
add combined date/time formats for ISO 8601 that allow for local time

### DIFF
--- a/packages/gatsby/src/schema/types/type-date.js
+++ b/packages/gatsby/src/schema/types/type-date.js
@@ -13,6 +13,17 @@ const ISO_8601_FORMAT = [
   `YYYY-MM`,
   `YYYY-MM-DD`,
   `YYYYMMDD`,
+
+  // Local Time
+  `YYYY-MM-DDTHH`,
+  `YYYY-MM-DDTHH:mm`,
+  `YYYY-MM-DDTHHmm`,
+  `YYYY-MM-DDTHH:mm:ss`,
+  `YYYY-MM-DDTHHmmss`,
+  `YYYY-MM-DDTHH:mm:ss.SSS`,
+  `YYYY-MM-DDTHHmmss.SSS`,
+
+  // Coordinated Universal Time (UTC)
   `YYYY-MM-DDTHHZ`,
   `YYYY-MM-DDTHH:mmZ`,
   `YYYY-MM-DDTHHmmZ`,
@@ -20,6 +31,7 @@ const ISO_8601_FORMAT = [
   `YYYY-MM-DDTHHmmssZ`,
   `YYYY-MM-DDTHH:mm:ss.SSSZ`,
   `YYYY-MM-DDTHHmmss.SSSZ`,
+  
   `YYYY-[W]WW`,
   `YYYY[W]WW`,
   `YYYY-[W]WW-E`,


### PR DESCRIPTION
Currently **local time** ISO 8601 formats are not identified as a "date" and thus aren't eligible for the formatString() argument in Gatsby's GraphQL queries. This allows the use of both Local Time and UTC dates and resolves issue #4789

A brief recap from ISO 8601 [Wiki](https://en.wikipedia.org/wiki/ISO_8601):

> Time zones in ISO 8601 are represented as **local time** (with the location unspecified), as UTC, or as an offset from UTC.

> If the time is in UTC, add a Z directly after the time without a space. Z is the zone designator for the zero UTC offset.

Includes the local date/time combination formats (no time zone designator on the end) within the ISO_8601_FORMAT const. This way we ensure local date/time combinations can be received / manipulated by the .utc() method as well.