### PR TITLE
Add support for loading .pdf files in V2

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -339,6 +339,16 @@ module.exports = async ({
   }
 
   /**
+   * Loads pdf assets
+   */
+  rules.pdfs = () => {
+    return {
+      use: [loaders.url()],
+      test: /\.pdf$/,
+    }
+  }
+
+  /**
    * Loads image assets, inlines images via a data URI if they are below
    * the size threshold
    */

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -289,6 +289,7 @@ module.exports = async (
       rules.js(),
       rules.yaml(),
       rules.fonts(),
+      rules.pdfs(),
       rules.images(),
       rules.audioVideo(),
     ]


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
V2 did not include webpack support for loading in .pdf files. This feature adds a new webpack rule for handling .pdf files.
Fixes issue https://github.com/gatsbyjs/gatsby/issues/5998 