### PR TITLE
Bump all packages to use babel 7

### DIFF
--- a/packages/gatsby-plugin-facebook-analytics/.babelrc
+++ b/packages/gatsby-plugin-facebook-analytics/.babelrc
@@ -1,6 +1,3 @@
 {
-  "presets": [
-    ["../../.babelrc.js", { "browser": true }]
-  ]
+  "presets": [["../../.babel-preset.js", { "browser": true }]]
 }
-

--- a/packages/gatsby-plugin-facebook-analytics/package.json
+++ b/packages/gatsby-plugin-facebook-analytics/package.json
@@ -7,19 +7,16 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "babel-runtime": "6.26.0"
+    "@babel/runtime": "^7.0.0-beta.42"
   },
   "devDependencies": {
-    "babel-cli": "6.26.0",
-    "cross-env": "5.1.3"
+    "@babel/cli": "^7.0.0-beta.42",
+    "@babel/core": "^7.0.0-beta.42",
+    "cross-env": "^5.1.4"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics#readme",
-  "keywords": [
-    "facebook analytics",
-    "facebook sdk",
-    "gatsby",
-    "gatsby-plugin"
-  ],
+  "homepage":
+    "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics#readme",
+  "keywords": ["facebook analytics", "facebook sdk", "gatsby", "gatsby-plugin"],
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {

--- a/packages/gatsby-plugin-fullstory/.babelrc
+++ b/packages/gatsby-plugin-fullstory/.babelrc
@@ -1,5 +1,3 @@
 {
-  "presets": [
-    ["../../.babelrc.js", { "browser": true }]
-  ]
+  "presets": [["../../.babel-preset.js", { "browser": true }]]
 }

--- a/packages/gatsby-plugin-fullstory/package.json
+++ b/packages/gatsby-plugin-fullstory/package.json
@@ -8,25 +8,24 @@
     "watch": "babel -w src --out-dir . --ignore __tests__",
     "prepublish": "cross-env NODE_ENV=production npm run build"
   },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin"
-  ],
+  "keywords": ["gatsby", "gatsby-plugin"],
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-fullstory#readme",
+  "homepage":
+    "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-fullstory#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git"
   },
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^6.26.0"
+    "@babel/runtime": "^7.0.0-beta.42"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
+    "@babel/cli": "^7.0.0-beta.42",
+    "@babel/core": "^7.0.0-beta.42",
+    "cross-env": "^5.1.4"
   }
 }

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.42",
-    "gatsby-remark-prismjs": "^2.0.1",
+    "gatsby-remark-prismjs": "^1.2.16-3",
     "normalize-path": "^2.1.1",
     "parse-numeric-range": "^0.0.2",
     "unist-util-map": "^1.0.3"

--- a/packages/gatsby-source-npm-package-search/package.json
+++ b/packages/gatsby-source-npm-package-search/package.json
@@ -1,20 +1,19 @@
 {
   "name": "gatsby-source-npm-package-search",
-  "description": "Search NPM packages and pull NPM & GitHub metadata from Algolia's NPM index",
+  "description":
+    "Search NPM packages and pull NPM & GitHub metadata from Algolia's NPM index",
   "version": "1.0.8",
   "author": "james.a.stack@gmail.com",
   "dependencies": {
     "algoliasearch": "^3.25.1",
-    "babel-runtime": "^6.26.0"
+    "@babel/runtime": "^7.0.0-beta.42"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "cross-env": "^5.0.5"
+    "@babel/cli": "^7.0.0-beta.42",
+    "@babel/core": "^7.0.0-beta.42",
+    "cross-env": "^5.1.4"
   },
-  "keywords": [
-    "gatsby",
-    "gatsby-plugin"
-  ],
+  "keywords": ["gatsby", "gatsby-plugin"],
   "license": "MIT",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This allows `yarn run bootstrap` to complete without errors for the v2 branch