### PR TITLE
use proper zipkin-javascript-opentracing library

### DIFF
--- a/packages/gatsby/src/utils/tracer/zipkin-local.js
+++ b/packages/gatsby/src/utils/tracer/zipkin-local.js
@@ -1,6 +1,6 @@
 const zipkin = require(`zipkin`)
 const { HttpLogger } = require(`zipkin-transport-http`)
-const ZipkinTracer = require(`moocar-zipkin-javascript-opentracing`)
+const ZipkinTracer = require(`zipkin-javascript-opentracing`)
 const fetch = require(`node-fetch`)
 
 let logger


### PR DESCRIPTION
Related to #6347. 

Now that https://github.com/DanielMSchmidt/zipkin-javascript-opentracing/pull/68 has been merged, and released as version 1.6.0, we can use the original library. 