### PR TITLE
 Opt-out of lazy-load: Add 'critical' flag to Img component

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -277,3 +277,6 @@ prop. e.g. `<Img fluid={fluid} />`
 - Images marked as `critical` will start loading immediately as the DOM is 
   parsed, but unless `fadeIn` is set to `false`, the transition from placeholder
   to final image will not occur until after the component is mounted.
+- Gatsby-Image now is backed by newer `<picture>` tag. This newer standard allows for
+  media types to be chosen by the browser without using javascript. It also is
+  backward compatible to older browsers (IE 11, etc)

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -260,6 +260,7 @@ prop. e.g. `<Img fluid={fluid} />`
 | `backgroundColor`       | `string` / `bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
 | `onLoad`                | `func`              | A callback that is called when the full-size image has loaded.                                                              |
 | `Tag`                   | `string`            | Which HTML tag to use for wrapping elements. Defaults to `div`.                                                             |
+| `critical`              | `bool`              | Opt-out of lazy-loading behavior. Defaults to `false`.                                                                      |
 
 ## Image processing arguments
 
@@ -270,6 +271,9 @@ prop. e.g. `<Img fluid={fluid} />`
 
 - If you want to set `display: none;` on a component using a `fixed` prop,
   you need to also pass in to the style prop `{ display: 'inherit' }`.
-- Images don't load until JavaScript is loaded. Gatsby's automatic code
+- By default, images don't load until JavaScript is loaded. Gatsby's automatic code
   splitting generally makes this fine but if images seem slow coming in on a
   page, check how much JavaScript is being loaded there.
+- Images marked as `critical` will start loading immediately as the DOM is 
+  parsed, but unless `fadeIn` is set to `false`, the transition from placeholder
+  to final image will not occur until after the component is mounted.

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -14,17 +14,25 @@ exports[`<Img /> should render fixed size images 1`] = `
         style="width: 100px; opacity: 0; height: 100px;"
         title="Title for the image"
       />
-      <img
-        alt="Alt text for the image"
-        height="100"
-        src="test_image.jpg"
-        srcset="some srcSet"
-        style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1;"
-        title="Title for the image"
-        width="100"
-      />
+      <picture>
+        <source
+          srcset="some srcSetWebp"
+          type="image/webp"
+        />
+        <source
+          srcset="some srcSet"
+        />
+        <img
+          alt="Alt text for the image"
+          height="100"
+          src="test_image.jpg"
+          style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1;"
+          title="Title for the image"
+          width="100"
+        />
+      </picture>
       <noscript>
-        &lt;img width="100" height="100" src="test_image.jpg" srcset="some srcSet" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;
+        &lt;picture&gt;&lt;source type='image/webp' srcSet="some srcSetWebp" /&gt;&lt;source srcSet="some srcSet" /&gt;&lt;img width="100" height="100" src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
       </noscript>
     </div>
   </div>
@@ -48,16 +56,25 @@ exports[`<Img /> should render fluid images 1`] = `
         style="position: absolute; top: 0px; bottom: 0px; opacity: 0; right: 0px; left: 0px;"
         title="Title for the image"
       />
-      <img
-        alt="Alt text for the image"
-        sizes="(max-width: 600px) 100vw, 600px"
-        src="test_image.jpg"
-        srcset="some srcSet"
-        style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1;"
-        title="Title for the image"
-      />
+      <picture>
+        <source
+          sizes="(max-width: 600px) 100vw, 600px"
+          srcset="some srcSetWebp"
+          type="image/webp"
+        />
+        <source
+          sizes="(max-width: 600px) 100vw, 600px"
+          srcset="some srcSet"
+        />
+        <img
+          alt="Alt text for the image"
+          src="test_image.jpg"
+          style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1;"
+          title="Title for the image"
+        />
+      </picture>
       <noscript>
-        &lt;img src="test_image.jpg" srcset="some srcSet" alt="Alt text for the image" title="Title for the image" sizes="(max-width: 600px) 100vw, 600px" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;
+        &lt;picture&gt;&lt;source type='image/webp' srcSet="some srcSetWebp" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;source srcSet="some srcSet" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;img src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
       </noscript>
     </div>
   </div>

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -10,12 +10,14 @@ const fixedShapeMock = {
   height: 100,
   src: `test_image.jpg`,
   srcSet: `some srcSet`,
+  srcSetWebp: `some srcSetWebp`,
 }
 
 const fluidShapeMock = {
   aspectRatio: 1.5,
   src: `test_image.jpg`,
   srcSet: `some srcSet`,
+  srcSetWebp: `some srcSetWebp`,
   sizes: `(max-width: 600px) 100vw, 600px`,
 }
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -69,24 +69,6 @@ const listenToIntersections = (el, cb) => {
   listeners.push([el, cb])
 }
 
-let isWebpSupportedCache = null
-const isWebpSupported = () => {
-  if (isWebpSupportedCache !== null) {
-    return isWebpSupportedCache
-  }
-
-  const elem =
-    typeof window !== `undefined` ? window.document.createElement(`canvas`) : {}
-  if (elem.getContext && elem.getContext(`2d`)) {
-    isWebpSupportedCache =
-      elem.toDataURL(`image/webp`).indexOf(`data:image/webp`) === 0
-  } else {
-    isWebpSupportedCache = false
-  }
-
-  return isWebpSupportedCache
-}
-
 const noscriptImg = props => {
   // Check if prop exists before adding each attribute to the string output below to prevent
   // HTML validation issues caused by empty values like width="" and height=""
@@ -143,7 +125,7 @@ class Image extends React.Component {
 
     // If this image has already been loaded before then we can assume it's
     // already in the browser cache so it's cheap to just show directly.
-    const seenBefore = inImageCache(props)
+    const seenBefore = !props.critical && inImageCache(props)
 
     if (
       !seenBefore &&
@@ -161,6 +143,10 @@ class Image extends React.Component {
       imgLoaded = false
     }
 
+    if (props.critical) {
+      isVisible = true
+    }
+
     this.state = {
       isVisible,
       imgLoaded,
@@ -170,10 +156,16 @@ class Image extends React.Component {
     this.handleRef = this.handleRef.bind(this)
   }
 
+  componentDidMount() {
+    if (this.props.critical) {
+      this.setState({ imgLoaded: true })
+    }
+  }
+
   handleRef(ref) {
     if (this.state.IOSupported && ref) {
       listenToIntersections(ref, () => {
-        this.setState({ isVisible: true, imgLoaded: false })
+        this.setState({ isVisible: true })
       })
     }
   }
@@ -215,12 +207,6 @@ class Image extends React.Component {
     if (fluid) {
       const image = fluid
 
-      // Use webp by default if browser supports it
-      if (image.srcWebp && image.srcSetWebp && isWebpSupported()) {
-        image.src = image.srcWebp
-        image.srcSet = image.srcSetWebp
-      }
-
       // The outer div is necessary to reset the z-index to 0.
       return (
         <Tag
@@ -249,7 +235,7 @@ class Image extends React.Component {
               }}
             />
 
-            {/* Show the blury base64 image. */}
+            {/* Show the blurry base64 image. */}
             {image.base64 && (
               <Img
                 alt={alt}
@@ -288,27 +274,42 @@ class Image extends React.Component {
 
             {/* Once the image is visible (or the browser doesn't support IntersectionObserver), start downloading the image */}
             {this.state.isVisible && (
-              <Img
-                alt={alt}
-                title={title}
-                srcSet={image.srcSet}
-                src={image.src}
-                sizes={image.sizes}
-                style={imageStyle}
-                onLoad={() => {
-                  this.state.IOSupported && this.setState({ imgLoaded: true })
-                  this.props.onLoad && this.props.onLoad()
-                }}
-                onError={this.props.onError}
-              />
+              <picture>
+                {image.srcSetWebp && (<source
+                  type={`image/webp`}
+                  srcSet={image.srcSetWebp}
+                  sizes={image.sizes}
+                />)}
+
+                <source
+                  srcSet={image.srcSet}
+                  sizes={image.sizes}
+                />
+
+                <Img
+                  alt={alt}
+                  title={title}
+                  src={image.src}
+                  srcSet={image.srcSet}
+                  sizes={image.sizes}
+                  style={imageStyle}
+                  onLoad={() => {
+                    this.state.IOSupported && this.setState({ imgLoaded: true })
+                    this.props.onLoad && this.props.onLoad()
+                  }}
+                  onError={this.props.onError}
+                />
+              </picture>
             )}
 
             {/* Show the original image during server-side rendering if JavaScript is disabled */}
-            <noscript
-              dangerouslySetInnerHTML={{
-                __html: noscriptImg({ alt, title, ...image }),
-              }}
-            />
+            {!this.props.critical && (
+              <noscript
+                dangerouslySetInnerHTML={{
+                  __html: noscriptImg({ alt, title, ...image }),
+                }}
+              />
+            )}
           </Tag>
         </Tag>
       )
@@ -329,12 +330,6 @@ class Image extends React.Component {
         delete divStyle.display
       }
 
-      // Use webp by default if browser supports it
-      if (image.srcWebp && image.srcSetWebp && isWebpSupported()) {
-        image.src = image.srcWebp
-        image.srcSet = image.srcSetWebp
-      }
-
       // The outer div is necessary to reset the z-index to 0.
       return (
         <Tag
@@ -351,7 +346,7 @@ class Image extends React.Component {
             style={divStyle}
             ref={this.handleRef}
           >
-            {/* Show the blury base64 image. */}
+            {/* Show the blurry base64 image. */}
             {image.base64 && (
               <Img
                 alt={alt}
@@ -387,34 +382,50 @@ class Image extends React.Component {
 
             {/* Once the image is visible, start downloading the image */}
             {this.state.isVisible && (
-              <Img
-                alt={alt}
-                title={title}
-                width={image.width}
-                height={image.height}
-                srcSet={image.srcSet}
-                src={image.src}
-                style={imageStyle}
-                onLoad={() => {
-                  this.setState({ imgLoaded: true })
-                  this.props.onLoad && this.props.onLoad()
-                }}
-                onError={this.props.onError}
-              />
+              <picture>
+                {image.srcSetWebp && (<source
+                  type={`image/webp`}
+                  srcSet={image.srcSetWebp}
+                  sizes={image.sizes}
+                />)}
+
+                <source
+                  srcSet={image.srcSet}
+                  sizes={image.sizes}
+                />
+
+                <Img
+                  alt={alt}
+                  title={title}
+                  width={image.width}
+                  height={image.height}
+                  src={image.src}
+                  srcSet={image.srcSet}
+                  sizes={image.sizes}
+                  style={imageStyle}
+                  onLoad={() => {
+                    this.setState({ imgLoaded: true })
+                    this.props.onLoad && this.props.onLoad()
+                  }}
+                  onError={this.props.onError}
+                />
+              </picture>
             )}
 
             {/* Show the original image during server-side rendering if JavaScript is disabled */}
-            <noscript
-              dangerouslySetInnerHTML={{
-                __html: noscriptImg({
-                  alt,
-                  title,
-                  width: image.width,
-                  height: image.height,
-                  ...image,
-                }),
-              }}
-            />
+            {!this.props.critical && (
+              <noscript
+                dangerouslySetInnerHTML={{
+                  __html: noscriptImg({
+                    alt,
+                    title,
+                    width: image.width,
+                    height: image.height,
+                    ...image,
+                  }),
+                }}
+              />
+            )}
           </Tag>
         </Tag>
       )
@@ -425,6 +436,7 @@ class Image extends React.Component {
 }
 
 Image.defaultProps = {
+  critical: false,
   fadeIn: true,
   alt: ``,
   Tag: `div`,
@@ -465,6 +477,7 @@ Image.propTypes = {
     PropTypes.string,
     PropTypes.object,
   ]),
+  critical: PropTypes.bool,
   style: PropTypes.object,
   imgStyle: PropTypes.object,
   placeholderStyle: PropTypes.object,

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -221,7 +221,7 @@ class Image extends React.Component {
 
     const imageStyle = {
       opacity: this.state.imgLoaded || this.state.fadeIn === false ? 1 : 0,
-      transition: this.state.fadeIn === true ? `opacity 0.5s` : ``,
+      transition: this.state.fadeIn === true ? `opacity 0.5s` : `none`,
       ...imgStyle,
     }
 


### PR DESCRIPTION
Address #4297 

* Add `critical` attribute to opt-out of lazy-loading behavior
* Picture tag to allow browser to select best matching file format (webp detection)
* if fadeIn is true (default) - then the loaded image still will not appear until after the component is mounted

```
	    <Img fixed={images.file1.childImageSharp.fixed} />
	    <Img fixed={images.file1.childImageSharp.fixed} />
	    <Img fixed={images.file2.childImageSharp.fixed} critical fadeIn={false}/>
	    <Img fixed={images.file2.childImageSharp.fixed} critical/>
```