### PR TITLE
[gatsby-source-filesystem] add gatsby as peer dependency and set it to current latest

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -28,6 +28,9 @@
     "gatsby-plugin"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "gatsby": "^1.9.250"
+  },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",


### PR DESCRIPTION
this will warn users that they need to update gatsby package after installing latest gatsby-source-filesystem