### PR TITLE
Fix migration doc links

### DIFF
--- a/docs/blog/2018-06-16-announcing-gatsby-v2-beta-launch/index.md
+++ b/docs/blog/2018-06-16-announcing-gatsby-v2-beta-launch/index.md
@@ -21,7 +21,7 @@ Gatsby v2 builds on the foundations of v1 to introduce a range of improvements:
 
   We’ve renamed `sizes` and `resolutions` to `fluid` and `fixed`, `boundActionCreators` to `actions`, as well as other changes intended to make API names more consistent and prevent common gotchas.
 
-  To see the full list of renamings, take a look at the upgrade guide for [image queries](https://next.gatsbyjs.com/docs/migrating-from-v1-to-v2/#rename-responsive-image-queries), [actions](https://next.gatsbyjs.com/docs/migrating-from-v1-to-v2/#rename-code-classlanguage-textboundactioncreatorscode-to-code-classlanguage-textactionscode) and the [babel](https://next.gatsbyjs.com/docs/migrating-from-v1-to-v2/#change-code-classlanguage-textmodifybabelrccode-to-code-classlanguage-textoncreatebabelconfigcode) and [webpack](https://next.gatsbyjs.com/docs/migrating-from-v1-to-v2/#change-code-classlanguage-textmodifywebpackconfigcode-to-code-classlanguage-textoncreatewebpackconfigcode) API hooks.
+  To see the full list of renamings, take a look at the upgrade guide for [image queries](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-responsive-image-queries), [actions](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-code-classlanguage-textboundactioncreatorscode-to-code-classlanguage-textactionscode) and the [babel](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#change-code-classlanguage-textmodifybabelrccode-to-code-classlanguage-textoncreatebabelconfigcode) and [webpack](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#change-code-classlanguage-textmodifywebpackconfigcode-to-code-classlanguage-textoncreatewebpackconfigcode) API hooks.
 
 - Hotter Hot Reloading
 


### PR DESCRIPTION
<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Fix hyperlinks to migration doc.
