### PR TITLE
Add "Insights" by Just Ask Users to the list of Gatsby-powered sites.

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2167,3 +2167,15 @@
     - Software
     - Documentation
   featured: false
+- title: Insights
+  main_url: https://justaskusers.com/
+  url: https://justaskusers.com/
+  description: >
+    Insights helps user experience (UX) researchers conduct their research and make sense of the findings.
+  categories:
+    - User Experience
+    - Research
+    - Design
+  built_by: Just Ask Users
+  built_by_url: https://justaskusers.com/
+  featured: false


### PR DESCRIPTION
A new showcase:

> "Insights" by Just Ask Users helps user experience research teams make sense of their user study findings. Teams can see their users' pains and needs easily so that they can enhance the product that they are designing.