### PR TITLE
[v2] [gatsby-plugin-offline] get exact filenames for js staticFileGlob

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -1,3 +1,4 @@
+const fs = require(`fs`)
 const precache = require(`sw-precache`)
 const path = require(`path`)
 const slash = require(`slash`)
@@ -13,19 +14,37 @@ exports.createPages = ({ actions }) => {
   }
 }
 
+let s
+const readStats = () => {
+  if (s) {
+    return s
+  } else {
+    s = JSON.parse(
+      fs.readFileSync(`${process.cwd()}/public/webpack.stats.json`, `utf-8`)
+    )
+    return s
+  }
+}
+
+const getAssetsForChunks = (chunks, rootDir) => {
+  return _.flatten(chunks.map(chunk => readStats().assetsByChunkName[chunk]))
+    .filter(assetFileName => assetFileName.indexOf(`webpack-runtime-`) !== 0)
+    .map(assetFileName => `${rootDir}/${assetFileName}`)
+}
+
 exports.onPostBuild = (args, pluginOptions) => {
   const rootDir = `public`
 
+  // Get exact asset filenames for app and offline app shell chunks
+  const files = getAssetsForChunks(['app', 'component---node-modules-gatsby-plugin-offline-app-shell-js'], rootDir)
+
   const options = {
-    staticFileGlobs: [
-      `${rootDir}/**/*.{woff2}`,
-      `${rootDir}/commons-*js`,
-      `${rootDir}/app-*js`,
+    staticFileGlobs: files.concat([
       `${rootDir}/index.html`,
       `${rootDir}/manifest.json`,
       `${rootDir}/manifest.webmanifest`,
       `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
-    ],
+    ]),
     stripPrefix: rootDir,
     // If `pathPrefix` is configured by user, we should replace
     // the `public` prefix with `pathPrefix`.

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -26,17 +26,18 @@ const readStats = () => {
   }
 }
 
-const getAssetsForChunks = (chunks, rootDir) => {
-  return _.flatten(chunks.map(chunk => readStats().assetsByChunkName[chunk]))
+const getAssetsForChunks = (chunks, rootDir) => _.flatten(chunks.map(chunk => readStats().assetsByChunkName[chunk]))
     .filter(assetFileName => assetFileName.indexOf(`webpack-runtime-`) !== 0)
     .map(assetFileName => `${rootDir}/${assetFileName}`)
-}
 
 exports.onPostBuild = (args, pluginOptions) => {
   const rootDir = `public`
 
   // Get exact asset filenames for app and offline app shell chunks
-  const files = getAssetsForChunks(['app', 'component---node-modules-gatsby-plugin-offline-app-shell-js'], rootDir)
+  const files = getAssetsForChunks(
+    [`app`, `component---node-modules-gatsby-plugin-offline-app-shell-js`],
+    rootDir
+  )
 
   const options = {
     staticFileGlobs: files.concat([


### PR DESCRIPTION
Potentially we could read `.cache/pages.json` to get chunk names for index page too