### PR TITLE
gatsby-link: Scroll to hash when no pathname

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -134,7 +134,7 @@ class GatsbyLink extends React.Component {
             // Is this link pointing to a hash on the same page? If so,
             // just scroll there.
             const { pathname, hash } = parsePath(to)
-            if (pathname === location.pathname) {
+            if (pathname === location.pathname || !pathname) {
               const element = hash
                 ? document.getElementById(hash.substr(1))
                 : null


### PR DESCRIPTION
When we have a `<Link to="#learnmore" />`  in the page, it wont scroll to the fragment.
