### PR TITLE
[v2] Fix children type in README

### DIFF
--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -102,7 +102,7 @@ const IndexLayout = ({ children, location }) => {
   return (
     <div>
       <h1>Welcome {isHomepage ? "home" : "aboard"}!</h1>
-      {children()}
+      {children}
     </div>
   )
 }


### PR DESCRIPTION
In v2, children is not function. I use `children`.