### PR TITLE
Fix json transforming when json comes from contentful

### DIFF
--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -41,7 +41,7 @@ async function onCreateNode({ node, boundActionCreators, loadNodeContent }) {
         _.upperFirst(_.camelCase(`${node.name} Json`))
       )
     })
-  } else if (_.isPlainObject(parsedContent)) {
+  } else if (_.isPlainObject(parsedContent) && typeof node.dir !== 'undefined') {
     transformObject(
       parsedContent,
       parsedContent.id ? parsedContent.id : `${node.id} >>> JSON`,

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -41,7 +41,7 @@ async function onCreateNode({ node, boundActionCreators, loadNodeContent }) {
         _.upperFirst(_.camelCase(`${node.name} Json`))
       )
     })
-  } else if (_.isPlainObject(parsedContent) && typeof node.dir !== 'undefined') {
+  } else if (_.isPlainObject(parsedContent) && typeof node.dir !== `undefined`) {
     transformObject(
       parsedContent,
       parsedContent.id ? parsedContent.id : `${node.id} >>> JSON`,


### PR DESCRIPTION
Problem:
If Contentful model has a field which is type of json, transformer-json tries to transform it and fails because of missing node.dir variable. This `if statement` fixes the problem (might not be the best way to fix this). 