### PR TITLE
jest: ignore built __tests__

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,13 +4,16 @@ const glob = require(`glob`)
 const pkgs = glob.sync(`./packages/*`).map(p => p.replace(/^\./, `<rootDir>`))
 
 const distDirs = pkgs.map(p => path.join(p, `dist`))
+const builtTestsDirs = pkgs.map(p => path.join(p, `__tests__`))
+
+const ignoreDirs = [].concat(distDirs, builtTestsDirs)
 
 module.exports = {
   notify: true,
   verbose: true,
   roots: pkgs,
-  modulePathIgnorePatterns: distDirs,
-  coveragePathIgnorePatterns: distDirs,
+  modulePathIgnorePatterns: ignoreDirs,
+  coveragePathIgnorePatterns: ignoreDirs,
   testPathIgnorePatterns: [
     `/examples/`,
     `/www/`,


### PR DESCRIPTION
Currently used version of `@babel/cli` seems to not honor `--ignore` on windows, so` __tests__` dirs are getting built. This temporary hack should fix some of the tests failing on appveyor and should be reverted when `@babel/cli` issue will be fixed

ref: #6087
