### PR TITLE
[v2][www] Fix missing search sidebar for plugins/packages pages

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",
     "react-icons": "^2.2.7",
+    "react-instantsearch": "^4.5.1",
     "react-typography": "^0.16.13",
     "slash": "^1.0.0",
     "typeface-space-mono": "^0.0.54",

--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -1,9 +1,9 @@
 import React, { Component, Fragment } from "react"
-import SearchBar from "./searchbar-body"
+import PluginSearchBar from "./plugin-searchbar-body"
 import { rhythm } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
 
-class PageWithSearchBar extends Component {
+class PageWithPluginSearchBar extends Component {
   render() {
     const searchbarWidth = rhythm(17)
 
@@ -37,7 +37,7 @@ class PageWithSearchBar extends Component {
         <div
           css={{
             ...styles,
-            // mobile: hide SearchBar when on gatsbyjs.org/packages/foo, aka package README page
+            // mobile: hide PluginSearchBar when on gatsbyjs.org/packages/foo, aka package README page
             display: `${!this.props.isPluginsIndex && `none`}`,
             [presets.Tablet]: {
               ...tabletStyles,
@@ -45,7 +45,7 @@ class PageWithSearchBar extends Component {
             },
           }}
         >
-          <SearchBar history={this.props.history} />
+          <PluginSearchBar history={this.props.history} />
         </div>
         <div
           css={{
@@ -64,4 +64,4 @@ class PageWithSearchBar extends Component {
   }
 }
 
-export default PageWithSearchBar
+export default PageWithPluginSearchBar

--- a/www/src/components/page-with-searchbar.js
+++ b/www/src/components/page-with-searchbar.js
@@ -1,0 +1,67 @@
+import React, { Component, Fragment } from "react"
+import SearchBar from "./searchbar-body"
+import { rhythm } from "../utils/typography"
+import presets, { colors } from "../utils/presets"
+
+class PageWithSearchBar extends Component {
+  render() {
+    const searchbarWidth = rhythm(17)
+
+    const styles = {
+      height: `calc(100vh - ${presets.headerHeight} + 1px)`,
+      width: `100vw`,
+      padding: rhythm(3 / 4),
+      zIndex: 1,
+      WebkitOverflowScrolling: `touch`,
+      "::-webkit-scrollbar": {
+        width: `6px`,
+        height: `6px`,
+      },
+      "::-webkit-scrollbar-thumb": {
+        background: colors.ui.bright,
+      },
+      "::-webkit-scrollbar-track": {
+        background: colors.ui.light,
+      },
+    }
+
+    const tabletStyles = {
+      width: searchbarWidth,
+      position: `fixed`,
+      background: colors.ui.whisper,
+      borderRight: `1px solid ${colors.ui.light}`,
+    }
+
+    return (
+      <Fragment>
+        <div
+          css={{
+            ...styles,
+            // mobile: hide SearchBar when on gatsbyjs.org/packages/foo, aka package README page
+            display: `${!this.props.isPluginsIndex && `none`}`,
+            [presets.Tablet]: {
+              ...tabletStyles,
+              display: `block`,
+            },
+          }}
+        >
+          <SearchBar history={this.props.history} />
+        </div>
+        <div
+          css={{
+            // mobile: hide README on gatsbyjs.org/plugins index page
+            display: `${this.props.isPluginsIndex && `none` }`,
+            [presets.Tablet]: {
+              display: `block`,
+              paddingLeft: `${searchbarWidth}`,
+            },
+          }}
+        >
+          {this.props.children}
+        </div>
+      </Fragment>
+    )
+  }
+}
+
+export default PageWithSearchBar

--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -165,7 +165,7 @@ glam.insert(`
   }
 `)
 
-// Search shows a list of "hits", and is a child of the SearchBar component
+// Search shows a list of "hits", and is a child of the PluginSearchBar component
 class Search extends Component {
   constructor(props, context) {
     super(props)
@@ -391,7 +391,7 @@ const Result = ({ hit, pathname, search }) => {
 }
 
 // the search bar holds the Search component in the InstantSearch widget
-class SearchBar extends Component {
+class PluginSearchBar extends Component {
   constructor(props) {
     super(props)
     this.state = { searchState: { query: this.urlToSearch(), page: 1 } }
@@ -432,4 +432,4 @@ class SearchBar extends Component {
   }
 }
 
-export default SearchBar
+export default PluginSearchBar

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react"
 import Layout from "../components/layout"
 import Container from "../components/container"
+import PageWithSearchBar from "../components/page-with-searchbar"
 import { Link } from "gatsby"
 import logo from "../monogram.svg"
 import { rhythm, options } from "../utils/typography"
@@ -10,59 +11,61 @@ class Plugins extends Component {
   render() {
     return (
       <Layout location={this.props.location}>
-        <Container
-          css={{
-            alignItems: `center`,
-            display: `flex`,
-            minHeight: `calc(100vh - (${presets.headerHeight} + 2.8rem - 1px))`,
-          }}
-        >
-          <div
+        <PageWithSearchBar history={this.props.history} isPluginsIndex>
+          <Container
             css={{
+              alignItems: `center`,
               display: `flex`,
-              flexDirection: `column`,
+              minHeight: `calc(100vh - (${presets.headerHeight} + 2.8rem - 1px))`,
             }}
           >
-            <img
-              src={logo}
+            <div
               css={{
-                display: `inline-block`,
-                height: rhythm(5.2),
-                width: rhythm(5.2),
-                marginLeft: `auto`,
-                marginRight: `auto`,
-              }}
-              alt=""
-            />
-            <h1
-              css={{
-                fontSize: rhythm(1),
-                marginTop: rhythm(1 / 4),
-                marginLeft: rhythm(1),
-                marginRight: rhythm(1),
-                textAlign: `center`,
+                display: `flex`,
+                flexDirection: `column`,
               }}
             >
-              Welcome to the Gatsby Plugin Library!
-            </h1>
-            <p
-              css={{
-                color: colors.gray.calm,
-                marginLeft: rhythm(3),
-                marginRight: rhythm(3),
-                fontSize: rhythm(3 / 4),
-                fontFamily: options.headerFontFamily.join(`,`),
-                textAlign: `center`,
-              }}
-            >
-              Please use the search bar to find plugins that will make your
-              blazing-fast site even more awesome. If you'd like to create your
-              own plugin, see the{` `}
-              <Link to="/docs/plugin-authoring/">Plugin Authoring</Link> page in
-              the docs!
-            </p>
-          </div>
-        </Container>
+              <img
+                src={logo}
+                css={{
+                  display: `inline-block`,
+                  height: rhythm(5.2),
+                  width: rhythm(5.2),
+                  marginLeft: `auto`,
+                  marginRight: `auto`,
+                }}
+                alt=""
+              />
+              <h1
+                css={{
+                  fontSize: rhythm(1),
+                  marginTop: rhythm(1 / 4),
+                  marginLeft: rhythm(1),
+                  marginRight: rhythm(1),
+                  textAlign: `center`,
+                }}
+              >
+                Welcome to the Gatsby Plugin Library!
+              </h1>
+              <p
+                css={{
+                  color: colors.gray.calm,
+                  marginLeft: rhythm(3),
+                  marginRight: rhythm(3),
+                  fontSize: rhythm(3 / 4),
+                  fontFamily: options.headerFontFamily.join(`,`),
+                  textAlign: `center`,
+                }}
+              >
+                Please use the search bar to find plugins that will make your
+                blazing-fast site even more awesome. If you'd like to create your
+                own plugin, see the{` `}
+                <Link to="/docs/plugin-authoring/">Plugin Authoring</Link> page in
+                the docs!
+              </p>
+            </div>
+          </Container>
+        </PageWithSearchBar>
       </Layout>
     )
   }

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react"
 import Layout from "../components/layout"
 import Container from "../components/container"
-import PageWithSearchBar from "../components/page-with-searchbar"
+import PageWithPluginSearchBar from "../components/page-with-plugin-searchbar"
 import { Link } from "gatsby"
 import logo from "../monogram.svg"
 import { rhythm, options } from "../utils/typography"
@@ -11,7 +11,7 @@ class Plugins extends Component {
   render() {
     return (
       <Layout location={this.props.location}>
-        <PageWithSearchBar history={this.props.history} isPluginsIndex>
+        <PageWithPluginSearchBar history={this.props.history} isPluginsIndex>
           <Container
             css={{
               alignItems: `center`,
@@ -65,7 +65,7 @@ class Plugins extends Component {
               </p>
             </div>
           </Container>
-        </PageWithSearchBar>
+        </PageWithPluginSearchBar>
       </Layout>
     )
   }

--- a/www/src/templates/template-docs-local-packages.js
+++ b/www/src/templates/template-docs-local-packages.js
@@ -2,7 +2,7 @@ import React from "react"
 import _ from "lodash"
 
 import Layout from "../components/layout"
-import PageWithSearchBar from "../components/page-with-searchbar"
+import PageWithPluginSearchBar from "../components/page-with-plugin-searchbar"
 import PackageReadme from "../components/package-readme"
 
 class DocsLocalPackagesTemplate extends React.Component {
@@ -29,7 +29,7 @@ class DocsLocalPackagesTemplate extends React.Component {
 
     return (
       <Layout location={this.props.location}>
-        <PageWithSearchBar history={this.props.history}>
+        <PageWithPluginSearchBar history={this.props.history}>
           <PackageReadme
             page={markdownRemark ? _.pick(markdownRemark, `parent`) : false}
             packageName={
@@ -67,7 +67,7 @@ class DocsLocalPackagesTemplate extends React.Component {
                 : npmPackageNotFound.lastPublisher
             }
           />
-        </PageWithSearchBar>
+        </PageWithPluginSearchBar>
       </Layout>
     )
   }

--- a/www/src/templates/template-docs-local-packages.js
+++ b/www/src/templates/template-docs-local-packages.js
@@ -2,6 +2,7 @@ import React from "react"
 import _ from "lodash"
 
 import Layout from "../components/layout"
+import PageWithSearchBar from "../components/page-with-searchbar"
 import PackageReadme from "../components/package-readme"
 
 class DocsLocalPackagesTemplate extends React.Component {
@@ -28,43 +29,45 @@ class DocsLocalPackagesTemplate extends React.Component {
 
     return (
       <Layout location={this.props.location}>
-        <PackageReadme
-          page={markdownRemark ? _.pick(markdownRemark, `parent`) : false}
-          packageName={
-            markdownRemark
-              ? markdownRemark.fields.title
-              : markdownRemarkNotFound.fields.title
-          }
-          excerpt={
-            markdownRemark
-              ? markdownRemark.excerpt
-              : markdownRemarkNotFound.excerpt
-          }
-          html={
-            markdownRemark ? markdownRemark.html : markdownRemarkNotFound.html
-          }
-          githubUrl={`https://github.com/gatsbyjs/gatsby/tree/master/packages/${
-            markdownRemark
-              ? markdownRemark.fields.title
-              : markdownRemarkNotFound.fields.title
-          }`}
-          timeToRead={
-            markdownRemark
-              ? markdownRemark.timeToRead
-              : markdownRemarkNotFound.timeToRead
-          }
-          modified={
-            npmPackage ? npmPackage.modified : npmPackageNotFound.modified
-          }
-          keywords={
-            npmPackage ? npmPackage.keywords : npmPackageNotFound.keywords
-          }
-          lastPublisher={
-            npmPackage
-              ? npmPackage.lastPublisher
-              : npmPackageNotFound.lastPublisher
-          }
-        />
+        <PageWithSearchBar history={this.props.history}>
+          <PackageReadme
+            page={markdownRemark ? _.pick(markdownRemark, `parent`) : false}
+            packageName={
+              markdownRemark
+                ? markdownRemark.fields.title
+                : markdownRemarkNotFound.fields.title
+            }
+            excerpt={
+              markdownRemark
+                ? markdownRemark.excerpt
+                : markdownRemarkNotFound.excerpt
+            }
+            html={
+              markdownRemark ? markdownRemark.html : markdownRemarkNotFound.html
+            }
+            githubUrl={`https://github.com/gatsbyjs/gatsby/tree/master/packages/${
+              markdownRemark
+                ? markdownRemark.fields.title
+                : markdownRemarkNotFound.fields.title
+            }`}
+            timeToRead={
+              markdownRemark
+                ? markdownRemark.timeToRead
+                : markdownRemarkNotFound.timeToRead
+            }
+            modified={
+              npmPackage ? npmPackage.modified : npmPackageNotFound.modified
+            }
+            keywords={
+              npmPackage ? npmPackage.keywords : npmPackageNotFound.keywords
+            }
+            lastPublisher={
+              npmPackage
+                ? npmPackage.lastPublisher
+                : npmPackageNotFound.lastPublisher
+            }
+          />
+        </PageWithSearchBar>
       </Layout>
     )
   }

--- a/www/src/templates/template-docs-remote-packages.js
+++ b/www/src/templates/template-docs-remote-packages.js
@@ -1,7 +1,7 @@
 import React from "react"
 
 import Layout from "../components/layout"
-import PageWithSearchBar from "../components/page-with-searchbar"
+import PageWithPluginSearchBar from "../components/page-with-plugin-searchbar"
 import PackageReadme from "../components/package-readme"
 
 class DocsRemotePackagesTemplate extends React.Component {
@@ -11,7 +11,7 @@ class DocsRemotePackagesTemplate extends React.Component {
     } = this.props
     return (
       <Layout location={this.props.location}>
-        <PageWithSearchBar history={this.props.history}>
+        <PageWithPluginSearchBar history={this.props.history}>
           <PackageReadme
             page={markdownRemark}
             packageName={npmPackage.name}
@@ -27,7 +27,7 @@ class DocsRemotePackagesTemplate extends React.Component {
             keywords={npmPackage.keywords}
             lastPublisher={npmPackage.lastPublisher}
           />
-        </PageWithSearchBar>
+        </PageWithPluginSearchBar>
       </Layout>
     )
   }

--- a/www/src/templates/template-docs-remote-packages.js
+++ b/www/src/templates/template-docs-remote-packages.js
@@ -1,6 +1,7 @@
 import React from "react"
 
 import Layout from "../components/layout"
+import PageWithSearchBar from "../components/page-with-searchbar"
 import PackageReadme from "../components/package-readme"
 
 class DocsRemotePackagesTemplate extends React.Component {
@@ -10,21 +11,23 @@ class DocsRemotePackagesTemplate extends React.Component {
     } = this.props
     return (
       <Layout location={this.props.location}>
-        <PackageReadme
-          page={markdownRemark}
-          packageName={npmPackage.name}
-          excerpt={npmPackage.readme.childMarkdownRemark.excerpt}
-          html={npmPackage.readme.childMarkdownRemark.html}
-          githubUrl={
-            npmPackage.repository !== null
-              ? npmPackage.repository.url
-              : `https://github.com/search?q=${npmPackage.name}`
-          }
-          modified={npmPackage.modified}
-          timeToRead={npmPackage.readme.childMarkdownRemark.timeToRead}
-          keywords={npmPackage.keywords}
-          lastPublisher={npmPackage.lastPublisher}
-        />
+        <PageWithSearchBar history={this.props.history}>
+          <PackageReadme
+            page={markdownRemark}
+            packageName={npmPackage.name}
+            excerpt={npmPackage.readme.childMarkdownRemark.excerpt}
+            html={npmPackage.readme.childMarkdownRemark.html}
+            githubUrl={
+              npmPackage.repository !== null
+                ? npmPackage.repository.url
+                : `https://github.com/search?q=${npmPackage.name}`
+            }
+            modified={npmPackage.modified}
+            timeToRead={npmPackage.readme.childMarkdownRemark.timeToRead}
+            keywords={npmPackage.keywords}
+            lastPublisher={npmPackage.lastPublisher}
+          />
+        </PageWithSearchBar>
       </Layout>
     )
   }


### PR DESCRIPTION
Ref: https://github.com/gatsbyjs/gatsby/issues/5348#issuecomment-389814208

`PageWithSearchBar` component styles are taken from [master’s layout](https://github.com/gatsbyjs/gatsby/blob/master/www/src/layouts/index.js#L47-L121) and streamlined.