### PR TITLE
fix: introducing graphiql link

### DIFF
--- a/docs/docs/introducing-graphiql.md
+++ b/docs/docs/introducing-graphiql.md
@@ -1,5 +1,5 @@
 ---
-title: Introducting GraphiQL
+title: Introducing GraphiQL
 ---
 
 This is a stub. Help our community expand it.


### PR DESCRIPTION
Currently in v2 Docs the url from `Guides -> Querying your data with GraphQL -> Introducing GraphiQL` is pointing to https://next.gatsbyjs.org/docs/introducing-graphiql/ (as expected)

However, the filename is called `introducting-graphiql`, so the url is broken. 