### PR TITLE
[WIP] add new algolia index & pull from it

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -11,7 +11,8 @@ module.exports = {
     {
       resolve: `gatsby-source-npm-package-search`,
       options: {
-        keywords: [`gatsby-plugin`, `gatsby-component`],
+        queryStrings: [`gatsby-source`, `gatsby-plugin`, `gatsby-transformer`],
+        keywords: [`gatsby-plugin`, `gatsby-component`, `gatsby-source`, `gatsby-transformer`],
       },
     },
     {

--- a/www/src/components/searchbar-body.js
+++ b/www/src/components/searchbar-body.js
@@ -416,9 +416,9 @@ class SearchBar extends Component {
     return (
       <div>
         <InstantSearch
-          apiKey="ae43b69014c017e05950a1cd4273f404"
-          appId="OFCNCOG2CU"
-          indexName="npm-search"
+          apiKey="31037ceaa94c61c19e42abcc67739b6c"
+          appId="CJN8T7ZVN1"
+          indexName="gatsby-custom-npm-search"
           searchState={this.state.searchState}
           onSearchStateChange={this.onSearchStateChange.bind(this)}
         >


### PR DESCRIPTION
Fixes #5092 

Adds more plugins that aren't being captured by the current search. Approach here is to create a new index from the existing npm-search index & populate it with only Gatsby data so that we can restrict results to only Gatsby plugins without needing these plugins to have specific keywords when published to npm (as often users forget to use them. 

Result is +30% in the number of plugins we capture.

Results:
* Right now the plugin search finds 269 plugins
* Adding a couple of extra keywords to filter for (`gatsby-source`, `gatsby-transformer`) bumped that up to 288
* Adding in results from search strings `gatsby-source`, `gatsby-plugin`, `gatsby-transformer`bumped that up too 355

See all of them here: https://www.algolia.com/realtime-search-demo/test-25976e6e-7f0c-4033-b57a-7e76c8c2a88d

Bugs / Todos:
(1) Exposes an admin Algolia key.
(2) Pushes data into algolia on site build -- local development shouldn't mutate remote APIs
(3) Data doesn't show up correctly right now -- possibly due to DNS propagation delays from Algolia? 
(4) Uses the a new Algolia account.
(5) Automatically truncate / filter large JSON blobs before sending them to Algolia (eg `gatsby-source-aem`)

Moving this over to our existing Algolia account, and running this on a Lambda crontab somewhere should fix (1) - (4).