### PR TITLE
[gatsby-transformer-excel] add option to disable raw output

### DIFF
--- a/packages/gatsby-transformer-excel/README.md
+++ b/packages/gatsby-transformer-excel/README.md
@@ -108,3 +108,24 @@ Which would return:
   }
 }
 ```
+
+## Troubleshooting
+### Field Type Conflicts
+If your columns have different data types, e.g. numbers and strings graphql will omit these values and provide you with a field type conflicts warning during build.
+To solve this, you can set the rawOutput option of the plugin to false. This will convert all values to strings.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-transformer-excel`,
+      options: {
+        rawOutput: false,
+      }
+    }
+  ],
+};
+```
+
+This will make sure, that all field types are converted to strings.

--- a/packages/gatsby-transformer-excel/src/gatsby-node.js
+++ b/packages/gatsby-transformer-excel/src/gatsby-node.js
@@ -27,7 +27,7 @@ async function onCreateNode(
   let wb = XLSX.read(content, { type: `binary`, cellDates: true })
   wb.SheetNames.forEach((n, idx) => {
     let ws = wb.Sheets[n]
-    let parsedContent = XLSX.utils.sheet_to_json(ws, { raw: true })
+    let parsedContent = XLSX.utils.sheet_to_json(ws, { raw: options && `rawOutput` in options ? options.rawOutput : true })
 
     if (_.isArray(parsedContent)) {
       const csvArray = parsedContent.map((obj, i) => {


### PR DESCRIPTION
The option to disable the raw output for the excel parsing prevents field type conflicts, if there are e.g. numbers and strings in a column. (https://github.com/gatsbyjs/gatsby/issues/5724)

This PR adds the option to configure the plugin, that everything is converted to a string. This prevents field type conflicts.
If no options are provided, the default will be true, so no breaking changes.