### PR TITLE
[gatsby-plugin-offline] - Invalid regular expression

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -80,7 +80,7 @@ exports.onPostBuild = (args, pluginOptions) => {
     // URLs and not any files hosted on the site.
     //
     // Regex based on http://stackoverflow.com/a/18017805
-    navigateFallbackWhitelist: [/^.*([^.]{5}|.html)(?<!(\?|&)no-cache=1)$/],
+    navigateFallbackWhitelist: [/^.*([^.]{5}|.html(?<!(\?|&)no-cache=1)$/],
     cacheId: `gatsby-plugin-offline`,
     // Don't cache-bust JS files and anything in the static directory
     dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,


### PR DESCRIPTION
This removes the stray ) in the `navigateFallbackWhitelist` regex which is causing builds to fail, and errors when installing the service worker in FireFox.

<img width="798" alt="screen shot 2018-08-22 at 16 06 41" src="https://user-images.githubusercontent.com/130948/44472326-cf7ee200-a625-11e8-9382-72db21dfff44.png">
