### PR TITLE
Wait for images to load before screenshotting

### DIFF
--- a/packages/gatsby-transformer-screenshot/lambda/index.js
+++ b/packages/gatsby-transformer-screenshot/lambda/index.js
@@ -85,6 +85,8 @@ exports.run = async (browser, url, width, height) => {
 
   await page.setViewport({ width, height })
   await page.goto(url, { waitUntil: [`load`, `networkidle0`] })
+  // wait for full-size images to fade in
+  await page.waitFor(1000);
 
   const screenshot = await page.screenshot()
   const up = await s3PutObject(key, screenshot)


### PR DESCRIPTION
It looks like all images are loaded before the screenshot is taken, but there's a 0.5s transition fading from the low-res image to the high-res image. This PR makes the lambda wait until that fade has happened before taking a screenshot.

Signed-off-by: David Beckley <beckl.ds@gmail.com>