### PR TITLE
[gatsby-plugin-google-analytics] Extends OutboundLink onClick event instead of override it

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/index.js
+++ b/packages/gatsby-plugin-google-analytics/src/index.js
@@ -6,6 +6,9 @@ function OutboundLink(props) {
     <a
       {...props}
       onClick={e => {
+        if (typeof props.onClick === `function`) {
+          props.onClick()
+        }
         let redirect = true
         if (
           e.button !== 0 ||
@@ -47,6 +50,7 @@ function OutboundLink(props) {
 OutboundLink.propTypes = {
   href: PropTypes.string,
   target: PropTypes.string,
+  onClick: PropTypes.func,
 }
 
 export { OutboundLink }


### PR DESCRIPTION
As subject extends the onClick event defined in the OutboundLink component, for example for logging purpose.
```jsx
<OutboundLink
  href="https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/"
  onClick={this.log}
>
  Visit the Google Analytics plugin page!
</OutboundLink>
```