### PR TITLE
add migrating doc with update gatsby related deps

### DIFF
--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -64,7 +64,7 @@ You can start with a few of the most important steps - install Gatsby v2 depende
 
 ## Update Gatsby version
 
-Update your `package.json` to use the pre-release versions of Gatsby and any related packages.
+Update your `package.json` to use the pre-release versions of Gatsby.
 
 `package.json`
 
@@ -77,6 +77,20 @@ Update your `package.json` to use the pre-release versions of Gatsby and any rel
 ```
 
 > Note: Gatsby v2 is in pre-release so you may encounter further breaking changes.
+
+## Update Gatsby related packages
+
+Update your `package.json` to use the pre-release versions of Gatsby related packages. Any package name that starts with `gatsby-` should be upgraded to use the `next` version. For example:
+
+`package.json`
+
+```json
+"dependencies": {
+    "gatsby-plugin-google-analytics": "next",
+    "gatsby-plugin-netlify": "next",
+    "gatsby-plugin-sass": "next",
+}
+```
 
 ## Manually install React
 

--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -80,7 +80,7 @@ Update your `package.json` to use the pre-release versions of Gatsby.
 
 ## Update Gatsby related packages
 
-Update your `package.json` to use the pre-release versions of Gatsby related packages. Any package name that starts with `gatsby-` should be upgraded to use the `next` version. For example:
+Update your `package.json` to use the pre-release versions of Gatsby related packages. Any package name that starts with `gatsby-` should be upgraded to use the `next` version. Note, this only applies to plugins managed in the gatsbyjs/gatsby repo. If you're using community plugins, they might not be upgraded yet. Check their repo for the status. Many plugins won't actually need upgraded so they very well might keep working. For example:
 
 `package.json`
 


### PR DESCRIPTION
calls out what seems to be an issue a number of people are having in #5774. It's not clear that all gatsby-* deps need to be upgraded to `next` as well.
