### PR TITLE
Adds snapshot test + onError event for gatsby-image

### DIFF
--- a/packages/gatsby-image/package.json
+++ b/packages/gatsby-image/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.52",
-    "prop-types": "^15.6.1"
+    "prop-types": "^15.6.1",
+    "react-testing-library": "^4.1.7"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Img /> should render fixed size images 1`] = `
+<div>
+  <div
+    class=" gatsby-image-outer-wrapper"
+    style="position: relative;"
+  >
+    <div
+      class="fixedImage gatsby-image-wrapper"
+      style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
+    >
+      <div
+        style="width: 100px; opacity: 0; height: 100px;"
+        title="Title for the image"
+      />
+      <img
+        alt="Alt text for the image"
+        height="100"
+        src="test_image.jpg"
+        srcset="some srcSet"
+        style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1;"
+        title="Title for the image"
+        width="100"
+      />
+      <noscript>
+        &lt;img width="100" height="100" src="test_image.jpg" srcset="some srcSet" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;
+      </noscript>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Img /> should render fluid images 1`] = `
+<div>
+  <div
+    class=" gatsby-image-outer-wrapper"
+    style="position: relative;"
+  >
+    <div
+      class="fixedImage gatsby-image-wrapper"
+      style="position: relative; overflow: hidden; display: inline;"
+    >
+      <div
+        style="width: 100%; padding-bottom: 66.66666666666667%;"
+      />
+      <div
+        style="position: absolute; top: 0px; bottom: 0px; opacity: 0; right: 0px; left: 0px;"
+        title="Title for the image"
+      />
+      <img
+        alt="Alt text for the image"
+        sizes="(max-width: 600px) 100vw, 600px"
+        src="test_image.jpg"
+        srcset="some srcSet"
+        style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1;"
+        title="Title for the image"
+      />
+      <noscript>
+        &lt;img src="test_image.jpg" srcset="some srcSet" alt="Alt text for the image" title="Title for the image" sizes="(max-width: 600px) 100vw, 600px" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;
+      </noscript>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -1,0 +1,73 @@
+import "@babel/polyfill"
+import React from 'react'
+import { render, cleanup, fireEvent } from 'react-testing-library'
+import Img from "../"
+
+afterAll(cleanup)
+
+const fixedShapeMock = {
+  width: 100,
+  height: 100,
+  src: `test_image.jpg`,
+  srcSet: `some srcSet`,
+}
+
+const fluidShapeMock = {
+  aspectRatio: 1.5,
+  src: `test_image.jpg`,
+  srcSet: `some srcSet`,
+  sizes: `(max-width: 600px) 100vw, 600px`,
+}
+
+const setup = (
+  fluid = false,
+  onLoad = () => { },
+  onError = () => { }
+) => {
+  const { container } = render(
+    <Img
+      backgroundColor
+      className={`fixedImage`}
+      style={{ display: `inline` }}
+      title={`Title for the image`}
+      alt={`Alt text for the image`}
+      {...(fluid && { fluid: fluidShapeMock })}
+      {...(!fluid && { fixed: fixedShapeMock })}
+      onLoad={onLoad}
+      onError={onError}
+    />
+  )
+
+  return container
+}
+
+describe(`<Img />`, () => {
+  it(`should render fixed size images`, () => {
+    const component = setup()
+    expect(component).toMatchSnapshot()
+  })
+
+  it(`should render fluid images`, () => {
+    const component = setup(true)
+    expect(component).toMatchSnapshot()
+  })
+
+  it(`should have correct src, title and alt attributes`, () => {
+    const imageTag = setup().querySelector(`img`)
+    expect(imageTag.getAttribute(`src`)).toEqual(`test_image.jpg`)
+    expect(imageTag.getAttribute(`title`)).toEqual(`Title for the image`)
+    expect(imageTag.getAttribute(`alt`)).toEqual(`Alt text for the image`)
+  })
+
+  it(`should call onLoad and onError image events`, () => {
+    const onLoadMock = jest.fn()
+    const onErrorMock = jest.fn()
+    const imageTag = setup(true, onLoadMock, onErrorMock).querySelector(`img`)
+    fireEvent.load(imageTag)
+    fireEvent.error(imageTag)
+
+    expect(onLoadMock).toHaveBeenCalledTimes(1)
+    expect(onErrorMock).toHaveBeenCalledTimes(1)
+
+  })
+})

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -104,11 +104,12 @@ const noscriptImg = props => {
 }
 
 const Img = props => {
-  const { style, onLoad, ...otherProps } = props
+  const { style, onLoad, onError, ...otherProps } = props
   return (
     <img
       {...otherProps}
       onLoad={onLoad}
+      onError={onError}
       style={{
         position: `absolute`,
         top: 0,
@@ -126,6 +127,7 @@ const Img = props => {
 
 Img.propTypes = {
   style: PropTypes.object,
+  onError: PropTypes.func,
   onLoad: PropTypes.func,
 }
 
@@ -297,6 +299,7 @@ class Image extends React.Component {
                   this.state.IOSupported && this.setState({ imgLoaded: true })
                   this.props.onLoad && this.props.onLoad()
                 }}
+                onError={this.props.onError}
               />
             )}
 
@@ -396,6 +399,7 @@ class Image extends React.Component {
                   this.setState({ imgLoaded: true })
                   this.props.onLoad && this.props.onLoad()
                 }}
+                onError={this.props.onError}
               />
             )}
 
@@ -467,6 +471,7 @@ Image.propTypes = {
   position: PropTypes.string,
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onLoad: PropTypes.func,
+  onError: PropTypes.func,
   Tag: PropTypes.string,
 }
 


### PR DESCRIPTION
1. Closes: #7099
2. Adds an `onError` on `gatsby-image` for listening on error if any.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
