### PR TITLE
Make plugin-styled-jsx configurable

### DIFF
--- a/packages/gatsby-plugin-styled-jsx/README.md
+++ b/packages/gatsby-plugin-styled-jsx/README.md
@@ -13,3 +13,16 @@ Add the plugin to the plugins array in your `gatsby-config.js` and use `<style j
 ```javascript
 plugins: [`gatsby-plugin-styled-jsx`]
 ```
+
+You can add styled-jsx [plugins](https://github.com/zeit/styled-jsx#css-preprocessing-via-plugins) with the `jsxPlugins` option 
+
+```js
+plugins: [
+  {
+    resolve: `gatsby-plugin-styled-jsx`,
+    options: {
+      jsxPlugins: ['styled-jsx-plugin-postcss']
+    },
+  },
+]
+```

--- a/packages/gatsby-plugin-styled-jsx/src/gatsby-node.js
+++ b/packages/gatsby-plugin-styled-jsx/src/gatsby-node.js
@@ -3,7 +3,7 @@ exports.onCreateBabelConfig = ({ actions }, { jsxPlugins }) => {
   actions.setBabelPlugin({
     name: `styled-jsx/babel`,
     options: {
-      plugins: jsxPlugins || []
-    }
-  });
-};
+      plugins: jsxPlugins || [],
+    },
+  })
+}

--- a/packages/gatsby-plugin-styled-jsx/src/gatsby-node.js
+++ b/packages/gatsby-plugin-styled-jsx/src/gatsby-node.js
@@ -1,6 +1,9 @@
 // Add babel plugin
-exports.onCreateBabelConfig = ({ actions }) => {
+exports.onCreateBabelConfig = ({ actions }, { jsxPlugins }) => {
   actions.setBabelPlugin({
     name: `styled-jsx/babel`,
-  })
-}
+    options: {
+      plugins: jsxPlugins || []
+    }
+  });
+};


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Fixes #6884.

Uses a hacky `jsxPlugins` option rather than just passing an options block as follows

```js
{
	resolve: ...
	options: {
		plugins: ['styled-jsx-plugin-postcss']
	}
}
```

Because it seems there's a bug with Gatsby treating that `plugins` param as a Gatsby plugin array and mangling it before giving it to styled-jsx. Not sure if that's a known bug or not... If so that should probably be fixed before merging this, and I'll update it to just pass in the full standard options block for styled-jsx.