### PR TITLE
[v2][www] Remove unneeded imports causing no-unused-vars lint errors

### DIFF
--- a/www/src/components/card-headline.js
+++ b/www/src/components/card-headline.js
@@ -1,6 +1,6 @@
 import React from "react"
 import presets from "../utils/presets"
-import { rhythm, scale, options } from "../utils/typography"
+import { scale } from "../utils/typography"
 
 const CardHeadline = ({ children }) => (
   <h2

--- a/www/src/components/card.js
+++ b/www/src/components/card.js
@@ -1,7 +1,7 @@
 import React from "react"
 import presets, { colors } from "../utils/presets"
-import { rhythm, scale, options } from "../utils/typography"
-import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
+import { rhythm } from "../utils/typography"
+import { vP, vPHd, vPVHd } from "../components/gutters"
 
 const Card = ({ children }) => (
   <div

--- a/www/src/components/cards.js
+++ b/www/src/components/cards.js
@@ -1,7 +1,5 @@
 import React from "react"
 import presets from "../utils/presets"
-import { rhythm, scale, options } from "../utils/typography"
-import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
 
 const Cards = ({ children }) => (
   <div

--- a/www/src/components/container.js
+++ b/www/src/components/container.js
@@ -1,7 +1,7 @@
 import React from "react"
 import presets from "../utils/presets"
 
-import { rhythm, scale, options } from "../utils/typography"
+import { rhythm, options } from "../utils/typography"
 
 export default ({ children, className, hasSideBar = true, css = {} }) => (
   <div

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -5,7 +5,7 @@ import { rhythm, scale, options } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
 import logo from "../monogram.svg"
 import { GraphQLIcon, ReactJSIcon } from "../assets/logos"
-import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
+import { vP } from "../components/gutters"
 import FuturaParagraph from "../components/futura-paragraph"
 import TechWithIcon from "../components/tech-with-icon"
 

--- a/www/src/components/evaluation-table-section-header-top.js
+++ b/www/src/components/evaluation-table-section-header-top.js
@@ -1,6 +1,6 @@
 import React from "react"
 import presets, { colors } from "../utils/presets"
-import { scale, rhythm, options } from "../utils/typography"
+import { scale, rhythm } from "../utils/typography"
 
 const superHeaderTitles = [
   `Feature`,

--- a/www/src/components/evaluation-table.js
+++ b/www/src/components/evaluation-table.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react"
 import presets, { colors } from "../utils/presets"
 import EvaluationCell from "./evaluation-cell"
-import { Link } from "gatsby"
 import infoIcon from "../assets/info-icon.svg"
 import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"

--- a/www/src/components/futura-paragraph.js
+++ b/www/src/components/futura-paragraph.js
@@ -1,6 +1,5 @@
 import React from "react"
-import { rhythm, scale, options } from "../utils/typography"
-import presets from "../utils/presets"
+import { options } from "../utils/typography"
 
 const FuturaParagraph = ({ children }) => (
   <p

--- a/www/src/components/markdown-page-footer.js
+++ b/www/src/components/markdown-page-footer.js
@@ -5,7 +5,7 @@ import CrossIcon from "react-icons/lib/md/thumb-down"
 import { GraphQLClient } from "graphql-request"
 
 import { rhythm, scale } from "../utils/typography"
-import presets, { colors } from "../utils/presets"
+import { colors } from "../utils/presets"
 
 const client = new GraphQLClient(
   `https://api.graph.cool/relay/v1/cj8xuo77f0a3a0164y7jketkr`

--- a/www/src/components/masthead-bg.js
+++ b/www/src/components/masthead-bg.js
@@ -1,7 +1,6 @@
 import React from "react"
 import presets, { colors } from "../utils/presets"
-import { rhythm, scale, options } from "../utils/typography"
-import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
+import { rhythm } from "../utils/typography"
 
 const vPOff = rhythm(presets.gutters.default - presets.logoOffset)
 const vPHdOff = rhythm(presets.gutters.HdR - presets.logoOffset)

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -1,12 +1,9 @@
 import React from "react"
-import { Link } from "gatsby"
 import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
 
-import { rhythm, scale, options } from "../utils/typography"
+import { rhythm, scale } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
 import CtaButton from "./cta-button"
-import MastheadBg from "./masthead-bg"
-import FuturaParagraph from "./futura-paragraph"
 import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
 
 const MastheadContent = () => (
@@ -16,7 +13,6 @@ const MastheadContent = () => (
       display: `flex`,
       padding: vP,
       paddingTop: rhythm(5),
-      paddingBottom: rhythm(1),
       paddingBottom: rhythm(1),
       flexGrow: `0`,
       flexShrink: `1`,

--- a/www/src/components/used-by.js
+++ b/www/src/components/used-by.js
@@ -1,5 +1,5 @@
 import React from "react"
-import typography, { rhythm, scale, options } from "../utils/typography"
+import typography, { rhythm, scale } from "../utils/typography"
 import presets from "../utils/presets"
 import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
 import { FormidableIcon, FabricIcon, SegmentIcon } from "../assets/logos"

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -1,8 +1,7 @@
 import React from "react"
 import Helmet from "react-helmet"
 
-import { rhythm, options } from "../utils/typography"
-import presets, { colors } from "../utils/presets"
+import presets from "../utils/presets"
 import Navigation from "../components/navigation"
 import MobileNavigation from "../components/navigation-mobile"
 import "../css/prism-coy.css"
@@ -20,6 +19,7 @@ import "typeface-space-mono"
 class DefaultLayout extends React.Component {
   render() {
     const isHomepage = this.props.location.pathname === `/`
+    // TODO: isBlogLanding is unused var, is this still needed?
     const isBlogLanding = this.props.location.pathname === `/blog/`
 
     return (

--- a/www/src/pages/blog/index.js
+++ b/www/src/pages/blog/index.js
@@ -6,7 +6,7 @@ import Container from "../../components/container"
 import BlogPostPreviewItem from "../../components/blog-post-preview-item"
 
 import presets, { colors } from "../../utils/presets"
-import { rhythm, scale, options } from "../../utils/typography"
+import { rhythm, options } from "../../utils/typography"
 import logo from "../../monogram.svg"
 
 class BlogPostsIndex extends React.Component {


### PR DESCRIPTION
And a very apparent dupe-key error.

Refs: https://github.com/gatsbyjs/gatsby/issues/5348