### PR TITLE
Fix resolving @babel/runtime for external modules

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -377,6 +377,9 @@ module.exports = async (
         // Using directories for module resolution is mandatory because
         // relative path imports are used sometimes
         // See https://stackoverflow.com/a/49455609/6420957 for more details
+        "@babel/runtime": path.dirname(
+          require.resolve(`@babel/runtime/package.json`)
+        ),
         "core-js": path.dirname(require.resolve(`core-js/package.json`)),
         "react-hot-loader": path.dirname(
           require.resolve(`react-hot-loader/package.json`)


### PR DESCRIPTION
See https://github.com/gatsbyjs/gatsby/issues/6030#issuecomment-405624139 for further details

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
