### PR TITLE
Remove broken links from docs

### DIFF
--- a/examples/no-plugins/README.md
+++ b/examples/no-plugins/README.md
@@ -1,5 +1,3 @@
 # No plugins
 
-https://no-plugins.gatsbyjs.org
-
 Gatsby example site that proves functionality without the use of plugins.

--- a/examples/using-csv/README.md
+++ b/examples/using-csv/README.md
@@ -1,3 +1,3 @@
 # using-csv
 
-Demonstrates de usage of CSV files with Gatsby.
+Demonstrates the usage of CSV files with Gatsby.

--- a/examples/using-csv/README.md
+++ b/examples/using-csv/README.md
@@ -1,3 +1,3 @@
 # using-csv
 
-https://using-csv.gatsbyjs.org
+Demonstrates de usage of CSV files with Gatsby.

--- a/examples/using-emotion-prismjs/README.md
+++ b/examples/using-emotion-prismjs/README.md
@@ -1,7 +1,5 @@
 # using-emotion-prismjs
 
-https://using-emotion-prismjs.gatsbyjs.org
-
 Example site that demonstrates how to build Gatsby sites that use code
 highlighting with [emotion](https://emotion.sh/) and the
 [Gatsby PrismJS plugin](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/).

--- a/examples/using-excel/README.md
+++ b/examples/using-excel/README.md
@@ -1,3 +1,3 @@
 # using-excel
 
-https://using-excel.gatsbyjs.org
+Demonstrates de use of excel with Gatsby.

--- a/examples/using-excel/README.md
+++ b/examples/using-excel/README.md
@@ -1,3 +1,3 @@
 # using-excel
 
-Demonstrates the use of excel with Gatsby.
+Demonstrates the use of Excel with Gatsby.

--- a/examples/using-excel/README.md
+++ b/examples/using-excel/README.md
@@ -1,3 +1,3 @@
 # using-excel
 
-Demonstrates de use of excel with Gatsby.
+Demonstrates the use of excel with Gatsby.

--- a/examples/using-page-loading-indicator/README.md
+++ b/examples/using-page-loading-indicator/README.md
@@ -1,7 +1,5 @@
 # using-page-loading-indicator
 
-https://using-page-loading-indicator.gatsbyjs.org
-
 The loading indicator only will show up in the production version of the site.
 
 So first run `gatsby build` then `gatsby serve`.

--- a/examples/using-prefetching-preloading-modules/README.md
+++ b/examples/using-prefetching-preloading-modules/README.md
@@ -1,6 +1,6 @@
 # Using Prefetching/Preloading modules
 
-https://using-prefetch-preload-module.gatsbyjs.org
+Demonstrates de usage of Prefetching and Preloaded modules with Gatsby.
 
 ## References
 

--- a/examples/using-prefetching-preloading-modules/README.md
+++ b/examples/using-prefetching-preloading-modules/README.md
@@ -1,6 +1,6 @@
 # Using Prefetching/Preloading modules
 
-Demonstrates de usage of Prefetching and Preloaded modules with Gatsby.
+Demonstrates the usage of Prefetching and Preloaded modules with Gatsby.
 
 ## References
 

--- a/examples/using-remark-copy-linked-files/README.md
+++ b/examples/using-remark-copy-linked-files/README.md
@@ -1,5 +1,4 @@
 # using-gatsby-remark-copy-linked-files
 
-https://using-gatsby-remark-copy-linked-files.gatsbyjs.org
 
 Stub README description


### PR DESCRIPTION
#6829 Removing broken links from the following example pages:

- gatsby/examples/using-remark-copy-linked-files/
- gatsby/examples/using-prefetching-preloading-modules/
- gatsby/examples/using-page-loading-indicator/
- gatsby/examples/using-hjson
- gatsby/examples/using-excel/
- gatsby/examples/using-emotion-prismjs/
- gatsby/examples/using-csv/
- gatsby/examples/no-plugins