### PR TITLE
Call onRouteUpdate when history changes

### DIFF
--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -93,6 +93,10 @@ class RouteHandler extends React.Component {
   componentDidMount() {
     onRouteUpdate(this.props.location)
   }
+
+  componentDidUpdate() {
+    onRouteUpdate(this.props.location)
+  }
 }
 
 const Root = () =>


### PR DESCRIPTION
Fixes #7590

My solution to this was just to call `onRouteUpdate` in `componentDidUpdate` as well. Not entirely sure if this might break other stuff. Maybe it's better to use the `Location` component from `reach/router` and call `onRouteChange` there instead?