### PR TITLE
Add dependency instruction

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/README.md
+++ b/packages/gatsby-transformer-javascript-frontmatter/README.md
@@ -8,6 +8,8 @@ Parses JavaScript files to extract frontmatter from exports.
 
 ## How to use
 
+To use this plugin you need [gatsby-source-filesystem](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) installed.
+
 ```javascript
 // In your gatsby-config.js
 plugins: [`gatsby-transformer-javascript-frontmatter`];

--- a/packages/gatsby-transformer-javascript-frontmatter/README.md
+++ b/packages/gatsby-transformer-javascript-frontmatter/README.md
@@ -8,11 +8,13 @@ Parses JavaScript files to extract frontmatter from exports.
 
 ## How to use
 
-To use this plugin you need [gatsby-source-filesystem](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) installed.
+To use this plugin you also need [gatsby-source-filesystem](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) installed.
 
 ```javascript
 // In your gatsby-config.js
-plugins: [`gatsby-transformer-javascript-frontmatter`];
+module.exports = {
+  plugins: [`gatsby-transformer-javascript-frontmatter`]
+}
 ```
 
 ## Parsing algorithm


### PR DESCRIPTION
When using the gatsby-transformer-javascript-frontmatter the
gatsby-source-filesystem plugin needs to be installed as well but this
is nowhere documented.