### PR TITLE
Add gatsby-link snapshot testing

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",
     "@babel/core": "7.0.0-beta.52",
-    "cross-env": "^5.1.4"
+    "cross-env": "^5.1.4",
     "react-testing-library": "^4.1.7"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -16,6 +16,7 @@
     "@babel/cli": "7.0.0-beta.52",
     "@babel/core": "7.0.0-beta.52",
     "cross-env": "^5.1.4"
+    "react-testing-library": "^4.1.7"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",
   "keywords": [

--- a/packages/gatsby-link/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-link/src/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Link /> matches active snapshot 1`] = `
+<div>
+  <a
+    aria-current="page"
+    class="link is-active"
+    href="/active"
+    style="color: black; text-decoration: underline;"
+  >
+    link
+  </a>
+</div>
+`;
+
+exports[`<Link /> matches basic snapshot 1`] = `
+<div>
+  <a
+    class="link"
+    href="/"
+    style="color: black;"
+  >
+    link
+  </a>
+</div>
+`;

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -5,19 +5,13 @@ import {
   createHistory,
   LocationProvider,
 } from "@reach/router"
-import Link from "../"
+import Link, { push, replace, withPrefix } from "../"
 
 afterEach(cleanup)
 
 const getInstance = (props, pathPrefix = ``) => {
-  Object.assign(global.window, {
-    __PATH_PREFIX__: pathPrefix,
-  })
-
-  const context = { router: { history: {} } }
-
-  const Link = require(`../`).default
-  return Link(props, context)
+  getWithPrefix()(pathPrefix)
+  return Link(props)
 }
 
 const getPush = () => {
@@ -25,7 +19,7 @@ const getPush = () => {
     ___push: jest.fn(),
   })
 
-  return require(`../`).push
+  return push
 }
 
 const getReplace = () => {
@@ -33,14 +27,14 @@ const getReplace = () => {
     ___replace: jest.fn(),
   })
 
-  return require(`../`).replace
+  return replace
 }
 
 const getWithPrefix = (pathPrefix = ``) => {
   Object.assign(global.window, {
     __PATH_PREFIX__: pathPrefix,
   })
-  return require(`../`).withPrefix
+  return withPrefix
 }
 
 const setup = ({ sourcePath = `/active`, linkProps } = {}) => {

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -1,3 +1,4 @@
+import "@babel/polyfill"
 import React from "react"
 import { render, cleanup } from "react-testing-library"
 import {
@@ -56,10 +57,9 @@ const setup = ({ sourcePath = `/active`, linkProps } = {}) => {
     </LocationProvider>
   )
 
-  return {
-    ...utils,
+  return Object.assign({}, utils, {
     link: utils.getByText(`link`),
-  }
+  })
 }
 
 describe(`<Link />`, () => {


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Fixes #7089

Right now this is a very simple setup of snapshots but can easily the extended in the future. With `react-testing-library` there is also the possibility of adding more DOM tests which is very nice.

Similar setup should be fairly simple to add to other packages as well

Noticed that `react-router-dom` is still a dependency but saw that there already is a PR for that so I won't touch that now.