### PR TITLE
[gatsby-source-wordpress] dont request remote file if we already have cached up to date version of it

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -34,7 +34,7 @@ exports.sourceNodes = async (
     excludedRoutes = [],
   }
 ) => {
-  const { createNode } = boundActionCreators
+  const { createNode, touchNode } = boundActionCreators
   _verbose = verboseOutput
   _siteURL = `${protocol}://${baseUrl}`
   _useACF = useACF
@@ -99,6 +99,7 @@ exports.sourceNodes = async (
     store,
     cache,
     createNode,
+    touchNode,
     _auth,
   })
 


### PR DESCRIPTION
this avoids doing requests for attachments that didn't change since last run, this should be helpful especially for wordpress instance with large media libraries, as currently we need to make request to check if file changed