### PR TITLE
[testing] Adds cypress e2e tests for client-only-paths

### DIFF
--- a/examples/client-only-paths/cypress.json
+++ b/examples/client-only-paths/cypress.json
@@ -1,0 +1,4 @@
+{
+  "baseUrl": "http://localhost:8000",
+  "video": false
+}

--- a/examples/client-only-paths/cypress/integration/test_client_paths.js
+++ b/examples/client-only-paths/cypress/integration/test_client_paths.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-undef */
+
+const getFullUrl = (route) => `${Cypress.config(`baseUrl`)}/${route}`
+
+describe(`Client Only Paths Tests`, () => {
+  it(`should render properly`, () => {
+    cy.visit(`/`)
+    cy.get(`.page`).should(`have.text`, `1`)
+  })
+
+  it(`all page routes should work`, () => {
+    cy.visit(`/page/1`)
+    cy.url().should(`eq`, getFullUrl(`page/1`))
+    cy.get(`.page`).should(`have.text`, `1`)
+
+    cy.visit(`/page/2`)
+    cy.url().should(`eq`, getFullUrl(`page/2`))
+    cy.get(`.page`).should(`have.text`, `2`)
+
+    cy.visit(`/page/3`)
+    cy.url().should(`eq`, getFullUrl(`page/3`))
+    cy.get(`.page`).should(`have.text`, `3`)
+
+    cy.visit(`/page/4`)
+    cy.url().should(`eq`, getFullUrl(`page/4`))
+    cy.get(`.page`).should(`have.text`, `4`)
+  })
+})

--- a/examples/client-only-paths/package.json
+++ b/examples/client-only-paths/package.json
@@ -20,6 +20,13 @@
   "main": "n/a",
   "scripts": {
     "develop": "gatsby develop",
-    "build": "gatsby build"
+    "build": "gatsby build",
+    "test": "start-server-and-test develop http://localhost:8000 cy:run",
+    "cy:open": "cypress open",
+    "cy:run": "cypress run"
+  },
+  "devDependencies": {
+    "cypress": "^3.1.0",
+    "start-server-and-test": "^1.7.0"
   }
 }


### PR DESCRIPTION
#### Description
This adds a base cypress test to the `client-only-paths` example site. 

#### Checklist

- [x] Test all supported routes
- [x] Base cypress boilerplate
- [ ] Test 404 pages
- [ ] Maybe add travis config (`.travis.yml`)

Refs: #7421 
