### PR TITLE
allow mix of date objects and date strings

### DIFF
--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -205,6 +205,154 @@ describe(`Gatsby data tree utils`, () => {
     expect(example.numbers.length).toBe(1)
     expect(example.numbers[0]).toBe(2.5)
   })
+
+  it(`handles mix of date strings and date objects`, () => {
+    let example
+
+    // should be valid
+    example = getExampleValues({
+      nodes: [
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+        { date: `2017-01-12T18:13:38.326Z` },
+      ],
+    })
+    expect(example.date).not.toBe(INVALID_VALUE)
+
+    // should be invalid (string is not a date)
+    example = getExampleValues({
+      nodes: [
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+        { date: `This is not a date!!!!!!` },
+      ],
+    })
+    expect(example.date).toBe(INVALID_VALUE)
+
+    // should be valid - reversed order
+    example = getExampleValues({
+      nodes: [
+        { date: `2017-01-12T18:13:38.326Z` },
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+      ],
+    })
+    expect(example.date).not.toBe(INVALID_VALUE)
+
+    // should be invalid (string is not a date) - reversed order
+    example = getExampleValues({
+      nodes: [
+        { date: `This is not a date!!!!!!` },
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+      ],
+    })
+    expect(example.date).toBe(INVALID_VALUE)
+  })
+
+  it(`handles arrays with mix of date strings and date objects`, () => {
+    let example
+
+    // should be valid - separate arrays of unique types
+    example = getExampleValues({
+      nodes: [
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`2017-01-12T18:13:38.326Z`] },
+      ],
+    })
+    expect(example.dates).not.toBe(INVALID_VALUE)
+
+    // should be invalid - separate arrays of unique types (string is not a date)
+    example = getExampleValues({
+      nodes: [
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`This is not a date!!!!!!`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - single array of mixed types
+    example = getExampleValues({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `2017-01-12T18:13:38.326Z`,
+          ],
+        },
+      ],
+    })
+    expect(example.dates).not.toBe(INVALID_VALUE)
+
+    // should be invalid - single array of mixed types (string is not a date)
+    example = getExampleValues({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `This is not a date!!!!!!`,
+          ],
+        },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types
+    example = getExampleValues({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `2017-01-12T18:13:38.326Z`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`2017-01-12T18:13:38.326Z`] },
+      ],
+    })
+    expect(example.dates).not.toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types (string is not a date) #1
+    example = getExampleValues({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `This is not a date!!!!!!`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`2017-01-12T18:13:38.326Z`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types (string is not a date) #2
+    example = getExampleValues({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `2017-01-12T18:13:38.326Z`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`This is not a date!!!!!!`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types (string is not a date) #2
+    example = getExampleValues({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `This is not a date!!!!!!`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`This is not a date!!!!!!`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+  })
 })
 
 describe(`Type conflicts`, () => {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -6,6 +6,7 @@ const invariant = require(`invariant`)
 
 const createKey = require(`./create-key`)
 const { typeConflictReporter } = require(`./type-conflict-reporter`)
+const DateType = require(`./types/type-date`)
 
 import type { TypeEntry } from "./type-conflict-reporter"
 
@@ -56,6 +57,62 @@ const extractTypes = value => {
   }
 }
 
+const isMixOfDateObjectsAndDateStrings = (
+  values: any[],
+  uniqueTypes: string[]
+): boolean => {
+  if (
+    uniqueTypes.length === 2 &&
+    uniqueTypes.includes(`string`) &&
+    uniqueTypes.includes(`date`)
+  ) {
+    const allValuesAreDates = values.every(value => {
+      if (typeOf(value) === `date`) return true
+
+      // use infer checker to determine if string is a date
+      return DateType.shouldInfer(value)
+    })
+
+    return allValuesAreDates
+  }
+
+  return false
+}
+
+const conflictIsValidSpecialCase = (
+  entries: TypeEntry[],
+  entriesOfUniqueType: TypeEntry[]
+): boolean => {
+  const isConsistentlyScalarOrArray = entriesOfUniqueType.every(
+    entry =>
+      entry.arrayTypes.length > 0 ===
+      entriesOfUniqueType[0].arrayTypes.length > 0
+  )
+  if (isConsistentlyScalarOrArray) {
+    // Get values and run them through special cases, to see if there actually
+    // is a conflict. This is done so late in process, because those checks
+    // would be expensive to do earlier during extraction, so we do them
+    // only when we have potential conflict.
+
+    let uniqueTypes: string[]
+    let values: any[]
+    const isArray = entriesOfUniqueType[0].arrayTypes.length > 0
+
+    if (isArray) {
+      values = _.flatten(entries.map(entry => entry.value))
+      uniqueTypes = _.uniq(
+        _.flatten(entriesOfUniqueType.map(entry => entry.arrayTypes))
+      )
+    } else {
+      values = entries.map(entry => entry.value)
+      uniqueTypes = entriesOfUniqueType.map(entry => entry.type)
+    }
+
+    return isMixOfDateObjectsAndDateStrings(values, uniqueTypes)
+  }
+  return false
+}
+
 const getExampleScalarFromArray = values =>
   _.reduce(
     values,
@@ -87,10 +144,13 @@ const extractFromEntries = (
     entriesOfUniqueType[0].arrayTypes.length > 1
   ) {
     // there is multiple types or array of multiple types
-    if (selector) {
-      typeConflictReporter.addConflict(selector, entriesOfUniqueType)
+    // that aren't handled by any special case
+    if (!conflictIsValidSpecialCase(entries, entriesOfUniqueType)) {
+      if (selector) {
+        typeConflictReporter.addConflict(selector, entriesOfUniqueType)
+      }
+      return INVALID_VALUE
     }
-    return INVALID_VALUE
   }
 
   // Now we have entries of single type, we can merge them


### PR DESCRIPTION
fixes #5842

Problem reported in above issue is a result of serializing dates to date strings when writing nodes data to `redux-state.json` and fresh nodes using date objects. This PR allows to mix date string and date objects and not mark it as a conflict (schema will handle it just fine)

Added tests to catch any regressions