### PR TITLE
Fix the version of imagemin-pngquant

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -11,7 +11,7 @@
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
     "imagemin": "^5.2.2",
-    "imagemin-pngquant": "^5.0.0",
+    "imagemin-pngquant": "5.0.1",
     "imagemin-webp": "^4.0.0",
     "lodash": "^4.17.4",
     "potrace": "^2.1.1",


### PR DESCRIPTION
Fix the version of `imagemin-pngquant` to `5.0.1` to avoid the change made in `5.1.0.` which is causing lots of people issues when running `npm install`

The issue is being discussed here:

https://github.com/imagemin/imagemin-pngquant/issues/46
https://github.com/imagemin/pngquant-bin/issues/78

Fixes #4866