### PR TITLE
Fix regression with prefix paths and gatsby-plugin-manifest

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -6,7 +6,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     <link
       key={`gatsby-plugin-manifest-link`}
       rel="manifest"
-      href={withPrefix(`manifest.webmanifest`)}
+      href={withPrefix(`/manifest.webmanifest`)}
     />,
     <meta
       key={`gatsby-plugin-manifest-meta`}


### PR DESCRIPTION
as per https://github.com/gatsbyjs/gatsby/commit/69ca24750ecba8945a57f2c662cc5ca44964d76a#diff-079fdad4111264c646208511aa18a321 manifest.webmanifest should start with /

it just works (tm) when your site is flat, but when your pages are in sub directory and prefixed, its assumes your manifest files are in the subdirectory, not the root of your site (which might be prefixed).

Fixing reversion