### PR TITLE
[WIP][gatsby-plugin-sharp] use MozJPEG for jpg compression

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -11,6 +11,7 @@
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
     "imagemin": "^5.2.2",
+    "imagemin-mozjpeg": "^7.0.0",
     "imagemin-pngquant": "5.0.1",
     "imagemin-webp": "^4.0.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This is a working PR using [MozJPEG](https://github.com/mozilla/mozjpeg) for jpg compression in `gatsby-plugin-sharp`.

As images are often the heaviest resources on websites, it would be great if we could squeeze the file size of jpgs even more (despite the fact that current compression is really good). MozJPEG provides even better compression for jpg files than the current implementation. However, it takes more time to compress the images.

**Test results with `using-gatsby-image` example**
* Average image file-size compared to current compression: **-8.1%**
* Best result compared to current compression: **-12.1%**
* Gatsby thumbnail creation time increase: **2.3x**

**Concerns**
Due to the increased thumbnail creation time I am not sure if we should use MozJPEG as a default.
* Will the longer build-time frustrate Gatsby users? Or will the better compression results balance this out?
* Would it be an option to make using MozJPEG an opt-in via the config?

Would like to hear your thoughts on this!
