### PR TITLE
[gatsby-plugin-netlify] update static cache header to match docs

### DIFF
--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -25,7 +25,7 @@ export const SECURITY_HEADERS = {
 }
 
 export const CACHING_HEADERS = {
-  "/static/*": [`Cache-Control: max-age=31536000`],
+  "/static/*": [`Cache-Control: public, max-age=31536000, immutable`],
 }
 
 export const LINK_REGEX = /^(Link: <\/)(.+)(>;.+)/


### PR DESCRIPTION
Add `public` and `immutable` to the `Cache-Control` header for all files in the `static` directory to match the recommended configuration from the [Gatsby caching docs](https://github.com/gatsbyjs/gatsby/blob/f3ab35fc9be3fd12a3174b9e72355bc209ce35ab/docs/docs/caching.md).