### PR TITLE
[gatsby-source-wordpress] Improves README, “permalinks should not be set to Plain”

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -138,8 +138,8 @@ plugins.
 
 Set `hostingWPCOM: true`.
 
-You will need to provide an (API
-Key)[https://en.support.wordpress.com/api-keys/].
+You will need to provide an [API
+Key](https://en.support.wordpress.com/api-keys/).
 
 Note : you don't need this for Wordpress.org hosting in which your WordPress
 will behave like a self-hosted instance.

--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -144,6 +144,12 @@ Key](https://en.support.wordpress.com/api-keys/).
 Note : you don't need this for Wordpress.org hosting in which your WordPress
 will behave like a self-hosted instance.
 
+## Test your WordPress API
+
+Before you run your first query, ensure the WordPress JSON API is working correctly by visiting /wp-json at your WordPress install. The result should be similar to the [WordPress demo API](https://demo.wp-api.org/wp-json/).
+
+If you see a page on your site, rather than the JSON output, check if your permalink settings are set to “Plain”. After changing this to any of the other settings, the JSON API should be accessible.
+
 ## How to query
 
 You can query nodes created from Wordpress using GraphQL like the following:


### PR DESCRIPTION
Updates the documentation to explain the WordPress “Plain” permalinks issue in #1871, which I also encountered. It’s fixed by switching the permalink setting, as described https://github.com/gatsbyjs/gatsby/issues/1871#issuecomment-329985382 here, and now in the docs.

A more comprehensive fix might be to support the query parameter URL style in the plugin too, like http://demo.wp-api.org/?rest_route=/ (found here https://github.com/WP-API/WP-API/issues/1489#issuecomment-133421748).

I think it’s worth supporting this in the plugin itself, because WordPress default seems to be Plain permalinks, so the WP JSON API is off if you are starting from a fresh install. Should the Plain url be a config option that is off by default?

Thanks for the ongoing hard work on Gatsby :)