### PR TITLE
Add LT, LTE, GT, GTE options to GraphQL filters for Int/Float

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
@@ -21,6 +21,10 @@ function isIntInput(type) {
   expect(type.getFields()).toEqual({
     eq: { name: `eq`, type: GraphQLInt },
     ne: { name: `ne`, type: GraphQLInt },
+    lt: { name: `lt`, type: GraphQLInt },
+    lte: { name: `lte`, type: GraphQLInt },
+    gt: { name: `gt`, type: GraphQLInt },
+    gte: { name: `gte`, type: GraphQLInt },
   })
 }
 
@@ -89,6 +93,10 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     expect(float.getFields()).toEqual({
       eq: { name: `eq`, type: GraphQLFloat },
       ne: { name: `ne`, type: GraphQLFloat },
+      lt: { name: `lt`, type: GraphQLFloat },
+      lte: { name: `lte`, type: GraphQLFloat },
+      gt: { name: `gt`, type: GraphQLFloat },
+      gte: { name: `gte`, type: GraphQLFloat },
     })
 
     const string = inferredFields.scal_string.type
@@ -293,6 +301,10 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     expect(list.getFields()).toEqual({
       eq: { name: `eq`, type: GraphQLFloat },
       ne: { name: `ne`, type: GraphQLFloat },
+      gt: { name: `gt`, type: GraphQLFloat },
+      gte: { name: `gte`, type: GraphQLFloat },
+      lt: { name: `lt`, type: GraphQLFloat },
+      lte: { name: `lte`, type: GraphQLFloat },
       in: { name: `in`, type: new GraphQLList(GraphQLFloat) },
     })
   })

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -334,6 +334,78 @@ describe(`GraphQL Input args`, () => {
     expect(result.data.allNode.edges[0].node.hair).toEqual(1)
   })
 
+  it(`handles lt operator`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: {hair: { lt: 2 }}) {
+            edges { node { hair }}
+          }
+        }
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(2)
+    expect(result.data.allNode.edges[0].node.hair).toEqual(1)
+    expect(result.data.allNode.edges[1].node.hair).toEqual(0)
+  })
+
+  it(`handles lte operator`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: {hair: { lte: 1 }}) {
+            edges { node { hair }}
+          }
+        }
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(2)
+    expect(result.data.allNode.edges[0].node.hair).toEqual(1)
+    expect(result.data.allNode.edges[1].node.hair).toEqual(0)
+  })
+
+  it(`handles gt operator`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: {hair: { gt: 0 }}) {
+            edges { node { hair }}
+          }
+        }
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(2)
+    expect(result.data.allNode.edges[0].node.hair).toEqual(1)
+    expect(result.data.allNode.edges[1].node.hair).toEqual(2)
+  })
+
+  it(`handles gte operator`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: {hair: { gte: 1 }}) {
+            edges { node { hair }}
+          }
+        }
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(2)
+    expect(result.data.allNode.edges[0].node.hair).toEqual(1)
+    expect(result.data.allNode.edges[1].node.hair).toEqual(2)
+  })
+
   it(`handles the regex operator`, async () => {
     let result = await queryResult(
       nodes,

--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -85,10 +85,18 @@ const scalarFilterMap = {
   Int: {
     eq: { type: GraphQLInt },
     ne: { type: GraphQLInt },
+    gt: { type: GraphQLInt },
+    gte: { type: GraphQLInt },
+    lt: { type: GraphQLInt },
+    lte: { type: GraphQLInt },
   },
   Float: {
     eq: { type: GraphQLFloat },
     ne: { type: GraphQLFloat },
+    gt: { type: GraphQLFloat },
+    gte: { type: GraphQLFloat },
+    lt: { type: GraphQLFloat },
+    lte: { type: GraphQLFloat },
   },
   ID: {
     eq: { type: GraphQLID },

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -45,11 +45,19 @@ function typeFields(type): GraphQLInputFieldConfigMap {
       return {
         eq: { type: GraphQLInt },
         ne: { type: GraphQLInt },
+        gt: { type: GraphQLInt },
+        gte: { type: GraphQLInt },
+        lt: { type: GraphQLInt },
+        lte: { type: GraphQLInt },
       }
     case `float`:
       return {
         eq: { type: GraphQLFloat },
         ne: { type: GraphQLFloat },
+        gt: { type: GraphQLFloat },
+        gte: { type: GraphQLFloat },
+        lt: { type: GraphQLFloat },
+        lte: { type: GraphQLFloat },
       }
   }
   return {}


### PR DESCRIPTION
I've added support for `$lt`, `$lte`, `$gt`, `$gte` filters within a GraphQL query. You can now do something like this:

````
filter: { example_field: { lte: 3 } }
````

* * *

I hope I've done this correctly, it was a lot of guess work, trying to work out what I had to change inside Gatsby as I'm not very familiar with the internals, and GraphQL.

I was trying to make this work for dates too (which was the whole reason for me doing this), but I cannot work out how to do it.. Inside the body of the query, a date is of type `Date`, but inside the filter, a date is of type `String` and I'm not sure how you would make it into a `Date`. I'd be happy to append to this PR to add support for dates if someone could give me some pointers. Otherwise I can create an issue for it :)