### PR TITLE
Update docs with v2 compatible examples

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -81,8 +81,7 @@ you to commit the change and raise a PR right in the UI. This is the _easiest_
 way you can contribute to the project!
 
 However, if you want to make more changes to the website, that is, change
-layouts, add sections/pages, follow the steps below. You can then spin up your
-own instance of the Gatsby website and make/preview your changes before raising
+layout components or templates, add sections/pages, follow the steps below. You can then spin up your own instance of the Gatsby website and make/preview your changes before raising
 a pull request.
 
 - Clone the repo and navigate to `/www`

--- a/docs/docs/querying-with-graphql.md
+++ b/docs/docs/querying-with-graphql.md
@@ -14,7 +14,7 @@ familiar with SQL, it works in a very similar way. Using a special syntax, you d
 the data you want in your component and then that data is given
 to you.
 
-Gatsby uses GraphQL to enable [page and layout
+Gatsby uses GraphQL to enable [page and StaticQuery
 components](/docs/building-with-components/) to declare what data they and their
 sub-components need. Then, Gatsby makes that data available in
 the browser when needed by your components.

--- a/packages/gatsby-react-router-scroll/README.md
+++ b/packages/gatsby-react-router-scroll/README.md
@@ -4,3 +4,5 @@ React Router scroll management forked from
 https://github.com/ytase/react-router-scroll for Gatsby which itself was forked
 to upgrade to RR v4 from Jimmy Jia's original scroll managment library for React
 Router 2/3.
+
+This has been modified now to be compatible with `@reach/router`.

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -94,8 +94,8 @@ The following is taken from [Gatsby Tutorial, Part Seven](https://www.gatsbyjs.o
 ```javascript
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
-exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
-  const { createNodeField } = boundActionCreators
+exports.onCreateNode = ({ node, getNode, actions }) => {
+  const { createNodeField } = actions
   // Ensures we are processing only markdown files
   if (node.internal.type === "MarkdownRemark") {
     // Use `createFilePath` to turn markdown files in our `data/faqs` directory into `/faqs/slug`

--- a/packages/gatsby-source-lever/README.md
+++ b/packages/gatsby-source-lever/README.md
@@ -74,8 +74,8 @@ const Promise = require(`bluebird`)
 const path = require(`path`)
 const slash = require(`slash`)
 
-exports.createPages = ({ graphql, boundActionCreators }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ graphql, actions }) => {
+  const { createPage } = actions
   return new Promise((resolve, reject) => {
     // The “graphql” function allows us to run arbitrary
     // queries against the local WordPress graphql schema. Think of

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1134,11 +1134,11 @@ actions.addThirdPartySchema = (
 }
 
 /**
- * All defined actions.
+ * All action creators wrapped with a dispatch.
  */
 exports.actions = actions
 
 /**
- * All action creators wrapped with a dispatch.
+ * All action creators wrapped with a dispatch. - *DEPRECATED*
  */
 exports.boundActionCreators = bindActionCreators(actions, store.dispatch)

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -23,7 +23,7 @@
           link: /docs/gatsby-on-macs/
         - title: Gatsby on Windows
           link: /docs/gatsby-on-windows/
-    - title: Deploying & Hosting*
+    - title: Deploying & hosting
       link: /docs/deploying-and-hosting/
       items:
         - title: Preparing your site for deployment*
@@ -34,7 +34,7 @@
           link: /docs/path-prefix/
         - title: How Gatsby works with GitHub pages
           link: /docs/how-gatsby-works-with-github-pages/
-    - title: Custom configuration*
+    - title: Custom configuration
       link: /docs/customization/
       items:
         - title: Babel.js
@@ -157,7 +157,7 @@
           link: /docs/debugging-the-build-process/
         - title: Trace Gatsby builds
           link: /docs/performance-tracing/
-    - title: Building Apps with Gatsby
+    - title: Building apps with Gatsby
       link: /docs/building-apps-with-gatsby/
       items:
         - title: Progressive web app (PWA)

--- a/www/src/pages/docs/actions.js
+++ b/www/src/pages/docs/actions.js
@@ -35,7 +35,7 @@ class ActionCreatorsDocs extends React.Component {
           <p>
             The object
             {` `}
-            <code>boundActionCreators</code>
+            <code>actions</code>
             {` `}
             contains the functions and these can be individually extracted by
             using ES6 object destructuring.
@@ -45,8 +45,8 @@ class ActionCreatorsDocs extends React.Component {
               className="language-javascript"
               dangerouslySetInnerHTML={{
                 __html: `<code class="language-javascript"><span class="token comment">// For function createNodeField</span>
-  exports<span class="token punctuation">.</span><span class="token function-variable function">onCreateNode</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token punctuation">{</span> node<span class="token punctuation">,</span> getNode<span class="token punctuation">,</span> boundActionCreators <span class="token punctuation">}</span><span class="token punctuation">)</span> <span class="token operator">=&gt;</span> <span class="token punctuation">{</span>
-    <span class="token keyword">const</span> <span class="token punctuation">{</span> createNodeField <span class="token punctuation">}</span> <span class="token operator">=</span> boundActionCreators
+  exports<span class="token punctuation">.</span><span class="token function-variable function">onCreateNode</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token punctuation">{</span> node<span class="token punctuation">,</span> getNode<span class="token punctuation">,</span> actions <span class="token punctuation">}</span><span class="token punctuation">)</span> <span class="token operator">=&gt;</span> <span class="token punctuation">{</span>
+    <span class="token keyword">const</span> <span class="token punctuation">{</span> createNodeField <span class="token punctuation">}</span> <span class="token operator">=</span> actions
   <span class="token punctuation">}</span></code>`,
               }}
             />


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Took a last pass through docs and READMEs looking for examples and docs that make references to v1 APIs and updating them to v2 APIs

Closes #5853