### PR TITLE
Update gatsby-node.js in gatsby-plugin-manifest to fix 404 in development

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -18,7 +18,7 @@ function generateIcons(icons, srcIcon) {
   })
 }
 
-exports.onPostBuild = (args, pluginOptions) =>
+exports.onPostBootstrap = (args, pluginOptions) =>
   new Promise((resolve, reject) => {
     const { icon } = pluginOptions
     const manifest = { ...pluginOptions }


### PR DESCRIPTION
Currently, when starting with `gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-default#v2` or any time someone is using `gatsby-plugin-manifest` and running `gatsby develop` you get a `GET http://localhost:8000/icons/icon-48x48.png 404 (Not Found)` because `gatsby-ssr.js` is building the link in `<head/>` but `gatsby-node.js` only generates the icons `onPostBuild`

Changing it to `onPostBootstrap` adds 0.135s to `gatsby develop` but at least, as a first time user you won't be opening up the console to a 404 error every time.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
