### PR TITLE
WIP: add repl command to gatsby-cli

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -215,6 +215,15 @@ function buildLocalCommands(cli, isLocalSite) {
       }
     },
   })
+
+  cli.command({
+    command: `repl`,
+    desc: `Get a node repl with context of Gatsby environment, see (add docs link here)`,
+    handler: getCommandHandler(`repl`, (args, cmd) => {
+      process.env.NODE_ENV = process.env.NODE_ENV || `development`
+      return cmd(args)
+    }),
+  })
 }
 
 function isLocalGatsbySite() {

--- a/packages/gatsby/src/commands/repl.js
+++ b/packages/gatsby/src/commands/repl.js
@@ -1,7 +1,13 @@
 const repl = require(`repl`)
 const { graphql } = require(`graphql`)
 const bootstrap = require(`../bootstrap`)
-const { store } = require(`../redux`)
+const {
+  store,
+  loadNodeContent,
+  getNodes,
+  getNode,
+  hasNodeChanged,
+} = require(`../redux`)
 
 module.exports = async program => {
   // run bootstrap
@@ -19,6 +25,11 @@ module.exports = async program => {
     nodes,
   } = store.getState()
 
+  const query = async query => {
+    const result = await graphql(schema, query, {}, {}, {})
+    console.log(`query result: ${JSON.stringify(result)}`)
+  }
+
   // init new repl
   const _ = repl.start({
     prompt: `gatsby > `,
@@ -28,19 +39,16 @@ module.exports = async program => {
   _.context.babelrc = babelrc
   _.context.components = components
   _.context.dataPaths = jsonDataPaths
+  _.context.getNode = getNode
+  _.context.getNodes = getNodes
+  _.context.hasNodeChanged = hasNodeChanged
+  _.context.loadNodeContent = loadNodeContent
   _.context.nodes = [...nodes.entries()]
   _.context.pages = [...pages.entries()]
+  _.context.runQuery = query
   _.context.schema = schema
   _.context.siteConfig = config
   _.context.staticQueries = staticQueryComponents
-
-  // add custom repl commands, used in repl lik: `.query "{ site { ... } }"`
-  _.defineCommand(`query`, {
-    action: async query => {
-      const result = await graphql(schema, query, {}, {}, {})
-      return result
-    },
-  })
 
   _.on(`exit`, () => process.exit(0))
 }

--- a/packages/gatsby/src/commands/repl.js
+++ b/packages/gatsby/src/commands/repl.js
@@ -1,0 +1,46 @@
+const repl = require(`repl`)
+const { graphql } = require(`graphql`)
+const bootstrap = require(`../bootstrap`)
+const { store } = require(`../redux`)
+
+module.exports = async program => {
+  // run bootstrap
+  await bootstrap(program)
+
+  // get all the goodies from the store
+  const {
+    schema,
+    config,
+    babelrc,
+    jsonDataPaths,
+    pages,
+    components,
+    staticQueryComponents,
+    nodes,
+  } = store.getState()
+
+  // init new repl
+  const _ = repl.start({
+    prompt: `gatsby > `,
+  })
+
+  // set some globals to make life easier
+  _.context.babelrc = babelrc
+  _.context.components = components
+  _.context.dataPaths = jsonDataPaths
+  _.context.nodes = [...nodes.entries()]
+  _.context.pages = [...pages.entries()]
+  _.context.schema = schema
+  _.context.siteConfig = config
+  _.context.staticQueries = staticQueryComponents
+
+  // add custom repl commands, used in repl lik: `.query "{ site { ... } }"`
+  _.defineCommand(`query`, {
+    action: async query => {
+      const result = await graphql(schema, query, {}, {}, {})
+      return result
+    },
+  })
+
+  _.on(`exit`, () => process.exit(0))
+}

--- a/packages/gatsby/src/commands/repl.js
+++ b/packages/gatsby/src/commands/repl.js
@@ -41,11 +41,10 @@ module.exports = async program => {
   _.context.dataPaths = jsonDataPaths
   _.context.getNode = getNode
   _.context.getNodes = getNodes
-  _.context.hasNodeChanged = hasNodeChanged
   _.context.loadNodeContent = loadNodeContent
   _.context.nodes = [...nodes.entries()]
   _.context.pages = [...pages.entries()]
-  _.context.runQuery = query
+  _.context.graphql = query
   _.context.schema = schema
   _.context.siteConfig = config
   _.context.staticQueries = staticQueryComponents


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
I got the itch to experiment with this idea to gauge LOE. I was able to create a basic repl with lots of Gatsby info in global context, however it's really just JSON data and would be hard to work with as is.

I would like to add some globals and commands to make life easier, maybe things like:

- [x] babelrc
- [x] components
- [x] jsonDataPaths
- [x] getNode
- [x] getNodes
- [x] hadNodeChanged
- [X] loadNodeContent
- [x] nodes
- [x] pages
- [x] runQuery
- [x] schema
- [x] (site) config
- [x] static queries
- [ ] create docs

Profit 🎉

This will also need an accompanying docs guide I would imagine. :smile:

Closes #6952 

<img width="670" alt="screen shot 2018-08-12 at 11 20 09 am" src="https://user-images.githubusercontent.com/3629876/44003517-b6ba55ee-9e21-11e8-9733-3dc563c3b0b2.png">

