### PR TITLE
fix condition for url with hash but no activeItemHash

### DIFF
--- a/www/src/utils/sidebar/get-active-item.js
+++ b/www/src/utils/sidebar/get-active-item.js
@@ -14,7 +14,7 @@ const isItemActive = (location, item, activeItemHash) => {
     }
   }
 
-  if (linkMatchesPathname && !location.hash && activeItemHashFalsy) {
+  if (linkMatchesPathname && activeItemHashFalsy) {
     return item
   }
 


### PR DESCRIPTION
Fixes #7428 

Selecting a searched item on the docs page does not activate the selected section on the sidebar. This was happening because of the hash in the URL. Similar behaviour was observed if you refresh a page with a hash in the url.

This PR fixes the issue by removed the hash check condition when activeItemHash is unavailable.