### PR TITLE
Duplicate document fix 

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/file-parser.js.snap
@@ -204,5 +204,59 @@ Map {
     ],
     "kind": "Document",
   },
+  "static-query-named-export.js" => Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "hash": 407706182,
+        "isStaticQuery": true,
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 29,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 21,
+            "start": 6,
+          },
+          "value": "StaticQueryName",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 29,
+            "start": 22,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 27,
+                "start": 24,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 27,
+                  "start": 24,
+                },
+                "value": "foo",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "text": "query StaticQueryName { foo }",
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
 }
 `;

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
@@ -37,6 +37,12 @@ query {
     render={data => <div>{data.foo}</div>}
   />
 )`,
+    "static-query-named-export.js": `export const Component = () => (
+  <StaticQuery
+    query={graphql\`query StaticQueryName { foo }\`}
+    render={data => <div>{data.doo}</div>}
+  />
+)`,
   }
 
   const parser = new FileParser()
@@ -47,6 +53,7 @@ query {
 
   it(`extracts query AST correctly from files`, async () => {
     const results = await parser.parseFiles(Object.keys(MOCK_FILE_INFO))
+    console.log(results)
     expect(results).toMatchSnapshot()
   })
 })

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
@@ -53,7 +53,6 @@ query {
 
   it(`extracts query AST correctly from files`, async () => {
     const results = await parser.parseFiles(Object.keys(MOCK_FILE_INFO))
-    console.log(results)
     expect(results).toMatchSnapshot()
   })
 })

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -137,9 +137,9 @@ async function findGraphQLTags(file, text): Promise<Array<DefinitionNode>> {
                     )
                 )
 
-                uniqueAstDefinitions.forEach(def => {
-                  return generateQueryName({ def, hash, file })
-                })
+                uniqueAstDefinitions.forEach(def =>
+                  generateQueryName({ def, hash, file })
+                )
 
                 queries.push(...uniqueAstDefinitions)
               },

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -127,11 +127,21 @@ async function findGraphQLTags(file, text): Promise<Array<DefinitionNode>> {
 
                 if (isGlobal) warnForGlobalTag(file)
 
-                gqlAst.definitions.forEach(def =>
-                  generateQueryName({ def, hash, file })
+                const uniqueAstDefinitions = gqlAst.definitions.filter(
+                  def =>
+                    !queries.find(
+                      query =>
+                        query.name.value == def.name.value &&
+                        query.name.loc.start == def.name.loc.start &&
+                        query.name.loc.end == def.name.loc.end
+                    )
                 )
 
-                queries.push(...gqlAst.definitions)
+                uniqueAstDefinitions.forEach(def => {
+                  return generateQueryName({ def, hash, file })
+                })
+
+                queries.push(...uniqueAstDefinitions)
               },
             })
           },

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -127,26 +127,20 @@ async function findGraphQLTags(file, text): Promise<Array<DefinitionNode>> {
 
                 if (isGlobal) warnForGlobalTag(file)
 
-                const uniqueAstDefinitions = gqlAst.definitions.filter(
-                  def =>
-                    !queries.find(
-                      query =>
-                        query.name.value == def.name.value &&
-                        query.name.loc.start == def.name.loc.start &&
-                        query.name.loc.end == def.name.loc.end
-                    )
-                )
-
-                uniqueAstDefinitions.forEach(def =>
+                gqlAst.definitions.forEach(def =>
                   generateQueryName({ def, hash, file })
                 )
 
-                queries.push(...uniqueAstDefinitions)
+                queries.push(...gqlAst.definitions)
               },
             })
           },
         })
-        resolve(queries)
+
+        // Remove duplicate queries
+        const uniqueQueries = _.uniqBy(queries, _.isEqual)
+
+        resolve(uniqueQueries)
       })
       .catch(reject)
   })


### PR DESCRIPTION
This fixes `findGraphQLTags` from inserting the same `graphql` template tag twice into queries.

What was happening is that both `ExportNamedDeclaration` and `TaggedTemplateExpression` traversals we're seeing the same `graphql` tag. This fix introduces a filter inside `ExportNamedDeclaration` that will skip adding any new `graphql` definitions that were already added by `TaggedTemplateExpression`. 

Closes #6337 

