### PR TITLE
[gatsby-plugin-canonical-urls] Allow forcing a trailing slash

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/README.md
+++ b/packages/gatsby-plugin-canonical-urls/README.md
@@ -19,6 +19,7 @@ plugins: [
     resolve: `gatsby-plugin-canonical-urls`,
     options: {
       siteUrl: `https://www.example.com`,
+      requireTrailingSlash: false,
     },
   },
 ]
@@ -28,5 +29,5 @@ With the above configuration, the plugin will add to the head of every HTML page
 a `rel=canonical` e.g.
 
 ```html
-<link rel="canonical" href="http://www.example.com/about-us/" />
+<link rel="canonical" href="http://www.example.com/about-us" />
 ```

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-canonical-urls",
   "description": "Stub description for gatsby-plugin-canonical-urls",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Adds canonical link to head correctly applies a trailing slash to the canonical link when set 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        <link
+          data-basehost="someurl.com"
+          data-baseprotocol="http:"
+          href="http://someurl.com/somepost/"
+          rel="canonical"
+        />,
+      ],
+    ],
+  ],
+}
+`;
+
 exports[`Adds canonical link to head correctly creates a canonical link if siteUrl is set 1`] = `
 [MockFunction] {
   "calls": Array [

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -8,7 +8,7 @@ exports[`Adds canonical link to head correctly applies a trailing slash to the c
         <link
           data-baseHost="someurl.com"
           data-baseProtocol="http:"
-          data-trailingSlash="true"
+          data-requireTrailingSlash="true"
           href="http://someurl.com/somepost/"
           rel="canonical"
         />,
@@ -26,7 +26,7 @@ exports[`Adds canonical link to head correctly creates a canonical link if siteU
         <link
           data-baseHost="someurl.com"
           data-baseProtocol="http:"
-          data-trailingSlash="false"
+          data-requireTrailingSlash="false"
           href="http://someurl.com/somepost"
           rel="canonical"
         />,

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -6,8 +6,9 @@ exports[`Adds canonical link to head correctly applies a trailing slash to the c
     Array [
       Array [
         <link
-          data-basehost="someurl.com"
-          data-baseprotocol="http:"
+          data-baseHost="someurl.com"
+          data-baseProtocol="http:"
+          data-trailingSlash="true"
           href="http://someurl.com/somepost/"
           rel="canonical"
         />,
@@ -23,8 +24,9 @@ exports[`Adds canonical link to head correctly creates a canonical link if siteU
     Array [
       Array [
         <link
-          data-basehost="someurl.com"
-          data-baseprotocol="http:"
+          data-baseHost="someurl.com"
+          data-baseProtocol="http:"
+          data-trailingSlash="false"
           href="http://someurl.com/somepost"
           rel="canonical"
         />,

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-ssr.js
@@ -36,4 +36,24 @@ describe(`Adds canonical link to head correctly`, () => {
     expect(setHeadComponents).toMatchSnapshot()
     expect(setHeadComponents).toHaveBeenCalledTimes(0)
   })
+
+  it(`applies a trailing slash to the canonical link when set`, async () => {
+    const pluginOptions = {
+      siteUrl: `http://someurl.com`,
+      requireTrailingSlash: true,
+    }
+    const setHeadComponents = jest.fn()
+    const pathname = `/somepost`
+
+    await onRenderBody(
+      {
+        setHeadComponents,
+        pathname,
+      },
+      pluginOptions,
+    )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,12 +1,16 @@
 exports.onRouteUpdate = ({ location }) => {
   const domElem = document.querySelector(`link[rel='canonical']`)
-  var existingValue = domElem.getAttribute(`href`)
-  var baseProtocol = domElem.getAttribute(`data-baseProtocol`)
-  var baseHost = domElem.getAttribute(`data-baseHost`)
+  const existingValue = domElem.getAttribute(`href`)
+  const baseProtocol = domElem.getAttribute(`data-baseProtocol`)
+  const baseHost = domElem.getAttribute(`data-baseHost`)
+  let pathname = location.pathname
+  if(domElem.getAttribute(`data-requireTrailingSlash`) === `true`) {
+    pathname = pathname.replace(/\/$|$/, `/`)
+  }
   if (existingValue && baseProtocol && baseHost) {
     domElem.setAttribute(
       `href`,
-      `${baseProtocol}//${baseHost}${location.pathname}${location.search}${
+      `${baseProtocol}//${baseHost}${pathname}${location.search}${
         location.hash
       }`
     )

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -7,20 +7,19 @@ exports.onRenderBody = (
 ) => {
   if (pluginOptions && pluginOptions.siteUrl) {
     const parsedUrl = url.parse(pluginOptions.siteUrl)
+    const requireTrailingSlash = pluginOptions.requireTrailingSlash || false
     let myUrl = `${pluginOptions.siteUrl}${pathname}`
-    console.log(`What are plugin options ${JSON.stringify(pluginOptions)}`)
-    if(pluginOptions.requireTrailingSlash || false) {
-      console.log(`Requiring trailing slash on url ${myUrl}`)
+    if(requireTrailingSlash) {
       myUrl = myUrl.replace(/\/$|$/, `/`)
-      console.log(`Finished: ${myUrl}`)
     }
     setHeadComponents([
       <link
         rel="canonical"
         key={myUrl}
         href={myUrl}
-        data-baseprotocol={parsedUrl.protocol}
-        data-basehost={parsedUrl.host}
+        data-baseProtocol={parsedUrl.protocol}
+        data-baseHost={parsedUrl.host}
+        data-requireTrailingSlash={`${requireTrailingSlash}`}
       />,
     ])
   }

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -7,7 +7,13 @@ exports.onRenderBody = (
 ) => {
   if (pluginOptions && pluginOptions.siteUrl) {
     const parsedUrl = url.parse(pluginOptions.siteUrl)
-    const myUrl = `${pluginOptions.siteUrl}${pathname}`
+    let myUrl = `${pluginOptions.siteUrl}${pathname}`
+    console.log(`What are plugin options ${JSON.stringify(pluginOptions)}`)
+    if(pluginOptions.requireTrailingSlash || false) {
+      console.log(`Requiring trailing slash on url ${myUrl}`)
+      myUrl = myUrl.replace(/\/$|$/, `/`)
+      console.log(`Finished: ${myUrl}`)
+    }
     setHeadComponents([
       <link
         rel="canonical"


### PR DESCRIPTION
This is the last thing I needed to tweak in order to force a trailing slash for my site (a limitation of Github Pages). I also think I fixed a discrepancy in some of the data attributes in the browser (mismatched names).

This shouldn't change any existing behavior as it's entirely opt-in via the new plugin option.

Happy to tweak whatever in the PR as this is the first time I've done it here :)
