### PR TITLE
[v2] fix sass and less variants of css modules in build-html stage

### DIFF
--- a/packages/gatsby-plugin-less/src/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/gatsby-node.js
@@ -6,6 +6,7 @@ exports.onCreateWebpackConfig = (
 ) => {
   const { setWebpackConfig } = actions
   const PRODUCTION = stage !== `develop`
+  const isSSR = stage.includes(`html`)
 
   const lessLoader = {
     loader: resolve(`less-loader`),
@@ -17,25 +18,19 @@ exports.onCreateWebpackConfig = (
 
   const lessRule = {
     test: /\.less$/,
-    use: [
-      loaders.miniCssExtract(),
-      loaders.css({ importLoaders: 1 }),
-      loaders.postcss({ plugins: postCssPlugins }),
-      lessLoader,
-    ],
+    use: isSSR
+      ? [loaders.null()]
+      : [
+          loaders.miniCssExtract(),
+          loaders.css({ importLoaders: 1 }),
+          loaders.postcss({ plugins: postCssPlugins }),
+          lessLoader,
+        ],
   }
   const lessRuleModules = {
     test: /\.module\.less$/,
     use: [
       loaders.miniCssExtract(),
-      loaders.css({ modules: true, importLoaders: 1 }),
-      loaders.postcss({ plugins: postCssPlugins }),
-      lessLoader,
-    ],
-  }
-  const lessRuleModulesSSR = {
-    test: /\.module\.less$/,
-    use: [
       loaders.css({ modules: true, importLoaders: 1 }),
       loaders.postcss({ plugins: postCssPlugins }),
       lessLoader,
@@ -47,24 +42,11 @@ exports.onCreateWebpackConfig = (
   switch (stage) {
     case `develop`:
     case `build-javascript`:
-      configRules = configRules.concat([
-        {
-          oneOf: [lessRuleModules, lessRule],
-        },
-      ])
-      break
-
     case `build-html`:
     case `develop-html`:
       configRules = configRules.concat([
         {
-          oneOf: [
-            lessRuleModulesSSR,
-            {
-              ...lessRule,
-              use: [loaders.null()],
-            },
-          ],
+          oneOf: [lessRuleModules, lessRule],
         },
       ])
       break

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -6,6 +6,7 @@ exports.onCreateWebpackConfig = (
 ) => {
   const { setWebpackConfig } = actions
   const PRODUCTION = stage !== `develop`
+  const isSSR = stage.includes(`html`)
 
   const sassLoader = {
     loader: resolve(`sass-loader`),
@@ -17,25 +18,19 @@ exports.onCreateWebpackConfig = (
 
   const sassRule = {
     test: /\.s(a|c)ss$/,
-    use: [
-      loaders.miniCssExtract(),
-      loaders.css({ importLoaders: 1 }),
-      loaders.postcss({ plugins: postCssPlugins }),
-      sassLoader,
-    ],
+    use: isSSR
+      ? [loaders.null()]
+      : [
+          loaders.miniCssExtract(),
+          loaders.css({ importLoaders: 1 }),
+          loaders.postcss({ plugins: postCssPlugins }),
+          sassLoader,
+        ],
   }
   const sassRuleModules = {
     test: /\.module\.s(a|c)ss$/,
     use: [
       loaders.miniCssExtract(),
-      loaders.css({ modules: true, importLoaders: 1 }),
-      loaders.postcss({ plugins: postCssPlugins }),
-      sassLoader,
-    ],
-  }
-  const sassRuleModulesSSR = {
-    test: /\.module\.s(a|c)ss$/,
-    use: [
       loaders.css({ modules: true, importLoaders: 1 }),
       loaders.postcss({ plugins: postCssPlugins }),
       sassLoader,
@@ -47,24 +42,11 @@ exports.onCreateWebpackConfig = (
   switch (stage) {
     case `develop`:
     case `build-javascript`:
-      configRules = configRules.concat([
-        {
-          oneOf: [sassRuleModules, sassRule],
-        },
-      ])
-      break
-
     case `build-html`:
     case `develop-html`:
       configRules = configRules.concat([
         {
-          oneOf: [
-            sassRuleModulesSSR,
-            {
-              ...sassRule,
-              use: [loaders.null()],
-            },
-          ],
+          oneOf: [sassRuleModules, sassRule],
         },
       ])
       break

--- a/packages/gatsby/src/utils/webpack-extract-css-modules-map.js
+++ b/packages/gatsby/src/utils/webpack-extract-css-modules-map.js
@@ -1,0 +1,19 @@
+const Module = require(`module`)
+const loaderUtils = require(`loader-utils`)
+const path = require(`path`)
+
+module.exports = function(content) {
+  const [filename] = loaderUtils
+    .getRemainingRequest(this)
+    .split(`!`)
+    .slice(-1)
+
+  const dir = path.dirname(filename)
+
+  var m = new Module(filename, this)
+  m.filename = filename
+  m.paths = Module._nodeModulePaths(dir)
+  m._compile(content, filename)
+
+  return `module.exports = ${JSON.stringify(m.exports.locals)}`
+}

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -181,7 +181,9 @@ module.exports = async ({
         options,
         // use MiniCssExtractPlugin only on production builds
         loader: PRODUCTION
-          ? MiniCssExtractPlugin.loader
+          ? stage === `build-html`
+            ? require.resolve(`./webpack-extract-css-modules-map`)
+            : MiniCssExtractPlugin.loader
           : require.resolve(`style-loader`),
       }
     },

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -150,20 +150,15 @@ module.exports = async (
         __PREFIX_PATHS__: program.prefixPaths,
         __PATH_PREFIX__: JSON.stringify(store.getState().config.pathPrefix),
       }),
-
-      plugins.extractText(
-        stage === `develop`
-          ? {
-              filename: `[name].css`,
-              chunkFilename: `[name].css`,
-            }
-          : {}
-      ),
     ]
 
     switch (stage) {
       case `develop`:
         configPlugins = configPlugins.concat([
+          plugins.extractText({
+            filename: `[name].css`,
+            chunkFilename: `[name].css`,
+          }),
           plugins.hotModuleReplacement(),
           plugins.noEmitOnErrors(),
 
@@ -184,6 +179,7 @@ module.exports = async (
         break
       case `build-javascript`: {
         configPlugins = configPlugins.concat([
+          plugins.extractText(),
           // Minify Javascript.
           plugins.uglify({
             uglifyOptions: {


### PR DESCRIPTION
As mentioned in #5223 sass (and less) variants of css modules don't work properly during `build-html` stage and return something like this:
```js
[ [ './src/styles/sass.module.scss',
    '.sass-module--page--v-l14{background:#f4fa58;padding:4rem}.sass-module--header--1fvbg{font-size:4rem;line-height:1;margin:0;margin-bottom:1rem}.sass-module--link--3VrgQ{background:#fe2e2e;color:#fbfbef;font-size:2rem}',
    '' ],
  toString: [Function: toString],
  i: [Function],
  locals: { page: 'sass-module--page--v-l14',
    header: 'sass-module--header--1fvbg',
    link: 'sass-module--link--3VrgQ' } ]
```

This PR adds local webpack loader that will extract just `locals` export and use it in `build-html` stage (maybe it would also be worth renaming `loaders.miniCssExtract` to something else). This also only adds `mini-css-extract` plugin in `develop` and `build-html` stages, as other stages are covered with either style-loader or that new local loader.