### PR TITLE
Added createTypeName to ensure unique name for union types.

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -248,10 +248,10 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
     // If there's more than one type, we'll create a union type.
     if (fields.length > 1) {
       type = new GraphQLUnionType({
-        name: `Union_${key}_${fields
+        name: createTypeName(`Union_${key}_${fields
           .map(f => f.name)
           .sort()
-          .join(`__`)}`,
+          .join(`__`)}`),
         description: `Union interface for the field "${key}" for types [${fields
           .map(f => f.name)
           .sort()


### PR DESCRIPTION
Union type was missing a createTypeName wrapping call. Fixes #3544 