### PR TITLE
[v2] gatsby develop - prefetch data and wait for it before changing path

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -151,12 +151,10 @@ class GatsbyLink extends React.Component {
               }
             }
 
-            // In production, make sure the necessary scripts are
+            // Make sure the necessary scripts and data are
             // loaded before continuing.
-            if (process.env.NODE_ENV === `production`) {
-              e.preventDefault()
-              window.___push(this.state.to)
-            }
+            e.preventDefault()
+            window.___push(this.state.to)
           }
 
           return true

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -6,6 +6,8 @@ import socketIo from "./socketIo"
 import emitter from "./emitter"
 import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
 import loader from "./loader"
+import syncRequires from "./sync-requires"
+import pages from "./pages.json"
 
 window.___emitter = emitter
 
@@ -42,6 +44,9 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     undefined,
     ReactDOM.render
   )[0]
+
+  loader.addPagesArray(pages)
+  loader.addDevRequires(syncRequires)
 
   loader.getResourcesForPathname(window.location.pathname, () => {
     let Root = preferDefault(require(`./root`))

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -5,6 +5,7 @@ import domReady from "domready"
 import socketIo from "./socketIo"
 import emitter from "./emitter"
 import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
+import loader from "./loader"
 
 window.___emitter = emitter
 
@@ -36,17 +37,18 @@ apiRunnerAsync(`onClientEntry`).then(() => {
 
   const rootElement = document.getElementById(`___gatsby`)
 
-  let Root = preferDefault(require(`./root`))
-
   const renderer = apiRunner(
     `replaceHydrateFunction`,
     undefined,
     ReactDOM.render
   )[0]
 
-  domReady(() => {
-    renderer(<Root />, rootElement, () => {
-      apiRunner(`onInitialClientRender`)
+  loader.getResourcesForPathname(window.location.pathname, () => {
+    let Root = preferDefault(require(`./root`))
+    domReady(() => {
+      renderer(<Root />, rootElement, () => {
+        apiRunner(`onInitialClientRender`)
+      })
     })
   })
 })

--- a/packages/gatsby/cache-dir/json-store.js
+++ b/packages/gatsby/cache-dir/json-store.js
@@ -4,6 +4,12 @@ import PageRenderer from "./page-renderer"
 import { StaticQueryContext } from "gatsby"
 import socketIo, { getStaticQueryData, getPageQueryData } from "./socketIo"
 
+if (process.env.NODE_ENV === `production`) {
+  throw new Error(
+    `It appears like Gatsby is misconfigured. JSONStore shouldn't be used in production.`
+  )
+}
+
 const getPathFromProps = props =>
   props.pageResources && props.pageResources.page
     ? props.pageResources.page.path
@@ -17,32 +23,25 @@ class JSONStore extends React.Component {
       pageQueryData: getPageQueryData(),
       path: null,
     }
-    if (process.env.NODE_ENV !== `production`) {
-      this.socket = socketIo()
-    }
+
+    this.socket = socketIo()
   }
 
   handleMittEvent = (type, event) => {
-    if (process.env.NODE_ENV !== `production`) {
-      this.setState({
-        staticQueryData: getStaticQueryData(),
-        pageQueryData: getPageQueryData(),
-      })
-    }
+    this.setState({
+      staticQueryData: getStaticQueryData(),
+      pageQueryData: getPageQueryData(),
+    })
   }
 
   componentDidMount() {
-    if (process.env.NODE_ENV !== `production`) {
-      this.registerPath(getPathFromProps(this.props))
-      ___emitter.on(`*`, this.handleMittEvent)
-    }
+    this.registerPath(getPathFromProps(this.props))
+    ___emitter.on(`*`, this.handleMittEvent)
   }
 
   componentWillUnmount() {
-    if (process.env.NODE_ENV !== `production`) {
-      this.unregisterPath(this.state.path)
-      ___emitter.off(`*`, this.handleMittEvent)
-    }
+    this.unregisterPath(this.state.path)
+    ___emitter.off(`*`, this.handleMittEvent)
   }
 
   componentDidUpdate() {
@@ -55,17 +54,13 @@ class JSONStore extends React.Component {
   }
 
   registerPath(path) {
-    if (process.env.NODE_ENV !== `production`) {
-      this.setState({ path })
-      this.socket.emit(`registerPath`, path)
-    }
+    this.setState({ path })
+    this.socket.emit(`registerPath`, path)
   }
 
   unregisterPath(path) {
-    if (process.env.NODE_ENV !== `production`) {
-      this.setState({ path: null })
-      this.socket.emit(`unregisterPath`, path)
-    }
+    this.setState({ path: null })
+    this.socket.emit(`unregisterPath`, path)
   }
 
   render() {

--- a/packages/gatsby/cache-dir/json-store.js
+++ b/packages/gatsby/cache-dir/json-store.js
@@ -11,7 +11,12 @@ import {
 
 if (process.env.NODE_ENV === `production`) {
   throw new Error(
-    `It appears like Gatsby is misconfigured. JSONStore shouldn't be used in production.`
+    `It appears like Gatsby is misconfigured. JSONStore is Gatsby internal ` +
+      `development-only component and should never be used in production.\n\n` +
+      `Unless your site has a complex or custom webpack/Gatsby ` +
+      `configuration this is likely a bug in Gatsby. ` +
+      `Please report this at https://github.com/gatsbyjs/gatsby/issues ` +
+      `with steps to reproduce this error.`
   )
 }
 

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -5,6 +5,7 @@ import stripPrefix from "./strip-prefix"
 const preferDefault = m => (m && m.default) || m
 
 let prefetcher
+let devGetPageData
 let inInitialRender = true
 let hasFetched = Object.create(null)
 let syncRequires = {}
@@ -19,6 +20,10 @@ const failedResources = {}
 const MAX_HISTORY = 5
 
 const jsonPromiseStore = {}
+
+if (process.env.NODE_ENV !== `production`) {
+  devGetPageData = require(`./socketIo`).getPageData
+}
 
 /**
  * Fetch resource map (pages data and paths to json files with results of
@@ -227,6 +232,10 @@ const queue = {
       return false
     }
 
+    if (process.env.NODE_ENV !== `production`) {
+      devGetPageData(path)
+    }
+
     const mountOrderBoost = 1 / mountOrder
     mountOrder += 1
 
@@ -305,8 +314,15 @@ const queue = {
         component: syncRequires.components[page.componentChunkName],
         page,
       }
-      cb(pageResources)
-      return pageResources
+
+      const onDataCallback = () => {
+        cb(pageResources)
+      }
+
+      if (devGetPageData(page.path, onDataCallback)) {
+        return pageResources
+      }
+      return null
     }
     // Production code path
     if (failedPaths[path]) {

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -232,7 +232,10 @@ const queue = {
       return false
     }
 
-    if (process.env.NODE_ENV !== `production`) {
+    if (
+      process.env.NODE_ENV !== `production` &&
+      process.env.NODE_ENV !== `test`
+    ) {
       devGetPageData(path)
     }
 

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -236,7 +236,7 @@ const queue = {
       process.env.NODE_ENV !== `production` &&
       process.env.NODE_ENV !== `test`
     ) {
-      devGetPageData(path)
+      devGetPageData(page.path)
     }
 
     const mountOrderBoost = 1 / mountOrder

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -1,0 +1,155 @@
+import loader, { setApiRunnerForLoader } from "./loader"
+import redirects from "./redirects.json"
+import { apiRunner } from "./api-runner-browser"
+import { createLocation } from "history"
+import emitter from "./emitter"
+
+// Convert to a map for faster lookup in maybeRedirect()
+const redirectMap = redirects.reduce((map, redirect) => {
+  map[redirect.fromPath] = redirect
+  return map
+}, {})
+
+function maybeRedirect(pathname) {
+  const redirect = redirectMap[pathname]
+
+  if (redirect != null) {
+    if (process.env.NODE_ENV !== `production`) {
+      const pageResources = loader.getResourcesForPathname(pathname)
+
+      if (pageResources != null) {
+        console.error(
+          `The route "${pathname}" matches both a page and a redirect; this is probably not intentional.`
+        )
+      }
+    }
+
+    history.replace(redirect.toPath)
+    return true
+  } else {
+    return false
+  }
+}
+
+let lastNavigateToLocationString = null
+
+let initialAttachDone = false
+function attachToHistory(history) {
+  if (!window.___history || initialAttachDone === false) {
+    window.___history = history
+    initialAttachDone = true
+
+    history.listen((location, action) => {
+      if (!maybeRedirect(location.pathname)) {
+        // Check if we already ran onPreRouteUpdate API
+        // in navigateTo function
+        if (
+          lastNavigateToLocationString !==
+          `${location.pathname}${location.search}${location.hash}`
+        ) {
+          apiRunner(`onPreRouteUpdate`, { location, action })
+        }
+        // Make sure React has had a chance to flush to DOM first.
+        setTimeout(() => {
+          apiRunner(`onRouteUpdate`, { location, action })
+        }, 0)
+      }
+    })
+  }
+}
+
+const navigate = (to, replace) => {
+  const location = createLocation(to, null, null, history.location)
+  let { pathname } = location
+  const redirect = redirectMap[pathname]
+
+  // If we're redirecting, just replace the passed in pathname
+  // to the one we want to redirect to.
+  if (redirect) {
+    pathname = redirect.toPath
+  }
+
+  // If we had a service worker update, no matter the path, reload window
+  if (window.GATSBY_SW_UPDATED) {
+    window.location = pathname
+  }
+
+  const wl = window.location
+
+  // If we're already at this location, do nothing.
+  if (
+    wl.pathname === location.pathname &&
+    wl.search === location.search &&
+    wl.hash === location.hash
+  ) {
+    return
+  }
+
+  const historyNavigateFunc = replace
+    ? window.___history.replace
+    : window.___history.push
+
+  const historyNavigateAction = replace ? `REPLACE` : `PUSH`
+
+  // Start a timer to wait for a second before transitioning and showing a
+  // loader in case resources aren't around yet.
+  const timeoutId = setTimeout(() => {
+    emitter.emit(`onDelayedLoadPageResources`, { pathname })
+    apiRunner(`onRouteUpdateDelayed`, {
+      location,
+      action: historyNavigateAction,
+    })
+  }, 1000)
+
+  lastNavigateToLocationString = `${location.pathname}${location.search}${
+    location.hash
+  }`
+
+  apiRunner(`onPreRouteUpdate`, { location, action: historyNavigateAction })
+
+  const loaderCallback = pageResources => {
+    if (!pageResources) {
+      // We fetch resources for 404 page in page-renderer.js. Calling it
+      // here is to ensure that we have needed resouces to render page
+      // before navigating to it
+      loader.getResourcesForPathname(`/404.html`, loaderCallback)
+    } else {
+      clearTimeout(timeoutId)
+      historyNavigateFunc(location)
+    }
+  }
+
+  loader.getResourcesForPathname(pathname, loaderCallback)
+}
+
+function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
+  const results = apiRunner(`shouldUpdateScroll`, {
+    prevRouterProps,
+    pathname,
+  })
+  if (results.length > 0) {
+    return results[0]
+  }
+
+  if (prevRouterProps) {
+    const {
+      location: { pathname: oldPathname },
+    } = prevRouterProps
+    if (oldPathname === pathname) {
+      return false
+    }
+  }
+  return true
+}
+
+function init() {
+  setApiRunnerForLoader(apiRunner)
+  window.___loader = loader
+  window.___push = to => navigate(to, false)
+  window.___replace = to => navigate(to, true)
+
+  // Check for initial page-load redirect
+  maybeRedirect(window.location.pathname)
+}
+
+export { init, shouldUpdateScroll, attachToHistory }

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -4,46 +4,27 @@ import ReactDOM from "react-dom"
 import { Router, Route, withRouter, matchPath } from "react-router-dom"
 import { ScrollContext } from "gatsby-react-router-scroll"
 import domReady from "domready"
-import { createLocation } from "history"
+import {
+  shouldUpdateScroll,
+  attachToHistory,
+  init as navigationInit,
+} from "./navigation"
 import history from "./history"
 window.___history = history
 import emitter from "./emitter"
 window.___emitter = emitter
-import redirects from "./redirects.json"
 import PageRenderer from "./page-renderer"
 import asyncRequires from "./async-requires"
-import loader, { setApiRunnerForLoader } from "./loader"
+import loader from "./loader"
 
 window.asyncRequires = asyncRequires
-window.___emitter = emitter
-window.___loader = loader
-
 window.matchPath = matchPath
 
-setApiRunnerForLoader(apiRunner)
 loader.addPagesArray([window.page])
 loader.addDataPaths({ [window.page.jsonName]: window.dataPath })
 loader.addProdRequires(asyncRequires)
 
-// Convert to a map for faster lookup in maybeRedirect()
-const redirectMap = redirects.reduce((map, redirect) => {
-  map[redirect.fromPath] = redirect
-  return map
-}, {})
-
-const maybeRedirect = pathname => {
-  const redirect = redirectMap[pathname]
-
-  if (redirect != null) {
-    history.replace(redirect.toPath)
-    return true
-  } else {
-    return false
-  }
-}
-
-// Check for initial page-load redirect
-maybeRedirect(window.location.pathname)
+navigationInit()
 
 // Let the site/plugins run code very early.
 apiRunnerAsync(`onClientEntry`).then(() => {
@@ -53,126 +34,11 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     require(`./register-service-worker`)
   }
 
-  let lastNavigateToLocationString = null
-
-  const navigate = (to, replace) => {
-    const location = createLocation(to, null, null, history.location)
-    let { pathname } = location
-    const redirect = redirectMap[pathname]
-
-    // If we're redirecting, just replace the passed in pathname
-    // to the one we want to redirect to.
-    if (redirect) {
-      pathname = redirect.toPath
-    }
-
-    // If we had a service worker update, no matter the path, reload window
-    if (window.GATSBY_SW_UPDATED) {
-      window.location = pathname
-    }
-
-    const wl = window.location
-
-    // If we're already at this location, do nothing.
-    if (
-      wl.pathname === location.pathname &&
-      wl.search === location.search &&
-      wl.hash === location.hash
-    ) {
-      return
-    }
-
-    const historyNavigateFunc = replace
-      ? window.___history.replace
-      : window.___history.push
-
-    const historyNavigateAction = replace ? `REPLACE` : `PUSH`
-
-    // Start a timer to wait for a second before transitioning and showing a
-    // loader in case resources aren't around yet.
-    const timeoutId = setTimeout(() => {
-      emitter.emit(`onDelayedLoadPageResources`, { pathname })
-      apiRunner(`onRouteUpdateDelayed`, {
-        location,
-        action: historyNavigateAction,
-      })
-    }, 1000)
-
-    lastNavigateToLocationString = `${location.pathname}${location.search}${
-      location.hash
-    }`
-
-    apiRunner(`onPreRouteUpdate`, { location, action: historyNavigateAction })
-
-    const loaderCallback = pageResources => {
-      if (!pageResources) {
-        // We fetch resources for 404 page in page-renderer.js. Calling it
-        // here is to ensure that we have needed resouces to render page
-        // before navigating to it
-        loader.getResourcesForPathname(`/404.html`, loaderCallback)
-      } else {
-        clearTimeout(timeoutId)
-        historyNavigateFunc(location)
-      }
-    }
-
-    loader.getResourcesForPathname(pathname, loaderCallback)
-  }
-
-  // window.___loadScriptsForPath = loadScriptsForPath
-  window.___push = to => navigate(to, false)
-  window.___replace = to => navigate(to, true)
-
   // Call onRouteUpdate on the initial page load.
   apiRunner(`onRouteUpdate`, {
     location: history.location,
     action: history.action,
   })
-
-  let initialAttachDone = false
-  function attachToHistory(history) {
-    if (!window.___history || initialAttachDone === false) {
-      window.___history = history
-      initialAttachDone = true
-
-      history.listen((location, action) => {
-        if (!maybeRedirect(location.pathname)) {
-          // Check if we already ran onPreRouteUpdate API
-          // in navigateTo function
-          if (
-            lastNavigateToLocationString !==
-            `${location.pathname}${location.search}${location.hash}`
-          ) {
-            apiRunner(`onPreRouteUpdate`, { location, action })
-          }
-          // Make sure React has had a chance to flush to DOM first.
-          setTimeout(() => {
-            apiRunner(`onRouteUpdate`, { location, action })
-          }, 0)
-        }
-      })
-    }
-  }
-
-  function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
-    const results = apiRunner(`shouldUpdateScroll`, {
-      prevRouterProps,
-      pathname,
-    })
-    if (results.length > 0) {
-      return results[0]
-    }
-
-    if (prevRouterProps) {
-      const {
-        location: { pathname: oldPathname },
-      } = prevRouterProps
-      if (oldPathname === pathname) {
-        return false
-      }
-    }
-    return true
-  }
 
   const AltRouter = apiRunner(`replaceRouterComponent`, { history })[0]
 

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -46,9 +46,6 @@ if (window.__webpack_hot_middleware_reporter__ !== undefined) {
   })
 }
 
-loader.addPagesArray(pages)
-loader.addDevRequires(syncRequires)
-
 navigationInit()
 
 // Call onRouteUpdate on the initial page load.

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -1,12 +1,16 @@
 import { createElement } from "react"
 import { Router, Route } from "react-router-dom"
 import { ScrollContext } from "gatsby-react-router-scroll"
+import {
+  shouldUpdateScroll,
+  attachToHistory,
+  init as navigationInit,
+} from "./navigation"
 import history from "./history"
 import { apiRunner } from "./api-runner-browser"
 import syncRequires from "./sync-requires"
 import pages from "./pages.json"
-import redirects from "./redirects.json"
-import loader, { setApiRunnerForLoader } from "./loader"
+import loader from "./loader"
 import { hot } from "react-hot-loader"
 import JSONStore from "./json-store"
 
@@ -42,88 +46,16 @@ if (window.__webpack_hot_middleware_reporter__ !== undefined) {
   })
 }
 
-setApiRunnerForLoader(apiRunner)
 loader.addPagesArray(pages)
 loader.addDevRequires(syncRequires)
-window.___loader = loader
 
-// Convert to a map for faster lookup in maybeRedirect()
-const redirectMap = redirects.reduce((map, redirect) => {
-  map[redirect.fromPath] = redirect
-  return map
-}, {})
-
-// Check for initial page-load redirect
-maybeRedirect(location.pathname)
+navigationInit()
 
 // Call onRouteUpdate on the initial page load.
 apiRunner(`onRouteUpdate`, {
   location: history.location,
   action: history.action,
 })
-
-function attachToHistory(history) {
-  if (!window.___history) {
-    window.___history = history
-
-    history.listen((location, action) => {
-      if (!maybeRedirect(location.pathname)) {
-        apiRunner(`onPreRouteUpdate`, { location, action })
-        apiRunner(`onRouteUpdate`, { location, action })
-      }
-    })
-  }
-}
-
-function maybeRedirect(pathname) {
-  const redirect = redirectMap[pathname]
-
-  if (redirect != null) {
-    const pageResources = loader.getResourcesForPathname(pathname)
-
-    if (pageResources != null) {
-      console.error(
-        `The route "${pathname}" matches both a page and a redirect; this is probably not intentional.`
-      )
-    }
-
-    history.replace(redirect.toPath)
-    return true
-  } else {
-    return false
-  }
-}
-
-function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
-  const results = apiRunner(`shouldUpdateScroll`, {
-    prevRouterProps,
-    pathname,
-  })
-  if (results.length > 0) {
-    return results[0]
-  }
-
-  if (prevRouterProps) {
-    const {
-      location: { pathname: oldPathname },
-    } = prevRouterProps
-    if (oldPathname === pathname) {
-      return false
-    }
-  }
-  return true
-}
-
-const push = to => {
-  window.___history.push(to)
-}
-
-const replace = to => {
-  window.___history.replace(to)
-}
-
-window.___push = push
-window.___replace = replace
 
 const AltRouter = apiRunner(`replaceRouterComponent`, { history })[0]
 


### PR DESCRIPTION
- Removes navigation code duplicated in production and dev runtime.
- Waits for page data before transitioning to new page in dev
- Limits page re-renders - only updates JSONStore component if:
  - path changed
  - data for current path changed
  - data for static queries changed

Closes #5094
Closes #6309 
Closes #1625 