### PR TITLE
[www] Fix package.json name, description, version

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gatsby-starter-default",
-  "description": "Gatsby default starter",
-  "version": "1.1.0-alpha.03b9df85",
+  "name": "gatsbyjs.org",
+  "description": "Gatsby's Website",
+  "version": "2.0.0-beta",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "bluebird": "^3.5.1",


### PR DESCRIPTION
Analog to www on v1: https://github.com/gatsbyjs/gatsby/blob/cd7a357a17f3faa22ad6a05073d11dba129e592a/www/package.json#L2-L4