### PR TITLE
Quick fix for www

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -5,7 +5,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "bluebird": "^3.5.1",
-    "email-validator": "^1.1.1",
+    "email-validator": "1.1.1",
     "gatsby": "^1.9.246",
     "gatsby-image": "^1.0.43",
     "gatsby-link": "^1.6.40",


### PR DESCRIPTION
Netlify builds are failing at the moment: https://app.netlify.com/sites/gatsbyjs/deploys

This will fix it for now.