### PR TITLE
start query watching after we extract queries

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -62,22 +62,22 @@ exports.extractQueries = () => {
       `)
     }
 
+    // During development start watching files to recompile & run
+    // queries on the fly.
+    if (process.env.NODE_ENV !== `production`) {
+      watch(state.program.directory)
+
+      // Ensure every component is being watched.
+      components.forEach(component => {
+        watcher.add(component)
+      })
+      staticQueryComponents.forEach(component => {
+        watcher.add(component)
+      })
+    }
+
     return
   })
-
-  // During development start watching files to recompile & run
-  // queries on the fly.
-  if (process.env.NODE_ENV !== `production`) {
-    watch(state.program.directory)
-
-    // Ensure every component is being watched.
-    components.forEach(component => {
-      watcher.add(component)
-    })
-    staticQueryComponents.forEach(component => {
-      watcher.add(component)
-    })
-  }
 
   return queryCompilerPromise
 }

--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -115,6 +115,7 @@ const runQueriesForStaticComponent = ({
     jsonName,
     query,
     context: { path: jsonName },
+    componentPath,
   })
 }
 


### PR DESCRIPTION
Delay component watching to after Gatsby do initial query extraction. Otherwise `staticQueryComponents` is empty array and we aren't actually adding it to watch list and rely on watching default `src` directory.