### PR TITLE
Update README.md

### DIFF
--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -8,7 +8,7 @@ Plugin for connecting arbitrary GraphQL APIs to Gatsby GraphQL. Remote schemas a
 
 ## Install
 
-`npm install --save gatsby-source-graphql`
+`npm install --save gatsby-source-graphql@next`
 
 ## How to use
 


### PR DESCRIPTION
I spent 1 hour last night trying to figure out what is wrong with the plugin and it turned out that `latest` version was the old version that fails silently without creating the Graphql node.
for now, people should use the `@next` version.
