### PR TITLE
[gatsby-link] Fix Reach Router types import

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { NavigateFn, LinkProps } from "@types/reach__router"
+import { NavigateFn, LinkProps } from "@reach/router"
 
 export interface GatsbyLinkProps extends LinkProps {
   activeClassName?: string


### PR DESCRIPTION
Sorry, I should be importing the types from `@reach/router` instead of `@types/reach__router` but missed this in my [previous PR](https://github.com/gatsbyjs/gatsby/pull/7345). Thanks @resir014 for [pointing it out](https://github.com/gatsbyjs/gatsby/pull/7345/files/81dfcae4b5f0c50fa201eac3a4deb5fdc0055a13#r210269093).