### PR TITLE
[gatsby-transformer-sharp] Remove the width/maxWidth default values

### DIFF
--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -105,7 +105,6 @@ const fixedNodeType = ({
     args: {
       width: {
         type: GraphQLInt,
-        defaultValue: 400,
       },
       height: {
         type: GraphQLInt,
@@ -222,7 +221,6 @@ const fluidNodeType = ({
     args: {
       maxWidth: {
         type: GraphQLInt,
-        defaultValue: 800,
       },
       maxHeight: {
         type: GraphQLInt,
@@ -377,7 +375,6 @@ module.exports = ({
       args: {
         width: {
           type: GraphQLInt,
-          defaultValue: 400,
         },
         height: {
           type: GraphQLInt,


### PR DESCRIPTION
As of [this commit](https://github.com/gatsbyjs/gatsby/commit/7cda59b359f4281e67030c777a985c05c6943b92) gatsby-plugin-sharp can now calculate the image's width based on its height but for that the work the default values need to be removed.

I chose to simply remove the values since `gatsby-plugin-sharp` adds default values when both width and height aren't set (and the same goes for maxWidth/maxHeight).

Fixes: https://github.com/gatsbyjs/gatsby/issues/7663

Note: This depends on the changes in [this pr](https://github.com/gatsbyjs/gatsby/pull/7671) to work. Otherwise the width will be set to NaN and Sharp will throw an error.