### PR TITLE
Disable www-graphql-docker-push.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,15 +43,15 @@ jobs:
           script:
           - yarn test
 
-
-        - stage: www graphql docker image build and push
-          if: (NOT type = pull_request) AND branch = master
-          env:
-            - DOCKER_USER=mikeallanson
-            - secure: "oF3OuabOsUtqf1IIo/YQA/FzVzZOQFlNqGbnu7/KO5LugtMBkxDcrT9FA33LHn1kX2TsblOaMviY5ukTVIQIAFTcaqPmYzt8phCi3x6tugcT0bfYmTWIQZ/KsZFFufB8MiLFAgILpfhpooDPFhiRZMdv/NLlTPO50iAth6/WqfgMffvtU3xpWrqxLzvAJLw1Dgx0cDsw515FcMjy2QJHmwob3eb7/PTfd0qmpQlzrspvf7PxTfGd6mZDfXsaOnqHAH36oiXe5Hwhnfoz0oePeb7d36RY1/SUX7kYBhf/gWNcFMzERGGnFjbT5RtQPAViMjCpPuPI3RsytA1DdH/I/ykobQ0fx94Vr+R3xe4+gujYDkTRek6JvnS1gj2BxJ6J8rZHOJyI0WpGNORwkOwDla2KRuJZLWBaZ6MvDH+uWeRuEDZnSlqgNERWztLpCAjx8V+MdHbI/rG4OC2AanrgD3BabGm/YwBptfc0x+23ibSlez4LtJmozx6wOzYDXhqfvRk6pD4YhXc0XXUlwBqAymFszZY7yyDkdeN+2SgBBye+dSbDqS7X26r/tyT+0NrjQH+oUM5EeHL8mH2I5Tvwx3fgaK5d3Uuvaet49CROMKb+IcDnK5qZnaD3Oq6glDgAfINPXPT3ptVjQSCDenrUbRkNR3x3bgETCPRak4/x1nw=" # DOCKER_PASS
-          before_install:
-            - chmod +x scripts/www-graphql-docker-push.sh
-          script:
-            - travis_wait 30 ./scripts/www-graphql-docker-push.sh
-
-
+# new pushes aren't working at the moment (the build times out processing showcase images)
+# the existing image works fine, and can be manually updated by running through the steps
+# in scripts/www-graphql-docker-push.sh
+        # - stage: www graphql docker image build and push
+        #   if: (NOT type = pull_request) AND branch = master
+        #   env:
+        #     - DOCKER_USER=mikeallanson
+        #     - secure: "oF3OuabOsUtqf1IIo/YQA/FzVzZOQFlNqGbnu7/KO5LugtMBkxDcrT9FA33LHn1kX2TsblOaMviY5ukTVIQIAFTcaqPmYzt8phCi3x6tugcT0bfYmTWIQZ/KsZFFufB8MiLFAgILpfhpooDPFhiRZMdv/NLlTPO50iAth6/WqfgMffvtU3xpWrqxLzvAJLw1Dgx0cDsw515FcMjy2QJHmwob3eb7/PTfd0qmpQlzrspvf7PxTfGd6mZDfXsaOnqHAH36oiXe5Hwhnfoz0oePeb7d36RY1/SUX7kYBhf/gWNcFMzERGGnFjbT5RtQPAViMjCpPuPI3RsytA1DdH/I/ykobQ0fx94Vr+R3xe4+gujYDkTRek6JvnS1gj2BxJ6J8rZHOJyI0WpGNORwkOwDla2KRuJZLWBaZ6MvDH+uWeRuEDZnSlqgNERWztLpCAjx8V+MdHbI/rG4OC2AanrgD3BabGm/YwBptfc0x+23ibSlez4LtJmozx6wOzYDXhqfvRk6pD4YhXc0XXUlwBqAymFszZY7yyDkdeN+2SgBBye+dSbDqS7X26r/tyT+0NrjQH+oUM5EeHL8mH2I5Tvwx3fgaK5d3Uuvaet49CROMKb+IcDnK5qZnaD3Oq6glDgAfINPXPT3ptVjQSCDenrUbRkNR3x3bgETCPRak4/x1nw=" # DOCKER_PASS
+        #   before_install:
+        #     - chmod +x scripts/www-graphql-docker-push.sh
+        #   script:
+        #     - travis_wait 30 ./scripts/www-graphql-docker-push.sh


### PR DESCRIPTION
At the moment this times out and causes builds to fail.

The existing image hosted at https://gatsbygraphql.sloppy.zone will continue to work, but will need manual updating until www-graphql-docker-push.sh is fixed.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
