### PR TITLE
Up Gatsby's peerDependencies on react/react-dom to latest as @reach/router needs 16.4+

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -172,8 +172,8 @@
   "license": "MIT",
   "main": "cache-dir/gatsby-browser-entry.js",
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Address problems like https://github.com/gatsbyjs/gatsby/issues/7263#issuecomment-412629468