### PR TITLE
Add mention of publicPath to doc so people who know webpack can find this doc

### DIFF
--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -11,7 +11,7 @@ Each of these sites need a prefix added to all paths on the site. So a link to
 `/my-sweet-blog-post/` should be rewritten to `/blog/my-sweet-blog-post`.
 
 In addition links to various resources (JavaScript, images, CSS) need the same
-prefix added.
+prefix added (this is accomplished by setting the `publicPath` in webpack).
 
 Luckily, for most sites, this work can be offloaded to Gatsby. Using
 [Gatsby's Link component](/packages/gatsby/) for internal links ensures those links


### PR DESCRIPTION
@shannonbux interviewed someone who was looking for `publicPath` but couldn't find it. Let's add a mention of `publicPath` to the `pathPrefix` doc so people searching for `publicPath` can find it.