### PR TITLE
Fix options for the stylus plugin

### DIFF
--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-stylus",
   "description": "Gatsby support for Stylus",
-  "version": "1.1.22",
+  "version": "1.1.21",
   "author": "Ian Sinnott <ian@iansinnott.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-stylus",
   "description": "Gatsby support for Stylus",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "author": "Ian Sinnott <ian@iansinnott.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -24,34 +24,10 @@ const { cssModulesConfig } = require(`gatsby-1-config-css-modules`)
 
 exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
   // Pass in stylus options regardless of stage.
-  if (Array.isArray(options.use)) {
-    config.merge(current => {
-      current.stylus = {
-        use: options.use,
-      }
-      return current
-    })
-  } else if (options.use) {
-    throw new Error(
-      `gatsby-plugin-stylus "use" option passed with ${
-        options.use
-      }. Pass an array of stylus plugins instead`
-    )
-  }
-  if (Array.isArray(options.import)) {
-    config.merge(current => {
-      current.stylus = {
-        import: options.import,
-      }
-      return current
-    })
-  } else if (options.import) {
-    throw new Error(
-      `gatsby-plugin-stylus "import" option passed with ${
-        options.import
-      }. Pass an array of filenames instead`
-    )
-  }
+  config.merge(function (current) {
+    current.stylus = options;
+    return current;
+  });
 
   const stylusFiles = /\.styl$/
   const stylusModulesFiles = /\.module\.styl$/

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -25,9 +25,9 @@ const { cssModulesConfig } = require(`gatsby-1-config-css-modules`)
 exports.modifyWebpackConfig = ({ config, stage }, options = {}) => {
   // Pass in stylus options regardless of stage.
   config.merge(function (current) {
-    current.stylus = options;
-    return current;
-  });
+    current.stylus = options
+    return current
+  })
 
   const stylusFiles = /\.styl$/
   const stylusModulesFiles = /\.module\.styl$/


### PR DESCRIPTION
This PR fixes https://github.com/gatsbyjs/gatsby/issues/6431

Considering what [gatsby does in v2](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-stylus/src/gatsby-node.js#L37), I think just passing the options (unchanged) is enough. It's not our duty to check the validity of the options which is supposed to be passed to stylus-loader.