### PR TITLE
Add new onPreInit hook

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -78,12 +78,15 @@ module.exports = async (args: BootstrapArgs) => {
 
   activity.end()
 
-  const flattenedPlugins = await loadPlugins(config)
-
-  // onPreBootstrap
-  activity = report.activityTimer(`onPreBootstrap`)
+  activity = report.activityTimer(`load plugins`)
   activity.start()
-  await apiRunnerNode(`onPreBootstrap`)
+  const flattenedPlugins = await loadPlugins(config)
+  activity.end()
+
+  // onPreInit
+  activity = report.activityTimer(`onPreInit`)
+  activity.start()
+  await apiRunnerNode(`onPreInit`)
   activity.end()
 
   // Delete html and css files from the public directory as we don't want
@@ -100,6 +103,8 @@ module.exports = async (args: BootstrapArgs) => {
   ])
   activity.end()
 
+  activity = report.activityTimer(`initialize cache`)
+  activity.start()
   // Check if any plugins have been updated since our last run. If so
   // we delete the cache is there's likely been changes
   // since the previous run.
@@ -168,6 +173,7 @@ module.exports = async (args: BootstrapArgs) => {
       fs.ensureDir(`${program.directory}/public/static/d/${i}`)
     )
   )
+  activity.end()
 
   // Copy our site files to the root of the site.
   activity = report.activityTimer(`copy gatsby files`)
@@ -267,6 +273,12 @@ module.exports = async (args: BootstrapArgs) => {
   /**
    * Start the main bootstrap processes.
    */
+
+  // onPreBootstrap
+  activity = report.activityTimer(`onPreBootstrap`)
+  activity.start()
+  await apiRunnerNode(`onPreBootstrap`)
+  activity.end()
 
   // Source nodes
   activity = report.activityTimer(`source and transform nodes`)

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -1,5 +1,5 @@
 /**
- * Let's plugins implementing support for other compile-to-js add to the list
+ * Lets plugins implementing support for other compile-to-js add to the list
  * of "resolvable" file extensions. Gatsby supports `.js` and `.jsx` by default.
  * @returns {Array} array of extensions
  */
@@ -219,7 +219,12 @@ exports.onCreateBabelConfig = true
 exports.onCreateWebpackConfig = true
 
 /**
- * Called at the start of the bootstrap process before any other extension APIs are called.
+ * The first API called during Gatsby execution, runs as soon as plugins are loaded, before cache initialization and bootstrap preparation.
+ */
+exports.onPreInit = true
+
+/**
+ * Called once Gatsby has initialized itself and is ready to bootstrap your site.
  */
 exports.onPreBootstrap = true
 


### PR DESCRIPTION
This reverts the `onPreBootstrap` change in https://github.com/gatsbyjs/gatsby/pull/5862, and adds the `onPreInit` hook suggested by @axe312ger. 

The `onPreInit` name doesn't sound right, but I can't think of a better name.

I've also added activity timers for a couple of steps that were being skipped over. `load plugins` and `initialize cache`. Here's an example of the updated output:

```
$ gatsby develop
success open and validate gatsby-config — 0.006 s
success load plugins — 0.224 s
success onPreInit — 0.499 s
success delete html and css files from previous builds — 0.193 s
success initialize cache — 0.096 s
success copy gatsby files — 0.082 s
success onPreBootstrap — 0.003 s
success source and transform nodes — 0.237 s
success building schema — 0.559 s
success createPages — 0.081 s
success createPagesStatefully — 0.043 s
success onPreExtractQueries — 0.006 s
success update schema — 0.210 s
success extract queries from components — 0.229 s
success run graphql queries — 0.027 s — 5/5 215.94 queries/second
success write out page data — 0.021 s
success write out redirect data — 0.002 s
success onPostBootstrap — 0.002 s

info bootstrap finished - 5.283 s
```

Note that the ~0.5 second run time for the empty `onPreInit` hook is because it's the first call to `apiRunnerNode()`.