### PR TITLE
Add more conditions for Categories and Tags on Post

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -192,15 +192,17 @@ exports.mapPostsToTagsCategories = entities => {
   const categories = entities.filter(e => e.__type === `wordpress__CATEGORY`)
 
   return entities.map(e => {
-    if (e.__type === `wordpress__POST`) {
+    let hasCategories = (e.categories && e.categories.length);
+    let hasTags = (e.tags && e.tags.length);
+    if (e.__type === `wordpress__POST` || hasCategories || hasTags ) {
       // Replace tags & categories with links to their nodes.
-      if (e.tags.length) {
+      if (hasTags) {
         e.tags___NODE = e.tags.map(
           t => tags.find(tObj => t === tObj.wordpress_id).id
         )
         delete e.tags
       }
-      if (e.categories.length) {
+      if (hasCategories) {
         e.categories___NODE = e.categories.map(
           c => categories.find(cObj => c === cObj.wordpress_id).id
         )

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -192,9 +192,8 @@ exports.mapPostsToTagsCategories = entities => {
   const categories = entities.filter(e => e.__type === `wordpress__CATEGORY`)
 
   return entities.map(e => {
-    let hasCategories = (e.categories && e.categories.length);
-    let hasTags = (e.tags && e.tags.length);
-    if (e.__type === `wordpress__POST` || hasCategories || hasTags ) {
+    let hasCategories = (e.categories && Array.isArray(e.categories) && e.categories.length);
+    let hasTags = (e.tags && Array.isArray(e.tags) && e.tags.length);
       // Replace tags & categories with links to their nodes.
       if (hasTags) {
         e.tags___NODE = e.tags.map(
@@ -208,7 +207,6 @@ exports.mapPostsToTagsCategories = entities => {
         )
         delete e.categories
       }
-    }
     return e
   })
 }

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -192,8 +192,8 @@ exports.mapPostsToTagsCategories = entities => {
   const categories = entities.filter(e => e.__type === `wordpress__CATEGORY`)
 
   return entities.map(e => {
-    let hasCategories = (e.categories && Array.isArray(e.categories) && e.categories.length);
-    let hasTags = (e.tags && Array.isArray(e.tags) && e.tags.length);
+    let hasCategories = (e.categories && Array.isArray(e.categories) && e.categories.length)
+    let hasTags = (e.tags && Array.isArray(e.tags) && e.tags.length)
       // Replace tags & categories with links to their nodes.
       if (hasTags) {
         e.tags___NODE = e.tags.map(


### PR DESCRIPTION
Hi,

This is made to solve this problems :

-Some Posts can have removed taxonomy like tags or categories using something like this in WordPress : 
`   	unregister_taxonomy_for_object_type( 'category', 'post' );
`
The plugin can't check the length of categories or tags if null

-Custom posts , who doesn't have the type `wordpress__POST` ,  but they need to have linked categories and/or tags to their nodes for GraphQL request