### PR TITLE
 [V2] Docs - Import Link from gatsby.

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -320,7 +320,7 @@ links.
 ```jsx{3,18-19,29,47-49}
 import React from "react"
 import g from "glamorous"
-import Link from "gatsby-link"
+import { Link } from "gatsby"
 
 import { rhythm } from "../utils/typography"
 


### PR DESCRIPTION
I noticed we were still importing Link from gatsby-link
v2 - imports from gatsby