### PR TITLE
Added three new sections to the docs

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -64,25 +64,6 @@
           link: /docs/gatsby-source-filesystem-programmatic-import/
         - title: Working with images in Gatsby
           link: /docs/working-with-images/
-    - title: Querying your data with GraphQL*
-      link: /docs/graphql/
-      items:
-        - title: Introducing GraphiQL*
-          link: /docs/introducing-graphiql/
-        - title: Build a page with a GraphQL query
-          link: /docs/build-a-page-with-graphql-query/
-        - title: Creating and modifying pages
-          link: /docs/creating-and-modifying-pages/
-        - title: Adding Markdown pages
-          link: /docs/adding-markdown-pages/
-        - title: Adding a list of Markdown blog posts
-          link: /docs/adding-a-list-of-markdown-blog-posts/
-        - title: Creating slugs for pages*
-          link: /docs/creating-slugs-for-pages/
-        - title: Programmatically create pages from data*
-          link: /docs/programmatically-create-pages-from-data/
-        - title: Querying data with StaticQuery
-          link: /docs/static-query/
     - title: Sourcing content and data*
       link: /docs/sourcing-content-and-data
       items:
@@ -107,6 +88,25 @@
                 link: /docs/sourcing-from-contentful/
               - title: Sourcing from Prose*
                 link: /docs/sourcing-from-prose/
+    - title: Querying your data with GraphQL*
+      link: /docs/graphql/
+      items:
+        - title: Introducing GraphiQL*
+          link: /docs/introducing-graphiql/
+        - title: Build a page with a GraphQL query
+          link: /docs/build-a-page-with-graphql-query/
+        - title: Creating and modifying pages
+          link: /docs/creating-and-modifying-pages/
+        - title: Adding Markdown pages
+          link: /docs/adding-markdown-pages/
+        - title: Adding a list of Markdown blog posts
+          link: /docs/adding-a-list-of-markdown-blog-posts/
+        - title: Creating slugs for pages*
+          link: /docs/creating-slugs-for-pages/
+        - title: Programmatically create pages from data*
+          link: /docs/programmatically-create-pages-from-data/
+        - title: Querying data with StaticQuery
+          link: /docs/static-query/
     - title: Plugins*
       link: /docs/plugins/
       items:

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -86,27 +86,27 @@
     - title: Sourcing content and data*
       link: /docs/sourcing-content-and-data
       items:
-        - title: Filesystem*
-          link: /docs/filesystem/
-        - title: Database*
-          link: /docs/database/
-        - title: SaaS service*
-          link: /docs/saas-service/
-        - title: Private APIs*
-          link: /docs/private-apis/
+        - title: Sourcing from the filesystem*
+          link: /docs/sourcing-from-the-filesystem/
+        - title: Sourcing from databases*
+          link: /docs/sourcing-from-databases/
+        - title: Sourcing from SaaS services*
+          link: /docs/sourcing-from-saas-services/
+        - title: Sourcing from private APIs*
+          link: /docs/sourcing-from-private-apis/
         - title: Headless CMS*
           link: /docs/headless-cms/
             items:
-              - title: Netlify CMS
-                link: /docs/netlify-cms/
-              - title: WordPress*
-                link: /docs/wordpress/
-              - title: Drupal*
-                link: /docs/drupal/
-              - title: Contentful*
-                link: /docs/contentful/
-              - title: Prose*
-                link: /docs/prose/
+              - title: Sourcing from Netlify CMS
+                link: /docs/sourcing-from-netlify-cms/
+              - title: Sourcing from WordPress*
+                link: /docs/sourcing-from-wordpress/
+              - title: Sourcing from Drupal*
+                link: /docs/sourcing-from-drupal/
+              - title: Sourcing from Contentful*
+                link: /docs/sourcing-from-contentful/
+              - title: Sourcing from Prose*
+                link: /docs/sourcing-from-prose/
     - title: Plugins*
       link: /docs/plugins/
       items:
@@ -188,12 +188,12 @@
     - title: Adding third-party services*
       link: /docs/adding-third-party-services/
       items:
-        - title: Search*
-          link: /docs/search/
-        - title: Analytics*
-          link: /docs/analytics/
-        - title: Forms*
-          link: /docs/forms/
+        - title: Adding search*
+          link: /docs/adding-search/
+        - title: Adding analytics*
+          link: /docs/adding-analytics/
+        - title: Adding forms*
+          link: /docs/adding-forms/
     - title: Performance*
       link: /docs/performance/
       items:

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -83,19 +83,30 @@
           link: /docs/programmatically-create-pages-from-data/
         - title: Querying data with StaticQuery
           link: /docs/static-query/
-    - title: Headless CMS*
-      link: /docs/headless-cms/
+    - title: Sourcing content and data*
+      link: /docs/sourcing-content-and-data
       items:
-        - title: Netlify CMS
-          link: /docs/netlify-cms/
-        - title: WordPress*
-          link: /docs/wordpress/
-        - title: Drupal*
-          link: /docs/drupal/
-        - title: Contentful*
-          link: /docs/contentful/
-        - title: Prose*
-          link: /docs/prose/
+        - title: Filesystem*
+          link: /docs/filesystem/
+        - title: Database*
+          link: /docs/database/
+        - title: SaaS service*
+          link: /docs/saas-service/
+        - title: Private APIs*
+          link: /docs/private-apis/
+        - title: Headless CMS*
+          link: /docs/headless-cms/
+            items:
+              - title: Netlify CMS
+                link: /docs/netlify-cms/
+              - title: WordPress*
+                link: /docs/wordpress/
+              - title: Drupal*
+                link: /docs/drupal/
+              - title: Contentful*
+                link: /docs/contentful/
+              - title: Prose*
+                link: /docs/prose/
     - title: Plugins*
       link: /docs/plugins/
       items:
@@ -122,6 +133,19 @@
           link: /docs/component-css/
         - title: PostCSS*
           link: /docs/post-css/
+    - title: Testing*
+      link: /docs/testing/
+      items:
+        - title: Unit testing
+          link: /docs/unit-testing/
+        - title: Testing components with GraphQL
+          link: /docs/testing-components-with-graphql/
+        - title: End-to-end testing
+          link: /docs/end-to-end-testing/
+        - title: Testing CSS-in-JS
+          link: /docs/testing-css-in-js/
+        - title: Testing React components
+          link: /docs/testing-react-components/
     - title: Debugging
       link: /docs/debugging/
       items:
@@ -161,6 +185,15 @@
           link: /docs/linking-between-pages/
         - title: Search Engine Optimization (SEO)
           link: /docs/seo/
+    - title: Adding third-party services*
+      link: /docs/adding-third-party-services/
+      items:
+        - title: Search*
+          link: /docs/search/
+        - title: Analytics*
+          link: /docs/analytics/
+        - title: Forms*
+          link: /docs/forms/
     - title: Performance*
       link: /docs/performance/
       items:


### PR DESCRIPTION
The "Testing" section already has a few PRs about to be merged. 
#6708 
#6678 

Will need to make stub articles for the "Sourcing content and data" section and the "Adding third-party services" section.

@calcsam I don't know if I did the "Headless CMS" section inside the "Sourcing content and data" section correctly. Also, this process is giving me pause on how many levels of infinite nesting is reasonable. There is a point at which we'd need to actually create a whole new page for a set of docs if it has enough children with grand-children and great-great-grand-children, etc!


