### PR TITLE
gatsby-transformer-screenshot - Ignore nodes with no URL field

### DIFF
--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -44,8 +44,8 @@ exports.onPreBootstrap = (
 exports.onCreateNode = async ({ node, boundActionCreators, store, cache }) => {
   const { createNode, createParentChildLink } = boundActionCreators
 
-  // We only care about parsed sites.yaml files
-  if (node.internal.type !== `SitesYaml`) {
+  // We only care about parsed sites.yaml files with a url field
+  if (node.internal.type !== `SitesYaml` || !node.url) {
     return
   }
 


### PR DESCRIPTION
Currently, if you create a `sites.yml` file that does not have a `url` for every item, an error will occur. This should prevent that.