### PR TITLE
[v2] [gatsby-plugin-offline] Use a fragment for the app shell

### DIFF
--- a/packages/gatsby-plugin-offline/src/app-shell.js
+++ b/packages/gatsby-plugin-offline/src/app-shell.js
@@ -2,7 +2,7 @@ import React from "react"
 
 class AppShell extends React.Component {
   render() {
-    return <span />
+    return <React.Fragment />
   }
 }
 


### PR DESCRIPTION
As per @Maistho's suggestion in #6059 ([link to comment](https://github.com/gatsbyjs/gatsby/issues/6059#issuecomment-414919314)) - this ensures root element styling will always work, regardless of what the element is. I've also backported this to v1 for @anthkris and others - see #7535.