### PR TITLE
Update createRemoteFileNode auth options.

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -137,7 +137,7 @@ createRemoteFileNode({
 
   // OPTIONAL
   // Adds htaccess authentication to the download request if passed in.
-  auth: { user: `USER`, password: `PASSWORD` },
+  auth: { htaccess_user: `USER`, htaccess_pass: `PASSWORD` },
 });
 ```
 


### PR DESCRIPTION
It looks like the example for `createRemoteFileNode` has the wrong `auth` keys. I've updated them to match what `createRemoteFileNode` is expecting.