### PR TITLE
[gatsby-source-filesystem] Add AllFiles to directory queries #3727

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -34,7 +34,7 @@
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
-    "prepare": "cross-env NODE_ENV=production npm run build",
+    "prepublish": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -7,21 +7,21 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.42",
-    "bluebird": "^3.5.0",
-    "chokidar": "^1.7.0",
+    "@babel/runtime": "latest",
+    "chokidar": "^2.0.3",
     "fs-extra": "^5.0.0",
-    "got": "^7.1.0",
-    "md5-file": "^3.1.1",
-    "mime": "^2.2.0",
+    "got": "^8.3.0",
+    "md5-file": "^4.0.0",
+    "mime": "^2.3.1",
     "pretty-bytes": "^4.0.2",
-    "slash": "^1.0.0",
+    "slash": "^2.0.0",
     "valid-url": "^1.0.9",
-    "xstate": "^3.1.0"
+    "xstate": "^3.1.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-beta.42",
-    "@babel/core": "^7.0.0-beta.42",
+    "@babel/cli": "latest",
+    "@babel/core": "latest",
+    "@babel/plugin-proposal-object-rest-spread": "latest",
     "cross-env": "^5.1.4"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#readme",
@@ -30,10 +30,11 @@
     "gatsby-plugin"
   ],
   "license": "MIT",
+  "main": "index.js",
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore __tests__"
   }
 }

--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -1,79 +1,74 @@
-const slash = require(`slash`)
-const path = require(`path`)
+const crypto = require(`crypto`)
 const fs = require(`fs-extra`)
 const mime = require(`mime`)
+const path = require(`path`)
+const md5File = require(`md5-file/promise`)
 const prettyBytes = require(`pretty-bytes`)
+const slash = require(`slash`)
 
-const md5File = require(`bluebird`).promisify(require(`md5-file`))
-const crypto = require(`crypto`)
-
-exports.createFileNode = async (
-  pathToFile,
-  createNodeId,
-  pluginOptions = {}
-) => {
-  const slashed = slash(pathToFile)
-  const parsedSlashed = path.parse(slashed)
-  const slashedFile = {
-    ...parsedSlashed,
-    absolutePath: slashed,
-    // Useful for limiting graphql query with certain parent directory
-    relativeDirectory: path.relative(
-      pluginOptions.path || process.cwd(),
-      parsedSlashed.dir
-    ),
+const createFileNode = async (src, createNodeId, opts = {}) => {
+  let node = {
+    absolutePath: slash(src),
+    children: [],
+    cwd: slash(opts.path || process.cwd()),
+    id: createNodeId(src),
+    parent: `___SOURCE___`,
+    sourceInstanceName: opts.name || `__PROGRAMATTIC__`,
   }
 
-  const stats = await fs.stat(slashedFile.absolutePath)
-  let internal
-  if (stats.isDirectory()) {
-    const contentDigest = crypto
-      .createHash(`md5`)
-      .update(
-        JSON.stringify({ stats: stats, absolutePath: slashedFile.absolutePath })
-      )
-      .digest(`hex`)
-    internal = {
-      contentDigest,
-      type: `Directory`,
-    }
-  } else {
-    const contentDigest = await md5File(slashedFile.absolutePath)
-    const mediaType = mime.getType(slashedFile.ext)
-    internal = {
-      contentDigest,
-      type: `File`,
-      mediaType: mediaType ? mediaType : `application/octet-stream`,
-    }
+  const stats = await fs.stat(node.absolutePath)
+
+  node = {
+    ...node,
+    ...path.parse(node.absolutePath),
+    ...stats,
+    absPath: slash(path.resolve(node.absolutePath)),
+    relativePath: slash(path.relative(node.cwd, node.absolutePath)),
   }
 
-  // Stringify date objects.
-  return JSON.parse(
-    JSON.stringify({
-      // Don't actually make the File id the absolute path as otherwise
-      // people will use the id for that and ids shouldn't be treated as
-      // useful information.
-      id: createNodeId(pathToFile),
-      children: [],
-      parent: `___SOURCE___`,
-      internal,
-      sourceInstanceName: pluginOptions.name || `__PROGRAMATTIC__`,
-      absolutePath: slashedFile.absolutePath,
-      relativePath: slash(
-        path.relative(
-          pluginOptions.path || process.cwd(),
-          slashedFile.absolutePath
-        )
-      ),
-      extension: slashedFile.ext.slice(1).toLowerCase(),
-      size: stats.size,
-      prettySize: prettyBytes(stats.size),
-      modifiedTime: stats.mtime,
-      accessTime: stats.atime,
-      changeTime: stats.ctime,
-      birthTime: stats.birthtime,
-      ...slashedFile,
-      ...stats,
-    })
-  )
+  node = {
+    ...node,
+    accessTime: node.atime,
+    birthTime: node.birthtime,
+    changeTime: node.ctime,
+    extension: node.ext.slice(1).toLowerCase(),
+    internal: stats.isDirectory()
+      ? {
+          contentDigest: crypto
+            .createHash(`md5`)
+            .update(
+              JSON.stringify({
+                absolutePath: node.absolutePath,
+                stats: stats,
+              })
+            )
+            .digest(`hex`),
+          type: `Directory`,
+        }
+      : {
+          contentDigest: await md5File(node.absolutePath),
+          mediaType: mime.getType(node.ext) || `application/octet-stream`,
+          type: `File`,
+        },
+    modifiedTime: node.mtime,
+    prettySize: prettyBytes(node.size),
+    relativeDirectory: path.relative(node.cwd, node.dir),
+  }
+
+  node = {
+    ...node,
+    allFile: {
+      edges: stats.isDirectory()
+        ? await fs
+            .readdir(node.absolutePath)
+            .map(file => path.join(node.absolutePath, file))
+            .filter(file => fs.statSync(file).isFile())
+            .map(file => {return { node___NODE: createNodeId(file) }})
+        : [],
+    },
+  }
+
+  return JSON.parse(JSON.stringify(node))
 }
+
+module.exports = createFileNode

--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -12,8 +12,8 @@ const createFileNode = async (src, createNodeId, opts = {}) => {
     children: [],
     cwd: slash(opts.path || process.cwd()),
     id: createNodeId(src),
-    parent: `___SOURCE___`,
-    sourceInstanceName: opts.name || `__PROGRAMATTIC__`,
+    parent: null,
+    sourceInstanceName: opts.name,
   }
 
   const stats = await fs.stat(node.absolutePath)

--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -55,17 +55,15 @@ const createFileNode = async (src, createNodeId, opts = {}) => {
     relativeDirectory: path.relative(node.cwd, node.dir),
   }
 
-  node = {
-    ...node,
-    allFile: {
-      edges: stats.isDirectory()
-        ? await fs
-            .readdir(node.absolutePath)
-            .map(file => path.join(node.absolutePath, file))
-            .filter(file => fs.statSync(file).isFile())
-            .map(file => {return { node___NODE: createNodeId(file) }})
-        : [],
-    },
+  if (stats.isDirectory()) {
+    node = {
+      ...node,
+      files___NODE: await fs
+        .readdir(node.absolutePath)
+        .map(file => path.join(node.absolutePath, file))
+        .filter(file => fs.statSync(file).isFile())
+        .map(file => createNodeId(file)),
+    }
   }
 
   return JSON.parse(JSON.stringify(node))

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -1,8 +1,8 @@
 const chokidar = require(`chokidar`)
+const createFileNode = require(`./create-file-node`)
 const fs = require(`fs`)
 const { Machine } = require(`xstate`)
-
-const { createId, createFileNode } = require(`./create-file-node`)
+const path = require(`path`)
 
 /**
  * Create a state machine to manage Chokidar's not-ready/ready states and for
@@ -11,218 +11,159 @@ const { createId, createFileNode } = require(`./create-file-node`)
  * On the latter, this solves the problem where if you call createNode for the
  * same File node in quick succession, this can leave Gatsby's internal state
  * in disarray causing queries to fail. The latter state machine tracks when
- * Gatsby is "processing" a node update or when it's "idle". If updates come in
+ * Gatsby is "busy" with a node update or when it's "idle". If updates come in
  * while Gatsby is processing, we queue them until the system returns to an
  * "idle" state.
  */
+
 const fsMachine = Machine({
-  key: "emitFSEvents",
+  key: `emitFSEvents`,
   parallel: true,
-  strict: true,
   states: {
-    CHOKIDAR: {
-      initial: `CHOKIDAR_NOT_READY`,
+    SRC_FS: {
+      initial: `SRC_FS_INIT`,
       states: {
-        CHOKIDAR_NOT_READY: {
+        SRC_FS_BUSY: {
           on: {
-            CHOKIDAR_READY: "CHOKIDAR_WATCHING",
-            BOOTSTRAP_FINISHED: "CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED",
+            SRC_FS_IDLE: `SRC_FS_IDLE`,
           },
         },
-        CHOKIDAR_WATCHING: {
+        SRC_FS_IDLE: {
           on: {
-            BOOTSTRAP_FINISHED: "CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED",
-            CHOKIDAR_READY: "CHOKIDAR_WATCHING",
+            SRC_FS_BUSY: `SRC_FS_BUSY`,
           },
         },
-        CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED: {
+        SRC_FS_INIT: {
           on: {
-            CHOKIDAR_READY: "CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED",
+            SRC_FS_READY: `SRC_FS_READY`,
+            SRC_FS_SETUP: `SRC_FS_SETUP`,
           },
         },
-      },
-    },
-    PROCESSING: {
-      initial: `BOOTSTRAPPING`,
-      states: {
-        BOOTSTRAPPING: {
+        SRC_FS_READY: {
           on: {
-            BOOTSTRAP_FINISHED: "IDLE",
+            SRC_FS_SETUP: `SRC_FS_IDLE`,
           },
         },
-        IDLE: {
+        SRC_FS_SETUP: {
           on: {
-            EMIT_FS_EVENT: `PROCESSING`,
-          },
-        },
-        PROCESSING: {
-          on: {
-            QUERY_QUEUE_DRAINED: `IDLE`,
-            TOUCH_NODE: `IDLE`,
+            SRC_FS_READY: `SRC_FS_IDLE`,
           },
         },
       },
     },
   },
+  strict: true,
 })
 
-let currentState = fsMachine.initialState
-
-const fileQueue = new Map()
+let state = fsMachine.initialState
 
 exports.sourceNodes = (
-  { actions, getNode, createNodeId, hasNodeChanged, reporter, emitter },
-  pluginOptions
+  { actions, createNodeId, emitter, getNode, reporter },
+  opts = {}
 ) => {
   const { createNode, deleteNode } = actions
 
-  // Validate that the path exists.
-  if (!fs.existsSync(pluginOptions.path)) {
-    reporter.panic(`
-The path passed to gatsby-source-filesystem does not exist on your file system:
+  // Verify the path exists.
+  if (!fs.existsSync(opts.path)) {
+    reporter.panic(`gatsby-source-filesystem: "${opts.path}" does not exist.
+    Specify the path to an existing directory.
 
-${pluginOptions.path}
-
-Please pick a path to an existing directory.
-
-See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
-      `)
+    Visit https://www.gatsbyjs.org/packages/gatsby-source-filesystem/ for details.
+    `)
   }
-  let fileNodeQueue = new Map()
 
-  // Once bootstrap is finished, we only let one File node update go through
-  // the system at a time.
+  const queue = (() => {
+    let instance
+
+    const init = () => {
+      instance = instance || new Map()
+      return instance
+    }
+
+    const addNode = async (msg, src) => {
+      await createFileNode(src, createNodeId, opts)
+        .then(node => {
+          emitter.emit(`SRC_FS_BUSY`)
+          reporter.info(`${msg} at "${src}"`)
+          createNode(node)
+          emitter.emit(`SRC_FS_IDLE`)
+        })
+        .catch(reporter.error)
+    }
+
+    const delNode = (msg, src) => {
+      emitter.emit(`SRC_FS_BUSY`)
+      const node = getNode(createNodeId(src))
+
+      reporter.info(`${msg} at "${src}"`)
+      if (node) {
+        deleteNode(node.id, node)
+      }
+      emitter.emit(`SRC_FS_IDLE`)
+    }
+
+    const flush = () => {
+      const q = init()
+
+      q.forEach(({ evt, msg, src }, key) => {
+        if (/(IDLE|READY|SETUP)$/.test(state.value.SRC_FS)) {
+          evt === `add` ? addNode(msg, src) : delNode(msg, src)
+          q.delete(key)
+        }
+      })
+    }
+
+    return {
+      add: (evt, msg, src) => {
+        init().set(src, { evt, msg, src })
+        flush()
+      },
+      flush: flush,
+    }
+  })()
+
   emitter.on(`BOOTSTRAP_FINISHED`, () => {
-    currentState = fsMachine.transition(
-      currentState.value,
-      `BOOTSTRAP_FINISHED`
-    )
-  })
-  emitter.on(`TOUCH_NODE`, () => {
-    // If we create a node which is the same as the previous version, createNode
-    // returns TOUCH_NODE and then nothing else happens so we listen to that
-    // to return the state back to IDLE.
-    currentState = fsMachine.transition(currentState.value, `TOUCH_NODE`)
+    state = fsMachine.transition(state.value, `SRC_FS_SETUP`)
+    queue.flush()
   })
 
-  emitter.on(`QUERY_QUEUE_DRAINED`, () => {
-    currentState = fsMachine.transition(
-      currentState.value,
-      `QUERY_QUEUE_DRAINED`
-    )
-    // If we have any updates queued, run one of them now.
-    if (fileNodeQueue.size > 0) {
-      const toProcess = fileNodeQueue.get(Array.from(fileNodeQueue.keys())[0])
-      fileNodeQueue.delete(toProcess.id)
-      currentState = fsMachine.transition(currentState.value, `EMIT_FS_EVENT`)
-      createNode(toProcess)
-    }
+  emitter.on(`SRC_FS_READY`, () => {
+    state = fsMachine.transition(state.value, `SRC_FS_READY`)
+    queue.flush()
   })
 
-  const watcher = chokidar.watch(pluginOptions.path, {
-    ignored: [
-      `**/*.un~`,
-      `**/.gitignore`,
-      `**/.npmignore`,
-      `**/.babelrc`,
-      `**/yarn.lock`,
-      `**/node_modules`,
-      `../**/dist/**`,
-    ],
+  emitter.on(`SRC_FS_IDLE`, () => {
+    state = fsMachine.transition(state.value, `SRC_FS_IDLE`)
   })
 
-  const createAndProcessNode = path => {
-    const fileNodePromise = createFileNode(
-      path,
-      createNodeId,
-      pluginOptions
-    ).then(fileNode => {
-      if (currentState.value.PROCESSING === `PROCESSING`) {
-        fileNodeQueue.set(fileNode.id, fileNode)
-      } else {
-        currentState = fsMachine.transition(currentState.value, `EMIT_FS_EVENT`)
-        createNode(fileNode)
-      }
+  emitter.on(`SRC_FS_BUSY`, () => {
+    state = fsMachine.transition(state.value, `SRC_FS_BUSY`)
+  })
+
+  chokidar
+    .watch(opts.path, {
+      ignored: [
+        `../**/dist/**`,
+        `**/.babelrc`,
+        `**/.gitignore`,
+        `**/.npmignore`,
+        `**/*.un~`,
+        `**/node_modules`,
+        `**/yarn.lock`,
+      ],
     })
-    return fileNodePromise
-  }
-
-  // For every path that is reported before the 'ready' event, we throw them
-  // into a queue and then flush the queue when 'ready' event arrives.
-  // After 'ready', we handle the 'add' event without putting it into a queue.
-  let pathQueue = []
-  const flushPathQueue = () => {
-    let queue = pathQueue.slice()
-    pathQueue = []
-    return Promise.all(queue.map(createAndProcessNode))
-  }
-
-  watcher.on(`add`, path => {
-    if (currentState.value.CHOKIDAR !== `CHOKIDAR_NOT_READY`) {
-      if (
-        currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
-      ) {
-        reporter.info(`added file at ${path}`)
-      }
-      createAndProcessNode(path).catch(err => reporter.error(err))
-    } else {
-      pathQueue.push(path)
-    }
-  })
-
-  watcher.on(`change`, path => {
-    if (
-      currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
-    ) {
-      reporter.info(`changed file at ${path}`)
-    }
-    createAndProcessNode(path).catch(err => reporter.error(err))
-  })
-
-  watcher.on(`unlink`, path => {
-    if (
-      currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
-    ) {
-      reporter.info(`file deleted at ${path}`)
-    }
-    const node = getNode(createNodeId(path))
-    // It's possible the file node was never created as sometimes tools will
-    // write and then immediately delete temporary files to the file system.
-    if (node) {
-      currentState = fsMachine.transition(currentState.value, `EMIT_FS_EVENT`)
-      deleteNode(node.id, node)
-    }
-  })
-
-  watcher.on(`addDir`, path => {
-    if (currentState.value.CHOKIDAR !== `CHOKIDAR_NOT_READY`) {
-      if (
-        currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
-      ) {
-        reporter.info(`added directory at ${path}`)
-      }
-      createAndProcessNode(path).catch(err => reporter.error(err))
-    } else {
-      pathQueue.push(path)
-    }
-  })
-
-  watcher.on(`unlinkDir`, path => {
-    if (
-      currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
-    ) {
-      reporter.info(`directory deleted at ${path}`)
-    }
-    const node = getNode(createNodeId(path))
-    deleteNode(node.id, node)
-  })
-
-  return new Promise((resolve, reject) => {
-    watcher.on(`ready`, () => {
-      currentState = fsMachine.transition(currentState.value, `CHOKIDAR_READY`)
-      flushPathQueue().then(resolve, reject)
+    .on(`add`, src => {
+      queue.add(`add`, `added file`, src)
+      queue.add(`add`, `changed directory`, path.dirname(src))
     })
-  })
+    .on(`change`, src => queue.add(`add`, `changed file`, src))
+    .on(`unlink`, src => {
+      queue.add(`del`, `deleted file`, src)
+      queue.add(`add`, `changed directory`, path.dirname(src))
+    })
+    .on(`addDir`, src => queue.add(`add`, `added directory`, src))
+    .on(`unlinkDir`, src => queue.add(`del`, `deleted directory`, src))
+    .on(`ready`, () => emitter.emit(`SRC_FS_READY`))
 }
 
 exports.setFieldsOnGraphQLNodeType = require(`./extend-file-node`)

--- a/packages/gatsby-source-filesystem/src/index.js
+++ b/packages/gatsby-source-filesystem/src/index.js
@@ -1,10 +1,5 @@
 const fs = require(`fs-extra`)
 
-function loadNodeContent(fileNode) {
-  return fs.readFile(fileNode.absolutePath, `utf-8`)
-}
-
 exports.createFilePath = require(`./create-file-path`)
 exports.createRemoteFileNode = require(`./create-remote-file-node`)
-
-exports.loadNodeContent = loadNodeContent
+exports.loadNodeContent = file => fs.readFile(file.absolutePath, `utf-8`)


### PR DESCRIPTION
- Added AllFiles query to AllDirectory and directory GraphQL queries.
- Re-organized and simplified this plugin, removing duplicate reassignments and several temporary variables.
- Alphabetized object keys and required packages where possible.
- Updated dependencies.
- Simplified and streamlined file/directory changes queue.
- Simplified wording of reporter messages and comments (using Apple's style guide).

I hope this type of massive re-writing is welcome. This is my first foray into a source plugin and basically had to deconstruct the original to understand how it works. Also, I've never used async/await before, but I think I understand them now. Along the way, I noticed some ways of simplifying assignments as well as adding the functionality requested in issue #3727.