### PR TITLE
[v2] Never ignore cache-dir

### DIFF
--- a/packages/gatsby/.gitignore
+++ b/packages/gatsby/.gitignore
@@ -28,4 +28,7 @@ node_modules
 
 decls
 dist
-cache-dir
+./cache-dir
+
+# Never ignore the source cache-dir
+!src/cache-dir


### PR DESCRIPTION
Use a more specific ignore pattern for the cache directory.

The existing ignore pattern changes behaviour depending on whether the built `packages/gatsby/cache-dir` exists (which is created on yarn run build). 

My editor uses the `.gitignore` patterns to exclude paths from search.  When `packages/gatsby/cache-dir` does not exist, the `cache-dir` ignore pattern was being expanded to a glob and searches were ignoring the _source_ cache directory `packages/gatsby/src/cache-dir`. This was quite confusing!

From https://git-scm.com/docs/gitignore:

>If the pattern does not contain a slash /, Git treats it as a shell glob pattern and checks for a match against the pathname relative to the location of the .gitignore file (relative to the toplevel of the work tree if not from a .gitignore file).
>
>Otherwise, Git treats the pattern as a shell glob: "*" matches anything except "/", "?" matches any one character except "/" and "[]" matches one character in a selected range. See fnmatch(3) and the FNM_PATHNAME flag for a more detailed description.