### PR TITLE
Bumps `gatsby-plugin-mailchimp` to 2.2.2 b/c we updated its API

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -175,7 +175,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mailchimp`,
       options: {
-          endpoint: `https://gatsbyjs.us17.list-manage.com/subscribe/post-json?u=1dc33f19eb115f7ebe4afe5ee&amp;id=f366064ba7`,
+          endpoint: `https://gatsbyjs.us17.list-manage.com/subscribe/post?u=1dc33f19eb115f7ebe4afe5ee&amp;id=f366064ba7`,
       },
     },
   ],

--- a/www/package.json
+++ b/www/package.json
@@ -14,7 +14,7 @@
     "gatsby-plugin-glamor": "^1.6.13",
     "gatsby-plugin-google-analytics": "^1.0.28",
     "gatsby-plugin-lodash": "^1.0.11",
-    "gatsby-plugin-mailchimp": "^1.1.1",
+    "gatsby-plugin-mailchimp": "^2.2.2",
     "gatsby-plugin-manifest": "^1.0.19",
     "gatsby-plugin-netlify": "^1.0.19",
     "gatsby-plugin-nprogress": "^1.0.14",


### PR DESCRIPTION
_"don't make me think"_. ... I updated the API to be more inline with the README/docs and now allow the user to simply copy/paste their full MC endpoint into their gatsby-config.

Thanks!
