### PR TITLE
Fix gatsby-link dependencies

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.52",
-    "@types/history": "^4.6.2",
-    "@types/react-router-dom": "^4.2.5",
+    "@reach/router": "^1.1.1",
     "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2",
     "ric": "^1.3.0"
@@ -17,8 +16,7 @@
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",
     "@babel/core": "7.0.0-beta.52",
-    "cross-env": "^5.1.4",
-    "react-router-dom": "^4.2.2"
+    "cross-env": "^5.1.4"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",
   "keywords": [


### PR DESCRIPTION
Fix `gatsby-link` dependencies to `@reach/router` rather than `react-router-dom`.