### PR TITLE
[v2][gatsby] added TypeScript typings for StaticQuery component

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1,0 +1,14 @@
+import * as React from "react"
+
+interface StaticQueryRenderProps {
+  data: any
+}
+
+type RenderCallback = (props: StaticQueryRenderProps) => JSX.Element
+
+export interface StaticQueryProps {
+  query: any
+  render: RenderCallback
+}
+
+export class StaticQuery extends React.Component<Partial<StaticQueryProps>> {}

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -147,8 +147,10 @@
   },
   "files": [
     "./cache-dir",
-    "./dist"
+    "./dist",
+    "./index.d.ts"
   ],
+  "types": "index.d.ts",
   "homepage": "https://github.com/gatsbyjs/gatsby#readme",
   "keywords": [
     "blog",


### PR DESCRIPTION
This should make StaticQuery calls not give out any type errors in
TypeScript. Types are intentionally made weak, as I couldn't figure out
how to correctly type any GraphQL calls [here](https://github.com/gatsbyjs/gatsby/blob/v2/packages/gatsby/cache-dir/gatsby-browser-entry.js#L17-L34).