### PR TITLE
restore check-versions.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "private": true,
   "scripts": {
-    "bootstrap": "npm run lerna-prepare",
+    "bootstrap": "npm-run-all -s check-versions lerna-prepare",
     "check-versions": "babel-node scripts/check-versions.js",
     "format": "npm-run-all -p format-packages format-cache-dir format-www format-examples format-scripts format-markdown",
     "format-cache-dir": "prettier-eslint --write \"packages/gatsby/cache-dir/*.js\"",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "npm run lerna-prepare",
-    "check-versions": "babel-node scripts/check-versions.js --allow-next",
+    "check-versions": "babel-node scripts/check-versions.js",
     "format": "npm-run-all -p format-packages format-cache-dir format-www format-examples format-scripts format-markdown",
     "format-cache-dir": "prettier-eslint --write \"packages/gatsby/cache-dir/*.js\"",
     "format-examples": "prettier-eslint --write \"examples/**/gatsby-node.js\" \"examples/**/gatsby-config.js\" \"examples/**/src/**/*.js\"",

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.51",
     "cheerio": "^1.0.0-rc.2",
-    "gatsby-plugin-sharp": "next",
+    "gatsby-plugin-sharp": "^2.0.0-beta.1",
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.4",
     "slash": "^1.0.0",

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -14,7 +14,7 @@
     "contentful": "^6.1.0",
     "deep-map": "^1.5.0",
     "fs-extra": "^4.0.2",
-    "gatsby-plugin-sharp": "next",
+    "gatsby-plugin-sharp": "^2.0.0-beta.1",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",
     "qs": "^6.4.0"

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "7.0.0-beta.51",
     "axios": "^0.18.0",
     "bluebird": "^3.5.0",
-    "gatsby-source-filesystem": "next",
+    "gatsby-source-filesystem": "^2.0.1-beta.1",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -14,7 +14,7 @@
     "bluebird": "^3.5.0",
     "deep-map": "^1.5.0",
     "deep-map-keys": "^1.2.0",
-    "gatsby-source-filesystem": "next",
+    "gatsby-source-filesystem": "^2.0.1-beta.1",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.4",

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "7.0.0-beta.51",
     "axios": "^0.18.0",
     "fs-extra": "^4.0.2",
-    "gatsby-plugin-sharp": "next",
+    "gatsby-plugin-sharp": "^2.0.0-beta.1",
     "mini-svg-data-uri": "^1.0.0",
     "p-queue": "^2.3.0",
     "sqip": "^0.3.0"

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -1,9 +1,8 @@
 const { writeFileSync } = require(`fs`)
 const yargs = require(`yargs`)
-const Repository = require(`lerna/lib/Repository`)
-const PackageUtilities = require(`lerna/lib/PackageUtilities`)
-
-const packages = PackageUtilities.getPackages(new Repository())
+const collectPackages = require(`@lerna/collect-packages`);
+const PackageGraph = require(`@lerna/package-graph`)
+const semver = require(`semver`)
 
 let warned = false
 let argv = yargs
@@ -16,42 +15,49 @@ let argv = yargs
     describe: `Allow using "next" versions. Use this only for alpha/beta releases`,
   }).argv
 
-packages.forEach(pkg => {
-  let outdated = packages
-    .filter(p => !!pkg.allDependencies[p.name] && p.name !== pkg.name)
-    .filter(p => !pkg.hasMatchingDependency(p))
+collectPackages(process.cwd()).then(packages => {
+  const graph = new PackageGraph(packages, `allDependencies`, true)
+  
+  graph.forEach((pkgNode, name) => {
+    // const outdated = []
 
-  if (argv[`allow-next`]) {
-    outdated = outdated.filter(p => pkg.allDependencies[p.name] !== `next`)
-  }
+    let outdated = Array.from(pkgNode.localDependencies.values())
+      .filter(localDep => !semver.satisfies(graph.get(localDep.name).version, localDep.fetchSpec))
+    
+    if (argv[`allow-next`]) {
+      outdated = outdated.filter(localDep => localDep.fetchSpec !== `next`)
+    }
+    
+    if (!outdated.length) return
 
-  if (!outdated.length) return
-
-  warned = true
-  const msg = outdated
+    const msg = outdated
     .map(
       p =>
-        `  Depends on "${p.name}@${pkg.allDependencies[p.name]}" \n` +
-        `  instead of "${p.name}@${p.version}". \n`
+        `  Depends on "${p.name}@${p.fetchSpec}" \n` +
+        `  instead of "${p.name}@${graph.get(p.name).version}". \n`
     )
     .join(`\n`)
 
-  console.error(`${pkg.name}: \n${msg}`)
+    console.error(`${pkgNode.name}: \n${msg}`)
+    warned = true
 
-  if (argv.fix) {
-    let next = pkg.toJSON()
-    outdated.forEach(p => {
-      if (pkg.dependencies[p.name]) next.dependencies[p.name] = `^${p.version}`
-      else if (pkg.devDependencies[p.name])
-        next.devDependencies[p.name] = `v${p.version}`
-      else if (pkg.peerDependencies[p.name])
-        next.peerDependencies[p.name] = `v${p.version}`
-    })
+    if (argv.fix) {
+      const pkg = pkgNode.pkg
+      const next = pkg.toJSON()
+      const depTypes = [`dependencies`, `devDependencies`, `peerDependencies`]
+      outdated.forEach(p => {
+        depTypes.forEach(depKey => {
+          if (pkg[depKey][p.name]) {
+            next[depKey][p.name] = `^${graph.get(p.name).version}`
+          }
+        })
+      })
 
-    writeFileSync(`${pkg.location}/package.json`, JSON.stringify(next, null, 2))
+      writeFileSync(`${pkg.location}/package.json`, JSON.stringify(next, null, 2))
+    }
+  })
+
+  if (warned) {
+    process.exit(1)
   }
 })
-
-if (warned) {
-  process.exit(1)
-}

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -19,8 +19,6 @@ collectPackages(process.cwd()).then(packages => {
   const graph = new PackageGraph(packages, `allDependencies`, true)
   
   graph.forEach((pkgNode, name) => {
-    // const outdated = []
-
     let outdated = Array.from(pkgNode.localDependencies.values())
       .filter(localDep => !semver.satisfies(graph.get(localDep.name).version, localDep.fetchSpec))
     


### PR DESCRIPTION
updates version-check script to run using lerna@3

ran it with `--fix` and updated packages depending on `next` version (after v2/v1 version PR merge, we don't need to point to `next` in those packages anymore)

closes #5963