### PR TITLE
[gatsby-transformer-sqip] use process.env.GATSBY_BUILD_DIR

### DIFF
--- a/packages/gatsby-transformer-sqip/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sqip/src/extend-node-type.js
@@ -20,7 +20,8 @@ const generateSqip = require(`./generate-sqip`)
 
 const debug = Debug(`gatsby-transformer-sqip`)
 const SUPPORTED_NODES = [`ImageSharp`, `ContentfulAsset`]
-const CACHE_DIR = resolve(process.cwd(), `public`, `static`)
+const buildDirectory = process.env.GATSBY_BUILD_DIR || `public`
+const CACHE_DIR = resolve(process.cwd(), buildDirectory, `static`)
 
 module.exports = async args => {
   const {


### PR DESCRIPTION
missed in #4756