### PR TITLE
fix: update getting started docs to use v2 starter

### DIFF
--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -33,9 +33,13 @@ class IndexRoute extends React.Component {
             <h2 id="using-the-gatsby-cli">Using the Gatsby CLI</h2>
             <ol>
               <li>
-                Create a new site.
-                {` `}
-                <code>gatsby new gatsby-site</code>
+                <p>Create a new site.</p>
+                <pre>
+                  <code className="language-sh">
+                    gatsby new gatsby-site
+                    https://github.com/gatsbyjs/gatsby-starter-default#v2
+                  </code>
+                </pre>
               </li>
               <li>
                 <code>cd gatsby-site</code>


### PR DESCRIPTION
The v2 docs currently install a v1 starter. This PR fixes that.