### PR TITLE
[gatsby-plugin-sharp] Fix toFormat, preserve quality and other options when using duotone

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -156,7 +156,7 @@ const processFile = (file, jobs, cb, reporter) => {
     if (args.duotone) {
       clonedPipeline = await duotone(
         args.duotone,
-        job.file.extension,
+        args.toFormat || job.file.extension,
         clonedPipeline
       )
     }
@@ -413,7 +413,11 @@ async function notMemoizedbase64({ file, args = {}, reporter }) {
 
   // duotone
   if (options.duotone) {
-    pipeline = await duotone(options.duotone, file.extension, pipeline)
+    pipeline = await duotone(
+      options.duotone,
+      args.toFormat || file.extension,
+      pipeline
+    )
   }
 
   const [buffer, info] = await pipeline.toBufferAsync()
@@ -710,7 +714,11 @@ async function notMemoizedtraceSVG({ file, args, fileArgs, reporter }) {
 
   // duotone
   if (options.duotone) {
-    pipeline = await duotone(options.duotone, file.extension, pipeline)
+    pipeline = await duotone(
+      options.duotone,
+      args.toFormat || file.extension,
+      pipeline
+    )
   }
 
   const tmpDir = require(`os`).tmpdir()


### PR DESCRIPTION
Honor `gatsby-plugin-sharp`s `quality`, `toFormat`, `jpegProgressive` and `pngCompressionLevel` options when used along the `duotone` option. Fixes #7009

Apparently 🙄 when using [`raw`](https://sharp.readthedocs.io/en/stable/api-output/#raw) (to access the uncompressed image data we need to manipulate for the "duotone" effect), the JPG/PNG/WEBP/TIFF output options set in https://github.com/gatsbyjs/gatsby/blob/b0c87859449f4ea2413887c82ffcc503898ed8a5/packages/gatsby-plugin-sharp/src/index.js#L126-L143 are lost.

This PR fixes that by preserving the user options when forcing the new sharp buffer containing the duotoned image back into an output format using sharp's [`toFormat`](https://sharp.readthedocs.io/en/stable/api-output/#toformat).
Unfortunately we can't just spread the `clonedPipeline.options` here as `toFormat` expects different keys, e.g. `quality` instead of `clonedPipeline.options.jpegQuality`.

Also, the aforementioned output format was always set to source image's file extension, ignoring `gatsby-plugin-sharp`s potentially user-set `args.toFormat` -- resulting in images with filenames reflecting the desired format's file _extension_, but with the image still output in the original format.

Also updates the duotone code to remove the part that handled normalizing `filename.extension` (which usually is `jpg`, while sharp only accepted `jpeg` for `toFormat` [prior to sharp v0.18](http://sharp.dimens.io/en/stable/changelog/#v0180-30th-may-2017).
