### PR TITLE
[gatsby-transformer-remark] support frontmatter default values plugin option

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -10,7 +10,19 @@ Parses Markdown files using [Remark](http://remark.js.org/).
 
 ```javascript
 // In your gatsby-config.js
-plugins: [`gatsby-transformer-remark`];
+plugins: [
+  {
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      // define default values for frontmatter variables here (optional)
+      frontmatter: {
+        defaultValues: {
+          category: `Uncategorised`
+        }
+      }
+    }
+  }
+];
 ```
 
 A full explanation of how to use markdown in Gatsby can be found here:

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -4,7 +4,7 @@ const _ = require(`lodash`)
 
 module.exports = async function onCreateNode(
   { node, getNode, loadNodeContent, boundActionCreators },
-  pluginOptions
+  pluginOptions = {}
 ) {
   const { createNode, createParentChildLink } = boundActionCreators
 
@@ -18,6 +18,13 @@ module.exports = async function onCreateNode(
 
   const content = await loadNodeContent(node)
   let data = grayMatter(content, pluginOptions)
+  const frontmatterDefaults = pluginOptions.frontmatter && pluginOptions.frontmatter.defaultValues
+  if(frontmatterDefaults) {
+    const defaultKeys = _.keys(frontmatterDefaults)
+    for(const key of defaultKeys) {
+      data.data[key] = data.data[key] || frontmatterDefaults[key]
+    }
+  }
 
   // Convert date objects to string. Otherwise there's type mismatches
   // during inference as some dates are strings and others date objects.


### PR DESCRIPTION
This is for #5392. I'm quite not sure if it's okay to have this option defined at 2 levels deep frontmatter --> defaultValues, but this looks good to me.