### PR TITLE
prettier: ignore package.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+/package.json


### PR DESCRIPTION
This will prevent unnecessary changes; only yarn should be controlling the formatting of `package.json`.