### PR TITLE
Update deploy-gatsby.md

### DIFF
--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -87,6 +87,8 @@ Now run `npm run deploy`. Preview changes in your GitHub page
 `https://username.github.io/project-name/`. You can also find the link to your
 site on GitHub under `Settings` > `GitHub Pages`.
 
+If this is not successful, make sure that `gh-pages` is set as the source branch in your repositories `Settings` > `GitHub Pages` and then re-run `npm run deploy`.
+
 ### Deploying a user/organization site
 
 Unlike project pages, user/organization sites on GitHub live in a special


### PR DESCRIPTION
added clarification as if the gh-pages branch has not been created and set as the source for github pages then the above instructions for publishing to github repository page won't work. I also had a similar recommendation fix in [https://github.com/gatsbyjs/gatsby/pull/5786](https://github.com/gatsbyjs/gatsby/pull/5786)