### PR TITLE
gatsby-plugin-netlify generates wrong js Link

### DIFF
--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -42,7 +42,7 @@ function createScriptHeaderGenerator(manifest, pathPrefix) {
     }
 
     // Always add starting slash, as link entries start with slash as relative to deploy root
-    return linkTemplate(`${pathPrefix}/${chunk}`)
+    return linkTemplate(`${pathPrefix}/js/${chunk}`)
   }
 }
 


### PR DESCRIPTION
The _headers file generated is like:
```
/404.html
  Link: </webpack-runtime-538a792ce8cbb482dfed.js>; rel=preload; as=script
  Link: </component---src-pages-404-js-c6e3c0efeaf493f3355e.js>; rel=preload; as=script
```
When `public` folder was rearranged and js files start be puted on `/public/js` broke this
