### PR TITLE
[v2] docs - update page query docs

### DIFF
--- a/docs/docs/page-query.md
+++ b/docs/docs/page-query.md
@@ -1,10 +1,10 @@
 ---
-title: Build a page with a GraphQL query
+title: Querying data in pages with graphql
 ---
 
-Gatsby creates pages from components located within `src/pages`. It watches the folder and will create and remove pages as you add and remove components. The pathname for each page is derived from the name of the component. For example, `src/pages/about.js` would be located at `/about/` when published.
+Gatsby automatically creates pages from components located within `src/pages`. It watches the folder and will create and remove pages as you add and remove components. The pathname for each page is derived from the name of the component. For example, `src/pages/about.js` would be located at `/about/` when published.
 
-In this guide, you will learn how to perform a query of your site's metadata for the description to display on your homepage.
+In this guide, you will learn how to use Gatsby's `graphql` method in your site pages. We'll also go a little deeper into what the `graphql` method is really doing.
 
 ## Adding `description` to `siteMetadata`
 
@@ -21,7 +21,7 @@ module.exports = {
 }
 ```
 
-## Basic Index Page Markup
+## Basic index page markup
 
 A simple index page (`src/pages/index.js`) can be marked up like so:
 
@@ -35,9 +35,9 @@ const HomePage = () => {
 export default HomePage
 ```
 
-## Adding the GraphQL Query
+## Adding the `graphql` query
 
-The first thing to do is import GraphQL from Gatsby. At the top of `index.js` add:
+The first thing to do is import `graphql` from Gatsby. At the top of `index.js` add:
 
 ```diff
 import React from 'react'
@@ -87,7 +87,7 @@ export const query = graphql`
 `
 ```
 
-## Get Data into the `<HomePage />` Component
+## Get data into the `<HomePage />` component
 
 To start, update the `HomePage` component to destructure `data` from props.
 

--- a/docs/docs/page-query.md
+++ b/docs/docs/page-query.md
@@ -2,7 +2,9 @@
 title: Querying data in pages with graphql
 ---
 
-In this guide, you will learn [how to use Gatsby's `graphql` tag](/page-query#adding-the-graphql-query) in your site pages. We'll also go a little deeper into [how the `graphql` tag works](/page-query#how-does-the-graphql-tag-work).
+Gatsby's `graphql` tag enables page components to retrieve data via GraphQL query.
+
+In this guide, you will learn [how to use the `graphql` tag](/page-query#adding-the-graphql-query) in your pages, as well as go a little deeper into [how the `graphql` tag works](/page-query#how-does-the-graphql-tag-work).
 
 ## How to use the `graphql` tag in pages
 
@@ -124,7 +126,7 @@ After restarting `gatsby develop`, your home page will now display "This is wher
 
 ## How does the graphql tag work?
 
-You may have noticed that you used a [tag function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals) called `graphql`. Behind the scenes Gatsby handles these tags in a particular way - let's take a deeper look at what actually happens when you use Gatsby's `graphql` tag:
+`graphql` is a [tag function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals). Behind the scenes Gatsby handles these tags in a particular way:
 
 ### The short answer
 

--- a/docs/docs/page-query.md
+++ b/docs/docs/page-query.md
@@ -4,9 +4,11 @@ title: Querying data in pages with graphql
 
 Gatsby automatically creates pages from components located within `src/pages`. It watches the folder and will create and remove pages as you add and remove components. The pathname for each page is derived from the name of the component. For example, `src/pages/about.js` would be located at `/about/` when published.
 
-In this guide, you will learn how to use Gatsby's `graphql` method in your site pages. We'll also go a little deeper into what the `graphql` method is really doing.
+In this guide, you will learn [how to use Gatsby's `graphql` tag](/page-query#adding-the-graphql-query) in your site pages. We'll also go a little deeper into [how the `graphql` tag works](/page-query#how-does-the-graphql-tag-work).
 
-## Adding `description` to `siteMetadata`
+## How to use the `graphql` tag in pages
+
+### Add `description` to `siteMetadata`
 
 The first step in displaying the description will be ensuring you have one to begin with.
 
@@ -21,7 +23,7 @@ module.exports = {
 }
 ```
 
-## Basic index page markup
+### Mark up basic index page
 
 A simple index page (`src/pages/index.js`) can be marked up like so:
 
@@ -35,7 +37,7 @@ const HomePage = () => {
 export default HomePage
 ```
 
-## Adding the `graphql` query
+### Add the `graphql` query
 
 The first thing to do is import `graphql` from Gatsby. At the top of `index.js` add:
 
@@ -87,7 +89,7 @@ export const query = graphql`
 `
 ```
 
-## Get data into the `<HomePage />` component
+### Provide data to the `<HomePage />` component
 
 To start, update the `HomePage` component to destructure `data` from props.
 
@@ -121,3 +123,18 @@ export default HomePage
 ```
 
 After restarting `gatsby develop`, your home page will now display "This is where I write my thoughts." from the description set in `gatsby-config.js`!
+
+## How does the graphql tag work?
+
+You may have noticed that you used a [tag function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals) called `graphql`. Behind the scenes Gatsby handles these tags in a particular way - let's take a deeper look at what actually happens when you use Gatsby's `graphql` tag:
+
+### The short answer
+
+During the Gatsby build process, GraphQL queries are pulled out of the original source for parsing.
+
+### The longer answer
+
+The longer answer is a little more involved: Gatsby borrows a technique from
+[Relay](https://facebook.github.io/relay/) that converts your source code into an [abstract syntax tree (AST)](https://en.wikipedia.org/wiki/Abstract_syntax_tree) during the build step. [`file-parser.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/file-parser.js) and [`query-compiler.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js) pick out your `graphql`-tagged templates and effectively remove them from the original source code.
+
+This means that the `graphql` tag isn’t executed the way that you might expect. For example, you cannot use [expression interpolation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Expression_interpolation) with Gatsby's `graphql` tag.

--- a/docs/docs/page-query.md
+++ b/docs/docs/page-query.md
@@ -2,8 +2,6 @@
 title: Querying data in pages with graphql
 ---
 
-Gatsby automatically creates pages from components located within `src/pages`. It watches the folder and will create and remove pages as you add and remove components. The pathname for each page is derived from the name of the component. For example, `src/pages/about.js` would be located at `/about/` when published.
-
 In this guide, you will learn [how to use Gatsby's `graphql` tag](/page-query#adding-the-graphql-query) in your site pages. We'll also go a little deeper into [how the `graphql` tag works](/page-query#how-does-the-graphql-tag-work).
 
 ## How to use the `graphql` tag in pages

--- a/docs/docs/static-query.md
+++ b/docs/docs/static-query.md
@@ -4,6 +4,8 @@ title: Querying data in components using StaticQuery
 
 Gatsby v2 introduces `StaticQuery`, a new API that allows components to retrieve data via GraphQL query.
 
+In this guide, we'll walk through an example using `StaticQuery`, and discuss [the difference between a StaticQuery and a page query](/static-query/#how-staticquery-differs-from-page-query). 
+
 ## Basic example
 
 We'll create a new `Header` component located at `src/components/header.js`:

--- a/docs/docs/static-query.md
+++ b/docs/docs/static-query.md
@@ -4,9 +4,11 @@ title: Querying data in components using StaticQuery
 
 Gatsby v2 introduces `StaticQuery`, a new API that allows components to retrieve data via GraphQL query.
 
-In this guide, we'll walk through an example using `StaticQuery`, and discuss [the difference between a StaticQuery and a page query](/static-query/#how-staticquery-differs-from-page-query). 
+In this guide, we'll walk through an example using `StaticQuery`, and discuss [the difference between a StaticQuery and a page query](/static-query/#how-staticquery-differs-from-page-query).
 
-## Basic example
+## How to use `StaticQuery` in components
+
+### Basic example
 
 We'll create a new `Header` component located at `src/components/header.js`:
 
@@ -38,7 +40,7 @@ export default Header
 
 Using `StaticQuery`, you can colocate a component with its data. No longer is it required to, say, pass data down from `Layout` to `Header`.
 
-## Typechecking
+### Typechecking
 
 With the above pattern, you lose the ability to typecheck with PropTypes. To regain typechecking while achieving the same result, you can change the component to:
 

--- a/docs/docs/static-query.md
+++ b/docs/docs/static-query.md
@@ -1,5 +1,5 @@
 ---
-title: "Querying data in components using StaticQuery"
+title: Querying data in components using StaticQuery
 ---
 
 Gatsby v2 introduces `StaticQuery`, a new API that allows components to retrieve data via GraphQL query.

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -229,7 +229,7 @@ Restart the development server.
 
 ### Use a page query
 
-Now the site title is available to be queried; Let's add it to the `about.js` file using a page query:
+Now the site title is available to be queried; Let's add it to the `about.js` file using a [page query](/docs/page-query):
 
 ```jsx{2,5,7,14-23}
 import React from "react"

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -348,22 +348,6 @@ So almost everywhere, changes you make will immediately take effect. Edit the `g
 
 ![Both titles say Pandas Eating Lots](/pandas-eating-lots-titles.png)
 
-## How does the graphql tag work?
-
-You may have noticed that you used a [tag function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals) called `graphql`. Behind the scenes Gatsby handles these tags in a particular way - let's take a deeper look at what actually happens when you use Gatsby's `graphql` tag:
-
-### The short answer
-
-During the Gatsby build process, GraphQL queries are pulled out of the original source for parsing.
-
-### The longer answer
-
-The longer answer is a little more involved: Gatsby borrows a technique from
-[Relay](https://facebook.github.io/relay/) that converts your source code into an [abstract syntax tree (AST)](https://en.wikipedia.org/wiki/Abstract_syntax_tree) during the build step. [`file-parser.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/file-parser.js) and [`query-compiler.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js) pick out your `graphql`-tagged templates and effectively remove them from the original source code.
-
-This means that the `graphql` tag isn’t executed the way that you might expect. For example, you cannot use [expression interpolation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Expression_interpolation) with Gatsby's `graphql` tag.
-
-
 ## What's coming next?
 
 Next, you'll be learning about how to pull data into your Gatsby site using

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -93,8 +93,10 @@
       items:
         - title: Introducing GraphiQL*
           link: /docs/introducing-graphiql/
-        - title: Build a page with a GraphQL query
-          link: /docs/build-a-page-with-graphql-query/
+        - title: Querying data in pages with graphql
+          link: /docs/page-query/
+        - title: Querying data in components with StaticQuery
+          link: /docs/static-query/
         - title: Creating and modifying pages
           link: /docs/creating-and-modifying-pages/
         - title: Adding Markdown pages
@@ -105,8 +107,6 @@
           link: /docs/creating-slugs-for-pages/
         - title: Programmatically create pages from data*
           link: /docs/programmatically-create-pages-from-data/
-        - title: Querying data with StaticQuery
-          link: /docs/static-query/
     - title: Plugins*
       link: /docs/plugins/
       items:

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -93,12 +93,12 @@
       items:
         - title: Introducing GraphiQL*
           link: /docs/introducing-graphiql/
+        - title: Creating and modifying pages
+          link: /docs/creating-and-modifying-pages/
         - title: Querying data in pages with graphql
           link: /docs/page-query/
         - title: Querying data in components with StaticQuery
           link: /docs/static-query/
-        - title: Creating and modifying pages
-          link: /docs/creating-and-modifying-pages/
         - title: Adding Markdown pages
           link: /docs/adding-markdown-pages/
         - title: Adding a list of Markdown blog posts


### PR DESCRIPTION
closes #7278

Changes:

**docs/build-a-page-with-graphql-query**
- worked toward consistency with the static query docs
  - renamed this page to docs/page-query. These docs were tucked away in an "example" style page; for documentation (as opposed to tutorial style), I thought it made a lot more sense to have the page-query/static-query documentation be patterned similarly.
 
**docs/static-query**
- slight edits for consistency with `docs/page-query` docs.

**sidebars/doc-links**
- reordered to reflect the change in architecture: creating pages, then page query, then StaticQuery

**tutorial/part-four**
- a la @m-allanson https://github.com/gatsbyjs/gatsby/pull/7240#issuecomment-412502818: removed the "How does the `graphql` tag work?" section and integrated into `docs/page-query` 
- added a link back to `docs/page-query` (`docs/static-query` is already linked)