### PR TITLE
Resolve JSX extension-type when using gatsby-plugin-layout

### DIFF
--- a/packages/gatsby-plugin-layout/src/gatsby-node.js
+++ b/packages/gatsby-plugin-layout/src/gatsby-node.js
@@ -6,12 +6,11 @@ let absoluteComponentPath
 
 exports.onPreInit = ({ store }, { component }) => {
   let userSpecifiedPath = true
-  const defaultLayoutComponentPath = `src/layouts/index.js`
   if (!component) {
-    // Default to `src/layouts/index.js` for drop-in replacement of v1 layouts
+    // Default to `src/layouts/index.[js|jsx]` for drop-in replacement of v1 layouts
     component = path.join(
       store.getState().program.directory,
-      defaultLayoutComponentPath
+      `src/layouts/index`
     )
     userSpecifiedPath = false
   }

--- a/packages/gatsby-plugin-layout/src/gatsby-node.js
+++ b/packages/gatsby-plugin-layout/src/gatsby-node.js
@@ -6,11 +6,12 @@ let absoluteComponentPath
 
 exports.onPreInit = ({ store }, { component }) => {
   let userSpecifiedPath = true
+  const defaultLayoutComponentPath = `src/layouts/index`
   if (!component) {
     // Default to `src/layouts/index.[js|jsx]` for drop-in replacement of v1 layouts
     component = path.join(
       store.getState().program.directory,
-      `src/layouts/index`
+      defaultLayoutComponentPath
     )
     userSpecifiedPath = false
   }


### PR DESCRIPTION
This removes the explicit `js` filetype when consuming the `index` file needed for `gatsby-plugin-layout`.

This change emulates the current resolve path used in v1 here https://github.com/gatsbyjs/gatsby/blob/v1/packages/gatsby/src/internal-plugins/component-layout-creator/gatsby-node.js#L25

Closes https://github.com/gatsbyjs/gatsby/issues/7451
