### PR TITLE
Add getRenderer method

### DIFF
--- a/examples/using-react-native-web/package.json
+++ b/examples/using-react-native-web/package.json
@@ -4,17 +4,17 @@
   "description": "Example usage of gatsby-plugin-react-native-web",
   "author": "Sebastien Lorber <lorber.sebastien@gmail.com>",
   "dependencies": {
-    "gatsby": "^1.9.221",
+    "gatsby": "^1.9.251",
     "gatsby-link": "^1.6.37",
     "gatsby-plugin-google-analytics": "latest",
-    "gatsby-plugin-react-native-web": "^0.1.2",
+    "gatsby-plugin-react-native-web": "^0.2.0",
     "gatsby-plugin-react-next": "^1.0.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-native-web": "^0.5.1"
+    "react-native-web": "^0.6.0"
   },
   "devDependencies": {
-    "babel-plugin-react-native-web": "^0.5.1"
+    "babel-plugin-react-native-web": "^0.6.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -39,8 +39,10 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     Root = Root.default
   }
 
+  const renderer = apiRunner(`getRenderer`, undefined, ReactDOM.render)[0]
+
   domReady(() =>
-    ReactDOM.render(
+    renderer(
       <HotContainer>
         <Root />
       </HotContainer>,

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -39,7 +39,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     Root = Root.default
   }
 
-  const renderer = apiRunner(`getRenderer`, undefined, ReactDOM.render)[0]
+  const renderer = apiRunner(`replaceHydrateFunction`, undefined, ReactDOM.render)[0]
 
   domReady(() =>
     renderer(
@@ -59,7 +59,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       if (NextRoot.default) {
         NextRoot = NextRoot.default
       }
-      ReactDOM.render(
+      renderer(
         <HotContainer>
           <NextRoot />
         </HotContainer>,

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -186,8 +186,11 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       )
 
     const NewRoot = apiRunner(`wrapRootComponent`, { Root }, Root)[0]
+
+    const renderer = apiRunner(`getRenderer`, undefined, ReactDOM.render)[0]
+
     domReady(() =>
-      ReactDOM.render(
+      renderer(
         <NewRoot />,
         typeof window !== `undefined`
           ? document.getElementById(`___gatsby`)

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -187,7 +187,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
 
     const NewRoot = apiRunner(`wrapRootComponent`, { Root }, Root)[0]
 
-    const renderer = apiRunner(`getRenderer`, undefined, ReactDOM.render)[0]
+    const renderer = apiRunner(`replaceHydrateFunction`, undefined, ReactDOM.render)[0]
 
     domReady(() =>
       renderer(

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -72,3 +72,13 @@ exports.replaceHistory = true
  * @param {object} $0.Root The "Root" component built by Gatsby.
  */
 exports.wrapRootComponent = true
+
+/**
+ * Allow a plugin to replace the ReactDOM.render function call by a custom renderer.
+ * This method receives the same parameters as ReactDOM.render takes.
+ * Note it's very important to call the provided callback after rendering, otherwise Gatsby will not be able to call `onInitialClientRender`
+ * @param {object} $0 element
+ * @param {object} $1 container
+ * @param {object} $2 callback
+ */
+exports.replaceHydrateFunction = true


### PR DESCRIPTION
Signed-off-by: slorber <lorber.sebastien@gmail.com>

Add getRenderer method to browser API, so that we can use something else than ReactDOM.render, which is required for proper React-native-web integration