### PR TITLE
[v2] docs "Styling" overview

### DIFF
--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -1,8 +1,13 @@
 ---
 title: Styling
+overview: true
 ---
 
-This is a stub. Help our community expand it.
+There are so many ways to add styles to your website -- and Gatsby supports almost every possible option, through official and community plugins. (_If there isn’t a plugin yet for your favorite option, consider [contributing one](/docs/plugin-authoring/)!_)
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
-pull request gets accepted.
+In this section you'll find guides on different styling methods supported by Gatsby plugins.
+
+Gatsby doesn't prescribe or dictate any single styling approach. Choose what works best for you!
+
+[[guidelist]]
+

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -12,7 +12,7 @@
       link: /tutorial/
 - title: Guides
   items:
-    - title: Preparing your environment*
+    - title: Preparing your environment
       link: /docs/preparing-your-environment/
       items:
         - title: Basic hardware and software requirements*
@@ -107,7 +107,7 @@
           link: /docs/programmatically-create-pages-from-data/
         - title: Querying data with StaticQuery
           link: /docs/static-query/
-    - title: Plugins*
+    - title: Plugins
       link: /docs/plugins/
       items:
         - title: Plugin authoring
@@ -116,7 +116,7 @@
           link: /docs/submit-to-plugin-library/
         - title: Source plugin tutorial
           link: /docs/source-plugin-tutorial/
-    - title: Styling*
+    - title: Styling
       link: /docs/styling/
       items:
         - title: CSS Modules*


### PR DESCRIPTION
closes #6583 

- add styling overview to doc guides