### PR TITLE
Fixed prismjs theme instructions.

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -56,10 +56,10 @@ website][6]) that you can easily include in your Gatsby site, or you can build
 your own by copying and modifying an example (which is what we've done for
 [gatsbyjs.org](https://gatsbyjs.org)).
 
-To load a theme, just require its CSS file in your `gatsby-browser.js` file, e.g.
+To load a theme, just require its CSS file in your `layouts/index.js` file, e.g.
 
 ```javascript
-// gatsby-browser.js
+// layouts/index.js
 require("prismjs/themes/prism-solarizedlight.css")
 ```
 


### PR DESCRIPTION
Hi guys, this is a minor fix to the readme for `gatsby-remark-prismjs`. To load a theme, its css file should be required in layouts/index.js, not gatsby-browser.js. It caught me out when I tried it and it didn't work, so I looked at the v1 docs and realised this is an error in v2. Thanks.