### PR TITLE
Correct the name of the WordPress REST API

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -2,7 +2,7 @@
 
 Source plugin for pulling data into [Gatsby](https://github.com/gatsbyjs) from
 WordPress sites using the
-[WordPress JSON REST API](https://developer.wordpress.org/rest-api/reference/).
+[WordPress WP REST API](https://developer.wordpress.org/rest-api/reference/).
 
 An example site for this plugin is available.
 


### PR DESCRIPTION
The WordPress REST API is officially referred to as the WP REST API. There is a JSON REST API plugin, which could be confusing to users.