### PR TITLE
[gatsby-remark-copy-linked-files] Support reference-style images

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -82,6 +82,16 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
   })
 
+  it(`can copy reference-style images`, async () => {
+    const path = `images/sample-image.gif`
+
+    const markdownAST = remark.parse(`![sample][1]\n\n[1]: ${path}`)
+
+    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).toHaveBeenCalled()
+  })
+
   it(`can copy file links`, async () => {
     const path = `files/sample-file.txt`
 

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -162,6 +162,15 @@ module.exports = (
     visitor(link)
   })
 
+  visit(markdownAST, `definition`, definition => {
+    const ext = definition.url.split(`.`).pop()
+    if (options.ignoreFileExtensions.includes(ext)) {
+      return
+    }
+
+    visitor(definition)
+  })
+
   // This will only work for markdown img tags
   visit(markdownAST, `image`, image => {
     const ext = image.url.split(`.`).pop()


### PR DESCRIPTION
Support images inserted as a reference. Makes pages that reference an
image repeatedly more concise:

> This is a cat: \![cat]\[1]
> This is a dog: \![dog]\[2]
> This is a cat and dog: \![cat]\[1] \![dog]\[2]
> 
> \[1]: ./spotted-brown-cat.jpg
> \[2]: ./black-and-white-stripe-dogs.jpg

Reference:
https://daringfireball.net/projects/markdown/syntax#img