### PR TITLE
fix extraction of fragments (multiple named exports)

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/file-parser.js.snap
@@ -258,5 +258,287 @@ Map {
     ],
     "kind": "Document",
   },
+  "page-query-and-static-query-named-export.js" => Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "hash": 407706182,
+        "isStaticQuery": true,
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 29,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 21,
+            "start": 6,
+          },
+          "value": "StaticQueryName",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 29,
+            "start": 22,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 27,
+                "start": 24,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 27,
+                  "start": 24,
+                },
+                "value": "foo",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "text": "query StaticQueryName { foo }",
+        "variableDefinitions": Array [],
+      },
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 27,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 19,
+            "start": 6,
+          },
+          "value": "PageQueryName",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 27,
+            "start": 20,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 25,
+                "start": 22,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 25,
+                  "start": 22,
+                },
+                "value": "foo",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
+  "multiple-fragment-exports.js" => Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 53,
+          "start": 3,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 21,
+            "start": 12,
+          },
+          "value": "Fragment1",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 53,
+            "start": 40,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 49,
+                "start": 46,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 49,
+                  "start": 46,
+                },
+                "value": "foo",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 39,
+            "start": 25,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 39,
+              "start": 25,
+            },
+            "value": "RootQueryField",
+          },
+        },
+      },
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 106,
+          "start": 56,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 74,
+            "start": 65,
+          },
+          "value": "Fragment2",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 106,
+            "start": 93,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 102,
+                "start": 99,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 102,
+                  "start": 99,
+                },
+                "value": "bar",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 92,
+            "start": 78,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 92,
+              "start": 78,
+            },
+            "value": "RootQueryField",
+          },
+        },
+      },
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 53,
+          "start": 3,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 21,
+            "start": 12,
+          },
+          "value": "Fragment3",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 53,
+            "start": 40,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 49,
+                "start": 46,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 49,
+                  "start": 46,
+                },
+                "value": "baz",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 39,
+            "start": 25,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 39,
+              "start": 25,
+            },
+            "value": "RootQueryField",
+          },
+        },
+      },
+    ],
+    "kind": "Document",
+  },
 }
 `;

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
@@ -43,6 +43,28 @@ query {
     render={data => <div>{data.doo}</div>}
   />
 )`,
+    "page-query-and-static-query-named-export.js": `export const Component = () => (
+  <StaticQuery
+    query={graphql\`query StaticQueryName { foo }\`}
+    render={data => <div>{data.doo}</div>}
+  />
+)
+export const pageQuery = graphql\`query PageQueryName { foo }\`
+`,
+    "multiple-fragment-exports.js": `export const fragment1 = graphql\`
+  fragment Fragment1 on RootQueryField {
+    foo
+  }
+  fragment Fragment2 on RootQueryField {
+    bar
+  }
+\`
+export const fragment3 = graphql\`
+  fragment Fragment3 on RootQueryField {
+    baz
+  }
+\`
+`,
   }
 
   const parser = new FileParser()

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -84,9 +84,12 @@ async function findGraphQLTags(file, text): Promise<Array<DefinitionNode>> {
         }
 
         /**
-         * Mapping of graphql documents to concatenated location of graphql template
-         * literal that contains that document and location of graphql document inside
-         * template literal.
+         * A map of graphql documents to unique locations.
+         *
+         * A graphql document's unique location is made of: 
+         *
+         *  - the location of the graphql template literal that contains the document, and
+         *  - the document's location within the graphql template literal
          *
          * This is used to prevent returning duplicated documents.
          */


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/6765 had flawed implementation that I didn't catch in review - it caused to only handle single fragment exported from file, making fragments exported by `gatsby-transformer-sharp` not usable - this fixes it.

It uses concatenated location of graphql template literal location inside source file and graphql document (query/fragment) location inside graphql template literal to determine uniqueness of returned graphql documents

