### PR TITLE
[gatsby-remark-images] Fixed issue with wrapperStyle not being applied correctly

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -172,7 +172,7 @@ module.exports = (
   <span
     class="gatsby-resp-image-wrapper"
     style="position: relative; display: block; ${
-      options.wrapperStyle
+      options.showCaptions && node.title ? null : options.wrapperStyle 
     }; max-width: ${presentationWidth}px; margin-left: auto; margin-right: auto;"
   >
     <span
@@ -203,7 +203,7 @@ module.exports = (
 
     if (options.showCaptions && node.title) {
       rawHTML = `
-  <figure class="gatsby-resp-image-figure">
+  <figure class="gatsby-resp-image-figure" style="${options.wrapperStyle}">
   ${rawHTML}
   <figcaption class="gatsby-resp-image-figcaption">${node.title}</figcaption>
   </figure>

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -168,11 +168,12 @@ module.exports = (
     }
 
     // Construct new image node w/ aspect ratio placeholder
+    const showCaptions = options.showCaptions && node.title
     let rawHTML = `
   <span
     class="gatsby-resp-image-wrapper"
     style="position: relative; display: block; ${
-      options.showCaptions && node.title ? null : options.wrapperStyle 
+      showCaptions ? null : options.wrapperStyle 
     }; max-width: ${presentationWidth}px; margin-left: auto; margin-right: auto;"
   >
     <span
@@ -200,8 +201,7 @@ module.exports = (
     }
 
     // Wrap in figure and use title as caption
-
-    if (options.showCaptions && node.title) {
+    if (showCaptions) {
       rawHTML = `
   <figure class="gatsby-resp-image-figure" style="${options.wrapperStyle}">
   ${rawHTML}


### PR DESCRIPTION
Fix for #7201 .

`wrapperStyle` option was not being applied correctly when `showCaptions` was set to `true` so this PR fixes that.