### PR TITLE
Update docs to import Link from a gatsby package

### DIFF
--- a/docs/blog/2018-06-07-build-a-gatsby-blog-using-the-cosmic-js-source-plugin/index.md
+++ b/docs/blog/2018-06-07-build-a-gatsby-blog-using-the-cosmic-js-source-plugin/index.md
@@ -120,7 +120,7 @@ First, we want to display the list of posts on the homepage. To do so, add the f
 
 ```javascript
 import React from "react"
-import Link from "gatsby-link"
+import { Link } from "gatsby"
 import get from "lodash/get"
 import Helmet from "react-helmet"
 
@@ -212,7 +212,7 @@ Create the template at `src/templates/blog-post.js`:
 ```javascript
 import React from "react"
 import Helmet from "react-helmet"
-import Link from "gatsby-link"
+import { Link } from "gatsby"
 import get from "lodash/get"
 
 import Bio from "../components/Bio"

--- a/docs/docs/adding-a-list-of-markdown-blog-posts.md
+++ b/docs/docs/adding-a-list-of-markdown-blog-posts.md
@@ -89,7 +89,7 @@ The only thing left to do is to add the `PostLink` component. Create a new file 
 
 ```jsx
 import React from "react"
-import Link from "gatsby-link"
+import { Link } from "gatsby"
 
 const PostLink = ({ post }) => (
   <div>

--- a/docs/docs/ecommerce-tutorial/index.md
+++ b/docs/docs/ecommerce-tutorial/index.md
@@ -255,7 +255,7 @@ Now go to your `src/pages/index.js` file. This is your homepage that shows at th
 
 ```js{3,7}
 import React from 'react'
-import Link from 'gatsby-link'
+import { Link } from 'gatsby'
 import Checkout from '../components/checkout'
 
 const IndexPage = () => (


### PR DESCRIPTION
Here are some updates to docs. This tells to ditch gatsby-link and import Link directly from a gatsby package. 
Closes #6922.