### PR TITLE
[gatsby-transformer-yaml] Update docs: GraphQL query mismatch

### DIFF
--- a/packages/gatsby-transformer-yaml/README.md
+++ b/packages/gatsby-transformer-yaml/README.md
@@ -130,7 +130,7 @@ single objects, you'd be able to query your letters like:
   allLettersYaml {
     edges {
       node {
-        value
+        character
       }
     }
   }


### PR DESCRIPTION
GraphQL query references "value" when it should actually reference "character" as per the example output.