### PR TITLE
[gatsby website] Fix distance between masthead and the icon

### DIFF
--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -14,7 +14,7 @@ const MastheadContent = () => (
     css={{
       display: `flex`,
       padding: vP,
-      paddingTop: rhythm(4),
+      paddingTop: rhythm(5),
       paddingBottom: rhythm(1),
       paddingBottom: rhythm(1),
       flexGrow: `0`,


### PR DESCRIPTION
On mobile, the masthead is overlapping with the Gatsby icon.

**Before:**
<img width="374" alt="screen shot 2018-04-20 at 11 26 20 pm" src="https://user-images.githubusercontent.com/11723413/39080029-7dd684cc-44f4-11e8-96e4-affc5f8d66ff.png">

**After:**
<img width="378" alt="screen shot 2018-04-20 at 11 37 23 pm" src="https://user-images.githubusercontent.com/11723413/39080030-8000c2c6-44f4-11e8-8152-29b09ec35c7e.png">
