### PR TITLE
Fix gatsby-link hash scrolling

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -135,7 +135,9 @@ class GatsbyLink extends React.Component {
             // just scroll there.
             const { pathname, hash } = parsePath(to)
             if (pathname === location.pathname) {
-              const element = hash ? document.getElementById(hash) : null
+              const element = hash
+                ? document.getElementById(hash.substr(1))
+                : null
               if (element !== null) {
                 element.scrollIntoView()
               } else {


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Noticed that the hash scrolling wasn't working, but this should fix it. The problem was that we were trying to use `document.getElementById('#whatever')` when the `#` should be omitted.