### PR TITLE
Add top padding for tablet masthead

### DIFF
--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -26,7 +26,7 @@ const MastheadContent = () => (
         paddingRight: 0,
       },
       [presets.Tablet]: {
-        paddingTop: rhythm(4),
+        paddingTop: rhythm(5),
       },
       [presets.Desktop]: {
         paddingTop: rhythm(5),


### PR DESCRIPTION
Much like #5068 , adds padding to the masthead for the tablet size. The text now will not overlap with the logo at any screen width:

Before:
<img width="1072" alt="screen shot 2018-05-03 at 7 31 49 pm" src="https://user-images.githubusercontent.com/5553498/39607511-73f672ea-4f09-11e8-9f70-5ddcd4106b96.png">

After:
<img width="1072" alt="screen shot 2018-05-03 at 7 32 01 pm" src="https://user-images.githubusercontent.com/5553498/39607515-756ca8c4-4f09-11e8-91e4-40b7ff4d8bae.png">


<details><summary>Before, resizing screen width</summary><p>

![old-resize](https://user-images.githubusercontent.com/5553498/39607745-bee11098-4f0a-11e8-8709-c5cd66bd201a.gif)

</p>
</details>

<details><summary>After, resizing screen width</summary><p>

![new-resize-masthead](https://user-images.githubusercontent.com/5553498/39607637-02840bc6-4f0a-11e8-8e2b-94cdcfc6f47d.gif)

</p>
</details>

