### PR TITLE
Fix peerDep warning

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "graphql": "^0.11.7"
+    "graphql": "^0.13.2"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",


### PR DESCRIPTION
I was seeing `warning "gatsby > babel-plugin-remove-graphql-queries@2.0.2-beta.4" has incorrect peer dependency "graphql@^0.11.7".` messages. The Gatsby package asks for version `^0.13.2`, so I've updated `babel-plugin-remove-graphql-queries` to the same thing to see if that fixes it.

afaik `^0.11.7` and `^0.13.2` should resolve to the same version? 

Either way this PR is a good excuse to check that the tests are passing again.

Closes #6447