### PR TITLE
[v2] Transform modules to commonjs

### DIFF
--- a/packages/gatsby/src/internal-plugins/load-babel-config/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/load-babel-config/gatsby-node.js
@@ -157,7 +157,7 @@ const addDefaultPluginsPresets = (
     stage,
     options: {
       loose: true,
-      modules: false,
+      modules: `commonjs`,
       useBuiltIns: `usage`,
       targets,
     },


### PR DESCRIPTION
This change should resolve #4718 - allowing you to mix imports with commonjs. But I'm not sure if there's any wider implications to this? 

It looks like [Gatsby v1 was using `modules: "commonjs"`](https://github.com/gatsbyjs/gatsby/blob/v1/packages/gatsby/src/utils/babel-config.js#L153).

@jquense @KyleAMathews any thoughts?
