### PR TITLE
Improve UX for service worker updates

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -137,7 +137,9 @@ class GatsbyLink extends React.Component {
                 .split(`#`)
                 .slice(1)
                 .join(`#`)
-              const element = hashFragment ? document.getElementById(hashFragment) : null
+              const element = hashFragment
+                ? document.getElementById(hashFragment)
+                : null
               if (element !== null) {
                 element.scrollIntoView()
                 return true
@@ -153,7 +155,11 @@ class GatsbyLink extends React.Component {
             // loaded before continuing.
             if (process.env.NODE_ENV === `production`) {
               e.preventDefault()
-              window.___push(this.state.to)
+              if (window.GATSBY_SW_UPDATED) {
+                window.location = this.state.to
+              } else {
+                window.___push(this.state.to)
+              }
             }
           }
 

--- a/packages/gatsby/cache-dir/register-service-worker.js
+++ b/packages/gatsby/cache-dir/register-service-worker.js
@@ -17,7 +17,7 @@ if (`serviceWorker` in navigator) {
                 // have been added to the cache.
                 // We reload immediately so the user sees the new content.
                 // This could/should be made configurable in the future.
-                window.location.reload()
+                window.GATSBY_SW_UPDATED = true
               } else {
                 // At this point, everything has been precached.
                 // It's the perfect time to display a "Content is cached for offline use." message.


### PR DESCRIPTION
<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

This PR adds support for waiting on page refreshes from service worker updates. How this is achieved:

- Once a service worker update event is fired, a global constant is added to the page
- Gatsby Link then checks for the presence of this constant on each routing event, if its found a full page navigation is fired instead of a client side navigation event

This allows the new resources to be loaded without interrupting any current work or browsing being done by the site user. 