### PR TITLE
[v2] Fix looking for deprecated APIs

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -378,7 +378,7 @@ module.exports = async (program: any) => {
     const deprecatedLocations = {}
     deprecatedApis.forEach(api => (deprecatedLocations[api] = []))
 
-    glob.sync(`{,!(node_modules|public)/**/}*.js`).forEach(file => {
+    glob.sync(`{,!(node_modules|public)/**/}*.js`, { nodir: true }).forEach(file => {
       const fileText = fs.readFileSync(file)
       const matchingApis = deprecatedApis.filter(
         api => fileText.indexOf(api) !== -1


### PR DESCRIPTION
`glob.sync` returns files and directories by default.
It is not forbidden to name a directory `foo.js` and it would be returned by `glob`.
That's an issue because `fs.readFileSync(file)` will then fail with `EISDIR: illegal operation on a directory`.

This makes sure that `glob.sync` only returns files