### PR TITLE
gatsby-plugin-manifest: manifest file path

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -40,7 +40,7 @@ exports.onPostBuild = (args, pluginOptions) =>
       fs.mkdirSync(iconPath)
     }
 
-    fs.writeFileSync(`${iconPath}/manifest.json`, JSON.stringify(manifest))
+    fs.writeFileSync(`./public/manifest.json`, JSON.stringify(manifest))
     
     // Only auto-generate icons if a src icon is defined.
     if (icon !== undefined) {

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -12,7 +12,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     <link
       key={`gatsby-plugin-manifest-link`}
       rel="manifest"
-      href={withPrefix(`${iconPath}/manifest.json`)}
+      href={withPrefix(`/manifest.json`)}
     />,
     <meta
       key={`gatsby-plugin-manifest-meta`}


### PR DESCRIPTION
gatsby-plugin-manifest writes manifest file into the
'./public/icons' directory, where favicons are placed
themselfs.

According to specification how src member is being handled:
https://www.w3.org/TR/appmanifest/#dom-imageresource-src

> The algorithm takes a ImageResource icon, and a URL manifest URL,
> which is the URL from which the manifest was fetched.

manifest URL is used as base-URL and during the URL processing
it exposes in the wrong way.

You can reproduce it in your browser console.
```
new URL(
    'icons/some_icon.png',
    'http://localhost/icons/manifest.json'
);
```
```
 URL {
   href: "http://localhost/icons/icons/some_icon.png",
   ...
 }
```

For more info about URL parsing please take a look at specification:
https://url.spec.whatwg.org/#concept-url-parser

repoduced in:
 - Firefox Quantum 59.0.2;
 - Chromium Version 64.0.3282.119;