### PR TITLE
gatsby-plugin-netlify-cms: require Netlify CMS as a peer dependency

### DIFF
--- a/docs/docs/netlify-cms.md
+++ b/docs/docs/netlify-cms.md
@@ -37,7 +37,7 @@ gatsby new netlify-cms-tutorial https://github.com/gatsbyjs/gatsby-starter-hello
 Now move into the newly created directory and install the Gatsby plugin for Netlify CMS:
 
 ```shell
-cd netlify-cms-tutorial && npm install --save gatsby-plugin-netlify-cms
+cd netlify-cms-tutorial && npm install --save netlify-cms gatsby-plugin-netlify-cms
 ```
 
 Gatsby plugins are registered in a file called `gatsby-config.js` in the site root. Create that file

--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -9,7 +9,10 @@ site](https://netlifycms.org).
 
 ## Install
 
-`npm install --save gatsby-plugin-netlify-cms`
+```shell
+npm install --save netlify-cms
+npm install --save gatsby-plugin-netlify-cms
+```
 
 ## How to use
 

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-netlify-cms",
   "description": "A Gatsby plugin which generates the Netlify CMS single page app",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "author": "Shawn Erquhart <shawn@erquh.art>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
@@ -9,7 +9,6 @@
   "dependencies": {
     "html-webpack-include-assets-plugin": "^1.0.2",
     "html-webpack-plugin": "^2.30.1",
-    "netlify-cms": "^1.0.1",
     "netlify-identity-widget": "^1.4.11"
   },
   "devDependencies": {
@@ -21,12 +20,14 @@
     "gatsby",
     "gatsby-plugin",
     "netlify",
-    "netlify-cms"
+    "netlify-cms",
+    "cms"
   ],
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^1.0.0"
+    "gatsby": "^1.0.0",
+    "netlify-cms": "^1.0.0"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms",
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE

Allow/require users to get their own version of Netlify CMS.