### PR TITLE
Don't infer types for plugin provided GQL types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "yargs": "^10.0.3"
   },
   "engines": {
-    "yarn": "^1.2.1"
+    "yarn": "^1.2.1",
+    "node": ">=6.11.5"
   },
   "eslintIgnore": ["interfaces", "**/__tests__/fixtures/"],
   "private": true,

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/data-tree-utils-test.js.snap
@@ -5,6 +5,9 @@ Object {
   "anArray": Object {
     "field": "anArray",
   },
+  "context___nestedObject___name": Object {
+    "field": "context___nestedObject___name",
+  },
   "context___nestedObject___someOtherProperty": Object {
     "field": "context___nestedObject___someOtherProperty",
   },
@@ -51,6 +54,7 @@ Object {
   ],
   "context": Object {
     "nestedObject": Object {
+      "name": "Inner name",
       "someOtherProperty": 1,
     },
   },

--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -89,6 +89,7 @@ describe(`Gatsby data tree utils`, () => {
       },
       context: {
         nestedObject: {
+          name: `Inner name`,
           someOtherProperty: 3,
         },
       },
@@ -96,15 +97,15 @@ describe(`Gatsby data tree utils`, () => {
   ]
 
   it(`builds field examples from an array of nodes`, () => {
-    expect(getExampleValues(nodes)).toMatchSnapshot()
+    expect(getExampleValues({ nodes })).toMatchSnapshot()
   })
 
   it(`skips null fields`, () => {
-    expect(getExampleValues(nodes).iAmNull).not.toBeDefined()
+    expect(getExampleValues({ nodes }).iAmNull).not.toBeDefined()
   })
 
   it(`should not mutate the nodes`, () => {
-    getExampleValues(nodes)
+    getExampleValues({ nodes })
     expect(nodes[0].context.nestedObject).toBeNull()
     expect(nodes[1].context.nestedObject.someOtherProperty).toEqual(1)
     expect(nodes[2].context.nestedObject.someOtherProperty).toEqual(2)
@@ -112,44 +113,53 @@ describe(`Gatsby data tree utils`, () => {
   })
 
   it(`skips empty or sparse arrays`, () => {
-    expect(getExampleValues(nodes).emptyArray).not.toBeDefined()
-    expect(getExampleValues(nodes).hair).toBeDefined()
+    expect(getExampleValues({ nodes }).emptyArray).not.toBeDefined()
+    expect(getExampleValues({ nodes }).hair).toBeDefined()
+  })
+
+  it(`skips ignoredFields at the top level`, () => {
+    const example = getExampleValues({
+      nodes,
+      ignoreFields: [`name`, `anArray`],
+    })
+
+    expect(example.name).not.toBeDefined()
+    expect(example.anArray).not.toBeDefined()
+    expect(example.hair).toBeDefined()
+    expect(example.context.nestedObject.name).toBeDefined()
   })
 
   it(`build enum values for fields from array on nodes`, () => {
-    expect(buildFieldEnumValues(nodes)).toMatchSnapshot()
+    expect(buildFieldEnumValues({ nodes })).toMatchSnapshot()
   })
 
   it(`turns polymorphic fields null`, () => {
-    let example = getExampleValues([
-      { foo: null },
-      { foo: [1] },
-      { foo: { field: 1 } },
-    ])
+    let example = getExampleValues({
+      nodes: [{ foo: null }, { foo: [1] }, { foo: { field: 1 } }],
+    })
     expect(example.foo).toBe(INVALID_VALUE)
   })
 
   it(`handles polymorphic arrays`, () => {
-    let example = getExampleValues([
-      { foo: [[`foo`, `bar`]] },
-      { foo: [{ field: 1 }] },
-    ])
+    let example = getExampleValues({
+      nodes: [{ foo: [[`foo`, `bar`]] }, { foo: [{ field: 1 }] }],
+    })
     expect(example.foo).toBe(INVALID_VALUE)
   })
 
   it(`doesn't confuse empty fields for polymorhpic ones`, () => {
-    let example = getExampleValues([
-      { foo: { bar: 1 } },
-      { foo: null },
-      { foo: { field: 1 } },
-    ])
+    let example = getExampleValues({
+      nodes: [{ foo: { bar: 1 } }, { foo: null }, { foo: { field: 1 } }],
+    })
     expect(example.foo).toEqual({ field: 1, bar: 1 })
 
-    example = getExampleValues([
-      { foo: [{ bar: 1 }] },
-      { foo: null },
-      { foo: [{ field: 1 }, { baz: 1 }] },
-    ])
+    example = getExampleValues({
+      nodes: [
+        { foo: [{ bar: 1 }] },
+        { foo: null },
+        { foo: [{ field: 1 }, { baz: 1 }] },
+      ],
+    })
     expect(example.foo).toEqual([{ field: 1, bar: 1, baz: 1 }])
   })
 
@@ -199,7 +209,7 @@ describe(`Type conflicts`, () => {
       },
     ]
 
-    getExampleValues({ nodes, type: `NoConflict` })
+    getExampleValues({ nodes, typeName: `NoConflict` })
 
     expect(addConflictExampleSpy).not.toBeCalled()
   })
@@ -222,7 +232,7 @@ describe(`Type conflicts`, () => {
       },
     ]
 
-    getExampleValues({ nodes, type: `Conflict_1` })
+    getExampleValues({ nodes, typeName: `Conflict_1` })
 
     expect(addConflictSpy).toBeCalled()
     expect(addConflictSpy).toBeCalledWith(
@@ -230,7 +240,6 @@ describe(`Type conflicts`, () => {
       expect.any(Array)
     )
 
-    // expect(addConflictExampleSpy).toBeCalled()
     expect(addConflictExampleSpy).toHaveBeenCalledTimes(2)
     expect(addConflictExampleSpy).toBeCalledWith(
       expect.objectContaining({
@@ -256,7 +265,7 @@ describe(`Type conflicts`, () => {
       },
     ]
 
-    getExampleValues({ nodes, type: `Conflict_2` })
+    getExampleValues({ nodes, typeName: `Conflict_2` })
     expect(addConflictSpy).toBeCalled()
     expect(addConflictSpy).toBeCalledWith(
       `Conflict_2.arrayOfMixedType`,
@@ -272,5 +281,31 @@ describe(`Type conflicts`, () => {
         parent: nodes[0],
       })
     )
+  })
+
+  it(`Doesn't report ignored fields`, () => {
+    const nodes = [
+      {
+        id: `id1`,
+        stringOrNumber: `string`,
+        other: 1,
+      },
+      {
+        id: `id2`,
+        stringOrNumber: 5,
+        other: `foo`,
+      },
+    ]
+
+    getExampleValues({
+      nodes,
+      typeName: `Conflict_3`,
+      ignoreFields: [`stringOrNumber`],
+    })
+
+    expect(addConflictSpy).toBeCalled()
+    expect(addConflictSpy).toBeCalledWith(`Conflict_3.other`, expect.any(Array))
+    expect(addConflictSpy).not.toBeCalledWith(`Conflict_3.stringOrNumber`)
+    expect(addConflictExampleSpy).toBeCalled()
   })
 })

--- a/packages/gatsby/src/schema/build-connection-fields.js
+++ b/packages/gatsby/src/schema/build-connection-fields.js
@@ -17,7 +17,7 @@ const { buildFieldEnumValues } = require(`./data-tree-utils`)
 module.exports = type => {
   const enumValues = buildFieldEnumValues({
     nodes: type.nodes,
-    type: type.name,
+    typeName: type.name,
   })
   const { connectionType: groupConnection } = connectionDefinitions({
     name: _.camelCase(`${type.name} groupConnection`),

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -19,10 +19,7 @@ const { nodeInterface } = require(`./node-interface`)
 const { getNodes, getNode, getNodeAndSavePathDependency } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const { setFileNodeRootType } = require(`./types/type-file`)
-const {
-  clearTypeExampleValues,
-  getExampleValues,
-} = require(`./data-tree-utils`)
+const { clearTypeExampleValues } = require(`./data-tree-utils`)
 
 import type { ProcessedNodeType } from "./infer-graphql-type"
 
@@ -118,7 +115,7 @@ module.exports = async () => {
     const inferredFields = inferObjectStructureFromNodes({
       nodes: type.nodes,
       types: _.values(processedTypes),
-      exampleValue: getExampleValues({ type: type.name, nodes: type.nodes }),
+      ignoreFields: Object.keys(type.fieldsFromPlugins),
     })
 
     return {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -88,7 +88,6 @@ const extractFromEntries = (
   ) {
     // there is multiple types or array of multiple types
     if (selector) {
-      console.log(selector)
       typeConflictReporter.addConflict(selector, entriesOfUniqueType)
     }
     return INVALID_VALUE

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -2,9 +2,14 @@
 const _ = require(`lodash`)
 const flatten = require(`flat`)
 const typeOf = require(`type-of`)
+const invariant = require(`invariant`)
 
 const createKey = require(`./create-key`)
 const { typeConflictReporter } = require(`./type-conflict-reporter`)
+
+import type { TypeEntry } from "./type-conflict-reporter"
+
+type ExampleValue = Object
 
 const INVALID_VALUE = Symbol(`INVALID_VALUE`)
 const isDefined = v => v != null
@@ -34,7 +39,7 @@ const isEmptyObjectOrArray = (obj: any): boolean => {
 const isScalar = val => !_.isObject(val) || val instanceof Date
 
 const extractTypes = value => {
-  if (_.isArray(value)) {
+  if (Array.isArray(value)) {
     const uniqueTypes = _.uniq(
       value.filter(isDefined).map(item => extractTypes(item).type)
     ).sort()
@@ -67,7 +72,11 @@ const getExampleScalarFromArray = values =>
     null
   )
 
-const extractFromEntries = (entries, selector, key = null) => {
+const extractFromEntries = (
+  entries: TypeEntry[],
+  selector: string,
+  key: string
+): ?mixed => {
   const entriesOfUniqueType = _.uniqBy(entries, entry => entry.type)
 
   if (entriesOfUniqueType.length == 0) {
@@ -79,6 +88,7 @@ const extractFromEntries = (entries, selector, key = null) => {
   ) {
     // there is multiple types or array of multiple types
     if (selector) {
+      console.log(selector)
       typeConflictReporter.addConflict(selector, entriesOfUniqueType)
     }
     return INVALID_VALUE
@@ -88,14 +98,15 @@ const extractFromEntries = (entries, selector, key = null) => {
   const values = entries.map(entry => entry.value)
 
   const exampleValue = entriesOfUniqueType[0].value
+
   if (isScalar(exampleValue)) {
     return getExampleScalarFromArray(values)
   } else if (_.isObject(exampleValue)) {
-    if (_.isArray(exampleValue)) {
-      const concatanedItems = _.concat(...values)
+    if (Array.isArray(exampleValue)) {
+      const concatanedItems = [].concat(...values)
       // Linked node arrays don't get reduced further as we
       // want to preserve all the linked node types.
-      if (_.includes(key, `___NODE`)) {
+      if (key.includes(`___NODE`)) {
         return concatanedItems
       }
 
@@ -108,7 +119,7 @@ const extractFromEntries = (entries, selector, key = null) => {
   return INVALID_VALUE
 }
 
-const extractFromArrays = (values, entries, selector) => {
+const extractFromArrays = (values, entries: TypeEntry[], selector: string) => {
   const filteredItems = values.filter(isDefined)
   if (filteredItems.length === 0) {
     return null
@@ -117,19 +128,28 @@ const extractFromArrays = (values, entries, selector) => {
     return [getExampleScalarFromArray(filteredItems)]
   }
 
-  const flattenEntries = _.flatten(
-    entries.map(entry =>
-      entry.value.map(value => {
+  const flattenEntries: TypeEntry[] = _.flatten(
+    entries.map(entry => {
+      invariant(
+        Array.isArray(entry.value),
+        `this is validated in the previous call`
+      )
+
+      return entry.value.map(value => {
         return {
           value,
           parent: entry.parent,
           ...extractTypes(value),
         }
       })
-    )
+    })
   )
 
-  const arrayItemExample = extractFromEntries(flattenEntries, `${selector}[]`)
+  const arrayItemExample = extractFromEntries(
+    flattenEntries,
+    `${selector}[]`,
+    ``
+  )
   if (!isDefined(arrayItemExample) || arrayItemExample === INVALID_VALUE) {
     return INVALID_VALUE
   }
@@ -149,47 +169,54 @@ const extractFromArrays = (values, entries, selector) => {
  *
  * @param {*Nodes} args
  */
-const extractFieldExamples = (nodes: object[], selector: string) => {
+const extractFieldExamples = (
+  nodes: any[],
+  selector: string,
+  ignoreFields?: string[] = []
+): ExampleValue => {
   // get list of keys in all nodes
-  const allKeys = _.uniq(_.flatten(nodes.map(_.keys)))
+  const allKeys = _(nodes)
+    .flatMap(_.keys)
+    .uniq()
 
-  return _.pickBy(
-    _.zipObject(
-      allKeys,
-      allKeys.map(key => {
-        const nextSelector = selector && `${selector}.${key}`
+  const example = {}
+  for (let key of allKeys) {
+    if (ignoreFields.includes(key)) continue
+    const nextSelector = selector ? `${selector}.${key}` : key
 
-        const nodeWithValues = nodes.filter(node => {
-          if (!node) return false
+    const nodeWithValues = nodes.filter(node => {
+      if (!node) return false
 
-          const value = node[key]
-          if (_.isObject(value)) {
-            return !isEmptyObjectOrArray(value)
-          } else {
-            return isDefined(value)
-          }
-        })
+      const value = node[key]
+      if (_.isObject(value)) {
+        return !isEmptyObjectOrArray(value)
+      } else {
+        return isDefined(value)
+      }
+    })
 
-        // we want to keep track of nodes as we need it to get origin of data
-        const entries = nodeWithValues.map(node => {
-          const value = node[key]
-          return {
-            value,
-            parent: node,
-            ...extractTypes(value),
-          }
-        })
+    // we want to keep track of nodes as we need it to get origin of data
+    const entries = nodeWithValues.map(node => {
+      const value = node[key]
+      return {
+        value,
+        parent: node,
+        ...extractTypes(value),
+      }
+    })
 
-        return extractFromEntries(entries, nextSelector, key)
-      })
-    ),
-    isDefined
-  )
+    const value = extractFromEntries(entries, nextSelector, key)
+    if (!isDefined(value)) continue
+
+    example[key] = value
+  }
+
+  return example
 }
 
-const buildFieldEnumValues = arg => {
+const buildFieldEnumValues = (options: ExampleValueOptions) => {
   const enumValues = {}
-  const values = flatten(getExampleValues(arg), {
+  const values = flatten(getExampleValues(options), {
     maxDepth: 3,
     safe: true, // don't flatten arrays.
     delimiter: `___`,
@@ -202,63 +229,61 @@ const buildFieldEnumValues = arg => {
   return enumValues
 }
 
-// extract a list of field names
-// nested objects get flattened to "outer___inner" which will be converted back to
-// "outer.inner" by run-sift
-const extractFieldNames = arg => {
-  const values = flatten(getExampleValues(arg), {
-    maxDepth: 3,
-    safe: true, // don't flatten arrays.
-    delimiter: `___`,
-  })
-
-  return Object.keys(values)
-}
-
-let typeExampleValues = {}
+let typeExampleValues: Map<string, Object> = new Map()
 
 const clearTypeExampleValues = () => {
-  typeExampleValues = {}
+  typeExampleValues.clear()
   typeConflictReporter.clearConflicts()
 }
 
-const getNodesAndTypeFromArg = arg => {
-  let type, nodes
-
-  if (_.isPlainObject(arg)) {
-    type = arg.type
-    nodes = arg.nodes
-  } else if (_.isArray(arg)) {
-    nodes = arg
-    if (nodes.length > 0 && nodes[0].internal) {
-      type = nodes[0].internal.type
-    }
-  } else if (_.isString) {
-    type = arg
-  }
-
-  return { type, nodes }
+type ExampleValueOptions = {
+  nodes: Object[],
+  typeName?: string,
+  ignoreFields?: string[],
 }
 
-const getExampleValues = arg => {
-  const { type, nodes } = getNodesAndTypeFromArg(arg)
+const getExampleValues = ({
+  nodes,
+  typeName,
+  ignoreFields,
+}: ExampleValueOptions): ExampleValue => {
+  const cachedValue = typeName && typeExampleValues.get(typeName)
 
   // if type is defined and is in example value cache return it
-  if (type && type in typeExampleValues) {
-    return typeExampleValues[type]
-  }
+  if (cachedValue) return cachedValue
 
   // if nodes were passed extract field example from it
   if (nodes && nodes.length > 0) {
-    const exampleValue = extractFieldExamples(nodes, type)
+    const exampleValue = extractFieldExamples(
+      nodes,
+      typeName || ``,
+      ignoreFields
+    )
     // if type is set - cache results
-    if (type) {
-      typeExampleValues[type] = exampleValue
-    }
+    if (typeName) typeExampleValues.set(typeName, exampleValue)
     return exampleValue
   }
 
   return {}
+}
+
+// extract a list of field names
+// nested objects get flattened to "outer___inner" which will be converted back to
+// "outer.inner" by run-sift
+const extractFieldNames = (nodes: Object[]) => {
+  const values = flatten(
+    getExampleValues({
+      nodes,
+      typeName: _.get(nodes[0], `internal.type`),
+    }),
+    {
+      maxDepth: 3,
+      safe: true, // don't flatten arrays.
+      delimiter: `___`,
+    }
+  )
+
+  return Object.keys(values)
 }
 
 module.exports = {

--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -38,7 +38,7 @@ function makeNullable(type: GraphQLInputType): GraphQLNullableInputType<any> {
 
 function convertToInputType(
   type: GraphQLType,
-  typeMap: Set
+  typeMap: Set<GraphQLType>
 ): ?GraphQLInputType {
   // track types already processed in current tree, to avoid infinite recursion
   if (typeMap.has(type)) {

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -219,7 +219,7 @@ export function inferInputObjectStructureFromNodes({
 
   prefix = isRoot ? typeName : prefix
   if (exampleValue === null) {
-    exampleValue = getExampleValues(nodes)
+    exampleValue = getExampleValues({ nodes, typeName })
   }
 
   _.each(exampleValue, (v, k) => {
@@ -243,7 +243,7 @@ export function inferInputObjectStructureFromNodes({
         )
         value = getExampleValues({
           nodes: relatedNodes,
-          type: linkedNode.internal.type,
+          typeName: linkedNode.internal.type,
         })
         value = recursiveOmitBy(value, (_v, _k) => _.includes(_k, `___NODE`))
         linkedNodeCache[linkedNode.internal.type] = value

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -105,13 +105,15 @@ function inferGraphQLType({
       return {
         type: new GraphQLObjectType({
           name: createTypeName(fieldName),
-          fields: inferObjectStructureFromNodes({
-            ...otherArgs,
-            exampleValue,
-            selector,
-            nodes,
-            types,
-          }),
+          fields: _inferObjectStructureFromNodes(
+            {
+              ...otherArgs,
+              selector,
+              nodes,
+              types,
+            },
+            exampleValue
+          ),
         }),
       }
     case `number`:
@@ -299,8 +301,8 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
 type inferTypeOptions = {
   nodes: Object[],
   types: ProcessedNodeType[],
+  ignoreFields?: string[],
   selector?: string,
-  exampleValue?: Object,
 }
 
 const EXCLUDE_KEYS = {
@@ -311,12 +313,10 @@ const EXCLUDE_KEYS = {
 
 // Call this for the top level node + recursively for each sub-object.
 // E.g. This gets called for Markdown and then for its frontmatter subobject.
-export function inferObjectStructureFromNodes({
-  nodes,
-  types,
-  selector,
-  exampleValue = null,
-}: inferTypeOptions): GraphQLFieldConfigMap<*, *> {
+function _inferObjectStructureFromNodes(
+  { nodes, types, selector, ignoreFields }: inferTypeOptions,
+  exampleValue: ?Object
+): GraphQLFieldConfigMap<*, *> {
   const config = store.getState().config
   const isRoot = !selector
   const mapping = config && config.mapping
@@ -324,13 +324,15 @@ export function inferObjectStructureFromNodes({
   // Ensure nodes have internal key with object.
   nodes = nodes.map(n => (n.internal ? n : { ...n, internal: {} }))
 
-  const nodeTypeName = nodes[0].internal.type
-  if (exampleValue === null) {
-    exampleValue = getExampleValues({ type: nodeTypeName, nodes })
-  }
+  const typeName: string = nodes[0].internal.type
+
+  let resolvedExample: Object =
+    exampleValue != null
+      ? exampleValue
+      : getExampleValues({ nodes, typeName, ignoreFields })
 
   const inferredFields = {}
-  _.each(exampleValue, (value, key) => {
+  _.each(resolvedExample, (value, key) => {
     // Remove fields common to the top-level of all nodes.  We add these
     // elsewhere so don't need to infer their type.
     if (isRoot && EXCLUDE_KEYS[key]) return
@@ -338,7 +340,7 @@ export function inferObjectStructureFromNodes({
     // Several checks to see if a field is pointing to custom type
     // before we try automatic inference.
     const nextSelector = selector ? `${selector}.${key}` : key
-    const fieldSelector = `${nodeTypeName}.${nextSelector}`
+    const fieldSelector = `${typeName}.${nextSelector}`
 
     let fieldName = key
     let inferredField
@@ -350,9 +352,17 @@ export function inferObjectStructureFromNodes({
 
       // Second if the field has a suffix of ___node. We use then the value
       // (a node id) to find the node and use that node's type as the field
-    } else if (_.includes(key, `___NODE`)) {
+    } else if (key.includes(`___NODE`)) {
       ;[fieldName] = key.split(`___`)
       inferredField = inferFromFieldName(value, nextSelector, types)
+    }
+
+    // Replace unsupported values
+    const sanitizedFieldName = createKey(fieldName)
+
+    // If a pluging has already provided a type for this, don't infer it.
+    if (ignoreFields && ignoreFields.includes(sanitizedFieldName)) {
+      return
     }
 
     // Finally our automatic inference of field value type.
@@ -366,9 +376,6 @@ export function inferObjectStructureFromNodes({
     }
 
     if (!inferredField) return
-
-    // Replace unsupported values
-    const sanitizedFieldName = createKey(fieldName)
 
     // If sanitized field name is different from original field name
     // add resolve passthrough to reach value using original field name
@@ -399,4 +406,8 @@ export function inferObjectStructureFromNodes({
   })
 
   return inferredFields
+}
+
+export function inferObjectStructureFromNodes(options: inferTypeOptions) {
+  return _inferObjectStructureFromNodes(options, null)
 }

--- a/packages/gatsby/src/schema/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/type-conflict-reporter.js
@@ -5,6 +5,18 @@ const typeOf = require(`type-of`)
 const util = require(`util`)
 const { findRootNodeAncestor } = require(`./node-tracking`)
 
+export type TypeConflictExample = {
+  value: mixed,
+  parent: {},
+  type: string,
+  arrayTypes: string[],
+}
+
+type TypeConflict = {
+  value: mixed,
+  description: string,
+}
+
 const isNodeWithDescription = node =>
   node && node.internal && node.internal.description
 
@@ -49,21 +61,23 @@ const formatValue = value => {
 }
 
 class TypeConflictEntry {
-  constructor(selector) {
+  selector: string
+  types: Map<string, TypeConflict> = new Map()
+
+  constructor(selector: string) {
     this.selector = selector
-    this.types = {}
   }
 
-  addExample({ value, type, parent }) {
-    this.types[type] = {
+  addExample({ value, type, parent }: TypeConflictExample) {
+    this.types.set(type, {
       value,
       description: findNodeDescription(parent),
-    }
+    })
   }
 
   printEntry() {
     const sortedByTypeName = _.sortBy(
-      _.entries(this.types),
+      this.types.entries(),
       ([typeName, value]) => typeName
     )
 
@@ -81,25 +95,28 @@ class TypeConflictEntry {
 }
 
 class TypeConflictReporter {
+  entries: Map<string, TypeConflictEntry> = new Map()
+
   constructor() {
     this.clearConflicts()
   }
 
   clearConflicts() {
-    this.entries = {}
+    this.entries.clear()
   }
 
-  getFromSelector(selector) {
-    if (this.entries[selector]) {
-      return this.entries[selector]
+  getEntryFromSelector(selector: string): TypeConflictEntry {
+    let dataEntry = this.entries.get(selector)
+
+    if (!dataEntry) {
+      dataEntry = new TypeConflictEntry(selector)
+      this.entries.set(selector, dataEntry)
     }
 
-    const dataEntry = new TypeConflictEntry(selector)
-    this.entries[selector] = dataEntry
     return dataEntry
   }
 
-  addConflict(selector, examples) {
+  addConflict(selector: string, examples: TypeConflictExample[]) {
     if (selector.substring(0, 11) === `SitePlugin.`) {
       // Don't store and print out type conflicts in plugins.
       // This is out of user control so he can't do anything
@@ -107,19 +124,18 @@ class TypeConflictReporter {
       return
     }
 
-    const entry = this.getFromSelector(selector)
+    const entry = this.getEntryFromSelector(selector)
     examples
       .filter(example => example.value != null)
       .forEach(example => entry.addExample(example))
   }
 
   printConflicts() {
-    const entries = _.values(this.entries)
-    if (entries.length > 0) {
+    if (this.entries.size > 0) {
       report.warn(
         `There are conflicting field types in your data. GraphQL schema will omit those fields.`
       )
-      entries.forEach(entry => entry.printEntry())
+      this.entries.forEach(entry => entry.printEntry())
     }
   }
 }


### PR DESCRIPTION
This ended up optimizing code with the side benefit of fixing #5494 

What this is doing is skipping inference for top level node keys where a plugin has already provided a type manually. Which should also mean that you get no warnings for JSON scalars