### PR TITLE
Corrects the "AsciiDoc Example" - Issue #7031

### DIFF
--- a/examples/using-asciidoc/README.md
+++ b/examples/using-asciidoc/README.md
@@ -1,6 +1,6 @@
-# Using Drupal
+# Using AsciiDoc
 
-https://using-drupal.gatsbyjs.org
+https://using-asciidoc.gatsbyjs.org
 
-Example site that demostrates how to build Gatsby sites
-that pull data from the [Drupal CMS](https://www.drupal.org/).
+Example site that demostrates how to build a Gatsby site
+pulling in data from [asciidoc](http://asciidoc.org/)-files.

--- a/examples/using-asciidoc/src/pages/lots-of-text.adoc
+++ b/examples/using-asciidoc/src/pages/lots-of-text.adoc
@@ -12,7 +12,7 @@ Content entered directly below the header but before the first section heading i
 This is a paragraph with a *bold* word and an _italicized_ word.
 
 .Image caption
-image::image-file-name.png[I am the image alt text.]
+image::https://avatars3.githubusercontent.com/u/71047?s=100&v=4[Kyle Mathews]
 
 This is another paragraph.footnote:[I am footnote text and will be rendered at the bottom of the article.]
 


### PR DESCRIPTION
As requested I **corrected the readme**, which was before identical to the "Drupal Example".
However feel free to deploy the example to https://using-asciidoc.gatsbyjs.org now.

While at it I also **corrected a broken image** within `lots-of-text.adoc`.

This closes #7031.

Best regards from [Düsseldorf, Germany](https://de.wikipedia.org/wiki/D%C3%BCsseldorf#/media/File:Duesseldorf-Panorama-2016.jpg)!
