### PR TITLE
fix: update docs to remove `gatsby-link` reference

### DIFF
--- a/examples/simple-auth/package.json
+++ b/examples/simple-auth/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Jason Lengstorf <jason@lengstorf.com>",
   "dependencies": {
-    "gatsby": "^2.0.0-beta.91",
+    "gatsby": "next",
     "gatsby-plugin-react-helmet": "next",
     "prop-types": "^15.6.1",
     "react": "^16.4.0",

--- a/examples/using-redirects/src/pages/index.js
+++ b/examples/using-redirects/src/pages/index.js
@@ -45,7 +45,9 @@ const IndexPage = () => (
         {` `}
         link uses
         {` `}
-        <a href="https://www.gatsbyjs.org/packages/gatsby-link/">gatsby-link</a>
+        <a href="https://next.gatsbyjs.org/docs/gatsby-link/">
+          <code>Link</code>
+        </a>
         {` `}
         <code>activeClassName</code>
         to apply the <code>selected</code>

--- a/packages/gatsby-plugin-catch-links/README.md
+++ b/packages/gatsby-plugin-catch-links/README.md
@@ -7,7 +7,7 @@ For instance, in a markdown file with relative links (transformed
 to `a` tags by
 [`gatsby-transformer-remark`](/packages/gatsby-transformer-remark/)), this
 plugin replaces the default link behaviour
-with that of [`gatsby-link`'s `push`](https://www.gatsbyjs.org/packages/gatsby-link/#programmatic-navigation), preserving the
+with that of [`gatsby-link`'s `push`](https://next.gatsbyjs.org/docs/gatsby-link/#programmatic-navigation), preserving the
 SPA-like page change without reload.
 
 Check out the [_Using Remark_ example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark) to see this plugin in action.


### PR DESCRIPTION
Also updates the simple-auth example to use the latest version of gatsby@next.

close #6913


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->