### PR TITLE
Consistently pass the pathPrefix with linked files

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -211,6 +211,31 @@ describe(`gatsby-remark-copy-linked-files`, () => {
       })
     })
 
+    it(`copies file to destinationDir when supplied (with pathPrefix)`, async () => {
+      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const pathPrefix = `/blog`
+      const validDestinationDir = `path/to/dir`
+      const expectedNewPath = path.posix.join(
+        process.cwd(),
+        `public`,
+        validDestinationDir,
+        `/undefined-undefined.gif`
+      )
+      expect.assertions(3)
+      await plugin(
+        { files: getFiles(imagePath), markdownAST, markdownNode, pathPrefix, getNode },
+        {
+          destinationDir: validDestinationDir,
+        }
+      ).then(v => {
+        expect(v).toBeDefined()
+        expect(fsExtra.copy).toHaveBeenCalledWith(imagePath, expectedNewPath)
+        expect(imageURL(markdownAST)).toEqual(
+          `${pathPrefix}/path/to/dir/undefined-undefined.gif`
+        )
+      })
+    })
+
     it(`copies file to root dir when not supplied'`, async () => {
       const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
       const expectedNewPath = path.posix.join(

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -33,11 +33,14 @@ const newPath = (linkNode, destinationDir) => {
   return path.posix.join(process.cwd(), DEPLOY_DIR, newFileName(linkNode))
 }
 
-const newLinkURL = (linkNode, destinationDir) => {
-  if (destinationDir) {
-    return path.posix.join(`/`, destinationDir, newFileName(linkNode))
-  }
-  return path.posix.join(`/`, newFileName(linkNode))
+const newLinkURL = (linkNode, destinationDir, pathPrefix) => {
+  const linkPaths = [`/`, pathPrefix, destinationDir, newFileName(linkNode)]
+    .filter(function(lpath) {
+      if (lpath) return true
+        return false
+      })
+
+  return path.posix.join(...linkPaths)
 }
 
 function toArray(buf) {
@@ -51,7 +54,7 @@ function toArray(buf) {
 }
 
 module.exports = (
-  { files, markdownNode, markdownAST, getNode },
+  { files, markdownNode, markdownAST, pathPrefix, getNode },
   pluginOptions = {}
 ) => {
   const defaults = {
@@ -87,7 +90,7 @@ module.exports = (
         // Prevent uneeded copying
         if (linkPath === newFilePath) return
 
-        const linkURL = newLinkURL(linkNode, options.destinationDir)
+        const linkURL = newLinkURL(linkNode, options.destinationDir, pathPrefix)
         link.url = linkURL
         filesToCopy.set(linkPath, newFilePath)
       }


### PR DESCRIPTION
Fixes copied gifs and svgs missing the pathPrefix for production builds.

Refs #2440, #3338 