### PR TITLE
[gatsby-source-contentful] Import graphql from gatsby (fragments)

### DIFF
--- a/packages/gatsby-source-contentful/src/fragments.js
+++ b/packages/gatsby-source-contentful/src/fragments.js
@@ -1,4 +1,5 @@
-/* eslint-disable */
+import { graphql } from "gatsby"
+
 export const contentfulAssetFixed = graphql`
   fragment GatsbyContentfulFixed on ContentfulFixed {
     base64


### PR DESCRIPTION
Fixes the deprecation warnings.