### PR TITLE
Minor fix on wordpress source plugin tutorial

### DIFF
--- a/docs/docs/wordpress-source-plugin-tutorial.md
+++ b/docs/docs/wordpress-source-plugin-tutorial.md
@@ -131,7 +131,7 @@ export default ({ data }) => {
        </div>
      ))}
    </div>
- )T
+ )
 }
 
 // Set here the ID of the home page.


### PR DESCRIPTION
removed typo