### PR TITLE
[gatsby-transformer-remark] Make cache available to the plugins

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -118,6 +118,7 @@ module.exports = (
                     files,
                     getNode,
                     reporter,
+                    cache,
                   },
                   plugin.pluginOptions
                 )
@@ -185,6 +186,7 @@ module.exports = (
                       files,
                       pathPrefix,
                       reporter,
+                      cache,
                     },
                     plugin.pluginOptions
                   )


### PR DESCRIPTION
As discussed in https://github.com/gatsbyjs/gatsby/pull/5542/commits/d0d7dd4a76e7db643e77211fadfa282c4a4be5da

This is the 1st PR of the 3 PRs