### PR TITLE
[gatsby][types] added typings for `StaticQuery` children prop

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -9,15 +9,12 @@ export {
   withPrefix
 } from "gatsby-link"
 
-interface StaticQueryRenderProps {
-  data: any
-}
-
-type RenderCallback = (props: StaticQueryRenderProps) => JSX.Element
+type RenderCallback = (data: any) => React.ReactNode
 
 export interface StaticQueryProps {
   query: any
-  render: RenderCallback
+  render?: RenderCallback
+  children?: RenderCallback
 }
 
 export class StaticQuery extends React.Component<StaticQueryProps> {}


### PR DESCRIPTION
Since #6007 you can now pass a children prop inside `<StaticQuery>`.

I've also removed the typing inside RenderCallback to allow users to
add custom typings to the `data` callback. There's probably a better way
to do this, but I'll leave it like this for now.

<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
