### PR TITLE
Remove `type="text/css"` from style tag

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -262,7 +262,6 @@ export default (pagePath, callback) => {
       } else {
         headComponents.unshift(
           <style
-            type="text/css"
             data-href={urlJoin(pathPrefix, style.name)}
             dangerouslySetInnerHTML={{
               __html: fs.readFileSync(


### PR DESCRIPTION
W3C Validator throws a warning saying that it isn’t required:

![image](https://user-images.githubusercontent.com/16177372/42566103-a0d57a3e-852f-11e8-9fa5-e89286c05a5a.png)

Apparently, in HTML5, the default value for type is "text/css", therefore making this line redundant.
Reference: https://www.w3schools.com/tags/att_style_type.asp