### PR TITLE
Tutorial Part 2: Reorder import statement before console.log

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -466,9 +466,9 @@ Modify `about-css-modules.js` so it looks like the following:
 ```jsx{7-19,25-34}
 import React from "react";
 import styles from "./about-css-modules.module.css";
-console.log(styles);
-
 import Container from "../components/container";
+
+console.log(styles);
 
 const User = props => (
   <div className={styles.user}>


### PR DESCRIPTION
If the console.log is before the import statement I get the following error: 
"5:1  error  Import in body of module; reorder to top  import/first"

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
