### PR TITLE
[json-loader] develop - reading results from file improvments

### DIFF
--- a/packages/gatsby/cache-dir/json-store.js
+++ b/packages/gatsby/cache-dir/json-store.js
@@ -6,81 +6,89 @@ import socketIo from "./socketIo"
 import omit from "lodash/omit"
 import get from "lodash/get"
 
+const getPathFromProps = props => {
+  if (props.isPage) {
+    return get(props.pageResources, `page.path`)
+  } else {
+    return `/dev-404-page/`
+  }
+}
+
 class JSONStore extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
       data: {},
+      path: null,
     }
 
-    this.socket = socketIo()
-
     this.setPageData = this.setPageData.bind(this)
-    this.getPageData = this.getPageData.bind(this)
-  }
 
-  componentDidMount() {
+    this.socket = socketIo()
     this.socket.on(`queryResult`, this.setPageData)
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    if (nextProps !== this.props) return true
-
-    // if json for nextState is not available
-    const nextJsonId = get(nextProps.pageResources, `page.jsonName`)
-    if (!nextState.data[nextJsonId]) return false
-
-    // if nextState json is the same as current state json
-    const sameDataPath =
-      get(nextState, `data[${nextJsonId}].dataPath`) ===
-      get(this, `state.data[${nextJsonId}].dataPath`)
-
-    if (sameDataPath) return false
-
-    return true
+  componentWillMount() {
+    this.registerPath(getPathFromProps(this.props))
   }
 
-  setPageData(newData) {
+  componentWillReceiveProps(nextProps) {
+    const { path } = this.state
+    const newPath = getPathFromProps(nextProps)
+
+    if (path !== newPath) {
+      this.unregisterPath(path)
+      this.registerPath(newPath)
+    }
+  }
+
+  registerPath(path) {
+    this.setState({ path })
+    this.socket.emit(`registerPath`, path)
+  }
+
+  unregisterPath(path) {
+    this.setState({ path: null })
+    this.socket.emit(`unregisterPath`, path)
+  }
+
+  componentWillUnmount() {
+    this.unregisterPath(this.state.path)
+  }
+
+  setPageData({ path, result }) {
     this.setState({
-      data: { [newData.path]: newData },
+      data: {
+        ...this.state.data,
+        [path]: result,
+      },
     })
-  }
-
-  getPageData(path) {
-    const res = this.state.data[path]
-
-    // always check for fresh data
-    this.socket.emit(`getPageData`, path)
-
-    if (!res || !res.data) return false
-    return JSON.parse(res.data)
   }
 
   render() {
     const { isPage, pages, pageResources } = this.props
+    const data = this.state.data[this.state.path]
     const propsWithoutPages = omit(this.props, `pages`)
 
-    if (isPage) {
-      const jsonId = get(pageResources, `page.jsonName`)
-      const pageData = this.getPageData(jsonId)
-      if (pageData === false) return ``
+    if (!data) {
+      return null
+    } else if (isPage) {
       return createElement(ComponentRenderer, {
         key: `normal-page`,
         ...propsWithoutPages,
-        ...pageData,
+        ...data,
       })
     } else {
       const dev404Page = pages.find(p => /^\/dev-404-page/.test(p.path))
-      const dev404Props = {
-        ...propsWithoutPages,
-        ...this.getPageData(dev404Page.jsonName),
-      }
       return createElement(Route, {
         key: `404-page`,
         component: props =>
           createElement(
             syncRequires.components[dev404Page.componentChunkName],
-            dev404Props
+            {
+              ...propsWithoutPages,
+              ...data,
+            }
           ),
       })
     }

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -70,7 +70,7 @@ module.exports = async (pageOrLayout, component) => {
 
     const programType = program._[0]
 
-    if (programType === `develop`) {
+    if (programType === `develop` && pageOrLayout.path) {
       const data = {
         dataPath,
         data: resultJSON,

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -71,12 +71,10 @@ module.exports = async (pageOrLayout, component) => {
     const programType = program._[0]
 
     if (programType === `develop` && pageOrLayout.path) {
-      const data = {
-        dataPath,
-        data: resultJSON,
-        path: pageOrLayout.jsonName,
-      }
-      websocketManager.emitData({ data })
+      websocketManager.emitData({
+        result,
+        path: pageOrLayout.path,
+      })
     }
 
     const resultPath = path.join(


### PR DESCRIPTION
this remove excessive file reads:
 - store query results in memory
 - only read cached json files if we didn't run query (data didn't change since last gatsby run)