### PR TITLE
Fix typo

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -120,8 +120,7 @@ Gatsby uses Redux for managing state during development and building. It's often
 helpful to see the flow of actions and built-up state for a site you're working
 on or if adding new functionality to core. We leverage
 [Remote Redux Devtools](https://github.com/zalmoxisus/remote-redux-devtools) and
-[RemoteDev Server](https://github.com/zalmoxisus/remotedev-server) to give you use the Redux
-devtools extension for debugging Gatsby.
+[RemoteDev Server](https://github.com/zalmoxisus/remotedev-server) to help you debug Gatsby.
 
 To use this, first install
 [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension)

--- a/translations/es/CONTRIBUTING_ES.md
+++ b/translations/es/CONTRIBUTING_ES.md
@@ -85,9 +85,8 @@ propia instancia del sitio web Gatsby y hacer/previsualizar sus cambios antes de
 Gatsby utiliza <tt>Redux</tt> para administrar el estado durante el desarrollo y la construcción. A menudo es
 útil para ver el flujo de acciones y el estado acumulado de un sitio en el que se está trabajando
 o si agrega una nueva funcionalidad al núcleo. Aprovechamos
-https://github.com/zalmoxisus/remote-redux-devtools y
-https://github.com/zalmoxisus/remotedev-server para darle el uso a _Redux
-devtools extension_ para depurar Gatsby.
+_[Remote Redux Devtools](https://github.com/zalmoxisus/remote-redux-devtools)_ y
+_[RemoteDev Server](https://github.com/zalmoxisus/remotedev-server)_ para ayudarte depurar Gatsby.
 
 Para usar esto, primero instale
 [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension)


### PR DESCRIPTION
- The changed line didn't make sense in either English or Spanish.
- Added title to links in ES version.
