### PR TITLE
Add data attribute for language on gatsby highlight

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -22,7 +22,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\">
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\">
       <pre class=\\"custom-js\\"><code class=\\"custom-js\\"><span class=\\"token comment\\">// Fake</span></code></pre>
       </div>",
     },
@@ -65,7 +65,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\">
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"javascript\\">
       <pre class=\\"language-javascript\\"><code class=\\"language-javascript\\">// Fake</code></pre>
       </div>",
     },
@@ -108,7 +108,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\">
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\">
       <pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// Fake</span></code></pre>
       </div>",
     },

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -38,7 +38,7 @@ module.exports = (
     // Replace the node with the markup we need to make
     // 100% width highlighted code lines work
     node.type = `html`
-    node.value = `<div class="gatsby-highlight">
+    node.value = `<div class="gatsby-highlight" data-language="${languageName}">
       <pre class="${className}"><code class="${className}">${highlightCode(
       language,
       node.value,


### PR DESCRIPTION
Hi, I hope it is fine that I committed this very simple change trough Github's website.

Adding this data attribute makes it possible to work with the language in more ways (like styling):

![image](https://user-images.githubusercontent.com/6213695/40386441-0523dff0-5e0a-11e8-9446-2ad6e3674ecc.png)

This way we could style dynamically in CSS (no JS that needs to be run in the build):

```css
.gatsby-highlight::before {
  content: attr(data-language);
  …
}
```

Otherwise, when pulling in data from external sources (like Contentful) we have no way of accessing this and it needs a hacky workaround a la:

```js
document.querySelectorAll(`.gatsby-highlight`).forEach(codeblock => {
  const codeLang = codeblock.children[0].className.replace(`language-`, ``);
  codeblock.setAttribute(`data-language`, codeLang);
});
```

Let me know if this PR needs changes!