### PR TITLE
Respect HOST and PORT environment variables

### DIFF
--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -31,8 +31,8 @@ development server.
 Options
 
 ```
-  -H, --host    Set host. Defaults to localhost
-  -p, --port    Set port. Defaults to 8000
+  -H, --host    Set host. Defaults to the HOST environment variable or localhost if unset
+  -p, --port    Set port. Defaults to the PORT environment variable or 8000 if unset
   -o, --open    Open the site in your browser for you
   -S, --https   Use HTTPS
 ```

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -15,7 +15,9 @@ const handlerP = fn => (...args) => {
 }
 
 function buildLocalCommands(cli, isLocalSite) {
-  const defaultHost = `localhost`
+  const defaultHost = process.env.HOST || `localhost`
+  const defaultDevelopPort = process.env.PORT || `8000`
+  const defaultServePort = process.env.PORT || `9000`
   const directory = path.resolve(`.`)
 
   let siteInfo = { directory, browserslist: DEFAULT_BROWSERS }
@@ -92,8 +94,8 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`p`, {
           alias: `port`,
           type: `string`,
-          default: `8000`,
-          describe: `Set port. Defaults to 8000`,
+          default: defaultDevelopPort,
+          describe: `Set port. Defaults to ${defaultDevelopPort}`,
         })
         .option(`o`, {
           alias: `open`,
@@ -163,8 +165,8 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`p`, {
           alias: `port`,
           type: `string`,
-          default: `9000`,
-          describe: `Set port. Defaults to 9000`,
+          default: defaultServePort,
+          describe: `Set port. Defaults to ${defaultServePort}`,
         })
         .option(`o`, {
           alias: `open`,


### PR DESCRIPTION
This change makes the CLI utilize the `PORT` and `HOST` environment variables for `gatsby develop` and  the `PORT` environment variable for `gatsby serve`.

No defaults were changed in this pull request. Host still defaults to localhost and port still defaults to 8000. Serve port still defaults to 9000. `-H` and `-P` still override defaults as before. 