### PR TITLE
Add GraphQL filter for EXISTS and NOT EXISTS

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
@@ -25,6 +25,7 @@ function isIntInput(type) {
     lte: { name: `lte`, type: GraphQLInt },
     gt: { name: `gt`, type: GraphQLInt },
     gte: { name: `gte`, type: GraphQLInt },
+    exists: { name: `exists`, type: GraphQLBoolean },
   })
 }
 
@@ -43,6 +44,7 @@ function isStringInput(type) {
     ne: { name: `ne`, type: GraphQLString },
     regex: { name: `regex`, type: GraphQLString },
     glob: { name: `glob`, type: GraphQLString },
+    exists: { name: `exists`, type: GraphQLBoolean },
   })
 }
 
@@ -97,6 +99,7 @@ describe(`GraphQL Input args from fields, test-only`, () => {
       lte: { name: `lte`, type: GraphQLFloat },
       gt: { name: `gt`, type: GraphQLFloat },
       gte: { name: `gte`, type: GraphQLFloat },
+      exists: { name: `exists`, type: GraphQLBoolean },
     })
 
     const string = inferredFields.scal_string.type
@@ -109,6 +112,7 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     expect(bool.getFields()).toEqual({
       eq: { name: `eq`, type: GraphQLBoolean },
       ne: { name: `ne`, type: GraphQLBoolean },
+      exists: { name: `exists`, type: GraphQLBoolean },
     })
 
     expect(inferredFields).not.toHaveProperty(`scal_odd_unknown`)
@@ -306,6 +310,7 @@ describe(`GraphQL Input args from fields, test-only`, () => {
       lt: { name: `lt`, type: GraphQLFloat },
       lte: { name: `lte`, type: GraphQLFloat },
       in: { name: `in`, type: new GraphQLList(GraphQLFloat) },
+      exists: { name: `exists`, type: GraphQLBoolean },
     })
   })
 

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -406,6 +406,41 @@ describe(`GraphQL Input args`, () => {
     expect(result.data.allNode.edges[1].node.hair).toEqual(2)
   })
 
+  it(`handles exists operator with true`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: { boolean: { exists: true }}) {
+            edges { node { boolean }}
+          }
+        }
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(2)
+    expect(result.data.allNode.edges[0].node.boolean).toEqual(true)
+    expect(result.data.allNode.edges[1].node.boolean).toEqual(false)
+  })
+
+  it(`handles exists operator with false`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          allNode(filter: { boolean: { exists: false }}) {
+            edges { node { boolean }}
+          }
+        }
+      `
+    )
+
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.allNode.edges.length).toEqual(1)
+    expect(result.data.allNode.edges[0].node.boolean).toEqual(null)
+  })
+
   it(`handles the regex operator`, async () => {
     let result = await queryResult(
       nodes,

--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -89,6 +89,7 @@ const scalarFilterMap = {
     gte: { type: GraphQLInt },
     lt: { type: GraphQLInt },
     lte: { type: GraphQLInt },
+    exists: { type: GraphQLBoolean },
   },
   Float: {
     eq: { type: GraphQLFloat },
@@ -97,6 +98,7 @@ const scalarFilterMap = {
     gte: { type: GraphQLFloat },
     lt: { type: GraphQLFloat },
     lte: { type: GraphQLFloat },
+    exists: { type: GraphQLBoolean },
   },
   ID: {
     eq: { type: GraphQLID },
@@ -107,10 +109,12 @@ const scalarFilterMap = {
     ne: { type: GraphQLString },
     regex: { type: GraphQLString },
     glob: { type: GraphQLString },
+    exists: { type: GraphQLBoolean },
   },
   Boolean: {
     eq: { type: GraphQLBoolean },
     ne: { type: GraphQLBoolean },
+    exists: { type: GraphQLBoolean },
   },
 }
 

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -33,6 +33,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
       return {
         eq: { type: GraphQLBoolean },
         ne: { type: GraphQLBoolean },
+        exists: { type: GraphQLBoolean },
       }
     case `string`:
       return {
@@ -40,6 +41,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
         ne: { type: GraphQLString },
         regex: { type: GraphQLString },
         glob: { type: GraphQLString },
+        exists: { type: GraphQLBoolean },
       }
     case `int`:
       return {
@@ -49,6 +51,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
         gte: { type: GraphQLInt },
         lt: { type: GraphQLInt },
         lte: { type: GraphQLInt },
+        exists: { type: GraphQLBoolean },
       }
     case `float`:
       return {
@@ -58,6 +61,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
         gte: { type: GraphQLFloat },
         lt: { type: GraphQLFloat },
         lte: { type: GraphQLFloat },
+        exists: { type: GraphQLBoolean },
       }
   }
   return {}


### PR DESCRIPTION
This PR allows you to filter data based on what fields exists. For example:

```
{ name: 'Chris', age: null }, { name: 'John', age: 10 }, { name: 'Debbie', age: 15 }
```

You could write a filter:

```
filter: { age: { exists: true } }
```

Which would only return back John & Debbie as they have ages that are not NULL.

Or the opposite which would be:

```
filter: { age: { exists: false } }
```

Which would return back Chris as the age field is NULL.