### PR TITLE
add "in" operator for single value string, int, float and boolean fields

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
@@ -25,6 +25,7 @@ function isIntInput(type) {
     lte: { name: `lte`, type: GraphQLInt },
     gt: { name: `gt`, type: GraphQLInt },
     gte: { name: `gte`, type: GraphQLInt },
+    in: { name: `in`, type: new GraphQLList(GraphQLInt) },
   })
 }
 
@@ -33,6 +34,7 @@ function isIdInput(type) {
   expect(type.getFields()).toEqual({
     eq: { name: `eq`, type: GraphQLID },
     ne: { name: `ne`, type: GraphQLID },
+    in: { name: `in`, type: new GraphQLList(GraphQLID) },
   })
 }
 
@@ -43,6 +45,7 @@ function isStringInput(type) {
     ne: { name: `ne`, type: GraphQLString },
     regex: { name: `regex`, type: GraphQLString },
     glob: { name: `glob`, type: GraphQLString },
+    in: { name: `in`, type: new GraphQLList(GraphQLString) },
   })
 }
 
@@ -97,6 +100,7 @@ describe(`GraphQL Input args from fields, test-only`, () => {
       lte: { name: `lte`, type: GraphQLFloat },
       gt: { name: `gt`, type: GraphQLFloat },
       gte: { name: `gte`, type: GraphQLFloat },
+      in: { name: `in`, type: new GraphQLList(GraphQLFloat) },
     })
 
     const string = inferredFields.scal_string.type
@@ -109,6 +113,7 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     expect(bool.getFields()).toEqual({
       eq: { name: `eq`, type: GraphQLBoolean },
       ne: { name: `ne`, type: GraphQLBoolean },
+      in: { name: `in`, type: new GraphQLList(GraphQLBoolean) },
     })
 
     expect(inferredFields).not.toHaveProperty(`scal_odd_unknown`)

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -85,6 +85,8 @@ describe(`GraphQL Input args`, () => {
     {
       index: 0,
       name: `The Mad Max`,
+      string: `a`,
+      float: 1.5,
       hair: 1,
       date: `2006-07-22T22:39:53.000Z`,
       anArray: [1, 2, 3, 4],
@@ -112,6 +114,8 @@ describe(`GraphQL Input args`, () => {
     {
       index: 1,
       name: `The Mad Wax`,
+      string: `b`,
+      float: 2.5,
       hair: 2,
       anArray: [1, 2, 5, 4],
       anotherKey: {
@@ -130,6 +134,8 @@ describe(`GraphQL Input args`, () => {
     {
       index: 2,
       name: `The Mad Wax`,
+      string: `c`,
+      float: 3.5,
       hair: 0,
       date: `2006-07-29T22:39:53.000Z`,
       anotherKey: {
@@ -448,7 +454,42 @@ describe(`GraphQL Input args`, () => {
     expect(result.data.allNode.edges[0].node.name).toEqual(`The Mad Wax`)
   })
 
-  it(`handles the in operator`, async () => {
+  it(`handles the in operator for scalars`, async () => {
+    let result = await queryResult(
+      nodes,
+      `
+        {
+          string:allNode(filter: { string: { in: ["b", "c"] }}) {
+            edges { node { index }}
+          }
+          int:allNode(filter: { index: { in: [0, 2] }}) {
+            edges { node { index }}
+          }
+          float:allNode(filter: { float: { in: [1.5, 2.5] }}) {
+            edges { node { index }}
+          }
+          boolean:allNode(filter: { boolean: { in: [true, null] }}) {
+            edges { node { index }}
+          }
+        }
+      `
+    )
+    expect(result.errors).not.toBeDefined()
+    expect(result.data.string.edges.length).toEqual(2)
+    expect(result.data.string.edges[0].node.index).toEqual(1)
+    expect(result.data.string.edges[1].node.index).toEqual(2)
+    expect(result.data.int.edges.length).toEqual(2)
+    expect(result.data.int.edges[0].node.index).toEqual(0)
+    expect(result.data.int.edges[1].node.index).toEqual(2)
+    expect(result.data.float.edges.length).toEqual(2)
+    expect(result.data.float.edges[0].node.index).toEqual(0)
+    expect(result.data.float.edges[1].node.index).toEqual(1)
+    expect(result.data.boolean.edges.length).toEqual(2)
+    expect(result.data.boolean.edges[0].node.index).toEqual(0)
+    expect(result.data.boolean.edges[1].node.index).toEqual(2)
+  })
+
+  it(`handles the in operator for array`, async () => {
     let result = await queryResult(
       nodes,
       `

--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -89,6 +89,7 @@ const scalarFilterMap = {
     gte: { type: GraphQLInt },
     lt: { type: GraphQLInt },
     lte: { type: GraphQLInt },
+    in: { type: new GraphQLList(GraphQLInt) },
   },
   Float: {
     eq: { type: GraphQLFloat },
@@ -97,20 +98,24 @@ const scalarFilterMap = {
     gte: { type: GraphQLFloat },
     lt: { type: GraphQLFloat },
     lte: { type: GraphQLFloat },
+    in: { type: new GraphQLList(GraphQLFloat) },
   },
   ID: {
     eq: { type: GraphQLID },
     ne: { type: GraphQLID },
+    in: { type: new GraphQLList(GraphQLID) },
   },
   String: {
     eq: { type: GraphQLString },
     ne: { type: GraphQLString },
     regex: { type: GraphQLString },
     glob: { type: GraphQLString },
+    in: { type: new GraphQLList(GraphQLString) },
   },
   Boolean: {
     eq: { type: GraphQLBoolean },
     ne: { type: GraphQLBoolean },
+    in: { type: new GraphQLList(GraphQLBoolean) },
   },
 }
 

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -34,6 +34,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
       return {
         eq: { type: GraphQLBoolean },
         ne: { type: GraphQLBoolean },
+        in: { type: new GraphQLList(GraphQLBoolean) },
       }
     case `string`:
       return {
@@ -41,6 +42,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
         ne: { type: GraphQLString },
         regex: { type: GraphQLString },
         glob: { type: GraphQLString },
+        in: { type: new GraphQLList(GraphQLString) },
       }
     case `int`:
       return {
@@ -50,6 +52,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
         gte: { type: GraphQLInt },
         lt: { type: GraphQLInt },
         lte: { type: GraphQLInt },
+        in: { type: new GraphQLList(GraphQLInt) },
       }
     case `float`:
       return {
@@ -59,6 +62,7 @@ function typeFields(type): GraphQLInputFieldConfigMap {
         gte: { type: GraphQLFloat },
         lt: { type: GraphQLFloat },
         lte: { type: GraphQLFloat },
+        in: { type: new GraphQLList(GraphQLFloat) },
       }
   }
   return {}


### PR DESCRIPTION
It turns out, `in` operator in `sift` works with single values, not just with arrays - so this just needed schema update to support it.

Closes #2277
Closes #4111
Closes #6279

