### PR TITLE
[v2] Add the source plugin tutorial to the site nav

### DIFF
--- a/docs/docs/source-plugin-tutorial.md
+++ b/docs/docs/source-plugin-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: "Source plugin tutorial"
+title: "Source Plugin Tutorial"
 ---
 
 Creating your own source plugin.

--- a/docs/docs/wordpress-source-plugin-tutorial.md
+++ b/docs/docs/wordpress-source-plugin-tutorial.md
@@ -1,3 +1,7 @@
+---
+title: "Wordpress Source Plugin Tutorial"
+---
+
 ## How to create a site with data pulled from WordPress 
 
 ### What this tutorial covers:

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -84,6 +84,8 @@
       link: /docs/adding-search/
     - title: Working With Images in Gatsby
       link: /docs/working-with-images/
+    - title: Wordpress Source Plugin Tutorial
+      link: /docs/wordpress-source-plugin-tutorial/
     - title: Creating Dynamically-Rendered Navigation*
       link: /docs/creating-dynamically-rendered-navigation/
     - title: Dropping Images into Static Folders*

--- a/www/src/pages/docs/doc-links.yaml
+++ b/www/src/pages/docs/doc-links.yaml
@@ -40,6 +40,8 @@
       link: /docs/creating-and-modifying-pages/
     - title: Create a Source Plugin
       link: /docs/create-source-plugin/
+    - title: Source Plugin Tutorial
+      link: /docs/source-plugin-tutorial/
     - title: Custom webpack config
       link: /docs/add-custom-webpack-config/
     - title: Customizing html.js


### PR DESCRIPTION
The [source plugin tutorial](https://www.gatsbyjs.org/docs/source-plugin-tutorial/) is live on the site, but it doesn't appear in gatsbyjs.org's sidebar nav yet. This PR adds it to the nav.

This is slightly awkward naming as we now have "Create a Source Plugin" and "Source Plugin Tutorial" next to each other in the nav. And in the future we might have more source plugin tutorials.

Ok to publish like this or do we want to think about the naming a bit more? @KyleAMathews @shannonbux. 

