### PR TITLE
Update how-gatsby-works-with-github-pages.md

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -26,7 +26,7 @@ We are using prefix paths because our website is inside a folder `http://usernam
 }
 ```
 
-When you run `npm run deploy` all contents of `public` folder will be moved to your repositories `gh-pages` branch.
+When you run `npm run deploy` all contents of `public` folder will be moved to your repositories `gh-pages` branch.  Make sure that your repository's settings has the `gh-pages` branch set as the source.
 
 ## GitHub Organization or User page
 

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -26,7 +26,7 @@ We are using prefix paths because our website is inside a folder `http://usernam
 }
 ```
 
-When you run `npm run deploy` all contents of `public` folder will be moved to your repositories `gh-pages` branch.  Make sure that your repository's settings has the `gh-pages` branch set as the source.
+When you run `npm run deploy` all contents of the `public` folder will be moved to your repository's `gh-pages` branch.  Make sure that your repository's settings has the `gh-pages` branch set as the source.
 
 ## GitHub Organization or User page
 


### PR DESCRIPTION
added clarification as if the gh-pages branch has not been created and set as the source for github pages then the above instructions for publishing to github repository page won't work.