### PR TITLE
Fix extra space below the first line of new slogan

### DIFF
--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -48,7 +48,7 @@ const MastheadContent = () => (
         css={{
           ...scale(0.7),
           color: colors.gatsby,
-          lineHeight: 1,
+          lineHeight: 1.25,
           margin: 0,
           marginBottom: `1.2em`,
           padding: 0,


### PR DESCRIPTION
This issue was caused by conflicting line heights between the parent `<h1>` and the child `<Slider />` Component. I attempted to modify the `<Slider />` Component's line-height first, but this resulted in clipping of the `<Slider />` Component's contents.
