### PR TITLE
[gatsby-plugin-feed] Support nested output path

### DIFF
--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "lodash.merge": "^4.6.0",
+    "mkdirp": "^0.5.1",
     "pify": "^3.0.0",
     "rss": "^1.2.2"
   },

--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -1,6 +1,8 @@
+import fs from "fs"
 import path from "path"
 import RSS from "rss"
 import merge from "lodash.merge"
+import mkdirp from "mkdirp"
 import { defaultOptions, runQuery, writeFile } from "./internals"
 
 const publicPath = `./public`
@@ -54,7 +56,13 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
     const items = serializer(locals)
 
     items.forEach(i => feed.item(i))
-    await writeFile(path.join(publicPath, f.output), feed.xml())
+
+    const outputPath = path.join(publicPath, f.output)
+    const outputDir = path.dirname(outputPath)
+    if (!fs.existsSync(outputDir)) {
+      mkdirp.sync(outputDir)
+    }
+    await writeFile(outputPath, feed.xml())
   }
 
   return Promise.resolve()


### PR DESCRIPTION
gatsby-plugin-feed wasn't working with nested output path.

```json
feeds: [
  {
    output: "/posts/feed.xml",
  }
]
```

```
error Plugin gatsby-plugin-feed returned an error

  Error: ENOENT: no such file or directory, open 'public/posts/feed.xml'
```