### PR TITLE
Update package.json to add url-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "prettier-eslint-cli": "4.7.1",
     "rimraf": "^2.6.1",
     "yaml-lint": "^1.2.4",
-    "yargs": "^10.0.3"
+    "yargs": "^10.0.3",
+    "url-loader": "^1.0.1"
   },
   "engines": {
     "yarn": "^1.2.1",


### PR DESCRIPTION
Importing CCS and image files fails in a fresh installation of Gatsby 1.9.277.

A fix is to run:     

    `npm install url-loader --save-dev`

as described in #5479

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
