### PR TITLE
public-page-renderer: dev based on BUILD_STAGE

### DIFF
--- a/packages/gatsby/cache-dir/public-page-renderer.js
+++ b/packages/gatsby/cache-dir/public-page-renderer.js
@@ -1,6 +1,6 @@
 const preferDefault = m => (m && m.default) || m
 
-if (process.env.NODE_ENV !== `production`) {
+if (process.env.BUILD_STAGE === `develop`) {
   module.exports = preferDefault(require(`./public-page-renderer-dev`))
 } else if (process.env.BUILD_STAGE === `build-javascript`) {
   module.exports = preferDefault(require(`./public-page-renderer-prod`))


### PR DESCRIPTION
Pick the development page renderer based on BUILD_STAGE instead of NODE_ENV.

Fixes https://github.com/gatsbyjs/gatsby/issues/7270 by only including the page renderer dev version when running through the develop command instead of looking at NODE_ENV which isn't explicitly set by the CLI.