### PR TITLE
docs(css-modules): replace postcss-scss

### DIFF
--- a/packages/gatsby-plugin-react-css-modules/README.md
+++ b/packages/gatsby-plugin-react-css-modules/README.md
@@ -1,6 +1,6 @@
 > **NOTE**: You probably don't need this plugin!
 >
->Gatsby works with CSS Modules by default, no need for extra plugins. You should only use this if you already know what `babel-plugin-react-css-modules` is and want to enable it for your project.
+> Gatsby works with CSS Modules by default, no need for extra plugins. You should only use this if you already know what `babel-plugin-react-css-modules` is and want to enable it for your project.
 
 # gatsby-plugin-react-css-modules
 
@@ -21,12 +21,12 @@ plugins: [
   {
     resolve: `gatsby-plugin-react-css-modules`,
     options: {
-      // *.css files are included by default.	
-      // To support another syntax (e.g. SCSS),	
-      // add `postcss-scss` to your project's devDependencies	
-      // and add the following option here:	
-      filetypes: {	
-        ".scss": { syntax: `postcss-scss` },	
+      // *.css files are included by default.
+      // To support another syntax (e.g. SCSS),
+      // add `postcss-scss` to your project's devDependencies
+      // and add the following option here:
+      filetypes: {
+        ".scss": { syntax: `postcss-scss` },
       },
       // Exclude global styles from the plugin using a RegExp:
       exclude: `\/global\/`,

--- a/packages/gatsby-plugin-react-css-modules/README.md
+++ b/packages/gatsby-plugin-react-css-modules/README.md
@@ -1,3 +1,7 @@
+> **NOTE**: You probably don't need this plugin!
+>
+>Gatsby works with CSS Modules by default, no need for extra plugins. You should only use this if you already know what `babel-plugin-react-css-modules` is and want to enable it for your project.
+
 # gatsby-plugin-react-css-modules
 
 Transforms `styleName` to `className` using compile time CSS module resolution.

--- a/packages/gatsby-plugin-react-css-modules/README.md
+++ b/packages/gatsby-plugin-react-css-modules/README.md
@@ -25,10 +25,10 @@ plugins: [
       // To support another syntax (e.g. SCSS),
       // add `postcss-scss` to your project's devDependencies
       // and add the following option here:
-
       filetypes: {
         ".scss": { syntax: `postcss-scss` },
       },
+
       // Exclude global styles from the plugin using a RegExp:
       exclude: `\/global\/`,
     },

--- a/packages/gatsby-plugin-react-css-modules/README.md
+++ b/packages/gatsby-plugin-react-css-modules/README.md
@@ -14,17 +14,13 @@ for details.
 ```javascript
 // In your gatsby-config.js
 plugins: [
+  // *.css files are included by default.
+  // To support another syntax (e.g. SCSS),
+  // add `gatsby-plugin-sass`
+  `gatsby-plugin-sass`,
   {
     resolve: `gatsby-plugin-react-css-modules`,
     options: {
-      // *.css files are included by default.
-      // To support another syntax (e.g. SCSS),
-      // add `postcss-scss` to your project's devDependencies
-      // and add the following option here:
-      filetypes: {
-        ".scss": { syntax: `postcss-scss` },
-      },
-
       // Exclude global styles from the plugin using a RegExp:
       exclude: `\/global\/`,
     },

--- a/packages/gatsby-plugin-react-css-modules/README.md
+++ b/packages/gatsby-plugin-react-css-modules/README.md
@@ -18,13 +18,16 @@ for details.
 ```javascript
 // In your gatsby-config.js
 plugins: [
-  // *.css files are included by default.
-  // To support another syntax (e.g. SCSS),
-  // add `gatsby-plugin-sass`
-  `gatsby-plugin-sass`,
   {
     resolve: `gatsby-plugin-react-css-modules`,
     options: {
+      // *.css files are included by default.	
+      // To support another syntax (e.g. SCSS),	
+      // add `postcss-scss` to your project's devDependencies	
+      // and add the following option here:	
+      filetypes: {	
+        ".scss": { syntax: `postcss-scss` },	
+      },
       // Exclude global styles from the plugin using a RegExp:
       exclude: `\/global\/`,
     },

--- a/packages/gatsby-plugin-react-css-modules/README.md
+++ b/packages/gatsby-plugin-react-css-modules/README.md
@@ -25,6 +25,7 @@ plugins: [
       // To support another syntax (e.g. SCSS),
       // add `postcss-scss` to your project's devDependencies
       // and add the following option here:
+
       filetypes: {
         ".scss": { syntax: `postcss-scss` },
       },


### PR DESCRIPTION
Hello! 👋  

Just started a fresh gatsby project and was trying to use css-modules using `.scss` files. 

Unfortunately, I wasn't able to get this working with the `postcss-scss` as originally suggested in the docs. I found a solution on a [blog](https://medium.com/@PostgradExpat/using-gatsby-with-css-modules-and-scss-7e75a05533a4) that suggested using `gatsby-plugin-sass` and this worked for me right away. Using css-modules and scss plugins together allowed me to get what I wanted without any obstacles.

When trying to use `postcss-scss` with the filename as `filename.module.scss` or `filename.scss`, I get the following compile error in my terminal: 

```bash
 ERROR  Failed to compile with 1 errors                               22:00:20

 error  in ./src/components/HomePage/index.module.scss

Module parse failed: /Users/brianhan/dev/brianhan.co/src/components/HomePage/index.module.scss Unexpected token (1:0)
You may need an appropriate loader to handle this file type.
SyntaxError: Unexpected token (1:0)
    at Parser.pp$4.raise (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:2221:15)
    at Parser.pp.unexpected (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:603:10)
    at Parser.pp$3.parseExprAtom (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:1822:12)
    at Parser.pp$3.parseExprSubscripts (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:1715:21)
    at Parser.pp$3.parseMaybeUnary (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:1692:19)
    at Parser.pp$3.parseExprOps (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:1637:21)
    at Parser.pp$3.parseMaybeConditional (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:1620:21)
    at Parser.pp$3.parseMaybeAssign (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:1597:21)
    at Parser.pp$3.parseExpression (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:1573:21)
    at Parser.pp$1.parseStatement (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:727:47)
    at Parser.pp$1.parseTopLevel (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:638:25)
    at Parser.parse (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:516:17)
    at Object.parse (/Users/brianhan/dev/brianhan.co/node_modules/acorn/dist/acorn.js:3098:39)
    at Parser.parse (/Users/brianhan/dev/brianhan.co/node_modules/webpack/lib/Parser.js:902:15)
    at NormalModule.<anonymous> (/Users/brianhan/dev/brianhan.co/node_modules/webpack/lib/NormalModule.js:104:16)
    at NormalModule.onModuleBuild (/Users/brianhan/dev/brianhan.co/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:310:10)

 @ ./src/components/HomePage/index.jsx 10:19-49 17:2-19:4 18:4-34
```

Maybe I'm missing a step with using `postcss-scss` but just thought it might be helpful to switch the docs over to suggesting `gatsby-plugin-sass` since this worked for me right out of the box.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
