### PR TITLE
[gatsby-source-contentful] Fix storing new sync token

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -103,7 +103,7 @@ exports.sourceNodes = async (
   // This might change though
   if (host !== `preview.contentful.com`) {
     const newState = {}
-    newState[spaceId] = nextSyncToken
+    newState[`${spaceId}-${environment}`] = nextSyncToken
     setPluginStatus(newState)
   }
 


### PR DESCRIPTION
When adding the new `environment` option, the key used to read the sync token was changed from `spaceId` to `${spaceId}-${environment}` (see [gatsby-source-contentful/src/gatsby-node.js#L50](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/src/gatsby-node.js#L50)), but it hasn't been updated in the part of code that stores it.

This PR fixes this issue.

CC @Khaledgarbaya 