### PR TITLE
Add Stitch Fix & Snap Kit sites to site showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2167,13 +2167,3 @@
     - Software
     - Documentation
   featured: false
-    - title: Union Plus Credit Card Website
-  main_url: https://unionplus.capitalone.com/
-  url: https://unionplus.capitalone.com/
-  description: >
-    A website for Union Plus Credit Card holders.
-  categories:
-    - Services
-    - Finance
-  featured: false
-  

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2156,7 +2156,7 @@
     - Clothing
     - Fashion
   featured: false
-  - title: Snap Kit
+- title: Snap Kit
   main_url: https://kit.snapchat.com/
   url: https://kit.snapchat.com/
   description: >

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2146,3 +2146,34 @@
   built_by: Timm Stokke
   built_by_url: https://timm.stokke.me
   featured: false
+- title: Stitch Fix
+  main_url: https://www.stitchfix.com/
+  url: https://www.stitchfix.com/
+  description: >
+    Stitch Fix is an online styling service that delivers a truly personalized shopping experience.
+  categories:
+    - eCommerce
+    - Clothing
+    - Fashion
+  featured: false
+  - title: Snap Kit
+  main_url: https://kit.snapchat.com/
+  url: https://kit.snapchat.com/
+  description: >
+    Snap Kit lets developers integrate some of Snapchat’s best features across platforms.
+  categories:
+    - Technology
+    - Tool
+    - Software
+    - Documentation
+  featured: false
+    - title: Union Plus Credit Card Website
+  main_url: https://unionplus.capitalone.com/
+  url: https://unionplus.capitalone.com/
+  description: >
+    A website for Union Plus Credit Card holders.
+  categories:
+    - Services
+    - Finance
+  featured: false
+  


### PR DESCRIPTION
Adds some major websites to the site showcase.

Related Issue: https://github.com/gatsbyjs/gatsby/issues/7430