### PR TITLE
Treat integers longer than 32 bit as floats.

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -55,6 +55,14 @@ gatsby new my-blog https://github.com/gatsbyjs/gatsby-starter-blog#v2
 
 ## Community starters
 
+- [gatsby-starter-cosmicjs](https://github.com/cosmicjs/gatsby-starter)
+  [(demo)](https://cosmicjs-gatsby-starter.netlify.com)
+
+  Features:
+
+  - Same as `gatsby-starter-default` with dynamic content from [Cosmic JS](https://cosmicjs.com)
+  - Install and set up CMS in seconds [via the command line](https://github.com/cosmicjs/gatsby-starter)
+  
 - [gatsby-starter-blog-no-styles](https://github.com/noahg/gatsby-starter-blog-no-styles)
   [(demo)](http://capricious-spring.surge.sh/)
 

--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -176,34 +176,50 @@ describe(`Gatsby data tree utils`, () => {
   it(`prefers float when multiple number types`, () => {
     let example
 
-    // nodes starting with integer
+    // nodes starting with 32-bit integer ("big" ints are float)
     example = getExampleValues({ nodes: [{ number: 5 }, { number: 2.5 }] })
     expect(example.number).toBeDefined()
     expect(example.number).toEqual(2.5)
+    example = getExampleValues({ nodes: [{ number: 5 }, { number: 3000000000 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(3000000000)
 
     // with node not containing number field
     example = getExampleValues({ nodes: [{ number: 5 }, {}, { number: 2.5 }] })
     expect(example.number).toBeDefined()
     expect(example.number).toEqual(2.5)
 
-    // nodes starting with float
+    // nodes starting with float ("big" ints are float)
     example = getExampleValues({ nodes: [{ number: 2.5 }, { number: 5 }] })
     expect(example.number).toBeDefined()
     expect(example.number).toEqual(2.5)
+    example = getExampleValues({ nodes: [{ number: 3000000000 }, { number: 5 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(3000000000)
 
-    // array of numbers - starting with integer
+    // array of numbers - starting with float
     example = getExampleValues({ nodes: [{ numbers: [2.5, 5] }] })
     expect(example.numbers).toBeDefined()
     expect(Array.isArray(example.numbers)).toBe(true)
     expect(example.numbers.length).toBe(1)
     expect(example.numbers[0]).toBe(2.5)
+    example = getExampleValues({ nodes: [{ numbers: [3000000000, 5] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(3000000000)
 
-    // array of numbers - starting with float
+    // array of numbers - starting with 32-bit integer
     example = getExampleValues({ nodes: [{ numbers: [5, 2.5] }] })
     expect(example.numbers).toBeDefined()
     expect(Array.isArray(example.numbers)).toBe(true)
     expect(example.numbers.length).toBe(1)
     expect(example.numbers[0]).toBe(2.5)
+    example = getExampleValues({ nodes: [{ numbers: [5, 3000000000] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(3000000000)
   })
 
   it(`handles mix of date strings and date objects`, () => {

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -266,6 +266,21 @@ describe(`GraphQL Input args`, () => {
     expect(Object.keys(fields.foo.type.getFields())).toHaveLength(2)
   })
 
+  it(`infers number types`, () => {
+    const fields = inferInputObjectStructureFromNodes({
+      nodes: [
+        {
+          int32: 42,
+          float: 2.5,
+          longint: 3000000000,
+        },
+      ],
+    }).inferredFields
+    expect(fields.int32.type.name.endsWith(`Integer`)).toBe(true)
+    expect(fields.float.type.name.endsWith(`Float`)).toBe(true)
+    expect(fields.longint.type.name.endsWith(`Float`)).toBe(true)
+  })
+
   it(`handles eq operator`, async () => {
     let result = await queryResult(
       nodes,

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -124,6 +124,20 @@ describe(`GraphQL type inferance`, () => {
     )
   })
 
+  it(`doesn't throw errors at ints longer than 32-bit`, async () => {
+    const result = await queryResult(
+      [
+        { 
+          longint: 3000000000,
+        },
+      ],
+      `
+        longint
+      `
+    )
+    expect(result.errors).toBeUndefined()
+  })
+
   it(`prefers float when multiple number types`, async () => {
     let result = await queryResult(
       [{ number: 1.1 }, { number: 1 }],
@@ -197,6 +211,21 @@ describe(`GraphQL type inferance`, () => {
 
     expect(Object.keys(fields)).toHaveLength(2)
     expect(Object.keys(fields.foo.type.getFields())).toHaveLength(4)
+  })
+
+  it(`infers number types`, () => {
+    const fields = inferObjectStructureFromNodes({
+      nodes: [
+        {
+          int32: 42,
+          float: 2.5,
+          longint: 3000000000,
+        },
+      ],
+    })
+    expect(fields.int32.type.name).toEqual(`Int`)
+    expect(fields.float.type.name).toEqual(`Float`)
+    expect(fields.longint.type.name).toEqual(`Float`)
   })
 
   it(`Handle invalid graphql field names`, async () => {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -7,6 +7,7 @@ const invariant = require(`invariant`)
 const createKey = require(`./create-key`)
 const { typeConflictReporter } = require(`./type-conflict-reporter`)
 const DateType = require(`./types/type-date`)
+const is32BitInteger = require(`../utils/is-32-bit-integer`)
 
 import type { TypeEntry } from "./type-conflict-reporter"
 
@@ -118,7 +119,7 @@ const getExampleScalarFromArray = values =>
     values,
     (value, nextValue) => {
       // Prefer floats over ints as they're more specific.
-      if (nextValue && _.isNumber(nextValue) && !_.isInteger(nextValue)) {
+      if (nextValue && _.isNumber(nextValue) && !is32BitInteger(nextValue)) {
         return nextValue
       } else if (value === null) {
         return nextValue

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -21,6 +21,7 @@ const {
 
 const { findLinkedNode } = require(`./infer-graphql-type`)
 const { getNodes } = require(`../redux`)
+const is32BitInteger = require(`../utils/is-32-bit-integer`)
 
 import type {
   GraphQLInputFieldConfig,
@@ -76,7 +77,7 @@ function inferGraphQLInputFields({
       let headType = typeOf(headValue)
 
       if (headType === `number`)
-        headType = _.isInteger(headValue) ? `int` : `float`
+        headType = is32BitInteger(headValue) ? `int` : `float`
 
       // Determine type for in operator.
       let inType
@@ -165,7 +166,7 @@ function inferGraphQLInputFields({
       }
     }
     case `number`: {
-      if (value % 1 === 0) {
+      if (is32BitInteger(value)) {
         return {
           type: new GraphQLInputObjectType({
             name: createTypeName(`${prefix}QueryInteger`),

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -19,6 +19,7 @@ const createKey = require(`./create-key`)
 const { getExampleValues, isEmptyObjectOrArray } = require(`./data-tree-utils`)
 const DateType = require(`./types/type-date`)
 const FileType = require(`./types/type-file`)
+const is32BitInteger = require(`../utils/is-32-bit-integer`)
 
 import type { GraphQLOutputType } from "graphql"
 import type {
@@ -117,7 +118,7 @@ function inferGraphQLType({
         }),
       }
     case `number`:
-      return _.isInteger(exampleValue)
+      return is32BitInteger(exampleValue)
         ? { type: GraphQLInt }
         : { type: GraphQLFloat }
     default:

--- a/packages/gatsby/src/utils/__tests__/is-32-bit-integer.js
+++ b/packages/gatsby/src/utils/__tests__/is-32-bit-integer.js
@@ -1,0 +1,21 @@
+const is32BitInteger = require(`../is-32-bit-integer.js`)
+
+const MAX_INT = 2147483647
+const MIN_INT = -2147483648
+
+describe(`is32BitInteger`, () => {
+    it(`works with all kind of values`, () => {
+        expect(is32BitInteger(MAX_INT)).toBe(true)
+        expect(is32BitInteger(MIN_INT)).toBe(true)
+        expect(is32BitInteger(MAX_INT + 1)).toBe(false)
+        expect(is32BitInteger(MIN_INT - 1)).toBe(false)
+        expect(is32BitInteger(2.4)).toBe(false)
+        expect(is32BitInteger(`42`)).toBe(false)
+        expect(is32BitInteger({})).toBe(false)
+        expect(is32BitInteger([1])).toBe(false)
+        expect(is32BitInteger(true)).toBe(false)
+        expect(is32BitInteger(false)).toBe(false)
+        expect(is32BitInteger(undefined)).toBe(false)
+        expect(is32BitInteger(null)).toBe(false)
+    })
+})

--- a/packages/gatsby/src/utils/is-32-bit-integer.js
+++ b/packages/gatsby/src/utils/is-32-bit-integer.js
@@ -1,0 +1,3 @@
+module.exports = function(x) {
+    return (x | 0) === x
+}


### PR DESCRIPTION
The GraphQL specs limit the Integer type size to 32 bits. To be compliant, larger ints have to be treated as floats to prevent errors in query results.

fixes [#6069](https://github.com/gatsbyjs/gatsby/issues/6069)