### PR TITLE
Tell yargs to stop its clever boolean negation

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -193,5 +193,8 @@
     "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"
   },
   "types": "index.d.ts",
-  "gitHead": "788133e56dd005663f353fff90ffa37ce2fd87b9"
+  "gitHead": "788133e56dd005663f353fff90ffa37ce2fd87b9",
+  "yargs": {
+    "boolean-negation": false
+  }
 }


### PR DESCRIPTION
By default yargs does some trickery magic when it sees boolean args with a no prefix, like `--no-uglify` or `--no-color`. This PR turns off this behavior.

Closes #4820 .
