### PR TITLE
delay page transition until we have all resources

### DIFF
--- a/packages/gatsby-plugin-nprogress/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-nprogress/src/gatsby-browser.js
@@ -6,14 +6,6 @@ exports.onClientEntry = (a, pluginOptions = {}) => {
   // Merge default options with user defined options in `gatsby-config.js`
   const options = { ...defaultOptions, ...pluginOptions }
 
-  window.___emitter.on(`onDelayedLoadPageResources`, () => {
-    NProgress.configure(options)
-    NProgress.start()
-  })
-  window.___emitter.on(`onPostLoadPageResources`, () => {
-    NProgress.done()
-  })
-
   // Inject styles.
   const styles = `
     #nprogress {
@@ -88,4 +80,14 @@ exports.onClientEntry = (a, pluginOptions = {}) => {
   node.id = `nprogress-styles`
   node.innerHTML = styles
   document.head.appendChild(node)
+
+  NProgress.configure(options)
+}
+
+exports.onRouteUpdateDelayed = () => {
+  NProgress.start()
+}
+
+exports.onRouteUpdate = () => {
+  NProgress.done()
 }

--- a/packages/gatsby/src/cache-dir/root.js
+++ b/packages/gatsby/src/cache-dir/root.js
@@ -67,6 +67,7 @@ function attachToHistory(history) {
 
     history.listen((location, action) => {
       if (!maybeRedirect(location.pathname)) {
+        apiRunner(`onPreRouteUpdate`, { location, action })
         apiRunner(`onRouteUpdate`, { location, action })
       }
     })

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -18,6 +18,30 @@ exports.onClientEntry = true
 exports.onInitialClientRender = true
 
 /**
+ * Called when changing location is started.
+ * @param {object} $0
+ * @param {object} $0.location A location object
+ * @param {object} $0.action The "action" that caused the route change
+ * @example
+ * exports.onPreRouteUpdate = ({ location }) => {
+ *   console.log("Gatsby started to change location", location.pathname)
+ * }
+ */
+exports.onPreRouteUpdate = true
+
+/**
+ * Called when changing location is longer than 1 second.
+ * @param {object} $0
+ * @param {object} $0.location A location object
+ * @param {object} $0.action The "action" that caused the route change
+ * @example
+ * exports.onRouteUpdateDelayed = () => {
+ *   console.log("We can show loading indicator now")
+ * }
+ */
+exports.onRouteUpdateDelayed = true
+
+/**
  * Called when the user changes routes
  * @param {object} $0
  * @param {object} $0.location A location object


### PR DESCRIPTION
This does couple of things:
 - Gatsby won't navigate to new page until resources for it are loaded (previously path would change after 1s even if resources are not yet loaded, so this would cause scroll jump without page change)
 - If navigating to path that doesn't exist, it will wait to load resources for 404 page (to avoid similiar scroll jump as in point above)
 - Adds new browser APIs, so loading indicators can be implemented without hooking into Gatsby internal messages

Closes #3372