### PR TITLE
[transformer-screenshot] Skip out of onPreBootstrap if there's no nodes & throw if fileNode is null

### DIFF
--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -30,6 +30,10 @@ exports.onPreBootstrap = (
     n => n.internal.type === `Screenshot`
   )
 
+  if (screenshotNodes.length === 0) {
+    return
+  }
+
   // Check for updated screenshots
   // and prevent Gatsby from garbage collecting remote file nodes
   screenshotNodes.forEach(n => {
@@ -113,6 +117,10 @@ const createScreenshotNode = async ({
       createNode,
       createNodeId,
     })
+
+    if (!fileNode) {
+      throw new Error(`Remote file node is null`, screenshotResponse.data.url)
+    }
 
     const screenshotNode = {
       id: `${parent} >>> Screenshot`,


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->