### PR TITLE
Create retina screenshots

### DIFF
--- a/packages/gatsby-transformer-screenshot/lambda/index.js
+++ b/packages/gatsby-transformer-screenshot/lambda/index.js
@@ -83,7 +83,7 @@ exports.run = async (browser, url, width, height) => {
 
   const page = await browser.newPage()
 
-  await page.setViewport({ width, height })
+  await page.setViewport({ width, height, deviceScaleFactor: 2 })
   await page.goto(url, { waitUntil: [`load`, `networkidle0`] })
   // wait for full-size images to fade in
   await page.waitFor(1000);


### PR DESCRIPTION
The previous screenshots shown at full size on retina displays would be blurry