### PR TITLE
[www] Remove superfluous second forward slash at the beginning of location.pathname appearing during `gatsby build`…

### DIFF
--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -5,6 +5,7 @@ import { OutboundLink } from "gatsby-plugin-google-analytics"
 import MdClose from "react-icons/lib/md/close"
 import { navigate, PageRenderer } from "gatsby"
 import presets, { colors } from "../utils/presets"
+import healLocationPathname from "../utils/sidebar/heal-location-pathname"
 import Banner from "../components/banner"
 import Navigation from "../components/navigation"
 import MobileNavigation from "../components/navigation-mobile"
@@ -58,11 +59,8 @@ class DefaultLayout extends React.Component {
   }
 
   render() {
-    const {
-      location = {
-        pathname: `/starter-showcase`,
-      },
-    } = this.props // location will be undefined if on 'starter-showcase'
+    let { location } = this.props
+    location.pathname = healLocationPathname(location.pathname)
     const isHomepage = location.pathname === `/`
 
     // SEE: template-docs-markdown for why this.props.isSidebarDisabled is here
@@ -160,7 +158,7 @@ class DefaultLayout extends React.Component {
           <meta name="og:site_name" content="GatsbyJS" />
           <link
             rel="canonical"
-            href={`https://gatsbyjs.org${this.props.location.pathname}`}
+            href={`https://gatsbyjs.org${location.pathname}`}
           />
           <html lang="en" />
         </Helmet>
@@ -188,7 +186,7 @@ class DefaultLayout extends React.Component {
           </OutboundLink>
           .
         </Banner>
-        <Navigation pathname={this.props.location.pathname} />
+        <Navigation pathname={location.pathname} />
         <div
           className={`main-body`}
           css={{
@@ -204,7 +202,7 @@ class DefaultLayout extends React.Component {
           <PageWithSidebar
             disable={isSidebarDisabled}
             itemList={this.props.itemList}
-            location={this.props.location}
+            location={location}
             enableScrollSync={this.props.enableScrollSync}
             renderContent={() => this.props.children}
           />

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -4,6 +4,7 @@ import { graphql } from "gatsby"
 
 import Layout from "../components/layout"
 import { itemListDocs, itemListTutorial } from "../utils/sidebar/item-list"
+import healLocationPathname from "../utils/sidebar/heal-location-pathname"
 import MarkdownPageFooter from "../components/markdown-page-footer"
 import DocSearchContent from "../components/docsearch-content"
 
@@ -55,7 +56,8 @@ const getPageHTML = page => {
 class DocsTemplate extends React.Component {
   render() {
     const page = this.props.data.markdownRemark
-    const isDocsPage = this.props.location.pathname.slice(0, 5) === `/docs`
+    const pathname = healLocationPathname(this.props.location.pathname)
+    const isDocsPage = pathname.slice(0, 5) === `/docs`
     const html = getPageHTML(page)
 
     return (
@@ -72,9 +74,7 @@ class DocsTemplate extends React.Component {
         </Helmet>
         <Layout
           location={this.props.location}
-          isSidebarDisabled={
-            this.props.location.pathname === `/code-of-conduct/`
-          }
+          isSidebarDisabled={pathname === `/code-of-conduct/`}
           itemList={isDocsPage ? itemListDocs : itemListTutorial}
           enableScrollSync={isDocsPage ? false : true}
         >

--- a/www/src/utils/sidebar/heal-location-pathname.js
+++ b/www/src/utils/sidebar/heal-location-pathname.js
@@ -1,0 +1,6 @@
+// remove superfluous second forward slash at the beginning of
+// location.pathname appearing during `gatsby build`
+// @todo remove once this is resolved "upstream"
+const healLocationPathname = pathname => pathname.replace(`//`, `/`)
+
+export default healLocationPathname


### PR DESCRIPTION
in `www/src/components/layout.js` and `www/src/templates/template-docs-markdown.js`.

That additional forward slash trips up the sidebar UI's initial state/the initially rendered HTML (and probably other things, of which _some_ might be fixed by this via the changes in `layout.js`, too).

Fixes #7474, fixes #7468, and "Quick Start category name got indented too far" mentioned in https://github.com/gatsbyjs/gatsby/issues/7423 (and shown in https://github.com/gatsbyjs/gatsby/issues/7423#issuecomment-414303256).

---

While this fixes the issues with "Docs" and "Tutorial", I believe this to be just a hotfix -- please refer to https://github.com/gatsbyjs/gatsby/issues/7474#issuecomment-414422649 for (unfortunately not many more) details.