### PR TITLE
[gatsby-source-wordpress] Query endpoints with a sort order set

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -298,6 +298,8 @@ async function getPages(
         url: `${url}?${querystring.stringify({
           per_page: _perPage,
           page: page,
+          'filter[orderby]': `date`,
+          order: `asc`,
         })}`,
       }
       if (_hostingWPCOM) {


### PR DESCRIPTION
Query the endpoints using the same order each time, with the first post in the head of the response.