### PR TITLE
[v2] migrate gatsby-plugin-feed to use new Link

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-ssr.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { withPrefix } from "gatsby-link"
+import { withPrefix } from "gatsby"
 import { defaultOptions } from "./internals"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {


### PR DESCRIPTION
### Motivation

When gatsby-link is removed from a gatsby site it causes plugins 
that uses the old gatsby-link to break.

<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
