### PR TITLE
[v2] [gatsby-plugin-offline] [see #7605] Fix service worker failing to install due to incompatible regex

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -53,7 +53,7 @@ const options = {
   // Regex based on http://stackoverflow.com/a/18017805
   navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
   navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
-  navigateFallbackRegexesIncludeParameters: true,
+  navigateFallbackRegExpsIncludeParameters: true,
   cacheId: `gatsby-plugin-offline`,
   // Don't cache-bust JS files and anything in the static directory
   dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -51,7 +51,9 @@ const options = {
   // URLs and not any files hosted on the site.
   //
   // Regex based on http://stackoverflow.com/a/18017805
-  navigateFallbackWhitelist: [/^.*([^.]{5}|.html)(?<!(\?|&)no-cache=1)$/],
+  navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
+  navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
+  navigateFallbackRegexesIncludeParameters: true,
   cacheId: `gatsby-plugin-offline`,
   // Don't cache-bust JS files and anything in the static directory
   dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.52",
+    "@davidbailey00/sw-precache": "^5.3.0",
     "cheerio": "^1.0.0-rc.2",
-    "lodash": "^4.17.10",
-    "sw-precache": "^5.2.1"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.52",
-    "@davidbailey00/sw-precache": "^5.3.0",
+    "@davidbailey00/sw-precache": "^5.3.1",
     "cheerio": "^1.0.0-rc.2",
     "lodash": "^4.17.10"
   },

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -10,7 +10,6 @@
     "@babel/runtime": "7.0.0-beta.52",
     "cheerio": "^1.0.0-rc.2",
     "lodash": "^4.17.10",
-    "replace-in-file": "^3.4.2",
     "sw-precache": "^5.2.1"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -1,5 +1,5 @@
 const fs = require(`fs`)
-const precache = require(`sw-precache`)
+const precache = require(`@davidbailey00/sw-precache`)
 const path = require(`path`)
 const slash = require(`slash`)
 const _ = require(`lodash`)
@@ -81,7 +81,7 @@ exports.onPostBuild = (args, pluginOptions) => {
     // Regex based on http://stackoverflow.com/a/18017805
     navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
     navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
-    navigateFallbackRegexesIncludeParameters: true,
+    navigateFallbackRegExpsIncludeParameters: true,
     cacheId: `gatsby-plugin-offline`,
     // Don't cache-bust JS files and anything in the static directory
     dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -3,7 +3,6 @@ const precache = require(`sw-precache`)
 const path = require(`path`)
 const slash = require(`slash`)
 const _ = require(`lodash`)
-const replace = require(`replace-in-file`)
 
 const getResourcesFromHTML = require(`./get-resources-from-html`)
 
@@ -80,7 +79,9 @@ exports.onPostBuild = (args, pluginOptions) => {
     // URLs and not any files hosted on the site.
     //
     // Regex based on http://stackoverflow.com/a/18017805
-    navigateFallbackWhitelist: [/^.*([^.]{5}|.html)(?<!(\?|&)no-cache=1)$/],
+    navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
+    navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
+    navigateFallbackRegexesIncludeParameters: true,
     cacheId: `gatsby-plugin-offline`,
     // Don't cache-bust JS files and anything in the static directory
     dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,
@@ -95,20 +96,5 @@ exports.onPostBuild = (args, pluginOptions) => {
   }
 
   const combinedOptions = _.defaults(pluginOptions, options)
-
-  return precache.write(`public/sw.js`, combinedOptions).then(() =>
-    // Patch sw.js to include search queries when matching URLs against navigateFallbackWhitelist
-    replace({
-      files: `public/sw.js`,
-      from: `path = (new URL(absoluteUrlString)).pathname`,
-      to: `url = new URL(absoluteUrlString), path = url.pathname + url.search`,
-    }).then(changes => {
-      // Check that the patch has been applied correctly
-      if (changes.length !== 1)
-        throw new Error(
-          `Patching sw.js failed - sw-precache has probably been modified upstream.\n` +
-            `Please report this issue at https://github.com/gatsbyjs/gatsby/issues`
-        )
-    })
-  )
+  return precache.write(`public/sw.js`, combinedOptions)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13017,14 +13017,6 @@ replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-replace-in-file@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-3.4.2.tgz#6d40f076ac86948e28efeb6fab73fbad5c0bfa2a"
-  dependencies:
-    chalk "^2.4.1"
-    glob "^7.1.2"
-    yargs "^12.0.1"
-
 request-promise-core@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,9 +877,9 @@
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-"@davidbailey00/sw-precache@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@davidbailey00/sw-precache/-/sw-precache-5.3.0.tgz#e444636624d6a794f389d1a17f4d8099e60aa262"
+"@davidbailey00/sw-precache@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@davidbailey00/sw-precache/-/sw-precache-5.3.1.tgz#b2c89abae4dc28c26e1e8f58f00f1cc76b4b0001"
   dependencies:
     dom-urls "^1.1.0"
     es6-promise "^4.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,21 @@
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
+"@davidbailey00/sw-precache@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@davidbailey00/sw-precache/-/sw-precache-5.3.0.tgz#e444636624d6a794f389d1a17f4d8099e60aa262"
+  dependencies:
+    dom-urls "^1.1.0"
+    es6-promise "^4.0.5"
+    glob "^7.1.1"
+    lodash.defaults "^4.2.0"
+    lodash.template "^4.4.0"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    pretty-bytes "^4.0.2"
+    sw-toolbox "^3.4.0"
+    update-notifier "^2.3.0"
+
 "@lerna/add@^3.0.0-rc.0":
   version "3.0.0-rc.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.0.0-rc.0.tgz#a2963cecda704b0030601c1db2aee3a579d3af74"
@@ -14411,21 +14426,6 @@ svgo@^1.0.0:
     stable "~0.1.6"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-sw-precache@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/sw-precache/-/sw-precache-5.2.1.tgz#06134f319eec68f3b9583ce9a7036b1c119f7179"
-  dependencies:
-    dom-urls "^1.1.0"
-    es6-promise "^4.0.5"
-    glob "^7.1.1"
-    lodash.defaults "^4.2.0"
-    lodash.template "^4.4.0"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    pretty-bytes "^4.0.2"
-    sw-toolbox "^3.4.0"
-    update-notifier "^2.3.0"
 
 sw-toolbox@^3.4.0:
   version "3.6.0"


### PR DESCRIPTION
PR #7605 also fixes the same issue, as well as upgrading to Workbox.
I've left this PR open because it might take less time to review than #7605, in case the bug needs to be fixed urgently - I thought it's quite a nasty bug since SWs fail to install entirely on most non-Chromium-based browsers.

---

In #7355 I used regex lookbehind, which I thought works in every modern browser but later realised it only works in Chrome at the moment, since it's an ES2018 feature. This is breaking the SW entirely on most other browsers.

This PR uses my fork of sw-precache which supports more options, so we no longer need to use a lookbehind regex, or patch the output file.

~~In #7547 I suggested creating an official Gatsby fork of this package, since Google has abandoned it and having it as part of Gatsby would allow other contributors to write fixes easily. If this is thought to be a good idea, all that needs to happen is a fork from [my repo](https://github.com/davidbailey00/sw-precache) to gatsby-sw-precache and a few changes to `package.json` - I've already added all the copyright notices. If not, I'll just change Gatsby in those copyright notices to my name.~~

~~Inkteam - please let me know your thoughts regarding a fork of sw-precache! I can't really think of another way of getting gatsby-plugin-offline to work nicely, but maybe there's something better which I haven't thought of.~~

We'll use my forked version for now, but migrate to Workbox in the future.

Fixes #7547.

- [X] manual testing complete (as with #7355)