### PR TITLE
clear unused template components before initial query extraction

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -188,7 +188,7 @@ exports.extractQueries = () => {
   // only in initial run, because during development state will be adjusted.
   clearInactiveComponents()
 
-  updateStateAndRunQueries(true).then(() => {
+  return updateStateAndRunQueries(true).then(() => {
     // During development start watching files to recompile & run
     // queries on the fly.
     if (process.env.NODE_ENV !== `production`) {

--- a/packages/gatsby/src/redux/reducers/components.js
+++ b/packages/gatsby/src/redux/reducers/components.js
@@ -18,6 +18,9 @@ module.exports = (state = new Map(), action) => {
       action.payload.componentPath = normalize(action.payload.component)
       state.delete(action.payload.componentPath)
       return state
+    case `REMOVE_TEMPLATE_COMPONENT`:
+      state.delete(normalize(action.payload.componentPath))
+      return state
     case `REPLACE_COMPONENT_QUERY`:
       action.payload.componentPath = normalize(action.payload.componentPath)
       state.set(action.payload.componentPath, {


### PR DESCRIPTION
Unused might mean that file was deleted or project was moved and cached data points to file that doesn't exist anymore causing errors when trying to extract from it.

Fixes #6868