### PR TITLE
Fix gatsby-remark-embed-snippet with gatsby-remark-prismjs@2

### DIFF
--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "gatsby-remark-prismjs": "^1.2.24",
     "normalize-path": "^2.1.1",
     "parse-numeric-range": "^0.0.2",
     "unist-util-map": "^1.0.3"
@@ -24,6 +23,9 @@
     "prism",
     "remark"
   ],
+  "peerDependencies": {
+    "gatsby-remark-prismjs": "^2.0.3"
+  },
   "license": "MIT",
   "main": "index.js",
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet",

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-remark-embed-snippet",
   "description": "Gatsby plugin to embed formatted code snippets within markdown",
-  "version": "1.0.22",
+  "version": "2.0.0",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"


### PR DESCRIPTION
gatsby-remark-embed-snippet wasn't working with gatsby-remark-prismjs@2 because it had the wrong versions of things.

This may fix #5311 (but I can't recreate @Undistraction's problem :sad:)