### PR TITLE
Fix (gatsby-plugin-stylus v2): classes not getting applied

### DIFF
--- a/packages/gatsby-plugin-stylus/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-stylus/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -24,7 +24,6 @@ exports[`gatsby-plugin-stylus Stage: build-html / No options 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -72,7 +71,6 @@ exports[`gatsby-plugin-stylus Stage: build-html / PostCss plugins 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -123,7 +121,6 @@ exports[`gatsby-plugin-stylus Stage: build-html / Stylus options #1 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -181,7 +178,6 @@ exports[`gatsby-plugin-stylus Stage: build-html / Stylus options #2 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -236,7 +232,6 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / No options 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -284,7 +279,6 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / PostCss plugins 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -335,7 +329,6 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / Stylus options #1 1`] = 
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -393,7 +386,6 @@ exports[`gatsby-plugin-stylus Stage: build-javascript / Stylus options #2 1`] = 
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -448,7 +440,6 @@ exports[`gatsby-plugin-stylus Stage: develop / No options 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -496,7 +487,6 @@ exports[`gatsby-plugin-stylus Stage: develop / PostCss plugins 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -547,7 +537,6 @@ exports[`gatsby-plugin-stylus Stage: develop / Stylus options #1 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -605,7 +594,6 @@ exports[`gatsby-plugin-stylus Stage: develop / Stylus options #2 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -660,7 +648,6 @@ exports[`gatsby-plugin-stylus Stage: develop-html / No options 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -708,7 +695,6 @@ exports[`gatsby-plugin-stylus Stage: develop-html / PostCss plugins 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -759,7 +745,6 @@ exports[`gatsby-plugin-stylus Stage: develop-html / Stylus options #1 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",
@@ -817,7 +802,6 @@ exports[`gatsby-plugin-stylus Stage: develop-html / Stylus options #2 1`] = `
                   ],
                 },
                 Object {
-                  "exclude": /\\\\\\.module\\\\\\.styl\\$/,
                   "test": /\\\\\\.styl\\$/,
                   "use": Array [
                     "miniCssExtract",

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -38,24 +38,23 @@ exports.onCreateWebpackConfig = (
     },
   }
 
-  const stylusRuleModules = {
-    test: /\.module\.styl$/,
+  const stylusRule = {
+    test: /\.styl$/,
     use: isSSR
       ? [loaders.null()]
       : [
           loaders.miniCssExtract(),
-          loaders.css({ modules: true, importLoaders: 2 }),
+          loaders.css({ importLoaders: 2 }),
           loaders.postcss({ plugins: postCssPlugins }),
           stylusLoader,
         ],
   }
 
-  const stylusRule = {
-    test: /\.styl$/,
-    exclude: /\.module\.styl$/,
+  const stylusRuleModules = {
+    test: /\.module\.styl$/,
     use: [
       !isSSR && loaders.miniCssExtract(),
-      loaders.css({ importLoaders: 2 }),
+      loaders.css({ modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       stylusLoader,
     ].filter(Boolean),


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/6733
Rules for `.module.sty` and .`styl` were switched to match less/sass plugin configuration