### PR TITLE
[v2] deleteNode signature

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -68,8 +68,8 @@ exports.sourceNodes = async (
   // Remove deleted entries & assets.
   // TODO figure out if entries referencing now deleted entries/assets
   // are "updated" so will get the now deleted reference removed.
-  currentSyncData.deletedEntries.forEach(e => deleteNode(e.sys))
-  currentSyncData.deletedAssets.forEach(e => deleteNode(e.sys))
+  currentSyncData.deletedEntries.forEach(e => deleteNode({ node: e.sys }))
+  currentSyncData.deletedAssets.forEach(e => deleteNode({ node: e.sys }))
 
   const existingNodes = getNodes().filter(
     n => n.internal.owner === `gatsby-source-contentful`

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -68,8 +68,8 @@ exports.sourceNodes = async (
   // Remove deleted entries & assets.
   // TODO figure out if entries referencing now deleted entries/assets
   // are "updated" so will get the now deleted reference removed.
-  currentSyncData.deletedEntries.forEach(e => deleteNode(e.sys.id, e.sys))
-  currentSyncData.deletedAssets.forEach(e => deleteNode(e.sys.id, e.sys))
+  currentSyncData.deletedEntries.forEach(e => deleteNode(e.sys))
+  currentSyncData.deletedAssets.forEach(e => deleteNode(e.sys))
 
   const existingNodes = getNodes().filter(
     n => n.internal.owner === `gatsby-source-contentful`

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -74,7 +74,7 @@ exports.sourceNodes = async (
   const existingNodes = getNodes().filter(
     n => n.internal.owner === `gatsby-source-contentful`
   )
-  existingNodes.forEach(n => touchNode(n.id))
+  existingNodes.forEach(n => touchNode({ nodeId: n.id }))
 
   const assets = currentSyncData.assets
 

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -24,7 +24,7 @@ exports.sourceNodes = async (
   // Touch existing Drupal nodes so Gatsby doesn't garbage collect them.
   // _.values(store.getState().nodes)
   // .filter(n => n.internal.type.slice(0, 8) === `drupal__`)
-  // .forEach(n => touchNode(n.id))
+  // .forEach(n => touchNode({ nodeId: n.id }))
 
   // Fetch articles.
   // console.time(`fetch Drupal data`)

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -188,7 +188,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
     // write and then immediately delete temporary files to the file system.
     if (node) {
       currentState = fsMachine.transition(currentState.value, `EMIT_FS_EVENT`)
-      deleteNode(node)
+      deleteNode({ node })
     }
   })
 
@@ -212,7 +212,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
       reporter.info(`directory deleted at ${path}`)
     }
     const node = getNode(createNodeId(path))
-    deleteNode(node)
+    deleteNode({ node })
   })
 
   return new Promise((resolve, reject) => {

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -188,7 +188,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
     // write and then immediately delete temporary files to the file system.
     if (node) {
       currentState = fsMachine.transition(currentState.value, `EMIT_FS_EVENT`)
-      deleteNode(node.id, node)
+      deleteNode(node)
     }
   })
 
@@ -212,7 +212,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
       reporter.info(`directory deleted at ${path}`)
     }
     const node = getNode(createNodeId(path))
-    deleteNode(node.id, node)
+    deleteNode(node)
   })
 
   return new Promise((resolve, reject) => {

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -408,7 +408,7 @@ exports.downloadMediaFiles = async ({
         // previously created file node to not try to redownload
         if (cacheMediaData && e.modified === cacheMediaData.modified) {
           fileNodeID = cacheMediaData.fileNodeID
-          touchNode(cacheMediaData.fileNodeID)
+          touchNode({ nodeId: cacheMediaData.fileNodeID })
         }
 
         // If we don't have cached data, download the file

--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -35,7 +35,7 @@ exports.onPreBootstrap = (
         } else {
           // Screenshot hasn't yet expired, touch the image node
           // to prevent garbage collection
-          touchNode(n.screenshotFile___NODE)
+          touchNode({ nodeId: n.screenshotFile___NODE })
         }
       })
   )

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -174,8 +174,8 @@ const queue = {
   },
 
   addPagesArray: newPages => {
-    if (__PREFIX_PATHS__) {
-      pathPrefix = `${__PATH_PREFIX__}/`
+    if (typeof __PREFIX_PATHS__ !== `undefined`) {
+      pathPrefix = typeof __PATH_PREFIX__ !== `undefined` ? `${__PATH_PREFIX__}/` : `/`
     }
     findPage = pageFinderFactory(newPages, pathPrefix.slice(0, -1))
   },

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -168,5 +168,5 @@ exports.onCreatePage = ({ page, actions }) => {
 emitter.on(`DELETE_PAGE`, action => {
   const nodeId = createPageId(action.payload.path)
   const node = getNode(nodeId)
-  boundActionCreators.deleteNode(node)
+  boundActionCreators.deleteNode({ node })
 })

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -168,5 +168,5 @@ exports.onCreatePage = ({ page, actions }) => {
 emitter.on(`DELETE_PAGE`, action => {
   const nodeId = createPageId(action.payload.path)
   const node = getNode(nodeId)
-  boundActionCreators.deleteNode(nodeId, node)
+  boundActionCreators.deleteNode(node)
 })

--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -44,7 +44,7 @@ emitter.on(`CREATE_NODE`, action => {
 })
 
 emitter.on(`DELETE_NODE`, action => {
-  queuedDirtyActions.push({ payload: action.node })
+  queuedDirtyActions.push({ payload: action.payload })
 })
 
 const runQueuedActions = async () => {

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/nodes.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/nodes.js.snap
@@ -127,3 +127,16 @@ exports[`Create and update nodes throws error if a node sets a value on "fields"
     \\"name\\": \\"pluginA\\"
 }"
 `;
+
+exports[`Create and update nodes warns when using old deleteNode signature  1`] = `
+Object {
+  "children": Array [],
+  "id": "hi",
+  "internal": Object {
+    "contentDigest": "hasdfljds",
+    "owner": "tests",
+    "type": "Test",
+  },
+  "parent": "test",
+}
+`;

--- a/packages/gatsby/src/redux/__tests__/nodes.js
+++ b/packages/gatsby/src/redux/__tests__/nodes.js
@@ -227,7 +227,8 @@ describe(`Create and update nodes`, () => {
         { name: `tests` }
       )
     )
-    store.dispatch(actions.deleteNode(`hi`, getNode(`hi`), { name: `tests` }))
+
+    store.dispatch(actions.deleteNode(getNode(`hi`), { name: `tests` }))
     expect(Object.keys(store.getState().nodes).length).toEqual(1)
   })
 
@@ -315,8 +316,7 @@ describe(`Create and update nodes`, () => {
       },
       { name: `tests` }
     )
-    actions.deleteNode(`hi`, getNode(`hi`))
-
+    actions.deleteNode(getNode(`hi`))
     expect(getNode(`hi`)).toBeUndefined()
   })
 
@@ -463,7 +463,7 @@ describe(`Create and update nodes`, () => {
   })
 
   it(`does not crash when delete node is called on undefined`, () => {
-    actions.deleteNode(undefined, undefined, { name: `tests` })
+    actions.deleteNode(undefined, { name: `tests` })
     expect(Object.keys(store.getState().nodes).length).toEqual(0)
   })
 })

--- a/packages/gatsby/src/redux/__tests__/nodes.js
+++ b/packages/gatsby/src/redux/__tests__/nodes.js
@@ -1,63 +1,73 @@
-const { actions } = require(`../actions`)
-const { store, getNode } = require(`../index`)
+const {
+  actions,
+} = require(`../actions`)
+const {
+  store,
+  getNode,
+} = require(`../index`)
 const nodeReducer = require(`../reducers/nodes`)
 const nodeTouchedReducer = require(`../reducers/nodes-touched`)
 
 describe(`Create and update nodes`, () => {
+  beforeEach(() => {
+    store.dispatch({
+      type: `DELETE_CACHE`,
+    })
+  })
+
   it(`allows creating nodes`, () => {
-    const action = actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
-        },
-        pickle: true,
+    const action = actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
       },
-      { name: `tests` }
-    )
+      pickle: true,
+    }, {
+      name: `tests`,
+    })
     expect(action).toMatchSnapshot()
     expect(nodeReducer(undefined, action)).toMatchSnapshot()
   })
 
   it(`allows updating nodes`, () => {
-    const action = actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
-        },
-        pickle: true,
-        deep: {
-          array: [0, 1, { boom: true }],
-        },
+    const action = actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
       },
-      { name: `tests` }
-    )
-    const updateAction = actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
-        },
-        pickle: false,
-        deep: {
-          array: [1, 2],
-        },
-        deep2: {
-          boom: `foo`,
-        },
+      pickle: true,
+      deep: {
+        array: [0, 1, {
+          boom: true,
+        }],
       },
-      { name: `tests` }
-    )
+    }, {
+      name: `tests`,
+    })
+    const updateAction = actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
+      },
+      pickle: false,
+      deep: {
+        array: [1, 2],
+      },
+      deep2: {
+        boom: `foo`,
+      },
+    }, {
+      name: `tests`,
+    })
     let state = nodeReducer(undefined, action)
     state = nodeReducer(state, updateAction)
     expect(state[`hi`].pickle).toEqual(false)
@@ -66,349 +76,367 @@ describe(`Create and update nodes`, () => {
   })
 
   it(`deletes previously transformed children nodes when the parent node is updated`, () => {
-    store.dispatch({ type: `DELETE_CACHE` })
-
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi`,
-          children: [],
-          parent: null,
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `Test`,
-          },
+      actions.createNode({
+        id: `hi`,
+        children: [],
+        parent: null,
+        internal: {
+          contentDigest: `hasdfljds`,
+          type: `Test`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
 
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi-1`,
-          children: [],
-          parent: `hi`,
-          internal: {
-            contentDigest: `hasdfljds-1`,
-            type: `Test-1`,
-          },
+      actions.createNode({
+        id: `hi-1`,
+        children: [],
+        parent: `hi`,
+        internal: {
+          contentDigest: `hasdfljds-1`,
+          type: `Test-1`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
 
     store.dispatch(
-      actions.createParentChildLink(
-        {
-          parent: store.getState().nodes[`hi`],
-          child: store.getState().nodes[`hi-1`],
-        },
-        { name: `tests` }
-      )
+      actions.createParentChildLink({
+        parent: store.getState().nodes[`hi`],
+        child: store.getState().nodes[`hi-1`],
+      }, {
+        name: `tests`,
+      })
     )
 
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi-1-1`,
-          children: [],
-          parent: `hi-1`,
-          internal: {
-            contentDigest: `hasdfljds-1-1`,
-            type: `Test-1-1`,
-          },
+      actions.createNode({
+        id: `hi-1-1`,
+        children: [],
+        parent: `hi-1`,
+        internal: {
+          contentDigest: `hasdfljds-1-1`,
+          type: `Test-1-1`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
 
     store.dispatch(
-      actions.createParentChildLink(
-        {
-          parent: store.getState().nodes[`hi-1`],
-          child: store.getState().nodes[`hi-1-1`],
-        },
-        { name: `tests` }
-      )
+      actions.createParentChildLink({
+        parent: store.getState().nodes[`hi-1`],
+        child: store.getState().nodes[`hi-1-1`],
+      }, {
+        name: `tests`,
+      })
     )
 
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi`,
-          children: [],
-          parent: `test`,
-          internal: {
-            contentDigest: `hasdfljds2`,
-            type: `Test`,
-          },
+      actions.createNode({
+        id: `hi`,
+        children: [],
+        parent: `test`,
+        internal: {
+          contentDigest: `hasdfljds2`,
+          type: `Test`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
     expect(Object.keys(store.getState().nodes).length).toEqual(1)
   })
 
   it(`deletes previously transformed children nodes when the parent node is deleted`, () => {
-    store.dispatch({ type: `DELETE_CACHE` })
-
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi`,
-          children: [],
-          parent: `test`,
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `Test`,
-          },
+      actions.createNode({
+        id: `hi`,
+        children: [],
+        parent: `test`,
+        internal: {
+          contentDigest: `hasdfljds`,
+          type: `Test`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi2`,
-          children: [],
-          parent: `test`,
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `Test`,
-          },
+      actions.createNode({
+        id: `hi2`,
+        children: [],
+        parent: `test`,
+        internal: {
+          contentDigest: `hasdfljds`,
+          type: `Test`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi-1`,
-          children: [],
-          parent: `hi`,
-          internal: {
-            contentDigest: `hasdfljds-1`,
-            type: `Test-1`,
-          },
+      actions.createNode({
+        id: `hi-1`,
+        children: [],
+        parent: `hi`,
+        internal: {
+          contentDigest: `hasdfljds-1`,
+          type: `Test-1`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createParentChildLink(
-        {
-          parent: store.getState().nodes[`hi`],
-          child: getNode(`hi-1`),
-        },
-        { name: `tests` }
-      )
+      actions.createParentChildLink({
+        parent: store.getState().nodes[`hi`],
+        child: getNode(`hi-1`),
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi-1-1`,
-          children: [],
-          parent: `hi-1`,
-          internal: {
-            contentDigest: `hasdfljds-1-1`,
-            type: `Test-1-1`,
-          },
+      actions.createNode({
+        id: `hi-1-1`,
+        children: [],
+        parent: `hi-1`,
+        internal: {
+          contentDigest: `hasdfljds-1-1`,
+          type: `Test-1-1`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createParentChildLink(
-        {
-          parent: getNode(`hi-1`),
-          child: getNode(`hi-1-1`),
-        },
-        { name: `tests` }
-      )
+      actions.createParentChildLink({
+        parent: getNode(`hi-1`),
+        child: getNode(`hi-1-1`),
+      }, {
+        name: `tests`,
+      })
     )
 
-    store.dispatch(actions.deleteNode(getNode(`hi`), { name: `tests` }))
+    store.dispatch(actions.deleteNode({
+      node: getNode(`hi`),
+    }, {
+      name: `tests`,
+    }))
     expect(Object.keys(store.getState().nodes).length).toEqual(1)
   })
 
   it(`deletes previously transformed children nodes when parent nodes are deleted`, () => {
-    store.dispatch({ type: `DELETE_CACHE` })
+    store.dispatch(actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
+      },
+    }, {
+      name: `tests`,
+    }))
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi`,
-          children: [],
-          parent: `test`,
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `Test`,
-          },
+      actions.createNode({
+        id: `hi-1`,
+        children: [],
+        parent: `hi`,
+        internal: {
+          contentDigest: `hasdfljds-1`,
+          type: `Test-1`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi-1`,
-          children: [],
-          parent: `hi`,
-          internal: {
-            contentDigest: `hasdfljds-1`,
-            type: `Test-1`,
-          },
-        },
-        { name: `tests` }
-      )
+      actions.createParentChildLink({
+        parent: getNode(`hi`),
+        child: getNode(`hi-1`),
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createParentChildLink(
-        {
-          parent: getNode(`hi`),
-          child: getNode(`hi-1`),
+      actions.createNode({
+        id: `hi-1-1`,
+        children: [],
+        parent: `hi-1`,
+        internal: {
+          contentDigest: `hasdfljds-1-1`,
+          type: `Test-1-1`,
         },
-        { name: `tests` }
-      )
+      }, {
+        name: `tests`,
+      })
     )
     store.dispatch(
-      actions.createNode(
-        {
-          id: `hi-1-1`,
-          children: [],
-          parent: `hi-1`,
-          internal: {
-            contentDigest: `hasdfljds-1-1`,
-            type: `Test-1-1`,
-          },
-        },
-        { name: `tests` }
-      )
+      actions.createParentChildLink({
+        parent: getNode(`hi-1`),
+        child: getNode(`hi-1-1`),
+      }, {
+        name: `tests`,
+      })
     )
-    store.dispatch(
-      actions.createParentChildLink(
-        {
-          parent: getNode(`hi-1`),
-          child: getNode(`hi-1-1`),
-        },
-        { name: `tests` }
-      )
-    )
-    store.dispatch(actions.deleteNodes([`hi`], { name: `tests` }))
+    store.dispatch(actions.deleteNodes([`hi`], {
+      name: `tests`,
+    }))
     expect(Object.keys(store.getState().nodes).length).toEqual(0)
   })
 
   it(`allows deleting nodes`, () => {
-    store.dispatch({ type: `DELETE_CACHE` })
-    actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
-        },
-        pickle: true,
-        deep: {
-          array: [0, 1, { boom: true }],
-        },
+    actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
       },
-      { name: `tests` }
-    )
-    actions.deleteNode(getNode(`hi`))
+      pickle: true,
+      deep: {
+        array: [0, 1, {
+          boom: true,
+        }],
+      },
+    }, {
+      name: `tests`,
+    })
+    actions.deleteNode({
+      node: getNode(`hi`),
+    })
     expect(getNode(`hi`)).toBeUndefined()
   })
 
-  it(`nodes that are added are also "touched"`, () => {
-    const action = actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
-        },
-        pickle: true,
+  it(`warns when using old deleteNode signature `, () => {
+    console.warn = jest.fn()
+    store.dispatch(actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
       },
-      { name: `tests` }
-    )
+    }, {
+      name: `tests`,
+    }))
+
+    expect(getNode(`hi`)).toMatchSnapshot()
+    store.dispatch(actions.deleteNode(`hi`, getNode(`hi`), {
+      name: `tests`,
+    }))
+
+    expect(getNode(`hi`)).toBeUndefined()
+
+    const deprecationNotice = `Calling "deleteNode" with a nodeId is deprecated. Please pass an object containing a full node instead: deleteNode({ node })`
+    expect(console.warn).toHaveBeenCalledWith(deprecationNotice)
+
+    console.warn.mockRestore()
+  })
+
+  it(`nodes that are added are also "touched"`, () => {
+    const action = actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
+      },
+      pickle: true,
+    }, {
+      name: `tests`,
+    })
     let state = nodeTouchedReducer(undefined, action)
     expect(state[`hi`]).toBe(true)
   })
 
   it(`allows adding fields to nodes`, () => {
-    const action = actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
-        },
-        pickle: true,
+    const action = actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
       },
-      { name: `tests` }
-    )
+      pickle: true,
+    }, {
+      name: `tests`,
+    })
     let state = nodeReducer(undefined, action)
 
-    const addFieldAction = actions.createNodeField(
-      {
-        node: state[`hi`],
-        name: `joy`,
-        value: `soul's delight`,
-      },
-      { name: `test` }
-    )
+    const addFieldAction = actions.createNodeField({
+      node: state[`hi`],
+      name: `joy`,
+      value: `soul's delight`,
+    }, {
+      name: `test`,
+    })
     state = nodeReducer(state, addFieldAction)
     expect(state).toMatchSnapshot()
   })
 
   it(`throws error if a field is updated by a plugin not its owner`, () => {
-    const action = actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
-        },
-        pickle: true,
+    const action = actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `Test`,
       },
-      { name: `tests` }
-    )
+      pickle: true,
+    }, {
+      name: `tests`,
+    })
     let state = nodeReducer(undefined, action)
 
-    const addFieldAction = actions.createNodeField(
-      {
-        node: state[`hi`],
-        name: `joy`,
-        value: `soul's delight`,
-      },
-      { name: `test` }
-    )
+    const addFieldAction = actions.createNodeField({
+      node: state[`hi`],
+      name: `joy`,
+      value: `soul's delight`,
+    }, {
+      name: `test`,
+    })
     state = nodeReducer(state, addFieldAction)
 
     function callActionCreator() {
-      actions.createNodeField(
-        {
-          node: state[`hi`],
-          name: `joy`,
-          value: `soul's delight`,
-        },
-        { name: `test2` }
-      )
+      actions.createNodeField({
+        node: state[`hi`],
+        name: `joy`,
+        value: `soul's delight`,
+      }, {
+        name: `test2`,
+      })
     }
     expect(callActionCreator).toThrowErrorMatchingSnapshot()
   })
 
   it(`throws error if a node is created by a plugin not its owner`, () => {
-    actions.createNode(
-      {
-        id: `hi`,
+    actions.createNode({
+      id: `hi`,
+      children: [],
+      parent: `test`,
+      internal: {
+        contentDigest: `hasdfljds`,
+        type: `mineOnly`,
+      },
+      pickle: true,
+    }, {
+      name: `pluginA`,
+    })
+
+    function callActionCreator() {
+      actions.createNode({
+        id: `hi2`,
         children: [],
         parent: `test`,
         internal: {
@@ -416,24 +444,9 @@ describe(`Create and update nodes`, () => {
           type: `mineOnly`,
         },
         pickle: true,
-      },
-      { name: `pluginA` }
-    )
-
-    function callActionCreator() {
-      actions.createNode(
-        {
-          id: `hi2`,
-          children: [],
-          parent: `test`,
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `mineOnly`,
-          },
-          pickle: true,
-        },
-        { name: `pluginB` }
-      )
+      }, {
+        name: `pluginB`,
+      })
     }
 
     expect(callActionCreator).toThrowErrorMatchingSnapshot()
@@ -441,29 +454,30 @@ describe(`Create and update nodes`, () => {
 
   it(`throws error if a node sets a value on "fields"`, () => {
     function callActionCreator() {
-      actions.createNode(
-        {
-          id: `hi`,
-          children: [],
-          parent: `test`,
-          fields: {
-            test: `I can't do this but I like to test boundaries`,
-          },
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `mineOnly`,
-          },
-          pickle: true,
+      actions.createNode({
+        id: `hi`,
+        children: [],
+        parent: `test`,
+        fields: {
+          test: `I can't do this but I like to test boundaries`,
         },
-        { name: `pluginA` }
-      )
+        internal: {
+          contentDigest: `hasdfljds`,
+          type: `mineOnly`,
+        },
+        pickle: true,
+      }, {
+        name: `pluginA`,
+      })
     }
 
     expect(callActionCreator).toThrowErrorMatchingSnapshot()
   })
 
   it(`does not crash when delete node is called on undefined`, () => {
-    actions.deleteNode(undefined, { name: `tests` })
+    actions.deleteNode(undefined, {
+      name: `tests`,
+    })
     expect(Object.keys(store.getState().nodes).length).toEqual(0)
   })
 })

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -293,18 +293,26 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
 
 /**
  * Delete a node
- * @param {object} node the node object
+ * @param {object} $0
+ * @param {object} $0.node the node object
  * @example
- * deleteNode(node)
+ * deleteNode({node: node})
  */
-actions.deleteNode = (node: any, plugin: Plugin) => {
-  if (typeof node === `string`) {
-    console.log(
-      `The "deleteNode" action no longer accepts a nodeId string. Please pass a full node object instead.`
+actions.deleteNode = (options: any, plugin: Plugin, ...args) => {
+  let node = _.get(options, `node`)
+
+  // Check if using old method signature. Warn about incorrect usage but get
+  // node from nodeID anyway.
+  if (typeof options === `string`) {
+    console.warn(
+      `Calling "deleteNode" with a nodeId is deprecated. Please pass an object containing a full node instead: deleteNode({ node })`
     )
-    if (plugin && plugin.name) {
-      console.log(`"deleteNode" was called by ${plugin.name}`)
+
+    if (args[0] && args[0].name) { // `plugin` used to be the third argument
+      console.log(`"deleteNode" was called by ${args[0].name}`)
     }
+
+    node = getNode(options)
   }
 
   let deleteDescendantsActions
@@ -315,7 +323,7 @@ actions.deleteNode = (node: any, plugin: Plugin) => {
     const descendantNodes = findChildrenRecursively(node.children)
     if (descendantNodes.length > 0) {
       deleteDescendantsActions = descendantNodes.map(n =>
-        actions.deleteNode(getNode(n), plugin)
+        actions.deleteNode({ node: getNode(n) }, plugin)
       )
     }
   }
@@ -354,7 +362,7 @@ actions.deleteNodes = (nodes: any[], plugin: Plugin) => {
   let deleteDescendantsActions
   if (descendantNodes.length > 0) {
     deleteDescendantsActions = descendantNodes.map(n =>
-      actions.deleteNode(getNode(n), plugin)
+      actions.deleteNode({ node: getNode(n) }, plugin)
     )
   }
 

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -293,12 +293,20 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
 
 /**
  * Delete a node
- * @param {string} nodeId a node id
  * @param {object} node the node object
  * @example
- * deleteNode(node.id, node)
+ * deleteNode(node)
  */
-actions.deleteNode = (nodeId: string, node: any, plugin: Plugin) => {
+actions.deleteNode = (node: any, plugin: Plugin) => {
+  if (typeof node === `string`) {
+    console.log(
+      `The "deleteNode" action no longer accepts a nodeId string. Please pass a full node object instead.`
+    )
+    if (plugin && plugin.name) {
+      console.log(`"deleteNode" was called by ${plugin.name}`)
+    }
+  }
+
   let deleteDescendantsActions
   // It's possible the file node was never created as sometimes tools will
   // write and then immediately delete temporary files to the file system.
@@ -307,7 +315,7 @@ actions.deleteNode = (nodeId: string, node: any, plugin: Plugin) => {
     const descendantNodes = findChildrenRecursively(node.children)
     if (descendantNodes.length > 0) {
       deleteDescendantsActions = descendantNodes.map(n =>
-        actions.deleteNode(n, getNode(n), plugin)
+        actions.deleteNode(getNode(n), plugin)
       )
     }
   }
@@ -315,8 +323,7 @@ actions.deleteNode = (nodeId: string, node: any, plugin: Plugin) => {
   const deleteAction = {
     type: `DELETE_NODE`,
     plugin,
-    node,
-    payload: nodeId,
+    payload: node,
   }
 
   if (deleteDescendantsActions) {
@@ -334,7 +341,7 @@ actions.deleteNode = (nodeId: string, node: any, plugin: Plugin) => {
  */
 actions.deleteNodes = (nodes: any[], plugin: Plugin) => {
   console.log(
-    `The "deleteNodes" is now deprecated and will be removed in Gatsby v3. Please use "deleteNode" instead`
+    `The "deleteNodes" action is now deprecated and will be removed in Gatsby v3. Please use "deleteNode" instead.`
   )
   if (plugin && plugin.name) {
     console.log(`"deleteNodes" was called by ${plugin.name}`)
@@ -347,7 +354,7 @@ actions.deleteNodes = (nodes: any[], plugin: Plugin) => {
   let deleteDescendantsActions
   if (descendantNodes.length > 0) {
     deleteDescendantsActions = descendantNodes.map(n =>
-      actions.deleteNode(n, getNode(n), plugin)
+      actions.deleteNode(getNode(n), plugin)
     )
   }
 

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -587,11 +587,27 @@ actions.createNode = (node: any, plugin?: Plugin, traceId?: string) => {
  * nodes from a remote system that can return only nodes that have
  * updated. The source plugin then touches all the nodes that haven't
  * updated but still exist so Gatsby knows to keep them.
- * @param {string} nodeId The id of a node.
+ * @param {Object} $0
+ * @param {string} $0.nodeId The id of a node
  * @example
- * touchNode(`a-node-id`)
+ * touchNode({ nodeId: `a-node-id` })
  */
-actions.touchNode = (nodeId: string, plugin?: Plugin) => {
+actions.touchNode = (options: any, plugin?: Plugin) => {
+  let nodeId = _.get(options, `nodeId`)
+
+  // Check if using old method signature. Warn about incorrect usage
+  if (typeof options === `string`) {
+    console.warn(
+      `Calling "touchNode" with a nodeId is deprecated. Please pass an object containing a nodeId instead: touchNode({ nodeId: 'a-node-id' })`
+    )
+
+    if (plugin && plugin.name) {
+      console.log(`"touchNode" was called by ${plugin.name}`)
+    }
+
+    nodeId = options
+  }
+
   return {
     type: `TOUCH_NODE`,
     plugin,

--- a/packages/gatsby/src/redux/reducers/nodes.js
+++ b/packages/gatsby/src/redux/reducers/nodes.js
@@ -22,7 +22,7 @@ module.exports = (state = {}, action) => {
       return newState
 
     case `DELETE_NODE`: {
-      newState = _.omit(state, action.payload)
+      newState = _.omit(state, action.payload.id)
       return newState
     }
 

--- a/packages/gatsby/src/utils/source-nodes.js
+++ b/packages/gatsby/src/utils/source-nodes.js
@@ -67,6 +67,6 @@ module.exports = async () => {
   })
 
   if (staleNodes.length > 0) {
-    staleNodes.forEach(n => deleteNode(n))
+    staleNodes.forEach(node => deleteNode({ node }))
   }
 }

--- a/packages/gatsby/src/utils/source-nodes.js
+++ b/packages/gatsby/src/utils/source-nodes.js
@@ -67,6 +67,6 @@ module.exports = async () => {
   })
 
   if (staleNodes.length > 0) {
-    staleNodes.forEach(n => deleteNode(n.id, n))
+    staleNodes.forEach(n => deleteNode(n))
   }
 }


### PR DESCRIPTION
I did this and realised I've changed the signature to `(node, plugin)`, but @KyleAMathews asked for it to be `({ node }, plugin)`. 

It looks like other actions use a mix of styles, so I've left this PR as-is. I'm happy to change it to `({ node }, plugin)` if that's better?

Closes #4409 