### PR TITLE
Remove empty space from react-helmet <title>

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -266,7 +266,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               }}
             >
               <Helmet>
-                <title> {data.sitesYaml.title} </title>
+                <title>{data.sitesYaml.title}</title>
                 <meta
                   name="og:image"
                   content={`https://next.gatsbyjs.org${


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/6714