### PR TITLE
plugin-feed: Note feed xml file is production only

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -83,3 +83,5 @@ plugins: [
   },
 ];
 ```
+
+NOTE: This plugin only generates the `/rss.xml` file when run in `production` mode! To test your feed, run: `gatsby build && gatsby serve`.


### PR DESCRIPTION
Add note that the rss.xml feed is only generated in production.