### PR TITLE
Support typescript when parsing GraphQL queries

### DIFF
--- a/examples/using-typescript/src/pages/index.tsx
+++ b/examples/using-typescript/src/pages/index.tsx
@@ -24,14 +24,17 @@ export const pageQuery = graphql`
   }
 `
 
-export default ({ data }: IndexPageProps) => {
-  const { siteName } = data.site.siteMetadata
-  return (
-    <Layout>
-      <h1>Hello Typescript world!</h1>
-      <p>
-        This site is named <strong>{siteName}</strong>
-      </p>
-    </Layout>
-  )
+export default class IndexPage extends React.Component<IndexPageProps, {}> {
+  readonly hello = `Hello`
+  public render() {
+    const { siteName } = this.props.data.site.siteMetadata
+    return (
+      <Layout>
+        <h1>{this.hello} Typescript world!</h1>
+        <p>
+          This site is named <strong>{siteName}</strong>
+        </p>
+      </Layout>
+    )
+  }
 }

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -1,8 +1,8 @@
 // @flow
 const fs = require(`fs`)
-const babylon = require(`@babel/parser`)
 const traverse = require(`babel-traverse`).default
 const get = require(`lodash/get`)
+import { babelParseToAst } from "../utils/babel-parse-to-ast"
 
 /**
  * Given a `require.resolve()` compatible path pointing to a JS module,
@@ -24,25 +24,7 @@ module.exports = (modulePath, resolver = require.resolve) => {
   }
   const code = fs.readFileSync(absPath, `utf8`) // get file contents
 
-  const babylonOpts = {
-    sourceType: `module`,
-    allowImportExportEverywhere: true,
-    plugins: [
-      `jsx`,
-      `doExpressions`,
-      `objectRestSpread`,
-      `decorators`,
-      `classProperties`,
-      `exportExtensions`,
-      `asyncGenerators`,
-      `functionBind`,
-      `functionSent`,
-      `dynamicImport`,
-      `flow`,
-    ],
-  }
-
-  const ast = babylon.parse(code, babylonOpts)
+  const ast = babelParseToAst(code, absPath)
 
   // extract names of exports from file
   traverse(ast, {

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -4,46 +4,15 @@ const crypto = require(`crypto`)
 
 // Traverse is a es6 module...
 import traverse from "babel-traverse"
-const babylon = require(`@babel/parser`)
 const getGraphQLTag = require(`babel-plugin-remove-graphql-queries`)
   .getGraphQLTag
 const report = require(`gatsby-cli/lib/reporter`)
 
 import type { DocumentNode, DefinitionNode } from "graphql"
+import { babelParseToAst } from '../../utils/babel-parse-to-ast'
 
 const apiRunnerNode = require(`../../utils/api-runner-node`)
 
-const BABYLON_OPTIONS = {
-  allowImportExportEverywhere: true,
-  allowReturnOutsideFunction: true,
-  allowSuperOutsideMethod: true,
-  sourceType: `unambigious`,
-  sourceFilename: true,
-  plugins: [
-    `jsx`,
-    `flow`,
-    `doExpressions`,
-    `objectRestSpread`,
-    `decorators`,
-    `classProperties`,
-    `classPrivateProperties`,
-    `classPrivateMethods`,
-    `exportDefaultFrom`,
-    `exportNamespaceFrom`,
-    `asyncGenerators`,
-    `functionBind`,
-    `functionSent`,
-    `dynamicImport`,
-    `numericSeparator`,
-    `optionalChaining`,
-    `importMeta`,
-    `bigInt`,
-    `optionalCatchBinding`,
-    `throwExpressions`,
-    `pipelineOperator`,
-    `nullishCoalescingOperator`,
-  ],
-}
 
 const getMissingNameErrorMessage = file => report.stripIndent`
   GraphQL definitions must be "named".
@@ -72,11 +41,10 @@ async function parseToAst(filePath, fileStr) {
     filename: filePath,
     contents: fileStr,
   })
-
   if (transpiled && transpiled.length) {
     for (const item of transpiled) {
       try {
-        const tmp = babylon.parse(item, BABYLON_OPTIONS)
+        const tmp = babelParseToAst(item, filePath)
         ast = tmp
         break
       } catch (error) {
@@ -89,7 +57,7 @@ async function parseToAst(filePath, fileStr) {
     }
   } else {
     try {
-      ast = babylon.parse(fileStr, BABYLON_OPTIONS)
+      ast = babelParseToAst(fileStr, filePath)
     } catch (error) {
       report.error(
         `There was a problem parsing "${filePath}"; any GraphQL ` +

--- a/packages/gatsby/src/utils/babel-parse-to-ast.js
+++ b/packages/gatsby/src/utils/babel-parse-to-ast.js
@@ -1,0 +1,54 @@
+/* @flow */
+const parser = require(`@babel/parser`)
+
+const PARSER_OPTIONS = {
+  allowImportExportEverywhere: true,
+  allowReturnOutsideFunction: true,
+  allowSuperOutsideMethod: true,
+  sourceType: `unambigious`,
+  sourceFilename: true,
+  plugins: [
+    `jsx`,
+    `flow`,
+    `doExpressions`,
+    `objectRestSpread`,
+    `decorators`,
+    `classProperties`,
+    `classPrivateProperties`,
+    `classPrivateMethods`,
+    `exportDefaultFrom`,
+    `exportNamespaceFrom`,
+    `asyncGenerators`,
+    `functionBind`,
+    `functionSent`,
+    `dynamicImport`,
+    `numericSeparator`,
+    `optionalChaining`,
+    `importMeta`,
+    `bigInt`,
+    `optionalCatchBinding`,
+    `throwExpressions`,
+    `pipelineOperator`,
+    `nullishCoalescingOperator`,
+  ],
+}
+
+export function getBabelParserOptions(filePath) {
+  // Flow and typescript plugins can't be enabled simultaneously
+  if (/\.tsx?/.test(filePath)) {
+    const { plugins } = PARSER_OPTIONS
+    return {
+      ...PARSER_OPTIONS,
+      plugins: plugins.map(
+        plugin => (plugin === `flow` ? `typescript` : plugin)
+      ),
+    }
+  }
+  return PARSER_OPTIONS
+}
+
+export function babelParseToAst(contents, filePath) {
+  return parser.parse(contents, getBabelParserOptions(filePath))
+}
+
+


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Also extract ast parsing into a utility function