### PR TITLE
[v2] slash paths before passing to chokidar

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -24,6 +24,7 @@ const address = require(`address`)
 const sourceNodes = require(`../utils/source-nodes`)
 const websocketManager = require(`../utils/websocket-manager`)
 const getSslCert = require(`../utils/get-ssl-cert`)
+const slash = require(`slash`)
 
 // const isInteractive = process.stdout.isTTY
 
@@ -231,7 +232,7 @@ async function startServer(program) {
 
   // Register watcher that rebuilds index.html every time html.js changes.
   const watchGlobs = [`src/html.js`, `plugins/**/gatsby-ssr.js`].map(path =>
-    directoryPath(path)
+    slash(directoryPath(path))
   )
 
   chokidar.watch(watchGlobs).on(`change`, async () => {


### PR DESCRIPTION
This is caused by this change in chokidar:
> Breaking: Upgrade globbing dependencies which require globs to be more strict and always use POSIX-style slashes because Windows-style slashes are used as escape sequences

(we were passing windows style slashes on windows). This fixes `gatsby develop` errors on windows