### PR TITLE
[gatsby-remark-autolink-headers] Add option to choose a SVG icon

### DIFF
--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -27,6 +27,7 @@ module.exports = {
 ## Options
 
 - `offsetY`: Signed integer, vertical offset value in pixels, e.g.
+- `icon`: Use your own svg icon
 
 ```javascript
 // In your gatsby-config.js
@@ -40,31 +41,7 @@ module.exports = {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
               offsetY: `100`,
-            },
-          },
-        ],
-      },
-    },
-  ],
-}
-```
-
-## Options
-
-- `offsetY`: Signed integer, vertical offset value in pixels, e.g.
-
-```javascript
-// In your gatsby-config.js
-module.exports = {
-  plugins: [
-    {
-      resolve: `gatsby-transformer-remark`,
-      options: {
-        plugins: [
-          {
-            resolve: `gatsby-remark-autolink-headers`,
-            options: {
-              offsetY: `100`,
+              icon: `<svg aria-hidden="true" height="20" version="1.1" viewBox="0 0 16 16" width="20"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`,
             },
           },
         ],

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -26,8 +26,8 @@ module.exports = {
 
 ## Options
 
-- `offsetY`: Signed integer, vertical offset value in pixels, e.g.
-- `icon`: Use your own svg icon
+- `offsetY`: Signed integer. Vertical offset value in pixels (optional)
+- `icon`: SVG shape inside a template literal. Set your own svg icon (optional)
 
 ```javascript
 // In your gatsby-config.js

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
@@ -64,3 +64,68 @@ Object {
   "type": "heading",
 }
 `;
+
+exports[`gatsby-remark-autolink-headers adds id to a markdown header with custom svg icon 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg width=\\"400\\" height=\\"110\\"><rect width=\\"300\\" height=\\"100\\" /></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-hidden": true,
+          "class": "anchor",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#heading-uno",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
@@ -13,7 +13,7 @@ describe(`gatsby-remark-autolink-headers`, () => {
   it(`adds id to a markdown header`, () => {
     const markdownAST = remark.parse(`# Heading Uno`)
 
-    const transformed = plugin({ markdownAST })
+    const transformed = plugin({ markdownAST }, {})
 
     visit(transformed, `heading`, node => {
       expect(node.data.id).toBeDefined()
@@ -31,7 +31,7 @@ describe(`gatsby-remark-autolink-headers`, () => {
 ### Heading Three
     `)
 
-    const transformed = plugin({ markdownAST })
+    const transformed = plugin({ markdownAST }, {})
 
     visit(transformed, `heading`, node => {
       expect(node.data.id).toBeDefined()

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
@@ -37,4 +37,33 @@ describe(`gatsby-remark-autolink-headers`, () => {
       expect(node.data.id).toBeDefined()
     })
   })
+  it(`adds id to a markdown header with custom svg icon`, () => {
+    const markdownAST = remark.parse(`# Heading Uno`)
+    const icon = `<svg width="400" height="110"><rect width="300" height="100" /></svg>`
+
+    const transformed = plugin({ markdownAST }, { icon })
+
+    visit(transformed, `heading`, node => {
+      expect(node.data.id).toBeDefined()
+
+      expect(node).toMatchSnapshot()
+    })
+  })
+
+  it(`adds ids to each markdown header with custom svg icon`, () => {
+    const markdownAST = remark.parse(`
+# Heading One
+
+## Heading Two
+
+### Heading Three
+    `)
+    const icon = `<svg width="400" height="110"><rect width="300" height="100" /></svg>`
+
+    const transformed = plugin({ markdownAST }, { icon })
+
+    visit(transformed, `heading`, node => {
+      expect(node.data.id).toBeDefined()
+    })
+  })
 })

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -9,7 +9,10 @@ function patch(context, key, value) {
 
   return context[key]
 }
-module.exports = ({ markdownAST }) => {
+
+const svgIcon = `<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`
+
+module.exports = ({ markdownAST }, { icon = svgIcon }) => {
   slugs.reset()
 
   visit(markdownAST, `heading`, node => {
@@ -34,8 +37,8 @@ module.exports = ({ markdownAST }) => {
         hChildren: [
           {
             type: `raw`,
-            // The Octicon link icon.
-            value: `<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`,
+            // The Octicon link icon is the default. But users can set their own icon via the "icon" option.
+            value: icon,
           },
         ],
       },


### PR DESCRIPTION
Since v2 got merged to master I re-did my previous PR https://github.com/gatsbyjs/gatsby/pull/5926.
Oddly enough I had to delete a duplicate of the options this time 🤔 