### PR TITLE
Fixed performance tracing link

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -130,7 +130,7 @@
         - title: Debugging the build process
           link: /docs/debugging-the-build-process/
         - title: Trace Gatsby builds
-          link: /docs/performance-tracing.md
+          link: /docs/performance-tracing/
     - title: Apps with Gatsby
       link: /docs/building-apps-with-gatsby/
       items:

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -130,7 +130,7 @@
         - title: Debugging the build process
           link: /docs/debugging-the-build-process/
         - title: Trace Gatsby builds
-          link: /docs/docs/performance-tracing.md
+          link: /docs/performance-tracing.md
     - title: Apps with Gatsby
       link: /docs/building-apps-with-gatsby/
       items:


### PR DESCRIPTION
Link at https://next.gatsbyjs.org/docs/docs/performance-tracing.md is broken. Fixed