### PR TITLE
Update `link` docs to have an accessibile clickable `div`

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -59,7 +59,7 @@ For cases when you can only use event handlers for navigation, you can use `push
 import { push } from "gatsby"
 
 render () {
-  <div onClick={ () => push('/example')}>
+  <div onClick={ () => push('/example')} role="link" tabIndex="0" onKeyUp={this.handleKeyUp}>
     <p>Example</p>
   </div>
 }


### PR DESCRIPTION
## What is this?

I love that Gatsby has updated to use a router which manages focus for AT users! 🎉  When reading through the docs I noticed there's an example that puts an `onClick` handler on a plain `div`, which isn't accessibile. I've added a few props to the example so if people do choose to copy & paste it, they don't lose any accessibility (unless they don't implement the `onKeyUp` handler).

Thanks for all the work you all have put into this!