### PR TITLE
support multiple files for codesandbox import

### DIFF
--- a/packages/gatsby-remark-code-repls/README.md
+++ b/packages/gatsby-remark-code-repls/README.md
@@ -80,7 +80,7 @@ Sometimes a larger code example would require more than a single file, with vari
 CodesandBox supports code example with multiple files. With this plugin, you can do:
 
 ```html
-[Try it on CodePen](codesandbox://my-example/index.js,my-example/util.js,my-example/index.css)
+[Try it on CodeSandbox](codesandbox://my-example/index.js,my-example/util.js,my-example/index.css)
 ```
 
 > Caveat
@@ -90,9 +90,9 @@ CodesandBox supports code example with multiple files. With this plugin, you can
 And in `index.js`, you could import other files using the ES6 modules syntax:
 
 ```js
-import { foo } from './utils';
+import { foo } from "./utils"
 
-import './index.css';
+import "./index.css"
 ```
 
 ### How does it work?

--- a/packages/gatsby-remark-code-repls/README.md
+++ b/packages/gatsby-remark-code-repls/README.md
@@ -42,7 +42,7 @@ to HTML links that open the embedded code examples in a REPL. For example:
 
 ```html
 <!-- before -->
-[See it in Babel](babel://hello-world)
+[See it in Babel](babel://hello-world.js)
 
 <!-- after -->
 <a href="https://babeljs.io/repl/#?presets=react&code_lz=...">
@@ -50,7 +50,7 @@ to HTML links that open the embedded code examples in a REPL. For example:
 </a>
 
 <!-- before -->
-[Try it on CodePen](codepen://components-and-props/rendering-a-component)
+[Try it on CodePen](codepen://components-and-props/rendering-a-component.js)
 
 <!-- after -->
 <a href="/redirect-to-codepen/components-and-props/rendering-a-component">
@@ -58,12 +58,41 @@ to HTML links that open the embedded code examples in a REPL. For example:
 </a>
 
 <!-- before -->
-[Try it on CodeSandbox](codesandbox://components-and-props/rendering-a-component)
+[Try it on CodeSandbox](codesandbox://components-and-props/rendering-a-component.js)
 
 <!-- after -->
 <a href="https://codesandbox.io/api/v1/sandboxes/define?parameters=...">
   Try it on CodeSandbox
 </a>
+```
+
+### Creating CodeSandbox Example With Multiple Files
+
+Sometimes a larger code example would require more than a single file, with various types. For example, you might have an example folder like this:
+
+```
+├── my-example
+│   ├── index.js
+│   ├── util.js
+│   └── index.css
+```
+
+CodesandBox supports code example with multiple files. With this plugin, you can do:
+
+```html
+[Try it on CodePen](codesandbox://my-example/index.js,my-example/util.js,my-example/index.css)
+```
+
+> Caveat
+>
+> The first file path you passed to `codesandbox://` will be the entry of your example, that is, the `main` field specified in your `package.json`.
+
+And in `index.js`, you could import other files using the ES6 modules syntax:
+
+```js
+import { foo } from './utils';
+
+import './index.css';
 ```
 
 ### How does it work?

--- a/packages/gatsby-remark-code-repls/README.md
+++ b/packages/gatsby-remark-code-repls/README.md
@@ -77,7 +77,7 @@ Sometimes a larger code example would require more than a single file, with vari
 │   └── index.css
 ```
 
-CodesandBox supports code example with multiple files. With this plugin, you can do:
+CodeSandbox supports code example with multiple files. With this plugin, you can do:
 
 ```html
 [Try it on CodeSandbox](codesandbox://my-example/index.js,my-example/util.js,my-example/index.css)

--- a/packages/gatsby-remark-code-repls/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-code-repls/src/__tests__/__snapshots__/index.js.snap
@@ -217,7 +217,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDwsIANwAEEFgF4AOiABOpUrQcA-IwHpTZ9_OFIWGIEZBA9ekYkcIo4WgswFwsbCwcAIzRHBwBueQUgA\\" >REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqIQ6WgAsA9LVLzy8ei3mRYxBPyEgJbAB4FZtEVGY1GDJlIA8LCADcABBBYBeADogATqSktL4AfPbyTs4hIPoyCkoqajAaWoQkVnS2SCDWcLSuYIGunq6-AEZofr4A3DF6QA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -427,7 +427,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTzMBOMTE0QgoaenCYAaEIOEBaFqQC2SEORgAPGSBT9SKBbQCeHBKICMAVgLWQAX1kq0ESqMixiCB05Bu2LQIAC1oVKGYaRgYREAAeFggANwACCBYAXgAdOVJSWhyAPjiAekSkwsdZT0ISSLoY9SipFLA8lIyUnIAjNH4cgG5HXyA\\" >REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTzMBOMTE0QgoaenCYAaEIOEBaFqQC2SEORgAPGSBT9SKBbQCeHBKICMAVgLWQAX1kq0ESqPS0AFgHpapH00pGBYfSFhiBAcnEDc2LQIvWhUoZhpGBhEQAB4WCAA3AAIIFgBeAB05UlJaSoA-bJ88_LrHWU9ff0D4elDwwhI0ukz1dKlCsGrC0sLKgCM0fkqAbkdooA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -469,7 +469,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDxx05AAQQWAXgA64UqXsA-IwHpTacs_nDIsYgRkED16RiQQijhaczBHc2tzewAjNAAnewBueQUgA\\" >REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqIQ6WgAsA9LVLzy8ei3mRYxBPyEgJbAB4FZtEVGY1GDJlIA8cdOQAEEFgF4AOuFKkfAHz28k5o5AEg-jIKSipqMBpahCRWdLZIINZwtC5gfi4eLj4ARmgATj4A3JF6QA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -493,6 +493,48 @@ Object {
       "column": 41,
       "line": 1,
       "offset": 40,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`gatsby-remark-code-repls CodeSandbox remark transform supports importing multiple files 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "html",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqIQ6WgAsA9LVLzy8ei3mRYxBPyEgJbAB4FZtEVGY1GDJlIA8LCADcABBBYBeADogATqSktL4AfPbyTs4hIPoyCkoqajAaWoQkVnS2SCDWcLSuYIGunq6-AEZofr4A3DHCcYrKqnnJ8mjkQbIwfgBi0GkIyDmZjNm5-YWkxaUgFVUgtbFoco2JLSn9BBhwg9QjdsPkeQVFJeWVNTF6QA\\" >REPL</a>",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 95,
+          "line": 1,
+          "offset": 94,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 95,
+      "line": 1,
+      "offset": 94,
     },
     "start": Object {
       "column": 1,

--- a/packages/gatsby-remark-code-repls/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-code-repls/src/__tests__/__snapshots__/index.js.snap
@@ -217,7 +217,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-ggDQgI5NgA9iCZCBqMGTRHIpxaAAjClS6gLzqAOiABGaAE5GA3CH4ixkggAtaAWyjN59RkhAAeFhAAbuoQLLpGZtq0RgB8vgD0AYExNoJAA\\" >REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDwsIANwAEEFgF4AOiABOpUrQcA-IwHpTZ9_OFIWGIEZBA9ekYkcIo4WgswFwsbCwcAIzRHBwBueQUgA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -259,7 +259,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-ggDQgI5NgA9iCZCBqMGTRHIpxaAAjClS6gLzqAOiABGaAE5GA3CH4ixkggAtaAWyjN59RkhAAeFhAAbuoQLLpGZtq0RgB8vgD0AYExNoJAA\\" >REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDwsIANwAEEFgF4AOiABOpUrQcA-IwHpTZ9_OFIWGIEZBA9ekYkcIo4WgswFwsbCwcAIzRHBwBueQUgA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -301,7 +301,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-ggDQgI5NgA9iCZCBqMGTRHIpxaAAjClS6gLzqAOiABGaAE5GA3CH4ixkggAtaAWyjN59RkhAAeFhAAbuoQLLpGZtq0RgB8vgD0AYExNoJAA\\" >Click me</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDwsIANwAEEFgF4AOiABOpUrQcA-IwHpTZ9_OFIWGIEZBA9ekYkcIo4WgswFwsbCwcAIzRHBwBueQUgA\\" >Click me</a>",
         },
       ],
       "position": Position {
@@ -343,7 +343,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-ggDQgI5NgA9iCZCBqMGTRHIpxaAAjClS6gLzqAOiABGaAE5GA3CH4ixkggAtaAWyjN59RkhAAeFhAAbuoQLLpGZtq0RgB8vgD0AYExNoJAA\\" >Custom link text</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDwsIANwAEEFgF4AOiABOpUrQcA-IwHpTZ9_OFIWGIEZBA9ekYkcIo4WgswFwsbCwcAIzRHBwBueQUgA\\" >Custom link text</a>",
         },
       ],
       "position": Position {
@@ -385,7 +385,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-ggDQgI5NgA9iCZCBqMGTRHIpxaAAjClS6gLzqAOiABGaAE5GA3CH4ixkggAtaAWyjN59RkhAAeFhAAbuoQLLpGZtq0RgB8vgD0AYExNoJAA\\" target=\\"_blank\\" rel=\\"noreferrer\\">REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDwsIANwAEEFgF4AOiABOpUrQcA-IwHpTZ9_OFIWGIEZBA9ekYkcIo4WgswFwsbCwcAIzRHBwBueQUgA\\" target=\\"_blank\\" rel=\\"noreferrer\\">REPL</a>",
         },
       ],
       "position": Position {
@@ -427,7 +427,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTzMBOMTE0QgoaenCYAaEIOEBaFqQC2SEORgAPGSBT9SKBbQCeHBKICMAVgLWQAXyeyI5NluIXqdBiJA1yKQACMFJSIIBeIIAdEAAjNH5YgG5HFzdtAgALWhUoZgD6RnUAHhYIADcgiBYI2INSWliAPhKAenKK5scnIA\\" >REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTzMBOMTE0QgoaenCYAaEIOEBaFqQC2SEORgAPGSBT9SKBbQCeHBKICMAVgLWQAX1kq0ESqMixiCB05Bu2LQIAC1oVKGYaRgYREAAeFggANwACCBYAXgAdOVJSWhyAPjiAekSkwsdZT0ISSLoY9SipFLA8lIyUnIAjNH4cgG5HXyA\\" >REPL</a>",
         },
       ],
       "position": Position {
@@ -469,7 +469,7 @@ Object {
       "children": Array [
         Object {
           "type": "html",
-          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-ggDQgI5NgA9iCZCBqMGTRHIpxaAAjClS6gLzqAOiABGaAE5GA3CH4ixkggAtaAWyjN59RkhAAeOOjk6hAsukZapEYAfL4A9AFo5FE2gkA\\" >REPL</a>",
+          "value": "<a href=\\"https://codesandbox.io/api/v1/sandboxes/define?parameters=N4IgZglgNgpgziAXKADgQwMYGs0HMYB0AVnAPYB2SoGFALjObVSACYwoNvkYTxUC-AGhABbNBEqJw0QiRD8hICWwAeBABa0RUZjUYMmUgDxx05AAQQWAXgA64UqXsA-IwHpTacs_nDIsYgRkED16RiQQijhaczBHc2tzewAjNAAnewBueQUgA\\" >REPL</a>",
         },
       ],
       "position": Position {

--- a/packages/gatsby-remark-code-repls/src/__tests__/index.js
+++ b/packages/gatsby-remark-code-repls/src/__tests__/index.js
@@ -125,11 +125,12 @@ describe(`gatsby-remark-code-repls`, () => {
         const markdownAST = remark.parse(
           `[](${protocol}path/to/nested/file.js,path/to/nested/anotherFile.js,path/to/nested/file.css)`
         )
-        const runPlugin = () => plugin({ markdownAST }, { directory: `examples` })
+        const runPlugin = () =>
+          plugin({ markdownAST }, { directory: `examples` })
 
         if (protocol !== PROTOCOL_CODE_SANDBOX) {
           expect(runPlugin).toThrow(
-            `Code example path should only contain a single file, but found more than one: ` + 
+            `Code example path should only contain a single file, but found more than one: ` +
               `path/to/nested/file.js,path/to/nested/anotherFile.js,path/to/nested/file.css. ` +
               `Only CodeSandbox REPL supports multiple files entries, the protocol prefix of which starts with codesandbox://`
           )

--- a/packages/gatsby-remark-code-repls/src/__tests__/index.js
+++ b/packages/gatsby-remark-code-repls/src/__tests__/index.js
@@ -121,6 +121,22 @@ describe(`gatsby-remark-code-repls`, () => {
         )
       })
 
+      it(`errors if you provide multiple files in non-codesandbox examples`, () => {
+        const markdownAST = remark.parse(
+          `[](${protocol}path/to/nested/file.js,path/to/nested/anotherFile.js,path/to/nested/file.css)`
+        )
+        const runPlugin = () => plugin({ markdownAST }, { directory: `examples` })
+
+        if (protocol !== PROTOCOL_CODE_SANDBOX) {
+          expect(runPlugin).toThrow(
+            `Code example path should only contain a single file, but found more than one: ` +
+              `path/to/nested/file.js,path/to/nested/anotherFile.js,path/to/nested/file.css`
+          )
+        } else {
+          expect(runPlugin).not.toThrow()
+        }
+      })
+
       if (protocol === PROTOCOL_CODE_SANDBOX) {
         it(`supports custom html config option for index html`, () => {
           const markdownAST = remark.parse(
@@ -151,6 +167,14 @@ describe(`gatsby-remark-code-repls`, () => {
             }
           )
 
+          expect(transformed).toMatchSnapshot()
+        })
+
+        it(`supports importing multiple files`, () => {
+          const markdownAST = remark.parse(
+            `[](${protocol}path/to/nested/file.js,path/to/nested/anotherFile.js,path/to/nested/file.css)`
+          )
+          const transformed = plugin({ markdownAST }, { directory: `examples` })
           expect(transformed).toMatchSnapshot()
         })
       }

--- a/packages/gatsby-remark-code-repls/src/__tests__/index.js
+++ b/packages/gatsby-remark-code-repls/src/__tests__/index.js
@@ -129,8 +129,9 @@ describe(`gatsby-remark-code-repls`, () => {
 
         if (protocol !== PROTOCOL_CODE_SANDBOX) {
           expect(runPlugin).toThrow(
-            `Code example path should only contain a single file, but found more than one: ` +
-              `path/to/nested/file.js,path/to/nested/anotherFile.js,path/to/nested/file.css`
+            `Code example path should only contain a single file, but found more than one: ` + 
+              `path/to/nested/file.js,path/to/nested/anotherFile.js,path/to/nested/file.css. ` +
+              `Only CodeSandbox REPL supports multiple files entries, the protocol prefix of which starts with codesandbox://`
           )
         } else {
           expect(runPlugin).not.toThrow()

--- a/packages/gatsby-remark-code-repls/src/index.js
+++ b/packages/gatsby-remark-code-repls/src/index.js
@@ -57,7 +57,7 @@ module.exports = (
 
   const getFilePath = (url, protocol, directory) => {
     let filePath = url.replace(protocol, ``)
-    if (!filePath.endsWith(`.js`) && !filePath.endsWith(`.css`)) {
+    if (!filePath.indexOf(`.`) > 0) {
       filePath += `.js`
     }
     filePath = normalizePath(join(directory, filePath))
@@ -66,7 +66,7 @@ module.exports = (
 
   const getMultipleFilesPaths = (urls, protocol, directory) => (
     urls.replace(protocol, ``).split(`,`).map((url) => {
-      if (!url.endsWith(`.js`) && !url.endsWith(`.css`)) {
+      if (!url.indexOf(`.`) > 0) {
         url += `.js`
       }
       
@@ -79,7 +79,10 @@ module.exports = (
 
   const verifyFile = (path, protocol) => {
     if (protocol !== PROTOCOL_CODE_SANDBOX && path.split(`,`).length > 1) {
-      throw Error(`Code example path should only contain a single file, but found more than one: ${path.replace(directory, ``)}`)
+      throw Error(
+        `Code example path should only contain a single file, but found more than one: ${path.replace(directory, ``)}. ` +
+          `Only CodeSandbox REPL supports multiple files entries, the protocol prefix of which starts with ${PROTOCOL_CODE_SANDBOX}`
+      )
     }
     if (!fs.existsSync(path)) {
       throw Error(`Invalid REPL link specified; no such file "${path}"`)

--- a/packages/gatsby-remark-code-repls/src/index.js
+++ b/packages/gatsby-remark-code-repls/src/index.js
@@ -64,23 +64,28 @@ module.exports = (
     return filePath
   }
 
-  const getMultipleFilesPaths = (urls, protocol, directory) => (
-    urls.replace(protocol, ``).split(`,`).map((url) => {
-      if (!url.includes(`.`)) {
-        url += `.js`
-      }
-      
-      return {
-        url,  // filename itself
-        filePath: normalizePath(join(directory, url)),  // absolute path
-      }
-    })
-  )
+  const getMultipleFilesPaths = (urls, protocol, directory) =>
+    urls
+      .replace(protocol, ``)
+      .split(`,`)
+      .map(url => {
+        if (!url.includes(`.`)) {
+          url += `.js`
+        }
+
+        return {
+          url, // filename itself
+          filePath: normalizePath(join(directory, url)), // absolute path
+        }
+      })
 
   const verifyFile = (path, protocol) => {
     if (protocol !== PROTOCOL_CODE_SANDBOX && path.split(`,`).length > 1) {
       throw Error(
-        `Code example path should only contain a single file, but found more than one: ${path.replace(directory, ``)}. ` +
+        `Code example path should only contain a single file, but found more than one: ${path.replace(
+          directory,
+          ``
+        )}. ` +
           `Only CodeSandbox REPL supports multiple files entries, the protocol prefix of which starts with ${PROTOCOL_CODE_SANDBOX}`
       )
     }
@@ -89,7 +94,8 @@ module.exports = (
     }
   }
 
-  const verifyMultipleFiles = (paths, protocol) => paths.forEach((path) => verifyFile(path.filePath, protocol))
+  const verifyMultipleFiles = (paths, protocol) =>
+    paths.forEach(path => verifyFile(path.filePath, protocol))
 
   map(markdownAST, (node, index, parent) => {
     if (node.type === `link`) {
@@ -115,7 +121,11 @@ module.exports = (
 
         convertNodeToLink(node, text, href, target)
       } else if (node.url.startsWith(PROTOCOL_CODE_SANDBOX)) {
-        const filesPaths = getMultipleFilesPaths(node.url, PROTOCOL_CODE_SANDBOX, directory)
+        const filesPaths = getMultipleFilesPaths(
+          node.url,
+          PROTOCOL_CODE_SANDBOX,
+          directory
+        )
         verifyMultipleFiles(filesPaths, PROTOCOL_CODE_SANDBOX)
 
         // CodeSandbox GET API requires a list of "files" keyed by name

--- a/packages/gatsby-remark-code-repls/src/index.js
+++ b/packages/gatsby-remark-code-repls/src/index.js
@@ -57,7 +57,7 @@ module.exports = (
 
   const getFilePath = (url, protocol, directory) => {
     let filePath = url.replace(protocol, ``)
-    if (!filePath.indexOf(`.`) > 0) {
+    if (!filePath.includes(`.`)) {
       filePath += `.js`
     }
     filePath = normalizePath(join(directory, filePath))
@@ -66,7 +66,7 @@ module.exports = (
 
   const getMultipleFilesPaths = (urls, protocol, directory) => (
     urls.replace(protocol, ``).split(`,`).map((url) => {
-      if (!url.indexOf(`.`) > 0) {
+      if (!url.includes(`.`)) {
         url += `.js`
       }
       


### PR DESCRIPTION
Reference: https://github.com/reactjs/reactjs.org/pull/913

This PR adds the ability when you want to import a CodeSandbox with multiple files (like css files). So you could do something like:

```
[codesandbox://components-and-props/rendering-a-component.js,components-and-props/rendering-a-component.css]
```

However, I came across an issue when we have more than one JavaScript files and could not decide which one is the entry. Previously we just port whatever content into `index.js` and that becomes the entry. My current quick workaround is to allow only a single JavaScript file in the list and throw an error if it's more than one. The advantage is that it has a good backward compatibility. We don't need to change the name of the file or add extraneous logic.

Anyway, I tested with the reactjs.org repo and it works. But I'm not quite sure about the changes of the snapshot test, which causes the fail of the CI build. Do I need to just change the snapshot accordingly?

cc @bvaughn @washingtonsoares
