### PR TITLE
fix: syntax error in docs

### DIFF
--- a/examples/using-remark/src/pages/2018-01-27---custom-components/index.md
+++ b/examples/using-remark/src/pages/2018-01-27---custom-components/index.md
@@ -107,7 +107,7 @@ In order to display this component within a Markdown file, you'll need to add a 
 
     ```js
     {
-      renderAst(post.htmlAst);
+      renderAst(post.htmlAst)
     }
     ```
 


### PR DESCRIPTION
There was a semicolon in the example code that tripped me up for a while today. Removed.