### PR TITLE
(#6649): Don't use `css` prop in components to pass in styles

### DIFF
--- a/www/src/components/container.js
+++ b/www/src/components/container.js
@@ -3,7 +3,7 @@ import presets from "../utils/presets"
 
 import { rhythm, options } from "../utils/typography"
 
-const Container = ({ children, className, hasSideBar = true, containerCss = {} }) => (
+const Container = ({ children, className, hasSideBar = true, overrideCSS = {} }) => (
   <div
     css={{
       maxWidth: hasSideBar
@@ -16,7 +16,7 @@ const Container = ({ children, className, hasSideBar = true, containerCss = {} }
       [presets.Tablet]: {
         paddingBottom: rhythm(1.5),
       },
-      ...containerCss,
+      ...overrideCSS,
     }}
     className={className}
   >

--- a/www/src/components/container.js
+++ b/www/src/components/container.js
@@ -3,7 +3,7 @@ import presets from "../utils/presets"
 
 import { rhythm, options } from "../utils/typography"
 
-export default ({ children, className, hasSideBar = true, css = {} }) => (
+const Container = ({ children, className, hasSideBar = true, containerCss = {} }) => (
   <div
     css={{
       maxWidth: hasSideBar
@@ -16,10 +16,12 @@ export default ({ children, className, hasSideBar = true, css = {} }) => (
       [presets.Tablet]: {
         paddingBottom: rhythm(1.5),
       },
-      ...css,
+      ...containerCss,
     }}
     className={className}
   >
     {children}
   </div>
 )
+
+export default Container

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -222,7 +222,7 @@ const Gatsby = ({ children }) => (
   </div>
 )
 
-const Diagram = ({ containerCss }) => (
+const Diagram = () => (
   <section
     className="Diagram"
     css={{
@@ -231,7 +231,10 @@ const Diagram = ({ containerCss }) => (
       padding: vP,
       marginTop: rhythm(1),
       textAlign: `center`,
-      ...containerCss,
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0,
+      flex: `1 1 100%`,
+      borderTop: `1px solid ${colors.ui.light}`,
       [presets.Tablet]: {
         marginTop: 0,
       },

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -222,7 +222,7 @@ const Gatsby = ({ children }) => (
   </div>
 )
 
-const Diagram = ({ containerCSS }) => (
+const Diagram = ({ containerCss }) => (
   <section
     className="Diagram"
     css={{
@@ -231,7 +231,7 @@ const Diagram = ({ containerCSS }) => (
       padding: vP,
       marginTop: rhythm(1),
       textAlign: `center`,
-      ...containerCSS,
+      ...containerCss,
       [presets.Tablet]: {
         marginTop: 0,
       },

--- a/www/src/components/email-capture-form.js
+++ b/www/src/components/email-capture-form.js
@@ -69,7 +69,7 @@ class EmailCaptureForm extends React.Component {
   }
 
   render() {
-    const { signupMessage, confirmMessage, containerCss } = this.props
+    const { signupMessage, confirmMessage, overrideCSS } = this.props
 
     return (
       <div
@@ -77,7 +77,7 @@ class EmailCaptureForm extends React.Component {
           borderTop: `2px solid ${colors.lilac}`,
           marginTop: rhythm(3),
           paddingTop: `${rhythm(1)}`,
-          ...containerCss,
+          ...overrideCSS,
         }}
       >
         {this.state.status === `success` ? (
@@ -148,7 +148,7 @@ class EmailCaptureForm extends React.Component {
 EmailCaptureForm.defaultProps = {
   signupMessage: `Enjoyed this post? Receive the next one in your inbox!`,
   confirmMessage: `Thank you! Youʼll receive your first email shortly.`,
-  containerCss: {},
+  overrideCSS: {},
 }
 
 export default EmailCaptureForm

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -134,7 +134,7 @@ class IndexRoute extends React.Component {
                   </Card>
 
                   <Diagram
-                    containerCSS={{
+                    containerCss={{
                       borderTopLeftRadius: 0,
                       borderTopRightRadius: 0,
                       flex: `1 1 100%`,
@@ -175,7 +175,7 @@ class IndexRoute extends React.Component {
                   >
                     <Container
                       hasSideBar={false}
-                      css={{
+                      containerCss={{
                         maxWidth: rhythm(30),
                         paddingBottom: `0 !important`,
                       }}

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -168,14 +168,14 @@ class IndexRoute extends React.Component {
                   >
                     <Container
                       hasSideBar={false}
-                      containerCss={{
+                      overrideCSS={{
                         maxWidth: rhythm(30),
                         paddingBottom: `0 !important`,
                       }}
                     >
                       <EmailCaptureForm
                         signupMessage="Want to keep up to date with the latest posts on our blog? Subscribe to our newsletter!"
-                        containerCss={{
+                        overrideCSS={{
                           marginTop: 0,
                           marginBottom: rhythm(1),
                           border: `none`,

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -133,14 +133,7 @@ class IndexRoute extends React.Component {
                     </FuturaParagraph>
                   </Card>
 
-                  <Diagram
-                    containerCss={{
-                      borderTopLeftRadius: 0,
-                      borderTopRightRadius: 0,
-                      flex: `1 1 100%`,
-                      borderTop: `1px solid ${colors.ui.light}`,
-                    }}
-                  />
+                  <Diagram/>
 
                   <div css={{ flex: `1 1 100%` }}>
                     <Container hasSideBar={false}>

--- a/www/src/pages/newsletter.js
+++ b/www/src/pages/newsletter.js
@@ -35,7 +35,7 @@ class NewsLetter extends Component {
           <EmailCaptureForm
             signupMessage="Sign up for the Gatsby Newsletter"
             confirmMessage="Success! You have been subscribed to the Gatsby newsletter. Expect to see a newsletter in your inbox each Wednesday (or the equivalent of US Wednesday in your time zone)!"
-            containerCss={{
+            overrideCSS={{
               marginTop: rhythm(1),
               paddingTop: rhythm(1 / 2),
               borderTop: `2px solid ${colors.lilac}`,


### PR DESCRIPTION
Closes #6649 

Glamor isn't actually used in the Container component, if I understand correctly. 
- I replaced the `css` prop with the one that is using everywhere else called `containerCss`
- Replaced `containerCSS` with `containerCss` so it is the same everywhere
- Named the container component, the linter was giving me some warnings

This is my first time doing work with React and/or Gatsby so I'm trying to figure things out please don't go hard on me :smiley: