### PR TITLE
Fix README

### DIFF
--- a/packages/gatsby-source-faker/README.md
+++ b/packages/gatsby-source-faker/README.md
@@ -26,9 +26,9 @@ plugins: [
     options: {
       schema: {
         name: ["firstName", "lastName"],
-        count: 3, // how many fake objects you need
-        type: "NameData", // Name of the graphql query node
       },
+      count: 3, // how many fake objects you need
+      type: "NameData", // Name of the graphql query node
     },
   },
 ];


### PR DESCRIPTION
`count` and `type` should be siblings of `schema`.

Refs:
- https://github.com/gatsbyjs/gatsby/blob/master/examples/using-faker/gatsby-config.js
- https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-faker/src/gatsby-node.js#L6