### PR TITLE
Add missing `graphql` import in `StaticQuery` docs

### DIFF
--- a/docs/docs/static-query.md
+++ b/docs/docs/static-query.md
@@ -8,7 +8,7 @@ Gatsby v2 introduces `StaticQuery`, a new API that allows non-page components to
 
 ```jsx
 import React from "react"
-import { StaticQuery } from "gatsby"
+import { StaticQuery, graphql } from "gatsby"
 
 const Header = () => (
   <StaticQuery


### PR DESCRIPTION
Simple tweak to the docs to add the missing `graphql` import which I believe is now required in v2.