### PR TITLE
[gatsby] Remove `.js` suffixes in require() to allow transpilation

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -72,10 +72,10 @@ module.exports = async (args: BootstrapArgs) => {
   activity.end()
 
   // Try opening the site's gatsby-config.js file.
-  activity = report.activityTimer(`open and validate gatsby-config.js`)
+  activity = report.activityTimer(`open and validate gatsby-config`)
   activity.start()
   const config = await preferDefault(
-    getConfigFile(program.directory, `gatsby-config.js`)
+    getConfigFile(program.directory, `gatsby-config`)
   )
 
   store.dispatch({
@@ -182,7 +182,7 @@ module.exports = async (args: BootstrapArgs) => {
 
     const envAPIs = plugin[`${env}APIs`]
     if (envAPIs && Array.isArray(envAPIs) && envAPIs.length > 0) {
-      return slash(path.join(plugin.resolve, `gatsby-${env}.js`))
+      return slash(path.join(plugin.resolve, `gatsby-${env}`))
     }
     return undefined
   }


### PR DESCRIPTION
In earlier v1, one could write files such as `gatsby-config` in typescript and use babel to transpile the file into js on the fly via `babel-node --presets @babel/preset-typescript --extensions '.ts' gatsby
develop`(see my [implementation](https://github.com/alvis/barebone-webapp) for example). However, it's no longer possible in recent releases.

The reason is that the current implementation put a `.js` suffix on each require(`gatsby-${env}.js`), which blocks `gatsby-{$env}` files being transpiled from other languages via babel. The PR addresses this problem by removing the unnecessary suffix and preserving the integrity.