### PR TITLE
[www] Fix #6295

### DIFF
--- a/www/src/components/evaluation-table.js
+++ b/www/src/components/evaluation-table.js
@@ -124,13 +124,6 @@ class EvaluationTable extends Component {
                         display={row.node.Subcategory}
                         category={row.node.Subcategory}
                       />,
-                      <div
-                        dangerouslySetInnerHTML={{
-                          __html: `<span id="${row.node.Feature.toLowerCase()
-                            .split(` `)
-                            .join(`-`)}"></span>`,
-                        }}
-                      />,
                       <tr>
                         {headers.map((header, j) => (
                           <td
@@ -151,6 +144,13 @@ class EvaluationTable extends Component {
                               fontSize: `90%`,
                               lineHeight: `${rhythm(3 / 4)}`,
                             }}
+                            id={
+                              j === 0
+                                ? row.node.Feature.toLowerCase()
+                                    .split(` `)
+                                    .join(`-`)
+                                : false
+                            }
                             onClick={() => {
                               this.setState({
                                 [`${s},${i}`]: !showTooltip(s, i),

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -181,7 +181,7 @@ class Accordion extends React.Component {
                         location,
                         onLinkClick,
                         section,
-                        isSubsectionLink: item.ui === `steps`,
+                        stepsUI: item.ui === `steps`,
                       })}
                     </li>
                   ))}

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -83,7 +83,7 @@ class Accordion extends React.Component {
       location,
       onLinkClick,
       onSectionTitleClick,
-      section,
+      item: section,
       hideSectionTitle,
       activeItemLink,
       itemStyles,

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -1,7 +1,9 @@
 import React from "react"
+import hex2rgba from "hex2rgba"
 
 import presets, { colors } from "../../utils/presets"
-import { rhythm } from "../../utils/typography"
+import { rhythm, options, scale } from "../../utils/typography"
+import { css as glam } from "glamor"
 
 import SectionTitle from "./section-title"
 import ChevronSvg from "./chevron-svg"
@@ -83,10 +85,11 @@ class Accordion extends React.Component {
       onSectionTitleClick,
       section,
       hideSectionTitle,
-      singleSection,
       activeItemLink,
       itemStyles,
       isActive,
+      isFirstItem,
+      isLastItem,
     } = this.props
     const uid = `section_` + this.state.uid
     const SectionTitleComponent = section.disableAccordions
@@ -94,7 +97,22 @@ class Accordion extends React.Component {
       : ToggleSectionButton
 
     return (
-      <div>
+      <div
+        className="accordion"
+        css={{
+          position: `relative`,
+          marginTop: isFirstItem ? 0 : rhythm(options.blockMarginBottom / 2),
+          marginBottom: rhythm(options.blockMarginBottom / 2),
+          "&:before": {
+            ...(!isFirstItem && { ...styles.ulHorizontalDivider }),
+          },
+          "&:after": {
+            ...(!isLastItem && { ...styles.ulHorizontalDivider }),
+            top: `auto`,
+            bottom: 0,
+          },
+        }}
+      >
         <SectionTitleComponent
           title={section.title}
           isActive={isActive}
@@ -106,7 +124,6 @@ class Accordion extends React.Component {
           id={uid}
           css={{
             ...styles.ul,
-            ...(!singleSection && { ...styles.ulHorizontalDivider }),
             position: `relative`,
             paddingBottom: rhythm(3 / 4),
             "& li": {
@@ -123,8 +140,14 @@ class Accordion extends React.Component {
               css={{
                 ...((item.items && item.link === activeItemLink) ||
                 this._isChildItemActive(item, activeItemLink)
-                  ? { ...styles.liActive }
+                  ? {
+                      ...styles.liActive,
+                      paddingTop: rhythm(options.blockMarginBottom / 2),
+                    }
                   : {}),
+                ...(section.ui === `tutorial` && {
+                  ...styles.tutorialStuff,
+                }),
               }}
             >
               {createLink({
@@ -146,7 +169,7 @@ class Accordion extends React.Component {
                     ...styles.ul,
                     ...styles.ulSubitems,
                     ...(item.ui === `steps` && {
-                      ...styles.tutorialSubsection,
+                      ...styles.stepsSubsection,
                     }),
                   }}
                 >
@@ -158,7 +181,7 @@ class Accordion extends React.Component {
                         location,
                         onLinkClick,
                         section,
-                        isSubsectionLink: true,
+                        isSubsectionLink: item.ui === `steps`,
                       })}
                     </li>
                   ))}
@@ -174,15 +197,32 @@ class Accordion extends React.Component {
 
 export default Accordion
 
+glam.insert(`
+  .accordion + .accordion {
+    margin: 0;
+  }
+
+  .item ~ .accordion {
+    margin-bottom: 0;
+  }
+
+  .accordion + .item {
+    margin-top: ${rhythm(options.blockMarginBottom / 2)};
+  }
+
+  .accordion + .accordion::before {
+    display: none;
+  }
+`)
+
 const styles = {
   ul: {
     listStyle: `none`,
     margin: 0,
-    marginBottom: rhythm(1 / 2),
     position: `relative`,
   },
-  tutorialSubsection: {
-    paddingBottom: 10,
+  stepsSubsection: {
+    paddingBottom: rhythm(options.blockMarginBottom / 2),
     "&:after": {
       background: colors.ui.bright,
       content: ` `,
@@ -220,13 +260,14 @@ const styles = {
   liActive: {
     background: colors.ui.light,
     "&&": {
-      marginTop: rhythm(1 / 2),
-      marginBottom: rhythm(1 / 2),
-      paddingTop: rhythm(1 / 2),
+      marginTop: rhythm(options.blockMarginBottom / 2),
+      marginBottom: rhythm(options.blockMarginBottom / 2),
+      paddingTop: rhythm(options.blockMarginBottom / 2),
     },
   },
   ulSubitems: {
-    paddingTop: rhythm(1 / 2),
+    paddingTop: rhythm(options.blockMarginBottom / 2),
+    paddingBottom: rhythm(options.blockMarginBottom / 2),
     [presets.Desktop]: {
       "&& li": {
         paddingLeft: rhythm(3 / 4),
@@ -235,16 +276,35 @@ const styles = {
     },
   },
   ulHorizontalDivider: {
-    "&:after": {
-      background: colors.ui.light,
-      bottom: 0,
-      content: ` `,
-      height: 1,
-      position: `absolute`,
-      right: 0,
-      left: horizontalPadding,
-      [presets.Desktop]: {
-        left: horizontalPaddingDesktop,
+    background: hex2rgba(colors.ui.bright, 0.3),
+    top: 0,
+    content: ` `,
+    height: 1,
+    position: `absolute`,
+    right: 0,
+    left: horizontalPadding,
+    [presets.Desktop]: {
+      left: horizontalPaddingDesktop,
+    },
+  },
+  tutorialStuff: {
+    "&&": {
+      marginBottom: `1rem`,
+      "& a": {
+        fontWeight: `bold`,
+        fontFamily: options.headerFontFamily.join(`,`),
+        fontSize: scale(-2 / 10).fontSize,
+      },
+      "& ul a": {
+        fontWeight: `normal`,
+        fontFamily: options.systemFontFamily.join(`,`),
+        fontSize: scale(-1 / 10).fontSize,
+        [presets.Phablet]: {
+          fontSize: scale(-2 / 10).fontSize,
+        },
+        [presets.Tablet]: {
+          fontSize: scale(-4 / 10).fontSize,
+        },
       },
     },
   },

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -146,7 +146,7 @@ class Accordion extends React.Component {
                     }
                   : {}),
                 ...(section.ui === `tutorial` && {
-                  ...styles.tutorialStuff,
+                  ...styles.liTutorial,
                 }),
               }}
             >
@@ -169,7 +169,7 @@ class Accordion extends React.Component {
                     ...styles.ul,
                     ...styles.ulSubitems,
                     ...(item.ui === `steps` && {
-                      ...styles.stepsSubsection,
+                      ...styles.ulStepsUI,
                     }),
                   }}
                 >
@@ -221,7 +221,7 @@ const styles = {
     margin: 0,
     position: `relative`,
   },
-  stepsSubsection: {
+  ulStepsUI: {
     paddingBottom: rhythm(options.blockMarginBottom / 2),
     "&:after": {
       background: colors.ui.bright,
@@ -287,7 +287,7 @@ const styles = {
       left: horizontalPaddingDesktop,
     },
   },
-  tutorialStuff: {
+  liTutorial: {
     "&&": {
       marginBottom: `1rem`,
       "& a": {

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -64,8 +64,8 @@ class Accordion extends React.Component {
   state = { uid: (`` + Math.random()).replace(/\D/g, ``) }
 
   _isChildItemActive = (item, activeItemLink) => {
-    if (item.subitems) {
-      const matches = item.subitems.filter(function(subitem) {
+    if (item.items) {
+      const matches = item.items.filter(function(subitem) {
         return (
           subitem.link === activeItemLink && item.link === subitem.parentLink
         )
@@ -121,7 +121,7 @@ class Accordion extends React.Component {
             <li
               key={item.link}
               css={{
-                ...((item.subitems && item.link === activeItemLink) ||
+                ...((item.items && item.link === activeItemLink) ||
                 this._isChildItemActive(item, activeItemLink)
                   ? { ...styles.liActive }
                   : {}),
@@ -140,7 +140,7 @@ class Accordion extends React.Component {
                   activeItemLink
                 ),
               })}
-              {item.subitems && (
+              {item.items && (
                 <ul
                   css={{
                     ...styles.ul,
@@ -150,7 +150,7 @@ class Accordion extends React.Component {
                     }),
                   }}
                 >
-                  {item.subitems.map(subitem => (
+                  {item.items.map(subitem => (
                     <li key={subitem.link}>
                       {createLink({
                         isActive: subitem.link === activeItemLink,

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -58,7 +58,7 @@ const Title = ({ title }) => (
       },
     }}
   >
-    <SectionTitle>{title}</SectionTitle>
+    <SectionTitle disabled>{title}</SectionTitle>
   </div>
 )
 

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -1,8 +1,7 @@
 import React from "react"
 
-import getActiveItem from "../../utils/sidebar/get-active-item"
 import presets, { colors } from "../../utils/presets"
-import { scale, rhythm } from "../../utils/typography"
+import { rhythm } from "../../utils/typography"
 
 import SectionTitle from "./section-title"
 import ChevronSvg from "./chevron-svg"
@@ -61,13 +60,15 @@ const Title = ({ title }) => (
   </div>
 )
 
-class Section extends React.Component {
+class Accordion extends React.Component {
   state = { uid: (`` + Math.random()).replace(/\D/g, ``) }
 
-  _isChildItemActive = (item, activeItemId) => {
+  _isChildItemActive = (item, activeItemLink) => {
     if (item.subitems) {
       const matches = item.subitems.filter(function(subitem) {
-        return subitem.link === activeItemId && item.link === subitem.parentLink
+        return (
+          subitem.link === activeItemLink && item.link === subitem.parentLink
+        )
       })
 
       return matches.length >= 1
@@ -76,7 +77,6 @@ class Section extends React.Component {
 
   render() {
     const {
-      activeItemHash,
       createLink,
       location,
       onLinkClick,
@@ -84,14 +84,14 @@ class Section extends React.Component {
       section,
       hideSectionTitle,
       singleSection,
+      activeItemLink,
+      itemStyles,
+      isActive,
     } = this.props
     const uid = `section_` + this.state.uid
-    const activeItemId = getActiveItem(section, location, activeItemHash)
     const SectionTitleComponent = section.disableAccordions
       ? Title
       : ToggleSectionButton
-
-    const isActive = this.props.isActive || section.disableAccordions
 
     return (
       <div>
@@ -106,44 +106,14 @@ class Section extends React.Component {
           id={uid}
           css={{
             ...styles.ul,
+            ...(!singleSection && { ...styles.ulHorizontalDivider }),
             position: `relative`,
             paddingBottom: rhythm(3 / 4),
-            "&:after": {
-              background: colors.ui.light,
-              bottom: 0,
-              content: ` `,
-              display: singleSection ? `none` : `block`,
-              height: 1,
-              position: `absolute`,
-              right: 0,
-              left: horizontalPadding,
-            },
             "& li": {
-              lineHeight: 1.3,
-              margin: 0,
-              paddingLeft: horizontalPadding,
-              paddingRight: horizontalPadding,
-              fontSize: scale(-1 / 10).fontSize,
-            },
-            [presets.Phablet]: {
-              "& li": {
-                fontSize: scale(-2 / 10).fontSize,
-              },
+              ...itemStyles.item,
             },
             [presets.Tablet]: {
               display: isActive ? `block` : `none`,
-              "& li": {
-                fontSize: scale(-4 / 10).fontSize,
-              },
-            },
-            [presets.Desktop]: {
-              "&:after": {
-                left: horizontalPaddingDesktop,
-              },
-              "& li": {
-                paddingLeft: horizontalPaddingDesktop,
-                paddingRight: horizontalPaddingDesktop,
-              },
             },
           }}
         >
@@ -151,45 +121,39 @@ class Section extends React.Component {
             <li
               key={item.link}
               css={{
-                ...((item.subitems && item.link === activeItemId) ||
-                this._isChildItemActive(item, activeItemId)
+                ...((item.subitems && item.link === activeItemLink) ||
+                this._isChildItemActive(item, activeItemLink)
                   ? { ...styles.liActive }
                   : {}),
               }}
             >
               {createLink({
                 isActive:
-                  item.link === activeItemId ||
-                  this._isChildItemActive(item, activeItemId),
+                  item.link === activeItemLink ||
+                  this._isChildItemActive(item, activeItemLink),
                 item,
                 section,
                 location,
                 onLinkClick,
                 isParentOfActiveItem: this._isChildItemActive(
                   item,
-                  activeItemId
+                  activeItemLink
                 ),
               })}
               {item.subitems && (
                 <ul
                   css={{
                     ...styles.ul,
-                    paddingTop: rhythm(1 / 2),
-                    [presets.Desktop]: {
-                      "&& li": {
-                        paddingLeft: rhythm(3 / 4),
-                        paddingRight: rhythm(3 / 4),
-                      },
-                    },
-                    ...(section.directory === `tutorial`
-                      ? { ...styles.tutorialSubsection }
-                      : {}),
+                    ...styles.ulSubitems,
+                    ...(item.ui === `steps` && {
+                      ...styles.tutorialSubsection,
+                    }),
                   }}
                 >
                   {item.subitems.map(subitem => (
                     <li key={subitem.link}>
                       {createLink({
-                        isActive: subitem.link === activeItemId,
+                        isActive: subitem.link === activeItemLink,
                         item: subitem,
                         location,
                         onLinkClick,
@@ -208,7 +172,7 @@ class Section extends React.Component {
   }
 }
 
-export default Section
+export default Accordion
 
 const styles = {
   ul: {
@@ -259,6 +223,29 @@ const styles = {
       marginTop: rhythm(1 / 2),
       marginBottom: rhythm(1 / 2),
       paddingTop: rhythm(1 / 2),
+    },
+  },
+  ulSubitems: {
+    paddingTop: rhythm(1 / 2),
+    [presets.Desktop]: {
+      "&& li": {
+        paddingLeft: rhythm(3 / 4),
+        paddingRight: rhythm(3 / 4),
+      },
+    },
+  },
+  ulHorizontalDivider: {
+    "&:after": {
+      background: colors.ui.light,
+      bottom: 0,
+      content: ` `,
+      height: 1,
+      position: `absolute`,
+      right: 0,
+      left: horizontalPadding,
+      [presets.Desktop]: {
+        left: horizontalPaddingDesktop,
+      },
     },
   },
 }

--- a/www/src/components/sidebar/body.js
+++ b/www/src/components/sidebar/body.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-import Section from "./section"
+import Item from "./item"
 import presets, { colors } from "../../utils/presets"
 import { options, rhythm, scale } from "../../utils/typography"
 
@@ -86,16 +86,16 @@ class SidebarBody extends React.Component {
         {sectionList.length > 1 && (
           <ExpandAllButton onClick={this._expandAll} />
         )}
-        {sectionList.map((section, index) => (
-          <Section
+        {sectionList.map((item, index) => (
+          <Item
             createLink={createLink}
-            isActive={openSectionHash[section.title] || singleSection}
+            isActive={openSectionHash[item.title] || singleSection}
             key={index}
-            name={section.title}
+            name={item.title}
             location={location}
             onLinkClick={closeParentMenu}
-            onSectionTitleClick={() => this._toggleSection(section)}
-            section={section}
+            onSectionTitleClick={() => this._toggleSection(item)}
+            section={item}
             hideSectionTitle={singleSection}
             activeItemHash={activeItemHash}
             isScrollSync={enableScrollSync}

--- a/www/src/components/sidebar/body.js
+++ b/www/src/components/sidebar/body.js
@@ -1,6 +1,7 @@
 import React from "react"
 
 import Item from "./item"
+import getActiveItem from "../../utils/sidebar/get-active-item"
 import presets, { colors } from "../../utils/presets"
 import { options, rhythm, scale } from "../../utils/typography"
 
@@ -80,6 +81,7 @@ class SidebarBody extends React.Component {
     } = this.props
     let { openSectionHash } = this.state
     const singleSection = sectionList.length === 1
+    const activeItemLink = getActiveItem(sectionList, location, activeItemHash)
 
     return (
       <div className="docSearch-sidebar">
@@ -98,6 +100,7 @@ class SidebarBody extends React.Component {
             section={item}
             hideSectionTitle={singleSection}
             activeItemHash={activeItemHash}
+            activeItemLink={activeItemLink}
             isScrollSync={enableScrollSync}
             singleSection={singleSection}
           />

--- a/www/src/components/sidebar/body.js
+++ b/www/src/components/sidebar/body.js
@@ -103,6 +103,8 @@ class SidebarBody extends React.Component {
             activeItemLink={activeItemLink}
             isScrollSync={enableScrollSync}
             singleSection={singleSection}
+            isFirstItem={index === 0}
+            isLastItem={index === sectionList.length - 1}
           />
         ))}
       </div>

--- a/www/src/components/sidebar/body.js
+++ b/www/src/components/sidebar/body.js
@@ -97,7 +97,7 @@ class SidebarBody extends React.Component {
             location={location}
             onLinkClick={closeParentMenu}
             onSectionTitleClick={() => this._toggleSection(item)}
-            section={item}
+            item={item}
             hideSectionTitle={singleSection}
             activeItemHash={activeItemHash}
             activeItemLink={activeItemLink}

--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -5,7 +5,7 @@ import getActiveItem from "../../utils/sidebar/get-active-item"
 import presets from "../../utils/presets"
 import { scale, rhythm } from "../../utils/typography"
 
-class Section extends React.Component {
+class Item extends React.Component {
   render() {
     const {
       activeItemHash,
@@ -53,7 +53,7 @@ class Section extends React.Component {
   }
 }
 
-export default Section
+export default Item
 
 const horizontalPadding = rhythm(3 / 4)
 const horizontalPaddingDesktop = rhythm(3 / 2)

--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Fragment } from "react"
 
 import Accordion from "./accordion"
 import presets from "../../utils/presets"
@@ -7,7 +7,6 @@ import { scale, rhythm } from "../../utils/typography"
 class Item extends React.Component {
   render() {
     const {
-      activeItemHash,
       createLink,
       location,
       onLinkClick,
@@ -16,10 +15,12 @@ class Item extends React.Component {
       hideSectionTitle,
       singleSection,
       activeItemLink,
+      isFirstItem,
+      isLastItem,
     } = this.props
 
     return (
-      <div>
+      <Fragment>
         {section.items ? (
           <Accordion
             itemStyles={styles}
@@ -31,9 +32,12 @@ class Item extends React.Component {
             activeItemLink={activeItemLink}
             createLink={createLink}
             location={location}
+            isFirstItem={isFirstItem}
+            isLastItem={isLastItem}
           />
         ) : (
           <div
+            className="item"
             css={{
               ...styles.item,
             }}
@@ -47,7 +51,7 @@ class Item extends React.Component {
             })}
           </div>
         )}
-      </div>
+      </Fragment>
     )
   }
 }

--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -1,7 +1,6 @@
 import React from "react"
 
 import Accordion from "./accordion"
-import getActiveItem from "../../utils/sidebar/get-active-item"
 import presets from "../../utils/presets"
 import { scale, rhythm } from "../../utils/typography"
 
@@ -16,8 +15,8 @@ class Item extends React.Component {
       section,
       hideSectionTitle,
       singleSection,
+      activeItemLink,
     } = this.props
-    const activeItemLink = getActiveItem(section, location, activeItemHash)
 
     return (
       <div>

--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -11,7 +11,7 @@ class Item extends React.Component {
       location,
       onLinkClick,
       onSectionTitleClick,
-      section,
+      item,
       hideSectionTitle,
       singleSection,
       activeItemLink,
@@ -21,14 +21,14 @@ class Item extends React.Component {
 
     return (
       <Fragment>
-        {section.items ? (
+        {item.items ? (
           <Accordion
             itemStyles={styles}
-            isActive={this.props.isActive || section.disableAccordions}
+            isActive={this.props.isActive || item.disableAccordions}
             onSectionTitleClick={onSectionTitleClick}
             hideSectionTitle={hideSectionTitle}
             singleSection={singleSection}
-            section={section}
+            item={item}
             activeItemLink={activeItemLink}
             createLink={createLink}
             location={location}
@@ -43,9 +43,9 @@ class Item extends React.Component {
             }}
           >
             {createLink({
-              isActive: section.link === activeItemLink,
-              item: section,
-              section,
+              isActive: item.link === activeItemLink,
+              item: item,
+              item,
               location,
               onLinkClick,
             })}

--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -1,0 +1,78 @@
+import React from "react"
+
+import Accordion from "./accordion"
+import getActiveItem from "../../utils/sidebar/get-active-item"
+import presets from "../../utils/presets"
+import { scale, rhythm } from "../../utils/typography"
+
+class Section extends React.Component {
+  render() {
+    const {
+      activeItemHash,
+      createLink,
+      location,
+      onLinkClick,
+      onSectionTitleClick,
+      section,
+      hideSectionTitle,
+      singleSection,
+    } = this.props
+    const activeItemLink = getActiveItem(section, location, activeItemHash)
+
+    return (
+      <div>
+        {section.items ? (
+          <Accordion
+            itemStyles={styles}
+            isActive={this.props.isActive || section.disableAccordions}
+            onSectionTitleClick={onSectionTitleClick}
+            hideSectionTitle={hideSectionTitle}
+            singleSection={singleSection}
+            section={section}
+            activeItemLink={activeItemLink}
+            createLink={createLink}
+            location={location}
+          />
+        ) : (
+          <div
+            css={{
+              ...styles.item,
+            }}
+          >
+            {createLink({
+              isActive: section.link === activeItemLink,
+              item: section,
+              section,
+              location,
+              onLinkClick,
+            })}
+          </div>
+        )}
+      </div>
+    )
+  }
+}
+
+export default Section
+
+const horizontalPadding = rhythm(3 / 4)
+const horizontalPaddingDesktop = rhythm(3 / 2)
+const styles = {
+  item: {
+    lineHeight: 1.3,
+    margin: 0,
+    paddingLeft: horizontalPadding,
+    paddingRight: horizontalPadding,
+    fontSize: scale(-1 / 10).fontSize,
+    [presets.Phablet]: {
+      fontSize: scale(-2 / 10).fontSize,
+    },
+    [presets.Tablet]: {
+      fontSize: scale(-4 / 10).fontSize,
+    },
+    [presets.Desktop]: {
+      paddingLeft: horizontalPaddingDesktop,
+      paddingRight: horizontalPaddingDesktop,
+    },
+  },
+}

--- a/www/src/components/sidebar/scroll-sync-body.js
+++ b/www/src/components/sidebar/scroll-sync-body.js
@@ -74,8 +74,8 @@ const _getItemIds = sectionList => {
     let sectionItems = section.items
       .map(item => {
         let subItemIds = []
-        if (item.subitems) {
-          subItemIds = item.subitems.map(subitem => subitem.hash)
+        if (item.items) {
+          subItemIds = item.items.map(subitem => subitem.hash)
         }
         return [item.hash, ...subItemIds]
       })

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -2,7 +2,7 @@ import React from "react"
 import presets, { colors } from "../../utils/presets"
 import { scale, options, rhythm } from "../../utils/typography"
 
-const SectionTitle = ({ children, isActive }) => (
+const SectionTitle = ({ children, isActive, disabled }) => (
   <h3
     css={{
       alignItems: `center`,
@@ -18,8 +18,8 @@ const SectionTitle = ({ children, isActive }) => (
       paddingBottom: rhythm(options.blockMarginBottom),
       [presets.Tablet]: {
         color: isActive ? colors.gatsby : false,
-        ":hover": {
-          color: colors.gatsby,
+        "&:hover": {
+          color: disabled ? false : colors.gatsby,
         },
       },
     }}

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -1,6 +1,6 @@
 import React from "react"
 import presets, { colors } from "../../utils/presets"
-import { scale, options } from "../../utils/typography"
+import { scale, options, rhythm } from "../../utils/typography"
 
 const SectionTitle = ({ children, isActive }) => (
   <h3
@@ -11,10 +11,11 @@ const SectionTitle = ({ children, isActive }) => (
       fontFamily: options.headerFontFamily.join(`,`),
       fontSize: scale(-2 / 5).fontSize,
       fontWeight: `normal`,
-      letterSpacing: `.15em`,
+      letterSpacing: `.1em`,
       margin: 0,
-      lineHeight: 3,
       textTransform: `uppercase`,
+      paddingTop: rhythm(options.blockMarginBottom),
+      paddingBottom: rhythm(options.blockMarginBottom),
       [presets.Tablet]: {
         color: isActive ? colors.gatsby : false,
         ":hover": {

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -114,7 +114,6 @@ class StickyResponsiveSidebar extends Component {
 export default StickyResponsiveSidebar
 
 const horizontalPadding = rhythm(3 / 4)
-const horizontalPaddingDesktop = rhythm(3 / 2)
 
 const styles = {
   sidebar: {
@@ -157,8 +156,8 @@ const styles = {
     zIndex: 2,
   },
   sidebarLargerScreen: {
-    paddingTop: horizontalPaddingDesktop,
-    paddingBottom: horizontalPaddingDesktop,
+    paddingTop: horizontalPadding,
+    paddingBottom: horizontalPadding,
     width: rhythm(12),
   },
   button: {

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -1,34 +1,15 @@
-- title: Getting Started
-  link: /docs/
-- title: Fake Introduction
-  link: /docs/fake-intro/
 - title: Quick Start
   items:
+    - title: Getting Started
+      link: /docs/
     - title: Starters
       link: /docs/gatsby-starters/
     - title: Deploying
       link: /docs/deploy-gatsby/
-      ui: steps
-      items:
-        - title: A bunch of fake…
-          link: /docs/a-bunch/
-        - title: Sidebar items…
-          link: /docs/of-dummy/
-        - title: To test stuff! Bullet point stuff is opt-in ✨
-          link: /docs/sidebar-items/
     - title: Community
       link: /docs/community/
-      items:
-        - title: A bunch of fake…
-          link: /docs/a-bunch/
-        - title: Sidebar items…
-          link: /docs/of-dummy/
-        - title: To test stuff! Bullet point stuff is opt-in ✨
-          link: /docs/sidebar-items/
     - title: Awesome Gatsby
       link: /docs/awesome-gatsby/
-- title: Tutorial
-  link: /tutorial/
 - title: Core Concepts
   items:
     - title: Building with Components
@@ -145,5 +126,3 @@
       link: /docs/gatsby-style-guide/
     - title: Design Principles*
       link: /docs/design-principles/
-- title: Gatsby CLI
-  link: /gatsby-cli/

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -6,7 +6,7 @@
       link: /docs/gatsby-starters/
     - title: Deploying
       link: /docs/deploy-gatsby/
-      subitems:
+      items:
         - title: Community
           link: /docs/community/
 - title: Awesome Gatsby

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -1,128 +1,131 @@
+- title: Getting Started
+  link: /docs/
 - title: Quick Start
   items:
-    - title: Getting Started
-      link: /
     - title: Starters
-      link: /gatsby-starters/
+      link: /docs/gatsby-starters/
     - title: Deploying
-      link: /deploy-gatsby/
-    - title: Community
-      link: /community/
-    - title: Awesome Gatsby
-      link: /awesome-gatsby/
+      link: /docs/deploy-gatsby/
+      subitems:
+        - title: Community
+          link: /docs/community/
+- title: Awesome Gatsby
+  link: /docs/awesome-gatsby/
+- title: Tutorial
+  link: /tutorial/
 - title: Core Concepts
   items:
     - title: Building with Components
-      link: /building-with-components/
+      link: /docs/building-with-components/
     - title: Lifecycle APIs
-      link: /gatsby-lifecycle-apis/
+      link: /docs/gatsby-lifecycle-apis/
     - title: Plugins
-      link: /plugins/
+      link: /docs/plugins/
     - title: PRPL Pattern
-      link: /prpl-pattern/
+      link: /docs/prpl-pattern/
     - title: Querying Data with GraphQL
-      link: /querying-with-graphql/
+      link: /docs/querying-with-graphql/
 - title: Guides
   items:
     - title: Adding a 404 Page
-      link: /add-404-page/
+      link: /docs/add-404-page/
     - title: Adding Images, Fonts, and Files
-      link: /adding-images-fonts-files/
+      link: /docs/adding-images-fonts-files/
     - title: Adding Images to a WordPress Site
-      link: /image-tutorial/
+      link: /docs/image-tutorial/
     - title: Babel.js
-      link: /babel/
+      link: /docs/babel/
     - title: Browser Support
-      link: /browser-support/
+      link: /docs/browser-support/
     - title: Building Apps with Gatsby
-      link: /building-apps-with-gatsby/
+      link: /docs/building-apps-with-gatsby/
     - title: Caching
-      link: /caching/
+      link: /docs/caching/
     - title: Creating and Modifying Pages
-      link: /creating-and-modifying-pages/
+      link: /docs/creating-and-modifying-pages/
     - title: Create a Source Plugin
-      link: /create-source-plugin/
+      link: /docs/create-source-plugin/
     - title: Custom webpack config
-      link: /add-custom-webpack-config/
+      link: /docs/add-custom-webpack-config/
     - title: Customizing html.js
-      link: /custom-html/
+      link: /docs/custom-html/
     - title: Debugging HTML Builds
-      link: /debugging-html-builds/
+      link: /docs/debugging-html-builds/
     - title: Debugging Replace Renderer API
-      link: /debugging-replace-renderer-api/
+      link: /docs/debugging-replace-renderer-api/
     - title: E-commerce Tutorial
-      link: /ecommerce-tutorial/
+      link: /docs/ecommerce-tutorial/
     - title: Environment Variables
-      link: /environment-variables/
+      link: /docs/environment-variables/
     - title: Gatsby on Windows
-      link: /gatsby-on-windows/
+      link: /docs/gatsby-on-windows/
     - title: Local HTTPS
-      link: /local-https/
+      link: /docs/local-https/
     - title: Managing Content with Netlify CMS
-      link: /netlify-cms/
+      link: /docs/netlify-cms/
     - title: How Gatsby Works with GitHub Pages
-      link: /how-gatsby-works-with-github-pages/
+      link: /docs/how-gatsby-works-with-github-pages/
     - title: Migrating from v1 to v2
-      link: /migrating-from-v1-to-v2/
+      link: /docs/migrating-from-v1-to-v2/
     - title: Migrating from v0 to v1
-      link: /migrating-from-v0-to-v1/
+      link: /docs/migrating-from-v0-to-v1/
     - title: Path Prefix
-      link: /path-prefix/
+      link: /docs/path-prefix/
     - title: Plugin Authoring
-      link: /plugin-authoring/
+      link: /docs/plugin-authoring/
     - title: Proxying API Requests
-      link: /api-proxy/
+      link: /docs/api-proxy/
     - title: Querying data with StaticQuery
-      link: /static-query/
+      link: /docs/static-query/
     - title: Search Engine Optimization (SEO)
-      link: /seo/
+      link: /docs/seo/
     - title: Source Plugin Tutorial
-      link: /source-plugin-tutorial/
+      link: /docs/source-plugin-tutorial/
     - title: Using CSS-in-JS Library Glamor
-      link: /glamor/
+      link: /docs/glamor/
     - title: Using CSS-in-JS Library Styled Components
-      link: /styled-components/
+      link: /docs/styled-components/
     - title: Adding Markdown Pages
-      link: /adding-markdown-pages/
+      link: /docs/adding-markdown-pages/
     - title: Adding a List of Markdown Blog Posts
-      link: /adding-a-list-of-markdown-blog-posts/
+      link: /docs/adding-a-list-of-markdown-blog-posts/
     - title: Adding Tags and Categories to Blog Posts
-      link: /adding-tags-and-categories-to-blog-posts/
+      link: /docs/adding-tags-and-categories-to-blog-posts/
     - title: Adding search to your Gatsby website
-      link: /adding-search/
+      link: /docs/adding-search/
     - title: Working With Images in Gatsby
-      link: /working-with-images/
+      link: /docs/working-with-images/
     - title: Wordpress Source Plugin Tutorial
-      link: /wordpress-source-plugin-tutorial/
+      link: /docs/wordpress-source-plugin-tutorial/
     - title: Creating Dynamically-Rendered Navigation*
-      link: /creating-dynamically-rendered-navigation/
+      link: /docs/creating-dynamically-rendered-navigation/
     - title: Dropping Images into Static Folders*
-      link: /dropping-images-into-static-folders/
+      link: /docs/dropping-images-into-static-folders/
 - title: Reference
   items:
     - title: Node Interface
-      link: /node-interface/
+      link: /docs/node-interface/
     - title: API Specification
-      link: /api-specification/
+      link: /docs/api-specification/
     - title: Actions
-      link: /actions/
+      link: /docs/actions/
     - title: Gatsby Browser APIs
-      link: /browser-apis/
+      link: /docs/browser-apis/
     - title: Gatsby Node APIs
-      link: /node-apis/
+      link: /docs/node-apis/
     - title: Gatsby SSR APIs
-      link: /ssr-apis/
+      link: /docs/ssr-apis/
     - title: Gatsby Config
-      link: /gatsby-config/
+      link: /docs/gatsby-config/
     - title: GraphQL Reference
-      link: /graphql-reference/
+      link: /docs/graphql-reference/
 - title: Contributing
   items:
     - title: How to Contribute
-      link: /how-to-contribute/
+      link: /docs/how-to-contribute/
     - title: How to File an Issue
-      link: /how-to-file-an-issue/
+      link: /docs/how-to-file-an-issue/
     - title: Gatsby Style Guide
-      link: /gatsby-style-guide/
+      link: /docs/gatsby-style-guide/
     - title: Design Principles*
-      link: /design-principles/
+      link: /docs/design-principles/

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -1,16 +1,32 @@
 - title: Getting Started
   link: /docs/
+- title: Fake Introduction
+  link: /docs/fake-intro/
 - title: Quick Start
   items:
     - title: Starters
       link: /docs/gatsby-starters/
     - title: Deploying
       link: /docs/deploy-gatsby/
+      ui: steps
       items:
-        - title: Community
-          link: /docs/community/
-- title: Awesome Gatsby
-  link: /docs/awesome-gatsby/
+        - title: A bunch of fake…
+          link: /docs/a-bunch/
+        - title: Sidebar items…
+          link: /docs/of-dummy/
+        - title: To test stuff! Bullet point stuff is opt-in ✨
+          link: /docs/sidebar-items/
+    - title: Community
+      link: /docs/community/
+      items:
+        - title: A bunch of fake…
+          link: /docs/a-bunch/
+        - title: Sidebar items…
+          link: /docs/of-dummy/
+        - title: To test stuff! Bullet point stuff is opt-in ✨
+          link: /docs/sidebar-items/
+    - title: Awesome Gatsby
+      link: /docs/awesome-gatsby/
 - title: Tutorial
   link: /tutorial/
 - title: Core Concepts
@@ -129,3 +145,5 @@
       link: /docs/gatsby-style-guide/
     - title: Design Principles*
       link: /docs/design-principles/
+- title: Gatsby CLI
+  link: /gatsby-cli/

--- a/www/src/data/sidebars/features-links.yaml
+++ b/www/src/data/sidebars/features-links.yaml
@@ -1,72 +1,72 @@
 - title: Introduction
   items:
     - title: Introduction
-      link: /#introduction
+      link: /features/#introduction
     - title: Legend
-      link: /#legend
+      link: /features/#legend
 - title: Performance
   items:
     - title: Static content
-      link: /#static-content
+      link: /features/#static-content
     - title: CDN
-      link: /#cdn
+      link: /features/#cdn
     - title: AMP support
-      link: /#amp-support
+      link: /features/#amp-support
     - title: Offline access
-      link: /#offline-access
+      link: /features/#offline-access
     - title: Prefetch linked pages
-      link: /#prefetch-linked-pages
+      link: /features/#prefetch-linked-pages
     - title: Page caching
-      link: /#page-caching
+      link: /features/#page-caching
     - title: No extraneous code fetching
-      link: /#no-extraneous-code-fetching
+      link: /features/#no-extraneous-code-fetching
     - title: Progressive image loading
-      link: /#progressive-image-loading
+      link: /features/#progressive-image-loading
     - title: Responsive image loading
-      link: /#responsive-image-loading
+      link: /features/#responsive-image-loading
     - title: Inlines critical CSS
-      link: /#inlines-critical-css
+      link: /features/#inlines-critical-css
     - title: Font self-hosting
-      link: /#font-self-hosting
+      link: /features/#font-self-hosting
 - title: Developer Experience
   items:
     - title: Serverless
-      link: /#serverless
+      link: /features/#serverless
     - title: Export as Code
-      link: /#export-as-code
+      link: /features/#export-as-code
     - title: Refresh or link to preview
-      link: /#refresh-or-link-to-preview
+      link: /features/#refresh-or-link-to-preview
     - title: Hot reload content
-      link: /#hot-reload-content
+      link: /features/#hot-reload-content
     - title: Hot reload code
-      link: /#hot-reload-code
+      link: /features/#hot-reload-code
     - title: Componentization
-      link: /#componentization
+      link: /features/#componentization
     - title: One-way data binding
-      link: /#one-way-data-binding
+      link: /features/#one-way-data-binding
     - title: Declarative API data queries (GraphQL)
-      link: /#declarative-api-data-queries-(graphql)
+      link: /features/#declarative-api-data-queries-(graphql)
     - title: Declarative UI
-      link: /#declarative-ui
+      link: /features/#declarative-ui
     - title: Asset pipelines
-      link: /#asset-pipelines
+      link: /features/#asset-pipelines
     - title: CSS Extensions (eg Sass)
-      link: /#css-extensions-(eg-sass)
+      link: /features/#css-extensions-(eg-sass)
     - title: Advanced Javascript syntax
-      link: /#advanced-javascript-syntax
+      link: /features/#advanced-javascript-syntax
 - title: Ecosystem
   items:
     - title: Component ecosystem
-      link: /#component-ecosystem
+      link: /features/#component-ecosystem
     - title: Hosted option
-      link: /#hosted-option
+      link: /features/#hosted-option
     - title: Theme ecosystem
-      link: /#theme-ecosystem
+      link: /features/#theme-ecosystem
 - title: Design
   items:
     - title: Programmatic Design
-      link: /#programmatic-design
+      link: /features/#programmatic-design
     - title: Design systems
-      link: /#design-systems
+      link: /features/#design-systems
     - title: Component library
-      link: /#component-library
+      link: /features/#component-library

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -1,80 +1,88 @@
 - title: Tutorial
   items:
     - title: Introduction
-      link: /
+      link: /tutorial/
     - title: 0. Programming basics
-      link: /part-zero/
+      link: /tutorial/part-zero/
     - title: 1. Introduction to Gatsby basics
-      link: /part-one/
+      link: /tutorial/part-one/
+      ui: steps
       subitems:
         - title: Check environment
-          link: /part-one/#check-your-development-environment
+          link: /tutorial/part-one/#check-your-development-environment
         - title: Install the "Hello World" starter
-          link: /part-one/#install-the-hello-world-starter
+          link: /tutorial/part-one/#install-the-hello-world-starter
         - title: Linking between pages
-          link: /part-one/#linking-between-pages
+          link: /tutorial/part-one/#linking-between-pages
         - title: Interactive page
-          link: /part-one/#interactive-page
+          link: /tutorial/part-one/#interactive-page
         - title: Deploying Gatsby.js websites
-          link: /part-one/#deploying-gatsbyjs-websites
+          link: /tutorial/part-one/#deploying-gatsbyjs-websites
     - title: 2. Introduction to using CSS in Gatsby
-      link: /part-two/
+      link: /tutorial/part-two/
+      ui: steps
       subitems:
         - title: Building with components
-          link: /part-two/#building-with-components
+          link: /tutorial/part-two/#building-with-components
         - title: Creating Global Styles
-          link: /part-two/#creating-global-styles
+          link: /tutorial/part-two/#creating-global-styles
         - title: Typography.js
-          link: /part-two/#typographyjs
+          link: /tutorial/part-two/#typographyjs
         - title: Gatsby Plugins
-          link: /part-two/#gatsby-plugins
+          link: /tutorial/part-two/#gatsby-plugins
         - title: Component CSS
-          link: /part-two/#component-css
+          link: /tutorial/part-two/#component-css
         - title: CSS Modules
-          link: /part-two/#css-modules
+          link: /tutorial/part-two/#css-modules
     - title: 3. Creating nested layout components
-      link: /part-three/
+      link: /tutorial/part-three/
+      ui: steps
       subitems:
         - title: Your first layout component
-          link: /part-three/#your-first-layout-component
+          link: /tutorial/part-three/#your-first-layout-component
     - title: 4. Querying for data in a blog
-      link: /part-four/
+      link: /tutorial/part-four/
+      ui: steps
       subitems:
         - title: Recap of the first half of the tutorial
-          link: /part-four/#recap-of-first-half-of-the-tutorial
+          link: /tutorial/part-four/#recap-of-first-half-of-the-tutorial
         - title: Data in Gatsby
-          link: /part-four/#data-in-gatsby
+          link: /tutorial/part-four/#data-in-gatsby
         - title: How Gatsby's data layer uses GraphQL to pull data into components
-          link: /part-four/#how-gatsbys-data-layer-uses-graphql-to-pull-data-into-components
+          link: /tutorial/part-four/#how-gatsbys-data-layer-uses-graphql-to-pull-data-into-components
         - title: Your first GraphQL query
-          link: /part-four/#your-first-graphql-query
+          link: /tutorial/part-four/#your-first-graphql-query
     - title: 5. Source plugins and rendering queried data
-      link: /part-five/
+      link: /tutorial/part-five/
+      ui: steps
       subitems:
         - title: Introducing GraphiQL
-          link: /part-five/#introducing-graphiql
+          link: /tutorial/part-five/#introducing-graphiql
         - title: Source Plugins
-          link: /part-five/#source-plugins
+          link: /tutorial/part-five/#source-plugins
         - title: Build a page with a GraphQL query
-          link: /part-five/#build-a-page-with-a-graphql-query
+          link: /tutorial/part-five/#build-a-page-with-a-graphql-query
     - title: 6. Transformer plugins
-      link: /part-six/
+      link: /tutorial/part-six/
+      ui: steps
       subitems:
         - title: Transformer plugins
-          link: /part-six/#transformer-plugins
+          link: /tutorial/part-six/#transformer-plugins
         - title: Create a list of our site's markdown files
-          link: /part-six/#create-a-list-of-our-sites-markdown-files-in-srcpagesindexjs
+          link: /tutorial/part-six/#create-a-list-of-our-sites-markdown-files-in-srcpagesindexjs
     - title: 7. Programmatically create pages from data
-      link: /part-seven/
+      link: /tutorial/part-seven/
+      ui: steps
       subitems:
         - title: Creating slugs for pages
-          link: /part-seven/#creating-slugs-for-pages
+          link: /tutorial/part-seven/#creating-slugs-for-pages
         - title: Creating pages
-          link: /part-seven/#creating-pages
+          link: /tutorial/part-seven/#creating-pages
     - title: 8. Preparing a site to go live
-      link: /part-eight/
+      link: /tutorial/part-eight/
+      ui: steps
       subitems:
         - title: Creating slugs for pages
-          link: /part-eight/#creating-slugs-for-pages
+          link: /tutorial/part-eight/#creating-slugs-for-pages
         - title: Creating pages
-          link: /part-eight/#creating-pages
+          link: /tutorial/part-eight/#creating-pages

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -7,7 +7,7 @@
     - title: 1. Introduction to Gatsby basics
       link: /tutorial/part-one/
       ui: steps
-      subitems:
+      items:
         - title: Check environment
           link: /tutorial/part-one/#check-your-development-environment
         - title: Install the "Hello World" starter
@@ -21,7 +21,7 @@
     - title: 2. Introduction to using CSS in Gatsby
       link: /tutorial/part-two/
       ui: steps
-      subitems:
+      items:
         - title: Building with components
           link: /tutorial/part-two/#building-with-components
         - title: Creating Global Styles
@@ -37,13 +37,13 @@
     - title: 3. Creating nested layout components
       link: /tutorial/part-three/
       ui: steps
-      subitems:
+      items:
         - title: Your first layout component
           link: /tutorial/part-three/#your-first-layout-component
     - title: 4. Querying for data in a blog
       link: /tutorial/part-four/
       ui: steps
-      subitems:
+      items:
         - title: Recap of the first half of the tutorial
           link: /tutorial/part-four/#recap-of-first-half-of-the-tutorial
         - title: Data in Gatsby
@@ -55,7 +55,7 @@
     - title: 5. Source plugins and rendering queried data
       link: /tutorial/part-five/
       ui: steps
-      subitems:
+      items:
         - title: Introducing GraphiQL
           link: /tutorial/part-five/#introducing-graphiql
         - title: Source Plugins
@@ -65,7 +65,7 @@
     - title: 6. Transformer plugins
       link: /tutorial/part-six/
       ui: steps
-      subitems:
+      items:
         - title: Transformer plugins
           link: /tutorial/part-six/#transformer-plugins
         - title: Create a list of our site's markdown files
@@ -73,7 +73,7 @@
     - title: 7. Programmatically create pages from data
       link: /tutorial/part-seven/
       ui: steps
-      subitems:
+      items:
         - title: Creating slugs for pages
           link: /tutorial/part-seven/#creating-slugs-for-pages
         - title: Creating pages
@@ -81,7 +81,7 @@
     - title: 8. Preparing a site to go live
       link: /tutorial/part-eight/
       ui: steps
-      subitems:
+      items:
         - title: Creating slugs for pages
           link: /tutorial/part-eight/#creating-slugs-for-pages
         - title: Creating pages

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -1,4 +1,5 @@
 - title: Tutorial
+  ui: tutorial
   items:
     - title: Introduction
       link: /tutorial/

--- a/www/src/utils/sidebar/create-link.js
+++ b/www/src/utils/sidebar/create-link.js
@@ -11,7 +11,7 @@ const createLinkDocs = ({
   isActive,
   onLinkClick,
   isParentOfActiveItem,
-  isSubsectionLink,
+  stepsUI,
 }) => {
   const isDraft = _isDraft(item.title)
   const title = _getTitle(item.title, isDraft)
@@ -27,7 +27,7 @@ const createLinkDocs = ({
       onClick={onLinkClick}
       to={`${item.link}`}
     >
-      {isSubsectionLink && <span css={{ ...styles.subsectionLink }} />}
+      {stepsUI && <span css={{ ...styles.subsectionLink }} />}
       {title}
     </Link>
   )
@@ -38,7 +38,7 @@ const createLinkTutorial = ({
   onLinkClick,
   isActive,
   isParentOfActiveItem,
-  isSubsectionLink,
+  stepsUI,
 }) => {
   const isDraft = _isDraft(item.title)
   const title = _getTitle(item.title, isDraft)
@@ -54,7 +54,7 @@ const createLinkTutorial = ({
       onClick={onLinkClick}
       to={`${item.link}`}
     >
-      {isSubsectionLink && <span css={{ ...styles.subsectionLink }} />}
+      {stepsUI && <span css={{ ...styles.subsectionLink }} />}
       {title}
     </Link>
   )

--- a/www/src/utils/sidebar/create-link.js
+++ b/www/src/utils/sidebar/create-link.js
@@ -7,9 +7,8 @@ const _getTitle = (title, isDraft) => (isDraft ? title.slice(0, -1) : title)
 const _isDraft = title => title.slice(-1) === `*`
 
 const createLinkDocs = ({
-  isActive,
   item,
-  section,
+  isActive,
   onLinkClick,
   isParentOfActiveItem,
 }) => {
@@ -25,7 +24,7 @@ const createLinkDocs = ({
         isParentOfActiveItem && styles.parentOfActiveLink,
       ]}
       onClick={onLinkClick}
-      to={`/${section.directory}${item.link}`}
+      to={`${item.link}`}
     >
       {title}
     </Link>
@@ -33,10 +32,9 @@ const createLinkDocs = ({
 }
 
 const createLinkTutorial = ({
-  isActive,
   item,
-  section,
   onLinkClick,
+  isActive,
   isParentOfActiveItem,
   isSubsectionLink,
 }) => {
@@ -52,7 +50,7 @@ const createLinkTutorial = ({
         isParentOfActiveItem && styles.parentOfActiveLink,
       ]}
       onClick={onLinkClick}
-      to={`/${section.directory}${item.link}`}
+      to={`${item.link}`}
     >
       {isSubsectionLink && <span css={{ ...styles.subsectionLink }} />}
       {title}

--- a/www/src/utils/sidebar/create-link.js
+++ b/www/src/utils/sidebar/create-link.js
@@ -11,6 +11,7 @@ const createLinkDocs = ({
   isActive,
   onLinkClick,
   isParentOfActiveItem,
+  isSubsectionLink,
 }) => {
   const isDraft = _isDraft(item.title)
   const title = _getTitle(item.title, isDraft)
@@ -26,6 +27,7 @@ const createLinkDocs = ({
       onClick={onLinkClick}
       to={`${item.link}`}
     >
+      {isSubsectionLink && <span css={{ ...styles.subsectionLink }} />}
       {title}
     </Link>
   )

--- a/www/src/utils/sidebar/find-section-for-path.js
+++ b/www/src/utils/sidebar/find-section-for-path.js
@@ -1,19 +1,17 @@
-import getSlugId from "./get-slug-id"
-
 const findSectionForPath = (pathname, sections) => {
-  const slugId = getSlugId(pathname)
   let activeSection
 
   sections.forEach(section => {
-    const match = section.items.some(
-      item =>
-        `/${section.directory}${item.link}` === pathname ||
-        slugId === item.id ||
-        (item.link === `/` && slugId === section.directory) ||
-        (item.subitems && item.subitems.some(subitem => slugId === subitem.id))
-    )
-    if (match) {
-      activeSection = section
+    if (section.items) {
+      const match = section.items.some(
+        item =>
+          `${item.link}` === pathname ||
+          (item.subitems &&
+            item.subitems.some(subitem => pathname === subitem.link))
+      )
+      if (match) {
+        activeSection = section
+      }
     }
   })
 

--- a/www/src/utils/sidebar/find-section-for-path.js
+++ b/www/src/utils/sidebar/find-section-for-path.js
@@ -6,8 +6,7 @@ const findSectionForPath = (pathname, sections) => {
       const match = section.items.some(
         item =>
           `${item.link}` === pathname ||
-          (item.subitems &&
-            item.subitems.some(subitem => pathname === subitem.link))
+          (item.items && item.items.some(subitem => pathname === subitem.link))
       )
       if (match) {
         activeSection = section

--- a/www/src/utils/sidebar/get-active-item.js
+++ b/www/src/utils/sidebar/get-active-item.js
@@ -30,22 +30,24 @@ const isItemActive = (location, item, activeItemHash) => {
 }
 
 const getActiveItem = (sectionList, location, activeItemHash) => {
-  if (sectionList.items) {
-    for (let item of sectionList.items) {
-      if (isItemActive(location, item, activeItemHash)) {
-        return item.link
-      }
-      if (item.subitems) {
-        for (let subitem of item.subitems) {
-          if (isItemActive(location, subitem, activeItemHash)) {
-            return subitem.link
+  for (let item of sectionList) {
+    if (item.items) {
+      for (let subitem of item.items) {
+        if (isItemActive(location, subitem, activeItemHash)) {
+          return subitem.link
+        }
+        if (subitem.items) {
+          for (let subsubitem of subitem.items) {
+            if (isItemActive(location, subsubitem, activeItemHash)) {
+              return subsubitem.link
+            }
           }
         }
       }
-    }
-  } else {
-    if (isItemActive(location, sectionList, activeItemHash)) {
-      return sectionList.link
+    } else {
+      if (isItemActive(location, item, activeItemHash)) {
+        return item.link
+      }
     }
   }
 

--- a/www/src/utils/sidebar/get-active-item.js
+++ b/www/src/utils/sidebar/get-active-item.js
@@ -1,29 +1,28 @@
-import getSlugId from "./get-slug-id"
+const isItemActive = (location, item, activeItemHash) => {
+  const linkMatchesPathname = item.link === location.pathname
+  const linkWithoutHashMatchesPathname =
+    item.link.replace(/#.*/, ``) === location.pathname
+  const activeItemHashFalsy = !activeItemHash || activeItemHash === `NONE`
 
-const isItemActive = (location, item, directory, slugId, activeItemHash) => {
   if (activeItemHash) {
-    if (
-      activeItemHash === `NONE` &&
-      `/${directory}/${getSlugId(item.link)}/` === `${location.pathname}`
-    ) {
+    if (activeItemHash === `NONE` && linkWithoutHashMatchesPathname) {
       return true
     }
 
-    if (
-      `/${directory}${item.link}` === `${location.pathname}#${activeItemHash}`
-    ) {
+    if (item.link === `${location.pathname}#${activeItemHash}`) {
       return true
     }
   }
 
-  if (item.link === `/` && slugId === directory) {
+  if (linkMatchesPathname && !location.hash && activeItemHashFalsy) {
     return true
   }
 
-  if (
-    `/${directory}${item.link}` === `${location.pathname}${location.hash}` &&
-    !activeItemHash
-  ) {
+  if (item.link === `${location.pathname}${location.hash}` && !activeItemHash) {
+    return true
+  }
+
+  if (linkMatchesPathname && !location.hash && !activeItemHash) {
     return true
   }
 
@@ -31,21 +30,22 @@ const isItemActive = (location, item, directory, slugId, activeItemHash) => {
 }
 
 const getActiveItem = (sectionList, location, activeItemHash) => {
-  const directory = sectionList.directory
-  const slugId = getSlugId(location.pathname)
-
-  for (let item of sectionList.items) {
-    if (isItemActive(location, item, directory, slugId, activeItemHash)) {
-      return item.link
-    }
-    if (item.subitems) {
-      for (let subitem of item.subitems) {
-        if (
-          isItemActive(location, subitem, directory, slugId, activeItemHash)
-        ) {
-          return subitem.link
+  if (sectionList.items) {
+    for (let item of sectionList.items) {
+      if (isItemActive(location, item, activeItemHash)) {
+        return item.link
+      }
+      if (item.subitems) {
+        for (let subitem of item.subitems) {
+          if (isItemActive(location, subitem, activeItemHash)) {
+            return subitem.link
+          }
         }
       }
+    }
+  } else {
+    if (isItemActive(location, sectionList, activeItemHash)) {
+      return sectionList.link
     }
   }
 

--- a/www/src/utils/sidebar/get-slug-id.js
+++ b/www/src/utils/sidebar/get-slug-id.js
@@ -1,7 +1,0 @@
-const getSlugId = pathname =>
-  pathname
-    .split(`/`)
-    .slice(0, -1)
-    .pop()
-
-export default getSlugId

--- a/www/src/utils/sidebar/section-list.js
+++ b/www/src/utils/sidebar/section-list.js
@@ -29,14 +29,12 @@ const extendSectionList = sectionList => {
 const sectionListDocs = extendSectionList(docsSidebar).map(item => {
   return {
     ...item,
-    directory: `docs`,
   }
 })
 
 const sectionListFeatures = extendSectionList(featuresSidebar).map(item => {
   return {
     ...item,
-    directory: `features`,
     disableAccordions: true,
   }
 })
@@ -44,7 +42,6 @@ const sectionListFeatures = extendSectionList(featuresSidebar).map(item => {
 const sectionListTutorial = extendSectionList(tutorialSidebar).map(item => {
   return {
     ...item,
-    directory: `tutorial`,
   }
 })
 

--- a/www/src/utils/sidebar/section-list.js
+++ b/www/src/utils/sidebar/section-list.js
@@ -13,8 +13,8 @@ const extendSectionList = sectionList => {
       section.items.forEach((item, index) => {
         let parent = index
         item.hash = createId(item.link)
-        if (item.subitems) {
-          item.subitems.forEach(subitem => {
+        if (item.items) {
+          item.items.forEach(subitem => {
             subitem.hash = createId(subitem.link)
             subitem.parentLink = section.items[parent].link
           })

--- a/www/src/views/showcase/collabsible.js
+++ b/www/src/views/showcase/collabsible.js
@@ -28,7 +28,7 @@ class Collapsible extends Component {
             fontSize: scale(-2 / 5).fontSize,
             marginTop: rhythm(options.blockMarginBottom),
             marginRight: rhythm(5 / 4),
-            letterSpacing: `.15em`,
+            letterSpacing: `.1em`,
             textTransform: `uppercase`,
             "&:hover": {
               color: colors.gatsby,


### PR DESCRIPTION
* basically `section.js` becomes `item.js`—we don't expect every top-level sidebar `yaml` item to be "just" a container for a "section" (or group) of subitems anymore
* got rid of the "base directory" setting in `section-list.js` to allow linking to pages not living in the main directory associated with the current sidebar (e.g. `docs` for `doc-links.yaml`)
  * solving #6245's need of being able to put a link to "Tutorial" in the sidebar of "Docs": https://github.com/gatsbyjs/gatsby/blob/ba55b66e169a16bfb3333658ad804b7ef0d3d197/www/src/data/sidebars/doc-links.yaml#L7-L8 — via `/tutorial/` instead of the above ;-)
  * all links in the sidebar `yaml` files have to be explicit again, e.g. `/docs/` can't be ommitted anymore; that allows the code to be quite a bit simpler
* _does not_ allow subitems in top-level items w/o "turning them" into an accordion yet; `link` in a top-level item will be ignored if it also has sub`items`

* [x] fix false multiple active items on the "Features" page
* [x] adjust sidebar item layout a bit
* [x] naming is confusing in a couple of places right now
* [x] fix "Features" scrollspy
* [x] restore `doc-links.yaml` to fit current docs, moved some things for testing

Fixes #6295, #6193 