### PR TITLE
[gatsby-source-medium] fix next version

### DIFF
--- a/examples/using-medium/package.json
+++ b/examples/using-medium/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "gatsby": "next",
-    "gatsby-source-medium": "^1.0.1",
+    "gatsby-source-medium": "next",
     "react": "^16.4.0",
     "react-dom": "^16.4.0"
   },

--- a/packages/gatsby-source-medium/src/gatsby-node.js
+++ b/packages/gatsby-source-medium/src/gatsby-node.js
@@ -59,7 +59,18 @@ exports.sourceNodes = async ({ actions, createNodeId }, { username }) => {
       importableResources = importableResources.concat(collections)
     }
 
-    const resources = Array.prototype.concat(...importableResources)
+    const resources = Array.prototype
+      .concat(...importableResources)
+      .map(resource => {
+        return {
+          ...resource,
+          medium_id: resource.id,
+          id: createNodeId(resource.id ? resource.id : resource.userId),
+        }
+      })
+
+    const getID = node => (node ? node.id : null)
+
     resources.map(resource => {
       convertTimestamps(resource)
 
@@ -71,21 +82,24 @@ exports.sourceNodes = async ({ actions, createNodeId }, { username }) => {
       const links =
         resource.type === `Post`
           ? {
-              author___NODE: resource.creatorId,
+              author___NODE: getID(
+                resources.find(r => r.userId === resource.creatorId)
+              ),
             }
           : resource.type === `User`
             ? {
-                posts___NODE: posts
-                  .filter(post => post.creatorId === resource.userId)
-                  .map(post => post.id),
+                posts___NODE: resources
+                  .filter(
+                    r => r.type === `Post` && r.creatorId === resource.userId
+                  )
+                  .map(r => r.id),
               }
             : {}
 
       const node = Object.assign(
         resource,
         {
-          id: createNodeId(resource.id ? resource.id : resource.userId),
-          parent: `__SOURCE__`,
+          parent: null,
           children: [],
           internal: {
             type: `Medium${resource.type}`,


### PR DESCRIPTION
`___NODE` was linking to old style node IDs, wasn't adjusted after change to createNodeId