### PR TITLE
Update Relay/graphql

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -55,8 +55,8 @@
     "gatsby-module-loader": "^1.0.11",
     "gatsby-react-router-scroll": "^1.0.17",
     "glob": "^7.1.1",
-    "graphql": "^0.11.7",
-    "graphql-relay": "^0.5.1",
+    "graphql": "^0.13.2",
+    "graphql-relay": "^0.5.5",
     "graphql-skip-limit": "^1.0.11",
     "history": "^4.6.2",
     "invariant": "^2.2.2",
@@ -146,7 +146,7 @@
     "url": "git+https://github.com/gatsbyjs/gatsby.git"
   },
   "resolutions": {
-    "graphql": "^0.11.7"
+    "graphql": "^0.13.2"
   },
   "scripts": {
     "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles",

--- a/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
@@ -26,8 +26,8 @@ import type { DocumentNode, GraphQLSchema } from "graphql"
 const { printTransforms } = IRTransforms
 
 const {
-  ArgumentsOfCorrectTypeRule,
-  DefaultValuesOfCorrectTypeRule,
+  ValuesOfCorrectTypeRule,
+  VariablesDefaultValueAllowedRule,
   FragmentsOnCompositeTypesRule,
   KnownTypeNamesRule,
   LoneAnonymousOperationRule,
@@ -46,8 +46,8 @@ type RootQuery = {
 type Queries = Map<string, RootQuery>
 
 const validationRules = [
-  ArgumentsOfCorrectTypeRule,
-  DefaultValuesOfCorrectTypeRule,
+  ValuesOfCorrectTypeRule,
+  VariablesDefaultValueAllowedRule,
   FragmentsOnCompositeTypesRule,
   KnownTypeNamesRule,
   LoneAnonymousOperationRule,
@@ -146,7 +146,12 @@ class Runner {
       return compiledNodes
     }
 
-    const printContext = printTransforms.reduce(
+    // relay-compiler v1.5.0 added "StripUnusedVariablesTransform" to
+    // printTransforms. Unfortunately it currently doesn't detect variables
+    // in input objects widely used in gatsby, and therefore removing
+    // variable declaration from queries.
+    // As a temporary workaround remove that transform by slicing printTransforms.
+    const printContext = printTransforms.slice(0, -1).reduce(
       (ctx, transform) => transform(ctx, this.schema),
       compilerContext
     )

--- a/packages/graphql-skip-limit/package.json
+++ b/packages/graphql-skip-limit/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "graphql": "^0.11.7"
+    "graphql": "^0.13.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5694,7 +5694,7 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3,
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-relay@^0.5.1:
+graphql-relay@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.5.tgz#d6815e6edd618e878d5d921c13fc66033ec867e2"
 
@@ -5702,11 +5702,17 @@ graphql-type-json@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.1.4.tgz#89f13f5d32ce08c9a76c79fdf9c1968384d81a4e"
 
-graphql@^0.11.3, graphql@^0.11.7:
+graphql@^0.11.3:
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
   dependencies:
     iterall "1.1.3"
+
+graphql@^0.13.2, graphql@^0.32.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+  dependencies:
+    iterall "^1.2.1"
 
 gray-matter@^3.0.0:
   version "3.1.1"
@@ -7090,6 +7096,10 @@ items@2.x.x:
 iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+
+iterall@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
 jest-changed-files@^22.4.3:
   version "22.4.3"


### PR DESCRIPTION
Hey all, I'm hitting https://github.com/gatsbyjs/gatsby/issues/4154 but as I *need* to use an up-to-date version of relay (for [typescript support](https://github.com/facebook/relay/pull/2293)) 

Am I certain this isn't gonna break anything, no, but tests pass before and after this PR - so maybe!