### PR TITLE
[v2 tutorial pt 5] Added Layout to example to match image

### DIFF
--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -108,10 +108,11 @@ created:
 
 ```jsx{4}
 import React from "react"
+import Layout from "../components/layout"
 
 export default ({ data }) => {
   console.log(data)
-  return <div>Hello world</div>
+  return <Layout><div>Hello world</div></Layout>
 }
 
 export const query = graphql`
@@ -145,10 +146,12 @@ Let's add some code to our component to print out the File data.
 
 ```jsx{5-37}
 import React from "react"
+import Layout from "../components/layout"
 
 export default ({ data }) => {
   console.log(data)
   return (
+  <Layout>
     <div>
       <h1>My Site's Files</h1>
       <table>
@@ -180,6 +183,7 @@ export default ({ data }) => {
         </tbody>
       </table>
     </div>
+   <Layout/>
   )
 }
 


### PR DESCRIPTION
The image shows that the `my-file.js` page is inside a layout but the layout is not part of the example code.

![my-files-page-805866c0f82b5adf9b812e1c69ac3398-acb38](https://user-images.githubusercontent.com/11723413/39596606-e41c7066-4ee0-11e8-8247-1fec9d3ad7bf.png)
