### PR TITLE
Fix gatsby-link location prop

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -169,7 +169,9 @@ GatsbyLink.propTypes = {
 
 // eslint-disable-next-line react/display-name
 const withLocation = Comp => props => (
-  <Location>{location => <Comp location={location} {...props} />}</Location>
+  <Location>
+    {({ location }) => <Comp location={location} {...props} />}
+  </Location>
 )
 
 export default withLocation(GatsbyLink)


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Fixes a problem that was introduced in #7080. We switched to use the passed location prop in the `Link` component but that passed location prop was not the correct one from `@reach/router`. Sorry for this one!