### PR TITLE
[www] added Kata.ai documentation to site showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1216,3 +1216,14 @@
   source_url: https://github.com/WeOpenly/localgov.fyi
   built_by: Openly
   built_by_url: 'https://weopenly.com/'
+- title: Kata.ai Documentation
+  main_url: 'https://docs.kata.ai/'
+  url: 'https://docs.kata.ai/'
+  source_url: https://github.com/kata-ai/kata-platform-docs
+  featured: false
+  description: >-
+    Documentation website for the Kata Platform, an all-in-one platform for
+    building chatbots using AI technologies.
+  categories:
+    - Documentation
+    - Technology


### PR DESCRIPTION
As announced [on Twitter](https://twitter.com/resir014/status/1017756253945122822) earlier, the company where I work for, [Kata.ai](https://kata.ai/) has recently released an revamped version of their chatbot platform, and with that, I've helped them in building their all-new [documentation site](https://docs.kata.ai/).

This is all built from the ground-up with React and Gatsby.js, on top of an all-new [documentation skeleton](https://github.com/kata-ai/grundgesetz-skeleton) I built specifically for this (which I'll include in the Starters page soon).

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
