### PR TITLE
feature: add option to google tagmanager plugin to be included post body

### DIFF
--- a/examples/using-google-tagmanager/README.md
+++ b/examples/using-google-tagmanager/README.md
@@ -1,0 +1,6 @@
+# No plugins
+
+https://using-google-tagmanager.gatsbyjs.org
+
+Example site that demonstrates how to build Gatsby sites using the
+[Google Tag Manager](https://developers.google.com/tag-manager/) to manage analytics and advertising tools in your apps without having to rebuild and resubmit the applications' binaries to the app marketplaces

--- a/examples/using-google-tagmanager/gatsby-config.js
+++ b/examples/using-google-tagmanager/gatsby-config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  siteMetadata: {
+    title: `gatsby-example-using-plugin-google-tagmanager`,
+    description: `Blazing-fast React.js static site generator`,
+  },
+  plugins: [
+    {
+      resolve: `gatsby-plugin-google-tagmanager`,
+      options: {
+        id: "YOUR_GOOGLE_TAGMANAGER_ID",
+
+        // Include GTM in development.
+        // Defaults to false meaning GTM will only be loaded in production.
+        includeInDevelopment: false,
+
+        // Specify optional GTM environment details.
+        gtmAuth: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_AUTH_STRING",
+        gtmPreview: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_PREVIEW_NAME",
+
+        // Specify if you want GTM to be loaded in the <head> tag
+        // or at the end of the <body> tag
+        includePostBody: false //default false (optional)
+      },
+    },
+  ],
+}

--- a/examples/using-google-tagmanager/package.json
+++ b/examples/using-google-tagmanager/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "gatsby-example-no-plugins",
+  "private": true,
+  "description": "Gatsby example site that proves functionality without the use of plugins.",
+  "version": "1.0.0",
+  "author": "Horacio Herrera <me@hherrerag.com>",
+  "dependencies": {
+    "gatsby": "next",
+    "lodash": "^4.16.4",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
+    "slash": "^1.0.0",
+    "gatsby-plugin-google-tagmanager": "next"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build"
+  }
+}

--- a/examples/using-google-tagmanager/src/components/layout.js
+++ b/examples/using-google-tagmanager/src/components/layout.js
@@ -1,0 +1,28 @@
+import React from "react"
+import { Link } from "gatsby"
+
+class DefaultLayout extends React.Component {
+  render() {
+    return (
+      <div>
+        <Link to="/">
+          <h1>Example with Google Tag Managet Plugin</h1>
+        </Link>
+        <ul>
+          <li>
+            <Link to="/a/">a</Link>
+          </li>
+          <li>
+            <Link to="/b/">b</Link>
+          </li>
+          <li>
+            <Link to="/c/">c</Link>
+          </li>
+        </ul>
+        {this.props.children}
+      </div>
+    )
+  }
+}
+
+export default DefaultLayout

--- a/examples/using-google-tagmanager/src/html.js
+++ b/examples/using-google-tagmanager/src/html.js
@@ -1,0 +1,45 @@
+import React, { Component } from "react"
+import * as PropTypes from "prop-types"
+
+class Html extends Component {
+  render() {
+    return (
+      <html op="news" lang="en" {...this.props.htmlAttributes}>
+        <head>
+          <meta name="referrer" content="origin" />
+          <meta charSet="utf-8" />
+          <meta
+            name="description"
+            content="Gatsby example site showing use with Google Tagmanager plugin"
+          />
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0"
+          />
+          <title>Gatsby - GTM plugin</title>
+          {this.props.headComponents}
+        </head>
+        <body {...this.props.bodyAttributes}>
+          {this.props.preBodyComponents}
+          <div
+            id="___gatsby"
+            dangerouslySetInnerHTML={{ __html: this.props.body }}
+          />
+          {this.props.postBodyComponents}
+        </body>
+      </html>
+    )
+  }
+}
+
+Html.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}
+
+export default Html

--- a/examples/using-google-tagmanager/src/pages/a.js
+++ b/examples/using-google-tagmanager/src/pages/a.js
@@ -1,0 +1,10 @@
+import React from "react"
+import Layout from "../components/layout"
+
+const A = () => (
+  <Layout>
+    <p>A</p>
+  </Layout>
+)
+
+export default A

--- a/examples/using-google-tagmanager/src/pages/b.js
+++ b/examples/using-google-tagmanager/src/pages/b.js
@@ -1,0 +1,10 @@
+import React from "react"
+import Layout from "../components/layout"
+
+const B = () => (
+  <Layout>
+    <p>B</p>
+  </Layout>
+)
+
+export default B

--- a/examples/using-google-tagmanager/src/pages/c.js
+++ b/examples/using-google-tagmanager/src/pages/c.js
@@ -1,0 +1,10 @@
+import React from "react"
+import Layout from "../components/layout"
+
+const C = () => (
+  <Layout>
+    <p>C</p>
+  </Layout>
+)
+
+export default C

--- a/examples/using-google-tagmanager/src/pages/index.js
+++ b/examples/using-google-tagmanager/src/pages/index.js
@@ -1,0 +1,10 @@
+import React from "react"
+import Layout from "../components/layout"
+
+const Home = () => (
+  <Layout>
+    <p>Home</p>
+  </Layout>
+)
+
+export default Home

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -1,8 +1,6 @@
 import React from "react"
 import { oneLine, stripIndent } from "common-tags"
 
-const SCRIPT_METHOD = 'setPostBodyComponents';
-
 exports.onRenderBody = (
   { setHeadComponents, setPostBodyComponents, setPreBodyComponents },
   pluginOptions
@@ -32,7 +30,7 @@ exports.onRenderBody = (
             })(window,document,'script','dataLayer', '${pluginOptions.id}');`,
         }}
       />,
-    ];
+    ]
 
     if (pluginOptions.includePostBody) {
       setPostBodyComponents(scriptsArray)

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -1,8 +1,10 @@
 import React from "react"
 import { oneLine, stripIndent } from "common-tags"
 
+const SCRIPT_METHOD = 'setPostBodyComponents';
+
 exports.onRenderBody = (
-  { setHeadComponents, setPreBodyComponents },
+  { setHeadComponents, setPostBodyComponents, setPreBodyComponents },
   pluginOptions
 ) => {
   if (
@@ -18,7 +20,7 @@ exports.onRenderBody = (
     `
         : ``
 
-    setHeadComponents([
+    const scriptsArray = [
       <script
         key="plugin-google-tagmanager"
         dangerouslySetInnerHTML={{
@@ -30,7 +32,14 @@ exports.onRenderBody = (
             })(window,document,'script','dataLayer', '${pluginOptions.id}');`,
         }}
       />,
-    ])
+    ];
+
+    if (pluginOptions.includePostBody) {
+      setPostBodyComponents(scriptsArray)
+    } else {
+      setHeadComponents(scriptsArray)
+    }
+
 
     setPreBodyComponents([
       <noscript


### PR DESCRIPTION
- add an option to the `gatsby-plugin-google-tagmanager` to choose if you want the script to be inserted at the `<head>` tag or at the end of the `<body>` tag
- add an example how to use the plugin