### PR TITLE
Add link to example

### DIFF
--- a/packages/gatsby-source-faker/README.md
+++ b/packages/gatsby-source-faker/README.md
@@ -33,3 +33,5 @@ plugins: [
   },
 ];
 ```
+
+Example: [Using Faker](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-faker)


### PR DESCRIPTION
I was trying to figure out how to use this plugin, and found an example in the same repo that isn't linked here. 