### PR TITLE
[v2] Use replacementComponent directly in page-renderer

### DIFF
--- a/packages/gatsby/src/cache-dir/page-renderer.js
+++ b/packages/gatsby/src/cache-dir/page-renderer.js
@@ -131,7 +131,7 @@ class PageRenderer extends React.Component {
       pathContext,
     }
 
-    const replacementComponent = apiRunner(`replaceComponentRenderer`, {
+    const [replacementComponent] = apiRunner(`replaceComponentRenderer`, {
       props,
       loader: publicLoader,
     })

--- a/packages/gatsby/src/cache-dir/page-renderer.js
+++ b/packages/gatsby/src/cache-dir/page-renderer.js
@@ -131,13 +131,13 @@ class PageRenderer extends React.Component {
       pathContext,
     }
 
-    const [replacementComponent] = apiRunner(`replaceComponentRenderer`, {
+    const replacementComponent = apiRunner(`replaceComponentRenderer`, {
       props,
       loader: publicLoader,
     })
 
-    return createElement(
-      replacementComponent || this.state.pageResources.component,
+    return replacementComponent || createElement(
+      this.state.pageResources.component,
       props
     )
   }


### PR DESCRIPTION
I'm trying to Update examples in v2 branch (#5598). 
Using-page-transition sample is broken, because page-renderer returns error.

```
Users/yuki/.ghq/github.com/mottox2/gatsby/examples/using-page-transitions/node_modules/react-error-overlay/lib/index.js:2172 Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: object.

Check the render method of `PageRenderer`.
    in PageRenderer (created by JSONStore)
    in JSONStore (created by Route)
    in Route (created by Root)
    in ScrollContext (created by Route)
    in Route (created by withRouter(ScrollContext))
    in withRouter(ScrollContext) (created by Root)
    in Router (created by Root)
    in Root (created by HotExportedRoot)
    in AppContainer (created by HotExportedRoot)
    in HotExportedRoot
```

`this.state.pageResources.component` is expected created element by `React.createElement` in `replaceComponentRenderer `, so I returns replacementComponent directly.