### PR TITLE
extracting example values - bail early if array contains unsupported type

### DIFF
--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -152,6 +152,16 @@ describe(`Gatsby data tree utils`, () => {
     ])
     expect(example.foo).toEqual([{ field: 1, bar: 1, baz: 1 }])
   })
+
+  it(`skips unsupported types`, () => {
+    // Skips functions
+    let example = getExampleValues([{ foo: () => {} }])
+    expect(example.foo).toEqual(null)
+
+    // Skips array of functions
+    example = getExampleValues([{ foo: [() => {}] }])
+    expect(example.foo).toEqual(null)
+  })
 })
 
 describe(`Type conflicts`, () => {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -129,7 +129,12 @@ const extractFromArrays = (values, entries, selector) => {
     )
   )
 
-  return [extractFromEntries(flattenEntries, `${selector}[]`)]
+  const arrayItemExample = extractFromEntries(flattenEntries, `${selector}[]`)
+  if (!isDefined(arrayItemExample) || arrayItemExample === INVALID_VALUE) {
+    return INVALID_VALUE
+  }
+
+  return [arrayItemExample]
 }
 
 /**


### PR DESCRIPTION
fixes #4996

I will add more tests to cover cases like this shortly