### PR TITLE
Fix gatsby-link anchor click

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -149,11 +149,12 @@ class GatsbyLink extends React.Component {
                 // browser behavior by scrolling now to the top of the page.
                 window.scrollTo(0, 0)
               }
-            }
+            } else {
 
-            // Make sure the necessary scripts and data are
-            // loaded before continuing.
-            navigate(prefixedTo, { state })
+              // Make sure the necessary scripts and data are
+              // loaded before continuing.
+              navigate(prefixedTo, { state })
+            }
           }
 
           return true

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -138,7 +138,7 @@ class GatsbyLink extends React.Component {
             // Is this link pointing to a hash on the same page? If so,
             // just scroll there.
             const { pathname, hash } = parsePath(prefixedTo)
-            if (pathname === location.pathname || !pathname) {
+            if (pathname === location.pathname || to.startsWith(`#`)) {
               const element = hash
                 ? document.getElementById(hash.substr(1))
                 : null


### PR DESCRIPTION
When we have
```javascript
<Link to="#hash">Go to section</Link>
```
Clicking it would load / instead of scroll to section

This happens because pathname in not a empty string anymore but `/` because of `withPrefix`