### PR TITLE
[gatsby-source-contentful] delay creating cache directory

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -214,19 +214,16 @@ exports.sourceNodes = async (
   return
 }
 
-exports.onPreBootstrap = async ({ store }) => {
-  const program = store.getState().program
-  const CACHE_DIR = path.resolve(
-    `${program.directory}/.cache/contentful/assets/`
-  )
-  await fs.ensureDir(CACHE_DIR)
-}
-
 // Check if there are any ContentfulAsset nodes and if gatsby-image is installed. If so,
 // add fragments for ContentfulAsset and gatsby-image. The fragment will cause an error
 // if there's not ContentfulAsset nodes and without gatsby-image, the fragment is useless.
 exports.onPreExtractQueries = async ({ store, getNodes }) => {
   const program = store.getState().program
+
+  const CACHE_DIR = path.resolve(
+    `${program.directory}/.cache/contentful/assets/`
+  )
+  await fs.ensureDir(CACHE_DIR)
 
   const nodes = getNodes()
 


### PR DESCRIPTION
onPreBootstrap is now run earlier than before ( https://github.com/gatsbyjs/gatsby/pull/5862 ) and .cache can be deleted after that

currently this will cause files to not be saved, because `.cache/contentful/assets` doesn't exist