### PR TITLE
README rewrite for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For more advanced developers who just want to dig in and see how Gatsby handles 
 
   <span><!-- don’t remove this; it prevents the text below from smashing into the summary text --></span>
   
-  To add a global stylesheet, require the stylesheet in `gatsby-browser.js`:
+  If you prefer the “start from scratch” approach, setting up a Gatsby site requires three dependencies to start:
   ```sh
   # create a new project and move into it
   mkdir my-new-gatsby-site

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@
   <span> · </span>
   <a href="https://next.gatsbyjs.org/docs/gatsby-starters/">Starters</a>
   <span> · </span>
-  <a href="https://spectrum.chat/gatsby-js">Get Support</a>
-  <span> · </span>
   <a href="https://next.gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
+  <span> · </span>
+  Support: <a href="https://spectrum.chat/gatsby-js">Spectrum</a>
+  <span> & </span>
+  <a href="https://discord.gg/0ZcbPKXt5bVoxkfV">Discord</a>
 </h3>
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Gatsby is dedicated to building a welcoming, diverse, safe community. We expect 
 
 This repository is a [monorepo](https://trunkbaseddevelopment.com/monorepos/) managed using [Lerna](https://github.com/lerna/lerna). This means there are [multiple packages](/packages) managed in this codebase, even though we publish them to NPM as separate packages.
 
+### Contributing to Gatsby v1
+
+We are currently only accepting bug fixes for Gatsby v1. All new features, docs enhancements, and other improvements _must_ be created against v2 (the `master` branch).
+
 ## 💜 Thanks to Our Contributors and Sponsors
 
 Thanks to our many contributors and sponsors as well as the companies sponsoring

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@
   <a href="https://npmcharts.com/compare/gatsby?minimal=true">
     <img src="https://img.shields.io/npm/dm/gatsby.svg" alt="Downloads per month on npm." />
   </a>
-  <a href="https://spectrum.chat/gatsby-js">
-    <img src="https://withspectrum.github.io/badge/badge.svg" alt="Gatsby support community on Spectrum." />
-  </a>
   <a href="https://next.gatsbyjs.org/docs/how-to-submit-a-pr/">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
   </a>
@@ -54,6 +51,7 @@
 ## Table of Contents
 
 -   [Get Up and Running in 5 Minutes](#get-up-and-running-in-5-minutes)
+-   [How to Contribute](#how-to-contribute)
 
 
 ## Get Up and Running in 5 Minutes
@@ -79,11 +77,19 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
     > **NOTE:** If you prefer npm, you can also run `npm run develop` to start the site.
 
-3.  **Open the source code and start editing! 💪💜**
+3.  **Open the source code and start editing!**
 
     Your site is now running at `http://localhost:8000`. Open the the `my-blazing-fast-site` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
 
 At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://next.gatsbyjs.org/plugins/) and [the official tutorial](https://next.gatsbyjs.org/tutorial/).
+
+
+
+## How to Contribute
+
+Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community! :muscle::purple_heart:
+
+Check out our [contributor onboarding docs](https://next.gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repos up and running on your local machine.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
   <span> · </span>
   <a href="https://next.gatsbyjs.org/docs/gatsby-starters/">Starters</a>
   <span> · </span>
+  <a href="https://next.gatsbyjs.org/showcase/">Showcase</a>
+  <span> · </span>
   <a href="https://next.gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
   <span> · </span>
   Support: <a href="https://spectrum.chat/gatsby-js">Spectrum</a>
@@ -67,7 +69,11 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
     Get your Gatsby blog set up in a single command:
 
     ```sh
-    npx gatsby-cli new my-blazing-fast-site https://github.com/gatsbyjs/gatsby-starter-default#v2
+    # install the Gatsby CLI globally
+    npm install -g gatsby-cli
+    
+    # create a new Gatsby site using the default starter
+    gatsby new my-blazing-fast-site https://github.com/gatsbyjs/gatsby-starter-default#v2
     ```
 
 2.  **Start the site in `develop` mode.**
@@ -76,7 +82,7 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
     ```sh
     cd my-blazing-fast-site/
-    yarn develop
+    gatsby develop
     ```
 
     > **NOTE:** If you prefer npm, you can also run `npm run develop` to start the site.
@@ -118,10 +124,10 @@ For more advanced developers who just want to dig in and see how Gatsby handles 
   cd my-new-gatsby-site
   
   # initialize the project
-  yarn init
+  npm init
   
   # add the required dependencies
-  yarn add gatsby@next react react-dom
+  npm install gatsby@next react react-dom
   ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,35 @@
   <a href="https://discord.gg/0ZcbPKXt5bVoxkfV">Discord</a>
 </h3>
 
-## Table of Contents
+Gatsby is a modern framework for blazing fast websites.
+
+-   **Go Beyond Static Websites.** Get all the benefits of static websites with none of the
+    limitations. Gatsby sites are fully functional React apps, so you can create high-quality,
+    dynamic web apps, from blogs to ecommerce sites to user dashboards.
+
+-   **Use a Modern Stack for Every Site.** No matter where the data comes from, Gatsby sites are
+    built using React and GraphQL. Build a uniform workflow for you and your team, regardless of
+    whether the data is coming from the same back-end.
+
+-   **Load Data From Anywhere.** Gatsby pulls in data from any data source, whether it’s Markdown
+    files, a headless CMS like Contentful or WordPress, or a REST or GraphQL API. Use source plugins
+    to load your data, then develop using Gatsby’s uniform GraphQL interface.
+
+-   **Performance Is Baked In.** Ace your performance audits by default. Gatsby automates code
+    splitting, image optimization, inlining critical styles, lazy-loading and prefetching resources,
+    and more to ensure your site is fast — no manual tuning required.
+
+-   **Host at Scale for Pennies.** Gatsby sites don’t require servers, so you can host your entire
+    site on a CDN for a fraction of the cost of a server-rendered site. Many Gatsby sites can be 
+    hosted entirely free on services like GitHub Pages and Netlify.
+
+[**Learn how to use Gatsby for your next project.**](https://next.gatsbyjs.org/docs/)
+
+## What’s In This Document
 
 -   [Get Up and Running in 5 Minutes](#-get-up-and-running-in-5-minutes)
 -   [Learning Gatsby](#-learning-gatsby)
 -   [Migration Guides](#-migration-guides)
--   [For Advanced Developers: Code Samples & Recipes](#-code-samples-and-recipes)
 -   [How to Contribute](#-how-to-contribute)
 -   [Thanks to Our Contributors and Sponsors](#-thanks-to-our-contributors-and-sponsors)
 
@@ -85,8 +108,6 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
     gatsby develop
     ```
 
-    > **NOTE:** If you prefer npm, you can also run `npm run develop` to start the site.
-
 3.  **Open the source code and start editing!**
 
     Your site is now running at `http://localhost:8000`. Open the the `my-blazing-fast-site` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
@@ -95,9 +116,15 @@ At this point, you’ve got a fully functional Gatsby website. For additional in
 
 ## 🎓 Learning Gatsby
 
-For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://next.gatsbyjs.org/tutorial/). It starts with zero assumptions about your level of ability and walks through every step of the process, from [setting up your site](https://next.gatsbyjs.org/tutorial/part-one/), to [handling styles](https://next.gatsbyjs.org/tutorial/part-two/) and [layouts](https://next.gatsbyjs.org/tutorial/part-three/), to [querying for data in pages](https://next.gatsbyjs.org/tutorial/part-four/) and [adding data from external sources](https://next.gatsbyjs.org/tutorial/part-five/), to more advanced topics like [transforming data](https://next.gatsbyjs.org/tutorial/part-six/), [programmatically creating pages](https://next.gatsbyjs.org/tutorial/part-seven/), and [prepping your site for deployment](https://next.gatsbyjs.org/tutorial/part-eight/).
+Full documentation for Gatsby lives [on the website](https://next.gatsbyjs.org/).
 
-#### [Follow the Tutorial](https://next.gatsbyjs.org/tutorial/)
+For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://next.gatsbyjs.org/tutorial/). It starts with zero assumptions about your level of ability and walks through every step of the process.
+
+For advanced developers, check out the “Guides”, API reference, and “Advanced Tutorials” sections of [the Gatsby documentation](https://next.gatsbyjs.org/docs/).
+
+We welcome suggestions for improving our docs. See the [“how to contribute”](https://next.gatsbyjs.org/docs/how-to-contribute/) documentation for more details.
+
+**Start Learning Gatsby: [Follow the Tutorial](https://next.gatsbyjs.org/tutorial/) · [Read the Docs](https://next.gatsbyjs.org/docs/)**
 
 ## 💼 Migration Guides
 
@@ -106,112 +133,19 @@ Already have a Gatsby site? These handy guides will help you add the improvement
 - [Migrate a Gatsby site from v1 to v2](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/)
 - Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://next.gatsbyjs.org/docs/migrating-from-v0-to-v1/)
 
-## 👩‍💻 Code Samples and Recipes
-
-For more advanced developers who just want to dig in and see how Gatsby handles various patterns and workflows, this section is full of code samples and links through to specialized docs.
-
-> **NOTE:** This section is full of abbreviated examples. If you don’t see what you need here, [see the “Guides” section of the docs](https://next.gatsbyjs.org/docs/) to see these examples (and more!) in additional detail.
-
-<details>
-  <summary><strong>Create a Gatsby project without a starter</strong></summary>
-
-  <span><!-- don’t remove this; it prevents the text below from smashing into the summary text --></span>
-  
-  If you prefer the “start from scratch” approach, setting up a Gatsby site requires three dependencies to start:
-  ```sh
-  # create a new project and move into it
-  mkdir my-new-gatsby-site
-  cd my-new-gatsby-site
-  
-  # initialize the project
-  npm init
-  
-  # add the required dependencies
-  npm install gatsby@next react react-dom
-  ```
-</details>
-
-<details>
-  <summary><strong>Add global styles to your site</strong></summary>
-
-  <span><!-- don’t remove this; it prevents the text below from smashing into the summary text --></span>
-  
-  To add a global stylesheet, require the stylesheet in `gatsby-browser.js`:
-  ```jsx
-  require('./src/stylesheets/global.css');
-  
-  exports.onClientEntry = () => {/* other custom config here */}
-  ```
-  
-  #### Read the full guide: [creating global styles](https://next.gatsbyjs.org/docs/creating-global-styles/)
-
-</details>
-
-<details>
-  <summary><strong>Customize your Babel configuration</strong></summary>
-
-  <span><!-- don’t remove this; it prevents the text below from smashing into the summary text --></span>
-  
-  If you add a `.babelrc` in the root of your project, it overrides the default Gatsby config entirely. We recommend starting with our config and modifying as needed.
-
-  Gatsby’s default `.babelrc`:
-  ```json
-  {
-    "cacheDirectory": true,
-    "babelrc": false,
-    "presets": [
-      [
-        "@babel/preset-env",
-        {
-          "loose": true,
-          "modules": false,
-          "useBuiltIns": "usage",
-          "shippedProposals": true,
-          "targets": {
-            "browsers": [">0.25%", "not dead"],
-          },
-        },
-      ],
-      [
-        "@babel/preset-react",
-        {
-          "useBuiltIns": true,
-          "pragma": "React.createElement",
-        },
-      ],
-      "@babel/preset-flow",
-    ],
-    "plugins": [
-      [
-        "@babel/plugin-proposal-class-properties",
-        {
-          "loose": true,
-        },
-      ],
-      "@babel/plugin-syntax-dynamic-import",
-      [
-        "@babel/plugin-transform-runtime",
-        {
-          "helpers": true,
-          "regenerator": true,
-          "polyfill": false,
-        },
-      ],
-    ],
-  }
-  ```
-  
-  #### Read the full guide: [customize your Babel config](https://next.gatsbyjs.org/docs/babel/)
-
-</details>
-
 ## 🤝 How to Contribute
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community! :muscle::purple_heart:
 
 Check out our [contributor onboarding docs](https://next.gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repos up and running on your local machine.
 
-#### [Read the Contributing Guide](https://next.gatsbyjs.org/docs/how-to-contribute/)
+[**Read the Contributing Guide**](https://next.gatsbyjs.org/docs/how-to-contribute/)
+
+### Code of Conduct
+
+Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [Code of Conduct](https://next.gatsbyjs.org/docs/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
+
+[**Read the Code of Conduct**](https://next.gatsbyjs.org/docs/code-of-conduct/)
 
 ### A note on how this repository is organized
 

--- a/README.md
+++ b/README.md
@@ -4,27 +4,35 @@
   </a>
 </p>
 <h1 align="center">
-  Gatsby
+  Gatsby v2 [beta] · (see <a href="https://github.com/gatsbyjs/gatsby/tree/v1">v1</a>)
 </h1>
 
-<div align="center">
-  :muscle:
-</div>
-<div align="center">
-  <strong></strong>
-</div>
-
-[![Travis CI Build Status](https://travis-ci.org/gatsbyjs/gatsby.svg?branch=master)](https://travis-ci.org/gatsbyjs/gatsby)
-[![npm package](https://img.shields.io/npm/v/gatsby.svg?style=flat-square)](https://www.npmjs.org/package/gatsby)
-[![npm package](https://img.shields.io/npm/dm/gatsby.svg)](https://npmcharts.com/compare/gatsby?minimal=true)
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/gatsby-js)
-[![gatsby channel on discord](https://img.shields.io/badge/discord-gatsby%40reactiflux-738bd7.svg?style=flat-square)](https://discord.gg/0ZcbPKXt5bVoxkfV)
-[![Open Source Helpers](https://www.codetriage.com/gatsbyjs/gatsby/badges/users.svg)](https://www.codetriage.com/gatsbyjs/gatsby)
-[![Twitter Follow](https://img.shields.io/twitter/follow/gatsbyjs.svg?style=social)](https://twitter.com/gatsbyjs)
-
-# Gatsby v2 Beta
-
-⚛️📄🚀 Blazing-fast site generator for React
+<h3 align="center">
+  ⚛️ 📄 :rocket:
+</h3>
+<p align="center">
+  <strong>Blazing fast site generator for React</strong>
+</p>
+<p align="center">
+  <a href="https://github.com/gatsbyjs/gatsby/blob/master/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Gatsby is released under the MIT license." />
+  </a>
+  <a href="https://travis-ci.org/gatsbyjs/gatsby">
+    <img src="https://travis-ci.org/gatsbyjs/gatsby.svg?branch=master" alt="Current TravisCI build status." />
+  </a>
+  <a href="https://www.npmjs.org/package/gatsby">
+    <img src="https://img.shields.io/npm/v/gatsby.svg?style=flat-square" alt="Current npm package version." />
+  </a>
+  <a href="https://npmcharts.com/compare/gatsby?minimal=true">
+    <img src="https://img.shields.io/npm/dm/gatsby.svg" alt="Downloads per month on npm." />
+  </a>
+  <a href="https://spectrum.chat/gatsby-js">
+    <img src="https://withspectrum.github.io/badge/badge.svg" alt="Gatsby support community on Spectrum." />
+  </a>
+  <a href="https://next.gatsbyjs.org/docs/how-to-submit-a-pr/">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
+  </a>
+</p>
 
 **NOTE:** This branch is the beta version of Gatsby v2. You can find documentation at [next.gatsbyjs.org](https://next.gatsbyjs.org/).
 
@@ -67,230 +75,6 @@ The following policy will be in place during the v2 beta:
 
 We're using this policy as the Gatsby team currently spends a significant amount of time maintaining two active branches - the v1 branch and the v2 branch - we'd like to limit this work to focus on getting v2 released and start working on oft-requested new features like schema snapshots and schema stitching.
 
-## Showcase
-
-Websites built with Gatsby:
-
-- [React](https://reactjs.org/)
-  ([source](https://github.com/reactjs/reactjs.org))
-- [Sourcegraph](https://about.sourcegraph.com)
-- [Simply](https://simply.co.za)
-- [The freeCodeCamp Guide](https://guide.freecodecamp.org)
-  ([source](https://github.com/freeCodeCamp/guides))
-- [Storybook](https://storybook.js.org) ([source](https://github.com/storybooks/storybook))
-- [Learn Storybook](https://learnstorybook.com) ([source](https://github.com/hichroma/learnstorybook.com))
-- [FloydHub's Blog](https://blog.floydhub.com)
-- [mParticle's Documentation](https://docs.mparticle.com)
-- [Segment's Blog](https://segment.com/blog/)
-- [Fabric](https://meetfabric.com/)
-- [Formidable](https://formidable.com/)
-- [Ledgy](https://www.ledgy.com/)
-  ([source](https://github.com/morloy/ledgy.com))
-- [openFDA](https://open.fda.gov/)
-  ([source](https://github.com/FDA/open.fda.gov))
-- [Bricolage.io](https://www.bricolage.io/)
-  ([source](https://github.com/KyleAMathews/blog))
-- [Hack Club](https://hackclub.com/)
-  ([source](https://github.com/hackclub/site))
-- [High School Hackathons](https://hackathons.hackclub.com/)
-  ([source](https://github.com/hackclub/hackathons))
-- [Jamie Henson's Blog](http://jamiehenson.com/)
-  ([source](https://github.com/jamiehenson/jh47-gatsby))
-- [Sean Coker's Blog](https://sean.is/)
-- [Dustin Schau's Blog](https://dustinschau.com/blog/)
-  ([source](https://github.com/dschau/blog))
-- [The Chiedo Companies Website](https://www.chiedo.com)
-- [Damir.io](http://damir.io/)
-  ([source](https://github.com/dvzrd/gatsby-sfiction))
-- [Ruben's Blog](https://vagr9k.me/) ([source](https://github.com/Vagr9K/Blog))
-- [Kostas Bariotis' Blog](https://kostasbariotis.com/)
-  ([source](https://github.com/kbariotis/kostasbariotis.com))
-- [Thao Am Private Enterprise](http://thaoam.com/)
-- [Bakadono](http://bakadono.com/)
-- [Travellers.cafe](https://travellers.cafe/)
-- [Oliver Benns' Portfolio](https://oliverbenns.com)
-  ([source](https://github.com/oliverbenns/oliverbenns.com))
-- [angeloocana.com](https://angeloocana.com)
-  ([source](https://github.com/angeloocana/angeloocana))
-- [knpw.rs](https://knpw.rs) ([source](https://github.com/knpwrs/knpw.rs))
-- [Overlap.show](https://overlap.show)
-  ([source](https://github.com/pouretrebelle/overlap.show))
-- [smartive Company Website](https://smartive.ch)
-- [Haboba Find Jobs at Phu Quoc Island](http://haboba.com)
-- [Charlie Harrington's Blog](https://charlieharrington.com)
-  ([source](https://github.com/whatrocks/blog))
-- [Song Wang’s website](https://songwang.io/)
-  ([source](https://github.com/wangsongiam/songwang.io))
-- [Digital Psychology](http://digitalpsychology.io)
-  ([source](https://github.com/danistefanovic/digitalpsychology.io))
-- [Magicly's blog](https://magicly.me/)
-  ([source](https://github.com/magicly/gatsby-blog))
-- [Dalbinaco's website](http://dalbinaco.com/)
-  ([source](https://github.com/dalbinaco/dalbinaco.github.io))
-- [Phu Quoc Works](http://phuquocworks.net)
-- [Kabir Goel's website](https://kbrgl.github.io)
-  ([source](https://github.com/kbrgl/kbrgl.github.io))
-- [Gabriel Adorf's Portfolio](https://gabrieladorf.com/)
-  ([source](https://github.com/gabdorf/gabriel-adorf-portfolio))
-- [CSS Grid Playground by MozillaDev](https://mozilladevelopers.github.io/playground/)
-  ([source](https://github.com/MozillaDevelopers/playground))
-- [David James' Portfolio](http://dfjames.com)
-  ([source](https://github.com/daviddeejjames/dfjames-gatsby))
-- [Tic Tac Toe AI](https://tic-tac-toe-ai.surge.sh)
-  ([source](https://github.com/angeloocana/tic-tac-toe-ai))
-- [Etcetera Design](https://etcetera.design)
-  ([source](https://github.com/etceteradesign/website))
-- [Azer Koçulu](http://azer.bike)
-- [Random Screencast](https://randomscreencast.com)
-- [Phu Quoc Tea & Coffee Store](http://trasuaphuquoc.com)
-- [Steven Natera's blog](https://www.stevennatera.com)
-- [LekoArts - Graphic Designer Portfolio](https://www.lekoarts.de) ([source](https://github.com/LeKoArts/portfolio))
-- [Georgi Yanev](https://blog.georgi-yanev.com)
-  ([source](https://github.com/jumpalottahigh/blog.georgi-yanev.com))
-- [OnCallogy.com](https://www.oncallogy.com)
-- [doopoll's marketing site](https://doopoll.co)
-- [Design Systems Weekly](https://designsystems.email/)
-- [Slite landing pages](https://slite.com/)
-- [Hallingdata](http://hallingdata.no/)
-- [@swyx](http://swyx.io) ([source](https://github.com/sw-yx/swyxdotio))
-- [Portfolio of Piotr Fedorczyk](https://piotrf.pl)
-- [JavaScript Stuff](https://www.javascriptstuff.com)
-- [GRANDstack - GraphQL, React, Apollo, Neo4j Database](http://grandstack.io/)
-- [GraphCMS's website](https://graphcms.com)
-- [Mannequin.io](https://mannequin.io)
-  ([source](https://github.com/LastCallMedia/Mannequin/tree/master/site))
-- [Calpa's Blog](https://calpa.me) [(source)](https://github.com/calpa/blog)
-- [API Platform](https://api-platform.com)
-  ([source](https://github.com/api-platform/website))
-- [Bottender Docs](https://bottender.js.org/)
-  ([source](https://github.com/bottenderjs/bottenderjs.github.io))
-- [How to GraphQL](https://www.howtographql.com/)
-  ([source](https://github.com/howtographql/howtographql))
-- [greglobinski.com](https://greglobinski.com)
-  ([source](https://github.com/greglobinski/greglobinski-com))
-- [Vibert Thio's Portfolio](https://vibertthio.com/portfolio/)([source](https://github.com/vibertthio/portfolio))
-- [YouFoundRon.com](https://youfoundron.com)
-  ([source](https://github.com/rongierlach/yfr-dot-com))
-- [heml.io](https://heml.io)
-  ([source](https://github.com/SparkPost/heml.io))
-- [伊撒尔の窝](https://www.yisaer.com)
-- [Artivest's Public Website](https://artivest.co)
-- [William Owen UK](http://william-owen.co.uk)
-- [NYC Planning Labs (New York City Department of City Planning)](https://planninglabs.nyc)([source](https://github.com/nycplanning/labs-planninglabs-home))
-- [The State of European Tech 2017](https://2017.stateofeuropeantech.com)
-- [Santa Compañía Creativa](https://santacc.es) ([source](https://github.com/DesarrolloWebSantaCC/santacc-web))
-- [Pravdomil](https://pravdomil.com) ([source](https://github.com/pravdomil/pravdomil.com))
-- [Fabian Schultz' Portfolio](https://fabianschultz.com)
-  ([source](https://github.com/fabe/site))
-- [Caddy smells like trees - Free-folk band official page](https://caddysmellsliketrees.ru)
-  ([source](https://github.com/podabed/caddysmellsliketrees.github.io))
-- [BRIIM](https://bri.im/)
-- [KNW Photography](https://www.knw.io)
-  ([source](https://github.com/ryanwiemer/knw))
-- [NEON](http://neonrated.com)
-- [A4 纸网](http://www.a4z.cn)([source](https://github.com/hiooyUI/hiooyui.github.io))
-- [manu.ninja](https://manu.ninja/) ([source](https://github.com/Lorti/manu.ninja))
-- [Kris Hedstrom's Portfolio](https://k-create.com/) ([source](https://github.com/kristofferh/kristoffer))
-- [Chocolate free website](https://chocolate-free.com/) ([source](https://github.com/Khaledgarbaya/chocolate-free-website))
-- [Charles Pinnix Website](https://www.charlespinnix.com/)
-- [Verious](https://www.verious.io/) ([source](https://github.com/cpinnix/verious))
-- [Developer Ecosystem](https://www.developerecosystem.com/)
-- [Steve Meredith's Portfolio](http://www.steveeeie.io/)
-- [Landing page of Put.io](https://put.io/)
-- [Ryan Wiemer's Portfolio](https://www.ryanwiemer.com)
-  ([source](https://github.com/ryanwiemer/rw))
-- [yerevancoder](https://yerevancoder.com)
-  ([source](https://github.com/yerevancoder/yerevancoder.github.io))
-- [unrealcpp](https://unrealcpp.com/) ([source](https://github.com/Harrison1/unrealcpp-com))
-- [several levels](https://severallevels.io/) ([source](https://github.com/Harrison1/several-levels))
-- [Flooring Factories Outlets](https://www.flooringfactoriesoutlets.com/)
-- [Nortcast](https://nortcast.com/)
-- [VisitGemer](https://visitgemer.sk/)
-- [Nexit](https://nexit.sk/)
-- [ERC dEX](https://ercdex.com)
-- [iContract Blog](https://blog.icontract.co.uk)
-- [Dona Rita](https://donarita.co.uk) ([source](https://github.com/peduarte/dona-rita-website))
-- [Andy Slezak](https://www.aslezak.com) ([source](https://github.com/amslezak))
-- [Odayaka](http://odayaka.net) ([source](https://github.com/odayakanaasa/odayaka))
-- [Ventura Digitalagentur Köln](https://www.ventura-digital.de)
-- [Cardiogram](https://cardiogr.am/)
-- [LaserTime Clinic](https://lasertime.ru) ([source](https://github.com/oleglegun/lasertime))
-- [Gatsby Manor - themes for GatsbyJS](https://gatsbymanor.com)
-- [Darren Britton's Portfolio](https://darrenbritton.com) ([source](https://github.com/darrenbritton/darrenbritton.github.io))
-- [Portfolio / Blog of Preston Richey](https://prestonrichey.com/) ([source](https://github.com/prichey/prestonrichey.com))
-- [Beach Hut Poole](https://www.beachhutpoole.co.uk/)
-- [In Sowerby Bridge](https://www.insowerbybridge.co.uk/)
-- [枫上雾棋的日志](https://fengshangwuqi.github.io/)
-- [Juliette Pretot's Portfolio](https://juliette.sh)
-- [Théâtres Parisiens](http://theatres-parisiens.fr/) ([source](https://github.com/phacks/theatres-parisiens))
-- [Jia Hao's Website / Blog](https://jiahao.codes/) ([source](https://github.com/jiahaog/jiahao.codes))
-- [Orbit FM Podcasts](https://www.orbit.fm/) ([source](https://github.com/agarrharr/orbit.fm))
-- [Michele Mazzucco's Portfolio](https://www.michelemazzucco.it) ([source](https://github.com/michelemazzucco/michelemazzucco.it))
-- [Rung](https://rung.com.br)
-- [Óbuda University - EE Faculty Student Union Website](https://www.kandohok.hu)
-- [Neostack](https://neostack.com)
-- [Prosecco Springs](https://www.proseccosprings.com/)
-- [Fröhlich ∧ Frei](https://www.froehlichundfrei.de/)
-- [Alec Lomas's Portfolio & Blog](https://lowmess.com) ([source](https://github.com/lowmess/lowmess))
-- [Alex Pate - Blog/Portfolio](https://alexpate.uk) ([source](https://github.com/alexpate/alexpate.uk))
-- [Matthias Jordan - Portfolio](https://iammatthias.com) ([source](https://github.com/iammatthias/net))
-- [Daniel Hollcraft](https://danielhollcraft.com) ([source](https://github.com/danielbh/danielhollcraft.com))
-- [Investment Calculator](https://investmentcalculator.io/)
-- [Nikbelikov.ru](http://nikbelikov.ru/)
-- [Watchcards.ru](http://watchcards.ru/)
-- [John Meguerian's Portfolio](https://johnmeguerian.com) ([source](https://github.com/jmegs/portfolio))
-- [Krashna Musika Association Website](https://www.krashna.nl/) ([source](https://github.com/krashnamusika/krashna-site))
-- [Deliveroo.Design](https://www.deliveroo.design/)
-- [The Rick and Morty API](http://rickandmortyapi.com/)
-- [Adnan Fajlur - Portfolio](https://adnanfajlur.xyz/)
-- [Hapticmedia](https://hapticmedia.fr/en/)
-- [Smakosh](https://smakosh.com) ([source](https://github.com/smakosh/smakosh.com))
-- [Philipp Czernitzki - Blog/Website](http://philippczernitzki.me)
-- [CodeBushi](https://codebushi.com/)
-- [WebGazer](https://www.webgazer.io)
-- [Joe Seifi's Blog](http://seifi.org)
-- [Bartosz Dominiak Blog/Portfolio](http://www.bartoszdominiak.com/) ([source](https://github.com/bartdominiak/blog))
-- [The Audacious Project](https://audaciousproject.org/)
-- [upGizmo](https://www.upgizmo.com/)
-- [The Bastion Bot](https://bastionbot.org/ "The Bastion Bot")
-- [Yuuniworks](https://www.yuuniworks.com/) ([source](https://github.com/junkboy0315/yuuni-web))
-- [Chin Loong Tan - Blog/Portfolio](https://chinloongtan.com/)
-- [F1 Vision](https://f1vision.com/)
-- [GraphQL College](https://graphql.college) ([source](https://github.com/GraphQLCollege/graphql-college))
-- [Hyunwoo Kim - Blog/Portfolio](https://devhalloween.com) ([source](https://github.com/khw1031/dev-blog))
-- [Abinav Seelan - Personal Website](https://abinavseelan.com) ([source](https://github.com/abinavseelan/abinavseelan.com))
-- [Dovetail](https://dovetailapp.com)
-- [Bart van der Waerden Blog](http://bartvanderwaerden.com/) ([source](https://github.com/BartvdWaerden/BartvdWaerden.github.io))
-- [Canella Riccardo - Portfolio](https://canellariccardo.it) ([source](https://github.com/thecreazy/canellariccardo.it))
-- [Eviction Free NYC!](https://www.evictionfreenyc.org/) ([source](https://github.com/JustFixNYC/eviction-free-nyc))
-- [Rafael Belliard's Portfolio](https://rafael.do) ([source](https://github.com/rebelliard/rebelliard.github.io))
-- [Tinder Interracial Couple Emoji Project](https://emoji.tinder.com/)
-- [aQuICK](https://aquick.review/)
-  ([source](https://github.com/aQuICK-Review/aQuick))
-- [Workshop In The Woods](https://www.workshop-in-the-woods.com/) ([source](https://github.com/ryanwiemer/workshop))
-- [Steven Koerts - Portfolio](http://stevenkoerts.nl/)([source](https://github.com/Steven24K/Steven24K.github.io))
-- [Ray Gesualdo - Personal Website](http://www.raygesualdo.com/) ([source](https://github.com/raygesualdo/raygesualdo.com))
-- [10M GmbH](https://10m.de)
-- [Edge Database](https://edgedb.com/)
-- [Rolling Stone: The New Classics](https://www.rollingstone.com/the-new-classics)
-- [Jacob Bolda - Personal Website](https://www.jacobbolda.com/)
-- [Apideck](https://apideck.com)
-- [GDPR Checklist](https://gdprchecklist.io) ([source](https://github.com/privacyradius/gdpr-checklist))
-- [GDPR Tracker](https://gdprtracker.io)
-- [GDPR Form](https://gdprform.io)
-- [Josh Palacios - Personal Website](https://joshpalacios.com) ([source](https://github.com/jshwa/joshpalacios-site))
-- [Cup of Data](https://cupofdata.com) ([source](https://github.com/cupofdata/cupofdata.com))
-- [Natalia Acevedo - Personal Website](https://nataliaacevedo.com) ([source](https://github.com/yeion7/nataliaacevedo.com))
-- [Airbnb Cereal](https://airbnb.design/cereal/)
-- [mottox2 blog](https://mottox2.com)
-- [Tiger Facility Services](https://www.tigerfacilityservices.com/)
-- [Jersey Watch](https://www.jerseywatch.com/)
-- [Bench Accounting](https://bench.co/)
-- [杨二的博客](https://blog.yangerxiao.com/)
-- [GaiAma - We are wildlife](https://www.gaiama.org) ([source](https://github.com/GaiAma/gaiama.org))
-- [Rescue Amazonian Rainforest](https://www.rescue-amazonian-rainforest.com/) ([source](https://github.com/GaiAma/rescue-amazonian-rainforest.com))
-- [Michael McQuade - Personal Blog](https://giraffesyo.io) ([source](https://github.com/giraffesyo/giraffesyo.github.io))
-
 ## Docs
 
 **[View the docs on gatsbyjs.org](https://www.gatsbyjs.org/docs/)**
@@ -310,9 +94,9 @@ This repository is a monorepo managed using
 ## Thanks
 
 Thanks to our many contributors and sponsors as well as the companies sponsoring
-our testing and hosting infrastructure, Travis CI, Appveyor, and Netlify.
+our testing and hosting infrastructure: Travis CI, Appveyor, and Netlify.
 
-## Backers
+### Backers
 
 Support us with a monthly donation and help us continue our activities.
 [[Become a backer](https://opencollective.com/gatsby#backer)]
@@ -348,7 +132,7 @@ Support us with a monthly donation and help us continue our activities.
 <a href="https://opencollective.com/gatsby/backer/28/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/28/avatar.svg"></a>
 <a href="https://opencollective.com/gatsby/backer/29/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/29/avatar.svg"></a>
 
-## Sponsors
+### Sponsors
 
 Become a sponsor and get your logo on our README on GitHub with a link to your
 site. [[Become a sponsor](https://opencollective.com/gatsby#sponsor)]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://gatsbyjs.org">
+  <a href="https://next.gatsbyjs.org">
     <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
   </a>
 </p>
@@ -11,7 +11,8 @@
   ⚛️ 📄 :rocket:
 </h3>
 <p align="center">
-  <strong>Blazing fast site generator for React</strong>
+  <strong>Blazing fast site generator for React</strong><br>
+  Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby.
 </p>
 <p align="center">
   <a href="https://github.com/gatsbyjs/gatsby/blob/master/LICENSE">
@@ -33,6 +34,20 @@
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
   </a>
 </p>
+
+<h3 align="center">
+  <a href="https://next.gatsbyjs.org/docs/">Quickstart</a>
+  <span> · </span>
+  <a href="https://next.gatsbyjs.org/tutorial/">Tutorial</a>
+  <span> · </span>
+  <a href="https://next.gatsbyjs.org/plugins/">Plugins</a>
+  <span> · </span>
+  <a href="https://next.gatsbyjs.org/docs/gatsby-starters/">Starters</a>
+  <span> · </span>
+  <a href="https://spectrum.chat/gatsby-js">Get Support</a>
+  <span> · </span>
+  <a href="https://next.gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
+</h3>
 
 **NOTE:** This branch is the beta version of Gatsby v2. You can find documentation at [next.gatsbyjs.org](https://next.gatsbyjs.org/).
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,15 @@
 
 ## Table of Contents
 
--   [Get Up and Running in 5 Minutes](#get-up-and-running-in-5-minutes)
--   [How to Contribute](#how-to-contribute)
+-   [Get Up and Running in 5 Minutes](#-get-up-and-running-in-5-minutes)
+-   [Learning Gatsby](#-learning-gatsby)
+-   [Migration Guides](#-migration-guides)
+-   [For Advanced Developers: Code Samples & Recipes](#-code-samples-and-recipes)
+-   [How to Contribute](#-how-to-contribute)
+-   [Thanks to Our Contributors and Sponsors](#-thanks-to-our-contributors-and-sponsors)
 
 
-## Get Up and Running in 5 Minutes
+## 🚀 Get Up and Running in 5 Minutes
 
 You can get a new Gatsby site up and running on your local dev environment in 5 minutes with these three steps:
 
@@ -83,148 +87,131 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
 At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://next.gatsbyjs.org/plugins/) and [the official tutorial](https://next.gatsbyjs.org/tutorial/).
 
+## 🎓 Learning Gatsby
 
+For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://next.gatsbyjs.org/tutorial/). It starts with zero assumptions about your level of ability and walks through every step of the process, from [setting up your site](https://next.gatsbyjs.org/tutorial/part-one/), to [handling styles](https://next.gatsbyjs.org/tutorial/part-two/) and [layouts](https://next.gatsbyjs.org/tutorial/part-three/), to [querying for data in pages](https://next.gatsbyjs.org/tutorial/part-four/) and [adding data from external sources](https://next.gatsbyjs.org/tutorial/part-five/), to more advanced topics like [transforming data](https://next.gatsbyjs.org/tutorial/part-six/), [programmatically creating pages](https://next.gatsbyjs.org/tutorial/part-seven/), and [prepping your site for deployment](https://next.gatsbyjs.org/tutorial/part-eight/).
 
-## How to Contribute
+#### [Follow the Tutorial](https://next.gatsbyjs.org/tutorial/)
+
+## 💼 Migration Guide
+
+Already have a Gatsby site? These handy guides will help you add the improvements of Gatsby v2 to your site without starting from scratch!
+
+- [Migrate a Gatsby site from v1 to v2](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/)
+- Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://next.gatsbyjs.org/docs/migrating-from-v0-to-v1/)
+
+## 👩‍💻 Code Samples and Recipes
+
+For more advanced developers who just want to dig in and see how Gatsby handles various patterns and workflows, this section is full of code samples and links through to specialized docs.
+
+> **NOTE:** This section is full of abbreviated examples. If you don’t see what you need here, [see the “Guides” section of the docs](https://next.gatsbyjs.org/docs/) to see these examples (and more!) in additional detail.
+
+<details>
+  <summary><strong>Create a Gatsby project without a starter</strong></summary>
+
+  <span><!-- don’t remove this; it prevents the text below from smashing into the summary text --></span>
+  
+  To add a global stylesheet, require the stylesheet in `gatsby-browser.js`:
+  ```sh
+  # create a new project and move into it
+  mkdir my-new-gatsby-site
+  cd my-new-gatsby-site
+  
+  # initialize the project
+  yarn init
+  
+  # add the required dependencies
+  yarn add gatsby@next react react-dom
+  ```
+</details>
+
+<details>
+  <summary><strong>Add global styles to your site</strong></summary>
+
+  <span><!-- don’t remove this; it prevents the text below from smashing into the summary text --></span>
+  
+  To add a global stylesheet, require the stylesheet in `gatsby-browser.js`:
+  ```jsx
+  require('./src/stylesheets/global.css');
+  
+  exports.onClientEntry = () => {/* other custom config here */}
+  ```
+  
+  #### Read the full guide: [creating global styles](https://next.gatsbyjs.org/docs/creating-global-styles/)
+
+</details>
+
+<details>
+  <summary><strong>Customize your Babel configuration</strong></summary>
+
+  <span><!-- don’t remove this; it prevents the text below from smashing into the summary text --></span>
+  
+  If you add a `.babelrc` in the root of your project, it overrides the default Gatsby config entirely. We recommend starting with our config and modifying as needed.
+
+  Gatsby’s default `.babelrc`:
+  ```json
+  {
+    "cacheDirectory": true,
+    "babelrc": false,
+    "presets": [
+      [
+        "@babel/preset-env",
+        {
+          "loose": true,
+          "modules": false,
+          "useBuiltIns": "usage",
+          "shippedProposals": true,
+          "targets": {
+            "browsers": [">0.25%", "not dead"],
+          },
+        },
+      ],
+      [
+        "@babel/preset-react",
+        {
+          "useBuiltIns": true,
+          "pragma": "React.createElement",
+        },
+      ],
+      "@babel/preset-flow",
+    ],
+    "plugins": [
+      [
+        "@babel/plugin-proposal-class-properties",
+        {
+          "loose": true,
+        },
+      ],
+      "@babel/plugin-syntax-dynamic-import",
+      [
+        "@babel/plugin-transform-runtime",
+        {
+          "helpers": true,
+          "regenerator": true,
+          "polyfill": false,
+        },
+      ],
+    ],
+  }
+  ```
+  
+  #### Read the full guide: [customize your Babel config](https://next.gatsbyjs.org/docs/babel/)
+
+</details>
+
+## 🤝 How to Contribute
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community! :muscle::purple_heart:
 
 Check out our [contributor onboarding docs](https://next.gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repos up and running on your local machine.
 
----
+#### [Read the Contributing Guide](https://next.gatsbyjs.org/docs/how-to-contribute/)
 
-## Previous README
+### A note on how this repository is organized
 
-**NOTE:** This branch is the beta version of Gatsby v2. You can find documentation at [next.gatsbyjs.org](https://next.gatsbyjs.org/).
+This repository is a [monorepo](https://trunkbaseddevelopment.com/monorepos/) managed using [Lerna](https://github.com/lerna/lerna). This means there are [multiple packages](/packages) managed in this codebase, even though we publish them to NPM as separate packages.
 
-For `gatsby@1`, please see [the v1 branch](https://github.com/gatsbyjs/gatsby/tree/v1).
-
-**Are you using v1 and want to upgrade to the Gatsby v2 Beta? Check out [our v1 => v2 migration guide](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/).**
-
-**Starting a new project with Gatsby v2**
-If you'd like to start a new project with Gatsby v2 you can use the v2 edition of any offical starter. Install your favourite one with the Gatsby CLI.
-
-`gatsby-starter-default` with v2:
-
-```
-gatsby new my-default-project https://github.com/gatsbyjs/gatsby-starter-default#v2
-```
-
-`gatsby-starter-hello-world` with v2:
-
-```
-gatsby new my-hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world#v2
-```
-
-`gatsby-starter-blog` with v2:
-
-```
-gatsby new my-blog https://github.com/gatsbyjs/gatsby-starter-blog#v2
-```
-
-If you're a _start from scratch_ kind of person, you can install the Gatsby beta and React like this: `npm install gatsby@next react react-dom`
-
-**How are pull requests being handled during the v2 beta?**
-
-The following policy will be in place during the v2 beta:
-
-- We will only accept _bug fixes_ for Gatsby v1. Any PRs opened against v1 that are not bug fixes will be closed
-
-- If the bug fix is applicable to v2, we will open an additional issue to track porting the change to v2
-
-- All _new features_ should be opened as pull requests against v2 (the `master` branch)
-
-We're using this policy as the Gatsby team currently spends a significant amount of time maintaining two active branches - the v1 branch and the v2 branch - we'd like to limit this work to focus on getting v2 released and start working on oft-requested new features like schema snapshots and schema stitching.
-
-## Docs
-
-**[View the docs on gatsbyjs.org](https://www.gatsbyjs.org/docs/)**
-
-[Migrating from v1 to v2?](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/)
-
-[Migrating from v0 to v1?](https://www.gatsbyjs.org/docs/migrating-from-v0-to-v1/)
-
-[v0 docs](https://github.com/gatsbyjs/gatsby/blob/v0.12.48/docs/index.md)
-
-## Packages
-
-This repository is a monorepo managed using
-[Lerna](https://github.com/lerna/lerna). This means that we publish
-[many packages](/packages) to NPM from the same codebase.
-
-## Thanks
+## 💜 Thanks to Our Contributors and Sponsors
 
 Thanks to our many contributors and sponsors as well as the companies sponsoring
-our testing and hosting infrastructure: Travis CI, Appveyor, and Netlify.
-
-### Backers
-
-Support us with a monthly donation and help us continue our activities.
-[[Become a backer](https://opencollective.com/gatsby#backer)]
-
-<a href="https://opencollective.com/gatsby/backer/0/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/0/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/1/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/1/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/2/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/2/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/3/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/3/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/4/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/4/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/5/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/5/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/6/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/6/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/7/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/7/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/8/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/8/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/9/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/9/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/10/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/10/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/11/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/11/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/12/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/12/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/13/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/13/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/14/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/14/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/15/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/15/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/16/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/16/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/17/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/17/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/18/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/18/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/19/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/19/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/20/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/20/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/21/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/21/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/22/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/22/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/23/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/23/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/24/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/24/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/25/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/25/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/26/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/26/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/27/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/27/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/28/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/28/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/backer/29/website" target="_blank"><img src="https://opencollective.com/gatsby/backer/29/avatar.svg"></a>
-
-### Sponsors
-
-Become a sponsor and get your logo on our README on GitHub with a link to your
-site. [[Become a sponsor](https://opencollective.com/gatsby#sponsor)]
-
-<a href="https://opencollective.com/gatsby/sponsor/0/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/0/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/1/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/1/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/2/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/2/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/3/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/3/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/4/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/4/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/5/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/5/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/6/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/6/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/7/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/7/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/8/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/9/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/9/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/10/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/10/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/11/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/11/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/12/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/12/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/13/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/13/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/14/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/14/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/15/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/15/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/16/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/16/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/17/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/17/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/18/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/18/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/19/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/19/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/20/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/20/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/21/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/21/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/22/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/22/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/23/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/23/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/24/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/24/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/25/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/25/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/26/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/26/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/27/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/27/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/28/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/28/avatar.svg"></a>
-<a href="https://opencollective.com/gatsby/sponsor/29/website" target="_blank"><img src="https://opencollective.com/gatsby/sponsor/29/avatar.svg"></a>
+our testing and hosting infrastructure: [Travis CI](https://travis-ci.com/), [Appveyor](https://www.appveyor.com/), and [Netlify](https://www.netlify.com/).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+<p align="center">
+  <a href="https://gatsbyjs.org">
+    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
+  </a>
+</p>
+<h1 align="center">
+  Gatsby
+</h1>
+
+<div align="center">
+  :muscle:
+</div>
+<div align="center">
+  <strong></strong>
+</div>
+
 [![Travis CI Build Status](https://travis-ci.org/gatsbyjs/gatsby.svg?branch=master)](https://travis-ci.org/gatsbyjs/gatsby)
 [![npm package](https://img.shields.io/npm/v/gatsby.svg?style=flat-square)](https://www.npmjs.org/package/gatsby)
 [![npm package](https://img.shields.io/npm/dm/gatsby.svg)](https://npmcharts.com/compare/gatsby?minimal=true)
@@ -5,8 +21,6 @@
 [![gatsby channel on discord](https://img.shields.io/badge/discord-gatsby%40reactiflux-738bd7.svg?style=flat-square)](https://discord.gg/0ZcbPKXt5bVoxkfV)
 [![Open Source Helpers](https://www.codetriage.com/gatsbyjs/gatsby/badges/users.svg)](https://www.codetriage.com/gatsbyjs/gatsby)
 [![Twitter Follow](https://img.shields.io/twitter/follow/gatsbyjs.svg?style=social)](https://twitter.com/gatsbyjs)
-
-<img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="100">
 
 # Gatsby v2 Beta
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,44 @@
   <a href="https://next.gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
 </h3>
 
+## Table of Contents
+
+-   [Get Up and Running in 5 Minutes](#get-up-and-running-in-5-minutes)
+
+
+## Get Up and Running in 5 Minutes
+
+You can get a new Gatsby site up and running on your local dev environment in 5 minutes with these three steps:
+
+1.  **Create a Gatsby site from a Gatsby starter.**
+
+    Get your Gatsby blog set up in a single command:
+
+    ```sh
+    npx gatsby-cli new my-blazing-fast-site https://github.com/gatsbyjs/gatsby-starter-default#v2
+    ```
+
+2.  **Start the site in `develop` mode.**
+
+    Next, move into your new site’s directory and start it up:
+
+    ```sh
+    cd my-blazing-fast-site/
+    yarn develop
+    ```
+
+    > **NOTE:** If you prefer npm, you can also run `npm run develop` to start the site.
+
+3.  **Open the source code and start editing! 💪💜**
+
+    Your site is now running at `http://localhost:8000`. Open the the `my-blazing-fast-site` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
+
+At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://next.gatsbyjs.org/plugins/) and [the official tutorial](https://next.gatsbyjs.org/tutorial/).
+
+---
+
+## Previous README
+
 **NOTE:** This branch is the beta version of Gatsby v2. You can find documentation at [next.gatsbyjs.org](https://next.gatsbyjs.org/).
 
 For `gatsby@1`, please see [the v1 branch](https://github.com/gatsbyjs/gatsby/tree/v1).

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For most developers, we recommend starting with our [in-depth tutorial for creat
 
 #### [Follow the Tutorial](https://next.gatsbyjs.org/tutorial/)
 
-## 💼 Migration Guide
+## 💼 Migration Guides
 
 Already have a Gatsby site? These handy guides will help you add the improvements of Gatsby v2 to your site without starting from scratch!
 


### PR DESCRIPTION
This is the beginnings of a rewrite for the v2 README.

Huge thanks to https://github.com/choojs/choo and https://github.com/zeit/next.js for creating excellent READMEs I could steal liberally from. 😅 

### [See the new work-in-progress README](https://github.com/jlengstorf/gatsby/blob/docs/6569-readme-rewrite/README.md)

## Remaining work

- [x] Add a “what is Gatsby and why should I care?” section (see [the React README](https://github.com/facebook/react/#react------) for a good example)
- [x] Decide if we should keep the “advanced” section
	- How do we keep this from becoming a ton of duplicate doc maintenance work?
	- If we _don’t_ keep it, how do we make it easy for advanced users to find a quick reference of advanced topics?
	- If we _do_ keep it, what should be included?
- [x] Decide on pointing to v1 vs. v2 docs
- [x] Add a link to the Code of Conduct in the Contributing section
- [x] Add a license callout at the bottom of the README
- [x] Decide whether or not to keep Open Collective
	- Answered: [we should not](https://github.com/gatsbyjs/gatsby/pull/6843#pullrequestreview-141334559)


Overall I feel pretty good about this. Looking forward to feedback!

cc: @gatsbyjs/inkteam 