### PR TITLE
[v2] drupal test fix + drupal/wordpress dependency change

### DIFF
--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0-beta.42",
     "axios": "^0.18.0",
     "bluebird": "^3.5.0",
-    "gatsby-source-filesystem": "^2.0.0-alpha.8",
+    "gatsby-source-filesystem": "next",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -2,9 +2,8 @@ const { nodeFromData } = require(`../normalize`)
 const { idOverlayExample } = require(`./data.json`)
 
 describe(`node completion`, () => {
-  it(`should preserve the node ID from jsonapi`, () => {
-    const node = nodeFromData(idOverlayExample)
-    expect(node.id).toEqual(idOverlayExample.id)
+  it(`should correctly generate node from jsonapi`, () => {
+    const node = nodeFromData(idOverlayExample, id => id)
     expect(node.bundle).toEqual(idOverlayExample.attributes.bundle)
     expect(node._attributes_id).toEqual(idOverlayExample.attributes.id)
   })

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -14,7 +14,7 @@
     "bluebird": "^3.5.0",
     "deep-map": "^1.5.0",
     "deep-map-keys": "^1.2.0",
-    "gatsby-source-filesystem": "^2.0.0-alpha.8",
+    "gatsby-source-filesystem": "next",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
### drupal test change:

After change to use `createNodeId` in #5130 jsonapi id is no longer used as node id (it was moved to `drupal_id`), so I just removed that part of test and renamed the test

### package.json updates:

Both `gatsby-source-wordpress` and `gatsby-source-drupal` have dependency `gatsby-source-filesystem@^2.0.0-alpha.8` (which was published 1 day ago)
but yarn resolves that (I guess because of carret) to `2.0.0-alpha.f98688ee` (which was published 2 months ago). This change should hopefully point to latest alpha.