### PR TITLE
[v2] fix find-page

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/loader.js
+++ b/packages/gatsby/cache-dir/__tests__/loader.js
@@ -2,14 +2,14 @@ import loader from "../loader.js"
 
 describe(`Loader`, () => {
   beforeEach(() => {
-    delete global.__PATH_PREFIX__
-    delete global.__PREFIX_PATHS__
+    global.__PATH_PREFIX__ = ``
+    global.__PREFIX_PATHS__ = false
 
     // Workaround for Node 6 issue: https://github.com/facebook/jest/issues/5159
     if (global.hasOwnProperty(`__PATH_PREFIX__`))
-      global.__PATH_PREFIX__ = undefined
+      global.__PATH_PREFIX__ = ``
     if (global.hasOwnProperty(`__PREFIX_PATHS__`))
-      global.__PREFIX_PATHS__ = undefined
+      global.__PREFIX_PATHS__ = false
 
     loader.empty()
     loader.addPagesArray([

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -10,7 +10,7 @@ let hasFetched = Object.create(null)
 let syncRequires = {}
 let asyncRequires = {}
 let jsonDataPaths = {}
-let pathPrefix = ``
+let pathPrefix = `/`
 let fetchHistory = []
 let fetchingPageResourceMapPromise = null
 let fetchedPageResourceMap = false
@@ -48,7 +48,7 @@ const fetchResource = resourceName => {
         if (resourceName in jsonStore) {
           resolve(jsonStore[resourceName])
         } else {
-          const url = `${pathPrefix ? pathPrefix : `/`}static/d/${
+          const url = `${pathPrefix}static/d/${
             jsonDataPaths[resourceName]
           }.json`
           var req = new XMLHttpRequest()
@@ -156,7 +156,6 @@ const sortResourcesByCount = (a, b) => {
 }
 
 let findPage
-let pages = []
 let pathScriptsCache = {}
 let resourcesArray = []
 let mountOrder = 1
@@ -165,19 +164,14 @@ const queue = {
   empty: () => {
     resourcesCount = Object.create(null)
     resourcesArray = []
-    pages = []
-    pathPrefix = ``
+    pathPrefix = `/`
   },
 
   addPagesArray: newPages => {
-    pages = newPages
-    if (
-      typeof __PREFIX_PATHS__ !== `undefined` &&
-      typeof __PATH_PREFIX__ !== `undefined`
-    ) {
-      if (__PREFIX_PATHS__ === true) pathPrefix = `${__PATH_PREFIX__}/`
+    if (__PREFIX_PATHS__) {
+      pathPrefix = `${__PATH_PREFIX__}/`
     }
-    findPage = pageFinderFactory(newPages, pathPrefix)
+    findPage = pageFinderFactory(newPages, pathPrefix.slice(0, -1))
   },
   addDevRequires: devRequires => {
     syncRequires = devRequires
@@ -191,7 +185,7 @@ const queue = {
   dequeue: () => resourcesArray.pop(),
   enqueue: rawPath => {
     // Check page exists.
-    const path = stripPrefix(rawPath, pathPrefix)
+    const path = stripPrefix(rawPath, pathPrefix.slice(0, -1))
 
     let page = findPage(path)
 


### PR DESCRIPTION
right now find-page is broken with `prefix-paths`
BTW, I think it's confusing to add the trailing slash to the `prefixPath` from user definition, but still use the same var name, it should be `stripBasename` from my understanding,
so about about rename the `prefix-paths` to `basename` in the `gatsby-config` section, then `basename` with trailing slash is pathPrefix, and we can address it in another PR, any thoughts @KyleAMathews @m-allanson @jquense 