### PR TITLE
Tidy up the remark example

### DIFF
--- a/examples/using-remark/src/layouts/index.js
+++ b/examples/using-remark/src/layouts/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link, StaticQuery } from "gatsby"
+import { Link, StaticQuery, graphql } from "gatsby"
 import { scale } from "../utils/typography"
 import styles from "../styles"
 

--- a/examples/using-remark/src/pages/excerpt-example.js
+++ b/examples/using-remark/src/pages/excerpt-example.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import styles from "../styles"
 import presets from "../utils/presets"
 import { rhythm, scale } from "../utils/typography"

--- a/examples/using-remark/src/pages/index.js
+++ b/examples/using-remark/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import Layout from "../layouts"
 import styles from "../styles"
 import presets from "../utils/presets"

--- a/examples/using-remark/src/pages/tags.js
+++ b/examples/using-remark/src/pages/tags.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import Layout from "../layouts"
 import kebabCase from "lodash/kebabCase"
 

--- a/examples/using-remark/src/templates/template-blog-post.js
+++ b/examples/using-remark/src/templates/template-blog-post.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import Img from "gatsby-image"
 import rehypeReact from "rehype-react"
 

--- a/examples/using-remark/src/templates/template-tag-page.js
+++ b/examples/using-remark/src/templates/template-tag-page.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import Layout from "../layouts"
 
 class TagRoute extends React.Component {

--- a/packages/gatsby-transformer-sharp/src/fragments.js
+++ b/packages/gatsby-transformer-sharp/src/fragments.js
@@ -1,4 +1,6 @@
 /* eslint-disable */
+import { graphql } from "gatsby"
+
 export const gatsbyImageSharpFixed = graphql`
   fragment GatsbyImageSharpFixed on ImageSharpFixed {
     base64


### PR DESCRIPTION
Remove the graphql warnings: `warning Using the global `graphql` tag is deprecated, and will not be supported in v3.`

Refs: #6071