### PR TITLE
[gatsby-link] update TypeScript typings for `navigate` function

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,10 +1,14 @@
 import * as React from "react";
+import { NavigateOptions, LinkProps, NavigateFn } from "@reach/router";
 
-export const push: (to: LocationDescriptor) => void;
-export const replace: (to: LocationDescriptor) => void;
+export interface GatsbyLinkProps<TState = {}> extends LinkProps<TState> {}
 
-// TODO: Remove navigateTo for Gatsby v3
-export const navigateTo: (to: LocationDescriptor) => void;
+export const navigate: NavigateFn;
+
+// TODO: Remove these three functions for Gatsby v3
+export const push: (to: string) => void;
+export const replace: (to: string) => void;
+export const navigateTo: (to: string) => void;
 
 export const withPrefix: (path: string) => string;
 

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",
     "@babel/core": "7.0.0-beta.52",
+    "@types/reach__router": "^1.0.0",
     "cross-env": "^5.1.4",
     "react-testing-library": "^4.1.7"
   },

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -3,6 +3,7 @@ import * as React from "react"
 export {
   default as Link,
   GatsbyLinkProps,
+  navigate,
   navigateTo,
   push,
   replace,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,12 @@
   dependencies:
     "@types/node" "*"
 
+"@types/reach__router@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.0.0.tgz#c32d6a322f2dc8eb847df5ebe3fc931a340202c5"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.4.6"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"


### PR DESCRIPTION
Some additions:

* Added `@types/reach__router` as a devDependency
* Exported `navigate` function in the root `gatsby` package
* Included `push` and `replace` into the "to-deprecate" list

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
