### PR TITLE
Loading starter showcase #7391

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -44,10 +44,6 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-create-client-paths`,
-      options: { prefixes: [`/starter-showcase/*`] },
-    },
-    {
       resolve: `gatsby-plugin-typography`,
       options: {
         pathToConfigModule: `src/utils/typography`,

--- a/www/package.json
+++ b/www/package.json
@@ -11,7 +11,6 @@
     "gatsby-image": "next",
     "gatsby-plugin-canonical-urls": "next",
     "gatsby-plugin-catch-links": "next",
-    "gatsby-plugin-create-client-paths": "^1.0.8",
     "gatsby-plugin-feed": "next",
     "gatsby-plugin-fullstory": "^1.0.4-5",
     "gatsby-plugin-glamor": "next",


### PR DESCRIPTION
closes #7391 

- Removing the `create-client-paths` plugin use for the route renders `/starter-showcase/` as expected
- Removed the plugin dependency, not used elsewhere