### PR TITLE
QraphQL errors in browser

### DIFF
--- a/packages/gatsby/src/cache-dir/socketIo.js
+++ b/packages/gatsby/src/cache-dir/socketIo.js
@@ -30,7 +30,7 @@ export default function socketIo() {
             }
           }
           if (msg.type === `pageQueryError`) {
-            // console.error queryError
+            console.error(msg.payload.error)
           }
           if (msg.type && msg.payload) {
             ___emitter.emit(msg.type, msg.payload)

--- a/packages/gatsby/src/cache-dir/socketIo.js
+++ b/packages/gatsby/src/cache-dir/socketIo.js
@@ -29,6 +29,9 @@ export default function socketIo() {
                 .result,
             }
           }
+          if (msg.type === `pageQueryError`) {
+            // console.error queryError
+          }
           if (msg.type && msg.payload) {
             ___emitter.emit(msg.type, msg.payload)
           }

--- a/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
@@ -76,9 +76,10 @@ class Runner {
     if (process.env.NODE_ENV === `production`) {
       report.panic(`${report.format.red(`GraphQL Error`)} ${message}`)
     } else {
-      report.log(`${report.format.red(`GraphQL Error`)} ${message}`)
+      const queryError = `${report.format.red(`GraphQL Error`)} ${message}`
+      report.log(queryError)
       websocketManager.emitQueryError({
-        errors: [new Error(`${report.format.red(`GraphQL Error`)} ${message}`)],
+        error: queryError,
       })
     }
   }

--- a/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
@@ -20,6 +20,7 @@ import {
   multipleRootQueriesError,
 } from "./graphql-errors"
 import report from "gatsby-cli/lib/reporter"
+const websocketManager = require(`../../utils/websocket-manager`)
 
 import type { DocumentNode, GraphQLSchema } from "graphql"
 
@@ -76,6 +77,9 @@ class Runner {
       report.panic(`${report.format.red(`GraphQL Error`)} ${message}`)
     } else {
       report.log(`${report.format.red(`GraphQL Error`)} ${message}`)
+      websocketManager.emitQueryError({
+        errors: [new Error(`${report.format.red(`GraphQL Error`)} ${message}`)],
+      })
     }
   }
 

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -26,6 +26,7 @@ const indentString = string => string.replace(/\n/g, `\n  `)
 // Run query
 module.exports = async (queryJob: QueryJob, component: Any) => {
   const { schema, program } = store.getState()
+  const programType = program._[0]
 
   const graphql = (query, context) =>
     graphqlFunction(schema, query, context, context, context)
@@ -57,8 +58,13 @@ Plugin:
 Query:
   ${indentString(component.query)}`)
 
+    if (programType === `develop`) {
+      websocketManager.emitQueryError({
+        errors: result.errors,
+        id: queryJob.id,
+      })
     // Perhaps this isn't the best way to see if we're building?
-    if (program._[0] === `build`) {
+    } else if (programType === `build`) {
       process.exit(1)
     }
   }
@@ -84,8 +90,6 @@ Query:
   } else {
     dataPath = queryJob.hash
   }
-
-  const programType = program._[0]
 
   if (programType === `develop`) {
     if (queryJob.isPage) {

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -44,23 +44,25 @@ module.exports = async (queryJob: QueryJob, component: Any) => {
   // If there's a graphql error then log the error. If we're building, also
   // quit.
   if (result && result.errors) {
-    report.log(`
-The GraphQL query from ${component.componentPath} failed.
+    const queryError = `
+      The GraphQL query from ${component.componentPath} failed.
 
-Errors:
-  ${result.errors || []}
-URL path:
-  ${queryJob.path}
-Context:
-  ${indentString(JSON.stringify(queryJob.context, null, 2))}
-Plugin:
-  ${queryJob.pluginCreatorId || `none`}
-Query:
-  ${indentString(component.query)}`)
+      Errors:
+        ${result.errors || []}
+      URL path:
+        ${queryJob.path}
+      Context:
+        ${indentString(JSON.stringify(queryJob.context, null, 2))}
+      Plugin:
+        ${queryJob.pluginCreatorId || `none`}
+      Query:
+        ${indentString(component.query)}
+    `
+    report.log(queryError)
 
     if (programType === `develop`) {
       websocketManager.emitQueryError({
-        errors: result.errors,
+        error: queryError,
         id: queryJob.id,
       })
     // Perhaps this isn't the best way to see if we're building?

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -126,9 +126,9 @@ class WebsocketManager {
     this.pageResults.set(data.id, data)
   }
   emitQueryError(data) {
-    this.pageErrors.set(data.id, data.errors)
+    this.pageErrors.set(data.id, data)
     if (this.isInitialised) {
-      this.websocket.send({ type: `pageQueryError`, payload: data.errors })
+      this.websocket.send({ type: `pageQueryError`, payload: data })
     }
   }
 }

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -29,6 +29,7 @@ class WebsocketManager {
     this.activePaths = new Set()
     this.pageResults = new Map()
     this.staticQueryResults = new Map()
+    this.pageErrors = new Map()
     this.websocket
     this.programDir
 
@@ -36,6 +37,7 @@ class WebsocketManager {
     this.getSocket = this.getSocket.bind(this)
     this.emitPageData = this.emitPageData.bind(this)
     this.emitStaticQueryData = this.emitStaticQueryData.bind(this)
+    this.emitQueryError = this.emitQueryError.bind(this)
   }
 
   init({ server, directory }) {
@@ -52,10 +54,16 @@ class WebsocketManager {
           payload: { id, result },
         })
       })
-      this.pageResults.forEach((result, path) => {
+      this.pageResults.forEach((result, id) => {
         this.websocket.send({
           type: `pageQueryResult`,
           payload: result,
+        })
+      })
+      this.pageErrors.forEach((error, id) => {
+        this.websocket.send({
+          type: `pageQueryError`,
+          payload: error,
         })
       })
 
@@ -115,7 +123,13 @@ class WebsocketManager {
     if (this.isInitialised) {
       this.websocket.send({ type: `pageQueryResult`, payload: data })
     }
-    this.pageResults.set(data.path, data)
+    this.pageResults.set(data.id, data)
+  }
+  emitQueryError(data) {
+    this.pageErrors.set(data.id, data.errors)
+    if (this.isInitialised) {
+      this.websocket.send({ type: `pageQueryError`, payload: data.errors })
+    }
   }
 }
 


### PR DESCRIPTION
This approach to displaying GraphQL compilation and runtime errors in the browser console utilizes the WebSocket connecting node running gatsby package responsible for executing GraphQL queries and the cache loaded and used on the browser side (thanks @pieh for helping in this).

One more useful step would be to extract the error query and add a link to graphiql with the error query. 