### PR TITLE
[v2] Fix Gatsbygram Cypress tests

### DIFF
--- a/examples/gatsbygram/cypress/integration/home_page_spec.js
+++ b/examples/gatsbygram/cypress/integration/home_page_spec.js
@@ -65,7 +65,7 @@ describe(`The Home Page`, () => {
       const post1 = postsData[0]
       const post2 = postsData[1]
       // wait for page to initialize
-      cy.wait(500)
+      cy.wait(200)
       // open first post
       cy.getTestElement(`post`)
         .first()
@@ -74,6 +74,8 @@ describe(`The Home Page`, () => {
       // click right arrow icon to go to 2nd post
       cy.getTestElement(`next-post`).click()
       cy.url().should("contain", post2.id)
+      // wait for page to transition
+      cy.wait(200)
       // press left arrow to go back to 1st post
       cy.getTestElement(`previous-post`).click()
       cy.url().should("contain", post1.id)
@@ -87,7 +89,7 @@ describe(`The Home Page`, () => {
       const post1 = postsData[0]
       const post2 = postsData[1]
       // wait for page to initialize
-      cy.wait(500)
+      cy.wait(200)
       // open fist post
       cy.getTestElement(`post`)
         .first()
@@ -95,8 +97,8 @@ describe(`The Home Page`, () => {
         // the outer element causing Cypress to complain
         .click({ force: true })
       cy.url().should("contain", post1.id)
-      // wait for page to initialize
-      cy.wait(500)
+      // wait for page to transition
+      cy.wait(200)
       // press right arrow to go to 2nd post
       cy.get(`body`).type(`{rightarrow}`)
       cy.url().should("contain", post2.id)

--- a/examples/gatsbygram/cypress/integration/home_page_spec.js
+++ b/examples/gatsbygram/cypress/integration/home_page_spec.js
@@ -65,12 +65,10 @@ describe(`The Home Page`, () => {
       const post1 = postsData[0]
       const post2 = postsData[1]
       // wait for page to initialize
-      cy.wait(200)
+      cy.wait(500)
       // open first post
       cy.getTestElement(`post`)
         .first()
-        // find the first child, since it covers the parent
-        .find(`> div`)
         .click()
       cy.url().should("contain", post1.id)
       // click right arrow icon to go to 2nd post
@@ -89,16 +87,16 @@ describe(`The Home Page`, () => {
       const post1 = postsData[0]
       const post2 = postsData[1]
       // wait for page to initialize
-      cy.wait(200)
+      cy.wait(500)
       // open fist post
       cy.getTestElement(`post`)
         .first()
-        // find the first child, since it covers the parent
-        .find(`> div`)
-        .click()
+        // force, because sometimes the children cover
+        // the outer element causing Cypress to complain
+        .click({ force: true })
       cy.url().should("contain", post1.id)
       // wait for page to initialize
-      cy.wait(200)
+      cy.wait(500)
       // press right arrow to go to 2nd post
       cy.get(`body`).type(`{rightarrow}`)
       cy.url().should("contain", post2.id)

--- a/examples/gatsbygram/cypress/integration/home_page_spec.js
+++ b/examples/gatsbygram/cypress/integration/home_page_spec.js
@@ -65,10 +65,12 @@ describe(`The Home Page`, () => {
       const post1 = postsData[0]
       const post2 = postsData[1]
       // wait for page to initialize
-      cy.wait(100)
+      cy.wait(200)
       // open first post
       cy.getTestElement(`post`)
         .first()
+        // find the first child, since it covers the parent
+        .find(`> div`)
         .click()
       cy.url().should("contain", post1.id)
       // click right arrow icon to go to 2nd post
@@ -87,14 +89,16 @@ describe(`The Home Page`, () => {
       const post1 = postsData[0]
       const post2 = postsData[1]
       // wait for page to initialize
-      cy.wait(100)
+      cy.wait(200)
       // open fist post
       cy.getTestElement(`post`)
         .first()
+        // find the first child, since it covers the parent
+        .find(`> div`)
         .click()
       cy.url().should("contain", post1.id)
       // wait for page to initialize
-      cy.wait(100)
+      cy.wait(200)
       // press right arrow to go to 2nd post
       cy.get(`body`).type(`{rightarrow}`)
       cy.url().should("contain", post2.id)

--- a/examples/gatsbygram/cypress/integration/home_page_spec.js
+++ b/examples/gatsbygram/cypress/integration/home_page_spec.js
@@ -64,6 +64,8 @@ describe(`The Home Page`, () => {
     cy.fixture(`posts`).then(postsData => {
       const post1 = postsData[0]
       const post2 = postsData[1]
+      // wait for page to initialize
+      cy.wait(100)
       // open first post
       cy.getTestElement(`post`)
         .first()
@@ -84,11 +86,15 @@ describe(`The Home Page`, () => {
     cy.fixture(`posts`).then(postsData => {
       const post1 = postsData[0]
       const post2 = postsData[1]
+      // wait for page to initialize
+      cy.wait(100)
       // open fist post
       cy.getTestElement(`post`)
         .first()
         .click()
       cy.url().should("contain", post1.id)
+      // wait for page to initialize
+      cy.wait(100)
       // press right arrow to go to 2nd post
       cy.get(`body`).type(`{rightarrow}`)
       cy.url().should("contain", post2.id)

--- a/examples/gatsbygram/cypress/integration/home_page_spec.js
+++ b/examples/gatsbygram/cypress/integration/home_page_spec.js
@@ -102,6 +102,8 @@ describe(`The Home Page`, () => {
       // press right arrow to go to 2nd post
       cy.get(`body`).type(`{rightarrow}`)
       cy.url().should("contain", post2.id)
+      // wait for page to transition
+      cy.wait(200)
       // press left arrow to go back to 1st post
       cy.get(`body`).type(`{leftarrow}`)
       cy.url().should("contain", post1.id)


### PR DESCRIPTION
- Add delays to Cypress tests to wait until pages are ready after loading/clicking etc
- Force a click where Cypress previously threw an error due to one of its children covering it
  - Clicking its children produces the same result, but it's not predictable which one Cypress will detect in front since there are multiple