### PR TITLE
add relative path to resolve.modules

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -195,15 +195,17 @@ module.exports = async (
         break
       case `build-javascript`: {
         // Minify Javascript only if needed.
-        configPlugins = program.noUglify ? configPlugins : configPlugins.concat([
-          plugins.uglify({
-            uglifyOptions: {
-              compress: {
-                drop_console: false,
-              },
-            },
-          }),
-        ])
+        configPlugins = program.noUglify
+          ? configPlugins
+          : configPlugins.concat([
+              plugins.uglify({
+                uglifyOptions: {
+                  compress: {
+                    drop_console: false,
+                  },
+                },
+              }),
+            ])
         configPlugins = configPlugins.concat([
           plugins.extractText(),
           // Write out stats object mapping named dynamic imports (aka page
@@ -357,6 +359,9 @@ module.exports = async (
       modules: [
         directoryPath(path.join(`src`, `node_modules`)),
         `node_modules`,
+        // This is head scratching - without it css modules in production will fail
+        // to find module with relative path
+        `./`,
       ],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),


### PR DESCRIPTION
This is really head scratching css modules with `url('./path.png')` will fail to resolve module with relative path to it, without having this extra entry in `resolve.modules` in webpack config

closes #6290 
