### PR TITLE
[gatsby-plugin-google-analytics] Add exclude option

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -23,7 +23,7 @@ module.exports = {
         // Setting this parameter is also optional
         respectDNT: true,
         // Avoids sending pageview hits from custom paths
-        exclude: ["/preview", "/do-not-track/me/too"],
+        exclude: ["/preview/**", "/do-not-track/me/too/"],
       },
     },
   ],
@@ -78,4 +78,4 @@ If you enable this optional option, Google Analytics will not be loaded at all f
 
 ## The "exclude" option
 
-If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array as [regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) patterns.
+If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array as glob expressions.

--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -78,4 +78,4 @@ If you enable this optional option, Google Analytics will not be loaded at all f
 
 ## The "exclude" option
 
-If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array.
+If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array as [regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) patterns.

--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -22,6 +22,8 @@ module.exports = {
         anonymize: true,
         // Setting this parameter is also optional
         respectDNT: true,
+        // Avoids sending pageview hits from custom paths
+        exclude: ["/preview", "/do-not-track/me/too"],
       },
     },
   ],
@@ -73,3 +75,7 @@ you can set a link e.g. in your imprint as follows:
 ## The "respectDNT" option
 
 If you enable this optional option, Google Analytics will not be loaded at all for visitors that have "Do Not Track" enabled. While using Google Analytics does not necessarily constitute Tracking, you might still want to do this to cater to more privacy oriented users.
+
+## The "exclude" option
+
+If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array.

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,6 +1,13 @@
-exports.onRouteUpdate = function({ location }) {
+exports.onRouteUpdate = function({ location }, pluginOptions) {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production` && typeof ga === `function`) {
+    if (
+      location &&
+      typeof pluginOptions.exclude !== `undefined` &&
+      pluginOptions.exclude.some(rx => new RegExp(rx).test(location.pathname))
+    ) {
+      return
+    }
     window.ga(
       `set`,
       `page`,

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,10 +1,10 @@
-exports.onRouteUpdate = function({ location }, pluginOptions) {
+exports.onRouteUpdate = function({ location }) {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production` && typeof ga === `function`) {
     if (
       location &&
-      typeof pluginOptions.exclude !== `undefined` &&
-      pluginOptions.exclude.some(rx => new RegExp(rx).test(location.pathname))
+      typeof window.excludeGAPaths !== `undefined` &&
+      window.excludeGAPaths.some(rx => rx.test(location.pathname))
     ) {
       return
     }

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -5,6 +5,14 @@ exports.onRenderBody = (
   pluginOptions
 ) => {
   if (process.env.NODE_ENV === `production`) {
+    let excludeGAPaths = []
+    if (typeof pluginOptions.exclude !== `undefined`) {
+      const Minimatch = require(`minimatch`).Minimatch
+      pluginOptions.exclude.map(exclude => {
+        const mm = new Minimatch(exclude)
+        excludeGAPaths.push(mm.makeRe())
+      })
+    }
     const setComponents = pluginOptions.head
       ? setHeadComponents
       : setPostBodyComponents
@@ -13,6 +21,11 @@ exports.onRenderBody = (
         key={`gatsby-plugin-google-analytics`}
         dangerouslySetInnerHTML={{
           __html: `
+  ${
+    excludeGAPaths.length
+      ? `window.excludeGAPaths=[${excludeGAPaths.join(`,`)}];`
+      : ``
+  }          
   ${
     typeof pluginOptions.anonymize !== `undefined`
       ? `function gaOptout(){document.cookie=disableStr+'=true; expires=Thu, 31 Dec 2099 23:59:59 UTC;path=/',window[disableStr]=!0}var gaProperty='${

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -1,16 +1,10 @@
 import React from "react"
 
 exports.onRenderBody = (
-  { pathname, setHeadComponents, setPostBodyComponents },
+  { setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {
   if (process.env.NODE_ENV === `production`) {
-    if (
-      typeof pluginOptions.exclude !== `undefined` &&
-      pluginOptions.exclude.some(rx => new RegExp(rx).test(pathname))
-    ) {
-      return null
-    }
     const setComponents = pluginOptions.head
       ? setHeadComponents
       : setPostBodyComponents

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -1,10 +1,16 @@
 import React from "react"
 
 exports.onRenderBody = (
-  { setHeadComponents, setPostBodyComponents },
+  { pathname, setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {
   if (process.env.NODE_ENV === `production`) {
+    if (
+      typeof pluginOptions.exclude !== `undefined` &&
+      pluginOptions.exclude.some(rx => new RegExp(rx).test(pathname))
+    ) {
+      return null
+    }
     const setComponents = pluginOptions.head
       ? setHeadComponents
       : setPostBodyComponents


### PR DESCRIPTION
Added "exclude" option array to exclude GA from desired paths:
```js
{
   resolve: "gatsby-plugin-google-analytics",
   options: {
       exclude: ["/preview", "/test"]
    }
}
```
It matches every expression with the current production pathname.