### PR TITLE
[gatsby-source-contentful] Expose contentful_id in ContentfulAsset node

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
@@ -2051,6 +2051,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "3wtvPBbBjiMKqKKga8I2Cu",
       "description": "Brand logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2066,7 +2067,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "2024479d728f9130f5a6eefb28d89f65",
+        "contentDigest": "bbf9ba4506cb99492f0b07ea3a28f737",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2077,6 +2078,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "3wtvPBbBjiMKqKKga8I2Cu",
       "description": "Brand logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2092,7 +2094,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "3392b4440d3c91cb486b5b6c68e3bb1e",
+        "contentDigest": "11c01df3a61387333cf9f7ac613af20b",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2103,6 +2105,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "KTRF62Q4gg60q6WCsWKw8",
       "description": "by Lemnos",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2118,7 +2121,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "3a7957ae63ae0cda1078d5fca401faae",
+        "contentDigest": "a2addf44f7879e90d6b3058001a5880e",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2129,6 +2132,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "KTRF62Q4gg60q6WCsWKw8",
       "description": "by Lemnos",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2144,7 +2148,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "f1229d259f36861c2b7d8b81366492e8",
+        "contentDigest": "625a2b2257595edbe4efcfc5ae336dc3",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2155,6 +2159,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "Xc0ny7GWsMEMCeASWO2um",
       "description": "Merchandise image",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2170,7 +2175,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "8c5ffd7925d4fdb24a1631f04541fd13",
+        "contentDigest": "b54c3564fc75efb39c3759efee64b7f3",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2181,6 +2186,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "Xc0ny7GWsMEMCeASWO2um",
       "description": "Merchandise image",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2196,7 +2202,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "5502bbb6461c9a31fb238b8e8546e47a",
+        "contentDigest": "262af8b162da9de405bf6499467768fd",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2207,6 +2213,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "2Y8LhXLnYAYqKCGEWG4EKI",
       "description": "company logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2222,7 +2229,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "19d49c506794012b826a0a2a9b0f3b0b",
+        "contentDigest": "944b01fdfe82c76ed3e3e7bd1c462975",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2233,6 +2240,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "2Y8LhXLnYAYqKCGEWG4EKI",
       "description": "company logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2248,7 +2256,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "c4456421bdc406b0f283e79aa88a5eb1",
+        "contentDigest": "188a448b2b9c92aa20e4f2b921daff6f",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2259,6 +2267,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "6t4HKjytPi0mYgs240wkG",
       "description": "Category icon set",
       "file": Object {
         "contentType": "image/png",
@@ -2274,7 +2283,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "1972b8886a590294f24aeec43567b48c",
+        "contentDigest": "ccc48a348551b17fddce1efb97bf820b",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2285,6 +2294,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "6t4HKjytPi0mYgs240wkG",
       "description": "Category icon set",
       "file": Object {
         "contentType": "image/png",
@@ -2300,7 +2310,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "e1acc294b5b1d1c60a1d83ece78161c5",
+        "contentDigest": "cae9c5d552a6fcb3df4dea804c031845",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2311,6 +2321,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "1MgbdJNTsMWKI0W68oYqkU",
       "description": "Brand logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2326,7 +2337,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "5059d353be1bac4c06a753c7b42d71c5",
+        "contentDigest": "df2e57e86b4fe17655ed0889ffa243a6",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2337,6 +2348,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "1MgbdJNTsMWKI0W68oYqkU",
       "description": "Brand logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2352,7 +2364,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "f439bcacaaec96ae09c43edf4d42d498",
+        "contentDigest": "75e059f146658d383ce03f57ae2b7ffd",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2363,6 +2375,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "6m5AJ9vMPKc8OUoQeoCS4o",
       "description": "category icon",
       "file": Object {
         "contentType": "image/png",
@@ -2378,7 +2391,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "160c60023250c0e35f6f0a757989a9ac",
+        "contentDigest": "5062a26112b3dbb531d472b8903d46e9",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2389,6 +2402,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "6m5AJ9vMPKc8OUoQeoCS4o",
       "description": "category icon",
       "file": Object {
         "contentType": "image/png",
@@ -2404,7 +2418,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "626faa183d1c209b3705c35efd449a7b",
+        "contentDigest": "dd9c762ab326ced17232e9c96ea7a5d3",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2415,6 +2429,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "4zj1ZOfHgQ8oqgaSKm4Qo2",
       "description": "Brand logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2430,7 +2445,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "b5e748b808c2e914f95f22b85698ee69",
+        "contentDigest": "88c4ef0ed49551a82a33cccd09171d8e",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2441,6 +2456,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "4zj1ZOfHgQ8oqgaSKm4Qo2",
       "description": "Brand logo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2456,7 +2472,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "59a0fa2823b13dfd61ba168af0d64d9f",
+        "contentDigest": "891168271aa495c6afed1ba1014fa918",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2467,6 +2483,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "wtrHxeu3zEoEce2MokCSi",
       "description": "Merchandise photo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2482,7 +2499,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "7a128b72c470086f65127423e06d2c1c",
+        "contentDigest": "dfdac1f5a977d38a8ece0762c6ff1ed1",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2493,6 +2510,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "wtrHxeu3zEoEce2MokCSi",
       "description": "Merchandise photo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2508,7 +2526,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "c9f99cac382777dbdd0f200ec6df2cdd",
+        "contentDigest": "3e873879f0cc2622be2c1199a8f9d0d8",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2519,6 +2537,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "10TkaLheGeQG6qQGqWYqUI",
       "description": "Merchandise photo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2534,7 +2553,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "c9c930bacc6d354ed7c6626b52bf1c23",
+        "contentDigest": "4c42ff152ccfc22a7a8ad3fdb728d300",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2545,6 +2564,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "10TkaLheGeQG6qQGqWYqUI",
       "description": "Merchandise photo",
       "file": Object {
         "contentType": "image/jpeg",
@@ -2560,7 +2580,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "1ce83ba45d499820e9e5b7e03ebc9bc0",
+        "contentDigest": "ac654073536701214d653f3df7e31eca",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",
@@ -2571,6 +2591,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "6s3iG2OVmoUcosmA8ocqsG",
       "description": "Category icon set",
       "file": Object {
         "contentType": "image/png",
@@ -2586,7 +2607,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "e8cf0751f0fd103bc88049a11aebeaa8",
+        "contentDigest": "827ff632f8631d9317517068e0485c2d",
         "type": "ContentfulAsset",
       },
       "node_locale": "en-US",
@@ -2597,6 +2618,7 @@ Array [
   Array [
     Object {
       "children": Array [],
+      "contentful_id": "6s3iG2OVmoUcosmA8ocqsG",
       "description": "Category icon set",
       "file": Object {
         "contentType": "image/png",
@@ -2612,7 +2634,7 @@ Array [
       },
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "81e0040ddb8b946c56f2cab7a449e345",
+        "contentDigest": "5f38ab0214338d7b18e434a4a0509945",
         "type": "ContentfulAsset",
       },
       "node_locale": "de",

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -481,6 +481,7 @@ exports.createAssetNodes = ({
         : ``,
     }
     const assetNode = {
+      contentful_id: localizedAsset.sys.contentful_id,
       id: mId(localizedAsset.sys.id),
       parent: null,
       children: [],


### PR DESCRIPTION
Refs #7221

Simple one liner to expose `contentful_id` in Contentful Asset GraphQL queries, bringing it inline with other Contentful content types.

Meaning queries like the below are possible:
```
query MyQuery {
  contentfulAsset(
    contentful_id: {
      eq: "d7JXVNGePe86AIIAuSewe"
    }) 
  {	  
    ...
  }
} 
```

```
query MyQuery {
  allContentfulAsset(filter: {
    contentful_id: {
      in: ["d7JXVNGePe86AIIAuSewe","6yDjch4eVGe2AquGwOWi6g"]
    }
  }) {
    edges {      
      node {
        ...
      }
    }
  }
} 
```