### PR TITLE
Fix build error

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -439,9 +439,12 @@ module.exports = async (
 
   if (stage === `build-html` || stage === `develop-html`) {
     const externalList = [
-      /^lodash/,
+      // match `lodash` and `lodash/foo`
+      // but not things like `lodash-es`
+      `lodash`,
+      /^lodash\//,
       `react`,
-      /^react-dom/,
+      /^react-dom\//,
       `pify`,
       `@reach/router`,
       `@reach/router/lib/history`,
@@ -451,7 +454,7 @@ module.exports = async (
       `react-helmet`,
       `minimatch`,
       `fs`,
-      /^core-js/,
+      /^core-js\//,
       `es6-promise`,
       `crypto`,
       `zlib`,


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/7333

Tighten externals matching to prevent unwanted libs sneaking in. 

I had a dependency that included `lodash-es` which was causing the following build error:

```
error UNHANDLED REJECTION


  Error: /Users/mike/dev/project/node_modules/lodash-es/isPlainObject.js:1
  (function (exports, require, module, __filename, __dirname) { import baseGetTag from './_baseGetTag.js';
                                                                ^^^^^^
  SyntaxError: Unexpected token import
```

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->