### PR TITLE
[v2][gatsby-plugin-netlify-cms]Utilize actions/setWebpackConfig()

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -62,8 +62,8 @@ function module(config, stage) {
   }
 }
 
-exports.onCreateWebpackConfig = ({ config, stage }, { modulePath }) => {
-  config.merge({
+exports.onCreateWebpackConfig = ({ actions, stage }, { modulePath }) => {
+  const config = actions.setWebpackConfig({
     entry: {
       cms: [`${__dirname}/cms.js`, modulePath].filter(p => p),
     },
@@ -71,6 +71,4 @@ exports.onCreateWebpackConfig = ({ config, stage }, { modulePath }) => {
   })
 
   module(config, stage)
-
-  return config
 }


### PR DESCRIPTION
`config` was still being passed to `onCreateWebpackConfig` which was `undefined`. This fix applies the `actions.setWebpackConfig` instead.