### PR TITLE
Resolve gatsby-source-filesystem dependency error

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -17,7 +17,8 @@
     "mime": "^1.3.6",
     "pretty-bytes": "^4.0.2",
     "slash": "^1.0.0",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "better-queue": "^3.8.7"
   },
   "devDependencies": {
     "cross-env": "^5.0.5"


### PR DESCRIPTION
Added package better-queue to gatsby-source-filesystem. Not sure this resolves all issues, but atleast fixes the error thrown.

Addresses #5078 