### PR TITLE
schema: fix not preferring floats over ints in some situations

### DIFF
--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -162,6 +162,39 @@ describe(`Gatsby data tree utils`, () => {
     example = getExampleValues([{ foo: [() => {}] }])
     expect(example.foo).not.toBeDefined()
   })
+
+  it(`prefers float when multiple number types`, () => {
+    let example
+
+    // nodes starting with integer
+    example = getExampleValues({ nodes: [{ number: 5 }, { number: 2.5 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(2.5)
+
+    // with node not containing number field
+    example = getExampleValues({ nodes: [{ number: 5 }, {}, { number: 2.5 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(2.5)
+
+    // nodes starting with float
+    example = getExampleValues({ nodes: [{ number: 2.5 }, { number: 5 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(2.5)
+
+    // array of numbers - starting with integer
+    example = getExampleValues({ nodes: [{ numbers: [2.5, 5] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(2.5)
+
+    // array of numbers - starting with float
+    example = getExampleValues({ nodes: [{ numbers: [5, 2.5] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(2.5)
+  })
 })
 
 describe(`Type conflicts`, () => {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -56,8 +56,8 @@ const getExampleScalarFromArray = values =>
     values,
     (value, nextValue) => {
       // Prefer floats over ints as they're more specific.
-      if (value && _.isNumber(value) && !_.isInteger(value)) {
-        return value
+      if (nextValue && _.isNumber(nextValue) && !_.isInteger(nextValue)) {
+        return nextValue
       } else if (value === null) {
         return nextValue
       } else {


### PR DESCRIPTION
If first node or first element of array is integer and float is further in chain, gatsby wouldn't pick float as type. This was probably broken by me in #3905

fixes #5486