### PR TITLE
Extract `getNode` method from `args`, not `boundActionCreators` (fixes #4906)

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -30,13 +30,12 @@ exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`).extendNodeTyp
  */
 
 exports.sourceNodes = async (
-  { boundActionCreators, getNodes, hasNodeChanged, store },
+  { boundActionCreators, getNode, getNodes, hasNodeChanged, store },
   { spaceId, accessToken, host }
 ) => {
   const {
     createNode,
     deleteNode,
-    getNode,
     touchNode,
     setPluginStatus,
   } = boundActionCreators


### PR DESCRIPTION
cc: @pieh 