### PR TITLE
Add active state styles for top navbar items

### DIFF
--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -26,6 +26,10 @@ const navItemStyles = {
   "&:hover": {
     opacity: 0.8,
   },
+  "&.active": {
+    color: colors.gatsby,
+    fontWeight: `bold`,
+  },
 }
 const NavItem = ({ linkTo, children }) => (
   <li
@@ -34,7 +38,7 @@ const NavItem = ({ linkTo, children }) => (
       margin: 0,
     }}
   >
-    <Link to={linkTo} css={navItemStyles}>
+    <Link to={linkTo} css={navItemStyles} activeClassName="active">
       {children}
     </Link>
   </li>


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
# Background
The active item in doc's top navbar wasn't being highlighted, hence #7425 

# How I've fixed it:

- Added `activeClassName="active"` to `navigation.js` items
- Added styles for items with the class active

# Screenshots:

**BEFORE**
<img width="682" alt="screen shot 2018-08-17 at 19 03 18" src="https://user-images.githubusercontent.com/466367/44290695-45fb9880-a250-11e8-917b-732ac8fffefc.png">

**AFTER**
<img width="659" alt="screen shot 2018-08-17 at 19 03 27" src="https://user-images.githubusercontent.com/466367/44290699-4eec6a00-a250-11e8-9719-83c8de28ff94.png">

