### PR TITLE
Exit for query errors during build

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -58,7 +58,7 @@ Query:
   ${indentString(component.query)}`)
 
     // Perhaps this isn't the best way to see if we're building?
-    if (program._name === `build`) {
+    if (program._[0] === `build`) {
       process.exit(1)
     }
   }


### PR DESCRIPTION
`_name` doesn't exist, it should be `_[0]`