### PR TITLE
[gatsby-plugin-typescript] Implement preprocessSource

### DIFF
--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -4,7 +4,7 @@ const {
   resolvableExtensions,
   onCreateWebpackConfig,
 } = require(`../gatsby-node`)
-const { tsPresetsFromJsPresets } = require(`../`)
+const { compile, tsPresetsFromJsPresets } = require(`../`)
 const tsPresetPath = `/resolved/path/@babel/preset-typescript`
 const jsOptions = {
   options: {
@@ -17,6 +17,14 @@ const jsOptions = {
   },
   loader: `/resolved/path/babel-loader`,
 }
+
+describe(`compile`, () => {
+  it(`compiles typescript`, () => {
+    const ts = `const a: string = 'hello'`
+    const js = `var a = 'hello';`
+    expect(compile(ts, `test.ts`)).toEqual(js)
+  })
+})
 
 describe(`tsPresetsFromJsPresets`, () => {
   it(`handles empty presets`, () => {

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -1,8 +1,9 @@
-const { tsPresetsFromJsPresets } = require(`./`)
+import { compile, tsPresetsFromJsPresets } from "./"
 
-const resolvableExtensions = () => [`.ts`, `.tsx`]
+const TS = /\.tsx?$/
+export const resolvableExtensions = () => [`.ts`, `.tsx`]
 
-function onCreateWebpackConfig({ actions, loaders, stage }) {
+export function onCreateWebpackConfig({ actions, loaders, stage }) {
   const jsLoader = loaders.js()
   if (
     !(
@@ -18,7 +19,7 @@ function onCreateWebpackConfig({ actions, loaders, stage }) {
     module: {
       rules: [
         {
-          test: /\.tsx?$/,
+          test: TS,
           use: [
             {
               loader: jsLoader.loader,
@@ -33,5 +34,16 @@ function onCreateWebpackConfig({ actions, loaders, stage }) {
     },
   })
 }
-exports.onCreateWebpackConfig = onCreateWebpackConfig
-exports.resolvableExtensions = resolvableExtensions
+
+/**
+ * Gatsby uses preprocessSource when it parses
+ * GraphQL queries during build. Unfortunately
+ * with the current API there is no way to affect
+ * the Babel plugins which are used during that parsing.
+ */
+export function preprocessSource({ filename, contents }, pluginOptions) {
+  if (TS.test(filename)) {
+    return compile(contents, filename)
+  }
+  return null
+}

--- a/packages/gatsby-plugin-typescript/src/index.js
+++ b/packages/gatsby-plugin-typescript/src/index.js
@@ -1,6 +1,7 @@
-const resolve = require(`./resolve`)
+import resolve from "./resolve"
+import { transformSync } from "@babel/core"
 
-function tsPresetsFromJsPresets(jsPresets) {
+export function tsPresetsFromJsPresets(jsPresets) {
   const copy = (jsPresets && jsPresets.slice(0)) || []
   if (copy.length > 0) {
     const lastItem = copy[copy.length - 1]
@@ -15,4 +16,26 @@ function tsPresetsFromJsPresets(jsPresets) {
   return copy
 }
 
-exports.tsPresetsFromJsPresets = tsPresetsFromJsPresets
+const babelOptions = {
+  babelrc: false,
+  comments: false,
+  sourceType: `unambiguous`,
+  presets: [
+    require.resolve(`@babel/preset-env`),
+    require.resolve(`@babel/preset-react`),
+    require.resolve(`@babel/preset-typescript`),
+  ],
+  plugins: [
+    [
+      require.resolve(`@babel/plugin-proposal-class-properties`),
+      { loose: true },
+    ],
+    require.resolve(`@babel/plugin-syntax-dynamic-import`),
+  ],
+}
+
+export function compile(contents, filename) {
+  // preset-typescript needs the filename
+  const { code } = transformSync(contents, { ...babelOptions, filename })
+  return code
+}


### PR DESCRIPTION
<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Fixes issues #6163 and #6157.

The solution is here definitely suboptimal. A much cleaner way would be possible by changing the `preprocessSource` node api so that it'd be possible to use custom parsing options here: [file-parser.js#L79](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/file-parser.js#L79). But this is probably part of the broader issue of somehow being able to use the exact same babel configuration when parsing the GraphQL queries as when loading with webpack.
