### PR TITLE
[gatsby-source-filesystem] add fs error handling, bump got retry attemps count

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -132,7 +132,11 @@ async function pushToQueue(task, cb) {
  */
 const requestRemoteNode = (url, headers, tmpFilename, filename) =>
   new Promise((resolve, reject) => {
-    const responseStream = got.stream(url, { ...headers, timeout: 30000 })
+    const responseStream = got.stream(url, {
+      ...headers,
+      timeout: 30000,
+      retries: 5,
+    })
     const fsWriteStream = fs.createWriteStream(tmpFilename)
     responseStream.pipe(fsWriteStream)
     responseStream.on(`downloadProgress`, pro => console.log(pro))

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -144,11 +144,11 @@ const requestRemoteNode = (url, headers, tmpFilename, filename) =>
     // If there's a 400/500 response or other error.
     responseStream.on(`error`, (error, body, response) => {
       fs.removeSync(tmpFilename)
-      reject({ error, body, response })
+      reject(error)
     })
 
     fsWriteStream.on(`error`, error => {
-      reject({ error })
+      reject(error)
     })
 
     responseStream.on(`response`, response => {

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -143,6 +143,10 @@ const requestRemoteNode = (url, headers, tmpFilename, filename) =>
       reject({ error, body, response })
     })
 
+    fsWriteStream.on(`error`, error => {
+      reject({ error })
+    })
+
     responseStream.on(`response`, response => {
       fsWriteStream.on(`finish`, () => {
         resolve(response)


### PR DESCRIPTION
This is attempt to fix https://github.com/gatsbyjs/gatsby/issues/5371 and other issues that report that Gatsby bootstrap is getting stuck at `source and transform nodes` step.

Diffucult to say if this really help, as this issue is manifesting inconsistently, but at least handling fs stream errors should be added.

I bumped `got` retries from default 2 to 5 here, but I wonder if bumping request timeout and/or lowering concurrent requests from 200 to something lower wouldn't help here also.

Another thing to consider is that we currently return `null` on errors. I feel like we should stop build there as silently continuing may lead to succesful builds that are actually missing some assets. 