### PR TITLE
Only include gatsby-browser.js if it exists

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -220,7 +220,8 @@ module.exports = async (args: BootstrapArgs) => {
     // Always include the site's gatsby-browser.js if it exists as it's
     // a handy place to include global styles and other global imports.
     if (env === `browser` && plugin.name === `default-site-plugin`) {
-      return slash(path.join(plugin.resolve, `gatsby-${env}`))
+      const gatsbyBrowser = slash(path.join(plugin.resolve, `gatsby-${env}`))
+      if (fs.existsSync(gatsbyBrowser)) return gatsbyBrowser
     }
 
     if (envAPIs && Array.isArray(envAPIs) && envAPIs.length > 0) {


### PR DESCRIPTION
Update to #7011 - check gatsby-browser.js exists before including it