### PR TITLE
Fix invisible "Load More" button and small typo fix (double quotes) (See #7321)

### DIFF
--- a/www/src/views/shared/styles.js
+++ b/www/src/views/shared/styles.js
@@ -93,6 +93,16 @@ const styles = {
       },
     },
   },
+  loadMoreButton: {
+    alignItems: `center`,
+    display: `flex`,
+    flexFlow: `row wrap`,
+    margin: `0 auto ${rhythm(3)}`,
+    padding: `${rhythm(1 / 3)} ${rhythm(3)}`,
+    [presets.Desktop]: {
+      margin: `0 auto ${rhythm(2 / 2)}`,
+    },
+  },
   sticky: {
     paddingTop: rhythm(options.blockMarginBottom),
     position: `sticky`,
@@ -152,7 +162,7 @@ const styles = {
       color: colors.lilac,
     },
     "&:focus": {
-      outline: "none",
+      outline: `none`,
       width: `9rem`,
       background: colors.ui.light,
     },


### PR DESCRIPTION
This small patch should fix the issue #7321 about the Invisible "Load More" button on the Showcase page.

`loadMoreButton` was called but was missing from the shared `styles.js` file.

I also fixed a small issue with an old selector that used doubles quotes instead of backtick.

![screenshot-2018-08-15_17-33-28](https://user-images.githubusercontent.com/1554207/44156939-72c57980-a0b1-11e8-9189-a1832eef856e.png)
![screenshot-2018-08-15_17-34-02](https://user-images.githubusercontent.com/1554207/44156940-735e1000-a0b1-11e8-8efe-c94d9878d3a2.png)
