### PR TITLE
[documentation] Minor typo

### DIFF
--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -42,7 +42,7 @@ exports.resolvableExtensions = true
  *         // Create blog post pages.
  *         result.data.allMarkdownRemark.edges.forEach(edge => {
  *             createPage({
- *               path: `edge.node.fields.slug`, // required
+ *               path: `${edge.node.fields.slug}`, // required
  *               component: blogPostTemplate,
  *               context: {
  *                 // Add optional context data. Data can be used as


### PR DESCRIPTION
I replaced &#96;edge.node.fields.slug&#96; by &#96;${edge.node.fields.slug}&#96;

But maybe you prefer `edge.node.fields.slug` without backticks ? Feel free to modify it if so 😄 