### PR TITLE
fix(fragments): copy fragments from build files to easy up developing

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -212,7 +212,7 @@ exports.onPreExtractQueries = async ({
   // We have both gatsby-image installed as well as ImageSharp nodes so let's
   // add our fragments to .cache/fragments.
   await fs.copy(
-    require.resolve(`gatsby-source-contentful/src/fragments.js`),
-    `${program.directory}/.cache/fragments/contentful-asset-fragments.js`
+    require.resolve(`gatsby-source-contentful/fragments.js`),
+    `${program.directory}/.cache/fragments/contentful-fragments.js`
   )
 }

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -34,7 +34,7 @@ exports.onPreExtractQueries = async ({
   // We have both gatsby-image installed as well as ImageSharp nodes so let's
   // add our fragments to .cache/fragments.
   await fs.copy(
-    require.resolve(`gatsby-transformer-sharp/src/fragments.js`),
+    require.resolve(`gatsby-transformer-sharp/fragments.js`),
     `${program.directory}/.cache/fragments/image-sharp-fragments.js`
   )
 }


### PR DESCRIPTION
As pointed out [here](https://github.com/gatsbyjs/gatsby/pull/5659#issuecomment-393877212)  by @m-allanson, the fragments of the source files are copied. Since the gatsby-dev-cli does copy the build files, I propose this change to be sure that fragment copy also works while developing on these plugins.

It might be a rare edge case but still a valid change IMHO.