### PR TITLE
[babel-plugin-remove-graphql-queries] postpone import removal

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -11,6 +11,12 @@ export const query = graphql\`
   \`;"
 `;
 
+exports[`Removes all gatsby queries 1`] = `
+"export default (() => React.createElement(\\"div\\", null, data.site.siteMetadata.title));
+export const siteMetaQuery = \\"2673797374\\";
+export const query = \\"2589775908\\";"
+`;
+
 exports[`Transforms queries in <StaticQuery> 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import React from 'react';

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
@@ -159,3 +159,31 @@ it(`Leaves other graphql tags alone`, () => {
   `
   )
 })
+
+it(`Removes all gatsby queries`, () => {
+  matchesSnapshot(
+    `
+  import { graphql } from 'gatsby'
+
+  export default () => (
+    <div>{data.site.siteMetadata.title}</div>
+  )
+
+  export const siteMetaQuery = graphql\`
+    fragment siteMetaQuery on RootQueryType {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+    }
+  \`
+
+  export const query = graphql\`
+     {
+       ...siteMetaQuery
+     }
+  \`
+  `
+  )
+})


### PR DESCRIPTION
It seems like removing `graphql` import from gatsby does break extraction and removal of next queries. This PR postpones import removal to after extraction is done

/cc @jquense 

Closes #6456