### PR TITLE
webpack hmr path responding appropriately to env GATSBY_WEBPACK_PUBLICPATH

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -85,20 +85,20 @@ module.exports = async (
       program.ssl ? `https` : `http`
     }://${
       program.host
-    }:${webpackPort}/`;
+    }:${webpackPort}/`
 
-    const hmrSuffix = '__webpack_hmr&reload=true&overlay=false';
+    const hmrSuffix = `__webpack_hmr&reload=true&overlay=false`
 
     if (process.env.GATSBY_WEBPACK_PUBLICPATH) {
-      const pubPath = process.env.GATSBY_WEBPACK_PUBLICPATH;
-      if (pubPath.substr(-1) === '/') {
-        hmrBasePath = pubPath;
+      const pubPath = process.env.GATSBY_WEBPACK_PUBLICPATH
+      if (pubPath.substr(-1) === `/`) {
+        hmrBasePath = pubPath
       } else {
-        hmrBasePath = `${pubPath}/`;
+        hmrBasePath = `${pubPath}/`
       }
     }
 
-    return hmrBasePath + hmrSuffix;
+    return hmrBasePath + hmrSuffix
   }
 
   debug(`Loading webpack config for stage "${stage}"`)

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -80,6 +80,27 @@ module.exports = async (
     return Object.assign(envObject, gatsbyVarObject)
   }
 
+  function getHmrPath () {
+    let hmrBasePath = `${
+      program.ssl ? `https` : `http`
+    }://${
+      program.host
+    }:${webpackPort}/`;
+
+    const hmrSuffix = '__webpack_hmr&reload=true&overlay=false';
+
+    if (process.env.GATSBY_WEBPACK_PUBLICPATH) {
+      const pubPath = process.env.GATSBY_WEBPACK_PUBLICPATH;
+      if (pubPath.substr(-1) === '/') {
+        hmrBasePath = pubPath;
+      } else {
+        hmrBasePath = `${pubPath}/`;
+      }
+    }
+
+    return hmrBasePath + hmrSuffix;
+  }
+
   debug(`Loading webpack config for stage "${stage}"`)
   function output() {
     switch (stage) {
@@ -135,11 +156,7 @@ module.exports = async (
         return {
           commons: [
             require.resolve(`react-hot-loader/patch`),
-            `${require.resolve(`webpack-hot-middleware/client`)}?path=${
-              program.ssl ? `https` : `http`
-            }://${
-              program.host
-            }:${webpackPort}/__webpack_hmr&reload=true&overlay=false`,
+            `${require.resolve(`webpack-hot-middleware/client`)}?path=${getHmrPath()}`,
             directoryPath(`.cache/app`),
           ],
         }


### PR DESCRIPTION
See title.

I've tested this locally and it works

This fixes an issue where the webpack public path points to origin but hmr points to `0.0.0.0` when `GATSBY_WEBPACK_PUBLICPATH` is set to `/`, which breaks hmr if you aren't accessing the dev server from the machine it is running on.

See https://github.com/gatsbyjs/gatsby/pull/5527 for the commit that added the `GATSBY_WEBPACK_PUBLICPATH` option