### PR TITLE
fixed typo in gatsby-remark-prismjs README.md

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -197,7 +197,7 @@ Tutorial/Documentation][4] for line highlights:
   PrismJS-formatted `<pre><code>`-blocks.
 - Highlighted lines are wrapped in `<span class="gatsby-highlight-code-line">`.
 - We insert a linebreak before the closing tag of `.gatsby-highlight-code-line`
-  so it ends up at the start of the follwing line.
+  so it ends up at the start of the following line.
 
 With all of this in place, we can apply `float:left; min-width:100%` to `<pre>`,
 throw our overflow and background on `.gatsby-highlight`, and use


### PR DESCRIPTION
## Changes
- "follwing" to "following" on line 200 in gatsby-remark-prismjs README.md