### PR TITLE
Move store assignment out of component in using-redux example.

### DIFF
--- a/examples/using-redux/gatsby-browser.js
+++ b/examples/using-redux/gatsby-browser.js
@@ -4,8 +4,9 @@ import { Provider } from 'react-redux'
 
 import createStore from './src/state/createStore'
 
+const store = createStore()
+
 export const replaceRouterComponent = ({ history }) => {
-    const store = createStore()
 
     const ConnectedRouterWrapper = ({ children }) => (
         <Provider store={store}>


### PR DESCRIPTION
This fixes [#6118](https://github.com/gatsbyjs/gatsby/issues/6118).

It prevents the creation of multiple store instances.
