### PR TITLE
[v2] Best practices/XHTML 5 compatibility

### DIFF
--- a/packages/gatsby/cache-dir/develop-static-entry.js
+++ b/packages/gatsby/cache-dir/develop-static-entry.js
@@ -28,7 +28,7 @@ Html = Html && Html.__esModule ? Html.default : Html
 
 export default (pagePath, callback) => {
   let headComponents = []
-  let htmlAttributes = {}
+  let htmlAttributes = {xmlns: `http://www.w3.org/1999/xhtml`}
   let bodyAttributes = {}
   let preBodyComponents = []
   let postBodyComponents = []

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -60,7 +60,7 @@ export default (pagePath, callback) => {
 
   let bodyHtml = ``
   let headComponents = []
-  let htmlAttributes = {}
+  let htmlAttributes = {xmlns: `http://www.w3.org/1999/xhtml`}
   let bodyAttributes = {}
   let preBodyComponents = []
   let postBodyComponents = []
@@ -207,7 +207,7 @@ export default (pagePath, callback) => {
       key={`webpack-runtime`}
       id={`webpack-runtime`}
       dangerouslySetInnerHTML={{
-        __html: runtimeRaw,
+        __html: `/*<![CDATA[*/${runtimeRaw} /*]]>*/`,
       }}
     />
   )
@@ -275,7 +275,7 @@ export default (pagePath, callback) => {
           page.jsonName in dataPaths
             ? `window.dataPath="${dataPaths[page.jsonName]}";`
             : ``
-        }[${scriptsString}].forEach(function(s){document.write('<script src="'+s+'" defer></'+'script>')})/*]]>*/`,
+        }[${scriptsString}].forEach(function(s){var d=document,e=d.createElement("script");e.async=false,e.src=s,d.head.appendChild(e)})/*]]>*/`,
       }}
     />
   )


### PR DESCRIPTION
I have my local dev server set up to serve `.html` files as `application/xhtml+xml` for no other reason than to catch potentially harmful issues in my code. When served as xhtml, https://html5.validator.nu/ will report additional possible errors that are ignored for html documents. Setting `xmlns` in the `html` element is mostly all that is needed to make it xhtml conformant.

"Another issue to be considered about using document.write command (and not only in a script injection case): if the DOM tree has already been built, the use of document.write will force the browser to build it again… A pity for the performance! (document.write writes to the document stream, calling document.write on a closed – loaded – document will reset the current document.)"

From: https://blog.dareboost.com/en/2016/09/avoid-using-document-write-scripts-injection/

Instead of defer, mozilla recommends using async=false instead.

From: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer