### PR TITLE
The url of the sitemap should match the actual url

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -59,7 +59,7 @@ export const defaultOptions = {
   serialize: ({ site, allSitePage }) =>
     allSitePage.edges.map(edge => {
       return {
-        url: site.siteMetadata.siteUrl + edge.node.path,
+        url: site.siteMetadata.siteUrl + edge.node.path.toLowerCase(),
         changefreq: `daily`,
         priority: 0.7,
       }


### PR DESCRIPTION
Since gatsby forces the URL to be in lowercase letters, the URL of the site map must also be lowercase.

----
When use gatsby with markdowns, filename may contain UpperCase letter.

On this situation, gatsby-plugin-sitemap generates the url with UpperCase,
and Gatsby generates path with lowercase.

As a result, search engine claims that sitemap's url is not valid.

They say "There is no canonical tag in the URL of the Sitemap"
as they indexes the actual (lowercase) URL and 
thinks that the URL of the site map is not canonical.

----
e.g.

Filename:
2018-04-09-AboutJamStack.md

Sitemap URL:
https://www.some.org/2018-04-09-AboutJamStack/  (301 redirected to actual url)

Actual URL:
https://www.some.org/2018-04-09-aboutjamstack/