### PR TITLE
Update createRemoteFileNode documentation

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -176,4 +176,4 @@ exports.downloadMediaFiles = ({ nodes, store, cache, createNode, _auth }) => {
 };
 ```
 
-Your file node can then be queried using a transformer or source plugin as shown in this [use case](https://www.gatsbyjs.org/packages/gatsby-source-wordpress/?=wordpres#image-processing) in `gatsby-source-wordpress`. Here downloaded images are retrieved for use in required specifications using `gatsby-transformer-sharp`.
+The file node can then be queried using GraphQL. See an example of this in the [gatsby-source-wordpress README](/packages/gatsby-source-wordpress/#image-processing) where downloaded images are queried using [gatsby-transformer-sharp](/packages/gatsby-transformer-sharp/) to use in the component [gatsby-image](/packages/gatsby-image/).

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -175,3 +175,5 @@ exports.downloadMediaFiles = ({ nodes, store, cache, createNode, _auth }) => {
   });
 };
 ```
+
+Your file node can then be queried using a transformer or source plugin as shown in this [use case](https://www.gatsbyjs.org/packages/gatsby-source-wordpress/?=wordpres#image-processing) in `gatsby-source-wordpress`. Here downloaded images are retrieved for use in required specifications using `gatsby-transformer-sharp`.


### PR DESCRIPTION
Addresses #5147 
Adds link to usage example as in gatsby-source-wordpress