### PR TITLE
Modifications to support netlify-cms v2

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -33,7 +33,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.0-beta.29",
-    "netlify-cms": "^1.9.3"
+    "netlify-cms": "^2.0.0"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms",
   "scripts": {

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -1,5 +1,4 @@
 import CMS from "netlify-cms"
-import "netlify-cms/dist/cms.css"
 
 // eslint-disable-next-line no-undef
 if (NETLIFY_CMS_PREVIEW_STYLES_SET) {


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Got the following error when I tried to upgrade netlify-cms to v2:
```
ERROR  Failed to compile with 1 errors                                                                      

This dependency was not found:

* netlify-cms/dist/cms.css in ./node_modules/gatsby-plugin-netlify-cms/cms.js
```

This PR removes the import line and bump netlify-cms version.