### PR TITLE
[gatsby-plugin-manifest] Move default icons to common file

### DIFF
--- a/packages/gatsby-plugin-manifest/.gitignore
+++ b/packages/gatsby-plugin-manifest/.gitignore
@@ -1,4 +1,5 @@
 /gatsby-node.js
 /gatsby-ssr.js
 /gatsby-browser.js
+/common.js
 /app-shell.js

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -45,7 +45,7 @@ plugins: [
       background_color: "#f7f0eb",
       theme_color: "#a2466c",
       display: "minimal-ui",
-      icon: src/images/icon.png // This path is relative to the root of the site.
+      icon: "src/images/icon.png" // This path is relative to the root of the site.
     },
   },
 ];

--- a/packages/gatsby-plugin-manifest/src/common.js
+++ b/packages/gatsby-plugin-manifest/src/common.js
@@ -1,0 +1,44 @@
+// default icons for generating icons
+exports.defaultIcons = [
+  {
+      "src": `icons/icon-48x48.png`,
+      "sizes": `48x48`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-72x72.png`,
+      "sizes": `72x72`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-96x96.png`,
+      "sizes": `96x96`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-144x144.png`,
+      "sizes": `144x144`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-192x192.png`,
+      "sizes": `192x192`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-256x256.png`,
+      "sizes": `256x256`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-384x384.png`,
+      "sizes": `384x384`,
+      "type": `image/png`,
+  },
+  {
+      "src": `icons/icon-512x512.png`,
+      "sizes": `512x512`,
+      "type": `image/png`,
+  },
+]
+

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -1,50 +1,7 @@
 const fs = require(`fs`)
 const Promise = require(`bluebird`)
 const sharp = require(`sharp`)
-
-// default icons for generating icons
-const defaultIcons = [
-  {
-      "src": `icons/icon-48x48.png`,
-      "sizes": `48x48`,
-      "type": `image/png`,
-  },
-  {
-      "src": `icons/icon-72x72.png`,
-      "sizes": `72x72`,
-      "type": `image/png`,
-  },
-  {
-      "src": `icons/icon-96x96.png`,
-      "sizes": `96x96`,
-      "type": `image/png`,
-  },
-  {
-      "src": `icons/icon-144x144.png`,
-      "sizes": `144x144`,
-      "type": `image/png`,
-  },
-  {
-      "src": `icons/icon-192x192.png`,
-      "sizes": `192x192`,
-      "type": `image/png`,
-  },
-  {
-      "src": `icons/icon-256x256.png`,
-      "sizes": `256x256`,
-      "type": `image/png`,
-  },
-  {
-      "src": `icons/icon-384x384.png`,
-      "sizes": `384x384`,
-      "type": `image/png`,
-  },
-  {
-      "src": `icons/icon-512x512.png`,
-      "sizes": `512x512`,
-      "type": `image/png`,
-  },
-]
+const defaultIcons = require(`./common.js`).defaultIcons
 
 sharp.simd(true)
 

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -1,9 +1,11 @@
 import React from "react"
 import { withPrefix } from "gatsby-link"
+import { defaultIcons } from "./common.js"
+
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 
-  const { icons } = pluginOptions
+  const icons = pluginOptions.icons || defaultIcons
   const iconPath = icons[0].src.substring(0, icons[0].src.lastIndexOf(`/`))
 
   setHeadComponents([


### PR DESCRIPTION
Fixes #4865 