### PR TITLE
[v2] Build-html static file using the webpack magic comment to provide the link rel.

### DIFF
--- a/examples/using-prefetching-preloading-modules/.eslintrc.json
+++ b/examples/using-prefetching-preloading-modules/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "graphql": false
+  }
+}

--- a/examples/using-prefetching-preloading-modules/README.md
+++ b/examples/using-prefetching-preloading-modules/README.md
@@ -1,0 +1,6 @@
+# Using Prefetching/Preloading modules
+
+https://using-prefetch-preload-module.gatsbyjs.org
+
+## References
+- [Prefetching/Preloading Modules](https://webpack.js.org/guides/code-splitting/#prefetching-preloading-modules).

--- a/examples/using-prefetching-preloading-modules/gatsby-config.js
+++ b/examples/using-prefetching-preloading-modules/gatsby-config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  siteMetadata: {
+    title: `Gatsby with styled components`,
+  },
+  plugins: [
+    `gatsby-plugin-styled-components`,
+    {
+      resolve: `gatsby-plugin-typography`,
+      options: {
+        pathToConfigModule: `src/utils/typography.js`,
+      },
+    },
+    `gatsby-plugin-react-helmet`,
+    `gatsby-plugin-offline`,
+  ],
+}

--- a/examples/using-prefetching-preloading-modules/package.json
+++ b/examples/using-prefetching-preloading-modules/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "gatsby-example-using-prefetching-preloading-modules",
+  "private": true,
+  "description": "Gatsby example site using Prefetching/Preloading modules",
+  "version": "2.0.0",
+  "author": "Nuttapol Laoticharoen <pistachio.uss@gmail.com>",
+  "dependencies": {
+    "babel-plugin-styled-components": "^1.5.1",
+    "gatsby": "next",
+    "gatsby-plugin-offline": "next",
+    "gatsby-plugin-react-helmet": "next",
+    "gatsby-plugin-styled-components": "next",
+    "gatsby-plugin-typography": "next",
+    "lodash": "^4.16.4",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
+    "react-helmet": "^5.2.0",
+    "react-typography": "^0.16.13",
+    "slash": "^1.0.0",
+    "styled-components": "^3.3.2",
+    "typography": "^0.16.17",
+    "typography-breakpoint-constants": "^0.15.10"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build"
+  }
+}

--- a/examples/using-prefetching-preloading-modules/src/components/DynamicComponent.js
+++ b/examples/using-prefetching-preloading-modules/src/components/DynamicComponent.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+class DynamicComponent extends React.Component {
+  handleClick = () => {
+    console.log(`Sync-Click!`)
+    import(/* webpackChunkName: "async-console", webpackPreload: true */ `../utils/async-console`).then(module => {
+      const asyncConsole = module.default
+      asyncConsole(`Async-Log!`)
+    })
+  }
+
+  render() {
+    return <button onClick={this.handleClick}>
+        Dynamic Log
+      </button>
+  }
+}
+
+export default DynamicComponent

--- a/examples/using-prefetching-preloading-modules/src/pages/index.js
+++ b/examples/using-prefetching-preloading-modules/src/pages/index.js
@@ -1,0 +1,65 @@
+import React from "react"
+import Helmet from "react-helmet"
+import styled from "styled-components"
+import DynamicComponent from "../components/DynamicComponent"
+import "./style.css"
+
+// Create a Title component that'll render an <h1> tag with some styles
+const Title = styled.h1`
+  font-size: 1.5em;
+  text-align: center;
+  color: brown;
+`
+
+// Create a Wrapper component that'll render a <section> tag with some styles
+const Wrapper = styled.section`
+  padding: 4em;
+  background: papayawhip;
+`
+
+
+class IndexPage extends React.Component {
+  handleClick = () => {
+    console.log(`Sync-Click!`)
+    import(/* webpackChunkName: "async-alert", webpackPrefetch: true */ `../utils/async-alert`).then(module => {
+      const asyncAlert = module.default
+      asyncAlert(`Async-Click!`)
+    })
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <Helmet>
+          <title>Gatsby Prefetching/Preloading modules</title>
+          <meta
+            name="description"
+            content="Gatsby example site using prefetching/preloading modules"
+          />
+          <meta name="referrer" content="origin" />
+        </Helmet>
+        <div
+          style={{
+            margin: `0 auto`,
+            marginTop: `3rem`,
+            padding: `1.5rem`,
+            maxWidth: 900,
+            color: `red`,
+          }}
+        >
+          <Wrapper>
+            <Title>Hello World, this is my first prefetching/preloading component!</Title>
+            <p>
+              <button onClick={this.handleClick}>
+                Dynamic Alert!
+              </button>
+              <DynamicComponent />
+            </p>
+          </Wrapper>
+        </div>
+      </React.Fragment>
+    )
+  }
+}
+
+export default IndexPage

--- a/examples/using-prefetching-preloading-modules/src/pages/style.css
+++ b/examples/using-prefetching-preloading-modules/src/pages/style.css
@@ -1,0 +1,9 @@
+
+.changeable-title {
+  color: red;
+}
+
+button {
+  margin-right: 20px;
+  float: left;
+}

--- a/examples/using-prefetching-preloading-modules/src/utils/async-alert.js
+++ b/examples/using-prefetching-preloading-modules/src/utils/async-alert.js
@@ -1,0 +1,3 @@
+
+
+module.exports = x => alert(x)

--- a/examples/using-prefetching-preloading-modules/src/utils/async-console.js
+++ b/examples/using-prefetching-preloading-modules/src/utils/async-console.js
@@ -1,0 +1,3 @@
+
+
+module.exports = (...x) => console.log(...x)

--- a/examples/using-prefetching-preloading-modules/src/utils/typography.js
+++ b/examples/using-prefetching-preloading-modules/src/utils/typography.js
@@ -1,0 +1,35 @@
+import Typography from "typography"
+import {
+  MOBILE_MEDIA_QUERY,
+  TABLET_MEDIA_QUERY,
+} from "typography-breakpoint-constants"
+
+const options = {
+  baseFontSize: `18px`,
+  baseLineHeight: 1.45,
+  blockMarginBottom: 0.75,
+  scaleRatio: 2.15,
+  overrideStyles: ({ rhythm, scale }, options) => {
+    return {
+      "h1,h2,h3,h4": {
+        lineHeight: 1.2,
+      },
+      [TABLET_MEDIA_QUERY]: {
+        // Make baseFontSize on mobile 17px.
+        html: {
+          fontSize: `${17 / 16 * 100}%`,
+        },
+      },
+      [MOBILE_MEDIA_QUERY]: {
+        // Make baseFontSize on mobile 16px.
+        html: {
+          fontSize: `${16 / 16 * 100}%`,
+        },
+      },
+    }
+  },
+}
+
+const typography = new Typography(options)
+
+export default typography

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -122,7 +122,7 @@
     "url-loader": "^1.0.1",
     "uuid": "^3.1.0",
     "v8-compile-cache": "^1.1.0",
-    "webpack": "^4.4.1",
+    "webpack": "^4.12.0",
     "webpack-dev-middleware": "^3.0.1",
     "webpack-dev-server": "^3.1.1",
     "webpack-hot-middleware": "^2.21.0",

--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -276,7 +276,7 @@ export default (pagePath, callback) => {
   )
 
   const bodyScripts = scripts.map(s => {
-    const scriptPath = `${pathPrefix}${JSON.stringify(s).slice(1, -1)}`
+    const scriptPath = `${pathPrefix}${JSON.stringify(s.name).slice(1, -1)}`
     return <script key={scriptPath} src={scriptPath} async />
   })
 

--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -155,21 +155,30 @@ export default (pagePath, callback) => {
       const fetchKey = `assetsByChunkName[${s}]`
 
       let chunks = get(stats, fetchKey)
+      let fetchedEntryPoints = get(stats, `entrypoints`)
 
       if (!chunks) {
         return null
       }
 
-      return chunks.map(chunk => {
+      chunks = chunks.map(chunk => {
         if (chunk === `/`) {
           return null
         }
         return chunk
       })
+
+      console.log(`ChunkName: ${s}`)
+      console.log(fetchedEntryPoints)
+      console.log(chunks)
+      // return defineAssetScript(fetchedEntryPoints, chunks, { rel: `preload`, prefixedScript: chunks })
+      return chunks
     })
   ).filter(s => isString(s))
-  const scripts = scriptsAndStyles.filter(s => s.endsWith(`.js`))
-  const styles = scriptsAndStyles.filter(s => s.endsWith(`.css`))
+  const scripts = scriptsAndStyles.filter(script => script.endsWith(`.js`))
+  const styles = scriptsAndStyles.filter(script => script.endsWith(`.css`))
+  console.log(scripts)
+  console.log(styles)
 
   apiRunner(`onRenderBody`, {
     setHeadComponents,

--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -203,7 +203,7 @@ export default (pagePath, callback) => {
     .slice(0)
     .reverse()
     .forEach(script => {
-      // Add preload <link>s for scripts.
+      // Add preload/prefetch <link>s for scripts.
       headComponents.push(
         <link
           as="script"
@@ -216,10 +216,7 @@ export default (pagePath, callback) => {
 
   if (page.jsonName in dataPaths) {
     const dataPath = `${pathPrefix}static/d/${dataPaths[page.jsonName]}.json`
-    // Insert json data path after commons and app
-    headComponents.splice(
-      1,
-      0,
+    headComponents.push(
       <link
         rel="preload"
         key={dataPath}
@@ -258,7 +255,7 @@ export default (pagePath, callback) => {
       )
     })
 
-  // Add script loader for page scripts to the end of body element (after webpack manifest).
+  // Add page metadata for the current page
   const windowData = `/*<![CDATA[*/window.page=${JSON.stringify(page)};${
     page.jsonName in dataPaths
       ? `window.dataPath="${dataPaths[page.jsonName]}";`
@@ -275,7 +272,9 @@ export default (pagePath, callback) => {
     />
   )
 
-  const bodyScripts = scripts.map(s => {
+  // Filter out prefetched bundles as adding them as a script tag
+  // would force high priority fetching.
+  const bodyScripts = scripts.filter(s => s.rel !== `prefetch`).map(s => {
     const scriptPath = `${pathPrefix}${JSON.stringify(s.name).slice(1, -1)}`
     return <script key={scriptPath} src={scriptPath} async />
   })

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -212,9 +212,27 @@ module.exports = async (
               compiler.hooks.done.tapAsync(
                 `gatsby-webpack-stats-extractor`,
                 (stats, done) => {
+                  let assets = {}
+                  for (let chunkGroup of stats.compilation.chunkGroups) {
+                    if (chunkGroup.name) {
+                      let files = []
+                      for (let chunk of chunkGroup.chunks) {
+                        files.push(...chunk.files)
+                      }
+                      assets[chunkGroup.name] = files.filter(
+                        f => f.slice(-4) !== `.map`
+                      )
+                    }
+                  }
+
+                  const webpackStats = {
+                    ...stats.toJson({ all: false, chunkGroups: true }),
+                    assetsByChunkName: assets,
+                  }
+
                   fs.writeFile(
                     path.join(`public`, `webpack.stats.json`),
-                    JSON.stringify(stats.toJson({ all: false, assets: true, chunkGroups: true })),
+                    JSON.stringify(webpackStats),
                     done
                   )
                 }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -214,7 +214,7 @@ module.exports = async (
                 (stats, done) => {
                   fs.writeFile(
                     path.join(`public`, `webpack.stats.json`),
-                    JSON.stringify(stats.toJson()),
+                    JSON.stringify(stats.toJson({ all: false, assets: true, chunkGroups: true })),
                     done
                   )
                 }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -212,25 +212,9 @@ module.exports = async (
               compiler.hooks.done.tapAsync(
                 `gatsby-webpack-stats-extractor`,
                 (stats, done) => {
-                  let assets = {}
-
-                  for (let chunkGroup of stats.compilation.chunkGroups) {
-                    if (chunkGroup.name) {
-                      let files = []
-                      for (let chunk of chunkGroup.chunks) {
-                        files.push(...chunk.files)
-                      }
-                      assets[chunkGroup.name] = files.filter(
-                        f => f.slice(-4) !== `.map`
-                      )
-                    }
-                  }
-
                   fs.writeFile(
                     path.join(`public`, `webpack.stats.json`),
-                    JSON.stringify({
-                      assetsByChunkName: assets,
-                    }),
+                    JSON.stringify(stats.toJson()),
                     done
                   )
                 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11383,7 +11383,7 @@ printj@~1.1.0, printj@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
 
-prismjs@^1.13.0:
+prismjs@^1.13.0, prismjs@^1.14.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.14.0.tgz#bbccfdb8be5d850d26453933cb50122ca0362ae0"
   optionalDependencies:
@@ -15436,7 +15436,7 @@ webpack-stats-plugin@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/webpack-stats-plugin/-/webpack-stats-plugin-0.1.5.tgz#29e5f12ebfd53158d31d656a113ac1f7b86179d9"
 
-webpack@^4.4.1:
+webpack@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.12.0.tgz#14758e035ae69747f68dd0edf3c5a572a82bdee9"
   dependencies:


### PR DESCRIPTION
According to [#5748](https://github.com/gatsbyjs/gatsby/pull/5748).

We need to merge into branch v2 and upgrade webpack version to >4.6.0 for webpackPrefetch feature instead.

This PR solves this issue: [#5683](https://github.com/gatsbyjs/gatsby/pull/5683)
