### PR TITLE
Fix (www): next.gatsbyjs.org index page layout on Internet Explorer 11

### DIFF
--- a/www/src/components/card.js
+++ b/www/src/components/card.js
@@ -10,7 +10,7 @@ const Card = ({ children }) => (
       display: `flex`,
       transform: `translateZ(0)`,
       [presets.Tablet]: {
-        flex: `0 0 50%`,
+        flex: `0 0 auto`,
         maxWidth: `50%`,
         boxShadow: `0 1px 0 0 ${colors.ui.light}`,
         "&:nth-child(5),&:nth-child(6)": {
@@ -21,7 +21,7 @@ const Card = ({ children }) => (
         },
       },
       [presets.Hd]: {
-        flex: `0 0 33.33333333%`,
+        flex: `0 0 auto`,
         maxWidth: `33.33333333%`,
         borderLeft: `1px solid ${colors.ui.light}`,
         "&:nth-child(4)": {

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -128,6 +128,7 @@ const SourceItem = ({ children }) => (
       },
       [presets.Phablet]: {
         flex: `1 1 33%`,
+        maxWidth: `33%`
       },
     }}
   >

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -130,8 +130,7 @@ export default ({ pathname }) => {
           <img
             src={logo}
             css={{
-              height: 28,
-              width: `auto`,
+              width: 106,
               margin: 0,
             }}
             alt=""

--- a/www/src/components/used-by.js
+++ b/www/src/components/used-by.js
@@ -10,12 +10,16 @@ const Icon = ({ icon, alt, href }) => (
       marginRight: rhythm(3 / 4),
       display: `inline-block`,
       padding: 0,
+      height: `calc(14px + 1vw)`,
       [presets.Phablet]: {
         marginBottom: 0,
-        width: `auto`,
+        height: `calc(9px + 1vw)`,
         ":last-child": {
           marginRight: 0,
         },
+      },
+      [presets.Tablet]: {
+        height: `calc(12px + 1vw)`,
       },
     }}
   >
@@ -44,13 +48,7 @@ const Icon = ({ icon, alt, href }) => (
         alt={alt}
         css={{
           margin: 0,
-          height: `calc(14px + 1vw)`,
-          [presets.Phablet]: {
-            height: `calc(9px + 1vw)`,
-          },
-          [presets.Tablet]: {
-            height: `calc(12px + 1vw)`,
-          },
+          height: `100%`,
         }}
       />
     </a>

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -41,6 +41,7 @@ class IndexRoute extends React.Component {
               css={{
                 padding: rhythm(presets.gutters.default / 2),
                 flex: `0 0 100%`,
+                maxWidth: `100%`,
                 [presets.Hd]: {
                   padding: vP,
                   paddingTop: 0,


### PR DESCRIPTION
Fixes layout and logos on ie11 https://github.com/gatsbyjs/gatsby/issues/6398
![ie3](https://user-images.githubusercontent.com/12339068/42681852-727987fc-86a6-11e8-8d99-18c26a1e6c49.PNG)
