### PR TITLE
Updating tutorial docs #5609

### DIFF
--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -23,7 +23,7 @@ You can access it when your site's development server is running—normally at
 Here you poke around the built-in `Site` "type" and see what fields are available
 on it—including the `siteMetadata` object you queried earlier. Try opening
 Graph_i_QL and play with your data! Press <kbd>Ctrl + Space</kbd> to bring up
-the autocomplete window and <kbd>Ctrl + Enter</kbd> to run the query. You'll be
+the autocomplete window and <kbd>Ctrl + Enter</kbd> to run the GraphQL query. You'll be
 using Graph_i_QL a lot more through the remainder of the tutorial.
 
 ## Source plugins
@@ -103,7 +103,7 @@ to start building the UI.
 
 Let's try this.
 
-Create a new file at `src/pages/my-files.js` with the `allFile` query you just
+Create a new file at `src/pages/my-files.js` with the `allFile` GraphQL query you just
 created:
 
 ```jsx{6}
@@ -137,7 +137,7 @@ export const query = graphql`
 ```
 
 The `console.log(data)` line is highlighted above. It's often helpful when
-creating a new component to console out the data you're getting from the query
+creating a new component to console out the data you're getting from the GraphQL query
 so you can explore the data in your browser console while building the UI.
 
 If you visit the new page at `/my-files/` and open up your browser console
@@ -145,7 +145,7 @@ you will see something like:
 
 ![data-in-console](data-in-console.png)
 
-The shape of the data matches the shape of the query.
+The shape of the data matches the shape of the GraphQL query.
 
 Let's add some code to your component to print out the File data.
 

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -128,7 +128,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 ```
 
 Restart the development server and open or refresh Graph_i_QL. Then run this
-query to see your new slugs.
+GraphQL query to see your new slugs.
 
 ```graphql
 {

--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -100,7 +100,7 @@ blog post. With GraphQL you can _query_ for the current list of markdown blog
 posts so you won't need to maintain the list manually.
 
 Like with the `src/pages/my-files.js` page, replace `src/pages/index.js` with
-the following to add a query with some initial HTML and styling.
+the following to add a GraphQL query with some initial HTML and styling.
 
 ```jsx
 import React from "react"
@@ -190,12 +190,12 @@ seem to really enjoy bananas!
 Which looks great! Except… the order of the posts is wrong.
 
 But this is easy to fix. When querying a connection of some type, you can pass a
-variety of arguments to the query. You can `sort` and `filter` nodes, set how
+variety of arguments to the GraphQL query. You can `sort` and `filter` nodes, set how
 many nodes to `skip`, and choose the `limit` of how many nodes to retrieve. With
 this powerful set of operators, you can select any data you want—in the format you
 need.
 
-In your index page's query, change `allMarkdownRemark` to
+In your index page's GraphQL query, change `allMarkdownRemark` to
 `allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC })`. Save
 this and the sort order should be fixed.
 


### PR DESCRIPTION
Updating the tutorial docs to make more clear that "queries" refer to "GraphQL queries", as proposed by @shannonbux in #5609.
This would make it easier to new people to identify which part of the code the tutorial refers to. 🤖