### PR TITLE
Documentation: Add more detail to "What don't you need plugins for?" and move to a more prominent location 

### DIFF
--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -65,13 +65,3 @@ Like all `gatsby-*` files, the code is not processed by Babel. If you want
 to use JavaScript syntax which isn't supported by your version of Node.js, you
 can place the files in a `src` subfolder and build them to the plugin folder
 root.
-
-## What don't you need plugins for?
-
-Most third-party functionality you want to add to your website will follow standard Javascript and React.js patterns for importing packages and composing UIs. These do not require a Gatsby plugin!
-
-Some examples:
-
-- Importing Javascript packages that provide general functionality, such as `lodash` or `axios`
-- Using React components or component libraries you want to include in your UI, such as `Ant Design`, `Material UI`, or the typeahead from your component library.
-- Integrating visualization libraries, such as `Highcharts` or `d3`.

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -71,3 +71,15 @@ module.exports = {
 ```
 
 Note that plugin options will be stringified by Gatsby, so they cannot be functions.
+
+## What don't you need plugins for?
+
+Most third-party functionality you want to add to your website will follow standard Javascript and React.js patterns for importing packages and composing UIs. These do not require a Gatsby plugin!
+
+Some examples:
+
+- Importing Javascript packages that provide general functionality, such as `lodash` or `axios`
+- Using React components or component libraries you want to include in your UI, such as `Ant Design`, `Material UI`, or the typeahead from your component library.
+- Integrating visualization libraries, such as `Highcharts` or `d3`.
+
+As a general rule, you may use _any_ npm package you might use without Gatsby, with Gatsby. What plugins offer is a prepackaged integration into the core Gatsby API's to save you time and energy, with minimal configuration. In the case of `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could just use `gatsby-plugin-styled-components` which takes care of this step for you in addition to any other difficulties you may run into configuring Styled Components to work with server side rendering.


### PR DESCRIPTION
As a Gatsby newcomer, my first step was to skim through the "Core Concepts" and "Tutorial" sections. After doing so, I was convinced that Gatsby was an innovative and powerful new platform, but I was left with a nagging question that I wanted answered before moving further... "Does every little npm package need an accompanying plugin to be Gatsby compatible?? Surely not, but the docs kinda make it seem that way!"

I think that moving the `What Don't You Need Plugins For?` blurb to the core concepts area would increase visibility and help answer this question earlier in the process for people evaluating Gatsby for the first time.