### PR TITLE
Fix loading modules outside of the project's scope

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -370,9 +370,9 @@ module.exports = async (
       ],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),
-        'core-js': path.dirname(require.resolve('core-js/package.json')),
-        'react-hot-loader': path.dirname(
-          require.resolve('react-hot-loader/package.json'),
+        `core-js`: path.dirname(require.resolve(`core-js/package.json`)),
+        `react-hot-loader`: path.dirname(
+          require.resolve(`react-hot-loader/package.json`),
         ),
       },
     }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -370,6 +370,10 @@ module.exports = async (
       ],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),
+        'core-js': path.dirname(require.resolve('core-js/package.json')),
+        'react-hot-loader': path.dirname(
+          require.resolve('react-hot-loader/package.json'),
+        ),
       },
     }
   }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -370,6 +370,9 @@ module.exports = async (
       ],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),
+        // Using directories for module resolution is mandatory because
+        // relative path imports are used sometimes
+        // See https://stackoverflow.com/a/49455609/6420957 for more details
         'core-js': path.dirname(require.resolve(`core-js/package.json`)),
         'react-hot-loader': path.dirname(
           require.resolve(`react-hot-loader/package.json`),

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -370,8 +370,8 @@ module.exports = async (
       ],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),
-        `core-js`: path.dirname(require.resolve(`core-js/package.json`)),
-        `react-hot-loader`: path.dirname(
+        'core-js': path.dirname(require.resolve(`core-js/package.json`)),
+        'react-hot-loader': path.dirname(
           require.resolve(`react-hot-loader/package.json`),
         ),
       },


### PR DESCRIPTION
Fixes #6030

Special thanks to @jquense for the following instructions: https://github.com/gatsbyjs/gatsby/issues/6030#issuecomment-399198316

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
