### PR TITLE
Fix DESC to ASC in the tutorial

### DIFF
--- a/packages/gatsby-remark-graphviz/CHANGELOG.md
+++ b/packages/gatsby-remark-graphviz/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.0.0-beta.1"></a>
+
+# [1.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-beta.0...gatsby-remark-graphviz@1.0.0-beta.1) (2018-08-16)
+
+**Note:** Version bump only for package gatsby-remark-graphviz
+
 <a name="1.0.0-beta.0"></a>
 
 # 1.0.0-beta.0 (2018-08-15)

--- a/packages/gatsby-remark-graphviz/package.json
+++ b/packages/gatsby-remark-graphviz/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-remark-graphviz",
   "description": "Processes graphviz code blocks and renders to SVG using viz.js",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "author": "Anthony Marcar <anthony@moocar.me>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"


### PR DESCRIPTION
Hullo! I've never done a pull request before, please bear with me :)

I noticed that the order DESC in the tutorial (part 6) should be ASC.