### PR TITLE
Allow plugins to return custom @babel/parser options in preprocessSource

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -76,7 +76,9 @@ async function parseToAst(filePath, fileStr) {
   if (transpiled && transpiled.length) {
     for (const item of transpiled) {
       try {
-        const tmp = babylon.parse(item, BABYLON_OPTIONS)
+        const [code, options] =
+          typeof item === `string` ? [item, BABYLON_OPTIONS] : [fileStr, item]
+        const tmp = babylon.parse(code, options)
         ast = tmp
         break
       } catch (error) {

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -76,6 +76,8 @@ async function parseToAst(filePath, fileStr) {
   if (transpiled && transpiled.length) {
     for (const item of transpiled) {
       try {
+        // 'item' can be preprocessed code in a string or an object with
+        // custom @babel/parser options
         const [code, options] =
           typeof item === `string` ? [item, BABYLON_OPTIONS] : [fileStr, item]
         const tmp = babylon.parse(code, options)


### PR DESCRIPTION
<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
