### PR TITLE
fix: Bumping Serve Up to 9.2.0 Broke Calls to Serve's API

### DIFF
--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -7,11 +7,10 @@ module.exports = program => {
   let { port } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 
-  let server = http.createServer((request, response) => {
-    return handler(request, response, {
+  let server = http.createServer((request, response) => handler(request, response, {
       "public": `public`,
-    })
-  })
+    }),
+  )
 
   server.listen(port, () => {
     console.log(`gatsby serve running at port: `, port)

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -1,10 +1,11 @@
 /* @flow weak */
 const handler = require(`serve-handler`)
+const openurl = require(`opn`)
 const http = require(`http`)
 const signalExit = require(`signal-exit`)
 
 module.exports = program => {
-  let { port } = program
+  let { port, open } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 
   let server = http.createServer((request, response) => handler(request, response, {
@@ -13,7 +14,13 @@ module.exports = program => {
   )
 
   server.listen(port, () => {
-    console.log(`gatsby serve running at port: `, port)
+    let openUrlString = `http://localhost:` + port
+    console.log(`gatsby serve running at:`, openUrlString)
+    if (open) {
+      let openUrlString = `http://localhost:` + port
+      console.log(`Opening browser...`)
+      openurl(openUrlString)
+    }
   })
 
   signalExit((code, signal) => {

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -1,14 +1,23 @@
 /* @flow weak */
-const serve = require(`serve`)
+const handler = require('serve-handler');
+const http = require('http');
 const signalExit = require(`signal-exit`)
 
 module.exports = program => {
-  let { port, open, directory } = program
+  let { port } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 
-  let server = serve(`${directory}/public`, { port, open })
+  let server = http.createServer((request, response) => {
+    return handler(request, response, {
+      "public": "public"
+    });
+  });
+
+  server.listen(port, () => {
+    console.log("gatsby serve running at port: ", port)
+  });
 
   signalExit((code, signal) => {
-    server.stop()
+    server.close();
   })
 }

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -1,6 +1,6 @@
 /* @flow weak */
-const handler = require('serve-handler');
-const http = require('http');
+const handler = require(`serve-handler`)
+const http = require(`http`)
 const signalExit = require(`signal-exit`)
 
 module.exports = program => {
@@ -9,15 +9,15 @@ module.exports = program => {
 
   let server = http.createServer((request, response) => {
     return handler(request, response, {
-      "public": "public"
-    });
-  });
+      "public": `public`,
+    })
+  })
 
   server.listen(port, () => {
-    console.log("gatsby serve running at port: ", port)
-  });
+    console.log(`gatsby serve running at port: `, port)
+  })
 
   signalExit((code, signal) => {
-    server.close();
+    server.close()
   })
 }


### PR DESCRIPTION
Follow Up on:

https://github.com/gatsbyjs/gatsby/issues/6546

https://github.com/gatsbyjs/gatsby/commit/69125ccb5604830f6b11996ff3f6dddbe6fe0260

Apologies in advance if some things are lacking, not super familiar with gatsby code base yet. I tested locally for v1 and it was fine.

In particular:
- is `directory` still needed? See https://github.com/zeit/serve-handler#public-string
- is `open` still needed?