### PR TITLE
[v2] update load-plugins snapshot

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -99,7 +99,7 @@ Array [
     },
     "resolve": "",
     "ssrAPIs": Array [],
-    "version": "1.0.1",
+    "version": "1.0.0",
   },
 ]
 `;
@@ -214,7 +214,7 @@ Array [
     },
     "resolve": "",
     "ssrAPIs": Array [],
-    "version": "1.0.1",
+    "version": "1.0.0",
   },
 ]
 `;


### PR DESCRIPTION
applies change that wasn't transferred from the master merge 