### PR TITLE
Update hash link to scroll to right section of page

### DIFF
--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -19,7 +19,7 @@
         - title: Install the Gatsby CLI
           link: /tutorial/part-zero/#install-the-gatsby-cli
         - title: Create a Gatsby site
-          link: /tutorial/part-zero/#create-a-gatsby-site
+          link: /tutorial/part-zero/#-create-a-gatsby-site
         - title: Set up a code editor
           link: /tutorial/part-zero/#set-up-a-code-editor
     - title: 1. Get to know Gatsby building blocks

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -19,7 +19,7 @@
         - title: Install the Gatsby CLI
           link: /tutorial/part-zero/#install-the-gatsby-cli
         - title: Create a Gatsby site
-          link: /tutorial/part-zero/#-create-a-gatsby-site
+          link: /tutorial/part-zero/#create-a-site
         - title: Set up a code editor
           link: /tutorial/part-zero/#set-up-a-code-editor
     - title: 1. Get to know Gatsby building blocks


### PR DESCRIPTION
Fix for #7154

Updated link in scrollbar to match anchor ref of `Create a Gatsby Site`.
