### PR TITLE
Add mapping example for Markdown files

### DIFF
--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -10,15 +10,15 @@ _Note: There are many sample configs which may be helpful to reference in the di
 
 Options available to set within `gatsby-config.js` include:
 
-1.  siteMetadata (object)
-2.  plugins (array)
-3.  pathPrefix (string)
-4.  polyfill (boolean)
-5.  mapping (object)
-6.  proxy (object)
-7.  developMiddleware (function)
+1.  [siteMetadata](#siteMetadata) (object)
+2.  [plugins](#plugins) (array)
+3.  [pathPrefix](#pathPrefix) (string)
+4.  [polyfill](#polyfill) (boolean)
+5.  [mapping](#mapping-node-types) (object)
+6.  [proxy](#proxy) (object)
+7.  [developMiddleware](#advanced-proxying-with-developmiddleware) (function)
 
-## siteMetadata
+## siteMetadata ##
 
 When you want to reuse common pieces of data across the site (for example, your site title), you can store that data in `siteMetadata`:
 

--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -18,7 +18,7 @@ Options available to set within `gatsby-config.js` include:
 6.  [proxy](#proxy) (object)
 7.  [developMiddleware](#advanced-proxying-with-developmiddleware) (function)
 
-## siteMetadata ##
+## siteMetadata
 
 When you want to reuse common pieces of data across the site (for example, your site title), you can store that data in `siteMetadata`:
 
@@ -221,6 +221,30 @@ query {
   }
 }
 ```
+
+Mapping also works between Markdown files. For example, instead of having all authors in a YAML file, you could have info about each author in a separate Markdown file:
+
+```markdown
+---
+author_id: Kyle Mathews
+twitter: "@kylemathews"
+---
+
+Founder @ GatsbyJS. Likes tech, reading/writing, founding things. Blogs at bricolage.io.
+```
+
+And then add the following rule to your `gatsby-config.js`:
+
+```javascript
+module.exports = {
+  plugins: [...],
+  mapping: {
+    'MarkdownRemark.frontmatter.author': `MarkdownRemark.frontmatter.author_id`
+  },
+}
+```
+
+Similarly to YAML and JSON files, mapping between Markdown files can also be used to map an array of ids.
 
 ## Proxy
 


### PR DESCRIPTION
This PR adds info about using `mapping` to create mapping between Markdown files and links to individual sections in the file.

It could also be useful to add an example how to create nested associations, e.g. in my case I've got `events` that have many `talks` that have many `speakers` and it looks like Gatsby is handling it pretty well. However, then the whole section would probably need to be rewritten to create subsections about JSON/YAML mapping, Markdown mapping, arrays and nested associations.