### PR TITLE
V2 migration docs : Add snippet on tracking page views with new router

### DIFF
--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -569,6 +569,9 @@ import { Provider } from 'react-redux'
 ### Browser API `replaceHistory` was removed
 
 Similar to `replaceRouterComponent`, we no longer support custom histories so this was removed.
+The `replaceHistory()` method could be used for tracking page views as it is possible to register listeners on route changes using `history.listen()`.
+
+In order to track page views, you can use the [`onRouteUpdate`](/docs/browser-apis/#onRouteUpdate) API to track pages changes.
 
 ### Browser API `wrapRootComponent` was replaced with `wrapRootElement`
 

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -49,6 +49,14 @@ exports.onRouteUpdateDelayed = true
  * @example
  * exports.onRouteUpdate = ({ location }) => {
  *   console.log('new pathname', location.pathname)
+ *
+ *   // Track pageview with google analytics
+ *   window.ga(
+ *     `set`,
+ *     `page`,
+ *     location.pathname + location.search + location.hash,
+ *   )
+ *   window.ga(`send`, `pageview`)
  * }
  */
 exports.onRouteUpdate = true


### PR DESCRIPTION
When migrating to gatsby v2, I struggled a bit with the replaceHistory() removal, I used to rely on it to create an history instance and register a listener to track page views.

I tried using the https://reach.tech/router/api/createHistory api and history.listen(), it works partially as it only track browser changes (back/forward button).
I ended up on https://github.com/reach/router/issues/43#issuecomment-395492569 and it worked.

There are maybe simpler alternatives, but I haven't found them.
Also the snippet is maybe not necessary, we could just give the link to https://github.com/reach/router/issues/43#issuecomment-395492569, but the snippet there is "pseudo-code", it doesn't work out of the box.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
