### PR TITLE
Change setState call to use functional form

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -329,18 +329,18 @@ class Counter extends React.Component {
         <p>current count: {this.state.count}</p>
         <button
           onClick={() =>
-            this.setState({
-              count: this.state.count + 1,
-            })
+            this.setState(prevState => ({
+              count: prevState.count + 1,
+            }))
           }
         >
           plus
         </button>
         <button
           onClick={() =>
-            this.setState({
-              count: this.state.count - 1,
-            })
+            this.setState(prevState => ({
+              count: prevState.count - 1,
+            }))
           }
         >
           minus


### PR DESCRIPTION
Not important to the function of the tutorial, as it's React specific and not Gatsby specific, but the example using state for the counter should use the functional form of `setState`. This example is so trivial that this instance would never really run up against the async nature of `setState`, so I understand if you wouldn't want to accept this PR. However, my feeling is that as this tutorial is geared towards those that might be new to React, we should teach them the "right" ways, so they don't get bit later.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
