### PR TITLE
Add space after empty src and alt attributes on noscript images

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -90,11 +90,11 @@ const isWebpSupported = () => {
 const noscriptImg = props => {
   // Check if prop exists before adding each attribute to the string output below to prevent
   // HTML validation issues caused by empty values like width="" and height=""
-  const src = props.src ? `src="${props.src}" ` : `src=""` // required attribute
+  const src = props.src ? `src="${props.src}" ` : `src="" ` // required attribute
   const srcSet = props.srcSet ? `srcset="${props.srcSet}" ` : ``
   const sizes = props.sizes ? `sizes="${props.sizes}" ` : ``
   const title = props.title ? `title="${props.title}" ` : ``
-  const alt = props.alt ? `alt="${props.alt}" ` : `alt=""` // required attribute
+  const alt = props.alt ? `alt="${props.alt}" ` : `alt="" ` // required attribute
   const width = props.width ? `width="${props.width}" ` : ``
   const height = props.height ? `height="${props.height}" ` : ``
   const opacity = props.opacity ? props.opacity : `1`


### PR DESCRIPTION
My previous commit missed adding a space after the backup empty `src=""` and `alt=""` attributes. This causes an HTML validation error in cases where no `alt` value is supplied.

This commit simply adds a space after each attribute (which clears the "no space between attributes" validation error).