### PR TITLE
[v2] Update plugin-typescript to use Babel

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -4,12 +4,11 @@ Provides drop-in support for TypeScript and TSX.
 
 ## Install
 
-`npm install --save gatsby-plugin-typescript typescript`
+`yarn add gatsby-plugin-typescript`
 
 ## How to use
 
 1.  Include the plugin in your `gatsby-config.js` file.
-1.  Add `tsconfig.json` file on your root directory.
 1.  Write your components in TSX or TypeScript.
 1.  You're good to go.
 
@@ -19,37 +18,30 @@ Provides drop-in support for TypeScript and TSX.
 plugins: [`gatsby-plugin-typescript`]
 ```
 
-Or with optional configuration:
+## Caveats
 
-```javascript
-plugins: [
-  {
-    resolve: "gatsby-plugin-typescript",
-    options: {
-      transpileOnly: true, // default
-      compilerOptions: {
-        target: `esnext`,
-        experimentalDecorators: true,
-        jsx: `react`,
-      }, // default
-    },
-  },
-]
-```
+This plugin uses [`babel-plugin-transform-typescript`](https://new.babeljs.io/docs/en/next/babel-plugin-transform-typescript.html) to transpile typescript. It does _not do type checking_. Also since the TypeScript
+compiler is not involved, the following applies:
 
-`tsconfig.json`
+> Does not support namespaces.
+> Workaround: Move to using file exports, or
+> migrate to using the module { } syntax instead.
+>
+> Does not support const enums because those require
+> type information to compile. Workaround: Remove the
+> const, which makes it available at runtime.
+>
+> Does not support export = and import =, because those
+> cannot be compile to ES.next. Workaround: Convert
+> to using export default and export const,
+> and import x, {y} from "z".
 
-```json
-{
-  "compilerOptions": {
-    "outDir": "./dist/",
-    "sourceMap": true,
-    "noImplicitAny": true,
-    "module": "commonjs",
-    "target": "esnext",
-    "jsx": "react",
-    "lib": ["dom", "es2015", "es2017"]
-  },
-  "include": ["./src/**/*"]
-}
-```
+https://new.babeljs.io/docs/en/next/babel-plugin-transform-typescript.html
+
+## Type checking
+
+First of all you should set up your IDE so that type errors are surfaced.
+Visual Studio Code is very good in this regard.
+
+In addition, you can see the instructions in [TypeScript-Babel-Starter](https://github.com/Microsoft/TypeScript-Babel-Starter)
+for setting up a `type-check` task.

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -4,7 +4,7 @@ Provides drop-in support for TypeScript and TSX.
 
 ## Install
 
-`yarn add gatsby-plugin-typescript`
+`npm install gatsby-plugin-typescript`
 
 ## How to use
 

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-typescript",
   "description": "Adds TypeScript support to Gatsby",
-  "version": "1.4.17-11",
+  "version": "2.0.0-alpha.1",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -10,10 +10,9 @@
     "Noah Lange <noahrlange@gmail.com>"
   ],
   "dependencies": {
+    "@babel/preset-typescript": "7.0.0-beta.47",
     "@babel/runtime": "7.0.0-beta.47",
-    "babel-plugin-remove-graphql-queries": "^2.0.1-9",
-    "ts-loader": "^2.0.3",
-    "typescript": "^2.7.2"
+    "babel-plugin-remove-graphql-queries": "^2.0.1-9"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.47",

--- a/packages/gatsby-plugin-typescript/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-typescript/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -8,17 +8,21 @@ Array [
         Object {
           "test": /\\\\\\.tsx\\?\\$/,
           "use": Array [
-            "babel-loader",
             Object {
-              "loader": "/resolved/path/ts-loader",
+              "loader": "/resolved/path/babel-loader",
               "options": Object {
-                "compilerOptions": Object {
-                  "experimentalDecorators": true,
-                  "jsx": "react",
-                  "module": "es6",
-                  "target": "esnext",
-                },
-                "transpileOnly": true,
+                "plugins": Array [
+                  "babel-plugin-remove-graphql-queries",
+                ],
+                "presets": Array [
+                  Array [
+                    "@babel/preset-env",
+                  ],
+                  Array [
+                    "@babel/preset-react",
+                  ],
+                  "/resolved/path/@babel/preset-typescript",
+                ],
               },
             },
           ],
@@ -27,17 +31,6 @@ Array [
     },
   },
 ]
-`;
-
-exports[`gatsby-plugin-typescript pre-processing transforms .ts files 1`] = `
-"const now = moment().format('HH:MM:ss');
-"
-`;
-
-exports[`gatsby-plugin-typescript pre-processing transforms JSX files 1`] = `
-"import * as React from 'react';
-export default () => React.createElement(\\"h1\\", null, \\"Hello World\\");
-"
 `;
 
 exports[`gatsby-plugin-typescript returns correct extensions 1`] = `

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -4,9 +4,38 @@ const babelPluginRemoveQueries = require(`babel-plugin-remove-graphql-queries`)
   .default
 const {
   resolvableExtensions,
-  onCreateWebpackConfig,
-  preprocessSource,
+  onCreateWebpackConfig
 } = require(`../gatsby-node`)
+const { tsPresetsFromJsPresets } = require(`../`)
+const tsPresetPath = `/resolved/path/@babel/preset-typescript`
+const jsOptions = {
+  options: {
+    presets: [
+      ["@babel/preset-env"],
+      ["@babel/preset-react"],
+      ["@babel/preset-flow"],
+    ],
+    plugins: ["babel-plugin-remove-graphql-queries"],
+  },
+  loader: "/resolved/path/babel-loader",
+}
+
+describe(`tsPresetsFromJsPresets`, () => {
+  it(`handles empty presets`, () => {
+    const presets = []
+    expect(tsPresetsFromJsPresets(presets)).toEqual([tsPresetPath])
+  })
+  it(`replaces preset-flow if it's last`, () => {
+    const presets = ["@babel/preset-flow"]
+    expect(tsPresetsFromJsPresets(presets)).toEqual([tsPresetPath])
+  })
+  it(`appends if preset-flow is not last`, () => {
+    const presets = [["@babel/preset-flow"], ["@babel/preset-foo"]]
+    expect(tsPresetsFromJsPresets(presets)).toEqual(
+      presets.concat([tsPresetPath])
+    )
+  })
+})
 
 describe(`gatsby-plugin-typescript`, () => {
   let args
@@ -20,7 +49,7 @@ describe(`gatsby-plugin-typescript`, () => {
     const actions = {
       setWebpackConfig: jest.fn(),
     }
-    const loaders = { js: jest.fn(() => `babel-loader`) }
+    const loaders = { js: jest.fn(() => jsOptions) }
     args = { actions, loaders }
   })
 
@@ -42,129 +71,5 @@ describe(`gatsby-plugin-typescript`, () => {
     expect(args.actions.setWebpackConfig).toHaveBeenCalledTimes(1)
     const lastCall = args.actions.setWebpackConfig.mock.calls.pop()
     expect(lastCall).toMatchSnapshot()
-  })
-
-  // TODO: re-enable this test
-  it.skip(`adds the remove graphql queries plugin`, () => {
-    onCreateWebpackConfig(args, { compilerOptions: {} })
-
-    expect(args.loaders.js).toHaveBeenCalledTimes(1)
-    const lastCall = args.loaders.js.mock.calls.pop()
-
-    expect(lastCall[0]).toEqual({
-      plugins: [babelPluginRemoveQueries],
-    })
-  })
-
-  it(`passes the configuration to the ts-loader plugin`, () => {
-    const babelConfig = { plugins: [``] }
-    const config = {
-      loader: jest.fn(),
-    }
-    const options = { compilerOptions: { foo: `bar` }, transpileOnly: false }
-
-    onCreateWebpackConfig({ config, babelConfig, ...args }, options)
-
-    const expectedOptions = {
-      compilerOptions: {
-        target: `esnext`,
-        experimentalDecorators: true,
-        jsx: `react`,
-        foo: `bar`,
-        module: `es6`,
-      },
-      transpileOnly: false,
-    }
-
-    expect(getLoader()).toEqual({
-      test: /\.tsx?$/,
-      use: [
-        `babel-loader`,
-        {
-          loader: `/resolved/path/ts-loader`,
-          options: expectedOptions,
-        },
-      ],
-    })
-  })
-
-  it(`uses default configuration for the ts-loader plugin when no config is provided`, () => {
-    const babelConfig = { plugins: [``] }
-    const config = {
-      loader: jest.fn(),
-    }
-    onCreateWebpackConfig(
-      { config, babelConfig, ...args },
-      { compilerOptions: {} }
-    )
-
-    const expectedOptions = {
-      compilerOptions: {
-        target: `esnext`,
-        experimentalDecorators: true,
-        jsx: `react`,
-        module: `es6`,
-      },
-      transpileOnly: true,
-    }
-
-    expect(getLoader()).toEqual({
-      test: /\.tsx?$/,
-      use: [
-        `babel-loader`,
-        {
-          loader: `/resolved/path/ts-loader`,
-          options: expectedOptions,
-        },
-      ],
-    })
-  })
-
-  describe(`pre-processing`, () => {
-    const opts = { compilerOptions: {} }
-    it(`leaves non-tsx? files alone`, () => {
-      expect(
-        preprocessSource(
-          {
-            contents: `alert('hello');`,
-            filename: `test.js`,
-          },
-          opts
-        )
-      ).toBeNull()
-    })
-
-    it(`transforms .ts files`, () => {
-      const js = preprocessSource(
-        {
-          filename: `index.ts`,
-          contents: `
-          declare let moment: any;
-
-          const now: string = moment().format('HH:MM:ss');
-        `,
-        },
-        opts
-      )
-      expect(js).not.toBeNull()
-      expect(js).toMatchSnapshot()
-    })
-
-    it(`transforms JSX files`, () => {
-      const js = preprocessSource(
-        {
-          filename: `tags.ts`,
-          contents: `
-          import * as React from 'react';
-
-          export default () => <h1>Hello World</h1>;
-        `,
-        },
-        opts
-      )
-
-      expect(js).not.toBeNull()
-      expect(js).toMatchSnapshot()
-    })
   })
 })

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -1,23 +1,21 @@
 jest.mock(`../resolve`, () => module => `/resolved/path/${module}`)
 
-const babelPluginRemoveQueries = require(`babel-plugin-remove-graphql-queries`)
-  .default
 const {
   resolvableExtensions,
-  onCreateWebpackConfig
+  onCreateWebpackConfig,
 } = require(`../gatsby-node`)
 const { tsPresetsFromJsPresets } = require(`../`)
 const tsPresetPath = `/resolved/path/@babel/preset-typescript`
 const jsOptions = {
   options: {
     presets: [
-      ["@babel/preset-env"],
-      ["@babel/preset-react"],
-      ["@babel/preset-flow"],
+      [`@babel/preset-env`],
+      [`@babel/preset-react`],
+      [`@babel/preset-flow`],
     ],
-    plugins: ["babel-plugin-remove-graphql-queries"],
+    plugins: [`babel-plugin-remove-graphql-queries`],
   },
-  loader: "/resolved/path/babel-loader",
+  loader: `/resolved/path/babel-loader`,
 }
 
 describe(`tsPresetsFromJsPresets`, () => {
@@ -26,11 +24,11 @@ describe(`tsPresetsFromJsPresets`, () => {
     expect(tsPresetsFromJsPresets(presets)).toEqual([tsPresetPath])
   })
   it(`replaces preset-flow if it's last`, () => {
-    const presets = ["@babel/preset-flow"]
+    const presets = [`@babel/preset-flow`]
     expect(tsPresetsFromJsPresets(presets)).toEqual([tsPresetPath])
   })
   it(`appends if preset-flow is not last`, () => {
-    const presets = [["@babel/preset-flow"], ["@babel/preset-foo"]]
+    const presets = [[`@babel/preset-flow`], [`@babel/preset-foo`]]
     expect(tsPresetsFromJsPresets(presets)).toEqual(
       presets.concat([tsPresetPath])
     )
@@ -39,11 +37,6 @@ describe(`tsPresetsFromJsPresets`, () => {
 
 describe(`gatsby-plugin-typescript`, () => {
   let args
-
-  function getLoader() {
-    const call = args.actions.setWebpackConfig.mock.calls[0]
-    return call[0].module.rules[0]
-  }
 
   beforeEach(() => {
     const actions = {

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -1,45 +1,34 @@
-const { transpileModule } = require(`typescript`)
 const resolve = require(`./resolve`)
+const { tsPresetsFromJsPresets } = require(`./`)
 
-const test = /\.tsx?$/
-const compilerDefaults = {
-  target: `esnext`,
-  experimentalDecorators: true,
-  jsx: `react`,
-  module: `es6`,
+const resolvableExtensions = () => {
+  return [`.ts`, `.tsx`]
 }
 
-module.exports.resolvableExtensions = () => [`.ts`, `.tsx`]
-
-module.exports.onCreateWebpackConfig = (
-  { actions, loaders },
-  { compilerOptions, ...options }
-) => {
-  // Gatsby removes graphql queries from source code because the queries are
-  // run ahead of time. We need to do that here as well in order to avoid
-  // extra dead code sitting in the typescript files.
-
-  const typescriptOptions = {
-    // React-land is rather undertyped; nontrivial TS projects will most likely
-    // error (i.e., not build) at something or other.
-    transpileOnly: true,
-    compilerOptions: {
-      ...compilerDefaults,
-      ...compilerOptions,
-    },
-    ...options,
+function onCreateWebpackConfig({ actions, loaders, stage }) {
+  const jsLoader = loaders.js()
+  if (
+    !(
+      jsLoader &&
+      jsLoader.loader &&
+      jsLoader.options &&
+      jsLoader.options.presets
+    )
+  ) {
+    return undefined
   }
-
   actions.setWebpackConfig({
     module: {
       rules: [
         {
-          test,
+          test: /\.tsx?$/,
           use: [
-            loaders.js(),
             {
-              loader: resolve(`ts-loader`),
-              options: typescriptOptions,
+              loader: jsLoader.loader,
+              options: {
+                ...jsLoader.options,
+                presets: tsPresetsFromJsPresets(jsLoader.options.presets),
+              },
             },
           ],
         },
@@ -47,15 +36,5 @@ module.exports.onCreateWebpackConfig = (
     },
   })
 }
-
-module.exports.preprocessSource = (
-  { contents, filename },
-  { compilerOptions }
-) => {
-  const copts = { ...compilerDefaults, ...compilerOptions }
-
-  // return the transpiled source if it's TypeScript, otherwise null
-  return test.test(filename)
-    ? transpileModule(contents, { compilerOptions: copts }).outputText
-    : null
-}
+exports.onCreateWebpackConfig = onCreateWebpackConfig
+exports.resolvableExtensions = resolvableExtensions

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -1,9 +1,6 @@
-const resolve = require(`./resolve`)
 const { tsPresetsFromJsPresets } = require(`./`)
 
-const resolvableExtensions = () => {
-  return [`.ts`, `.tsx`]
-}
+const resolvableExtensions = () => [`.ts`, `.tsx`]
 
 function onCreateWebpackConfig({ actions, loaders, stage }) {
   const jsLoader = loaders.js()
@@ -15,7 +12,7 @@ function onCreateWebpackConfig({ actions, loaders, stage }) {
       jsLoader.options.presets
     )
   ) {
-    return undefined
+    return
   }
   actions.setWebpackConfig({
     module: {

--- a/packages/gatsby-plugin-typescript/src/index.js
+++ b/packages/gatsby-plugin-typescript/src/index.js
@@ -1,1 +1,18 @@
-// noop
+const resolve = require(`./resolve`)
+
+function tsPresetsFromJsPresets(jsPresets) {
+  const copy = (jsPresets && jsPresets.slice(0)) || []
+  if (copy.length > 0) {
+    const lastItem = copy[copy.length - 1]
+    const lastPreset = typeof lastItem === "string" ? lastItem : lastItem[0]
+    // If preset-flow is the last preset, which is the case without a custom .babelrc,
+    // assume we can replace it with preset-typescript.
+    if (lastPreset && lastPreset.indexOf(`@babel/preset-flow`) !== -1) {
+      copy.pop()
+    }
+  }
+  copy.push(resolve(`@babel/preset-typescript`))
+  return copy
+}
+
+exports.tsPresetsFromJsPresets = tsPresetsFromJsPresets

--- a/packages/gatsby-plugin-typescript/src/index.js
+++ b/packages/gatsby-plugin-typescript/src/index.js
@@ -4,7 +4,7 @@ function tsPresetsFromJsPresets(jsPresets) {
   const copy = (jsPresets && jsPresets.slice(0)) || []
   if (copy.length > 0) {
     const lastItem = copy[copy.length - 1]
-    const lastPreset = typeof lastItem === "string" ? lastItem : lastItem[0]
+    const lastPreset = typeof lastItem === `string` ? lastItem : lastItem[0]
     // If preset-flow is the last preset, which is the case without a custom .babelrc,
     // assume we can replace it with preset-typescript.
     if (lastPreset && lastPreset.indexOf(`@babel/preset-flow`) !== -1) {


### PR DESCRIPTION
This PR updates `plugin-typescript` to make use of the TypeScript parsing capabilities of Babel 7. The main benefits are speed improvements when compiling/building and a more streamlined webpack configuration.

There are some caveats too: https://new.babeljs.io/docs/en/next/babel-plugin-transform-typescript.html. 

In particular, it's important to realize that Babel does NOT do type checking. However the current version of `plugin-typescript` doesn't seem to do that either (it configures the typescript compiler to only transpile). I don't personally see this as a problem since in any sensible TS configuration the editor would do type checking any way. One could also configure a separate `type-check` script as is done here: https://github.com/Microsoft/TypeScript-Babel-Starter or even set up [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin).