### PR TITLE
Fix bug where 'null' is shown in plugin searchbar on next.gatsby.org

### DIFF
--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -401,7 +401,7 @@ class PluginSearchBar extends Component {
     if (this.props.location.search) {
       return this.props.location.search.slice(2)
     }
-    return null
+    return ``
   }
 
   updateHistory(value) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1434608/43987885-f675e4c2-9d28-11e8-972e-c2f965e7fe0c.png)

Clicking on any plugin on https://next.gatsbyjs.org/packages will set the query to `?=null`

Fixes the issue by returning empty string rather than null