### PR TITLE
[v2] add prismjs dep

### DIFF
--- a/packages/gatsby-transformer-documentationjs/package.json
+++ b/packages/gatsby-transformer-documentationjs/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.47",
-    "documentation": "^7.1.0"
+    "documentation": "^7.1.0",
+    "prismjs": "^1.14.0"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.47",


### PR DESCRIPTION
Closes #5872

In other plugins we've moved key dependencies out to peer dependencies. I'm not sure that makes sense here, so I've left it as a dependency.