### PR TITLE
update starter's link (`gatsby-advanced-blog`)

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -617,7 +617,7 @@ Community:
   * Disqus and Share Support
 
 * [gatsby-advanced-blog](https://github.com/wonism/gatsby-advanced-blog)
-  [(demo)](https://kind-cori-836fe1.netlify.com/)
+  [(demo)](https://wonism.github.io/)
 
   Features:
 


### PR DESCRIPTION
change link of `gatsby-advanced-blog`