### PR TITLE
[gatsby-plugin-manifest] Fix issue where favicon was not prefixed with --prefix-paths

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -8,7 +8,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       <link
         key={`gatsby-plugin-manifest-icon-link`}
         rel="shortcut icon"
-        href="/icons/icon-48x48.png"
+        href={withPrefix(`/icons/icon-48x48.png`)}
       />,
     ])
   }


### PR DESCRIPTION
Expected behavior: With `gatsby build --prefix-paths` favicon link should be created with configured path prefix.

Current behavior: `--prefix-paths` has no effect for hardcoded icon path.

I tried to write a test, but `gatsby-ssr.js` importing `withPrefix` from `gatsby` made it non-trivial for me.