### PR TITLE
fix running queries without explicit order

### DIFF
--- a/packages/gatsby/src/schema/create-sort-field.js
+++ b/packages/gatsby/src/schema/create-sort-field.js
@@ -33,7 +33,7 @@ module.exports = function createSortField(
         },
         order: {
           name: _.camelCase(`${typeName} sortOrder`),
-          defaultValue: `asc`,
+          defaultValue: `ASC`,
           type: new GraphQLEnumType({
             name: _.camelCase(`${typeName} sortOrderValues`),
             values: {


### PR DESCRIPTION
schema stitching seems to cause some changes and `defaultValue` wasn't used same as before, this should fix errors like https://app.netlify.com/sites/using-drupal/deploys/5b67fab182d3f13f73bdcdfe