### PR TITLE
[gatsby-remark-catch-link] Adds replace for absolute paths on same origin

### DIFF
--- a/examples/using-remark/src/pages/2017-03-21---copy-linked-files-intercepting-local-links/index.md
+++ b/examples/using-remark/src/pages/2017-03-21---copy-linked-files-intercepting-local-links/index.md
@@ -30,7 +30,9 @@ to refresh the page.
 
 Let's try linking to the
 "[Code and Syntax Highlighting with PrismJS](/code-and-syntax-highlighting/)"
-article…
+article using a relative path.
+
+Also, let's link to "[Rendering math equations with KaTeX](https://deploy-preview-6866--using-remark.netlify.com/katex/)" article using an absolute path.
 
 [1]: https://www.gatsbyjs.org/packages/gatsby-remark-copy-linked-files/
 [2]: https://www.gatsbyjs.org/packages/gatsby-plugin-catch-links/

--- a/examples/using-remark/src/pages/2017-03-21---copy-linked-files-intercepting-local-links/index.md
+++ b/examples/using-remark/src/pages/2017-03-21---copy-linked-files-intercepting-local-links/index.md
@@ -32,7 +32,7 @@ Let's try linking to the
 "[Code and Syntax Highlighting with PrismJS](/code-and-syntax-highlighting/)"
 article using a relative path.
 
-Also, let's link to "[Rendering math equations with KaTeX](https://deploy-preview-6866--using-remark.netlify.com/katex/)" article using an absolute path.
+Also, let's link to "[Rendering math equations with KaTeX](https://deploy-preview-6866--using-remark.netlify.com/katex/#math-equations-in-display-mode)" article using an absolute path.
 
 [1]: https://www.gatsbyjs.org/packages/gatsby-remark-copy-linked-files/
 [2]: https://www.gatsbyjs.org/packages/gatsby-plugin-catch-links/

--- a/examples/using-remark/src/pages/2017-03-21---copy-linked-files-intercepting-local-links/index.md
+++ b/examples/using-remark/src/pages/2017-03-21---copy-linked-files-intercepting-local-links/index.md
@@ -32,7 +32,7 @@ Let's try linking to the
 "[Code and Syntax Highlighting with PrismJS](/code-and-syntax-highlighting/)"
 article using a relative path.
 
-Also, let's link to "[Rendering math equations with KaTeX](https://deploy-preview-6866--using-remark.netlify.com/katex/#math-equations-in-display-mode)" article using an absolute path.
+Also, let's link to "[Rendering math equations with KaTeX](https://using-remark.gatsbyjs.org/katex/)" article using an absolute path.
 
 [1]: https://www.gatsbyjs.org/packages/gatsby-remark-copy-linked-files/
 [2]: https://www.gatsbyjs.org/packages/gatsby-plugin-catch-links/

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -78,7 +78,7 @@ module.exports = function (root, cb) {
     var re = new RegExp(`^${a2.host}${withPrefix(`/`)}`)
     if (!re.test(`${a1.host}${a1.pathname}`)) return true
 
-    // TODO: add a check for absolute internal links in a callback or here,
+    // Adding a check for absolute internal links in a callback or here,
     // or always pass only `${a1.pathname}${a1.hash}`
     // to avoid `https://example.com/myapp/https://example.com/myapp/here` navigation
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -89,7 +89,7 @@ module.exports = function (root, cb) {
 
     if (checkSameOriginWithoutProtocol(window.location.origin, anchoreUrl.origin)) {
       cb(anchoreUrl.pathname)
-      return true
+      return false
     }
 
     cb(anchor.getAttribute(`href`))

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -88,7 +88,7 @@ module.exports = function (root, cb) {
     var anchoreUrl = new URL(anchor.getAttribute(`href`))
 
     if (checkSameOriginWithoutProtocol(window.location.origin, anchoreUrl.origin)) {
-      cb(anchoreUrl.pathname)
+      cb(`${anchoreUrl.pathname}${anchoreUrl.search}${anchoreUrl.hash}`)
       return false
     }
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -1,7 +1,16 @@
 import { withPrefix } from "gatsby-link"
+import { replace } from 'gatsby'
 
-module.exports = function(root, cb) {
-  root.addEventListener(`click`, function(ev) {
+function checkSameOriginWithoutProtocol(origin1, origin2) {
+  const protocolRegex = new RegExp(/(^\w+:|^)\/\//)
+  const removeTrailingSlash = new RegExp(/\//g)
+
+  return origin1.replace(protocolRegex, ``).replace(removeTrailingSlash, ``) ===
+         origin2.replace(protocolRegex, ``).replace(removeTrailingSlash, ``)
+}
+
+module.exports = function (root, cb) {
+  root.addEventListener(`click`, function (ev) {
     if (
       ev.button !== 0 ||
       ev.altKey ||
@@ -20,6 +29,7 @@ module.exports = function(root, cb) {
         break
       }
     }
+
     if (!anchor) return true
 
     // Don't catch links where a target (other than self) is set
@@ -74,6 +84,14 @@ module.exports = function(root, cb) {
     // to avoid `https://example.com/myapp/https://example.com/myapp/here` navigation
 
     ev.preventDefault()
+
+
+    var anchoreUrl = new URL(anchor.getAttribute(`href`))
+
+    if (checkSameOriginWithoutProtocol(window.location.origin, anchoreUrl.origin)) {
+      replace(anchoreUrl.pathname)
+      return true
+    }
 
     cb(anchor.getAttribute(`href`))
     return false

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -1,12 +1,11 @@
 import { withPrefix } from "gatsby-link"
-import { replace } from 'gatsby'
 
 function checkSameOriginWithoutProtocol(origin1, origin2) {
   const protocolRegex = new RegExp(/(^\w+:|^)\/\//)
   const removeTrailingSlash = new RegExp(/\//g)
 
   return origin1.replace(protocolRegex, ``).replace(removeTrailingSlash, ``) ===
-         origin2.replace(protocolRegex, ``).replace(removeTrailingSlash, ``)
+    origin2.replace(protocolRegex, ``).replace(removeTrailingSlash, ``)
 }
 
 module.exports = function (root, cb) {
@@ -89,7 +88,7 @@ module.exports = function (root, cb) {
     var anchoreUrl = new URL(anchor.getAttribute(`href`))
 
     if (checkSameOriginWithoutProtocol(window.location.origin, anchoreUrl.origin)) {
-      replace(anchoreUrl.pathname)
+      cb(anchoreUrl.pathname)
       return true
     }
 


### PR DESCRIPTION
This PR handles the case when an anchor points to the same origin, with an absolute path.

Closes:  #6686

Test site - https://github.com/shobhitchittora/gatsby-catch-links-plugin-blog