### PR TITLE
New .org title -- Build blazing fast / modern / beautiful / secure websites with React (slider)

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -58,6 +58,7 @@
     "react-icons": "^2.2.7",
     "react-instantsearch": "^4.5.1",
     "react-modal": "^3.4.4",
+    "react-rotating-text": "^1.2.1",
     "react-typography": "^0.16.13",
     "slash": "^1.0.0",
     "slugify": "^1.3.0",

--- a/www/package.json
+++ b/www/package.json
@@ -58,7 +58,6 @@
     "react-icons": "^2.2.7",
     "react-instantsearch": "^4.5.1",
     "react-modal": "^3.4.4",
-    "react-rotating-text": "^1.2.1",
     "react-typography": "^0.16.13",
     "slash": "^1.0.0",
     "slugify": "^1.3.0",

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -1,10 +1,14 @@
 import React from "react"
 import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
+import RotatingText from "react-rotating-text"
+//import "react-rotating-text/src/ReactRotatingText.css"
 
 import { rhythm, scale } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
 import CtaButton from "./cta-button"
 import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
+import "./slider.css"
+
 
 const MastheadContent = () => (
   <div
@@ -62,15 +66,15 @@ const MastheadContent = () => (
           },
           [presets.Tablet]: {
             fontSize: scale(1.1).fontSize,
-            width: rhythm(12),
+            width: rhythm(14),
           },
           [presets.Hd]: {
             fontSize: scale(1.4).fontSize,
-            width: rhythm(14),
+            width: rhythm(16),
           },
           [presets.VHd]: {
             fontSize: scale(1.5).fontSize,
-            width: rhythm(16),
+            width: rhythm(18),
           },
           [presets.VVHd]: {
             fontSize: scale(1.6).fontSize,
@@ -78,7 +82,16 @@ const MastheadContent = () => (
           },
         }}
       >
-        Blazing-fast static site generator for React
+        <span css={{ display: `block`, marginBottom: rhythm(0.5) }}>
+          <span css={{ marginRight: rhythm(0.25) }}>Build</span>
+          <div class="slidingVertical">
+            <span>blazing fast</span>
+            <span>modern</span>
+            <span>beautiful</span>
+            <span>secure</span>
+          </div>
+        </span>
+        websites with React
       </h1>
       <CtaButton to="/docs/">
         <span css={{ verticalAlign: `middle` }}>Get Started</span>

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -91,7 +91,10 @@ const MastheadContent = () => (
               marginRight: rhythm(1 / 8),
             } 
           }}>Build</span>
-          <Slider items={[`blazing fast`, `modern`, `beautiful`, `secure`]} />
+          <Slider 
+            items={[`blazing fast`, `modern`, `beautiful`, `secure`]} 
+            color={colors.lilac}
+          />
         </span>
         websites with React
       </h1>

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -1,7 +1,5 @@
 import React from "react"
 import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
-import RotatingText from "react-rotating-text"
-//import "react-rotating-text/src/ReactRotatingText.css"
 
 import { rhythm, scale } from "../utils/typography"
 import presets, { colors } from "../utils/presets"

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -7,8 +7,7 @@ import { rhythm, scale } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
 import CtaButton from "./cta-button"
 import { vP, vPHd, vPVHd, vPVVHd } from "../components/gutters"
-import "./slider.css"
-
+import Slider from "./slider"
 
 const MastheadContent = () => (
   <div
@@ -92,12 +91,7 @@ const MastheadContent = () => (
               marginRight: rhythm(1 / 8),
             } 
           }}>Build</span>
-          <div class="slidingVertical">
-            <span>blazing fast</span>
-            <span>modern</span>
-            <span>beautiful</span>
-            <span>secure</span>
-          </div>
+          <Slider items={[`blazing fast`, `modern`, `beautiful`, `secure`]} />
         </span>
         websites with React
       </h1>

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -60,6 +60,10 @@ const MastheadContent = () => (
           [presets.Mobile]: {
             width: rhythm(10),
           },
+          fontSize: scale(3 / 5).fontSize,
+          "@media (min-width: 350px)": {
+            fontSize: scale(4 / 5).fontSize,
+          },          
           "@media (min-width: 650px)": {
             fontSize: scale(1).fontSize,
             width: rhythm(12),
@@ -83,7 +87,11 @@ const MastheadContent = () => (
         }}
       >
         <span css={{ display: `block` }}>
-          <span css={{ marginRight: rhythm(0.125) }}>Build</span>
+          <span css={{ 
+            [presets.Tablet]: {
+              marginRight: rhythm(1 / 8),
+            } 
+          }}>Build</span>
           <div class="slidingVertical">
             <span>blazing fast</span>
             <span>modern</span>

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -82,8 +82,8 @@ const MastheadContent = () => (
           },
         }}
       >
-        <span css={{ display: `block`, marginBottom: rhythm(0.5) }}>
-          <span css={{ marginRight: rhythm(0.25) }}>Build</span>
+        <span css={{ display: `block` }}>
+          <span css={{ marginRight: rhythm(0.125) }}>Build</span>
           <div class="slidingVertical">
             <span>blazing fast</span>
             <span>modern</span>

--- a/www/src/components/slider.css
+++ b/www/src/components/slider.css
@@ -1,0 +1,63 @@
+/*Vertical Sliding*/
+.slidingVertical{
+	display: inline;
+	text-indent: 8px;
+}
+.slidingVertical span{
+	animation: topToBottom 12.5s linear infinite 0s;
+	-ms-animation: topToBottom 12.5s linear infinite 0s;
+	-webkit-animation: topToBottom 12.5s linear infinite 0s;
+	color: #efa42b;
+	opacity: 0;
+	overflow: hidden;
+	position: absolute;
+}
+.slidingVertical span:nth-child(2){
+	animation-delay: 2.5s;
+	-ms-animation-delay: 2.5s;
+	-webkit-animation-delay: 2.5s;
+}
+.slidingVertical span:nth-child(3){
+	animation-delay: 5s;
+	-ms-animation-delay: 5s;
+	-webkit-animation-delay: 5s;
+}
+.slidingVertical span:nth-child(4){
+	animation-delay: 7.5s;
+	-ms-animation-delay: 7.5s;
+	-webkit-animation-delay: 7.5s;
+}
+.slidingVertical span:nth-child(5){
+	animation-delay: 10s;
+	-ms-animation-delay: 10s;
+	-webkit-animation-delay: 10s;
+}
+
+/*topToBottom Animation*/
+@-moz-keyframes topToBottom{
+	0% { opacity: 0; }
+	5% { opacity: 0; -moz-transform: translateY(-50px); }
+	10% { opacity: 1; -moz-transform: translateY(0px); }
+	25% { opacity: 1; -moz-transform: translateY(0px); }
+	30% { opacity: 0; -moz-transform: translateY(50px); }
+	80% { opacity: 0; }
+	100% { opacity: 0; }
+}
+@-webkit-keyframes topToBottom{
+	0% { opacity: 0; }
+	5% { opacity: 0; -webkit-transform: translateY(-50px); }
+	10% { opacity: 1; -webkit-transform: translateY(0px); }
+	25% { opacity: 1; -webkit-transform: translateY(0px); }
+	30% { opacity: 0; -webkit-transform: translateY(50px); }
+	80% { opacity: 0; }
+	100% { opacity: 0; }
+}
+@-ms-keyframes topToBottom{
+	0% { opacity: 0; }
+	5% { opacity: 0; -ms-transform: translateY(-50px); }
+	10% { opacity: 1; -ms-transform: translateY(0px); }
+	25% { opacity: 1; -ms-transform: translateY(0px); }
+	30% { opacity: 0; -ms-transform: translateY(50px); }
+	80% { opacity: 0; }
+	100% { opacity: 0; }
+}

--- a/www/src/components/slider.css
+++ b/www/src/components/slider.css
@@ -7,8 +7,8 @@
 .slidingVertical span{
 	animation: topToBottom 10s linear infinite 0s;
 	-ms-animation: topToBottom 10s linear infinite 0s;
-	-webkit-animation: topToBottom 10s linear infinite 0s;
-	color: #9D7CBF;
+    -webkit-animation: topToBottom 10s linear infinite 0s;
+    
 	opacity: 0;
 	overflow: hidden;
 	position: absolute;

--- a/www/src/components/slider.css
+++ b/www/src/components/slider.css
@@ -1,12 +1,13 @@
 /*Vertical Sliding*/
 .slidingVertical{
 	display: inline;
-	text-indent: 8px;
+    text-indent: 8px;
+    line-height: 1.25;
 }
 .slidingVertical span{
-	animation: topToBottom 12.5s linear infinite 0s;
-	-ms-animation: topToBottom 12.5s linear infinite 0s;
-	-webkit-animation: topToBottom 12.5s linear infinite 0s;
+	animation: topToBottom 10s linear infinite 0s;
+	-ms-animation: topToBottom 10s linear infinite 0s;
+	-webkit-animation: topToBottom 10s linear infinite 0s;
 	color: #efa42b;
 	opacity: 0;
 	overflow: hidden;
@@ -27,37 +28,32 @@
 	-ms-animation-delay: 7.5s;
 	-webkit-animation-delay: 7.5s;
 }
-.slidingVertical span:nth-child(5){
-	animation-delay: 10s;
-	-ms-animation-delay: 10s;
-	-webkit-animation-delay: 10s;
-}
 
 /*topToBottom Animation*/
 @-moz-keyframes topToBottom{
 	0% { opacity: 0; }
-	5% { opacity: 0; -moz-transform: translateY(-50px); }
+	6% { opacity: 0; -moz-transform: translateY(-30px); }
 	10% { opacity: 1; -moz-transform: translateY(0px); }
 	25% { opacity: 1; -moz-transform: translateY(0px); }
-	30% { opacity: 0; -moz-transform: translateY(50px); }
+	29% { opacity: 0; -moz-transform: translateY(30px); }
 	80% { opacity: 0; }
 	100% { opacity: 0; }
 }
 @-webkit-keyframes topToBottom{
 	0% { opacity: 0; }
-	5% { opacity: 0; -webkit-transform: translateY(-50px); }
+	6% { opacity: 0; -webkit-transform: translateY(-30px); }
 	10% { opacity: 1; -webkit-transform: translateY(0px); }
 	25% { opacity: 1; -webkit-transform: translateY(0px); }
-	30% { opacity: 0; -webkit-transform: translateY(50px); }
+	29% { opacity: 0; -webkit-transform: translateY(30px); }
 	80% { opacity: 0; }
 	100% { opacity: 0; }
 }
 @-ms-keyframes topToBottom{
 	0% { opacity: 0; }
-	5% { opacity: 0; -ms-transform: translateY(-50px); }
+	6% { opacity: 0; -ms-transform: translateY(-30px); }
 	10% { opacity: 1; -ms-transform: translateY(0px); }
 	25% { opacity: 1; -ms-transform: translateY(0px); }
-	30% { opacity: 0; -ms-transform: translateY(50px); }
+	29% { opacity: 0; -ms-transform: translateY(30px); }
 	80% { opacity: 0; }
 	100% { opacity: 0; }
 }

--- a/www/src/components/slider.css
+++ b/www/src/components/slider.css
@@ -8,7 +8,7 @@
 	animation: topToBottom 10s linear infinite 0s;
 	-ms-animation: topToBottom 10s linear infinite 0s;
 	-webkit-animation: topToBottom 10s linear infinite 0s;
-	color: #efa42b;
+	color: #9D7CBF;
 	opacity: 0;
 	overflow: hidden;
 	position: absolute;

--- a/www/src/components/slider.js
+++ b/www/src/components/slider.js
@@ -1,9 +1,9 @@
 import "./slider.css"
 
-export default ( { items } ) => (
+export default ( { items, color } ) => (
     <div class="slidingVertical">
         {
-            items.map(item => <span>{item}</span>)
+            items.map(item => <span css={{ color }}>{item}</span>)
         }
     </div>
 )

--- a/www/src/components/slider.js
+++ b/www/src/components/slider.js
@@ -1,0 +1,9 @@
+import "./slider.css"
+
+export default ( { items } ) => (
+    <div class="slidingVertical">
+        {
+            items.map(item => <span>{item}</span>)
+        }
+    </div>
+)


### PR DESCRIPTION
Changes the title to "Build blazing fast / modern / beautiful / secure websites with React."

(1) We want to do this to move away from the term "static". It's confusing to people because Gatsby can do way more than people expect from an SSG
(2) Want to highlight the capabilities of Gatsby. It can do so many things so a sliding adjective might highlight that better than just a simple transition => "Build blazing fast websites with React."

Notes and questions:
(1) @fk -- what do you think about drop-in animation vs other types? Eg anything on here: https://codepen.io/amritleone/pen/qERPmW. 
(2) By making the rotating world an adjective about website we aren't able to highlight other features of Gatsby. @jlengstorf suggested "Build blazing fast sites  / more efficient teams / React + GraphQL apps / modern apps / happier with Gatsby." 

We currently treat the homepage as more of a homepage for a docs site, rather than talking about organizational / personal / etc benefits to Gatsby. Open to change this but worth a discussion.
(3) Are there other adjectives we'd want to use in addition to / in place of the ones above?
(4) We probably want to clean this up a bit into its own component but want to get feedback on overall PR first.