### PR TITLE
Fix outdated babel-code-frame import to use @babel/code-frame

### DIFF
--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
@@ -3,7 +3,7 @@
  */
 
 const { readFileSync } = require(`fs`)
-const babelCodeFrame = require(`babel-code-frame`)
+const babelCodeFrame = require(`@babel/code-frame`)
 const stackTrace = require(`stack-trace`)
 const { SourceMapConsumer } = require(`source-map`)
 

--- a/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/graphql-errors.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { print, visit, GraphQLError, getLocation } from "graphql"
-import babelCodeFrame from "babel-code-frame"
+import babelCodeFrame from "@babel/code-frame"
 import _ from "lodash"
 import report from "gatsby-cli/lib/reporter"
 


### PR DESCRIPTION
Fix #5584

Signed-off-by: Helder S Ribeiro <hsribei.pub@gmail.com>