### PR TITLE
Import graphql from gatsby in blog template

### DIFF
--- a/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
+++ b/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
@@ -300,6 +300,7 @@ specified earlier.
 ```javascript{21-32}
 import React from 'react';
 import Helmet from 'react-helmet';
+import { graphql } from 'gatsby';
 
 // import '../css/blog-post.css';
 
@@ -533,7 +534,7 @@ available within the browser and the statically generated site.
 
 ```javascript
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import Helmet from "react-helmet"
 
 // import '../css/index.css'; // add some style if you want!

--- a/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
+++ b/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
@@ -295,6 +295,7 @@ specify a `pageQuery` that will pass data into the default export of that page.
 ```jsx
 // src/pages/index.js
 import React from "react"
+import { graphql } from "gatsby"
 
 export default class BlogIndex extends React.Component {
   render() {
@@ -673,6 +674,7 @@ Here it is in all it's glory:
 ```jsx
 // src/templates/post.js
 import React from "react"
+import { graphql } from "gatsby"
 
 export default class BlogPost extends React.Component {
   render() {

--- a/docs/blog/2018-06-18-moving-from-create-react-app-to-gatsby-js/index.md
+++ b/docs/blog/2018-06-18-moving-from-create-react-app-to-gatsby-js/index.md
@@ -216,6 +216,7 @@ You need to make some slight modifications to your `BlogPost` component.
 
 ```js
 import React from "react"
+import { graphql } from "gatsby"
 
 class BlogPost extends React.Component {
   render() {

--- a/docs/blog/2018-1-18-strapi-and-gatsby/index.md
+++ b/docs/blog/2018-1-18-strapi-and-gatsby/index.md
@@ -213,7 +213,7 @@ _Path: `src/pages/index.js`_
 
 ```jsx
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 const IndexPage = ({ data }) => (
   <div>

--- a/docs/blog/2018-2-27-why-i-upgraded-my-website-to-gatsbyjs-from-jekyll/index.md
+++ b/docs/blog/2018-2-27-why-i-upgraded-my-website-to-gatsbyjs-from-jekyll/index.md
@@ -52,6 +52,7 @@ For example, I defined a `PostTemplate` which will be used to render pages for a
 // src/templates/Post.jsx
 
 import React from "react"
+import { graphql } from "gatsby"
 
 export default function PostTemplate({
   data: {

--- a/docs/docs/adding-a-list-of-markdown-blog-posts.md
+++ b/docs/docs/adding-a-list-of-markdown-blog-posts.md
@@ -47,6 +47,7 @@ Second, you need to provide the data to your component with a GraphQL query. Let
 
 ```jsx
 import React from "react"
+import { graphql } from "gatsby"
 import PostLink from "../components/post-link"
 
 const IndexPage = ({

--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -79,6 +79,7 @@ Now create a `blogTemplate.js` inside it with the following content.
 
 ```jsx
 import React from "react"
+import { graphql } from "gatsby"
 
 export default function Template({
   data, // this prop will be injected by the GraphQL query below.

--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -77,7 +77,7 @@ import React from "react"
 import PropTypes from "prop-types"
 
 // Components
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 const Tags = ({ pageContext, data }) => {
   const { tag } = pageContext
@@ -241,7 +241,7 @@ import kebabCase from "lodash/kebabCase"
 
 // Components
 import Helmet from "react-helmet"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 const TagsPage = ({
   data: {

--- a/docs/docs/building-with-components.md
+++ b/docs/docs/building-with-components.md
@@ -86,6 +86,7 @@ Example:
 
 ```jsx
 import React from "react"
+import { graphql } from "gatsby"
 
 class BlogPostTemplate extends React.Component {
   render() {

--- a/docs/docs/wordpress-source-plugin-tutorial.md
+++ b/docs/docs/wordpress-source-plugin-tutorial.md
@@ -124,6 +124,7 @@ Now that you've created GraphQL queries that pull in the data you want, we'll us
 
 ```jsx
 import React from "react"
+import { graphql } from "gatsby"
 
 export default ({ data }) => {
   console.log(data)

--- a/examples/gatsbygram/src/pages/index.js
+++ b/examples/gatsbygram/src/pages/index.js
@@ -1,6 +1,7 @@
 import * as PropTypes from "prop-types"
 import chunk from "lodash/chunk"
 import React from "react"
+import { graphql } from "gatsby"
 
 import { rhythm, scale } from "../utils/typography"
 import presets from "../utils/presets"

--- a/examples/gatsbygram/src/templates/post-page.js
+++ b/examples/gatsbygram/src/templates/post-page.js
@@ -1,5 +1,6 @@
 import * as PropTypes from "prop-types"
 import React from "react"
+import { graphql } from "gatsby"
 import PostDetail from "../components/post-detail"
 import Layout from "../layouts"
 

--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import Img from "gatsby-image"
 import Layout from "../layouts"
 import { rhythm } from "../utils/typography"

--- a/examples/sitemap/src/templates/template-blog-post.js
+++ b/examples/sitemap/src/templates/template-blog-post.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 
 class BlogPost extends React.Component {
   render() {

--- a/examples/using-asciidoc/src/pages/index.js
+++ b/examples/using-asciidoc/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 import Layout from "../layouts"
 

--- a/examples/using-asciidoc/src/templates/article.js
+++ b/examples/using-asciidoc/src/templates/article.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 
 import Layout from "../layouts"
 

--- a/examples/using-contentful/src/pages/image-api.js
+++ b/examples/using-contentful/src/pages/image-api.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import Img from "gatsby-image"
 import Layout from "../layouts"
 import { rhythm } from "../utils/typography"

--- a/examples/using-contentful/src/pages/index.js
+++ b/examples/using-contentful/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import * as PropTypes from "prop-types"
 import Img from "gatsby-image"
 import { rhythm } from "../utils/typography"

--- a/examples/using-contentful/src/templates/category.js
+++ b/examples/using-contentful/src/templates/category.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import * as PropTypes from "prop-types"
 import Img from "gatsby-image"
 import Layout from "../layouts"

--- a/examples/using-contentful/src/templates/product.js
+++ b/examples/using-contentful/src/templates/product.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import * as PropTypes from "prop-types"
 import Img from "gatsby-image"
 import Layout from "../layouts"

--- a/examples/using-emotion-prismjs/src/templates/blog-post.js
+++ b/examples/using-emotion-prismjs/src/templates/blog-post.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { css } from "emotion"
+import { graphql } from "gatsby"
 import { rhythm, scale } from "../utils/typography"
 
 import Layout from "../components/layout"

--- a/examples/using-javascript-transforms/src/articles/2017-03-09-choropleth-on-d3v4/index.js
+++ b/examples/using-javascript-transforms/src/articles/2017-03-09-choropleth-on-d3v4/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import BlogPostChrome from "../../components/BlogPostChrome"
 var d3 = require(`d3`)
 

--- a/examples/using-javascript-transforms/src/articles/2017-05-30-choropleth-on-d3v4-alternate/index.js
+++ b/examples/using-javascript-transforms/src/articles/2017-05-30-choropleth-on-d3v4-alternate/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import BlogPostChrome from "../../components/BlogPostChrome"
 var d3 = require(`d3`)
 

--- a/examples/using-javascript-transforms/src/components/Layouts/blogPost.js
+++ b/examples/using-javascript-transforms/src/components/Layouts/blogPost.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 import MasterLayout from "./master"
 

--- a/examples/using-javascript-transforms/src/components/Layouts/insetPage.js
+++ b/examples/using-javascript-transforms/src/components/Layouts/insetPage.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import SiteSidebar from "../SiteSidebar"
 import MasterLayout from "./master"
 

--- a/examples/using-javascript-transforms/src/templates/mdBlogPost.js
+++ b/examples/using-javascript-transforms/src/templates/mdBlogPost.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import BlogPostChrome from "../components/BlogPostChrome"
 
 class mdBlogPost extends React.Component {

--- a/examples/using-javascript-transforms/src/templates/mdInsetPage.js
+++ b/examples/using-javascript-transforms/src/templates/mdInsetPage.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import InsetPageLayout from "../components/Layouts/insetPage"
 
 class mdInsetPage extends React.Component {

--- a/examples/using-medium/src/pages/index.js
+++ b/examples/using-medium/src/pages/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import Layout from "../components/layout"
 
 const mediumCDNUrl = `https://cdn-images-1.medium.com/max/150/`

--- a/examples/using-mongodb/src/pages/index.js
+++ b/examples/using-mongodb/src/pages/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import StoryItem from "../components/story-item"
 import Layout from "../layouts"
 

--- a/examples/using-mongodb/src/templates/item.js
+++ b/examples/using-mongodb/src/templates/item.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import Layout from "../layouts"
 
 class Item extends React.Component {

--- a/examples/using-remark-copy-linked-files/src/templates/blog-post.js
+++ b/examples/using-remark-copy-linked-files/src/templates/blog-post.js
@@ -1,5 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
+import { graphql } from "gatsby"
 import get from "lodash/get"
 
 import Layout from "../components/layout"

--- a/examples/using-wordpress/src/pages/index.js
+++ b/examples/using-wordpress/src/pages/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import ClockIcon from "react-icons/lib/fa/clock-o"
 
 import Layout from "../layouts"

--- a/examples/using-wordpress/src/templates/page.js
+++ b/examples/using-wordpress/src/templates/page.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react"
+import { graphql } from "gatsby"
 import PostIcons from "../components/PostIcons"
 import Layout from "../layouts"
 

--- a/examples/using-wordpress/src/templates/post.js
+++ b/examples/using-wordpress/src/templates/post.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react"
+import { graphql } from "gatsby"
 import PropTypes from "prop-types"
 import PostIcons from "../components/PostIcons"
 import Img from "gatsby-image"


### PR DESCRIPTION
First of all, thanks for all your work on this great project!

This adds imports for `graphql` from `gatsby`, building on the work by @fk in https://github.com/gatsbyjs/gatsby/pull/6196
