### PR TITLE
fix gatsby-remark-responsive-iframe doc

### DIFF
--- a/packages/gatsby-remark-responsive-iframe/README.md
+++ b/packages/gatsby-remark-responsive-iframe/README.md
@@ -33,5 +33,5 @@ example a percentage width), the wrapper will not be applied.
 Example usage:
 
     This is a beautiful iframe:
-
-    &lt;iframe url=&quot;http://www.example.com/&quot; width=&quot;600&quot; height=&quot;400&quot;&gt;&lt;/iframe&gt;
+    
+    <iframe url="http://www.example.com/" width="600" height="400"></iframe>


### PR DESCRIPTION
no need for escaped html right?