### PR TITLE
either preload OR inline CSS

### DIFF
--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -239,28 +239,32 @@ export default (pagePath, callback) => {
     .slice(0)
     .reverse()
     .forEach(style => {
-      // Add <link>s for styles.
-      headComponents.push(
-        <link
-          as="style"
-          rel={style.rel}
-          key={style.name}
-          href={urlJoin(pathPrefix, style.name)}
-        />
-      )
+      // Add <link>s for styles that should be prefetched
+      // otherwise, inline as a <style> tag
 
-      headComponents.unshift(
-        <style
-          type="text/css"
-          data-href={urlJoin(pathPrefix, style.name)}
-          dangerouslySetInnerHTML={{
-            __html: fs.readFileSync(
-              join(process.cwd(), `public`, style.name),
-              `utf-8`
-            ),
-          }}
-        />
-      )
+      if(style.rel === `prefetch`) {
+        headComponents.push(
+          <link
+            as="style"
+            rel={style.rel}
+            key={style.name}
+            href={urlJoin(pathPrefix, style.name)}
+          />
+        )
+      } else {
+        headComponents.unshift(
+          <style
+            type="text/css"
+            data-href={urlJoin(pathPrefix, style.name)}
+            dangerouslySetInnerHTML={{
+              __html: fs.readFileSync(
+                join(process.cwd(), `public`, style.name),
+                `utf-8`
+              ),
+            }}
+          />
+        )
+      }
     })
 
   // Add page metadata for the current page

--- a/packages/gatsby/src/cache-dir/static-entry.js
+++ b/packages/gatsby/src/cache-dir/static-entry.js
@@ -168,6 +168,10 @@ export default (pagePath, callback) => {
         return { rel: `preload`, name: chunk }
       })
 
+      namedChunkGroups[s].assets.forEach(asset =>
+        chunks.push({ rel: `preload`, name: asset })
+      )
+
       const childAssets = namedChunkGroups[s].childAssets
       for (const rel in childAssets) {
         chunks = merge(
@@ -242,7 +246,7 @@ export default (pagePath, callback) => {
       // Add <link>s for styles that should be prefetched
       // otherwise, inline as a <style> tag
 
-      if(style.rel === `prefetch`) {
+      if (style.rel === `prefetch`) {
         headComponents.push(
           <link
             as="style"


### PR DESCRIPTION
<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Resolves #6008 by either inlining styles OR prefetching them, but not both. 

**Note**: There where modifications to my local _yarh.lock_ file (not committed here) but was wondering if maybe it should be (in a different PR maybe?).  Not sure if maybe a recent contribution missed regenerating the local file?  Here's what I see locally
<details>
```shell
$ git diff yarn.lock
diff --git a/yarn.lock b/yarn.lock
index df3df885..76f10051 100644
--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,7 +3033,7 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000856"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000856.tgz#fbebb99abe15a5654fc7747ebb5315bdfde3358f"

-caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844:
+caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844:
   version "1.0.30000856"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz#ecc16978135a6f219b138991eb62009d25ee8daa"

@@ -3937,7 +3937,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"

-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.7:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"

@@ -4982,7 +4982,7 @@ ejs@^2.4.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"

-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
   version "1.3.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"

@@ -10673,14 +10673,6 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"

-parse-latin@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/parse-latin/-/parse-latin-3.2.0.tgz#cfe4b420982b1d20fc16c71dfb33f148de4f1d0b"
-  dependencies:
-    nlcst-to-string "^2.0.0"
-    unist-util-modify-children "^1.0.0"
-    unist-util-visit-children "^1.0.0"
-
 parse-latin@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/parse-latin/-/parse-latin-4.1.1.tgz#3a3edef405b2d5dce417b7157d3d8a5c7cdfab1d"
@@ -12751,11 +12743,11 @@ retext-english@^3.0.0:
     parse-english "^4.0.0"
     unherit "^1.0.4"

-retext-latin@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/retext-latin/-/retext-latin-1.0.0.tgz#57f41257b4d857b6c6df631ca5788d10080d7051"
+retext-latin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/retext-latin/-/retext-latin-2.0.0.tgz#b11bd6cae9113fa6293022a4527cd707221ac4b6"
   dependencies:
-    parse-latin "^3.1.0"
+    parse-latin "^4.0.0"
     unherit "^1.0.4"

 retext-smartypants@^3.0.0:
@@ -12765,9 +12757,9 @@ retext-smartypants@^3.0.0:
     nlcst-to-string "^2.0.0"
     unist-util-visit "^1.0.0"

-retext-stringify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/retext-stringify/-/retext-stringify-1.0.0.tgz#0032e4be3254ea56b19242ef406515479a3346a9"
+retext-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/retext-stringify/-/retext-stringify-2.0.0.tgz#00238facc5491f5bcdc589703a4658db2e54415b"
   dependencies:
     nlcst-to-string "^2.0.0"

@@ -14727,19 +14719,6 @@ unified@^4.1.1:
     trough "^1.0.0"
     vfile "^1.0.0"

-unified@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-5.1.0.tgz#61268da9b91ce925be1f3d198c0278b0e9716094"
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    has "^1.0.1"
-    is-buffer "^1.1.4"
-    once "^1.3.3"
-    trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-string "^0.1.0"
-
 unified@^6.0.0, unified@^6.1.4, unified@^6.1.5:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
```
</details>