### PR TITLE
fix: refs 6990 plugin-catch-links URL wrong parameter

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -85,7 +85,7 @@ module.exports = function (root, cb) {
     ev.preventDefault()
 
 
-    var anchoreUrl = new URL(anchor.getAttribute(`href`))
+    var anchoreUrl = new URL(anchor.href)
 
     if (checkSameOriginWithoutProtocol(window.location.origin, anchoreUrl.origin)) {
       cb(`${anchoreUrl.pathname}${anchoreUrl.search}${anchoreUrl.hash}`)


### PR DESCRIPTION
simple fix, resolve https://github.com/gatsbyjs/gatsby/issues/6990

cc @KyleAMathews 

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
