### PR TITLE
Added developers.sparkpost.com to showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1833,3 +1833,11 @@
     - Landing
     - Portfolio
   featured: false
+- title: SparkPost Developers
+  main_url: 'https://developers.sparkpost.com/'
+  url: 'https://developers.sparkpost.com/'
+  source_url: 'https://github.com/SparkPost/developers.sparkpost.com'
+  categories:
+    - Documentation
+    - API
+  featured: false


### PR DESCRIPTION
Take 2 😉

Added [developers.sparkpost.com](https://developers.sparkpost.com) to the site showcase.
