### PR TITLE
Document change from `RootQueryType` to `Query` in v1»v2 migration guide

### DIFF
--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -30,6 +30,7 @@ This is a reference for upgrading your site from Gatsby v1 to Gatsby v2. While t
   - [Browser API `replaceRouterComponent` was removed](#browser-api-replaceroutercomponent-was-removed)
   - [Browser API `replaceHistory` was removed](#browser-api-replacehistory-was-removed)
   - [Don't query nodes by ID](#dont-query-nodes-by-id)
+  - [Use Query in place of RootQueryType](#use-query-in-place-of-rootquerytype)
   - [Typography.js Plugin Config](#typographyjs-plugin-config-changes)
 
 - [Resolving Deprecations](#resolving-deprecations)
@@ -573,6 +574,26 @@ Here's an example querying an image:
 ```
 
 [See the Pull Request that implemented this change](https://github.com/gatsbyjs/gatsby/pull/3807/files)
+
+### Use `Query` in place of `RootQueryType`
+
+The GraphQL root type has been changed from `RootQueryType` to `Query`. This is only likely to impact you if you have top-level fragments in your GraphQL queries:
+
+```diff
+  query Blog {
+    ...Sidebar
+    blogPosts {
+      title
+      slug
+    }
+  }
+  
+- fragment Sidebar on RootQueryType {
++ fragment Sidebar on Query {
+    siteDescription
+  }
+}
+```
 
 ### Typography.js Plugin Config Changes
 


### PR DESCRIPTION
Addresses #7085

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
