### PR TITLE
Topics/netlify cms v2 improvements

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -1,5 +1,11 @@
 # gatsby-plugin-netlify-cms
 
+**Gatsby v1 and Netlify CMS 1.x require [`gatsby-plugin-netlify-cms@^2.0.0`](https://github.com/gatsbyjs/gatsby/blob/gatsby-plugin-netlify-cms@2.0.1/packages/gatsby-plugin-netlify-cms/README.md).**
+
+**Gatsby v2 and Netlify CMS 2.x require `gatsby-plugin-netlify-cms@^3.0.0-beta.0`, which is documented below.**
+
+## Overview
+
 Automatically generates an `admin/index.html` with a default Netlify CMS implementation.
 
 Netlify CMS is a React single page app for editing git based content via API.
@@ -10,7 +16,7 @@ site](https://netlifycms.org).
 ## Install
 
 ```shell
-npm install --save netlify-cms gatsby-plugin-netlify-cms
+npm install --save netlify-cms gatsby-plugin-netlify-cms@next
 ```
 
 ## How to use
@@ -40,7 +46,9 @@ widgets](https://www.netlifycms.org/docs/custom-widgets/#registerwidget) or
 styling the [preview
 pane](https://www.netlifycms.org/docs/customization/#registerpreviewstyle),
 you'll need to do so in a JavaScript module and provide Gatsby with the path to
-your module via the `modulePath` option:
+your module via the `modulePath` option. Any styles imported by this module (or
+by the modules that it imports, all the way down the chain) are automatically
+applied to the editor preview pane by the plugin.
 
 ```javascript
 plugins: [
@@ -60,7 +68,22 @@ plugins: [
 The js module might look like this:
 
 ```javascript
+/**
+ * The default export of `netlify-cms` is an object with all of the Netlify CMS
+ * extension registration methods, such as `registerWidget` and
+ * `registerPreviewTemplate`.
+ */
 import CMS from `netlify-cms`
+
+/**
+ * Any imported styles will automatically be applied to the editor preview
+ * pane, there is no need to use `registerPreviewStyle` for imported styles.
+ * All of the example imports below would result in styles being applied to the
+ * preview pane.
+ */
+import `module-that-imports-styles.js`
+import `styles.scss`
+import `../other-styles.css`
 
 /**
  * Let's say you've created widget and preview components for a custom image
@@ -95,21 +118,6 @@ plugins: [
   },
 ]
 ```
-
-### `stylesPath`
-
-(_optional_, default: `undefined`)
-
-Gatsby template components can be used as [preview
-templates](https://www.netlifycms.org/docs/customization/) in Netlify CMS. To
-apply your site styles to the preview pane as well, you would normally register
-a [custom
-stylesheet](https://www.netlifycms.org/docs/customization/#registerpreviewstyle),
-but your Gatsby style source may be Sass or CSS modules, and can't be passed to
-Netlify CMS as is. The `stylesPath` accepts a path or an array of paths to your
-raw styles. The styles are built using the same Webpack and Babel configuration
-that your Gatsby site uses, and the CSS output is automatically registered and
-used in the preview pane.
 
 ### `publicPath`
 

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -1,13 +1,14 @@
 {
   "name": "gatsby-plugin-netlify-cms",
   "description": "A Gatsby plugin which generates the Netlify CMS single page app",
-  "version": "2.0.0-beta.7",
+  "version": "3.0.0-beta.0",
   "author": "Shawn Erquhart <shawn@erquh.art>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
     "friendly-errors-webpack-plugin": "^1.7.0",
+    "html-webpack-exclude-assets-plugin": "^0.0.7",
     "html-webpack-plugin": "^3.2.0",
     "lodash": "^4.17.10",
     "mini-css-extract-plugin": "^0.4.1",
@@ -33,7 +34,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.0-beta.29",
-    "netlify-cms": "^1.9.3"
+    "netlify-cms": "^2.0.6"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms",
   "scripts": {

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -1,7 +1,6 @@
 import CMS from "netlify-cms"
-import "netlify-cms/dist/cms.css"
 
-// eslint-disable-next-line no-undef
-if (NETLIFY_CMS_PREVIEW_STYLES_SET) {
-  CMS.registerPreviewStyle(`styles.css`)
-}
+/**
+ * The stylesheet output from the module at `stylesPath` will be at `cms.css`.
+ */
+CMS.registerPreviewStyle(`cms.css`)

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-browser.js
@@ -1,6 +1,6 @@
 import netlifyIdentityWidget from "netlify-identity-widget"
 
-exports.onInitialClientRender = (_, { enableIdentityWidget }) => {
+exports.onInitialClientRender = (_, { enableIdentityWidget = true }) => {
   if (enableIdentityWidget) {
     netlifyIdentityWidget.on(`init`, user => {
       if (!user) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,6 +3239,14 @@ better-queue-memory@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/better-queue-memory/-/better-queue-memory-1.0.2.tgz#aa6d169aa1d0cc77409185cb9cb5c7dc251bcd41"
 
+better-queue@^3.8.10:
+  version "3.8.10"
+  resolved "https://registry.yarnpkg.com/better-queue/-/better-queue-3.8.10.tgz#1c93b9ec4cb3d1b72eb91d0efcb84fc80e8c6835"
+  dependencies:
+    better-queue-memory "^1.0.1"
+    node-eta "^0.9.0"
+    uuid "^3.0.0"
+
 better-queue@^3.8.6, better-queue@^3.8.7:
   version "3.8.7"
   resolved "https://registry.yarnpkg.com/better-queue/-/better-queue-3.8.7.tgz#de39b82b05f55d92ba065c9066958dad80789ab3"
@@ -7906,6 +7914,10 @@ html-minifier@^3.2.3:
 html-void-elements@^1.0.0, html-void-elements@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.3.tgz#956707dbecd10cf658c92c5d27fee763aa6aa982"
+
+html-webpack-exclude-assets-plugin@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/html-webpack-exclude-assets-plugin/-/html-webpack-exclude-assets-plugin-0.0.7.tgz#ee69906adb3d869e4e29f29b0f3e99b53fa87c99"
 
 html-webpack-plugin@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Fixes #6802, #6641.

Updates include:

* Bump version to `3.0.0-beta.0`, as the current Gatsby v1 variant is `2.0.1`
* Add v1/v2 version guidance in readme
* Update `netlify-cms` peer dependency to require 2.x
* Set `enableIdentityWidget` to true by default for non-cms pages
* Drop `stylesPath` option and apply all styles from `modulePath` to the preview pane automatically

That last one is the biggie - because Netlify CMS 2.x uses Emotion for all styling, we don't need to worry about our styles getting mixed with the Gatsby site's imports, so we can catch everything with the CSS extract plugin and register the output for preview pane styling.