### PR TITLE
Add warning for relative paths in source-filesystem.

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -1,5 +1,6 @@
 const chokidar = require(`chokidar`)
 const fs = require(`fs`)
+const path = require(`path`)
 const { Machine } = require(`xstate`)
 
 const { createFileNode } = require(`./create-file-node`)
@@ -84,6 +85,19 @@ Please pick a path to an existing directory.
 
 See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
       `)
+  }
+
+  // Validate that the path is absolute.
+  // Absolute paths are required to resolve images correctly.
+  if (!path.isAbsolute(pluginOptions.path)) {
+    reporter.warn(`The path passed to gatsby-source-filesystem is relative:
+
+${pluginOptions.path}
+
+It is recommended to use an absolute path.
+
+See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
+    `)
   }
 
   const fsMachine = createFSMachine()

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -90,14 +90,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
   // Validate that the path is absolute.
   // Absolute paths are required to resolve images correctly.
   if (!path.isAbsolute(pluginOptions.path)) {
-    reporter.warn(`The path passed to gatsby-source-filesystem is relative:
-
-${pluginOptions.path}
-
-It is recommended to use an absolute path.
-
-See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
-    `)
+    pluginOptions.path = path.resolve(process.cwd(), pluginOptions.path)
   }
 
   const fsMachine = createFSMachine()


### PR DESCRIPTION
This adds a warning when using `gatsby-source-filesystem` with a relative path. Relative paths work, but fail silently when trying to query images (type `File`). Related issue: #6367 

I added this as a warning, should it `panic` instead?