### PR TITLE
don't swallow console output during html build

### DIFF
--- a/packages/gatsby/src/utils/html-renderer-queue.js
+++ b/packages/gatsby/src/utils/html-renderer-queue.js
@@ -6,6 +6,9 @@ const { chunk } = require(`lodash`)
 
 const workerPool = new Worker(require.resolve(`./worker`), {
   numWorkers,
+  forkOptions: {
+    silent: false,
+  },
 })
 
 module.exports = (htmlComponentRendererPath, pages, activity) =>


### PR DESCRIPTION
when `jest-worker` support was added all console output happening inside worker was not visible - this change allow to see output again