### PR TITLE
Add envinfo to gatsby-cli, issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,10 @@ What happened.
 
 ### Environment
 
-<!-- Required. Run `gatsby info --clipboard` in your gatsby project directory and paste its contents here. -->
+<!--
+  Required. Run `gatsby info --clipboard` in your gatsby project directory and paste its contents here.
+  Not working? You may need to update your global gatsby-cli - `npm install -g gatsby-cli`
+-->
 
 ### File contents (if changed)
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,12 +30,11 @@ What should happen?
 What happened.
 
 ### Environment
-* Gatsby version (`npm list gatsby`):
-* gatsby-cli version (`gatsby --version`):
-* Node.js version:
-* Operating System:
+
+<!-- Required. Run `gatsby info --clipboard` in your gatsby project directory and paste its contents here. -->
 
 ### File contents (if changed)
+
 `gatsby-config.js`: N/A <!-- Please use a code block or just leave it as is if wasn't changed -->
 `package.json`: N/A <!-- Please use a code block or just leave it as is if wasn't changed -->
 `gatsby-node.js`: N/A <!-- Please use a code block or just leave it as is if wasn't changed -->

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -52,5 +52,4 @@ the site for testing.
 
 ### Info
 
-At the root of a Gatsby site run `gatsby info` to get helpful environment information which
-and will be required when reporting a bug.
+At the root of a Gatsby site run `gatsby info` to get helpful environment information which will be required when reporting a bug.

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -49,3 +49,8 @@ site.
 
 At the root of a Gatsby site run `gatsby serve` to serve the production build of
 the site for testing.
+
+### Info
+
+At the root of a Gatsby site run `gatsby info` to get helpful environment information which
+and will be required when reporting a bug.

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -16,6 +16,7 @@
     "common-tags": "^1.4.0",
     "convert-hrtime": "^2.0.0",
     "core-js": "^2.5.0",
+    "envinfo": "^5.8.1",
     "execa": "^0.8.0",
     "fs-extra": "^4.0.1",
     "hosted-git-info": "^2.5.0",

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -201,7 +201,7 @@ function buildLocalCommands(cli, isLocalSite) {
           }
         )
       } catch (err) {
-        console.log("Error: unable to print environment info")
+        console.log(`Error: unable to print environment info`)
         console.log(err)
       }
     },

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -3,6 +3,7 @@ const resolveCwd = require(`resolve-cwd`)
 const yargs = require(`yargs`)
 const report = require(`./reporter`)
 const fs = require(`fs`)
+const envinfo = require(`envinfo`)
 
 const DEFAULT_BROWSERS = [`> 1%`, `last 2 versions`, `IE >= 9`]
 
@@ -172,6 +173,38 @@ function buildLocalCommands(cli, isLocalSite) {
         }),
 
     handler: getCommandHandler(`serve`),
+  })
+
+  cli.command({
+    command: `info`,
+    desc: `Get environment information for debugging and issue reporting`,
+    builder: _ =>
+      _.option(`C`, {
+        alias: `clipboard`,
+        type: `boolean`,
+        default: false,
+        describe: `Automagically copy environment information to clipboard`,
+      }),
+    handler: args => {
+      try {
+        envinfo.run(
+          {
+            System: [`OS`, `CPU`, `Shell`],
+            Binaries: [`Node`, `npm`, `Yarn`],
+            Browsers: [`Chrome`, `Edge`, `Firefox`, `Safari`],
+            npmPackages: `gatsby*`,
+            npmGlobalPackages: `gatsby*`,
+          },
+          {
+            console: true,
+            clipboard: args.clipboard,
+          }
+        )
+      } catch (err) {
+        console.log("Error: unable to print environment info")
+        console.log(err)
+      }
+    },
   })
 }
 


### PR DESCRIPTION
Add `gatsby info --clipboard` returns something like this:

Note: npmPackages and npmGlobalPackages will return all gatsby packages matching glob "gatsby*"
```
  System:
    OS: macOS High Sierra 10.13
    CPU: x64 Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
    Shell: 5.4.2 - /usr/local/bin/zsh
  Binaries:
    Node: 8.11.0 - ~/.nvm/versions/node/v8.11.0/bin/node
    Yarn: 1.5.1 - ~/.yarn/bin/yarn
    npm: 5.6.0 - ~/.nvm/versions/node/v8.11.0/bin/npm
  Browsers:
    Chrome: 67.0.3396.62
    Firefox: 59.0.2
    Safari: 11.0
  npmPackages:
    gatsby: 1.9.261
  npmGlobalPackages:
    gatsby-cli: 1.1.52
```