### PR TITLE
fix(joi-schemas): allow mediaType to be null to support git submodule…

### DIFF
--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -34,7 +34,7 @@ export const nodeSchema = Joi.object()
     internal: Joi.object()
       .keys({
         contentDigest: Joi.string().required(),
-        mediaType: Joi.string(),
+        mediaType: Joi.string().allow(null),
         type: Joi.string().required(),
         owner: Joi.string().required(),
         fieldOwners: Joi.array(),


### PR DESCRIPTION
Small schema update to support git submodules inside `src/pages`.

Fixes #6606