### PR TITLE
[v2] [gatsby-remark-images] dependency version change

### DIFF
--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.47",
     "cheerio": "^1.0.0-rc.2",
-    "gatsby-plugin-sharp": "^2.0.0-alpha.15",
+    "gatsby-plugin-sharp": "next",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",
     "slash": "^1.0.0",


### PR DESCRIPTION
This changes `gatsby-plugin-sharp` version to `next` to avoid resolving version to outdated canary release. This is similiar change I've made in #5170

Ref #5440

If this gets merged will need to update "Pre-releases Todos" card in v2 project to revert this