### PR TITLE
bug: remark-prismjs, remove duplicate class from code tag

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -139,9 +139,10 @@ This is some beautiful code:
     ]
     ```
 
-You can also add line highlighting. It adds a span around lines of code with a
-special class `.gatsby-highlight-code-line` that you can target with styles. See
-this README for more info.
+This code will render three markup tags. The outermost being a `div` with the class `gatsby-highlight`. Then, a `pre` tag with either the class you specified as your `classPrefix` or the default of `language-`. Finally, a classless `code` tag is the innermost wrapper.
+
+You can also add line highlighting. This plugin adds a span around lines of code with a
+special class `.gatsby-highlight-code-line` that you can target with styles. 
 
 In the following code snippet, lines 1 and 4 through 6 will get the line
 highlighting. The line range parsing is done with

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -23,7 +23,7 @@ Object {
       },
       "type": "html",
       "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\">
-      <pre class=\\"custom-js\\"><code class=\\"custom-js\\"><span class=\\"token comment\\">// Fake</span></code></pre>
+      <pre class=\\"custom-js\\"><code><span class=\\"token comment\\">// Fake</span></code></pre>
       </div>",
     },
   ],
@@ -66,7 +66,7 @@ Object {
       },
       "type": "html",
       "value": "<div class=\\"gatsby-highlight\\" data-language=\\"javascript\\">
-      <pre class=\\"language-javascript\\"><code class=\\"language-javascript\\">// Fake</code></pre>
+      <pre class=\\"language-javascript\\"><code>// Fake</code></pre>
       </div>",
     },
   ],
@@ -109,7 +109,7 @@ Object {
       },
       "type": "html",
       "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\">
-      <pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// Fake</span></code></pre>
+      <pre class=\\"language-js\\"><code><span class=\\"token comment\\">// Fake</span></code></pre>
       </div>",
     },
   ],

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -39,7 +39,7 @@ module.exports = (
     // 100% width highlighted code lines work
     node.type = `html`
     node.value = `<div class="gatsby-highlight" data-language="${languageName}">
-      <pre class="${className}"><code class="${className}">${highlightCode(
+      <pre class="${className}"><code>${highlightCode(
       language,
       node.value,
       highlightLines


### PR DESCRIPTION
This resolves #6858 that was brought up in reactjs/reactjs.org#1072 and https://github.com/reactjs/reactjs.org/issues/1077.  I've removed the class from the inner `code` block. It is left intact when code is used inline as there is no `pre` tag wrapping the `code` tag.

It was not described to put a class on both tags in the documentation, but depending on how people wrote their css this could be considered a breaking change. 

For example if they noticed this and accounted for it by doing something like:

```css
pre[class*="language-"] > code {
    margin: -1rem;
}
```
