### PR TITLE
Update gatsby-remark-autolink-headers/README.md (issue #5061)

### DIFF
--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -23,3 +23,28 @@ module.exports = {
   ],
 };
 ```
+
+## Options
+
+* `offsetY`: Signed integer, vertical offset value in pixels, e.g.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-transformer-remark`,
+      options: {
+        plugins: [
+          {
+            resolve: `gatsby-remark-autolink-headers`,
+            options: {
+              offsetY: `100`,
+            },
+          }
+        ],
+      },
+    },
+  ],
+};
+```


### PR DESCRIPTION
Adding explanation about available option `offsetY` to solve issue #5061
Signed-off-by: Robin Cussol <me@robincussol.com>