### PR TITLE
docs(less-plugin): use next branch when install

### DIFF
--- a/packages/gatsby-plugin-less/README.md
+++ b/packages/gatsby-plugin-less/README.md
@@ -61,6 +61,8 @@ plugins: [
 
 ### v2.0.0
 
+- to work with v2 you have to install the next branch `npm install --save gatsby-plugin-less@next`
+
 - `less` is moved to a peer dependency. Installing the package
   alongside `gatsby-plugin-less` is now required. Use `npm install --save less`
 


### PR DESCRIPTION
Specify to use next branch to work with v2. #6252