### PR TITLE
always assume at least one cpu

### DIFF
--- a/packages/gatsby/src/utils/html-renderer-queue.js
+++ b/packages/gatsby/src/utils/html-renderer-queue.js
@@ -1,6 +1,6 @@
 const convertHrtime = require(`convert-hrtime`)
 const Worker = require(`jest-worker`).default
-const numWorkers = require(`physical-cpu-count`)
+const numWorkers = require(`physical-cpu-count`) || 1
 const { chunk } = require(`lodash`)
 
 const workerPool = new Worker(require.resolve(`./worker`), {


### PR DESCRIPTION
alpine doesn't come with `lscpu` so the cpu check fails, reporting 0, meaning no pages are written out