### PR TITLE
adjust indices used for extracting GraphQLParser errors

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
@@ -62,7 +62,7 @@ function extractError(error: Error): { message: string, docName: string } {
   while ((matches = docRegex.exec(error.toString())) !== null) {
     // This is necessary to avoid infinite loops with zero-width matches
     if (matches.index === docRegex.lastIndex) docRegex.lastIndex++
-    ;[, message, docName] = matches
+    ;[,, message, docName] = matches
   }
 
   if (!message) {


### PR DESCRIPTION
graphql error reporting seems to be broken after #4618 - it added new capturing group, but didn't adjust which matches we use to log errors

fixes #4888

@sielay do you have any feedback on this?