### PR TITLE
[v2] check-versions.js: add ability to accept "next" as valid version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "npm-run-all -s check-versions lerna-prepublish",
-    "check-versions": "babel-node scripts/check-versions.js",
+    "check-versions": "babel-node scripts/check-versions.js --allow-next",
     "format":
       "npm-run-all -p format-packages format-cache-dir format-www format-examples format-scripts format-markdown",
     "format-cache-dir":

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -6,12 +6,24 @@ const PackageUtilities = require(`lerna/lib/PackageUtilities`)
 const packages = PackageUtilities.getPackages(new Repository())
 
 let warned = false
-let argv = yargs.option(`fix`).argv
+let argv = yargs
+  .option(`fix`, {
+    default: false,
+    describe: `Fixes outdated dependencies`,
+  })
+  .option(`allow-next`, {
+    default: false,
+    describe: `Allow using "next" versions. Use this only for alpha/beta releases`,
+  }).argv
 
 packages.forEach(pkg => {
-  const outdated = packages
+  let outdated = packages
     .filter(p => !!pkg.allDependencies[p.name] && p.name !== pkg.name)
     .filter(p => !pkg.hasMatchingDependency(p))
+
+  if (argv[`allow-next`]) {
+    outdated = outdated.filter(p => pkg.allDependencies[p.name] !== `next`)
+  }
 
   if (!outdated.length) return
 


### PR DESCRIPTION
This should fix this error:
```
$ babel-node scripts/check-versions.js
gatsby-source-drupal: 
  Depends on "gatsby-source-filesystem@next" 
  instead of "gatsby-source-filesystem@2.0.0-alpha.8". 
gatsby-source-wordpress: 
  Depends on "gatsby-source-filesystem@next" 
  instead of "gatsby-source-filesystem@2.0.0-alpha.8". 
```
Alternatively we could just disable running this script for v2 alpha/beta, but I think approach in this PR is somewhat safer?