### PR TITLE
stop builds on errors in built-html step

### DIFF
--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
@@ -3,7 +3,7 @@
  */
 
 const { readFileSync } = require(`fs`)
-const babelCodeFrame = require(`@babel/code-frame`)
+const { codeFrameColumns } = require(`@babel/code-frame`)
 const stackTrace = require(`stack-trace`)
 const { SourceMapConsumer } = require(`source-map`)
 
@@ -28,10 +28,14 @@ function getErrorSource(map, topFrame) {
   let source = map.sourceContentFor(topFrame.getFileName(), true)
   return (
     source &&
-    babelCodeFrame(
+    codeFrameColumns(
       source,
-      topFrame.getLineNumber(),
-      topFrame.getColumnNumber(),
+      {
+        start: {
+          line: topFrame.getLineNumber(),
+          column: topFrame.getColumnNumber(),
+        },
+      },
       {
         highlightCode: true,
       }

--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -53,7 +53,7 @@ module.exports = async (program: any) => {
           return resolve(null, stats)
         })
         .catch(e => {
-          console.log(e)
+          reject(createErrorFromString(e.stack, `${outputFile}.map`))
         })
     })
   })


### PR DESCRIPTION
it also restores v1 error formatting

after:
```
error Building static HTML for pages failed

See our docs page on debugging HTML builds for help https://goo.gl/yL9lND

  10 |     <div>
  11 |       <h1>Hi people</h1>
> 12 |       { NotAnObject.errorThrower }
     |                     ^
  13 |     </div>
  14 |   )
  15 | }


  WebpackError: TypeError: Cannot read property 'errorThrower' of undefined

  - index.js:12 IndexPage
    lib/src/pages/index.js:12:21

  - react-dom-server.node.production.min.js:26 d
    [lib]/[react-dom]/cjs/react-dom-server.node.production.min.js:26:482

  - react-dom-server.node.production.min.js:28 wa
    [lib]/[react-dom]/cjs/react-dom-server.node.production.min.js:28:493

  - react-dom-server.node.production.min.js:33 a../node_modules/react-dom/cjs/react-dom-server.node.production.min.js.a.render
    [lib]/[react-dom]/cjs/react-dom-server.node.production.min.js:33:46
```

before:
```
error Building static HTML for pages failed

See our docs page on debugging HTML builds for help https://goo.gl/yL9lND


  TypeError: Cannot read property 'errorThrower' of undefined

  - render-page.js:26262 IndexPage
    D:/dev/blog-v2/public/render-page.js:26262:179

  - render-page.js:22314 d
    D:/dev/blog-v2/public/render-page.js:22314:492

  - render-page.js:22316 wa
    D:/dev/blog-v2/public/render-page.js:22316:493

  - render-page.js:22321 a../node_modules/react-dom/cjs/react-dom-server.node.production.min.js.a.render
    D:/dev/blog-v2/public/render-page.js:22321:48
```

closes #5301 