### PR TITLE
Fixed out of memory issue in extractFromEntries

### DIFF
--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -163,7 +163,7 @@ const extractFromEntries = (
     return getExampleScalarFromArray(values)
   } else if (_.isObject(exampleValue)) {
     if (Array.isArray(exampleValue)) {
-      const concatanedItems = [].concat(...values)
+      const concatanedItems = _.flatten(values)
       // Linked node arrays don't get reduced further as we
       // want to preserve all the linked node types.
       if (key.includes(`___NODE`)) {


### PR DESCRIPTION
When dealing with a large data set of 200k large documents, Gatsby runs out of memory in the `extractFromEntries` function in `data-tree-utlis.js`

Before the fix:

```
success source and transform nodes — 261.101 s
error UNHANDLED REJECTION

  RangeError: Maximum call stack size exceeded

  - data-tree-utils.js:140 extractFromEntries
    [website]/[gatsby]/dist/schema/data-tree-utils.js:140:34

  - data-tree-utils.js:239 extractFieldExamples
    [website]/[gatsby]/dist/schema/data-tree-utils.js:239:19

  - data-tree-utils.js:281 getExampleValues
    [website]/[gatsby]/dist/schema/data-tree-utils.js:281:26

  - infer-graphql-input-fields.js:310 inferInputObjectStructureFromNodes
    [website]/[gatsby]/dist/schema/infer-graphql-input-fields.js:310:20

  - build-node-types.js:186
    [website]/[gatsby]/dist/schema/build-node-types.js:186:36

  - Generator.next

  - next_tick.js:131 _combinedTickCallback
    internal/process/next_tick.js:131:7

  - next_tick.js:180 process._tickCallback
    internal/process/next_tick.js:180:9
```

By replacing `[].concat(...values)` with `_.flatten(values)`, it will use far less memory and get past this point in the build process, while achieving the exact same result.

Another OOM issue happens much further down the line after the `info bootstrap finished - 353.691 s` message, but that is likely a memory leak to track down in another ticket.