### PR TITLE
[using-remark] Fixed typo on hello-world-kitchen-sink page

### DIFF
--- a/examples/using-remark/src/pages/2016-04-15---hello-world-kitchen-sink/index.md
+++ b/examples/using-remark/src/pages/2016-04-15---hello-world-kitchen-sink/index.md
@@ -111,9 +111,9 @@ In this example, leading and trailing spaces are shown with with dots: ⋅
 ```no-highlight
 1. First ordered list item
 2. Another item
-⋅⋅⋅* Unordered sub-list.
+⋅⋅⋅⋅* Unordered sub-list.
 1. Actual numbers don't matter, just that it's a number
-⋅⋅⋅1. Ordered sub-list
+⋅⋅⋅⋅1. Ordered sub-list
 4. And another item.
 
 ⋅⋅⋅You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).


### PR DESCRIPTION
This page links to [Markdown-Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) as an example. The code for that page has:
<pre>
## Lists

(In this example, leading and trailing spaces are shown with with dots: ⋅)

```no-highlight
1. First ordered list item
2. Another item
⋅⋅* Unordered sub-list. 
1. Actual numbers don't matter, just that it's a number
⋅⋅1. Ordered sub-list
4. And another item.

⋅⋅⋅You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).

⋅⋅⋅To have a line break without a paragraph, you will need to use two trailing spaces.⋅⋅
⋅⋅⋅Note that this line is separate, but within the same paragraph.⋅⋅
⋅⋅⋅(This is contrary to the typical GFM line break behaviour, where trailing spaces are not required.)

* Unordered list can use asterisks
- Or minuses
+ Or pluses
```

1. First ordered list item
2. Another item
  * Unordered sub-list. 
1. Actual numbers don't matter, just that it's a number
  1. Ordered sub-list
4. And another item.
</pre>

The version of that snippet on this page is:
<pre>
## Lists

In this example, leading and trailing spaces are shown with with dots: ⋅

```no-highlight
1. First ordered list item
2. Another item
⋅⋅⋅* Unordered sub-list.
1. Actual numbers don't matter, just that it's a number
⋅⋅⋅1. Ordered sub-list
4. And another item.

⋅⋅⋅You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).

⋅⋅⋅To have a line break without a paragraph, you will need to use two trailing spaces.⋅⋅
⋅⋅⋅Note that this line is separate, but within the same paragraph.⋅⋅

* Unordered list can use asterisks
- Or minuses
+ Or pluses
```

1.  First ordered list item
2.  Another item
    * Unordered sub-list.
3.  Actual numbers don't matter, just that it's a number
    1.  Ordered sub-list
4.  And another item.
</pre>

The number of spaces for sub-lists is 2 (Markdown-Cheatsheet) vs. 4 (this page) while the number of dots is 3 for both.  I was getting tripped up by this because it seems that the `gatsby-transformer-remark` rendering of sublists with less than 3 spaces doesn't create the desired results (lists are run together instead of being sub-listed). With 3 and more spaces, however, sub-lists are rendered properly so I added a dot to sub-lists on this page to indicate the functioning syntax. I also could have left the dots alone and changed the number of spaces on sub-lists to 3.

I checked for an issue relating to `gatsby-transformer-remark` but didn't see one. It may or may not be desirable to have it rendering sub-lists using less than 3 spaces but it suits my purposes to remember and use 3 or more spaces. 