### PR TITLE
Fix getting page resources in page-renderer

### DIFF
--- a/packages/gatsby/cache-dir/public-page-renderer-dev.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-dev.js
@@ -6,7 +6,7 @@ import loader from "./loader"
 import JSONStore from "./json-store"
 
 const DevPageRenderer = ({ location }) => {
-  const pageResources = loader.getResourcesForPathname(location.pathname)
+  const pageResources = loader.getResourcesForPathnameSync(location.pathname)
   return React.createElement(JSONStore, {
     pages,
     location,


### PR DESCRIPTION
Fixes #7380

Using <PageRenderer> directly has the caveat that you can't use it
unless the page resources are already loaded. Which is fine if
you're using it to render behind a modal the page that's already loaded
(the only use case we know of right now). Otherwise it'll break.


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->