### PR TITLE
Add manifest.webmanifest to staticFileGlobs on gatsby-plugin-offline

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -30,9 +30,12 @@ and AppCache setup by changing these options so tread carefully.
 ```javascript
 const options = {
   staticFileGlobs: [
-    `${rootDir}/**/*.{js,woff2}`,
+    `${rootDir}/**/*.{woff2}`,
+    `${rootDir}/commons-*js`,
+    `${rootDir}/app-*js`,
     `${rootDir}/index.html`,
     `${rootDir}/manifest.json`,
+    `${rootDir}/manifest.webmanifest`,
     `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
   ],
   stripPrefix: rootDir,

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -23,6 +23,7 @@ exports.onPostBuild = (args, pluginOptions) => {
       `${rootDir}/app-*js`,
       `${rootDir}/index.html`,
       `${rootDir}/manifest.json`,
+      `${rootDir}/manifest.webmanifest`,
       `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
     ],
     stripPrefix: rootDir,


### PR DESCRIPTION
With the version `gatsby-plugin-manifest@1.0.21` the manifest extension was changed from `.json` to `.webmanifest` but that extension was not part of the `staticFileGlobs`. The result was that accessing the manifest file url would bring you to a 404 error page.

Signed-off-by: Kaue Machado <kaumac@gmail.com>