### PR TITLE
Don't add a forward slash to page path twice

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -52,8 +52,6 @@ const getPage = path => pagesObjectMap.get(path)
 const createElement = React.createElement
 
 export default (pagePath, callback) => {
-  const pathPrefix = __PATH_PREFIX__ ? `${__PATH_PREFIX__}/` : ""
-
   let bodyHtml = ``
   let headComponents = []
   let htmlAttributes = {}
@@ -152,11 +150,11 @@ export default (pagePath, callback) => {
   }
   const routerElement = createElement(
     ServerLocation,
-    { url: `${pathPrefix}${pagePath}` },
+    { url: `${__PATH_PREFIX__}/${pagePath}` },
     createElement(
       Router,
       {
-        baseuri: pathPrefix.slice(0, -1),
+        baseuri: `${__PATH_PREFIX__}/`,
       },
       createElement(RouteHandler, { path: `/*` })
     )
@@ -247,7 +245,7 @@ export default (pagePath, callback) => {
     bodyHtml,
     scripts,
     styles,
-    pathPrefix,
+    pathPrefix: __PATH_PREFIX__,
   })
 
   scripts
@@ -260,13 +258,13 @@ export default (pagePath, callback) => {
           as="script"
           rel={script.rel}
           key={script.name}
-          href={urlJoin(pathPrefix, script.name)}
+          href={urlJoin(__PATH_PREFIX__, script.name)}
         />
       )
     })
 
   if (page.jsonName in dataPaths) {
-    const dataPath = `${pathPrefix}static/d/${dataPaths[page.jsonName]}.json`
+    const dataPath = `${__PATH_PREFIX__}/static/d/${dataPaths[page.jsonName]}.json`
     headComponents.push(
       <link
         rel="preload"
@@ -291,13 +289,13 @@ export default (pagePath, callback) => {
             as="style"
             rel={style.rel}
             key={style.name}
-            href={urlJoin(pathPrefix, style.name)}
+            href={urlJoin(__PATH_PREFIX__, style.name)}
           />
         )
       } else {
         headComponents.unshift(
           <style
-            data-href={urlJoin(pathPrefix, style.name)}
+            data-href={urlJoin(__PATH_PREFIX__, style.name)}
             dangerouslySetInnerHTML={{
               __html: fs.readFileSync(
                 join(process.cwd(), `public`, style.name),
@@ -338,7 +336,7 @@ export default (pagePath, callback) => {
   // Filter out prefetched bundles as adding them as a script tag
   // would force high priority fetching.
   const bodyScripts = scripts.filter(s => s.rel !== `prefetch`).map(s => {
-    const scriptPath = `${pathPrefix}${JSON.stringify(s.name).slice(1, -1)}`
+    const scriptPath = `${__PATH_PREFIX__}/${JSON.stringify(s.name).slice(1, -1)}`
     return <script key={scriptPath} src={scriptPath} async />
   })
 

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -40,13 +40,6 @@ try {
 
 Html = Html && Html.__esModule ? Html.default : Html
 
-function urlJoin(...parts) {
-  return parts.reduce((r, next) => {
-    const segment = next == null ? `` : String(next).replace(/^\/+/, ``)
-    return segment ? `${r.replace(/\/$/, ``)}/${segment}` : r
-  }, ``)
-}
-
 const getPage = path => pagesObjectMap.get(path)
 
 const createElement = React.createElement
@@ -148,13 +141,14 @@ export default (pagePath, callback) => {
       return wrappedPage
     }
   }
+
   const routerElement = createElement(
     ServerLocation,
-    { url: `${__PATH_PREFIX__}/${pagePath}` },
+    { url: `${__PATH_PREFIX__}${pagePath}` },
     createElement(
       Router,
       {
-        baseuri: `${__PATH_PREFIX__}/`,
+        baseuri: `${__PATH_PREFIX__}`,
       },
       createElement(RouteHandler, { path: `/*` })
     )
@@ -258,7 +252,7 @@ export default (pagePath, callback) => {
           as="script"
           rel={script.rel}
           key={script.name}
-          href={urlJoin(__PATH_PREFIX__, script.name)}
+          href={`${__PATH_PREFIX__}/${script.name}`}
         />
       )
     })
@@ -289,13 +283,13 @@ export default (pagePath, callback) => {
             as="style"
             rel={style.rel}
             key={style.name}
-            href={urlJoin(__PATH_PREFIX__, style.name)}
+            href={`${__PATH_PREFIX__}/${style.name}`}
           />
         )
       } else {
         headComponents.unshift(
           <style
-            data-href={urlJoin(__PATH_PREFIX__, style.name)}
+            data-href={`${__PATH_PREFIX__}/${style.name}`}
             dangerouslySetInnerHTML={{
               __html: fs.readFileSync(
                 join(process.cwd(), `public`, style.name),

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -52,7 +52,7 @@ const getPage = path => pagesObjectMap.get(path)
 const createElement = React.createElement
 
 export default (pagePath, callback) => {
-  const pathPrefix = `${__PATH_PREFIX__}/`
+  const pathPrefix = __PATH_PREFIX__ ? `${__PATH_PREFIX__}/` : ""
 
   let bodyHtml = ``
   let headComponents = []
@@ -150,7 +150,6 @@ export default (pagePath, callback) => {
       return wrappedPage
     }
   }
-
   const routerElement = createElement(
     ServerLocation,
     { url: `${pathPrefix}${pagePath}` },


### PR DESCRIPTION
Hi folks. Here's a fix for #7528. We simply need to omit adding any slashes if a __PREFIX_PATH__ is empty.