### PR TITLE
Update descriptions about Gatsby as an SSG to better describe as both an SSG + PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   ⚛️ 📄 :rocket:
 </h3>
 <p align="center">
-  <strong>Blazing fast static site and PWA (Progressive Web App) generator for React</strong><br>
+  <strong>Blazing fast modern site generator for React</strong><br>
   Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby.
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   ⚛️ 📄 :rocket:
 </h3>
 <p align="center">
-  <strong>Blazing fast site generator for React</strong><br>
+  <strong>Blazing-fast static site and PWA (Progressive Web App) generator for React</strong><br>
   Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby.
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   ⚛️ 📄 :rocket:
 </h3>
 <p align="center">
-  <strong>Blazing-fast static site and PWA (Progressive Web App) generator for React</strong><br>
+  <strong>Blazing fast static site and PWA (Progressive Web App) generator for React</strong><br>
   Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby.
 </p>
 <p align="center">

--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -27,7 +27,7 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby`,
     siteUrl: `https://www.gatsbyjs.org`,
-    description: `Blazing-fast static site generator for React`,
+    description: `Blazing-fast static site and PWA (Progressive Web App) generator for React`,
   },
 }
 ```

--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -27,7 +27,7 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby`,
     siteUrl: `https://www.gatsbyjs.org`,
-    description: `Blazing fast static site and PWA (Progressive Web App) generator for React`,
+    description: `Blazing fast modern site generator for React`,
   },
 }
 ```

--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -27,7 +27,7 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby`,
     siteUrl: `https://www.gatsbyjs.org`,
-    description: `Blazing-fast static site and PWA (Progressive Web App) generator for React`,
+    description: `Blazing fast static site and PWA (Progressive Web App) generator for React`,
   },
 }
 ```

--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -13,7 +13,7 @@ to bridge this gap, providing a solid interface that works well for technical an
 users alike, and interacts with your static site repository via API so that every change results in
 a commit.
 
-A primary focus of Netlify CMS is to work well with static site generators like Gatsby. Installation
+A primary focus of Netlify CMS is to work well with modern site generators like Gatsby. Installation
 typically requires just an index.html file and a YAML configuration file, but we're going to
 leverage the Gatsby plugin for Netlify CMS to automatically install and build the CMS along with a
 static site.

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -343,7 +343,7 @@ The Gatsby `<Link />` component is for linking between pages within your site. F
 
 ## Deploying a Gatsby site
 
-Gatsby.js is a _static site generator_, which means there are no servers to setup or complicated databases to deploy. Instead, the Gatsby `build` command produces a directory of static HTML and JavaScript files which you can deploy to a static site hosting service.
+Gatsby.js is a _static site and PWA (Progressive Web App) generator_, which means there are no servers to setup or complicated databases to deploy. Instead, the Gatsby `build` command produces a directory of static HTML and JavaScript files which you can deploy to a static site hosting service.
 
 Let's try using [Surge](http://surge.sh/) for deploying your first Gatsby
 website. Surge is one of many "static site hosts" which make it possible to

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -343,7 +343,7 @@ The Gatsby `<Link />` component is for linking between pages within your site. F
 
 ## Deploying a Gatsby site
 
-Gatsby.js is a _static site and PWA (Progressive Web App) generator_, which means there are no servers to setup or complicated databases to deploy. Instead, the Gatsby `build` command produces a directory of static HTML and JavaScript files which you can deploy to a static site hosting service.
+Gatsby.js is a _modern site generator_, which means there are no servers to setup or complicated databases to deploy. Instead, the Gatsby `build` command produces a directory of static HTML and JavaScript files which you can deploy to a static site hosting service.
 
 Let's try using [Surge](http://surge.sh/) for deploying your first Gatsby
 website. Surge is one of many "static site hosts" which make it possible to

--- a/examples/using-csv/gatsby-config.js
+++ b/examples/using-csv/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-csv`,
-    description: `Blazing-fast React.js static site generator`,
+    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
   },
   plugins: [
     `gatsby-transformer-csv`,

--- a/examples/using-csv/gatsby-config.js
+++ b/examples/using-csv/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-csv`,
-    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast modern site generator for React`,
   },
   plugins: [
     `gatsby-transformer-csv`,

--- a/examples/using-csv/gatsby-config.js
+++ b/examples/using-csv/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-csv`,
-    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
   },
   plugins: [
     `gatsby-transformer-csv`,

--- a/examples/using-excel/gatsby-config.js
+++ b/examples/using-excel/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-excel`,
-    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
   },
   plugins: [
     `gatsby-transformer-excel`,

--- a/examples/using-excel/gatsby-config.js
+++ b/examples/using-excel/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-excel`,
-    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast modern site generator for React`,
   },
   plugins: [
     `gatsby-transformer-excel`,

--- a/examples/using-excel/gatsby-config.js
+++ b/examples/using-excel/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-excel`,
-    description: `Blazing-fast React.js static site generator`,
+    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
   },
   plugins: [
     `gatsby-transformer-excel`,

--- a/examples/using-hjson/gatsby-config.js
+++ b/examples/using-hjson/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-hjson`,
-    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast modern site generator for React`,
   },
   plugins: [
     `gatsby-transformer-hjson`,

--- a/examples/using-hjson/gatsby-config.js
+++ b/examples/using-hjson/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-hjson`,
-    description: `Blazing-fast React.js static site generator`,
+    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
   },
   plugins: [
     `gatsby-transformer-hjson`,

--- a/examples/using-hjson/gatsby-config.js
+++ b/examples/using-hjson/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-hjson`,
-    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
   },
   plugins: [
     `gatsby-transformer-hjson`,

--- a/examples/using-remark/gatsby-config.js
+++ b/examples/using-remark/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-remark`,
     author: `@gatsbyjs`,
-    description: `Blazing-fast React.js static site generator`,
+    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
     homepage: `https://www.gatsbyjs.org`,
   },
   mapping: {

--- a/examples/using-remark/gatsby-config.js
+++ b/examples/using-remark/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-remark`,
     author: `@gatsbyjs`,
-    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast modern site generator for React`,
     homepage: `https://www.gatsbyjs.org`,
   },
   mapping: {

--- a/examples/using-remark/gatsby-config.js
+++ b/examples/using-remark/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `gatsby-example-using-remark`,
     author: `@gatsbyjs`,
-    description: `Blazing-fast React.js static site and PWA (Progressive Web App) generator`,
+    description: `Blazing fast React.js static site and PWA (Progressive Web App) generator`,
     homepage: `https://www.gatsbyjs.org`,
   },
   mapping: {

--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -12,7 +12,7 @@ Create an RSS feed (or multiple feeds) for your Gatsby site.
 // In your gatsby-config.js
 siteMetadata: {
   title: `GatsbyJS`,
-  description: `A fantastic new static site generator.`,
+  description: `A fantastic new static site and PWA (Progressive Web App) generator.`,
   siteUrl: `https://www.gatsbyjs.org`
 },
 plugins: [

--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -12,7 +12,7 @@ Create an RSS feed (or multiple feeds) for your Gatsby site.
 // In your gatsby-config.js
 siteMetadata: {
   title: `GatsbyJS`,
-  description: `A fantastic new static site and PWA (Progressive Web App) generator.`,
+  description: `Blazing fast modern site generator for React`,
   siteUrl: `https://www.gatsbyjs.org`
 },
 plugins: [

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -11,7 +11,7 @@
   ⚛️ 📄 :rocket:
 </h3>
 <p align="center">
-  <strong>Blazing fast static site and PWA (Progressive Web App) generator for React</strong><br>
+  <strong>Blazing fast modern site generator for React</strong><br>
   Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby.
 </p>
 <p align="center">

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -11,7 +11,7 @@
   ⚛️ 📄 :rocket:
 </h3>
 <p align="center">
-  <strong>Blazing fast site generator for React</strong><br>
+  <strong>Blazing-fast static site and PWA (Progressive Web App) generator for React</strong><br>
   Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby.
 </p>
 <p align="center">

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -11,7 +11,7 @@
   ⚛️ 📄 :rocket:
 </h3>
 <p align="center">
-  <strong>Blazing-fast static site and PWA (Progressive Web App) generator for React</strong><br>
+  <strong>Blazing fast static site and PWA (Progressive Web App) generator for React</strong><br>
   Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby.
 </p>
 <p align="center">

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby",
-  "description": "React.js Static Site and PWA (Progressive Web App) Generator",
+  "description": "Blazing fast modern site generator for React",
   "version": "2.0.0-rc.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby",
-  "description": "React.js Static Site Generator",
+  "description": "React.js Static Site and PWA (Progressive Web App) Generator",
   "version": "2.0.0-rc.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {

--- a/packages/graphql-skip-limit/README.md
+++ b/packages/graphql-skip-limit/README.md
@@ -3,8 +3,8 @@
 This library provides helper functions for building Relay-style connections but
 with skip/limit style pagination instead of Relay's cursor-based pagination.
 
-It is built and maintained for the
-[React.js static site and PWA (Progressive Web App) generator Gatsby](https://github.com/gatsbyjs/gatsby) to
+It is built and maintained for 
+[React modern site generator Gatsby](https://github.com/gatsbyjs/gatsby) to
 drive its GraphQL-based data layer.
 
 It is a port from [graphql-relay](https://github.com/graphql/graphql-relay-js)

--- a/packages/graphql-skip-limit/README.md
+++ b/packages/graphql-skip-limit/README.md
@@ -4,7 +4,7 @@ This library provides helper functions for building Relay-style connections but
 with skip/limit style pagination instead of Relay's cursor-based pagination.
 
 It is built and maintained for the
-[React.js static site generator Gatsby](https://github.com/gatsbyjs/gatsby) to
+[React.js static site and PWA (Progressive Web App) generator Gatsby](https://github.com/gatsbyjs/gatsby) to
 drive its GraphQL-based data layer.
 
 It is a port from [graphql-relay](https://github.com/graphql/graphql-relay-js)

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby`,
     siteUrl: `https://www.gatsbyjs.org`,
-    description: `Blazing fast static site and PWA (Progressive Web App) generator for React`,
+    description: `Blazing fast modern site generator for React`,
   },
   mapping: {
     "MarkdownRemark.frontmatter.author": `AuthorYaml`,

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby`,
     siteUrl: `https://www.gatsbyjs.org`,
-    description: `Blazing-fast static site generator for React`,
+    description: `Blazing-fast static site and PWA (Progressive Web App) generator for React`,
   },
   mapping: {
     "MarkdownRemark.frontmatter.author": `AuthorYaml`,

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby`,
     siteUrl: `https://www.gatsbyjs.org`,
-    description: `Blazing-fast static site and PWA (Progressive Web App) generator for React`,
+    description: `Blazing fast static site and PWA (Progressive Web App) generator for React`,
   },
   mapping: {
     "MarkdownRemark.frontmatter.author": `AuthorYaml`,

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -243,7 +243,7 @@ const Diagram = () => (
     <h1 css={{ marginBottom: rhythm(1.5), ...scale(0.9) }}>How Gatsby works</h1>
     <div css={{ maxWidth: rhythm(20), margin: `0 auto ${rhythm(2)}` }}>
       <FuturaParagraph>
-        Gatsby lets you build blazing-fast sites with <em>your data</em>,
+        Gatsby lets you build blazing fast sites with <em>your data</em>,
         whatever the source. Liberate your sites from legacy CMSs and fly into
         the future.
       </FuturaParagraph>

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -21,7 +21,7 @@ class IndexRoute extends React.Component {
             <h1 id="get-started" css={{ marginTop: 0 }}>
               Get started
             </h1>
-            <p>Gatsby is a blazing-fast static site generator for React.</p>
+            <p>Gatsby is a blazing-fast static site and PWA (Progressive Web App) generator for React.</p>
             <h2>Install Gatsby{`'`}s command line tool</h2>
             <p>
               <code>npm install --global gatsby-cli</code>

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -21,7 +21,7 @@ class IndexRoute extends React.Component {
             <h1 id="get-started" css={{ marginTop: 0 }}>
               Get started
             </h1>
-            <p>Gatsby is a blazing fast static site and PWA (Progressive Web App) generator for React.</p>
+            <p>Gatsby is a blazing fast modern site generator for React.</p>
             <h2>Install Gatsby{`'`}s command line tool</h2>
             <p>
               <code>npm install --global gatsby-cli</code>

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -21,7 +21,7 @@ class IndexRoute extends React.Component {
             <h1 id="get-started" css={{ marginTop: 0 }}>
               Get started
             </h1>
-            <p>Gatsby is a blazing-fast static site and PWA (Progressive Web App) generator for React.</p>
+            <p>Gatsby is a blazing fast static site and PWA (Progressive Web App) generator for React.</p>
             <h2>Install Gatsby{`'`}s command line tool</h2>
             <p>
               <code>npm install --global gatsby-cli</code>

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -60,7 +60,7 @@ class Plugins extends Component {
                 }}
               >
                 Please use the search bar to find plugins that will make your
-                blazing-fast site even more awesome. If you'd like to create
+                blazing fast site even more awesome. If you'd like to create
                 your own plugin, see the
                 {` `}
                 <Link to="/docs/plugin-authoring/">Plugin Authoring</Link> page


### PR DESCRIPTION
Creating this PR to start a conversation about the descriptor for Gatsby. After using Gatsby as my primary tech for well over a year now, I've noticed that I still have to keep having conversations about the fact that Gatsby is so much more than a static site generator. It's a full-on PWA generator, and that, IMO, shouldn't be understated.

I've been following the great work of the core Gatsby team and notice that they have been having [workshops about Gatsby and the company](https://twitter.com/dominicfallows/status/1034024103307632640) so I understand that this PR and convo might be already taking place, or that I missed a similar conversation elsewhere. 

In reality, we _could_ generalise and describe any site made through Gatsby as a PWA (thanks to the optimised way Gatsby loads static, then dynamic components), but there is probably a period of time before that term means as much to the wider audience as "static site" so I've proposed that the descriptor evolves to include SSG and PWA keywords. 

**Gatsby, a blazing-fast static site and PWA (Progressive Web App) generator for React**

A bit more 'wordy' indeed, and definitely needs group thought, hence starting a conversation.

**Gatsby, a blazing fast web app generator** might be more simple, but again does it say enough?
