### PR TITLE
[gatsby] Add missing 'typeName' parameter to 'runSift' call

### DIFF
--- a/packages/gatsby/src/schema/build-node-connections.js
+++ b/packages/gatsby/src/schema/build-node-connections.js
@@ -77,6 +77,7 @@ module.exports = (types: any) => {
           nodes: latestNodes,
           connection: true,
           path,
+          typeName: typeName,
           type: type.node.type,
         })
       },


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/6443.