### PR TITLE
fix: remark excerpt add halfChop option

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -68,10 +68,9 @@ A sample GraphQL query to get MarkdownRemark nodes:
 
 ### Excerpts for non-latin languages
 
-By default, excerpts is avoid half-chopped words when truncating content.
-But it might fail for non-latin languages, and return to `...`
+By default, excerpt uses underscore.string/prune which doesn't handle non-latin characters (https://github.com/epeli/underscore.string/issues/418).
 
-To solve this, you can set `truncate` option on `excerpt` field, like:
+If that is the case, you can set truncate option on excerpt field, like:
 
 ```graphql
 {

--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -68,9 +68,9 @@ A sample GraphQL query to get MarkdownRemark nodes:
 
 ### Excerpts for non-latin languages
 
-By default, excerpt uses underscore.string/prune which doesn't handle non-latin characters (https://github.com/epeli/underscore.string/issues/418).
+By default, `excerpt` uses `underscore.string/prune` which doesn't handle non-latin characters ([https://github.com/epeli/underscore.string/issues/418](https://github.com/epeli/underscore.string/issues/418)).
 
-If that is the case, you can set truncate option on excerpt field, like:
+If that is the case, you can set `truncate` option on `excerpt` field, like:
 
 ```graphql
 {

--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -63,3 +63,20 @@ A sample GraphQL query to get MarkdownRemark nodes:
   }
 }
 ```
+
+## Troubleshooting
+
+### Excerpts for non-latin languages
+
+By default, excerpts is avoid half-chopped words when truncating content.
+But it might fail for non-latin languages, and return to `...`
+
+To solve this, you can set `truncate` option on `excerpt` field, like:
+
+```graphql
+{
+  markdownRemark {
+    excerpt (truncate: true)
+  }
+}
+```

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -347,12 +347,12 @@ module.exports = (
             type: GraphQLInt,
             defaultValue: 140,
           },
-          halfChop: {
+          truncate: {
             type: GraphQLBoolean,
-            defaultValue: true,
+            defaultValue: false,
           },
         },
-        resolve(markdownNode, { pruneLength, halfChop }) {
+        resolve(markdownNode, { pruneLength, truncate }) {
           if (markdownNode.excerpt) {
             return Promise.resolve(markdownNode.excerpt)
           }
@@ -364,7 +364,7 @@ module.exports = (
               }
               return
             })
-            if (halfChop) {
+            if (!truncate) {
               return prune(excerptNodes.join(` `), pruneLength, `…`)
             }
             return _.truncate(excerptNodes.join(` `), {

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -5,6 +5,7 @@ const {
   GraphQLInt,
   GraphQLEnumType,
   GraphQLJSON,
+  GraphQLBoolean,
 } = require(`gatsby/graphql`)
 const Remark = require(`remark`)
 const select = require(`unist-util-select`)
@@ -346,8 +347,12 @@ module.exports = (
             type: GraphQLInt,
             defaultValue: 140,
           },
+          halfChop: {
+            type: GraphQLBoolean,
+            defaultValue: true,
+          },
         },
-        resolve(markdownNode, { pruneLength }) {
+        resolve(markdownNode, { pruneLength, halfChop }) {
           if (markdownNode.excerpt) {
             return Promise.resolve(markdownNode.excerpt)
           }
@@ -359,8 +364,13 @@ module.exports = (
               }
               return
             })
-
-            return prune(excerptNodes.join(` `), pruneLength, `…`)
+            if (halfChop) {
+              return prune(excerptNodes.join(` `), pruneLength, `…`)
+            }
+            return _.truncate(excerptNodes.join(` `), {
+              length: pruneLength,
+              omission: `…`,
+            })
           })
         },
       },


### PR DESCRIPTION
Default prune won't work for non-english text.  Add `halfChop` (default to true) option, set it to false so that non-english blogs will make it fallback to lodash `truncate`. 

I think this resolve https://github.com/gatsbyjs/gatsby/issues/6916

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
