### PR TITLE
[gatsby-source-contentful] Fix prepareJSONNode for array normalization

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -342,7 +342,7 @@ exports.createContentTypeNodes = ({
           entryItemFields[`${entryItemFieldKey}___NODE`] = textNode.id
 
           delete entryItemFields[entryItemFieldKey]
-        } else if (fieldType === `Object`) {
+        } else if (fieldType === `Object` && _.isPlainObject(entryItemFields[entryItemFieldKey])) {
           const jsonNode = prepareJSONNode(
             entryNode,
             entryItemFieldKey,
@@ -351,6 +351,21 @@ exports.createContentTypeNodes = ({
 
           childrenNodes.push(jsonNode)
           entryItemFields[`${entryItemFieldKey}___NODE`] = jsonNode.id
+
+          delete entryItemFields[entryItemFieldKey]
+        } else if (fieldType === `Object` && _.isArray(entryItemFields[entryItemFieldKey])) {
+          entryItemFields[`${entryItemFieldKey}___NODE`] = []
+
+          entryItemFields[entryItemFieldKey].forEach((obj, i) => {
+            const jsonNode = prepareJSONNode(
+              entryNode,
+              entryItemFieldKey,
+              obj
+            )
+
+            childrenNodes.push(jsonNode)
+            entryItemFields[`${entryItemFieldKey}___NODE`].push(jsonNode.id)
+          })
 
           delete entryItemFields[entryItemFieldKey]
         }

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -169,11 +169,11 @@ function prepareTextNode(node, key, text) {
   return textNode
 }
 
-function prepareJSONNode(node, key, content) {
+function prepareJSONNode(node, key, content, i = ``) {
   const str = JSON.stringify(content)
   const JSONNode = {
     ...content,
-    id: `${node.id}${key}JSONNode`,
+    id: `${node.id}${key}${i}JSONNode`,
     parent: node.id,
     children: [],
     internal: {
@@ -360,7 +360,8 @@ exports.createContentTypeNodes = ({
             const jsonNode = prepareJSONNode(
               entryNode,
               entryItemFieldKey,
-              obj
+              obj,
+              i
             )
 
             childrenNodes.push(jsonNode)


### PR DESCRIPTION
In the process of building the schema, when the content of a JSON node is an array, a similar error is thrown:

```
Error: Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "0___image" does not.
```

This is caused by the spread operator transforming the index of the array to numbered keys of the object, resulting in an error because the name doesn't comply with the GraphQL naming rules.

In order not to break the compatibility I keep spreading the object if the content of the JSON is a plain object, but I nest it under `items` if it's an array. This could be changed and made more consistent in the next major update.

Tests are still to be updated, I will do it ASAP.