### PR TITLE
Add context to query-runner error log

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -40,6 +40,8 @@ module.exports = async (pageOrLayout, component) => {
           ${result.errors || []}
         URL path:
           ${pageOrLayout.path}
+        Context:
+          ${JSON.stringify(pageOrLayout.context, null, 4)}
         Plugin:
           ${pageOrLayout.pluginCreatorId || `none`}
         Query:


### PR DESCRIPTION
Having context in debug log can make debugging more easy