### PR TITLE
Docs Code Change Color Scheme

### DIFF
--- a/www/src/utils/colors.js
+++ b/www/src/utils/colors.js
@@ -76,6 +76,10 @@ const colors = {
     bright: gray(64, 270),
     light: gray(80, 270),
   },
+  code: {
+    remove: `#e45c5c`,
+    add: `#4a9c59`,
+  }
 }
 
 let pointer = `a`

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -280,11 +280,11 @@ const _options = {
         // color: `blue`,
         color: colors.c[12],
       },
-      ".token.property,.token.tag,.token.boolean,.token.number,.token.function-name,.token.constant,.token.symbol,.token.deleted": {
+      ".token.property,.token.tag,.token.boolean,.token.number,.token.function-name,.token.constant,.token.symbol": {
         // color: `#a285d8`,
         color: colors.b[9],
       },
-      ".token.selector,.token.attr-name,.token.string,.token.char,.token.function,.token.builtin,.token.inserted": {
+      ".token.selector,.token.attr-name,.token.string,.token.char,.token.function,.token.builtin": {
         // color: `#a2466c`,
         color: colors.a[9],
       },
@@ -296,6 +296,12 @@ const _options = {
         // color: `#a285d8`,
         // color: `blue`,
         color: colors.b[8],
+      },
+      ".token.inserted": {
+        color: colors.code.add,
+      },
+      ".token.deleted": {
+        color: colors.code.remove,
       },
       // Fancy external links in posts, borrowed from
       // https://github.com/comfusion/after-dark/


### PR DESCRIPTION
Made a tweak to the docs color schemes for additions and removals to use a more familiar green for additions and red for removals. The current color for additions is a bit similar to red, which is more commonly displayed as a removal (such as in the code diff here).

I tried to pick 2 color values that meshed well with the rest of the scheme but were distinguished enough from other colors used, as I didn't really find any available I thought worked well, open to feedback there.

## Current
![image](https://user-images.githubusercontent.com/1045274/43436835-2be1438c-9454-11e8-9477-1196ab0ad27d.png)

## With Changes
![image](https://user-images.githubusercontent.com/1045274/43436812-190bf7a2-9454-11e8-9de9-18fc30c42ff2.png)
