### PR TITLE
[Docs][Minor] Link Gatsbygram Case Study in README

### DIFF
--- a/examples/gatsbygram/README.md
+++ b/examples/gatsbygram/README.md
@@ -5,6 +5,4 @@ https://gatsbygram.gatsbyjs.org/
 Built with Gatsby 1.0 as a demo of Gatsby's new built-in image processing
 capabilities.
 
-To read more about this example, check out the [Gatsbygram Case Study][1]!
-
-[1]: (https://www.gatsbyjs.org/blog/gatsbygram-case-study/)
+To read more about this example, check out the [Gatsbygram Case Study](https://www.gatsbyjs.org/blog/gatsbygram-case-study/)


### PR DESCRIPTION
I see that the link existed, but I couldn’t get the footnote to render in any way on GitHub. Is the README being rendered elsewhere? Screenshot before fix: 

![screen shot 2018-04-06 at 17 53 06](https://user-images.githubusercontent.com/2069737/38449391-5f889e2e-39c3-11e8-8685-23cbe0cbb10b.png)
