### PR TITLE
feat: add option to configure default image quality

### DIFF
--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -1,7 +1,7 @@
 # gatsby-transformer-sharp
 
 Creates `ImageSharp` nodes from image types that are supported by the
-[Sharp](https://github.com/lovell/sharp) image processing library and provides
+[Sharp][sharp] image processing library and provides
 fields in their GraphQL types for processing your images in a variety of ways
 including resizing, cropping, and creating responsive images.
 
@@ -21,6 +21,25 @@ module.exports = {
 }
 ```
 
+### Configure default quality
+
+By default, all image operations presume a default quality threshold passed to [sharp][sharp] (currently configured to `50`). To set a default quality for all image operations, do so with a configurable threshold passed to the plugin like so:
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    `gatsby-plugin-sharp`,
+    {
+      resolve: `gatsby-transformer-sharp`,
+      options: {
+        defaultQuality: 60 // 60% of the time it works every time
+      }
+    }
+  ]
+}
+```
+
 ## Parsing algorithm
 
 It recognizes files with the following extensions as images.
@@ -33,3 +52,5 @@ It recognizes files with the following extensions as images.
 - tiff
 
 Each image file is parsed into a node of type `ImageSharp`.
+
+[sharp]: (https://github.com/lovell/sharp)

--- a/packages/gatsby-transformer-sharp/src/__tests__/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/__tests__/extend-node-type.js
@@ -1,0 +1,53 @@
+const extendNodeType = require(`../extend-node-type`)
+const { __DEFAULT_QUALITY__ } = extendNodeType
+
+const getOptions = (options = {}) => {return {
+  type: {
+    name: `ImageSharp`,
+  },
+  pathPrefix: `/`,
+  getNodeAndSavePathDependency: jest.fn(),
+  reporter: jest.fn(),
+  ...options,
+}}
+
+describe(`basic functionality`, () => {
+  it(`returns empty object if not ImageSharp type`, () => {
+    const options = getOptions({ type: `MarkdownRemark` })
+
+    expect(extendNodeType(options)).toEqual({})
+  })
+
+  it(`returns expected image operations`, () => {
+    const expected = [`fixed`, `resolutions`, `fluid`, `sizes`, `original`, `resize`]
+      .reduce((merged, key) => {
+        merged[key] = expect.any(Object)
+        return merged
+      }, {})
+        
+    expect(extendNodeType(getOptions())).toEqual(expected)
+  })
+})
+
+describe(`quality`, () => {
+  const options = getOptions()
+
+  it(`uses fallback quality if not passed`, () => {
+    const node = extendNodeType(options);
+
+    [node.fixed, node.fluid]
+      .forEach(type => {
+        expect(type.args.quality.defaultValue).toBe(__DEFAULT_QUALITY__)
+      })
+  })
+
+  it(`allows for configuration of quality`, () => {
+    const defaultQuality = 100
+    const node = extendNodeType(options, { defaultQuality });
+
+    [node.fixed, node.fluid]
+      .forEach(type => {
+        expect(type.args.quality.defaultValue).toBe(defaultQuality)
+      })
+  })
+})

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -27,6 +27,8 @@ const {
   PotraceType,
 } = require(`./types`)
 
+const DEFAULT_QUALITY = 50
+
 function toArray(buf) {
   var arr = new Array(buf.length)
 
@@ -50,6 +52,7 @@ const fixedNodeType = ({
   getNodeAndSavePathDependency,
   reporter,
   name,
+  defaultQuality,
 }) => {
   return {
     type: new GraphQLObjectType({
@@ -128,7 +131,7 @@ const fixedNodeType = ({
       },
       quality: {
         type: GraphQLInt,
-        defaultValue: 50,
+        defaultValue: defaultQuality,
       },
       toFormat: {
         type: ImageFormatType,
@@ -169,6 +172,7 @@ const fluidNodeType = ({
   getNodeAndSavePathDependency,
   reporter,
   name,
+  defaultQuality,
 }) => {
   return {
     type: new GraphQLObjectType({
@@ -245,7 +249,7 @@ const fluidNodeType = ({
       },
       quality: {
         type: GraphQLInt,
-        defaultValue: 50,
+        defaultValue: defaultQuality,
       },
       toFormat: {
         type: ImageFormatType,
@@ -285,7 +289,7 @@ module.exports = ({
   pathPrefix,
   getNodeAndSavePathDependency,
   reporter,
-}) => {
+}, { defaultQuality = DEFAULT_QUALITY } = {}) => {
   if (type.name !== `ImageSharp`) {
     return {}
   }
@@ -295,6 +299,7 @@ module.exports = ({
     pathPrefix,
     getNodeAndSavePathDependency,
     reporter,
+    defaultQuality,
   }
 
   // TODO: Remove resolutionsNode and sizesNode for Gatsby v3
@@ -451,3 +456,5 @@ module.exports = ({
     },
   }
 }
+
+module.exports.__DEFAULT_QUALITY__ = 50


### PR DESCRIPTION
Fixes #4873 

Don't love exporting the `__DEFAULT_QUALITY__`, but hey it works and makes it testable, so that's a win.