### PR TITLE
Update gatsby-link typescript definitions

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,21 +1,21 @@
-import * as React from "react";
+import React from "react"
+import { LinkProps } from "reach__router"
 
-export const push: (to: string) => void;
-export const replace: (to: string) => void;
+export const push: (to: string) => void
+export const replace: (to: string) => void
 
 // TODO: Remove navigateTo for Gatsby v3
-export const navigateTo: (to: string) => void;
+export const navigateTo: (to: string) => void
 
-export const withPrefix: (path: string) => string;
+export const withPrefix: (path: string) => string
 
-export interface GatsbyLinkProps extends NavLinkProps {
-  onClick?: (event: any) => void;
-  innerRef?: (instance: any) => void;
-  className?: string;
-  activeClassName?: string;
-  style?: { [key: string]: any };
-  activeStyle?: { [key: string]: any };
-  to: string;
+export interface GatsbyLinkProps extends LinkProps<any> {
+  onClick?: (event: any) => void
+  innerRef?: (instance: any) => void
+  className?: string
+  activeClassName?: string
+  style?: React.CSSProperties
+  activeStyle?: React.CSSProperties
 }
 
 export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> {}

--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,11 +1,21 @@
-import * as React from "react";
+import * as React from 'react';
 
-export const push: (to: LocationDescriptor) => void;
-export const replace: (to: LocationDescriptor) => void;
+export const push: (to: string) => void;
+export const replace: (to: string) => void;
 
 // TODO: Remove navigateTo for Gatsby v3
-export const navigateTo: (to: LocationDescriptor) => void;
+export const navigateTo: (to: string) => void;
 
 export const withPrefix: (path: string) => string;
 
-export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> { }
+export interface GatsbyLinkProps extends NavLinkProps {
+  onClick?: (event: any) => void;
+  innerRef?: (instancee: any) => void;
+  className?: string;
+  activeClassName?: string;
+  style?: { [key: string]: any };
+  activeStyle?: { [key: string]: any };
+  to: string;
+}
+
+export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> {}

--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 
 export const push: (to: string) => void;
 export const replace: (to: string) => void;
@@ -10,7 +10,7 @@ export const withPrefix: (path: string) => string;
 
 export interface GatsbyLinkProps extends NavLinkProps {
   onClick?: (event: any) => void;
-  innerRef?: (instancee: any) => void;
+  innerRef?: (instance: any) => void;
   className?: string;
   activeClassName?: string;
   style?: { [key: string]: any };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,6 +1650,12 @@
   dependencies:
     "@types/node" "*"
 
+"@types/reach__router@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.0.0.tgz#c32d6a322f2dc8eb847df5ebe3fc931a340202c5"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.4.6"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"


### PR DESCRIPTION
Looks like LocationDescriptor and GatsbyLinkProps were accidentally removed with the move to reach router.