### PR TITLE
Fix migration docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Websites built with Gatsby:
 
 **[View the docs on gatsbyjs.org](https://www.gatsbyjs.org/docs/)**
 
-[Migrating from v1 to v2?](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/)
+[Migrating from v1 to v2?](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/)
 
 [Migrating from v0 to v1?](https://www.gatsbyjs.org/docs/migrating-from-v0-to-v1/)
 


### PR DESCRIPTION
This link at the bottom of the README is pointing to https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/ — which currently lands one at this:

![image](https://user-images.githubusercontent.com/1242537/41808459-c116130c-76d5-11e8-9426-1da24ed59a4c.png)

This link is used at the top of the README, and works: https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/ 