### PR TITLE
Add missing require

### DIFF
--- a/packages/gatsby/src/utils/html-renderer-queue.js
+++ b/packages/gatsby/src/utils/html-renderer-queue.js
@@ -1,3 +1,4 @@
+const Promise = require(`bluebird`)
 const convertHrtime = require(`convert-hrtime`)
 const Worker = require(`jest-worker`).default
 const numWorkers = require(`physical-cpu-count`) || 1


### PR DESCRIPTION
Seems like this was causing build failures after #6727. Not sure why Gatsby's CI or build tests didn't pick this up...

Here's the error from building Gatsbygram:

```
success Building production JavaScript and CSS bundles — 23.246 s

error Building static HTML for pages failed

See our docs page on debugging HTML builds for help https://goo.gl/yL9lND

   7 |  		// Check if module is in cache
   8 |  		if(installedModules[moduleId]) {
>  9 |  			return installedModules[moduleId].exports;
     | ^
  10 |  		}
  11 |  		// Create a new module (and put it into the cache)
  12 |  		var module = installedModules[moduleId] = {


  WebpackError: TypeError: Promise.map is not a function
```