### PR TITLE
[v2] Correct inlined css upgrade guide

### DIFF
--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -376,6 +376,6 @@ See [Gatsby's webpack docs for more details](/docs/add-custom-webpack-config) ab
 
 ## Remove inlined CSS in `html.js`
 
-Gatsby v2 automatically inlines CSS. Gatsby v1 required you to create a [custom `html.js` file](/docs/custom-html) to do this. You can remove any custom CSS inlining from your custom `html.js`, in many cases this allows you to completely remove your `html.js` file.
+Gatsby v2 automatically inlines CSS. You can remove any custom CSS inlining from your custom `html.js`.
 
 See an example in [this PR that upgrades the `using-remark` site to Gatsby v2](https://github.com/gatsbyjs/gatsby/commit/765b679cbc222fd5f527690427ee431cca7ccd61#diff-637c76e3c059ed8efacedf6e30de2d61).


### PR DESCRIPTION
v1's default html.js also inlined css https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/default-html.js

The change is that with mini-css-extract-plugin, we have css splitting so we handle inlining css in core as it requires understanding webpack's stats object.