### PR TITLE
fix(sqip): ensures that the cache dir exists

### DIFF
--- a/packages/gatsby-transformer-sqip/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sqip/src/extend-node-type.js
@@ -31,6 +31,10 @@ module.exports = async args => {
   if (!SUPPORTED_NODES.includes(name)) {
     return {}
   }
+
+  // Ensure cache dir exists
+  await fs.ensureDir(CACHE_DIR)
+
   if (name === `ImageSharp`) {
     return sqipSharp(args)
   }


### PR DESCRIPTION
On fresh installs with contentful sqip fails when `public/static` does not exist. This fixes this issue.