### PR TITLE
Build-html static file using the Webpack magic comment to provide the link rel

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/define-asset-script.js
+++ b/packages/gatsby/cache-dir/__tests__/define-asset-script.js
@@ -1,0 +1,26 @@
+import defineAssetScript from '../define-asset-script'
+import get from 'lodash/get'
+import isArray from 'lodash/isArray'
+
+const mockStats = require(`../json/mock-stats-object`)
+
+describe(`define-asset-script`, () => {
+  it(`should mutate "ChartBar.js" rel item to "prefetch"`, () => {
+    const linkComponent = [`About`,`ChartBar`, `foo`, `main`].map(s => { 
+      const fetchKey = `assetsByChunkName[${s}]`
+      const fetchedEntryPoints = get(mockStats, `entrypoints`)
+
+      let fetchedScript = get(mockStats, fetchKey)
+      fetchedScript = isArray(fetchedScript) ? fetchedScript[0] : fetchedScript
+      return defineAssetScript(fetchedEntryPoints, fetchedScript, { rel: `preload`, prefixedScript: fetchedScript })
+    })
+    // expect(linkComponent).toEqual()
+    linkComponent.forEach(({ rel, prefixedScript }) => {
+      if(prefixedScript === `ChartBar.js`) {
+        expect(rel).toBe(`prefetch`)
+      } else {
+        expect(rel).toBe(`preload`)
+      }
+    })
+  })
+})

--- a/packages/gatsby/cache-dir/__tests__/define-asset-script.js
+++ b/packages/gatsby/cache-dir/__tests__/define-asset-script.js
@@ -14,7 +14,7 @@ describe(`define-asset-script`, () => {
       fetchedScript = isArray(fetchedScript) ? fetchedScript[0] : fetchedScript
       return defineAssetScript(fetchedEntryPoints, fetchedScript, { rel: `preload`, prefixedScript: fetchedScript })
     })
-    // expect(linkComponent).toEqual()
+
     linkComponent.forEach(({ rel, prefixedScript }) => {
       if(prefixedScript === `ChartBar.js`) {
         expect(rel).toBe(`prefetch`)

--- a/packages/gatsby/cache-dir/define-asset-script.js
+++ b/packages/gatsby/cache-dir/define-asset-script.js
@@ -1,0 +1,19 @@
+ // NOTE: this function mutate the data argument object.
+ // The behavior of this function is finding the `childAssets` object and check script
+ // has exists in the array of webpack magic comment action. If exists. It mutate data.rel.
+ export default function defineAssetScript(entryPoint, chunkFileName, data) {
+   for (const objKey in entryPoint) {
+     if (typeof entryPoint[objKey] == typeof {}) {
+       if (objKey === `childAssets`) {
+         Object.entries(entryPoint[objKey]).forEach(([key, value]) => {
+           if (value.includes(chunkFileName)) {
+             data.rel = key
+           }
+         })
+       } else {
+         defineAssetScript(entryPoint[objKey], chunkFileName, data)
+       }
+     }
+   }
+   return data
+ }

--- a/packages/gatsby/cache-dir/json/mock-stats-object.json
+++ b/packages/gatsby/cache-dir/json/mock-stats-object.json
@@ -1,0 +1,74 @@
+{
+    "assetsByChunkName": {
+        "About": [
+            "About.js",
+            "About.js.map"
+        ],
+        "ChartBar": [
+            "ChartBar.js",
+            "ChartBar.js.map"
+        ],
+        "foo": [
+            "foo.js",
+            "foo.js.map"
+        ],
+        "main": [
+            "main.js",
+            "main.js.map"
+        ]
+    },
+    "entrypoints": {
+        "main": {
+            "chunks": [
+                3
+            ],
+            "assets": [
+                "main.js",
+                "main.js.map"
+            ],
+            "children": {
+                "preload": [{
+                    "name": "About",
+                    "chunks": [
+                        0
+                    ],
+                    "assets": [
+                        "About.js",
+                        "About.js.map"
+                    ]
+                }],
+                "prefetch": [{
+                    "name": "ChartBar",
+                    "chunks": [
+                        1
+                    ],
+                    "assets": [
+                        "ChartBar.js",
+                        "ChartBar.js.map"
+                    ]
+                }]
+            },
+            "childAssets": {
+                "preload": [
+                    "About.js",
+                    "About.js.map"
+                ],
+                "prefetch": [
+                    "ChartBar.js",
+                    "ChartBar.js.map"
+                ]
+            }
+        },
+        "foo": {
+            "chunks": [
+                2
+            ],
+            "assets": [
+                "foo.js",
+                "foo.js.map"
+            ],
+            "children": {},
+            "childAssets": {}
+        }
+    }
+}

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -172,14 +172,14 @@ module.exports = (locals, callback) => {
         return null
       }
 
-      return prefixedScript
+      return { rel: `preload`, prefixedScript }
     })
     .filter(s => isString(s))
 
-  scripts.forEach(script => {
+  scripts.forEach(({ rel, prefixedScript }) => {
     // Add preload <link>s for scripts.
     headComponents.unshift(
-      <link rel="preload" key={script} href={script} as="script" />
+      <link rel={rel} key={prefixedScript} href={prefixedScript} as="script" />
     )
   })
 

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -7,6 +7,7 @@ import apiRunner from "./api-runner-ssr"
 import pages from "./pages.json"
 import syncRequires from "./sync-requires"
 import testRequireError from "./test-require-error"
+import defineAssetScript from "./define-asset-script"
 
 let Html
 try {
@@ -156,26 +157,6 @@ module.exports = (locals, callback) => {
     .map(s => {
       const fetchKey = `assetsByChunkName[${s}]`
       const fetchedEntryPoints = get(stats, `entrypoints`)
-
-      // NOTE: this function mutate the data argument object.
-      // The behavior of this function is finding the `childAssets` object and check script
-      // has exists in the array of webpack magic comment action. If exists. It mutate data.rel.
-      function defineAssetScript(entryPoint, chunkFileName, data) {
-        for (const objKey in entryPoint) {
-          if (typeof entryPoint[objKey] == typeof {}) {
-            if (objKey === `childAssets`) {
-              Object.entries(entryPoint[objKey]).forEach(([key, value]) => {
-                if (value.includes(chunkFileName)) {
-                  data.rel = key
-                }
-              })
-            } else {
-              defineAssetScript(entryPoint[objKey], chunkFileName, data)
-            }
-          }
-        }
-        return data
-      }
 
       let fetchedScript = get(stats, fetchKey)
       if (!fetchedScript) {


### PR DESCRIPTION
Follow from this article
 [https://medium.com/webpack/link-rel-prefetch-preload-in-webpack-51a52358f84c](https://medium.com/webpack/link-rel-prefetch-preload-in-webpack-51a52358f84c)

the new Webpack version also has a magic comment to help to do the Code splitting using by dynamic import like this.
```js
import(
  /* webpackChunkName: "redeem", webpackPrefetch: true */
  "./RedeemModal"
)
```
and that, In the `build-html` we will using the magic comment to generate the `link tag` like.
```html
<link rel="prefetch"  href="/3.0.0/0-7f890f8c04b440c6714b.js" as="script" />
```
But...unforturnaly, the current version of Gastby doesn't has support yet. This PR will be the brand new feature to build-html in the dynamic import and improvement the UX experience.