### PR TITLE
flag importance of plugin order for prism-js vs embed-snippet

### DIFF
--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -116,6 +116,8 @@ quz: "highlighted"
 
 ## How to use
 
+Important: This module must appear before `gatsby-remark-prismjs` in your plugins array, or the markup will have already been transformed into a code block and this plugin will fail to detect it and inline the file.  
+
 ```javascript
 // In your gatsby-config.js
 module.exports = {


### PR DESCRIPTION
If gatsby-remark-prism-js is declared before gatsby-remark-embed-snippet, the latter will not pick up the `embed:example.js` syntax because it is looking for an inline-code node and it will have been transformed into a p node by gatsby-remark-prism-js. This needs to be noted as this is far from obvious.