### PR TITLE
docs: fix generated api doc title for createPage

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -82,6 +82,8 @@ const pascalCase = _.flow(
   _.upperFirst
 )
 const hasWarnedForPageComponent = new Set()
+const fileOkCache = {}
+
 /**
  * Create a page. See [the guide on creating and modifying pages](/docs/creating-and-modifying-pages/)
  * for detailed documenation about creating pages.
@@ -102,7 +104,6 @@ const hasWarnedForPageComponent = new Set()
  *   },
  * })
  */
-const fileOkCache = {}
 actions.createPage = (
   page: PageInput,
   plugin?: Plugin,


### PR DESCRIPTION
Doc currently shows `fileOkCache` instead of `createPage` title

https://next.gatsbyjs.org/docs/actions/#createPage

 
![screen shot 2018-08-10 at 08 24 21](https://user-images.githubusercontent.com/13813/43942056-d2239acc-9c76-11e8-882c-febac12f9400.png)
