### PR TITLE
Make getElementById Conditional

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -137,7 +137,7 @@ class GatsbyLink extends React.Component {
                 .split(`#`)
                 .slice(1)
                 .join(`#`)
-              const element = document.getElementById(hashFragment)
+              const element = hashFragment ? document.getElementById(hashFragment) : null
               if (element !== null) {
                 element.scrollIntoView()
                 return true


### PR DESCRIPTION
Firefox shows this warning...
Empty string passed to getElementById()

<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
