### PR TITLE
fix deletePage wiping query text for all other pages that uses same template

### DIFF
--- a/packages/gatsby/src/redux/reducers/components.js
+++ b/packages/gatsby/src/redux/reducers/components.js
@@ -14,10 +14,6 @@ module.exports = (state = new Map(), action) => {
         })
       )
       return state
-    case `DELETE_PAGE`:
-      action.payload.componentPath = normalize(action.payload.component)
-      state.delete(action.payload.componentPath)
-      return state
     case `REMOVE_TEMPLATE_COMPONENT`:
       state.delete(normalize(action.payload.componentPath))
       return state


### PR DESCRIPTION
`gatsby-plugin-remove-trailing-slashes` plugin deletes and recreates pages and it's causing problems because we currently clear the query text when we deletePage

this adds checking if we have any pages using template before clearing query text

fixes #7314