### PR TITLE
[docs] Rename boundActionCreators to actions

### DIFF
--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -123,13 +123,13 @@ Two things are important in the file above.
 
 Gatsby exposes a powerful Node.js API, which allows for functionality such as creating dynamic pages. This API is available in the `gatsby-node.js` file in the root directory of your project, at the same level as `gatsby-config.js`. Each export found in this file will be run by Gatsby, as detailed in its [Node API specification](/docs/node-apis/). However, we only care about one particular API in this instance, `createPages`.
 
-Gatsby calls the `createPages` API (if present) at build time with injected parameters, `boundActionCreators` and `graphql`. Use the `graphql` to query Markdown file data as below. Next use `createPage` action creator to create a page for each of the Markdown files using the `blogTemplate.js` we created in the previous step.
+Gatsby calls the `createPages` API (if present) at build time with injected parameters, `actions` and `graphql`. Use the `graphql` to query Markdown file data as below. Next use `createPage` action creator to create a page for each of the Markdown files using the `blogTemplate.js` we created in the previous step.
 
 ```javascript
 const path = require("path")
 
-exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ actions, graphql }) => {
+  const { createPage } = actions
 
   const blogPostTemplate = path.resolve(`src/templates/blogTemplate.js`)
 

--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -79,8 +79,8 @@ import PropTypes from "prop-types"
 // Components
 import { Link } from "gatsby"
 
-const Tags = ({ pathContext, data }) => {
-  const { tag } = pathContext
+const Tags = ({ pageContext, data }) => {
+  const { tag } = pageContext
   const { edges, totalCount } = data.allMarkdownRemark
   const tagHeader = `${totalCount} post${
     totalCount === 1 ? "" : "s"
@@ -161,8 +161,8 @@ Now we've got a template. Great! I'll assume you followed the tutorial for [Addi
 ```js
 const path = require("path")
 
-exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ actions, graphql }) => {
+  const { createPage } = actions
 
   const blogPostTemplate = path.resolve("src/templates/blog.js")
   const tagTemplate = path.resolve("src/templates/tags.js")

--- a/docs/docs/building-apps-with-gatsby.md
+++ b/docs/docs/building-apps-with-gatsby.md
@@ -35,8 +35,8 @@ _Note: There's also a plugin that can aid in creating client-only routes:
 ```javascript
 // Implement the Gatsby API “onCreatePage”. This is
 // called after every page is created.
-exports.onCreatePage = async ({ page, boundActionCreators }) => {
-  const { createPage } = boundActionCreators
+exports.onCreatePage = async ({ page, actions }) => {
+  const { createPage } = actions
 
   // page.matchPath is a special key that's used for matching pages
   // only on the client.

--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -60,8 +60,8 @@ follow this pattern.
 Your `gatsby-node.js` should look something like:
 
 ```javascript
-exports.sourceNodes = async ({ boundActionCreators }) => {
-  const { createNode } = boundActionCreators
+exports.sourceNodes = async ({ actions }) => {
+  const { createNode } = actions
   // Create nodes here, generally by downloading data
   // from a remote API.
   const data = await fetch(REMOTE_API)

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -52,8 +52,8 @@ of the markdown file.
 ```javascript
 // Implement the Gatsby API “createPages”. This is called once the
 // data layer is bootstrapped to let plugins create pages from data.
-exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ graphql, actions }) => {
+  const { createPage } = actions
 
   return new Promise((resolve, reject) => {
     const blogPostTemplate = path.resolve(`src/templates/blog-post.js`)
@@ -116,8 +116,8 @@ _Note: There's also a plugin that will remove all trailing slashes from pages au
 ```javascript
 // Implement the Gatsby API “onCreatePage”. This is
 // called after every page is created.
-exports.onCreatePage = ({ page, boundActionCreators }) => {
-  const { createPage, deletePage } = boundActionCreators
+exports.onCreatePage = ({ page, actions }) => {
+  const { createPage, deletePage } = actions
   return new Promise(resolve => {
     const oldPage = Object.assign({}, page)
     // Remove trailing slash unless page is /

--- a/docs/docs/source-plugin-tutorial.md
+++ b/docs/docs/source-plugin-tutorial.md
@@ -121,10 +121,10 @@ const fetch = require("node-fetch")
 const queryString = require("query-string")
 
 exports.sourceNodes = (
-  { boundActionCreators, createNodeId },
+  { actions, createNodeId },
   configOptions
 ) => {
-  const { createNode } = boundActionCreators
+  const { createNode } = actions
 
   // Gatsby adds a configOption that's not needed for this plugin, delete it
   delete configOptions.plugins
@@ -144,11 +144,11 @@ const fetch = require("node-fetch")
 const queryString = require("query-string")
 ```
 
-Then you implemented Gatsby's [`sourceNodes` API](/docs/node-apis/#sourceNodes) which Gatsby will run as part of its bootstrap process. When Gatsby calls `sourceNodes`, it'll pass in some helper functions (`boundActionCreators` and `createNodeId`) along with any config options that are provided in your project's `gatsby-config.js` file:
+Then you implemented Gatsby's [`sourceNodes` API](/docs/node-apis/#sourceNodes) which Gatsby will run as part of its bootstrap process. When Gatsby calls `sourceNodes`, it'll pass in some helper functions (`actions` and `createNodeId`) along with any config options that are provided in your project's `gatsby-config.js` file:
 
 ```js
 exports.sourceNodes = (
-  { boundActionCreators, createNodeId },
+  { actions, createNodeId },
   configOptions
 ) => {
 ```
@@ -156,7 +156,7 @@ exports.sourceNodes = (
 You do some initial setup:
 
 ```js
-const { createNode } = boundActionCreators
+const { createNode } = actions
 
 // Gatsby adds a configOption that's not needed for this plugin, delete it
 delete configOptions.plugins
@@ -220,10 +220,10 @@ const queryString = require('query-string')
 const crypto = require('crypto')
 
 exports.sourceNodes = (
-  { boundActionCreators, createNodeId },
+  { actions, createNodeId },
   configOptions
 ) => {
-  const { createNode } = boundActionCreators
+  const { createNode } = actions
 
   // Gatsby adds a configOption that's not needed for this plugin, delete it
   delete configOptions.plugins


### PR DESCRIPTION
Hopefully I don't have to rebase again 😆 
So, I mainly renamed boundActionsCreators to actions.

Sometimes `actions, graphql` were in the "wrong" order according to the Node API docs. So it's not consistent currently on all sites.

(Hijacking this PR: Could someone please delete the `LeKoArts-patch-1` and `LeKoArts-add-tutorials` branches? Thanks!)