### PR TITLE
[v2] remove static-site-generator-webpack-plugin and render html files ourselves

### DIFF
--- a/packages/gatsby/cache-dir/develop-static-entry.js
+++ b/packages/gatsby/cache-dir/develop-static-entry.js
@@ -26,7 +26,7 @@ try {
 
 Html = Html && Html.__esModule ? Html.default : Html
 
-export default (locals, callback) => {
+export default (pagePath, callback) => {
   let headComponents = []
   let htmlAttributes = {}
   let bodyAttributes = {}

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -59,7 +59,7 @@ const getLayout = page => {
 
 const createElement = React.createElement
 
-export default (locals, callback) => {
+export default (pagePath, callback) => {
   let pathPrefix = `/`
   if (__PREFIX_PATHS__) {
     pathPrefix = `${__PATH_PREFIX__}/`
@@ -110,7 +110,7 @@ export default (locals, callback) => {
     {
       basename: pathPrefix,
       location: {
-        pathname: locals.path,
+        pathname: pagePath,
       },
       context: {},
     },
@@ -175,12 +175,12 @@ export default (locals, callback) => {
     setPreBodyComponents,
     setPostBodyComponents,
     setBodyProps,
-    pathname: locals.path,
+    pathname: pagePath,
     bodyHtml,
   })
 
   // Create paths to scripts
-  const page = pages.find(page => page.path === locals.path)
+  const page = pages.find(page => page.path === pagePath)
   let runtimeScript
   const scriptsAndStyles = flatten(
     [`app`, page.layoutComponentChunkName, page.componentChunkName].map(s => {
@@ -300,11 +300,9 @@ export default (locals, callback) => {
       preBodyComponents={preBodyComponents}
       postBodyComponents={postBodyComponents}
       body={bodyHtml}
-      path={locals.path}
+      path={pagePath}
     />
   )}`
 
   callback(null, html)
 }
-
-// export const __esModule = true

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -105,7 +105,6 @@
     "signal-exit": "^3.0.2",
     "slash": "^1.0.0",
     "socket.io": "^2.0.3",
-    "static-site-generator-webpack-plugin": "^3.4.1",
     "string-similarity": "^1.2.0",
     "style-loader": "^0.19.1",
     "type-of": "^2.0.1",

--- a/packages/gatsby/src/commands/develop-html.js
+++ b/packages/gatsby/src/commands/develop-html.js
@@ -4,6 +4,7 @@ const webpack = require(`webpack`)
 const { createErrorFromString } = require(`gatsby-cli/lib/reporter/errors`)
 const debug = require(`debug`)(`gatsby:html`)
 const webpackConfig = require(`../utils/webpack.config`)
+const renderHTML = require(`../utils/html-renderer`)
 
 module.exports = async (program: any) => {
   const { directory } = program
@@ -15,8 +16,7 @@ module.exports = async (program: any) => {
     program,
     directory,
     `develop-html`,
-    null,
-    [`/`]
+    null
   )
 
   return new Promise((resolve, reject) => {
@@ -33,14 +33,16 @@ module.exports = async (program: any) => {
         )
       }
 
-      // Remove the temp JS bundle file built for the static-site-generator-plugin
-      try {
-        fs.unlinkSync(outputFile)
-      } catch (e) {
-        // This function will fail on Windows with no further consequences.
-      }
+      return renderHTML(require(outputFile), [`/`]).then(() => {
+        // Remove the temp JS bundle file built for the static-site-generator-plugin
+        try {
+          fs.unlinkSync(outputFile)
+        } catch (e) {
+          // This function will fail on Windows with no further consequences.
+        }
 
-      return resolve(null, stats)
+        return resolve(null, stats)
+      })
     })
   })
 }

--- a/packages/gatsby/src/utils/html-renderer.js
+++ b/packages/gatsby/src/utils/html-renderer.js
@@ -1,0 +1,38 @@
+const Queue = require(`better-queue`)
+const fs = require(`fs-extra`)
+const path = require(`path`)
+
+// copied from https://github.com/markdalgleish/static-site-generator-webpack-plugin/blob/master/index.js#L161
+const generatePathToOutput = outputPath => {
+  let outputFileName = outputPath.replace(/^(\/|\\)/, ``) // Remove leading slashes for webpack-dev-server
+
+  if (!/\.(html?)$/i.test(outputFileName)) {
+    outputFileName = path.join(outputFileName, `index.html`)
+  }
+
+  return path.join(process.cwd(), `public`, outputFileName)
+}
+
+module.exports = (htmlComponentRenderer, pages) =>
+  new Promise(resolve => {
+    const queue = new Queue(
+      (path, callback) => {
+        htmlComponentRenderer.default(path, (throwAway, htmlString) => {
+          fs.outputFile(generatePathToOutput(path), htmlString).then(() => {
+            callback()
+          })
+        })
+      },
+      {
+        concurrent: 20,
+      }
+    )
+
+    pages.forEach(page => {
+      queue.push(page)
+    })
+
+    queue.on(`drain`, () => {
+      resolve()
+    })
+  })

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -3,7 +3,6 @@ require(`v8-compile-cache`)
 const fs = require(`fs`)
 const path = require(`path`)
 const dotenv = require(`dotenv`)
-const StaticSiteGeneratorPlugin = require(`static-site-generator-webpack-plugin`)
 const FriendlyErrorsWebpackPlugin = require(`friendly-errors-webpack-plugin`)
 const { store } = require(`../redux`)
 const { actions } = require(`../redux/actions`)
@@ -24,8 +23,7 @@ module.exports = async (
   program,
   directory,
   suppliedStage,
-  webpackPort = 1500,
-  pages = []
+  webpackPort = 1500
 ) => {
   const directoryPath = withBasePath(directory)
 
@@ -181,13 +179,6 @@ module.exports = async (
               ],
             },
           }),
-        ])
-        break
-
-      case `develop-html`:
-      case `build-html`:
-        configPlugins = configPlugins.concat([
-          new StaticSiteGeneratorPlugin(`render-page.js`, pages),
         ])
         break
       case `build-javascript`: {


### PR DESCRIPTION
this gives us more control over the process

this also initially use `better-queue` to limit concurrent page renders (right now hardcoded to 20) and decrease memory footprint for larger sites

