### PR TITLE
Suggest StaticQuery for exported queries that will not run

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -142,10 +142,12 @@ const updateStateAndRunQueries = isFirstRun => {
 
     if (queriesWillNotRun) {
       report.log(report.stripIndent`
-        Queries are only executed for Page components. Instead of a query,
-        co-locate a GraphQL fragment and compose that fragment into the query (or other
-        fragment) of the top-level page that renders this component. For more
-        info on fragments and composition see: http://graphql.org/learn/queries/#fragments
+        Exported queries are only executed for Page components. Instead of an exported
+        query, either co-locate a GraphQL fragment and compose that fragment into the
+        query (or other fragment) of the top-level page that renders this component, or
+        use a <StaticQuery> in this component. For more info on fragments and
+        composition, see http://graphql.org/learn/queries/#fragments and for more
+        information on <StaticQuery>, see https://next.gatsbyjs.org/docs/static-query
       `)
     }
     runQueuedQueries()


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
### What?

Modify the query watcher to suggest `<StaticQuery>` (in addition to the original fragment composition suggestion) when it encounters an exported query that will not run.

### Why?

Upon attempting to export a query from a non-page component, I was met with the following warning in the console:
```
warning The GraphQL query in the non-page component "/path/to/project/src/components/thing.js" will not be run.
Queries are only executed for Page components. Instead of a query,
co-locate a GraphQL fragment and compose that fragment into the query (or other
fragment) of the top-level page that renders this component. For more
info on fragments and composition see: http://graphql.org/learn/queries/#fragments
```
I thought this was quite helpful and started down the fragment composition route, until I realized what we (Gatsby and I) were doing and got a little confused why I wasn't just using a `<StaticQuery>` (I'm new to Gatsby, so I started with v2). I assume this warning just hasn't been updated yet, so here's a PR to hopefully help the next person.