### PR TITLE
[gatsby-source-filesystem] Introduce 'ignore' parameter

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -41,6 +41,34 @@ module.exports = {
 };
 ```
 
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    // The following setup creates "File" nodes for all files from
+    // "data" directory except files with "xml" extension.
+    //
+    // The "ignore" parameter will be passed to `chokidar` and currently must be one of the following:
+    //    - string to be directly matched,
+    //    - string with glob patterns,
+    //    - regular expression test,
+    //    - function that takes the testString as an argument and returns a truthy value if it should be matched,
+    //    - an array of any number and mix of these types.
+    //
+    // Note that the whole path is tested, not just filename.
+    // For more information about `chokidar`, please visit https://github.com/paulmillr/chokidar.
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `data`,
+        path: `${__dirname}/src/data/`,
+        ignore: `**/*.xml`,
+      },
+    },
+  ],
+};
+```
+
 ## How to query
 
 You can query file nodes like the following:

--- a/packages/gatsby-source-filesystem/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/gatsby-node.js
@@ -1,0 +1,77 @@
+const { sourceNodes } = require(`../gatsby-node`)
+const fs = require(`fs`)
+const chokidar = require(`chokidar`)
+
+jest.mock(`chokidar`, () => {
+  const chokidarMock = jest.genMockFromModule(`chokidar`)
+
+  chokidarMock.watch.mockImplementation(() => {
+    return {
+      on: jest.fn(),
+    }
+  })
+
+  return chokidarMock
+})
+
+jest.mock(`fs`, () => jest.genMockFromModule(`fs`))
+
+describe(`sourceNodes`, () => {
+  const mock = {
+    boundActionCreators: {
+      createNode: jest.fn(),
+      deleteNode: jest.fn(),
+    },
+    getNode: jest.fn(),
+    reporter: {
+      error: jest.fn(),
+      panic: jest.fn().mockImplementation(msg => { throw new Error(msg) }),
+      info: jest.fn(),
+    },
+  }
+
+  afterEach(() => jest.clearAllMocks())
+
+  describe(`accepts ignore patterns in plugin options`, () => {
+    beforeEach(() => fs.existsSync.mockReturnValue(true))
+
+    describe(`calls chokidar.watch with provided ignore pattern(s)`, () => {
+      it(`pluginOption.ignore is a string`, () => {
+        const pattern = `ignore/pattern`
+        sourceNodes(mock, { path: __dirname, ignore: pattern })
+        expect(chokidar.watch).toHaveBeenCalled()
+        expect(chokidar.watch.mock.calls[0][1].ignored).toContain(pattern)
+      })
+
+      it(`pluginOption.ignore is a RegExp`, () => {
+        const pattern = /www/g
+        sourceNodes(mock, { path: __dirname, ignore: pattern })
+        expect(chokidar.watch).toHaveBeenCalled()
+        expect(chokidar.watch.mock.calls[0][1].ignored).toContain(pattern)
+      })
+
+      it(`pluginOption.ignore is a function`, () => {
+        const pattern = () => true
+        sourceNodes(mock, { path: __dirname, ignore: pattern })
+        expect(chokidar.watch).toHaveBeenCalled()
+        expect(chokidar.watch.mock.calls[0][1].ignored).toContain(pattern)
+      })
+
+      it(`pluginOption.ignore is an array of string`, () => {
+        const pattern = `ignore/pattern`
+        sourceNodes(mock, { path: __dirname, ignore: [pattern] })
+        expect(chokidar.watch).toHaveBeenCalled()
+        expect(chokidar.watch.mock.calls[0][1].ignored).toContain(pattern)
+      })
+    })
+
+    it(`calls panic with invalid ignore`, () => {
+      expect(() => sourceNodes(mock, { path: __dirname, ignore: {} })).toThrow(/The 'ignore' passed to gatsby-source-filesystem/g)
+      expect(() => sourceNodes(mock, { path: __dirname, ignore: 0 })).toThrow(/The 'ignore' passed to gatsby-source-filesystem/g)
+      expect(() => sourceNodes(mock, { path: __dirname, ignore: null })).toThrow(/The 'ignore' passed to gatsby-source-filesystem/g)
+      expect(() => sourceNodes(mock, { path: __dirname, ignore: NaN })).toThrow(/The 'ignore' passed to gatsby-source-filesystem/g)
+      expect(() => sourceNodes(mock, { path: __dirname, ignore: [`src`, {}] })).toThrow(/The 'ignore' passed to gatsby-source-filesystem/g)
+      expect(() => sourceNodes(mock, { path: __dirname, ignore: [`src`, NaN] })).toThrow(/The 'ignore' passed to gatsby-source-filesystem/g)
+    })
+  })
+})

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -3,6 +3,24 @@ const fs = require(`fs`)
 
 const { createId, createFileNode } = require(`./create-file-node`)
 
+/**
+ * Determines whether ignore matcher is valid
+ * @param {any} matcher
+ * @return {Boolean}
+ */
+const isValidIgnoreMatcher = matcher => (typeof matcher === `string` || typeof matcher === `function` || matcher instanceof RegExp)
+
+// Default paths matchers to not be watched
+const DEFAULT_PATHS_TO_IGNORE = [
+  `**/*.un~`,
+  `**/.gitignore`,
+  `**/.npmignore`,
+  `**/.babelrc`,
+  `**/yarn.lock`,
+  `**/node_modules`,
+  `../**/dist/**`,
+]
+
 exports.sourceNodes = (
   { boundActionCreators, getNode, reporter },
   pluginOptions
@@ -26,20 +44,26 @@ Please pick a path to an existing directory.
       `)
   }
 
+  if (pluginOptions.hasOwnProperty(`ignore`)
+      && !(isValidIgnoreMatcher(pluginOptions.ignore) || (Array.isArray(pluginOptions.ignore) && pluginOptions.ignore.every(isValidIgnoreMatcher)))) {
+    reporter.panic(`
+  The 'ignore' passed to gatsby-source-filesystem must be one of the following:
+    - string to be directly matched,
+    - string with glob patterns,
+    - regular expression test,
+    - function that takes the testString as an argument and returns a truthy value if it should be matched,
+    - an array of any number and mix of these types.
+
+  Please pick a valid 'ignore'. See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
+    `)
+  }
+
   const { createNode, deleteNode } = boundActionCreators
 
   let ready = false
 
   const watcher = chokidar.watch(pluginOptions.path, {
-    ignored: [
-      `**/*.un~`,
-      `**/.gitignore`,
-      `**/.npmignore`,
-      `**/.babelrc`,
-      `**/yarn.lock`,
-      `**/node_modules`,
-      `../**/dist/**`,
-    ],
+    ignored: pluginOptions.ignore ? DEFAULT_PATHS_TO_IGNORE.concat(pluginOptions.ignore) : DEFAULT_PATHS_TO_IGNORE,
   })
 
   const createAndProcessNode = path =>


### PR DESCRIPTION
# What
This PR introduces `ignore` parameter to gatsby-source-filesystem plugin options.

The 'ignore' passed must be one of the following:
    - string to be directly matched,
    - string with glob patterns,
    - regular expression test,
    - function that takes the testString as an argument and returns a truthy value if it should be matched,
    - an array of any number and mix of these types.

# Use case example

Imagine following directory structure
```
.
├── index.md
├── some directory
|   ├── index.md
|   └── sec
├── www
|   ├── src
|   |    ├── pages
|   |    └── ...
|   ├── gatsby-config.js
|   └── ...
├── tea.md
└── coffee.md
```
Currently, if you want to import all markdowns from the parent directory, you have to create separate plugin instance for each directory and each markdown file, which is very inconvenient.

You could try setting the `path` in `gatsby-config.js` as follow:
```
    {
      resolve: `gatsby-source-filesystem`,
      options: {
        name: `pages`,
        path: path.resolve(__dirname, '..'),
      },
    },
```
but it results in watching directory with gatsby files and because content of`.cache` is watched, it leads to endless recompilling.
Current PR let you import all markdown files as follow:
```
    {
      resolve: `gatsby-source-filesystem`,
      options: {
        name: `pages`,
        path: path.resolve(__dirname, '..'),
        ignore: `**/www/**`,
      },
    },
```. 