### PR TITLE
[screenshot] Specify failed URL in error

### DIFF
--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -79,31 +79,35 @@ const createScreenshotNode = async ({
   createNode,
   createNodeId,
 }) => {
-  const screenshotResponse = await axios.post(SCREENSHOT_ENDPOINT, { url })
+  try {
+    const screenshotResponse = await axios.post(SCREENSHOT_ENDPOINT, { url })
 
-  const fileNode = await createRemoteFileNode({
-    url: screenshotResponse.data.url,
-    store,
-    cache,
-    createNode,
-    createNodeId,
-  })
+    const fileNode = await createRemoteFileNode({
+      url: screenshotResponse.data.url,
+      store,
+      cache,
+      createNode,
+      createNodeId,
+    })
 
-  const screenshotNode = {
-    id: `${parent} >>> Screenshot`,
-    url,
-    expires: screenshotResponse.data.expires,
-    parent,
-    children: [],
-    internal: {
-      type: `Screenshot`,
-    },
-    screenshotFile___NODE: fileNode.id,
+    const screenshotNode = {
+      id: `${parent} >>> Screenshot`,
+      url,
+      expires: screenshotResponse.data.expires,
+      parent,
+      children: [],
+      internal: {
+        type: `Screenshot`,
+      },
+      screenshotFile___NODE: fileNode.id,
+    }
+
+    screenshotNode.internal.contentDigest = createContentDigest(screenshotNode)
+
+    createNode(screenshotNode)
+
+    return screenshotNode
+  } catch (e) {
+    throw new Error(`Failed to screenshot ${url}`)
   }
-
-  screenshotNode.internal.contentDigest = createContentDigest(screenshotNode)
-
-  createNode(screenshotNode)
-
-  return screenshotNode
 }


### PR DESCRIPTION
If the screenshot lambda fails, it's often due to the specific URL that was passed in, so this adds an error message displaying that URL.