### PR TITLE
[gatsby] expose gatsby-link modules + fixed Partial declaration in .d.ts

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 export {
+  default as Link,
   GatsbyLinkProps,
   navigateTo,
   push,

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1,5 +1,13 @@
 import * as React from "react"
 
+export {
+  GatsbyLinkProps,
+  navigateTo,
+  push,
+  replace,
+  withPrefix
+} from "gatsby-link"
+
 interface StaticQueryRenderProps {
   data: any
 }
@@ -11,4 +19,4 @@ export interface StaticQueryProps {
   render: RenderCallback
 }
 
-export class StaticQuery extends React.Component<Partial<StaticQueryProps>> {}
+export class StaticQuery extends React.Component<StaticQueryProps> {}


### PR DESCRIPTION
Expose the `gatsby-link` typings now that it's exportable [directly from the `'gatsby'` module](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#import-link-from-gatsby).

<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
