### PR TITLE
fix #7637: pathname starts with an extra '/'

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -52,7 +52,7 @@ const getPage = path => pagesObjectMap.get(path)
 const createElement = React.createElement
 
 export default (pagePath, callback) => {
-  const pathPrefix = `${__PATH_PREFIX__}/`
+  const pathPrefix = `${__PATH_PREFIX__}`
 
   let bodyHtml = ``
   let headComponents = []


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Fixes the **very specific** issue raised by #7637, but there are still larger questions about whether or not the PageRenderer should still re-evaluate and re-render the wrapped content.

N.B.: This fix works for me on macOS, but it's possible that the extra slash was added for a Windows-specific bug...  It's been there since before the v2 branch was merged into master.