### PR TITLE
Docs: fix highlighted code fragment

### DIFF
--- a/docs/docs/querying-with-graphql.md
+++ b/docs/docs/querying-with-graphql.md
@@ -304,7 +304,7 @@ export const query = graphql`
 
 Now, we can use the component together with the exported fragment in our index page.
 
-```jsx{28}
+```jsx{26}
 // src/pages/index.jsx
 
 import React from "react";


### PR DESCRIPTION
## What does this change?

https://www.gatsbyjs.org/docs/querying-with-graphql/

<img width="784" alt="screen shot 2018-07-17 at 17 01 18" src="https://user-images.githubusercontent.com/2244375/42825766-0783f4ce-89e3-11e8-9347-cda87311cf8f.png">

Previously the wrong code fragment was highlighted in the documentation. Since this part talks about how to create the `IndexPostFragment` graphql fragment, it should be highlighted as a result.