### PR TITLE
[www] Gatsby/rebeccapurple banner

### DIFF
--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -2,7 +2,7 @@ import React from "react"
 import Modal from "react-modal"
 import Helmet from "react-helmet"
 import { OutboundLink } from "gatsby-plugin-google-analytics"
-import { rhythm, options } from "../utils/typography"
+import { rhythm, options, scale } from "../utils/typography"
 import MdClose from "react-icons/lib/md/close"
 import { push, PageRenderer } from "gatsby"
 import presets, { colors } from "../utils/presets"
@@ -163,30 +163,46 @@ class DefaultLayout extends React.Component {
           css={{
             width: `100%`,
             padding: rhythm(1 / 2),
-            background: presets.colors.ui.bright,
-            color: presets.colors.gatsby,
+            background: isHomepage ? `#402060` : colors.gatsby,
+            color: colors.ui.bright,
             fontFamily: options.headerFontFamily.join(`,`),
-            textAlign: `center`,
-            boxShadow: `inset 0px -3px 2px 0px ${presets.colors.ui.bright}`,
+            fontSize: scale(-1 / 5).fontSize,
             zIndex: `3`,
             position: `fixed`,
+            WebkitFontSmoothing: `antialiased`,
           }}
         >
-          You're viewing the docs for Gatsby v2 beta.{` `}
-          <OutboundLink href="https://gatsbyjs.org/">
-            View the v1 docs instead
+          These are the docs for v2 beta.{` `}
+          <OutboundLink
+            href="https://gatsbyjs.org/"
+            css={{
+              color: `#fff`,
+            }}
+          >
+            View the v1 docs
+            <span
+              css={{
+                display: `none`,
+                [presets.Mobile]: {
+                  display: `inline`,
+                },
+              }}
+            >
+              {` `}
+              instead
+            </span>
           </OutboundLink>.
         </div>
         <Navigation pathname={this.props.location.pathname} />
         <div
           className={`main-body`}
           css={{
-            paddingTop: `2.8rem`,
+            paddingTop: presets.bannerHeight,
             [presets.Tablet]: {
               margin: `0 auto`,
               paddingTop: isHomepage
-                ? `2.8rem`
-                : `calc(2.8rem + ${presets.headerHeight})`,
+                ? presets.bannerHeight
+                : `calc(${presets.bannerHeight} + ${presets.headerHeight})`,
             },
           }}
         >

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -90,7 +90,7 @@ export default ({ pathname }) => {
       css={{
         borderBottom: `1px solid ${colors.ui.light}`,
         backgroundColor: `rgba(255,255,255,0.975)`,
-        position: isHomepage ? `absolute` : false,
+        position: isHomepage ? `absolute` : `relative`,
         height: presets.headerHeight,
         zIndex: `2`,
         left: 0,

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -95,7 +95,7 @@ export default ({ pathname }) => {
         zIndex: `2`,
         left: 0,
         right: 0,
-        top: `calc(2.8rem - 1px)`,
+        top: `calc(${presets.bannerHeight} - 1px)`,
         [presets.Tablet]: {
           position: isHomepage || isBlog ? `absolute` : `fixed`,
         },

--- a/www/src/components/sidebar-body.js
+++ b/www/src/components/sidebar-body.js
@@ -203,21 +203,13 @@ class SidebarBody extends React.Component {
         css={{
           borderRight: `1px solid ${colors.ui.light}`,
           backgroundColor: colors.ui.whisper,
-          boxShadow: `inset 0 4px 5px 0 ${hex2rgba(
-            colors.gatsby,
-            presets.shadowKeyPenumbraOpacity
-          )}, inset 0 1px 10px 0 ${hex2rgba(
-            colors.lilac,
-            presets.shadowAmbientShadowOpacity
-          )}, inset 0 2px 4px -1px ${hex2rgba(
-            colors.lilac,
-            presets.shadowKeyUmbraOpacity
-          )}`,
           width: rhythm(10),
           position: `fixed`,
-          top: `calc(${presets.headerHeight} + 2.8rem - 1px)`,
+          top: `calc(${presets.headerHeight} + ${presets.bannerHeight} - 1px)`,
           overflowY: `auto`,
-          height: `calc(100vh - ${presets.headerHeight} - 2.8rem + 1px)`,
+          height: `calc(100vh - ${presets.headerHeight} - ${
+            presets.bannerHeight
+          } + 1px)`,
           WebkitOverflowScrolling: `touch`,
           "::-webkit-scrollbar": {
             width: `6px`,

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -16,9 +16,9 @@ class Plugins extends Component {
             css={{
               alignItems: `center`,
               display: `flex`,
-              minHeight: `calc(100vh - (${
-                presets.headerHeight
-              } + 2.8rem - 1px))`,
+              minHeight: `calc(100vh - (${presets.headerHeight} + ${
+                presets.bannerHeight
+              } - 1px))`,
             }}
           >
             <div

--- a/www/src/utils/presets.js
+++ b/www/src/utils/presets.js
@@ -35,4 +35,5 @@ module.exports = {
   },
   logoOffset: 1.8,
   headerHeight: `3.5rem`,
+  bannerHeight: `2.55rem`,
 }


### PR DESCRIPTION
* Reduce banner font-size.
* Store banner height in presets.bannerHeight.
* Reduce banner copy from „You're viewing the docs for Gatsby v2 beta. View the v1 docs instead.“ to „These are the docs for v2 beta. View the v1 docs instead.“ and drop the „instead“ for screens < presets.Mobile. This change makes the banner copy fit in one (instead of two) lines on screens with a maximum width of 320px.
* Remove sidebar inset box-shadow.

![image](https://user-images.githubusercontent.com/21834/41914978-e25d7efc-7954-11e8-97b7-5c85caddd340.png)

![image](https://user-images.githubusercontent.com/21834/41915017-f90a846a-7954-11e8-8e27-cde3da7cd9b5.png)
