### PR TITLE
Solve Loading (StaticQuery) on Page Component

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -70,27 +70,9 @@ const handleQuery = (
   query,
   component
 ) => {
-  // If this is page query
-  if (components.has(component)) {
-    if (components.get(component).query !== query.text) {
-      boundActionCreators.replaceComponentQuery({
-        query: query.text,
-        componentPath: component,
-      })
-
-      debug(
-        `Page query in ${component} ${
-          components.get(component).query.length === 0
-            ? `was added`
-            : `has changed`
-        }.`
-      )
-      queueQueriesForPageComponent(component)
-    }
-    return true
-
-    // Add action / reducer + watch staticquery files
-  } else if (query.isStaticQuery) {
+  // If this is a static query
+  // Add action / reducer + watch staticquery files
+  if (query.isStaticQuery) {
     const isNewQuery = !staticQueryComponents.has(query.jsonName)
     if (
       isNewQuery ||
@@ -113,6 +95,25 @@ const handleQuery = (
 
       boundActionCreators.deleteComponentsDependencies([query.jsonName])
       queueQueryForPathname(query.jsonName)
+    }
+    return true
+
+    // If this is page query
+  } else if (components.has(component)) {
+    if (components.get(component).query !== query.text) {
+      boundActionCreators.replaceComponentQuery({
+        query: query.text,
+        componentPath: component,
+      })
+
+      debug(
+        `Page query in ${component} ${
+          components.get(component).query.length === 0
+            ? `was added`
+            : `has changed`
+        }.`
+      )
+      queueQueriesForPageComponent(component)
     }
     return true
   }


### PR DESCRIPTION
#6350

All I did was switching the order of the query check:

1. Check if a query is a static query
2. Then check if it's a page query

Therefore all the static query in page component is being processed.

Can you check this out and give me some feedback on my approach, @KyleAMathews? Thanks!!