### PR TITLE
fix "invalid html.js fails silently"

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -34,12 +34,7 @@ try {
   if (testRequireError(`../src/html`, err)) {
     Html = require(`./default-html`)
   } else {
-    console.log(
-      `\n\nThere was an error requiring "src/html.js"\n\n`,
-      err,
-      `\n\n`
-    )
-    process.exit()
+    throw err
   }
 }
 


### PR DESCRIPTION
Using `process.exit()` doesn't seem to work well with `jest-worker` - it seems like it just keeps waiting. Throwing seems to be caught and is handled properly - Gatsby terminates build and displays error.

As bonus this also provide more meaningful error message pointing to location of error (previously it would show stack trace inside render-page.js bundle)

Using example reproduction steps from from #6498 we will get now

```
...
success Building production JavaScript and CSS bundles — 2.594 s

error Building static HTML for pages failed

See our docs page on debugging HTML builds for help https://goo.gl/yL9lND

  30 |
  31 | HTML.propTypes = {
> 32 |   htmlAttributes: PropTypes.object,
     |                   ^
  33 |   headComponents: PropTypes.array,
  34 |   bodyAttributes: PropTypes.object,
  35 |   preBodyComponents: PropTypes.array,


  WebpackError: ReferenceError: PropTypes is not defined

  - html.js:32 Module../src/html.js
    lib/src/html.js:32:19

...
```

Closes #6498
