### PR TITLE
Fix onRouteUpdate

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -35,8 +35,7 @@ function maybeRedirect(pathname) {
 
 let lastNavigateToLocationString = null
 
-globalHistory.listen(() => {
-  const location = globalHistory.location
+const onRouteUpdate = location => {
   if (!maybeRedirect(location.pathname)) {
     // Check if we already ran onPreRouteUpdate API
     // in navigateTo function
@@ -47,11 +46,9 @@ globalHistory.listen(() => {
       apiRunner(`onPreRouteUpdate`, { location })
     }
     // Make sure React has had a chance to flush to DOM first.
-    setTimeout(() => {
-      apiRunner(`onRouteUpdate`, { location })
-    }, 0)
+    apiRunner(`onRouteUpdate`, { location })
   }
-})
+}
 
 const navigate = (to, replace) => {
   let { pathname } = parsePath(to)
@@ -132,4 +129,4 @@ function init() {
   maybeRedirect(window.location.pathname)
 }
 
-export { init, shouldUpdateScroll }
+export { init, shouldUpdateScroll, onRouteUpdate }

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -4,7 +4,11 @@ import ReactDOM from "react-dom"
 import { Router } from "@reach/router"
 import { ScrollContext } from "gatsby-react-router-scroll"
 import domReady from "domready"
-import { shouldUpdateScroll, init as navigationInit } from "./navigation"
+import {
+  shouldUpdateScroll,
+  init as navigationInit,
+  onRouteUpdate,
+} from "./navigation"
 import emitter from "./emitter"
 window.___emitter = emitter
 import PageRenderer from "./page-renderer"
@@ -28,11 +32,6 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   if (apiRunner(`registerServiceWorker`).length > 0) {
     require(`./register-service-worker`)
   }
-
-  // Call onRouteUpdate on the initial page load.
-  apiRunner(`onRouteUpdate`, {
-    location: window.history.location,
-  })
 
   class RouteHandler extends React.Component {
     render() {
@@ -66,6 +65,15 @@ apiRunnerAsync(`onClientEntry`).then(() => {
           {child}
         </ScrollContext>
       )
+    }
+
+    // Call onRouteUpdate on the initial page load.
+    componentDidMount() {
+      onRouteUpdate(this.props.location)
+    }
+
+    componentDidUpdate() {
+      onRouteUpdate(this.props.location)
     }
   }
 

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -1,7 +1,11 @@
 import React, { createElement } from "react"
 import { Router } from "@reach/router"
 import { ScrollContext } from "gatsby-react-router-scroll"
-import { shouldUpdateScroll, init as navigationInit } from "./navigation"
+import {
+  shouldUpdateScroll,
+  init as navigationInit,
+  onRouteUpdate,
+} from "./navigation"
 import { apiRunner } from "./api-runner-browser"
 import syncRequires from "./sync-requires"
 import pages from "./pages.json"
@@ -43,11 +47,6 @@ if (window.__webpack_hot_middleware_reporter__ !== undefined) {
 
 navigationInit()
 
-// Call onRouteUpdate on the initial page load.
-apiRunner(`onRouteUpdate`, {
-  location: window.history.location,
-})
-
 class RouteHandler extends React.Component {
   render() {
     const { location } = this.props
@@ -83,6 +82,15 @@ class RouteHandler extends React.Component {
         {child}
       </ScrollContext>
     )
+  }
+
+  // Call onRouteUpdate on the initial page load.
+  componentDidMount() {
+    onRouteUpdate(this.props.location)
+  }
+
+  componentDidUpdate() {
+    onRouteUpdate(this.props.location)
   }
 }
 


### PR DESCRIPTION
Also makes the initial onRouteUpdate actually run after the route has been rendered (previously wasn't)

Also should be more reliable than the previous setTimeout thing as we're using
React's `componentDidUpdate` lifecycle hook which I believe also ensures
once React async hits that it's run after all children have finished rendering.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->