### PR TITLE
fix redirects

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -60,7 +60,8 @@ const navigate = (to, replace) => {
   // If we're redirecting, just replace the passed in pathname
   // to the one we want to redirect to.
   if (redirect) {
-    pathname = redirect.toPath
+    to = redirect.toPath
+    pathname = parsePath(to).pathname
   }
 
   // If we had a service worker update, no matter the path, reload window


### PR DESCRIPTION
need to update `to`, otherwise we would fetch data for correct page but still navigate to wrong one. This should also cover redirects with `#` or `?` parts