### PR TITLE
gatsby-plugin-netlify-cms: allow identity widget disabling

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -26,15 +26,19 @@ Then add your Netlify CMS [configuration
 file](https://www.netlifycms.org/docs/add-to-your-site/#configuration) in
 `static/admin/config.yml`.
 
-## Configuration
+## Options
+The Netlify CMS can be configured via the plugin options below. You can learn
+about how to pass options to plugins in the [Gatsby
+docs](https://www.gatsbyjs.org/docs/plugins/#how-to-use-gatsby-plugins).
+
+### `modulePath`
 
 If you need to customize Netlify CMS, e.g. registering [custom
 widgets](https://www.netlifycms.org/docs/custom-widgets/#registerwidget) or
 styling the [preview
 pane](https://www.netlifycms.org/docs/customization/#registerpreviewstyle),
-you'll need to do so in a js module and provide Gatsby with the path to your
-module. In `gatsby-config.js`, instead of simply adding the name of the plugin
-to the `plugins` array, you'll need to use an object:
+you'll need to do so in a JavaScript module and provide Gatsby with the path to
+your module via the `modulePath` option:
 
 ```javascript
 plugins: [
@@ -64,6 +68,25 @@ import ImageGalleryPreview from "./image-gallery-preview.js";
 
 // Register the imported widget:
 CMS.registerWidget("image-gallery", ImageGalleryWidget, ImageGalleryPreview);
+```
+
+### `enableIdentityWidget`
+
+`enableIdentityWidget` is `true` by default, allowing [Netlify
+Identity](https://www.netlify.com/docs/identity/) to be used without
+configuration, but you may need to disable it in some cases, such as when using
+a Netlify CMS backend that conflicts. This is currently known to be the case
+when using the GitLab backend, but only when using implicit OAuth.
+
+```javascript
+plugins: [
+  {
+    resolve: `gatsby-plugin-netlify-cms`,
+    options: {
+    enableIdentityWidget: true,
+    },
+  },
+];
 ```
 
 ## Support

--- a/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
@@ -1,0 +1,4 @@
+import netlifyIdentityWidget from "netlify-identity-widget"
+
+window.netlifyIdentity = netlifyIdentityWidget
+netlifyIdentityWidget.init()

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -2,7 +2,3 @@
 /* eslint-env browser */
 import CMS from "netlify-cms"
 import "netlify-cms/dist/cms.css"
-import netlifyIdentityWidget from "netlify-identity-widget"
-
-window.netlifyIdentity = netlifyIdentityWidget
-netlifyIdentityWidget.init()

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-browser.js
@@ -1,12 +1,14 @@
 import netlifyIdentityWidget from "netlify-identity-widget"
 
-exports.onInitialClientRender = () => {
-  netlifyIdentityWidget.on(`init`, user => {
-    if (!user) {
-      netlifyIdentityWidget.on(`login`, () => {
-        document.location.href = `/admin/`
-      })
-    }
-  })
-  netlifyIdentityWidget.init()
+exports.onInitialClientRender = (_, { enableIdentityWidget }) => {
+  if (enableIdentityWidget) {
+    netlifyIdentityWidget.on(`init`, user => {
+      if (!user) {
+        netlifyIdentityWidget.on(`login`, () => {
+          document.location.href = `/admin/`
+        })
+      }
+    })
+    netlifyIdentityWidget.init()
+  }
 }

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -62,10 +62,16 @@ function module(config, stage) {
   }
 }
 
-exports.modifyWebpackConfig = ({ config, stage }, { modulePath }) => {
+exports.modifyWebpackConfig = ({ config, stage }, { modulePath, enableIdentityWidget = true }) => {
+  const entryPaths = [
+    `${__dirname}/cms.js`,
+    enableIdentityWidget && `${__dirname}/cms-identity.js`,
+    modulePath,
+  ]
+
   config.merge({
     entry: {
-      cms: [`${__dirname}/cms.js`, modulePath].filter(p => p),
+      cms: entryPaths.filter(p => p),
     },
     plugins: plugins(stage),
   })


### PR DESCRIPTION
This should fix the Netlify CMS plugin breaking for GitLab users on implicit OAuth (or at least provide a way for them to configure around the break), did not have time to test locally - if someone that needs this has time to do so and confirm it works please comment!

cc/ @benaiah @tech4him1 @talves