### PR TITLE
actions.deletePage: fix docs

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -64,7 +64,7 @@ type ActionOptions = {
 
 /**
  * Delete a page
- * @param {Object} page a page object with at least the path set
+ * @param {Object} page a page object
  * @param {string} page.path The path of the page
  * @param {string} page.component The absolute path to the page component
  * @example


### PR DESCRIPTION
Currently the docs say that only the path has to be set:

https://github.com/gatsbyjs/gatsby/blob/6de0e4408e14e599d4ec73948eb4153dc3cde849/packages/gatsby/src/redux/actions.js#L67

...but Gatsby will crash if you don't pass the component path too:

https://github.com/gatsbyjs/gatsby/blob/37d007ac76851055303ff002126324563b5693d5/packages/gatsby/src/redux/reducers/components.js#L17-L18

...due to:
https://github.com/jonschlinkert/normalize-path/blob/ea100bbecf851e2cc89e54e295e91af7b835fe63/index.js#L10

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
