### PR TITLE
Update StaticQuery article to link to open issue

### DIFF
--- a/docs/docs/static-query.md
+++ b/docs/docs/static-query.md
@@ -1,11 +1,14 @@
 ---
-title: "Querying data in non-page components using StaticQuery"
+title: "Querying data in components using StaticQuery"
 ---
 
-Gatsby v2 introduces `StaticQuery`, a new API that allows non-page components to retrieve data via GraphQL query.
+Gatsby v2 introduces `StaticQuery`, a new API that allows components to retrieve data via GraphQL query.
+
+_Note: There is [a known issue with `StaticQuery`](https://github.com/gatsbyjs/gatsby/issues/6350) that only allows it to work with non-page components as seen in the example below. Until [#6350](https://github.com/gatsbyjs/gatsby/issues/6350) is resolved, page queries should be performed [as seen in this article](https://next.gatsbyjs.org/docs/build-a-page-with-graphql-query/)._
 
 ## Basic example
 
+We'll create a new `Header` component located at `src/components/header.js`:
 ```jsx
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"


### PR DESCRIPTION
As seen in  https://github.com/gatsbyjs/gatsby/issues/6350 there is a bug that is preventing `StaticQuery` from working for page components. This PR alerts the reader to this issue, and provides a link to a (not-there-yet-but-soon) article for performing queries at the page level.

![](https://media.giphy.com/media/Ph0oIVQeuvh0k/giphy.gif)

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
