### PR TITLE
Fix a bug with gatsby-browser.js not loading in production

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -216,6 +216,11 @@ module.exports = async (args: BootstrapArgs) => {
     if (env === `ssr` && plugin.skipSSR === true) return undefined
 
     const envAPIs = plugin[`${env}APIs`]
+
+    if (env === `browser` && plugin.name === `default-site-plugin`) {
+      return slash(path.join(plugin.resolve, `gatsby-${env}`))
+    }
+
     if (envAPIs && Array.isArray(envAPIs) && envAPIs.length > 0) {
       return slash(path.join(plugin.resolve, `gatsby-${env}`))
     }
@@ -231,6 +236,7 @@ module.exports = async (args: BootstrapArgs) => {
     }),
     plugin => plugin.resolve
   )
+
   const browserPlugins = _.filter(
     flattenedPlugins.map(plugin => {
       return {

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -217,6 +217,8 @@ module.exports = async (args: BootstrapArgs) => {
 
     const envAPIs = plugin[`${env}APIs`]
 
+    // Always include the site's gatsby-browser.js if it exists as it's
+    // a handy place to include global styles and other global imports.
     if (env === `browser` && plugin.name === `default-site-plugin`) {
       return slash(path.join(plugin.resolve, `gatsby-${env}`))
     }


### PR DESCRIPTION
Hey folks. I think I've got it. This PR fixes #6759. Now we always import the default browser plugin, because I may have styles imported.

Closes #6759 .

