### PR TITLE
[remark-copy-linked-files] Fix ignored html siblings

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -130,11 +130,42 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalledTimes(2)
   })
 
+  it(`can copy HTML multiple images when some are in ignore extensions`, async () => {
+    const path1 = `images/sample-image.jpg`
+    const path2 = `images/another-sample-image.gif`
+
+    const markdownAST = remark.parse(
+      `<div><img src="${path1}"><img src="${path2}"></div>`
+    )
+
+    await plugin({
+      files: [...getFiles(path1), ...getFiles(path2)],
+      markdownAST,
+      markdownNode,
+      getNode,
+    })
+
+    expect(fsExtra.copy).toHaveBeenCalledTimes(1)
+  })
+
   it(`can copy HTML videos`, async () => {
     const path = `videos/sample-video.mp4`
 
     const markdownAST = remark.parse(
       `<video controls="controls" autoplay="true" loop="true">\n<source type="video/mp4" src="${path}"></source>\n<p>Your browser does not support the video element.</p>\n</video>`
+    )
+
+    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).toHaveBeenCalled()
+  })
+
+  it(`can copy HTML videos when some siblings are in ignore extensions`, async () => {
+    const path = `videos/sample-video.mp4`
+    const path1 = `images/sample-image.jpg`
+
+    const markdownAST = remark.parse(
+      `<div><img src="${path1}"><video controls="controls" autoplay="true" loop="true">\n<source type="video/mp4" src="${path}"></source>\n<p>Your browser does not support the video element.</p>\n</video></div>`
     )
 
     await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -215,11 +215,9 @@ module.exports = (
           .attr(`src`)
           .split(`.`)
           .pop()
-        if (options.ignoreFileExtensions.includes(ext)) {
-          return
+        if (!options.ignoreFileExtensions.includes(ext)) {
+          generateImagesAndUpdateNode(thisImg, node)
         }
-
-        generateImagesAndUpdateNode(thisImg, node)
       } catch (err) {
         // Ignore
       }
@@ -243,18 +241,16 @@ module.exports = (
           .attr(`src`)
           .split(`.`)
           .pop()
-        if (options.ignoreFileExtensions.includes(ext)) {
-          return
+        if (!options.ignoreFileExtensions.includes(ext)) {
+          // The link object will be modified to the new location so we'll
+          // use that data to update our ref
+          const link = { url: thisVideo.attr(`src`) }
+          visitor(link)
+          node.value = node.value.replace(
+            new RegExp(thisVideo.attr(`src`), `g`),
+            link.url
+          )
         }
-
-        // The link object will be modified to the new location so we'll
-        // use that data to update our ref
-        const link = { url: thisVideo.attr(`src`) }
-        visitor(link)
-        node.value = node.value.replace(
-          new RegExp(thisVideo.attr(`src`), `g`),
-          link.url
-        )
       } catch (err) {
         // Ignore
       }
@@ -278,16 +274,14 @@ module.exports = (
           .attr(`src`)
           .split(`.`)
           .pop()
-        if (options.ignoreFileExtensions.includes(ext)) {
-          return
+        if (!options.ignoreFileExtensions.includes(ext)) {
+          const link = { url: thisAudio.attr(`src`) }
+          visitor(link)
+          node.value = node.value.replace(
+            new RegExp(thisAudio.attr(`src`), `g`),
+            link.url
+          )
         }
-
-        const link = { url: thisAudio.attr(`src`) }
-        visitor(link)
-        node.value = node.value.replace(
-          new RegExp(thisAudio.attr(`src`), `g`),
-          link.url
-        )
       } catch (err) {
         // Ignore
       }
@@ -311,17 +305,15 @@ module.exports = (
           .attr(`href`)
           .split(`.`)
           .pop()
-        if (options.ignoreFileExtensions.includes(ext)) {
-          return
+        if (!options.ignoreFileExtensions.includes(ext)) {
+          const link = { url: thisATag.attr(`href`) }
+          visitor(link)
+
+          node.value = node.value.replace(
+            new RegExp(thisATag.attr(`href`), `g`),
+            link.url
+          )
         }
-
-        const link = { url: thisATag.attr(`href`) }
-        visitor(link)
-
-        node.value = node.value.replace(
-          new RegExp(thisATag.attr(`href`), `g`),
-          link.url
-        )
       } catch (err) {
         // Ignore
       }


### PR DESCRIPTION
Update the visit calls to continue through all siblings even after finding files in the ignore extensions array

Fixes https://github.com/gatsbyjs/gatsby/issues/5644