### PR TITLE
[gatsby-plugin-netlify] Fix for allPageHeaders option

### DIFF
--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -180,14 +180,11 @@ const mapUserLinkAllPageHeaders = (
     transformLink(manifest, publicFolder, pathPrefix)
   )
 
-  const duplicateHeadersByPage = _.reduce(
-    pages,
-    (combined, page) => {
-      const pathKey = headersPath(pathPrefix, page.path)
-      return defaultMerge(combined, { [pathKey]: headersList })
-    },
-    {}
-  )
+  const duplicateHeadersByPage = {}
+  pages.forEach(page => {
+    const pathKey = headersPath(pathPrefix, page.path)
+    duplicateHeadersByPage[pathKey] = headersList
+  })
 
   return defaultMerge(headers, duplicateHeadersByPage)
 }


### PR DESCRIPTION
Fixes #6925 
Uses `Map.forEach` to iterate over the pages collection, because gatsby internal data structures have changed.