### PR TITLE
move Object.entries from worker to master - fixes node 6 builds

### DIFF
--- a/packages/gatsby/src/utils/html-renderer-queue.js
+++ b/packages/gatsby/src/utils/html-renderer-queue.js
@@ -15,11 +15,11 @@ module.exports = (htmlComponentRendererPath, pages, activity) =>
   new Promise((resolve, reject) => {
     // We need to only pass env vars that are set programatically in gatsby-cli
     // to child process. Other vars will be picked up from environment.
-    const envVars = {
+    const envVars = Object.entries({
       NODE_ENV: process.env.NODE_ENV,
       gatsby_executing_command: process.env.gatsby_executing_command,
       gatsby_log_level: process.env.gatsby_log_level,
-    }
+    })
 
     const start = process.hrtime()
     const segments = chunk(pages, 50)

--- a/packages/gatsby/src/utils/worker.js
+++ b/packages/gatsby/src/utils/worker.js
@@ -16,7 +16,7 @@ const generatePathToOutput = outputPath => {
 export function renderHTML({ htmlComponentRendererPath, paths, envVars }) {
   // This is being executed in child process, so we need to set some vars
   // for modules that aren't bundled by webpack.
-  Object.entries(envVars).forEach(([key, value]) => (process.env[key] = value))
+  envVars.forEach(([key, value]) => (process.env[key] = value))
 
   return Promise.map(
     paths,


### PR DESCRIPTION
fixes build errors on node 6 (using `Object.entries` in worker which isn't polyfilled)