### PR TITLE
Add DEV Community to community page

### DIFF
--- a/docs/docs/awesome-gatsby.md
+++ b/docs/docs/awesome-gatsby.md
@@ -59,3 +59,9 @@ See the [list of official and community plugins](/docs/plugins/)
 - [Kategorien & Tags zu Gatsby hinzufügen](https://www.lekoarts.de/blog/kategorien-tags-zu-gatsby-hinzufugen/)
 - [Erstelle dein Design System mit Gatsby](https://www.lekoarts.de/blog/erstelle-dein-design-system-mit-gatsby/)
 - [Upgrade-Guide: Gatsby v2 (German)](https://www.lekoarts.de/blog/upgrade-guide-gatsby-v-2/)
+
+## Other resources
+
+### DEV Community 
+
+[The DEV Community Gatsby tag](https://dev.to/t/gatsbyjs) is a place to share Gatsby projects, articles and tutorials as well as start discussions and ask for feedback on Gatsby-related topics. Developers of all skill-levels are welcome to take part.

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -44,3 +44,7 @@ If you need an answer right away, check out the
 [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bVoxkfV) #gatsby channel. There
 are usually a number of Gatsby experts there who can help out or point you to
 useful resources.
+
+### DEV Community 
+
+[The DEV Community Gatsby tag](https://dev.to/t/gatsbyjs) is a place to share Gatsby projects, articles and tutorials as well as start discussions and ask for feedback on Gatsby-related topics. Developers of all skill-levels are welcome to take part.

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -44,7 +44,3 @@ If you need an answer right away, check out the
 [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bVoxkfV) #gatsby channel. There
 are usually a number of Gatsby experts there who can help out or point you to
 useful resources.
-
-### DEV Community 
-
-[The DEV Community Gatsby tag](https://dev.to/t/gatsbyjs) is a place to share Gatsby projects, articles and tutorials as well as start discussions and ask for feedback on Gatsby-related topics. Developers of all skill-levels are welcome to take part.


### PR DESCRIPTION
[DEV Community](https://dev.to) is a burgeoning source of guidance and discussion on software topics, especially web dev. This will be a useful link to point to the official place to discuss Gatsby matters on the platform.

A few additional links pertaining to dev.to

Traffic stats: https://www.similarweb.com/website/dev.to
Twitter: https://twitter.com/thepracticaldev
Gatsby tag (as included in PR): https://dev.to/t/gatsbyjs

Some example Gatsby posts:
https://dev.to/whoisryosuke/deploy-a-static-react-blog-using-gatsbyjs-and-github-45gc
https://dev.to/singuerinc/migrate-from-jekyll-to-gatsby-11a
https://dev.to/leomeloxp/what-is-jam-stack-2957

Happy coding :heart: