### PR TITLE
fix: move async CSS load to gatsby-browser.js

### DIFF
--- a/www/gatsby-browser.js
+++ b/www/gatsby-browser.js
@@ -1,0 +1,10 @@
+exports.onClientEntry = () => {
+  ;(function() {
+    const path = `https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css`
+    const link = document.createElement(`link`)
+    link.setAttribute(`rel`, `stylesheet`)
+    link.setAttribute(`type`, `text/css`)
+    link.setAttribute(`href`, path)
+    document.head.appendChild(link)
+  })()
+}

--- a/www/src/html.js
+++ b/www/src/html.js
@@ -64,7 +64,10 @@ export default class HTML extends React.Component {
             color={colors.gatsby}
           />
           <meta name="msapplication-config" content={`/browserconfig.xml`} />
-          <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" defer />
+          <script
+            src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+            defer
+          />
         </head>
         <body {...this.props.bodyAttributes}>
           <div


### PR DESCRIPTION
Hey, @yeion7 — this is how I should have recommended adding the async CSS loading.