### PR TITLE
[gatsby-plugin-offline] Add criticlal scripts and links to static file globs

### DIFF
--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.51",
+    "cheerio": "^1.0.0-rc.2",
     "sw-precache": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -53,13 +53,20 @@ exports.onPostBuild = (args, pluginOptions) => {
   // party like it's 2006
   const $ = cheerio.load(html)
 
-  const criticalScripts = $(`script`)
-    .filter((_, elem) => $(elem).attr(`src`) !== undefined)
-    .map((_, elem) => `${rootDir}${$(elem).attr(`src`)}`)
+  // holds any paths for scripts and links
+  const criticalFilePaths = []
 
-  const criticalLinks = $(`link`)
+  $(`script`)
+    .filter((_, elem) => $(elem).attr(`src`) !== undefined)
+    .each((_, elem) => {
+      criticalFilePaths.push(`${rootDir}${$(elem).attr(`src`)}`)
+    })
+
+  $(`link`)
     .filter((_, elem) => $(elem).attr(`as`) !== `script`)
-    .map((_, elem) => `${rootDir}${$(elem).attr(`href`)}`)
+    .each((_, elem) => {
+      criticalFilePaths.push(`${rootDir}${$(elem).attr(`href`)}`)
+    })
 
   const options = {
     staticFileGlobs: files.concat([
@@ -67,8 +74,7 @@ exports.onPostBuild = (args, pluginOptions) => {
       `${rootDir}/manifest.json`,
       `${rootDir}/manifest.webmanifest`,
       `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
-      ...criticalScripts,
-      ...criticalLinks,
+      ...criticalFilePaths,
     ]),
     stripPrefix: rootDir,
     // If `pathPrefix` is configured by user, we should replace


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

This PR adds all the scripts and links added to `public/index.html` to the `staticFileGlobs` config for `sw-precache`. This resolves the issue of service worker updates breaking sites.

It seems the breakage was caused by index.html being loaded out of cache and when the JS kicks in, there are times when the needed data file (which isn't currently cached) isn't downloaded yet, this causes an error which causes the dreaded white screen.

Closes #6212