### PR TITLE
Add upgrade docs to error messages for deprecated APIs

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -390,11 +390,11 @@ module.exports = async (program: any) => {
     const fixMap = {
       boundActionCreators: {
         newName: `actions`,
-        docsLink: `https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions`,
+        docsLink: `https://gatsby.app/boundActionCreators`,
       },
       pathContext: {
         newName: `pageContext`,
-        docsLink: `https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-pathcontext-to-pagecontext`,
+        docsLink: `https://gatsby.app/pathContext`,
       },
     }
     const deprecatedLocations = {}
@@ -417,7 +417,7 @@ module.exports = async (program: any) => {
           chalk.cyan(api),
           chalk.yellow(`is deprecated. Use`),
           chalk.cyan(fixMap[api].newName),
-          chalk.yellow(`instead: ${fixMap[api].docsLink}\nCheck the following files:`)
+          chalk.yellow(`instead. For migration instructions, see ${fixMap[api].docsLink}\nCheck the following files:`)
         )
         console.log()
         deprecatedLocations[api].forEach(file => console.log(file))

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -415,7 +415,7 @@ module.exports = async (program: any) => {
         console.log(
           `%s %s %s %s`,
           chalk.cyan(api),
-          chalk.yellow(`is deprecated. Use`),
+          chalk.yellow(`is deprecated. Please use`),
           chalk.cyan(fixMap[api].newName),
           chalk.yellow(`instead. For migration instructions, see ${fixMap[api].docsLink}\nCheck the following files:`)
         )

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -388,8 +388,14 @@ module.exports = async (program: any) => {
   function printDeprecationWarnings() {
     const deprecatedApis = [`boundActionCreators`, `pathContext`]
     const fixMap = {
-      boundActionCreators: `actions`,
-      pathContext: `pageContext`,
+      boundActionCreators: {
+        newName: `actions`,
+        docsLink: `https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions`,
+      },
+      pathContext: {
+        newName: `pageContext`,
+        docsLink: `https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-pathcontext-to-pagecontext`,
+      },
     }
     const deprecatedLocations = {}
     deprecatedApis.forEach(api => (deprecatedLocations[api] = []))
@@ -410,8 +416,8 @@ module.exports = async (program: any) => {
           `%s %s %s %s`,
           chalk.cyan(api),
           chalk.yellow(`is deprecated. Use`),
-          chalk.cyan(fixMap[api]),
-          chalk.yellow(`instead. Check the following files:`)
+          chalk.cyan(fixMap[api].newName),
+          chalk.yellow(`instead: ${fixMap[api].docsLink}\nCheck the following files:`)
         )
         console.log()
         deprecatedLocations[api].forEach(file => console.log(file))


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Fixes #6825

Error messages for deprecated APIs (`boundActionCreators` and `pathContext`) now include links to their upgrade docs, like this:

![gatsby_link](https://user-images.githubusercontent.com/30595954/43487029-5922f39c-94e3-11e8-98d5-2e99f8575444.PNG)

However, the link gets cut if I make my terminal window smaller. Not sure if it's just me (I'm using Hyper).