### PR TITLE
[using-typescript] convert to use graphql imported from gatsby

### DIFF
--- a/examples/using-typescript/src/declarations.d.ts
+++ b/examples/using-typescript/src/declarations.d.ts
@@ -1,1 +1,8 @@
-declare const graphql: (query: TemplateStringsArray) => void;
+// This file is used to hold ambient type declarations, as well as type shims
+// for npm module without type declarations, and assets files.
+
+// For example, to shim modules without declarations, use:
+// declare module "package-without-declarations"
+
+// And to shim assets, use (one file extension per `declare`):
+// declare module "*.png"

--- a/examples/using-typescript/src/pages/index.tsx
+++ b/examples/using-typescript/src/pages/index.tsx
@@ -1,5 +1,7 @@
+import { graphql } from "gatsby"
 import * as React from "react"
 import Layout from "../layouts"
+
 // Please note that you can use https://github.com/dotansimha/graphql-code-generator
 // to generate all types from graphQL schema
 interface IndexPageProps {


### PR DESCRIPTION
This converts the TS example to use the `graphql` function imported from the `gatsby` package.

<!--
  Please choose the correct branch for your pull request:

  * `master` branch for Gatsby version 2 bug fixes
  * `master` branch for any new features (these will be released in the Gatsby v2 betas)
  * `v1` branch for updates to the `www` and `docs` directories
  * `v1` branch for Gatsby version 1 bug fixes

  Note: We will *not* accept new features for Gatsby v1, only bug fixes, documentation and updates to gatsbyjs.org.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
