### PR TITLE
[gatsbygram] use `graphql` imported from gatsby instead of global

### DIFF
--- a/examples/gatsbygram/src/components/Avatar.js
+++ b/examples/gatsbygram/src/components/Avatar.js
@@ -1,6 +1,7 @@
 import * as PropTypes from "prop-types"
 import React from "react"
 import { rhythm } from "../utils/typography"
+import { graphql } from "gatsby"
 
 const propTypes = {
   user: PropTypes.shape({

--- a/examples/gatsbygram/src/components/modal.js
+++ b/examples/gatsbygram/src/components/modal.js
@@ -9,6 +9,7 @@ import * as PropTypes from "prop-types"
 import { push, StaticQuery } from "gatsby"
 
 import { rhythm } from "../utils/typography"
+import { graphql } from "gatsby"
 
 let posts
 

--- a/examples/gatsbygram/src/components/modal.js
+++ b/examples/gatsbygram/src/components/modal.js
@@ -6,8 +6,7 @@ import Close from "react-icons/lib/md/close"
 import findIndex from "lodash/findIndex"
 import mousetrap from "mousetrap"
 import * as PropTypes from "prop-types"
-import { push, StaticQuery } from "gatsby"
-import { graphql } from "gatsby"
+import { push, StaticQuery, graphql } from "gatsby"
 
 import { rhythm } from "../utils/typography"
 

--- a/examples/gatsbygram/src/components/modal.js
+++ b/examples/gatsbygram/src/components/modal.js
@@ -7,9 +7,9 @@ import findIndex from "lodash/findIndex"
 import mousetrap from "mousetrap"
 import * as PropTypes from "prop-types"
 import { push, StaticQuery } from "gatsby"
+import { graphql } from "gatsby"
 
 import { rhythm } from "../utils/typography"
-import { graphql } from "gatsby"
 
 let posts
 

--- a/examples/gatsbygram/src/components/post-detail.js
+++ b/examples/gatsbygram/src/components/post-detail.js
@@ -2,6 +2,7 @@ import React from "react"
 
 import presets from "../utils/presets"
 import typography, { rhythm, scale } from "../utils/typography"
+import { graphql } from "gatsby"
 
 class PostDetail extends React.Component {
   render() {

--- a/examples/gatsbygram/src/components/post.js
+++ b/examples/gatsbygram/src/components/post.js
@@ -1,9 +1,8 @@
 import * as PropTypes from "prop-types"
 import React from "react"
 import HeartIcon from "react-icons/lib/fa/heart"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import Img from "gatsby-image"
-import { graphql } from "gatsby"
 
 import { rhythm, scale } from "../utils/typography"
 import presets from "../utils/presets"

--- a/examples/gatsbygram/src/components/post.js
+++ b/examples/gatsbygram/src/components/post.js
@@ -3,10 +3,10 @@ import React from "react"
 import HeartIcon from "react-icons/lib/fa/heart"
 import { Link } from "gatsby"
 import Img from "gatsby-image"
+import { graphql } from "gatsby"
 
 import { rhythm, scale } from "../utils/typography"
 import presets from "../utils/presets"
-import { graphql } from "gatsby"
 
 let touched = false
 

--- a/examples/gatsbygram/src/components/post.js
+++ b/examples/gatsbygram/src/components/post.js
@@ -6,6 +6,7 @@ import Img from "gatsby-image"
 
 import { rhythm, scale } from "../utils/typography"
 import presets from "../utils/presets"
+import { graphql } from "gatsby"
 
 let touched = false
 


### PR DESCRIPTION
This should get rid of the warnings when you run gatsbygram example.