### PR TITLE
load-plugins test and snapshot update after #4490

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -84,7 +84,7 @@ Array [
     },
     "resolve": "",
     "ssrAPIs": Array [],
-    "version": "d41d8cd98f00b204e9800998ecf8427e",
+    "version": "1.0.0",
   },
   Object {
     "browserAPIs": Array [],
@@ -188,6 +188,7 @@ Array [
     },
     "resolve": "",
     "ssrAPIs": Array [],
+    "version": "1.0.0",
   },
   Object {
     "browserAPIs": Array [],
@@ -199,7 +200,7 @@ Array [
     },
     "resolve": "",
     "ssrAPIs": Array [],
-    "version": "d41d8cd98f00b204e9800998ecf8427e",
+    "version": "1.0.0",
   },
   Object {
     "browserAPIs": Array [],

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
@@ -1,17 +1,24 @@
 const loadPlugins = require(`../index`)
 
 describe(`Load plugins`, () => {
+  /**
+   * Replace the resolve path and version string.
+   * Resolve path will vary depending on platform.
+   * Version can be updated (we use external plugin in default config).
+   * Both will cause snapshots to differ.
+   */
+  const replaceFieldsThatCanVary = plugins => plugins.map(plugin => {
+    return {
+      ...plugin,
+      resolve: ``,
+      version: `1.0.0`,
+    }
+  })
+
   it(`Load plugins for a site`, async () => {
     let plugins = await loadPlugins({ plugins: [] })
 
-    // Delete the resolve path as that varies depending
-    // on platform so will cause snapshots to differ.
-    plugins = plugins.map(plugin => {
-      return {
-        ...plugin,
-        resolve: ``,
-      }
-    })
+    plugins = replaceFieldsThatCanVary(plugins)
 
     expect(plugins).toMatchSnapshot()
   })
@@ -27,14 +34,7 @@ describe(`Load plugins`, () => {
 
     let plugins = await loadPlugins(config)
 
-    // Delete the resolve path as that varies depending
-    // on platform so will cause snapshots to differ.
-    plugins = plugins.map(plugin => {
-      return {
-        ...plugin,
-        resolve: ``,
-      }
-    })
+    plugins = replaceFieldsThatCanVary(plugins)
 
     expect(plugins).toMatchSnapshot()
   })


### PR DESCRIPTION
fixes snapshot not matching when we update gatsby-plugin-page-creator which is included in default config