### PR TITLE
fix displaying of graphql resolver errors

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/utils.js.snap
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/utils.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text formatting  format error details correctly 1`] = `
+"Field:
+  One line error
+Bar:
+  Three
+  line
+  error"
+`;
+
+exports[`Text formatting  indent string correctly 1`] = `
+"  Line 1
+  Line 2
+    - Line 3"
+`;

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/utils.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/utils.js
@@ -1,0 +1,20 @@
+import { indentString, formatErrorDetails } from "../utils"
+
+describe(`Text formatting `, () => {
+  it(`indent string correctly`, () => {
+    expect(indentString(
+      `  Line 1
+Line 2
+  - Line 3`
+    )).toMatchSnapshot()
+  })
+
+  it(`format error details correctly`, () => {
+    const testErrors = new Map()
+    testErrors.set(`Field`, `One line error`)
+    testErrors.set(`Bar`, `Three
+line
+error`)
+    expect(formatErrorDetails(testErrors)).toMatchSnapshot()
+  })
+})

--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -127,6 +127,7 @@ const runQueriesForPathnames = pathnames => {
           jsonName: page.jsonName,
           query: store.getState().components[page.componentPath].query,
           isPage: true,
+          componentPath: page.componentPath,
           context: {
             ...page,
             ...page.context,

--- a/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
@@ -185,7 +185,7 @@ class Runner {
         name,
         text,
         originalText: nameDefMap.get(name).text,
-        path: path.join(this.baseDir, filePath),
+        path: filePath,
         isStaticQuery: nameDefMap.get(name).isStaticQuery,
         hash: nameDefMap.get(name).hash,
       }

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -23,6 +23,14 @@ type QueryJob = {
 
 const indentString = string => string.replace(/\n/g, `\n  `)
 
+const formatErrorDetails = errorDetails =>
+  Array.from(errorDetails.entries())
+    .map(
+      ([name, details]) => `${name}:
+  ${indentString(details.toString())}`
+    )
+    .join(`\n`)
+
 // Run query
 module.exports = async (queryJob: QueryJob, component: Any) => {
   const { schema, program } = store.getState()
@@ -43,19 +51,22 @@ module.exports = async (queryJob: QueryJob, component: Any) => {
   // If there's a graphql error then log the error. If we're building, also
   // quit.
   if (result && result.errors) {
-    report.log(`
-The GraphQL query from ${component.componentPath} failed.
+    const errorDetails = new Map()
+    errorDetails.set(`Errors`, result.errors || [])
+    if (queryJob.isPage) {
+      errorDetails.set(`URL path`, queryJob.context.path)
+      errorDetails.set(
+        `Context`,
+        JSON.stringify(queryJob.context.context, null, 2)
+      )
+    }
+    errorDetails.set(`Plugin`, queryJob.pluginCreatorId || `none`)
+    errorDetails.set(`Query`, queryJob.query)
 
-Errors:
-  ${result.errors || []}
-URL path:
-  ${queryJob.path}
-Context:
-  ${indentString(JSON.stringify(queryJob.context, null, 2))}
-Plugin:
-  ${queryJob.pluginCreatorId || `none`}
-Query:
-  ${indentString(component.query)}`)
+    report.log(`
+The GraphQL query from ${queryJob.componentPath} failed.
+
+${formatErrorDetails(errorDetails)}`)
 
     // Perhaps this isn't the best way to see if we're building?
     if (program._[0] === `build`) {

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -8,6 +8,7 @@ const websocketManager = require(`../../utils/websocket-manager`)
 const path = require(`path`)
 const { store } = require(`../../redux`)
 const { generatePathChunkName } = require(`../../utils/js-chunk-names`)
+const { formatErrorDetails } = require(`./utils`)
 
 const resultHashes = {}
 
@@ -20,16 +21,6 @@ type QueryJob = {
   context: Object,
   isPage: Boolean,
 }
-
-const indentString = string => string.replace(/\n/g, `\n  `)
-
-const formatErrorDetails = errorDetails =>
-  Array.from(errorDetails.entries())
-    .map(
-      ([name, details]) => `${name}:
-  ${indentString(details.toString())}`
-    )
-    .join(`\n`)
 
 // Run query
 module.exports = async (queryJob: QueryJob, component: Any) => {

--- a/packages/gatsby/src/internal-plugins/query-runner/utils.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/utils.js
@@ -1,0 +1,13 @@
+// @flow
+
+const indentString = (string: string): string => string.replace(/\n/g, `\n  `) 
+
+const formatErrorDetails = (errorDetails: Map<string, any>): string =>
+  Array.from(errorDetails.entries())
+    .map(
+      ([name, details]) => `${name}:
+  ${indentString(details.toString())}`
+    )
+    .join(`\n`)
+
+export { indentString, formatErrorDetails }


### PR DESCRIPTION
Currently if something in graphql resolver will throw error we will see somethink like this in console:
```
run graphql queriesError running queryRunner TypeError: Cannot read property 'componentPath' of undefined
    at module.exports (/Users/mike/dev/gatsby-v2/examples/using-contentful/node_modules/gatsby/dist/internal-plugins/query-runner/query-runner.js:47:36)
```
This fixes this and displays formatted error message