### PR TITLE
don't force new release after running prettier on CHANGELOG

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,10 @@
       "cdVersion": "prerelease",
       "conventionalCommits": true,
       "message": "chore(release): Publish",
-      "preid": "beta"
+      "preid": "beta",
+      "ignoreChanges": [
+        "CHANGELOG.md"
+      ]
     }
   },
   "loglevel": "success",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:update": "jest --updateSnapshot",
     "test:watch": "jest --watch",
     "test_bkup": "npm-run-all -s lint test-node test-integration",
+    "version": "prettier --write \"**/CHANGELOG.md\" --no-semi",
     "watch": "lerna run watch --no-sort --stream --concurrency 999"
   },
   "workspaces": [


### PR DESCRIPTION
Running `format-markdown` will remove excesive empty lines in CHANGELOG.md and force releasing new version - this PR allows to ignore those changes.

Potential drawbacks: this relies on CHANGELOG.md being autogenerated - so only changes would be new content during release and running prettier on it, so any manual modification to won't be picked up.

From lerna docs:
> command.publish.ignoreChanges: an array of globs that won't be included in lerna changed/publish. Use this to prevent publishing a new version unnecessarily for changes, such as fixing a README.md typo.