### PR TITLE
createNode docs to show parent should be set to null instead of empty string

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -477,7 +477,7 @@ const typeOwners = {}
  * @param {string} node.id The node's ID. Must be globally unique.
  * @param {string} node.parent The ID of the parent's node. If the node is
  * derived from another node, set that node as the parent. Otherwise it can
- * just be an empty string.
+ * just be `null`.
  * @param {Array} node.children An array of children node IDs. If you're
  * creating the children nodes while creating the parent node, add the
  * children node IDs here directly. If you're adding a child node to a


### PR DESCRIPTION
Change per #4944 to show that parent attribute in createNode should be set to `null` when not used, not an empty string.

Signed-off-by: Grayson Hicks <graysonhicks@gmail.com>