### PR TITLE
[v2] Allow resolving modules from node_modules folders higher in the file system

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -337,7 +337,7 @@ module.exports = async (
       // part of your site.
       modules: [
         directoryPath(path.join(`src`, `node_modules`)),
-        directoryPath(`node_modules`),
+        `node_modules`,
       ],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),


### PR DESCRIPTION
I'm updating the emotion site which is in a monorepo with yarn workspaces(so the dependencies are hoisted to the top-level node_modules folder) and modules weren't getting resolved since this was only looking in the local node_modules folder.
