### PR TITLE
fix: focus on the root div after navigation

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -149,6 +149,7 @@ class GatsbyLink extends React.Component {
                 // This is just a normal link to the current page so let's emulate default
                 // browser behavior by scrolling now to the top of the page.
                 window.scrollTo(0, 0)
+                document.querySelector(`#___gatsby`).focus()
                 return true
               }
             }


### PR DESCRIPTION
This fix applies focus to the main app div after page navigation, which triggers screen readers and other assistive tech to announce the new page. Thanks to @nickcolley for initially pointing this out, and to @LJWatson for jumping in with a fix!

fix #5581