### PR TITLE
[gatsby-wordpress-source] Adds initial support for Gravity Forms

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -248,6 +248,37 @@ async function fetchData({
         }
       }
     }
+    // Gravity Forms
+    if (type == `wordpress__gf_forms`) {
+      for (let key in routeResponse) {
+        for (let formKey in routeResponse[key]) {
+          let form = routeResponse[key][formKey]
+          if (form && form.id && form.title) {
+            // Ex. /gf/v2/forms/12
+            let formUrl = `${url}/${form.id}`
+            let fetchedData = await fetchData({
+              route: { url: formUrl, type: `${type}_items` },
+              _verbose,
+              _perPage,
+              _hostingWPCOM,
+              _auth,
+              _accessToken,
+            })
+            entities = entities.concat(fetchedData)
+          }
+        }
+      }
+      if (_hostingWPCOM) {
+        // TODO : Need to test that out with Gravity Forms on Wordpress.com hosted site. Need a premium account on wp.com to install extensions. See also ACF options page.
+        if (_verbose)
+          console.log(
+            colorized.out(
+              `Gravity Forms untested under wordpress.com hosting. Please let me know if it works.`,
+              colorized.color.Effect.Blink
+            )
+          )
+      }
+    }
     // TODO : Get the number of created nodes using the nodes in state.
     let length
     if (routeResponse && Array.isArray(routeResponse)) {

--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -257,7 +257,7 @@ async function fetchData({
             // Ex. /gf/v2/forms/12
             let formUrl = `${url}/${form.id}`
             let fetchedData = await fetchData({
-              route: { url: formUrl, type: `${type}_items` },
+              route: { url: formUrl, type: `${type}` },
               _verbose,
               _perPage,
               _hostingWPCOM,

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -66,6 +66,8 @@
       link: /docs/api-proxy/
     - title: Search Engine Optimization (SEO)
       link: /docs/seo/
+    - title: Source Plugin Tutorial
+      link: /docs/source-plugin-tutorial/
     - title: Using CSS-in-JS Library Glamor
       link: /docs/glamor/
     - title: Using CSS-in-JS Library Styled Components
@@ -80,6 +82,8 @@
       link: /docs/adding-search/
     - title: Working With Images in Gatsby
       link: /docs/working-with-images/
+    - title: Wordpress Source Plugin Tutorial
+      link: /docs/wordpress-source-plugin-tutorial
     - title: Creating Dynamically-Rendered Navigation*
       link: /docs/creating-dynamically-rendered-navigation/
     - title: Dropping Images into Static Folders*

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -66,8 +66,6 @@
       link: /docs/api-proxy/
     - title: Search Engine Optimization (SEO)
       link: /docs/seo/
-    - title: Source Plugin Tutorial
-      link: /docs/source-plugin-tutorial/
     - title: Using CSS-in-JS Library Glamor
       link: /docs/glamor/
     - title: Using CSS-in-JS Library Styled Components
@@ -82,8 +80,6 @@
       link: /docs/adding-search/
     - title: Working With Images in Gatsby
       link: /docs/working-with-images/
-    - title: Wordpress Source Plugin Tutorial
-      link: /docs/wordpress-source-plugin-tutorial
     - title: Creating Dynamically-Rendered Navigation*
       link: /docs/creating-dynamically-rendered-navigation/
     - title: Dropping Images into Static Folders*


### PR DESCRIPTION
This pull request adds initial support for querying Gravity Forms, one the most popular WordPress plugins. 

This scope of this PR to add initial support for forms, so you can create a form within WordPress (ex. a contact form) and then display it on your site.

Here’s an example GraphQL query are now able to do:

```graphql
{
  wordpressGfForms(wordpress_id: {eq: 1}) {
    title
    description
    labelPlacement
    button {
      type
      text
    }
    wordpress_fields {
      label
      type
      isRequired
      inputMask
    }
    version
    useCurrentUserAsAuthor
    postContentTemplateEnabled
    # There is a lot more available…
  }
}
```

…and the response:

```json
{
"wordpressGfForms": {
      "title": "Contact Us",
      "description": "The default form for the Contact page.",
      "labelPlacement": "top_label",
      "button": {
        "type": "text",
        "text": "Submit"
      },
      "wordpress_fields": [
        {
          "label": "Names",
          "type": "text",
          "isRequired": true,
          "inputMask": false
        },
        {
          "label": "About you",
          "type": "textarea",
          "isRequired": true,
          "inputMask": false
        }
      ],
      "version": "2.3.2.1",
      "useCurrentUserAsAuthor": true,
      "postContentTemplateEnabled": false
    }
}
```

You also get access to `allWordpressGfForms`.

I’m working on another React component that will help with things from there, but obviously that part it outside of the scope of Gatsby. Feel free to let me know if this is of interest to you though!

Gravity Forms also has an endpoint for entries, so in theory you would be able to accept form submissions, manage them within your headless WordPress CMS, and then have Gatsby display them in some other way.

### Questions

Where is the right place for WordPress plugin wrappers to live?

The existing list of plugins that `gatsby-wordpress-source` has built-in for is short, and it probably makes sense it should stay that way. Gravity Forms is probably the only other plugin that I personally know of that makes sense to add to the list, but I’m open to moving this somewhere else if you’d like to cut that list off.

At some point there may need to be some kind of hook to support any WordPress plugin rather than just a conditional in this Gatsby plugin, but that time probably isn’t yet. :)

### Other things to note

- The Gravity Forms endpoint requires the basic auth setup, because the forms and especially the form data are sensitive
- I haven’t tried this with a WordPress.com setup, but added in the same console note as was done with the ACF plugin
- I based this on the WP menus implementation, but it could get a config option like ACF if you’re interested in this plugin being fully supported

### Links

- [Gravity Forms](https://www.gravityforms.com/)
- [Gravity Forms WP REST API v2 documentation](https://github.com/gravityforms/gravityformsrestapi)

Thanks for taking the time to review!