### PR TITLE
Add noInlineHighlight option to remark-prism plugin

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -45,6 +45,9 @@ plugins: [
             //  `require("prismjs/plugins/line-numbers/prism-line-numbers.css");`
             // Defaults to false.
             showLineNumbers: false,
+            // If setting this to true, the parser won't handle and highlight inline
+            // code used in markdown i.e. single backtick code like `this`.
+            noInlineHighlight: false,
           },
         },
       ],

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`remark prism plugin does not handle inline code if noInlineHighlight: true 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "some text ",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 35,
+              "line": 1,
+              "offset": 34,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "type": "inlineCode",
+          "value": "containing inline code",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 35,
+          "line": 1,
+          "offset": 34,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 35,
+      "line": 1,
+      "offset": 34,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`remark prism plugin generates a <pre> tag with a custom class prefix if configured 1`] = `
 Object {
   "children": Array [

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -58,6 +58,16 @@ describe(`remark prism plugin`, () => {
     })
   })
 
+  it(`does not handle inline code if noInlineHighlight: true`, () => {
+    const code = `some text \`containing inline code\``
+    const markdownAST = remark.parse(code)
+    plugin(
+      { markdownAST },
+      { noInlineHighlight: true }
+    )
+    expect(markdownAST).toMatchSnapshot()
+  })
+
   describe(`numberLines`, () => {
     it(`adds line-number markup when necessary`, () => {
       const code = `\`\`\`js{numberLines:5}\n//.foo { \ncolor: red;\n }\``

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -6,7 +6,7 @@ const addLineNumbers = require(`./add-line-numbers`)
 
 module.exports = (
   { markdownAST },
-  { classPrefix = `language-`, inlineCodeMarker = null, aliases = {} } = {}
+  { classPrefix = `language-`, inlineCodeMarker = null, aliases = {}, noInlineHighlight = false } = {}
 ) => {
   const normalizeLanguage = lang => {
     const lower = lang.toLowerCase()
@@ -65,23 +65,25 @@ module.exports = (
     + `</div>`
   })
 
-  visit(markdownAST, `inlineCode`, node => {
-    let languageName = `text`
+  if (!noInlineHighlight) {
+    visit(markdownAST, `inlineCode`, node => {
+      let languageName = `text`
 
-    if (inlineCodeMarker) {
-      let [language, restOfValue] = node.value.split(`${inlineCodeMarker}`, 2)
-      if (language && restOfValue) {
-        languageName = normalizeLanguage(language)
-        node.value = restOfValue
+      if (inlineCodeMarker) {
+        let [language, restOfValue] = node.value.split(`${inlineCodeMarker}`, 2)
+        if (language && restOfValue) {
+          languageName = normalizeLanguage(language)
+          node.value = restOfValue
+        }
       }
-    }
 
-    const className = `${classPrefix}${languageName}`
+      const className = `${classPrefix}${languageName}`
 
-    node.type = `html`
-    node.value = `<code class="${className}">${highlightCode(
-      languageName,
-      node.value
-    )}</code>`
-  })
+      node.type = `html`
+      node.value = `<code class="${className}">${highlightCode(
+        languageName,
+        node.value
+      )}</code>`
+    })
+  }
 }


### PR DESCRIPTION
This PR adds a `noInlineHighlight` option for to the `gatsby-remark-prismjs` plugin.

The use-case: sometimes people (more specific - in that case me :D) want to not have the prism styling and highlights applied to inline code tags, e.g. when using a dark theme that might look quiet weird:

> ![Screenshot of a paragraph with highlighted dark inline code](https://user-images.githubusercontent.com/877229/44489765-a4fc4b80-a65c-11e8-92f4-54d0799af21b.png)


In that case I think it's useful to have an option to turn prism off for inline code. An alternative would be: overwriting the prism CSS in your own stylings to remove everything you don't want. That is potentially error prone and a lot of work. Also for that use-case we still waste build time for highlighting those inline code even if the user doesn't need and want it. Thus I think having an option to the package to disable it completely for inline code makes more sense, than forcing users to overwrite the inline styles again.