### PR TITLE
[v2] [gatsby-plugin-offline] Migrate to Workbox from sw-precache

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -29,13 +29,8 @@ and AppCache setup by changing these options so tread carefully.
 
 ```javascript
 const options = {
-  globPatterns: files.concat([
-    `${rootDir}/index.html`,
-    `${rootDir}/manifest.json`,
-    `${rootDir}/manifest.webmanifest`,
-    `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
-    ...criticalFilePaths,
-  ]),
+  globDirectory: rootDir,
+  globPatterns,
   modifyUrlPrefix: {
     rootDir: ``,
     // If `pathPrefix` is configured by user, we should replace

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -59,5 +59,6 @@ const options = {
     },
   ],
   skipWaiting: true,
+  clientsClaim: true,
 }
 ```

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -29,19 +29,19 @@ and AppCache setup by changing these options so tread carefully.
 
 ```javascript
 const options = {
-  staticFileGlobs: files.concat([
+  globPatterns: files.concat([
     `${rootDir}/index.html`,
     `${rootDir}/manifest.json`,
     `${rootDir}/manifest.webmanifest`,
     `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
     ...criticalFilePaths,
   ]),
-  stripPrefix: rootDir,
-  // If `pathPrefix` is configured by user, we should replace
-  // the `public` prefix with `pathPrefix`.
-  // See more at:
-  // https://github.com/GoogleChrome/sw-precache#replaceprefix-string
-  replacePrefix: args.pathPrefix || ``,
+  modifyUrlPrefix: {
+    rootDir: ``,
+    // If `pathPrefix` is configured by user, we should replace
+    // the default prefix with `pathPrefix`.
+    "": args.pathPrefix || ``,
+  },
   navigateFallback: `/offline-plugin-app-shell-fallback/index.html`,
   // Only match URLs without extensions or the query `no-cache=1`.
   // So example.com/about/ will pass but
@@ -51,7 +51,8 @@ const options = {
   // URLs and not any files hosted on the site.
   //
   // Regex based on http://stackoverflow.com/a/18017805
-  navigateFallbackWhitelist: [/^.*([^.]{5}|.html)(?<!(\?|&)no-cache=1)$/],
+  navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
+  navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
   cacheId: `gatsby-plugin-offline`,
   // Don't cache-bust JS files and anything in the static directory
   dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,
@@ -59,7 +60,7 @@ const options = {
     {
       // Add runtime caching of various page resources.
       urlPattern: /\.(?:png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
-      handler: `fastest`,
+      handler: `staleWhileRevalidate`,
     },
   ],
   skipWaiting: true,

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -10,8 +10,7 @@
     "@babel/runtime": "7.0.0-beta.52",
     "cheerio": "^1.0.0-rc.2",
     "lodash": "^4.17.10",
-    "replace-in-file": "^3.4.2",
-    "sw-precache": "^5.2.1"
+    "workbox-build": "^3.4.1"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",

--- a/packages/gatsby-plugin-offline/src/__tests__/__snapshots__/get-resources-from-html.js.snap
+++ b/packages/gatsby-plugin-offline/src/__tests__/__snapshots__/get-resources-from-html.js.snap
@@ -2,18 +2,17 @@
 
 exports[`it extracts resources correctly 1`] = `
 Array [
-  "public/subfont/Inter_UI-400-333b8a8461.woff2",
-  "public/subfont/Canela-700-31ab7904d2.woff2",
-  "public/subfont/Canela-100-9a69ad19fe.woff2",
-  "public/subfont/Inter_UI-700-ed1e3f47cc.woff2",
-  "public/component---src-templates-page-js-32d4e861f265f4be46c4.js",
-  "public/app-4844abca0ccadef0d7f2.js",
-  "public/0-797a6e0c48926cc31252.js",
-  "public/2-d5375578f42dcd4bd7f2.js",
-  "public/4-fa29748992ddbba69dcd.js",
-  "public/1-48ed4ae6be7383859823.js",
-  "public/webpack-runtime-9f60bdb9348d2dc6ea90.js",
-  "public/static/d/622/path---index-6a9-bWm2zMuppzsmi10MGyNADBwfUpw.json",
-  "https://cdn.ravenjs.com/3.25.2/raven.min.js",
+  "subfont/Inter_UI-400-333b8a8461.woff2",
+  "subfont/Canela-700-31ab7904d2.woff2",
+  "subfont/Canela-100-9a69ad19fe.woff2",
+  "subfont/Inter_UI-700-ed1e3f47cc.woff2",
+  "component---src-templates-page-js-32d4e861f265f4be46c4.js",
+  "app-4844abca0ccadef0d7f2.js",
+  "0-797a6e0c48926cc31252.js",
+  "2-d5375578f42dcd4bd7f2.js",
+  "4-fa29748992ddbba69dcd.js",
+  "1-48ed4ae6be7383859823.js",
+  "webpack-runtime-9f60bdb9348d2dc6ea90.js",
+  "static/d/622/path---index-6a9-bWm2zMuppzsmi10MGyNADBwfUpw.json",
 ]
 `;

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -57,11 +57,12 @@ exports.onPostBuild = (args, pluginOptions) => {
   )
 
   const options = {
+    globDirectory: rootDir,
     globPatterns: files.concat([
-      `${rootDir}/index.html`,
-      `${rootDir}/manifest.json`,
-      `${rootDir}/manifest.webmanifest`,
-      `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
+      `/index.html`,
+      `/manifest.json`,
+      `/manifest.webmanifest`,
+      `/offline-plugin-app-shell-fallback/index.html`,
       ...criticalFilePaths,
     ]),
     modifyUrlPrefix: {
@@ -93,6 +94,11 @@ exports.onPostBuild = (args, pluginOptions) => {
     ],
     skipWaiting: true,
   }
+
+  // pluginOptions.plugins is assigned automatically when the user hasn't
+  // specified custom options - Workbox throws an error with unsupported
+  // parameters, so delete it
+  delete pluginOptions.plugins
 
   const combinedOptions = _.defaults(pluginOptions, options)
   return workboxBuild.generateSW({ swDest: `public/sw.js`, ...combinedOptions })

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -97,6 +97,7 @@ exports.onPostBuild = (args, pluginOptions) => {
       },
     ],
     skipWaiting: true,
+    clientsClaim: true,
   }
 
   // pluginOptions.plugins is assigned automatically when the user hasn't

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -1,9 +1,8 @@
 const fs = require(`fs`)
-const precache = require(`sw-precache`)
+const workboxBuild = require(`workbox-build`)
 const path = require(`path`)
 const slash = require(`slash`)
 const _ = require(`lodash`)
-const replace = require(`replace-in-file`)
 
 const getResourcesFromHTML = require(`./get-resources-from-html`)
 
@@ -58,19 +57,19 @@ exports.onPostBuild = (args, pluginOptions) => {
   )
 
   const options = {
-    staticFileGlobs: files.concat([
+    globPatterns: files.concat([
       `${rootDir}/index.html`,
       `${rootDir}/manifest.json`,
       `${rootDir}/manifest.webmanifest`,
       `${rootDir}/offline-plugin-app-shell-fallback/index.html`,
       ...criticalFilePaths,
     ]),
-    stripPrefix: rootDir,
-    // If `pathPrefix` is configured by user, we should replace
-    // the `public` prefix with `pathPrefix`.
-    // See more at:
-    // https://github.com/GoogleChrome/sw-precache#replaceprefix-string
-    replacePrefix: args.pathPrefix || ``,
+    modifyUrlPrefix: {
+      rootDir: ``,
+      // If `pathPrefix` is configured by user, we should replace
+      // the default prefix with `pathPrefix`.
+      "": args.pathPrefix || ``,
+    },
     navigateFallback: `/offline-plugin-app-shell-fallback/index.html`,
     // Only match URLs without extensions or the query `no-cache=1`.
     // So example.com/about/ will pass but
@@ -80,7 +79,8 @@ exports.onPostBuild = (args, pluginOptions) => {
     // URLs and not any files hosted on the site.
     //
     // Regex based on http://stackoverflow.com/a/18017805
-    navigateFallbackWhitelist: [/^.*([^.]{5}|.html)(?<!(\?|&)no-cache=1)$/],
+    navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
+    navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
     cacheId: `gatsby-plugin-offline`,
     // Don't cache-bust JS files and anything in the static directory
     dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,
@@ -88,27 +88,12 @@ exports.onPostBuild = (args, pluginOptions) => {
       {
         // Add runtime caching of various page resources.
         urlPattern: /\.(?:png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
-        handler: `fastest`,
+        handler: `staleWhileRevalidate`,
       },
     ],
     skipWaiting: true,
   }
 
   const combinedOptions = _.defaults(pluginOptions, options)
-
-  return precache.write(`public/sw.js`, combinedOptions).then(() =>
-    // Patch sw.js to include search queries when matching URLs against navigateFallbackWhitelist
-    replace({
-      files: `public/sw.js`,
-      from: `path = (new URL(absoluteUrlString)).pathname`,
-      to: `url = new URL(absoluteUrlString), path = url.pathname + url.search`,
-    }).then(changes => {
-      // Check that the patch has been applied correctly
-      if (changes.length !== 1)
-        throw new Error(
-          `Patching sw.js failed - sw-precache has probably been modified upstream.\n` +
-            `Please report this issue at https://github.com/gatsbyjs/gatsby/issues`
-        )
-    })
-  )
+  return workboxBuild.write({ swDest: `public/sw.js`, ...combinedOptions })
 }

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -95,5 +95,5 @@ exports.onPostBuild = (args, pluginOptions) => {
   }
 
   const combinedOptions = _.defaults(pluginOptions, options)
-  return workboxBuild.write({ swDest: `public/sw.js`, ...combinedOptions })
+  return workboxBuild.generateSW({ swDest: `public/sw.js`, ...combinedOptions })
 }

--- a/packages/gatsby-plugin-offline/src/get-resources-from-html.js
+++ b/packages/gatsby-plugin-offline/src/get-resources-from-html.js
@@ -37,15 +37,12 @@ module.exports = htmlPath => {
     const $elem = $(elem)
     const url =
       $elem.attr(`src`) || $elem.attr(`href`) || $elem.attr(`data-href`)
-    const blackListRegex = /\.xml$/
+
+    // Don't cache XML files, or external resources (beginning with // or http)
+    const blackListRegex = /(\.xml$|^\/\/|^http)/
 
     if (!blackListRegex.test(url)) {
-      let path = url
-      if (url.substr(0, 4) !== `http`) {
-        path = `public${url}`
-      }
-
-      criticalFilePaths.push(path)
+      criticalFilePaths.push(url)
     }
   })
 

--- a/packages/gatsby-plugin-offline/src/get-resources-from-html.js
+++ b/packages/gatsby-plugin-offline/src/get-resources-from-html.js
@@ -42,7 +42,7 @@ module.exports = htmlPath => {
     const blackListRegex = /(\.xml$|^\/\/|^http)/
 
     if (!blackListRegex.test(url)) {
-      criticalFilePaths.push(url)
+      criticalFilePaths.push(url.replace(/^\//, ``))
     }
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5449,12 +5449,6 @@ dom-testing-library@^3.1.0:
     pretty-format "^22.4.3"
     wait-for-expect "^0.4.0"
 
-dom-urls@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/dom-urls/-/dom-urls-1.1.0.tgz#001ddf81628cd1e706125c7176f53ccec55d918e"
-  dependencies:
-    urijs "^1.16.1"
-
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -5798,7 +5792,7 @@ es6-promise@^3.0.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
 
-es6-promise@^4.0.5, es6-promise@^4.1.0:
+es6-promise@^4.1.0:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
@@ -9064,6 +9058,14 @@ joi@12.x.x:
     isemail "3.x.x"
     topo "2.x.x"
 
+joi@^11.1.1:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-11.4.0.tgz#f674897537b625e9ac3d0b7e1604c828ad913ccb"
+  dependencies:
+    hoek "4.x.x"
+    isemail "3.x.x"
+    topo "2.x.x"
+
 jpeg-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.2.0.tgz#53e448ec9d263e683266467e9442d2c5a2ef5482"
@@ -9622,10 +9624,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
-lodash.defaults@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-
 lodash.escape@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698"
@@ -10091,7 +10089,7 @@ memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
 
-meow@^3.1.0, meow@^3.3.0, meow@^3.5.0, meow@^3.7.0:
+meow@^3.1.0, meow@^3.3.0, meow@^3.5.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -11474,12 +11472,6 @@ path-root@^0.1.1:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-
-path-to-regexp@^1.0.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -13017,14 +13009,6 @@ replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-replace-in-file@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-3.4.2.tgz#6d40f076ac86948e28efeb6fab73fbad5c0bfa2a"
-  dependencies:
-    chalk "^2.4.1"
-    glob "^7.1.2"
-    yargs "^12.0.1"
-
 request-promise-core@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
@@ -13532,10 +13516,6 @@ serve-static@1.13.2:
     escape-html "~1.0.3"
     parseurl "~1.3.2"
     send "0.16.2"
-
-serviceworker-cache-polyfill@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz#de19ee73bef21ab3c0740a37b33db62464babdeb"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -14420,28 +14400,6 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-sw-precache@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/sw-precache/-/sw-precache-5.2.1.tgz#06134f319eec68f3b9583ce9a7036b1c119f7179"
-  dependencies:
-    dom-urls "^1.1.0"
-    es6-promise "^4.0.5"
-    glob "^7.1.1"
-    lodash.defaults "^4.2.0"
-    lodash.template "^4.4.0"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    pretty-bytes "^4.0.2"
-    sw-toolbox "^3.4.0"
-    update-notifier "^2.3.0"
-
-sw-toolbox@^3.4.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/sw-toolbox/-/sw-toolbox-3.6.0.tgz#26df1d1c70348658e4dea2884319149b7b3183b5"
-  dependencies:
-    path-to-regexp "^1.0.1"
-    serviceworker-cache-polyfill "^4.0.0"
-
 swap-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-1.1.2.tgz#c39203a4587385fad3c850a0bd1bcafa081974e3"
@@ -15207,7 +15165,7 @@ uri-js@^4.2.1:
   dependencies:
     punycode "^2.1.0"
 
-urijs@^1.16.1, urijs@^1.19.0:
+urijs@^1.19.0:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"
 
@@ -15868,6 +15826,108 @@ wordwrap@~0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+workbox-background-sync@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-3.4.1.tgz#6957a0ff622ee08b7af958d561cf2d4821edb640"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-broadcast-cache-update@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.4.1.tgz#9861cd2b6d874d41be26a34bc5bdd7a794d3badf"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-build@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-3.4.1.tgz#65af4c81b05dac6a1819c88b8a2a944ddf5cec04"
+  dependencies:
+    babel-runtime "^6.26.0"
+    common-tags "^1.4.0"
+    fs-extra "^4.0.2"
+    glob "^7.1.2"
+    joi "^11.1.1"
+    lodash.template "^4.4.0"
+    pretty-bytes "^4.0.2"
+    workbox-background-sync "^3.4.1"
+    workbox-broadcast-cache-update "^3.4.1"
+    workbox-cache-expiration "^3.4.1"
+    workbox-cacheable-response "^3.4.1"
+    workbox-core "^3.4.1"
+    workbox-google-analytics "^3.4.1"
+    workbox-navigation-preload "^3.4.1"
+    workbox-precaching "^3.4.1"
+    workbox-range-requests "^3.4.1"
+    workbox-routing "^3.4.1"
+    workbox-strategies "^3.4.1"
+    workbox-streams "^3.4.1"
+    workbox-sw "^3.4.1"
+
+workbox-cache-expiration@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-cache-expiration/-/workbox-cache-expiration-3.4.1.tgz#6c92317ca43be7e3030662ffbb3fd413c1689f18"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-cacheable-response@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-3.4.1.tgz#5517b4d5a86c2ad5d48000109335c5af23f47e40"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-core@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-3.4.1.tgz#dd6d8ad7398a0e6224c04b079841045af0c62e1f"
+
+workbox-google-analytics@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-3.4.1.tgz#98f407b7d157be68087e0f3edb432cba291fd614"
+  dependencies:
+    workbox-background-sync "^3.4.1"
+    workbox-core "^3.4.1"
+    workbox-routing "^3.4.1"
+    workbox-strategies "^3.4.1"
+
+workbox-navigation-preload@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-3.4.1.tgz#d3eb75239cc4eed9314b25e233da2ba282dcc84d"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-precaching@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-3.4.1.tgz#2d4a3f6ae8d825e17ef51dddc51aae5ef2876fb5"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-range-requests@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-3.4.1.tgz#098474efecce49148ba925c75753e0ac96a8dd9a"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-routing@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-3.4.1.tgz#c5ac213480869da29a91a88db57b679ba7ddf58a"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-strategies@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-3.4.1.tgz#96f7947a9611ea599fcb71d44a5abab503fbe288"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-streams@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-3.4.1.tgz#b639843431ea38825909a557e54108fdc469f0eb"
+  dependencies:
+    workbox-core "^3.4.1"
+
+workbox-sw@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-3.4.1.tgz#7b51fc14c44b4e880c369f97681472cf6e117113"
 
 worker-farm@^1.5.2:
   version "1.6.0"


### PR DESCRIPTION
Changelog:

- Packages `sw-precache` and `replace-in-file` are removed, and `workbox-build` is installed
- `getAssetsForChunks` is modified:
  - To return a dense array (i.e. no `undefined` items, which was happening previously)
  - To not return items as `public/...` since this is now handled by `globDirectory`
- Workbox is more strict about invalid globs (it precaches **nothing**, if **any** glob doesn't match a file) so we check if each manifest exists before adding it
- Options updated to match the different names in Workbox
- Changes from #7569 are applied (using `navigateFallbackBlacklist` instead of all-in-one) to prevent needing lookbehinds in regexes (which aren't supported in many JS engines yet)
- `pluginOptions.plugins` is deleted since this is added by default (with the value `[]`), without options specified in the user's `gatsby-config.js` - Workbox throws an error given invalid options so we need to do this
- The function call to generate the service worker is updated, and a then-block added to display information
  - This info was displayed automatically by `sw-precache` but now we need to explicitly output it
- `get-resources-from-html.js` is updated to only return local files (since the SW can't precache external files) and output without the `public` prefix (again, now handled by `globDirectory`)
- The README is updated to match the latest config

Closes #7569, closes #7547.
I've left #7569 open because it might take less time to review than this PR, in case #7547 needs to be fixed urgently - I thought it's quite a nasty bug since SWs fail to install entirely on most non-Chromium-based browsers.

<details>
<summary>Manual tests (dropdown)</summary>

```
configurations:

- 1) online without gatsby-plugin-offline
- 2) online with gatsby-plugin-offline
- 3) offline with gatsby-plugin-offline
- 4) online in develop

- x.1) with a custom 404 page
- x.2) without a custom 404 page


tests:

- 1) 404s are handled correctly from internal links - custom 404 or server 404
  if custom is unavailable, or offline error, but no blank pages

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 2) 404s are handled correctly when entering a URL directly - as above

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 3) back button works properly after 404 (navigates to the expected page)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 4) pages which fail to load display a native offline error (no blank pages)

  requires: [3.1, 3.2]
  passed:   [3.1, 3.2]

- 5) the service worker remains installed after a 404/offline error

  requires: [3.1, 3.2]
  passed:   [3.1, 3.2]

- 6) Netlify CMS /admin/ loads or displays an offline error (no 404/blank page)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 7) going to a page by entering the URL directly works

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.1]
```

Note: I've only retested configurations 2.x and 3.x since #7355, since gatsby-plugin-offline doesn't affect configurations 1 and 4.
</details>