### PR TITLE
[using-typescript] Fix typing in index layout component

### DIFF
--- a/examples/using-typescript/src/layouts/index.tsx
+++ b/examples/using-typescript/src/layouts/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import { rhythm } from "../utils/typography"
 
-const MainLayout = ({ children }: { children: any }) => (
+const MainLayout: React.SFC = ({ children }) => (
   <div
     style={{
       margin: `0 auto`,


### PR DESCRIPTION
Fixed typing in `./layouts/index.ts` to use the standard `React.SFC` typing for stateless components.

<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
