### PR TITLE
Relocate manifest.json to ./public/

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -9,7 +9,7 @@ function generateIcons(icons, srcIcon) {
   return Promise.map(icons, icon => {
     const size = parseInt(icon.sizes.substring(0, icon.sizes.lastIndexOf(`x`)))
     const imgPath = `./public/` + icon.src
-    
+
     return sharp(srcIcon)
       .resize(size)
       .toFile(imgPath)
@@ -22,7 +22,7 @@ exports.onPostBuild = (args, pluginOptions) =>
   new Promise(resolve => {
     const { icon } = pluginOptions
     const manifest = { ...pluginOptions }
-  
+
     // Delete options we won't pass to the manifest.json.
     delete manifest.plugins
     delete manifest.icon
@@ -40,8 +40,8 @@ exports.onPostBuild = (args, pluginOptions) =>
       fs.mkdirSync(iconPath)
     }
 
-    fs.writeFileSync(`${iconPath}/manifest.json`, JSON.stringify(manifest))
-    
+    fs.writeFileSync(`./public/manifest.json`, JSON.stringify(manifest))
+
     // Only auto-generate icons if a src icon is defined.
     if (icon !== undefined) {
         generateIcons(manifest.icons, icon).then(() => {

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -6,13 +6,12 @@ import { defaultIcons } from "./common.js"
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 
   const icons = pluginOptions.icons || defaultIcons
-  const iconPath = icons[0].src.substring(0, icons[0].src.lastIndexOf(`/`))
 
   setHeadComponents([
     <link
       key={`gatsby-plugin-manifest-link`}
       rel="manifest"
-      href={withPrefix(`${iconPath}/manifest.json`)}
+      href={withPrefix(`manifest.json`)}
     />,
     <meta
       key={`gatsby-plugin-manifest-meta`}


### PR DESCRIPTION
This pull-request relocate manifest.json to `./public/` from `./public/icons/`.
(According to Google Developers manifest.json seems to be placed in Root.)
ref: https://developers.google.com/web/fundamentals/web-app-manifest/

### Background
Current version gatsby-plugin-manifest (1.0.17) create manifest.json to `./public/icons`.
However, generated manifest.json's icon-path contains `icons/` prefix.
Therefore, it is supposed to refer to a path which does not exist on the browser.
like: `localhost:9000/icons/icons/*****.png`

![screenshot](https://user-images.githubusercontent.com/1488898/38468608-c57cf7ae-3b83-11e8-9f6b-ab695af3ccaa.png)



