### PR TITLE
Fixes template literal in develop command

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -159,7 +159,7 @@ async function startServer(program) {
   app.get(`*`, (req, res, next) => {
     // Load file but ignore errors.
     res.sendFile(
-      directoryPath(`/${buildDirectory}{decodeURIComponent(req.path)}`),
+      directoryPath(`/${buildDirectory}/${decodeURIComponent(req.path)}`),
       err => {
         // No err so a file was sent successfully.
         if (!err || !err.path) {


### PR DESCRIPTION
When running develop the catchall (*) route will not find any pages. This should resolve that problem.