### PR TITLE
change using-redux example to not use replaceRouterComponent API

### DIFF
--- a/examples/using-redux/gatsby-browser.js
+++ b/examples/using-redux/gatsby-browser.js
@@ -1,18 +1,16 @@
-import React from 'react'
-import { Router } from 'react-router-dom'
-import { Provider } from 'react-redux'
+import React from "react"
+import { Provider } from "react-redux"
 
-import createStore from './src/state/createStore'
+import createStore from "./src/state/createStore"
 
 const store = createStore()
 
-export const replaceRouterComponent = ({ history }) => {
+export const wrapRootComponent = ({ Root }) => {
+  const ConnectedRootComponent = () => (
+    <Provider store={store}>
+      <Root />
+    </Provider>
+  )
 
-    const ConnectedRouterWrapper = ({ children }) => (
-        <Provider store={store}>
-            <Router history={history}>{children}</Router>
-        </Provider>
-    )
-
-    return ConnectedRouterWrapper
+  return ConnectedRootComponent
 }


### PR DESCRIPTION
`replaceRouterComponent` API will be removed in https://github.com/gatsbyjs/gatsby/pull/6918 and also it doesn't make sense to use this API for wrapping component tree if we have more appropiate API for it