### PR TITLE
Take siteUrl into consideration in browser

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,4 +1,7 @@
-exports.onRouteUpdate = ({ location }) => {
+exports.onRouteUpdate = ({ location }, pluginOptions) => {
   const domElem = document.querySelector(`link[rel='canonical']`)
-  domElem.setAttribute(`href`, `${window.location.origin}${location.pathname}`)
+  domElem.setAttribute(
+    `href`,
+    `${pluginOptions.siteUrl || window.location.origin}${location.pathname}`
+  )
 }


### PR DESCRIPTION
Currently the canonical url is changed to the current host once the page changes on the client side. That's not quite the idea of canonicals I think 😄

This PR takes the optional `siteUrl` into consideration and still falls back to `window.location.origin` if no siteUrl was specified.