### PR TITLE
[v2] schema: handle values of sanitized fieldnames

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -77,6 +77,9 @@ describe(`GraphQL type inferance`, () => {
           },
         },
       },
+      "with space": 1,
+      "with-hyphen": 2,
+      "with resolver": `1012-11-01`,
       aBoolean: true,
       externalUrl: `https://example.com/awesome.jpg`,
       domain: `pizza.com`,
@@ -95,6 +98,8 @@ describe(`GraphQL type inferance`, () => {
       anArray: [1, 2, 5, 4],
       aNestedArray: [[1, 2, 3, 4]],
       anObjectArray: [{ anotherObjectArray: [{ baz: `quz` }] }],
+      "with space": 3,
+      "with-hyphen": 4,
       frontmatter: {
         date: `1984-10-12`,
         title: `The world of slash and adventure`,
@@ -190,6 +195,25 @@ describe(`GraphQL type inferance`, () => {
 
     expect(Object.keys(fields)).toHaveLength(2)
     expect(Object.keys(fields.foo.type.getFields())).toHaveLength(4)
+  })
+
+  it(`Handle invalid graphql field names`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        with_space
+        with_hyphen
+        with_resolver(formatString:"DD.MM.YYYY")
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.listNode.length).toEqual(2)
+    expect(result.data.listNode[0].with_space).toEqual(1)
+    expect(result.data.listNode[0].with_hyphen).toEqual(2)
+    expect(result.data.listNode[1].with_space).toEqual(3)
+    expect(result.data.listNode[1].with_hyphen).toEqual(4)
+    expect(result.data.listNode[0].with_resolver).toEqual(`01.11.1012`)
   })
 
   describe(`Handles dates`, () => {

--- a/packages/gatsby/src/schema/types/type-file.js
+++ b/packages/gatsby/src/schema/types/type-file.js
@@ -130,7 +130,7 @@ export function shouldInfer(nodes, selector, value) {
 function createType(fileNodeRootType, isArray) {
   if (!fileNodeRootType) return null
 
-  return {
+  return Object.freeze({
     type: isArray ? new GraphQLList(fileNodeRootType) : fileNodeRootType,
     resolve: (node, args, { path }, { fieldName }) => {
       let fieldValue = node[fieldName]
@@ -173,7 +173,7 @@ function createType(fileNodeRootType, isArray) {
         return findLinkedFileNode(fieldValue)
       }
     },
-  }
+  })
 }
 
 export function getType() {


### PR DESCRIPTION
this will check if sanitized fieldname is different from original fieldname and will wrap/add resolver that will point to original fieldname

this implements point 2. from https://github.com/gatsbyjs/gatsby/issues/5124#issuecomment-384378148