### PR TITLE
[v2] Make default browserslist more futureproof

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -39,7 +39,7 @@ to root of your site and modifying it per your needs.
         "sourceType": "unambiguous",
         "shippedProposals": true,
         "targets": {
-          "browsers": ["> 1%", "IE >= 9", "last 2 versions"]
+          "browsers": [ ">0.25%", "not ie 11", "not op_mini all"]
         }
       }
     ],

--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -39,7 +39,7 @@ to root of your site and modifying it per your needs.
         "sourceType": "unambiguous",
         "shippedProposals": true,
         "targets": {
-          "browsers": [ ">0.25%", "not ie 11", "not op_mini all"]
+          "browsers": [ ">0.25%", "not dead"]
         }
       }
     ],

--- a/docs/docs/browser-support.md
+++ b/docs/docs/browser-support.md
@@ -39,9 +39,9 @@ By default, Gatsby emulates the following config:
 // package.json
 {
  "browserslist": [
-   "> 1%",
-   "IE >= 9",
-   "last 2 versions"
+   ">0.25%",
+   "not ie 11",
+   "not op_mini all"
  ]
 }
 ```

--- a/docs/docs/browser-support.md
+++ b/docs/docs/browser-support.md
@@ -40,8 +40,7 @@ By default, Gatsby emulates the following config:
 {
  "browserslist": [
    ">0.25%",
-   "not ie 11",
-   "not op_mini all"
+   "not dead"
  ]
 }
 ```

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -4,7 +4,7 @@ const yargs = require(`yargs`)
 const report = require(`./reporter`)
 const fs = require(`fs`)
 
-const DEFAULT_BROWSERS = [`> 1%`, `last 2 versions`, `IE >= 9`]
+const DEFAULT_BROWSERS = [`>0.25%`, `not ie 11`, `not op_mini all`]
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -4,7 +4,7 @@ const yargs = require(`yargs`)
 const report = require(`./reporter`)
 const fs = require(`fs`)
 
-const DEFAULT_BROWSERS = [`>0.25%`, `not ie 11`, `not op_mini all`]
+const DEFAULT_BROWSERS = [`>0.25%`, `not dead`]
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(


### PR DESCRIPTION
This is inspired by Jamie Kyle's blog post/issue in babel yesterday
on the problems of using "last 2 versions" with @babel/preset-env which
includes browsers which aren't receiving updates anymore so "last 2
versions" will always be building for them.

To quote his post:

>Using market share percentages as your baseline is much better than some arbitrary number of previous versions. If a browser is used by 0 people, then market percentages will reflect that.

* https://jamie.build/last-2-versions
* https://github.com/babel/babel/issues/7789