### PR TITLE
fix icon path in tutorial

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -99,7 +99,7 @@ npm install --save gatsby-plugin-manifest
         background_color: "#6b37bf",
         theme_color: "#6b37bf",
         display: "minimal-ui",
-        icon: "src/images/icon.png", // This path is relative to the root of the site.
+        icon: "src/images/gatsby-icon.png", // This path is relative to the root of the site.
       },
     },
   ]


### PR DESCRIPTION
The code copied from the tutorial would cause an error:

```
Error: icon (src/images/icon.png) does not exist as defined in gatsby-config.js. Make sure the file exists relative to the root of the site.
```

This fixes it :D

The correct icon name can be seen here: https://github.com/gatsbyjs/gatsby-starter-default/tree/v2/src/images