### PR TITLE
Updated `babel-loader` to latest beta

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -26,7 +26,7 @@
     "autoprefixer": "^7.1.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^8.2.2",
-    "babel-loader": "8.0.0-beta.0",
+    "babel-loader": "8.0.0-beta.4",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-remove-graphql-queries": "^2.0.2-beta.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,13 +2307,14 @@ babel-jest@^22.4.3, babel-jest@^22.4.4:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.4"
 
-babel-loader@8.0.0-beta.0:
-  version "8.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.0-beta.0.tgz#b85c3b52d1095949125c72c7ec1fa0fbb47a11ff"
+babel-loader@8.0.0-beta.4:
+  version "8.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.0-beta.4.tgz#c3fab00696c385c70c04dbe486391f0eb996f345"
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
+    util.promisify "^1.0.0"
 
 babel-messages@^6.23.0:
   version "6.23.0"


### PR DESCRIPTION
`babel-loader` has two breaking changes from `beta.0`, it are not related to gatsby codebase, but maybe relate to users of v2 of Gatsby who use custom options for `babel-loader` (by `rules.js` in `onCreateWebpackConfig` or by self).

1. The `babelrc` option was changed. It now only accepts `true` or `false` as valid option (similar to other babel packages) and does not allow setting a string. If you previously had a filename specified you need to change to `extends`.

```diff
rules.js({
-  babelrc: 'path/to/.babelrc'
+  babelrc: true,
+  extends: 'path/to/.babelrc'
})
```

2. The `forceEnv` option has been removed. You can simple replace it with the new option `envName` from babel-core

```diff
rules.js({
-  forceEnv: 'staging'
+  envName: 'staging'
})
```

Closes #5949