### PR TITLE
[gatsby-image] add css blur for better looking placeholders

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -200,6 +200,11 @@ class Image extends React.Component {
     const imagePlaceholderStyle = {
       opacity: this.state.imgLoaded ? 0 : 1,
       transitionDelay: `0.25s`,
+      filter: `blur(12px)`,
+      WebkitFilter: `blur(12px)`,
+      MozFilter: `blur(12px)`,
+      msFilter: `blur(12px`,
+      OFilter: `blur(12px)`,
       ...imgStyle,
     }
 


### PR DESCRIPTION
This adds a CSS blur filter to the placeholder images to make them look less blocky.

Screenshots:

Without CSS blur filter:
<img width="608" alt="screen shot 2018-05-31 at 6 17 19 pm" src="https://user-images.githubusercontent.com/2531751/40816281-edd6b018-6500-11e8-8e53-646cf93044f2.png">


With CSS blur filter:
<img width="609" alt="screen shot 2018-05-31 at 6 17 10 pm" src="https://user-images.githubusercontent.com/2531751/40816284-f993bb12-6500-11e8-824e-a3e32428fea8.png">
