### PR TITLE
add key prop in gatsby-image component

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -231,6 +231,7 @@ class Image extends React.Component {
             // Let users set component to be absolutely positioned.
             position: style.position === `absolute` ? `initial` : `relative`,
           }}
+          key={image.src}
         >
           <Tag
             className={`${className ? className : ``} gatsby-image-wrapper`}
@@ -345,6 +346,7 @@ class Image extends React.Component {
             // Let users set component to be absolutely positioned.
             position: style.position === `absolute` ? `initial` : `relative`,
           }}
+          key={image.src}
         >
           <Tag
             className={`${className ? className : ``} gatsby-image-wrapper`}


### PR DESCRIPTION
issue: https://github.com/gatsbyjs/gatsby/issues/7585

## why&what
it'd be better off giving `key` prop to each of react component so as to re-render them correctly. 
since `gatsby-image` does not have `key` prop in its most outer element, this PR complements that point.

## how
- component has two rendering types; `fluid` and `fixed`
- in both of those cases, the props should have `src`
  - https://github.com/gatsbyjs/gatsby/blob/88fb893/packages/gatsby-image/src/index.js#L436
  - https://github.com/gatsbyjs/gatsby/blob/88fb893/packages/gatsby-image/src/index.js#L446
- utilize the `src` prop as `key`of `gatsby-image` component