### PR TITLE
Update gatsby-link types (TypeScript)

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,11 +1,19 @@
-import * as React from "react";
+import * as React from "react"
+import { NavigateFn, LinkProps } from "@types/reach__router"
 
-export const push: (to: LocationDescriptor) => void;
-export const replace: (to: LocationDescriptor) => void;
+export interface GatsbyLinkProps extends LinkProps {
+  activeClassName?: string
+  activeStyle?: object
+  innerRef?: Function
+  onClick?: Function
+  to: string
+}
 
-// TODO: Remove navigateTo for Gatsby v3
-export const navigateTo: (to: LocationDescriptor) => void;
+export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> {}
+export const navigate: NavigateFn
+export const withPrefix: (path: string) => string
 
-export const withPrefix: (path: string) => string;
-
-export default class GatsbyLink extends React.Component<GatsbyLinkProps, any> { }
+// TODO: Remove navigateTo, push & replace for Gatsby v3
+export const push: (to: string) => void
+export const replace: (to: string) => void
+export const navigateTo: (to: string) => void

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.52",
     "@reach/router": "^1.1.1",
+    "@types/reach__router": "^1.0.0",
     "prop-types": "^15.6.1",
     "ric": "^1.3.0"
   },

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -3,10 +3,11 @@ import * as React from "react"
 export {
   default as Link,
   GatsbyLinkProps,
+  navigate,
   navigateTo,
   push,
   replace,
-  withPrefix
+  withPrefix,
 } from "gatsby-link"
 
 type RenderCallback = (data: any) => React.ReactNode

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,12 @@
   dependencies:
     "@types/node" "*"
 
+"@types/reach__router@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.0.0.tgz#c32d6a322f2dc8eb847df5ebe3fc931a340202c5"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.4.6"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"
@@ -9769,7 +9775,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
Looks like the gatsby-link types are broken after the move to [Reach Router](https://reach.tech/router). Fixing them. 