### PR TITLE
fix: use the language loader for imports not postcss

### DIFF
--- a/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -13,7 +13,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #1 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -31,7 +31,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #1 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -68,7 +68,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -85,7 +85,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -121,7 +121,7 @@ exports[`gatsby-plugin-less Stage: build-html / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -135,7 +135,7 @@ exports[`gatsby-plugin-less Stage: build-html / No options 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -168,7 +168,7 @@ exports[`gatsby-plugin-less Stage: build-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -182,7 +182,7 @@ exports[`gatsby-plugin-less Stage: build-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -215,7 +215,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -233,7 +233,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -270,7 +270,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -287,7 +287,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -323,7 +323,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -337,7 +337,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -370,7 +370,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -384,7 +384,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -417,7 +417,7 @@ exports[`gatsby-plugin-less Stage: develop / Less options #1 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -435,7 +435,7 @@ exports[`gatsby-plugin-less Stage: develop / Less options #1 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -472,7 +472,7 @@ exports[`gatsby-plugin-less Stage: develop / Less options #2 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -489,7 +489,7 @@ exports[`gatsby-plugin-less Stage: develop / Less options #2 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -525,7 +525,7 @@ exports[`gatsby-plugin-less Stage: develop / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -539,7 +539,7 @@ exports[`gatsby-plugin-less Stage: develop / No options 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -572,7 +572,7 @@ exports[`gatsby-plugin-less Stage: develop / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -586,7 +586,7 @@ exports[`gatsby-plugin-less Stage: develop / PostCss plugins 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -619,7 +619,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -637,7 +637,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -674,7 +674,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -691,7 +691,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -727,7 +727,7 @@ exports[`gatsby-plugin-less Stage: develop-html / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -741,7 +741,7 @@ exports[`gatsby-plugin-less Stage: develop-html / No options 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -774,7 +774,7 @@ exports[`gatsby-plugin-less Stage: develop-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
@@ -788,7 +788,7 @@ exports[`gatsby-plugin-less Stage: develop-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",

--- a/packages/gatsby-plugin-less/src/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/gatsby-node.js
@@ -22,7 +22,7 @@ exports.onCreateWebpackConfig = (
       ? [loaders.null()]
       : [
           loaders.miniCssExtract(),
-          loaders.css({ importLoaders: 1 }),
+          loaders.css({ importLoaders: 2 }),
           loaders.postcss({ plugins: postCssPlugins }),
           lessLoader,
         ],
@@ -31,7 +31,7 @@ exports.onCreateWebpackConfig = (
     test: /\.module\.less$/,
     use: [
       loaders.miniCssExtract(),
-      loaders.css({ modules: true, importLoaders: 1 }),
+      loaders.css({ modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       lessLoader,
     ],

--- a/packages/gatsby-plugin-sass/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-sass/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -13,7 +13,7 @@ exports[`gatsby-plugin-sass Stage: build-html / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -27,7 +27,7 @@ exports[`gatsby-plugin-sass Stage: build-html / No options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -60,7 +60,7 @@ exports[`gatsby-plugin-sass Stage: build-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -74,7 +74,7 @@ exports[`gatsby-plugin-sass Stage: build-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -107,7 +107,7 @@ exports[`gatsby-plugin-sass Stage: build-html / Sass options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -125,7 +125,7 @@ exports[`gatsby-plugin-sass Stage: build-html / Sass options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -162,7 +162,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -176,7 +176,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / No options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -209,7 +209,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -223,7 +223,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / PostCss plugins 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -256,7 +256,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / Sass options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -274,7 +274,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / Sass options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -311,7 +311,7 @@ exports[`gatsby-plugin-sass Stage: develop / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -325,7 +325,7 @@ exports[`gatsby-plugin-sass Stage: develop / No options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -358,7 +358,7 @@ exports[`gatsby-plugin-sass Stage: develop / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -372,7 +372,7 @@ exports[`gatsby-plugin-sass Stage: develop / PostCss plugins 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -405,7 +405,7 @@ exports[`gatsby-plugin-sass Stage: develop / Sass options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -423,7 +423,7 @@ exports[`gatsby-plugin-sass Stage: develop / Sass options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -460,7 +460,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -474,7 +474,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / No options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -507,7 +507,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -521,7 +521,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -554,7 +554,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / Sass options 1`] = `
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",
@@ -572,7 +572,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / Sass options 1`] = `
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/sass-loader",

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -22,7 +22,7 @@ exports.onCreateWebpackConfig = (
       ? [loaders.null()]
       : [
           loaders.miniCssExtract(),
-          loaders.css({ importLoaders: 1 }),
+          loaders.css({ importLoaders: 2 }),
           loaders.postcss({ plugins: postCssPlugins }),
           sassLoader,
         ],
@@ -31,7 +31,7 @@ exports.onCreateWebpackConfig = (
     test: /\.module\.s(a|c)ss$/,
     use: [
       loaders.miniCssExtract(),
-      loaders.css({ modules: true, importLoaders: 1 }),
+      loaders.css({ modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       sassLoader,
     ],

--- a/packages/gatsby-plugin-stylus/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-stylus/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -14,7 +14,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / No options 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -28,7 +28,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -62,7 +62,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -76,7 +76,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -110,7 +110,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / Stylus options #1 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -127,7 +127,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / Stylus options #1 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -164,7 +164,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / Stylus options #2 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -185,7 +185,7 @@ exports[`gatsby-plugin-stylus Stage: build-html / Stylus options #2 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -226,7 +226,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / No options 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -240,7 +240,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -274,7 +274,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / PostCss plugins 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -288,7 +288,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -322,7 +322,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / Stylus options #1 1`] = 
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -339,7 +339,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / Stylus options #1 1`] = 
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -376,7 +376,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / Stylus options #2 1`] = 
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -397,7 +397,7 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / Stylus options #2 1`] = 
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -438,7 +438,7 @@ exports[`gatsby-plugin-stylus Stage: develop / No options 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -452,7 +452,7 @@ exports[`gatsby-plugin-stylus Stage: develop / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -486,7 +486,7 @@ exports[`gatsby-plugin-stylus Stage: develop / PostCss plugins 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -500,7 +500,7 @@ exports[`gatsby-plugin-stylus Stage: develop / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -534,7 +534,7 @@ exports[`gatsby-plugin-stylus Stage: develop / Stylus options #1 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -551,7 +551,7 @@ exports[`gatsby-plugin-stylus Stage: develop / Stylus options #1 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -588,7 +588,7 @@ exports[`gatsby-plugin-stylus Stage: develop / Stylus options #2 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -609,7 +609,7 @@ exports[`gatsby-plugin-stylus Stage: develop / Stylus options #2 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -650,7 +650,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / No options 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -664,7 +664,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / No options 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -698,7 +698,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -712,7 +712,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / PostCss plugins 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -746,7 +746,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / Stylus options #1 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -763,7 +763,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / Stylus options #1 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -800,7 +800,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / Stylus options #2 1`] = `
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"importLoaders\\":1})",
+                    "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",
@@ -821,7 +821,7 @@ exports[`gatsby-plugin-stylus Stage: develop-html / Stylus options #2 1`] = `
                   "test": /\\\\\\.module\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css({\\"modules\\":true,\\"importLoaders\\":1})",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/stylus-loader",

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -42,7 +42,7 @@ exports.onCreateWebpackConfig = (
     exclude: /\.module\.styl$/,
     use: [
       loaders.miniCssExtract(),
-      loaders.css({ importLoaders: 1 }),
+      loaders.css({ importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       stylusLoader,
     ],
@@ -52,7 +52,7 @@ exports.onCreateWebpackConfig = (
     test: /\.module\.styl$/,
     use: [
       loaders.miniCssExtract(),
-      loaders.css({ modules: true, importLoaders: 1 }),
+      loaders.css({ modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       stylusLoader,
     ],


### PR DESCRIPTION
The css-loader still doesn’t have a good api for this :/ but this will tell imports to files inside the style files to use the sass/less/stylus loader first so code can import files correctly