### PR TITLE
#6808 Fixes anchor modifying YAML File for part six of tutorial

### DIFF
--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -71,7 +71,7 @@
         - title: What are transformer plugins?
           link: /tutorial/part-six/#transformer-plugins
         - title: Create a list of our site's markdown files
-          link: /tutorial/part-six/#create-a-list-of-our-sites-markdown-files-in-srcpagesindexjs
+          link: /tutorial/part-six/#create-a-list-of-your-sites-markdown-files-in-srcpagesindexjs
     - title: 7. Programmatically create pages from data
       link: /tutorial/part-seven/
       ui: steps

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -71,7 +71,7 @@
         - title: What are transformer plugins?
           link: /tutorial/part-six/#transformer-plugins
         - title: Create a list of our site's markdown files
-          link: /tutorial/part-six/#create-a-list-of-your-sites-markdown-files-in-srcpagesindexjs
+          link: /tutorial/part-six/#create-a-list-of-your-sites-markdown-files-in-code-classlanguage-textsrcpagesindexjscode
     - title: 7. Programmatically create pages from data
       link: /tutorial/part-seven/
       ui: steps

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -71,7 +71,7 @@
         - title: What are transformer plugins?
           link: /tutorial/part-six/#transformer-plugins
         - title: Create a list of our site's markdown files
-          link: /tutorial/part-six/#create-a-list-of-your-sites-markdown-files-in-code-classlanguage-textsrcpagesindexjscode
+          link: /tutorial/part-six/#create-a-list-of-your-sites-markdown-files-in-srcpagesindexjs
     - title: 7. Programmatically create pages from data
       link: /tutorial/part-seven/
       ui: steps


### PR DESCRIPTION
This PR is a fix for the issue #6808 .
The problem was a typo in the tutorial-links.yaml file.