### PR TITLE
[v2] use MiniCssExtractPlugin only on production builds

### DIFF
--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.42",
-    "mini-css-extract-plugin": "^0.2.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1"
   },

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require(`mini-css-extract-plugin`)
 /**
  * Usage:
  *
@@ -39,7 +38,7 @@ exports.onCreateWebpackConfig = (
     test: /\.styl$/,
     exclude: /\.module\.styl$/,
     use: [
-      MiniCssExtractPlugin.loader,
+      loaders.miniCssExtract(),
       loaders.css({ importLoaders: 1 }),
       loaders.postcss({ plugins: postCssPlugins }),
       stylusLoader,
@@ -49,7 +48,7 @@ exports.onCreateWebpackConfig = (
   const stylusRuleModules = {
     test: /\.module\.styl$/,
     use: [
-      MiniCssExtractPlugin.loader,
+      loaders.miniCssExtract(),
       loaders.css({ modules: true, importLoaders: 1 }),
       loaders.postcss({ plugins: postCssPlugins }),
       stylusLoader,

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -176,10 +176,13 @@ module.exports = async ({
       }
     },
 
-    miniCssExtract: ({ disable = !PRODUCTION, fallback, ...options }) => {
+    miniCssExtract: (options = {}) => {
       return {
         options,
-        loader: MiniCssExtractPlugin.loader,
+        // use MiniCssExtractPlugin only on production builds
+        loader: PRODUCTION
+          ? MiniCssExtractPlugin.loader
+          : require.resolve(`style-loader`),
       }
     },
 
@@ -351,7 +354,7 @@ module.exports = async ({
       return {
         test: /\.css$/,
         use: [
-          MiniCssExtractPlugin.loader,
+          loaders.miniCssExtract(),
           loaders.css({ ...options, importLoaders: 1 }),
           loaders.postcss({ browsers }),
         ],


### PR DESCRIPTION
`MiniCssExtractPlugin` should be used on production builds only as it doesn't support HMR right now, we can remove the fallback to style-loader when it supports HMR

https://github.com/webpack-contrib/mini-css-extract-plugin#advanced-configuration-example
https://github.com/webpack-contrib/mini-css-extract-plugin/pull/100