### PR TITLE
Increase timeout for the graphiql Docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,6 @@ jobs:
           before_install:
             - chmod +x scripts/www-graphql-docker-push.sh
           script:
-            - ./scripts/www-graphql-docker-push.sh
+            - travis_wait 30 ./scripts/www-graphql-docker-push.sh
 
 


### PR DESCRIPTION
Bump up to 30 minutes from default 10  - I haven't checked but I assume this is taking longer due to  processing extra showcase images now.