### PR TITLE
Don't set basepath w/ pathPrefix during builds

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -120,13 +120,7 @@ export default (pagePath, callback) => {
   const bodyComponent = createElement(
     ServerLocation,
     { url: pagePath },
-    createElement(
-      Router,
-      {
-        basepath: pathPrefix.slice(0, -1),
-      },
-      createElement(RouteHandler, { path: `/*` })
-    )
+    createElement(Router, null, createElement(RouteHandler, { path: `/*` }))
   )
 
   // Let the site or plugin render the page component.


### PR DESCRIPTION
Refs #7163

This broke the page matching in @reach/router (or we also didn't do this
in react-router?).


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->