### PR TITLE
[gatsby-image] add placeholderStyle prop to gatsby-image

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -184,6 +184,7 @@ class Image extends React.Component {
       outerWrapperClassName,
       style = {},
       imgStyle = {},
+      placeholderStyle = {},
       sizes,
       resolutions,
       backgroundColor,
@@ -201,6 +202,7 @@ class Image extends React.Component {
       opacity: this.state.imgLoaded ? 0 : 1,
       transitionDelay: `0.25s`,
       ...imgStyle,
+      ...placeholderStyle,
     }
 
     const imageStyle = {
@@ -439,6 +441,7 @@ Image.propTypes = {
   ]),
   style: PropTypes.object,
   imgStyle: PropTypes.object,
+  placeholderStyle: PropTypes.object,
   position: PropTypes.string,
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onLoad: PropTypes.func,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4201,6 +4201,10 @@ envify@^4.0.0:
     esprima "^4.0.0"
     through "~2.3.4"
 
+envinfo@^5.8.1:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-5.10.0.tgz#503a9774ae15b93ea68bdfae2ccd6306624ea6df"
+
 eol@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/eol/-/eol-0.8.1.tgz#defc3224990c7eca73bb34461a56cf9dc24761d0"
@@ -5263,15 +5267,6 @@ function-bind@^1.0.2, function-bind@^1.1.1:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-
-gatsby-remark-prismjs@^1.2.24:
-  version "1.2.24"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-prismjs/-/gatsby-remark-prismjs-1.2.24.tgz#b2cc4e9c4e71c08d89a32fd847244f927f4a7b79"
-  dependencies:
-    babel-runtime "^6.26.0"
-    parse-numeric-range "0.0.2"
-    prismjs "^1.12.2"
-    unist-util-visit "^1.3.0"
 
 gauge@~1.2.5:
   version "1.2.7"
@@ -10670,7 +10665,7 @@ printj@~1.1.0, printj@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
 
-prismjs@^1.12.2, prismjs@^1.13.0:
+prismjs@^1.13.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.14.0.tgz#bbccfdb8be5d850d26453933cb50122ca0362ae0"
   optionalDependencies:


### PR DESCRIPTION
@pieh Per our discussion, this replaces #5653

The original intention is to enable users to add styles to the image placeholder, such as a CSS blur.

For example, a nice blur can now be added with:
```jsx
<Img
  resolutions={data.file.childImageSharp.resolutions}
  placeholderStyle={{
    filter: `blur(12px)`,
    WebkitFilter: `blur(12px)`,
    MozFilter: `blur(12px)`,
    msFilter: `blur(12px`,
    OFilter: `blur(12px)`
  }}
/>
```