### PR TITLE
[www] paginate blog listing page

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -51,6 +51,7 @@ exports.createPages = ({ graphql, actions }) => {
   return new Promise((resolve, reject) => {
     const docsTemplate = path.resolve(`src/templates/template-docs-markdown.js`)
     const blogPostTemplate = path.resolve(`src/templates/template-blog-post.js`)
+    const blogListTemplate = path.resolve(`src/templates/template-blog-list.js`)
     const tagTemplate = path.resolve(`src/templates/tags.js`)
     const contributorPageTemplate = path.resolve(
       `src/templates/template-contributor-page.js`
@@ -162,7 +163,24 @@ exports.createPages = ({ graphql, actions }) => {
         return undefined
       })
 
-      // Create blog pages.
+      // Create blog-list pages.
+      const postsPerPage = 5
+      const numPages = Math.ceil(blogPosts.length / postsPerPage)
+
+      Array.from({ length: numPages }).forEach((_, i) => {
+        createPage({
+          path: i === 0 ? `/blog` : `/blog/${i + 1}`,
+          component: slash(blogListTemplate),
+          context: {
+            limit: postsPerPage,
+            skip: i * postsPerPage,
+            numPages,
+            currentPage: i + 1,
+          },
+        })
+      })
+
+      // Create blog-post pages.
       blogPosts.forEach((edge, index) => {
         const next = index === 0 ? null : blogPosts[index - 1].node
         const prev =

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -164,7 +164,7 @@ exports.createPages = ({ graphql, actions }) => {
       })
 
       // Create blog-list pages.
-      const postsPerPage = 5
+      const postsPerPage = 8
       const numPages = Math.ceil(blogPosts.length / postsPerPage)
 
       Array.from({ length: numPages }).forEach((_, i) => {

--- a/www/src/components/pagination/PaginationLink.js
+++ b/www/src/components/pagination/PaginationLink.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Link } from 'gatsby'
+
+const PaginationLink = props => {
+  if (props.to) {
+    return <Link to={props.to}>{props.children}</Link>
+  }
+  return <span>{props.children}</span>
+}
+
+export default PaginationLink

--- a/www/src/components/pagination/PaginationLink.js
+++ b/www/src/components/pagination/PaginationLink.js
@@ -1,11 +1,16 @@
 import React from 'react'
 import { Link } from 'gatsby'
+import { colors } from "../../utils/presets"
 
-const PaginationLink = props => {
-  if (props.to) {
-    return <Link to={props.to}>{props.children}</Link>
+const PaginationLink = ({ to, children, ...props }) => {
+  if (to) {
+    return (
+      <Link to={to} {...props}>
+        {children}
+      </Link>
+    )
   }
-  return <span>{props.children}</span>
+  return <span css={{ color: colors.gray.calm }}>{children}</span>
 }
 
 export default PaginationLink

--- a/www/src/components/pagination/index.js
+++ b/www/src/components/pagination/index.js
@@ -1,26 +1,118 @@
-import React from 'react'
-import { Link } from 'gatsby'
-import PaginationLink from './PaginationLink'
+import React from "react"
+import { navigate } from "gatsby"
+import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
+import ArrowBackIcon from "react-icons/lib/md/arrow-back"
+import PaginationLink from "./PaginationLink"
+import presets, { colors } from "../../utils/presets"
+import { options, rhythm } from "../../utils/typography"
 
-const Pagination = ({ context }) => {
-  const { numPages, currentPage } = context
-  const isFirst = currentPage === 1
-  const isLast = currentPage === numPages
-  const prevPageNum = currentPage - 1 === 1 ? `` : (currentPage - 1).toString()
-  const nextPageNum = (currentPage + 1).toString()
-  const prevPageLink = isFirst ? null : `/blog/${prevPageNum}`
-  const nextPageLink = isLast ? null : `/blog/${nextPageNum}`
-  return (
-    <div>
-      <PaginationLink to={prevPageLink} rel="prev">← Previous Page</PaginationLink>
-      {Array.from({ length: numPages }, (_, i) => (
-        <Link to={`blog/${i === 0 ? `` : i + 1}`} key={`pagination-number${i + 1}`}>
-          <span>{i + 1}</span>
-        </Link>
-      ))}
-      <PaginationLink to={nextPageLink} rel="next">Next Page →</PaginationLink>
-    </div>
-  )
+class Pagination extends React.Component {
+  changePage = e => {
+    navigate(`/blog/${e.target.value}`)
+  }
+  render() {
+    const { numPages, currentPage } = this.props.context
+    const isFirst = currentPage === 1
+    const isLast = currentPage === numPages
+    const prevPageNum =
+      currentPage - 1 === 1 ? `` : (currentPage - 1).toString()
+    const nextPageNum = (currentPage + 1).toString()
+    const prevPageLink = isFirst ? null : `/blog/${prevPageNum}`
+    const nextPageLink = isLast ? null : `/blog/${nextPageNum}`
+
+    const prevNextLinkStyles = {
+      "&&": {
+        boxShadow: `none`,
+        borderBottom: 0,
+        fontFamily: options.headerFontFamily.join(`,`),
+        fontWeight: `bold`,
+        color: colors.gatsby,
+      },
+    }
+
+    return (
+      <div
+        css={{
+          display: `flex`,
+          justifyContent: `space-between`,
+          margin: `${rhythm(1)} 0`,
+          flexDirection: `column`,
+          [presets.Tablet]: {
+            flexDirection: `row`,
+          },
+        }}
+      >
+        <div
+          css={{
+            display: `flex`,
+            margin: `0`,
+            padding: `0`,
+            justifyContent: `space-between`,
+            alignItems: `center`,
+            marginBottom: rhythm(1 / 2),
+            [presets.Tablet]: {
+              width: `15rem`,
+              marginBottom: 0,
+            },
+          }}
+        >
+          <PaginationLink to={prevPageLink} css={prevNextLinkStyles}>
+            <ArrowBackIcon style={{ verticalAlign: `sub` }} />
+            Newer posts
+          </PaginationLink>
+          <PaginationLink to={nextPageLink} css={prevNextLinkStyles}>
+            Older posts
+            <ArrowForwardIcon style={{ verticalAlign: `sub` }} />
+          </PaginationLink>
+        </div>
+        <div
+          css={{
+            display: `flex`,
+            alignItems: `center`,
+            justifyContent: `flex-end`,
+            fontFamily: options.headerFontFamily.join(`,`),
+          }}
+        >
+          <span>Showing page &nbsp;</span>
+          <select
+            value={currentPage === 1 ? `` : currentPage.toString()}
+            onChange={this.changePage}
+            css={{
+              appearance: `none`,
+              border: `none`,
+              padding: `0.5ch 2ch 0.5ch 0.5ch`,
+              color: `rebeccapurple`,
+              fontWeight: `bold`,
+            }}
+          >
+            {Array.from({ length: numPages }, (_, i) => (
+              <option
+                value={`${i === 0 ? `` : i + 1}`}
+                key={`pagination-number${i + 1}`}
+              >
+                {i + 1}
+              </option>
+            ))}
+          </select>
+          <svg
+            width="10"
+            height="5"
+            viewBox="0 0 10 5"
+            css={{
+              position: `relative`,
+              right: `1.5ch`,
+              fill: `rebeccapurple`,
+              pointerEvents: `none`,
+            }}
+          >
+            <path d="M0 0l5 4.998L10 0z" fillRule="evenodd" />
+          </svg>
+          <span>of &nbsp;</span>
+          <span>{numPages}</span>
+        </div>
+      </div>
+    )
+  }
 }
 
 export default Pagination

--- a/www/src/components/pagination/index.js
+++ b/www/src/components/pagination/index.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import PaginationLink from './PaginationLink'
+
+const Pagination = ({ context }) => {
+  const { numPages, currentPage } = context
+  const isFirst = currentPage === 1
+  const isLast = currentPage === numPages
+  const prevPageNum = currentPage - 1 === 1 ? `` : (currentPage - 1).toString()
+  const nextPageNum = (currentPage + 1).toString()
+  const prevPageLink = isFirst ? null : `/blog/${prevPageNum}`
+  const nextPageLink = isLast ? null : `/blog/${nextPageNum}`
+  return (
+    <div>
+      <PaginationLink to={prevPageLink} rel="prev">← Previous Page</PaginationLink>
+      {Array.from({ length: numPages }, (_, i) => (
+        <Link to={`blog/${i === 0 ? `` : i + 1}`} key={`pagination-number${i + 1}`}>
+          <span>{i + 1}</span>
+        </Link>
+      ))}
+      <PaginationLink to={nextPageLink} rel="next">Next Page →</PaginationLink>
+    </div>
+  )
+}
+
+export default Pagination

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -2,14 +2,15 @@ import React from "react"
 import { graphql } from "gatsby"
 import Helmet from "react-helmet"
 
-import Layout from "../../components/layout"
-import Container from "../../components/container"
-import BlogPostPreviewItem from "../../components/blog-post-preview-item"
-import EmailCaptureForm from "../../components/email-capture-form"
+import Layout from "../components/layout"
+import Container from "../components/container"
+import BlogPostPreviewItem from "../components/blog-post-preview-item"
+import Pagination from "../components/pagination"
+import EmailCaptureForm from "../components/email-capture-form"
 
-import presets, { colors } from "../../utils/presets"
-import { rhythm, options } from "../../utils/typography"
-import logo from "../../monogram.svg"
+import presets, { colors } from "../utils/presets"
+import { rhythm, options } from "../utils/typography"
+import logo from "../monogram.svg"
 
 class BlogPostsIndex extends React.Component {
   render() {
@@ -96,6 +97,7 @@ class BlogPostsIndex extends React.Component {
                 }}
               />
             ))}
+            <Pagination context={this.props.pageContext} />
             <EmailCaptureForm signupMessage="Enjoying our blog? Receive the next post in your inbox!" />
           </Container>
         </div>
@@ -107,13 +109,15 @@ class BlogPostsIndex extends React.Component {
 export default BlogPostsIndex
 
 export const pageQuery = graphql`
-  query {
+  query blogListQuery($skip: Int!, $limit: Int!) {
     allMarkdownRemark(
       sort: { order: DESC, fields: [frontmatter___date] }
       filter: {
         frontmatter: { draft: { ne: true } }
         fileAbsolutePath: { regex: "/docs.blog/" }
       }
+      limit: $limit
+      skip: $skip
     ) {
       edges {
         node {


### PR DESCRIPTION
Add pagination to the https://next.gatsbyjs.org/blog/ page.
<details>
<summary>Original post</summary>
**I haven't done any styling yet, mainly because I don't know how you want it to look.**

Currently showing 5 blog-posts per page, used that relatively low number to test.
That number is set by `postPerPage` in `gatsby-node`

Please give me feedback on how this should look/function.
The file structure to follow is also a question I have. 
Much refactoring to be done, posting here early to hear what I should change.

Thanks @pieh for showing me how to do this!

It's not pretty yet, but it works.
![chrome_2018-08-21_20-19-32](https://user-images.githubusercontent.com/30179461/44420930-8e33f700-a57f-11e8-9889-14c87cf2a6d0.png)
</details>
<br/>

After reading the resources @fk provided, I tried to implement it in https://github.com/gatsbyjs/gatsby/pull/7523/commits/3e3848ba9378459ac13eb433090d94fe350c48f4

![chrome_2018-08-23_20-47-37](https://user-images.githubusercontent.com/30179461/44545609-d1c06980-a715-11e8-806d-78789c556fda.png)

I would also like to contribute to the documentation for this somehow. @shannonbux suggested releasing the [blogpost](https://nickymeuleman.netlify.com/blog/gatsby-pagination/) I made as a doc here. I expect having to condense/rewrite it to make it fit the docs style.




