### PR TITLE
Adds new starter "gatsby-starter-procyon"

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -619,3 +619,22 @@ Community:
   * Portfolio
   * Resume
   * Redux for managing statement (with redux-saga / reselect)
+
+* [gatsby-starter-procyon](https://github.com/danielmahon/gatsby-starter-procyon)
+  [(demo)](https://gatsby-starter-procyon.netlify.com/)
+
+  Features:
+  
+  * [Gatsby](https://www.gatsbyjs.org/) + [ReactJS](https://reactjs.org/) (server side rendering)
+  * [GraphCMS](https://graphcms.com/) Headless CMS
+  * [DraftJS](https://draftjs.org/) (in-place) [Medium](https://medium.com)-like Editing
+  * [Apollo GraphQL](https://www.apollographql.com/) (client-side)
+  * Local caching between builds
+  * [Material-UI](https://material-ui-next.com/) (layout, typography, components, etc)
+  * Styled-Components™-like API via Material-UI
+  * [Netlify](https://www.netlify.com/) Deployment Friendly
+  * [Netlify Identity](https://www.netlify.com/docs/identity/) Authentication (enables editing)
+  * Automatic versioning, deployment and CHANGELOG
+  * Automatic rebuilds with GraphCMS and Netlify web hooks
+  * PWA (Progressive Web App)
+  * [Google Fonts](https://fonts.google.com/)


### PR DESCRIPTION
![gatsby-starter-procyon](https://github.com/danielmahon/gatsby-starter-procyon/raw/master/static/logo.png)

# gatsby-starter-procyon

An opinionated Gatsby starter designed for trash-eating pandas.

[View Demo - https://gatsby-starter-procyon.netlify.com/](https://gatsby-starter-procyon.netlify.com/)  
Click "Login" in the footer to enable client-side editing.  
`Email: demo@demo.com` `Password: demo`  
_You'll get an error when trying to save changes to remote, but you get the idea..._

### Features

* [Gatsby](https://www.gatsbyjs.org/) + [ReactJS](https://reactjs.org/) (server side rendering)
* [GraphCMS](https://graphcms.com/) Headless CMS
* [DraftJS](https://draftjs.org/) (in-place) [Medium](https://medium.com)-like Editing
* [Apollo GraphQL](https://www.apollographql.com/) (client-side)
* Local caching between builds
* [Material-UI](https://material-ui-next.com/) (layout, typography, components, etc)
* Styled-Components™-like API via Material-UI
* [Netlify](https://www.netlify.com/) Deployment Friendly
* [Netlify Identity](https://www.netlify.com/docs/identity/) Authentication (enables editing)
* Automatic versioning, deployment and CHANGELOG
* Automatic rebuilds with GraphCMS and Netlify web hooks
* PWA (Progressive Web App)
* [Google Fonts](https://fonts.google.com/)
* Trash Panda Approved\*