### PR TITLE
Updating site category to match others

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1299,7 +1299,7 @@
     There are different types of foster care that can suit you. We offer training and 24/7 support.
   categories:
     - Charity
-    - Non Profit
+    - Nonprofit
     - Education
     - Documentation
     - Marketing


### PR DESCRIPTION
Removed space in "non profit" category on site to match all others, which are using "nonprofit." Will ensure only one "nonprofit" category exists on the front end.