### PR TITLE
[v2] Preload links order

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -217,7 +217,7 @@ export default (pagePath, callback) => {
     .reverse()
     .forEach(script => {
       // Add preload <link>s for scripts.
-      headComponents.unshift(
+      headComponents.push(
         <link
           as="script"
           rel="preload"


### PR DESCRIPTION
Allow components in `setHeadComponents` to appear before auto-inserted bundle links.