### PR TITLE
Disable gatsby eslint if local found

### DIFF
--- a/packages/gatsby/src/utils/local-eslint-config-finder.js
+++ b/packages/gatsby/src/utils/local-eslint-config-finder.js
@@ -1,0 +1,23 @@
+const path = require(`path`)
+const glob = require(`glob`)
+
+module.exports = directory => {
+  let hasEslintConfig = false
+
+  try {
+    const pkg = require(path.resolve(directory, `package.json`))
+    if (pkg.eslintConfig) {
+      hasEslintConfig = true
+    }
+  } catch (error) {
+    // not sure what we should do here...
+  }
+
+  const eslintFiles = glob.sync(`.eslintrc*`, { cwd: directory })
+
+  if (eslintFiles.length) {
+    hasEslintConfig = true
+  }
+
+  return hasEslintConfig
+}

--- a/packages/gatsby/src/utils/local-eslint-config-finder.js
+++ b/packages/gatsby/src/utils/local-eslint-config-finder.js
@@ -13,7 +13,9 @@ module.exports = directory => {
     // not sure what we should do here...
   }
 
-  const eslintFiles = glob.sync(`.eslintrc*`, { cwd: directory })
+  const eslintFiles = glob.sync(`.eslintrc?(.js|.json|.yaml|.yml)`, {
+    cwd: directory,
+  })
 
   if (eslintFiles.length) {
     hasEslintConfig = true

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -12,6 +12,7 @@ const { withBasePath } = require(`./path`)
 
 const apiRunnerNode = require(`./api-runner-node`)
 const createUtils = require(`./webpack-utils`)
+const hasLocalEslint = require(`./local-eslint-config-finder`)
 
 // Four stages or modes:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
@@ -66,10 +67,8 @@ module.exports = async (
     return Object.assign(envObject, gatsbyVarObject)
   }
 
-  function getHmrPath () {
-    let hmrBasePath = `${
-      program.ssl ? `https` : `http`
-    }://${
+  function getHmrPath() {
+    let hmrBasePath = `${program.ssl ? `https` : `http`}://${
       program.host
     }:${webpackPort}/`
 
@@ -97,9 +96,11 @@ module.exports = async (
           // Add /* filename */ comments to generated require()s in the output.
           pathinfo: true,
           // Point sourcemap entries to original disk location (format as URL on Windows)
-          publicPath: process.env.GATSBY_WEBPACK_PUBLICPATH || `${program.ssl ? `https` : `http`}://${
-            program.host
-          }:${webpackPort}/`,
+          publicPath:
+            process.env.GATSBY_WEBPACK_PUBLICPATH ||
+            `${program.ssl ? `https` : `http`}://${
+              program.host
+            }:${webpackPort}/`,
           devtoolModuleFilenameTemplate: info =>
             path.resolve(info.absoluteResourcePath).replace(/\\/g, `/`),
         }
@@ -138,7 +139,9 @@ module.exports = async (
         return {
           commons: [
             require.resolve(`react-hot-loader/patch`),
-            `${require.resolve(`webpack-hot-middleware/client`)}?path=${getHmrPath()}`,
+            `${require.resolve(
+              `webpack-hot-middleware/client`
+            )}?path=${getHmrPath()}`,
             directoryPath(`.cache/app`),
           ],
         }
@@ -278,7 +281,6 @@ module.exports = async (
   }
 
   function getModule(config) {
-    const { schema } = store.getState()
     // Common config for every env.
     // prettier-ignore
     let configRules = [
@@ -289,15 +291,23 @@ module.exports = async (
       rules.audioVideo(),
     ]
     switch (stage) {
-      case `develop`:
+      case `develop`: {
+        // get schema to pass to eslint config and program for directory
+        const { schema, program } = store.getState()
+
+        // if no local eslint config, then add gatsby config
+        if (!hasLocalEslint(program.directory)) {
+          configRules = configRules.concat([rules.eslint(schema)])
+        }
+
         configRules = configRules.concat([
-          rules.eslint(schema),
           {
             oneOf: [rules.cssModules(), rules.css()],
           },
         ])
-        break
 
+        break
+      }
       case `build-html`:
       case `develop-html`:
         // We don't deal with CSS at all when building the HTML.


### PR DESCRIPTION
This PR adds a check for local eslint config and if found, disables the eslint check in Gatsby webpack config.

Closes #5763 
Closes #5493