### PR TITLE
[gatsby] WIP Fix 404 page rendered with missing props and without correct location.pathname

### DIFF
--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -170,17 +170,10 @@ apiRunnerAsync(`onClientEntry`).then(() => {
                   attachToHistory(routeProps.history)
                   const props = layoutProps ? layoutProps : routeProps
 
-                  if (loader.getPage(props.location.pathname)) {
-                    return createElement(ComponentRenderer, {
-                      page: true,
-                      ...props,
-                    })
-                  } else {
-                    return createElement(ComponentRenderer, {
-                      page: true,
-                      location: { pathname: `/404.html` },
-                    })
-                  }
+                  return createElement(ComponentRenderer, {
+                    page: true,
+                    ...props,
+                  })
                 },
               }),
           })


### PR DESCRIPTION
Currently no props (other than `location.pathname` are passed in to a custom 404 page, causing lots of potential errors when components used in the layout or in the page itself rely on props. This came to light in #5498 which highlighted the problem, but has lots of potential to effect projects that don't use styled components as well. The current implementation also overwrites `props.location.pathname`, meaning the path of the page that triggered the 404 is obliterated and is not available to the 404 page, so a message like 'There was no page found at /nope` is not possible because no matter what path triggered the 404, `location.pathname` is incorrectly forced to `/404`. This is doubly wrong because the url will still reflect the bad path.

It seems that there is duplicate handling of 404 pages both in `gatsby/cache-dir/production-app` and in `gatsby/cahce-dir/component-renderer`. Both check to see if the page is available, however the check that happens in `production-app` results in hardcoding of the `404.html` path, whereas the check that happens in `component-renderer` only results in the rendering of the 404 page, leaving `props.location.pathname` intact. In short, the check performed in `component-renderer` is enough on its own, so the extra check (which also has the negative side-effects of 1. obliterating the missing page path and 2. obliterating all props that the layout or other page components might be relying on) is unnecessary. 

This PR removes that check. I have verified that this fixes  #5498 and also resolves #5544 because the path is now available at `props.location.pathname`.

closes #5498
closes #5544