### PR TITLE
[v2] Update SSR API docs examples to use pure CommonJS

### DIFF
--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -24,8 +24,8 @@
  * @param {Object} pluginOptions
  * @example
  * // From gatsby-plugin-glamor
- * import { renderToString } from "react-dom/server"
- * import inline from "glamor-inline"
+ * const { renderToString } = require("react-dom/server")
+ * const inline = require("glamor-inline")
  *
  * exports.replaceRenderer = ({ bodyComponent, replaceBodyHTMLString }) => {
  *   const bodyHTML = renderToString(bodyComponent)
@@ -78,7 +78,7 @@ exports.replaceStaticRouterComponent = true
  * is merged with other body props and passed to `html.js` as `bodyProps`.
  * @param {Object} pluginOptions
  * @example
- * import Helmet from "react-helmet"
+ * const Helmet = require("react-helmet")
  *
  * exports.onRenderBody = (
  *   { setHeadComponents, setHtmlAttributes, setBodyAttributes },


### PR DESCRIPTION
Stumbled upon this today when I found a client site’s `gatsby-ssr.js` not working. Converting to pure CommonJS fixes it for me.

Ref: https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#convert-to-either-pure-commonjs-or-pure-es6