### PR TITLE
[tutorial] Add notice regarding 4-part tutorial near the top

### DIFF
--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -7,6 +7,10 @@ typora-copy-images-to: ./
 
 In this tutorial, you'll be learning about how to pull data into your Gatsby site using GraphQL and source plugins. Before you learn about these plugins, however, you'll want to know how to use something called Graph_i_QL, a tool that helps you structure your queries correctly.
 
+> _Note: this is the second of a 4-part tutorial (tutorial #4 through #7).  
+If you have skipped the first part, you should go back and complete it first.  
+[Click here to go back to tutorial #4](/tutorial/part-four/)._
+
 ## Introducing Graph_i_QL
 
 Graph_i_QL is the GraphQL integrated development environment (IDE). It's a powerful (and all-around awesome) tool

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -6,6 +6,9 @@ typora-copy-images-to: ./
 Welcome to Part Four of the tutorial! Halfway through! Hope things are starting
 to feel pretty comfortable 😀
 
+> _Note: this is the first of a 4-part tutorial through tutorial #7.  
+Tutorial #5, #6, and #7 will only make sense if you start here and progress in order._
+
 ## Recap of first half of the tutorial
 
 So far, we've been learning how to use React.js—how powerful it is to be able to

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -18,6 +18,10 @@ ways to use it for the remainder of the tutorial.
 
 Let's get started.
 
+> _Note: this is the last of a 4-part tutorial (tutorial #4 through #7).  
+If you have skipped any of the previous parts, you should go back and complete them first.  
+Click to go back to the [first (#4)](/tutorial/part-four/), [second (#5)](/tutorial/part-five/), or [third (#6)](/tutorial/part-six/) part._
+
 ## Creating slugs for pages
 
 Creating new pages has two steps:

--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -7,6 +7,10 @@ typora-copy-images-to: ./
 
 The previous tutorial showed how source plugins bring data _into_ Gatsby’s data system. In this tutorial, you'll learn how transformer plugins _transform_ the raw content brought by source plugins. The combination of source plugins and transformer plugins can handle all data sourcing and data transformation you might need when building a Gatsby site.
 
+> _Note: this is the third of a 4-part tutorial (tutorial #4 through #7).  
+If you have skipped any of the previous parts, you should go back and complete them first.  
+Click to go back to the [first (#4)](/tutorial/part-four/) or [second (#5)](/tutorial/part-five/) part._
+
 ## Transformer plugins
 
 Often, the format of the data we get from source plugins isn't what you want to


### PR DESCRIPTION
Refs: https://github.com/gatsbyjs/gatsby/issues/5612

The notice seems more casual, less in your face, when put after the first section instead of at the very top. Let me know what you think, @shannonbux.