### PR TITLE
Alias unused React polyfills

### DIFF
--- a/packages/gatsby/cache-dir/create-react-context.js
+++ b/packages/gatsby/cache-dir/create-react-context.js
@@ -1,0 +1,3 @@
+import React from "react"
+
+export default React.createContext

--- a/packages/gatsby/cache-dir/react-lifecycles-compat.js
+++ b/packages/gatsby/cache-dir/react-lifecycles-compat.js
@@ -1,0 +1,1 @@
+exports.polyfill = Component => Component

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -219,11 +219,15 @@ module.exports = async (args: BootstrapArgs) => {
 
     // Always include the site's gatsby-browser.js if it exists as it's
     // a handy place to include global styles and other global imports.
-    if (env === `browser` && plugin.name === `default-site-plugin`) {
-      const gatsbyBrowser = slash(
-        require.resolve(path.join(plugin.resolve, `gatsby-${env}`))
-      )
-      if (fs.existsSync(gatsbyBrowser)) return gatsbyBrowser
+    try {
+      if (env === `browser` && plugin.name === `default-site-plugin`) {
+        const gatsbyBrowser = slash(
+          require.resolve(path.join(plugin.resolve, `gatsby-${env}`))
+        )
+        if (fs.existsSync(gatsbyBrowser)) return gatsbyBrowser
+      }
+    } catch (e) {
+      // ignore
     }
 
     if (envAPIs && Array.isArray(envAPIs) && envAPIs.length > 0) {

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -221,10 +221,9 @@ module.exports = async (args: BootstrapArgs) => {
     // a handy place to include global styles and other global imports.
     try {
       if (env === `browser` && plugin.name === `default-site-plugin`) {
-        const gatsbyBrowser = slash(
+        return slash(
           require.resolve(path.join(plugin.resolve, `gatsby-${env}`))
         )
-        if (fs.existsSync(gatsbyBrowser)) return gatsbyBrowser
       }
     } catch (e) {
       // ignore

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -363,6 +363,10 @@ module.exports = async (
         "react-hot-loader": path.dirname(
           require.resolve(`react-hot-loader/package.json`)
         ),
+        "react-lifecycles-compat": directoryPath(
+          `.cache/react-lifecycles-compat.js`
+        ),
+        "create-react-context": directoryPath(`.cache/create-react-context.js`),
       },
     }
   }


### PR DESCRIPTION
- react-lifecycles-compat
- create-react-context

Both were added to polyfill coming React APIs. Since we require
versions of React added after the final versions of these APIs came out,
we can remove these polyfills from packages that use them.

This brings our hello-world JS bundle size to 55.0 KBs


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->