### PR TITLE
Typo in babel.md

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -22,7 +22,7 @@ browsers.
 ## How to use a custom .babelrc file
 
 Gatsby ships with a default .babelrc setup that should work for most sites. If you'd like
-to add custom Babel presets or plugins, we recommend copying our default .bablerc below
+to add custom Babel presets or plugins, we recommend copying our default .babelrc below
 to root of your site and modifying it per your needs.
 
 ```json5


### PR DESCRIPTION
Fix typo as it read
`[..] copying our default .bab*le*rc below [..]`

might lead to confusion

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
