### PR TITLE
Update Github Pages documentation (#243)

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -47,4 +47,4 @@ After running `npm run deploy` you should see your website at `http://username.g
 
 ## Custom domains
 
-If you use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add a `pathPrefix` as it will break navigation on your site. Path prefixing is only necessary when the site is _not_ at the root of the domain like with repository sites.
+If you use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add a `pathPrefix` as it will break navigation on your site. Path prefixing is only necessary when the site is _not_ at the root of the domain like with repository sites. Also don't forget to add your [CNAME](https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors) file to the `static` directory.


### PR DESCRIPTION
Adds a note about CNAME file in `static` to avoid confusion for newcomers.