### PR TITLE
[gatsby-plugin-offline] Handle the EISDIR error as well

### DIFF
--- a/packages/gatsby-plugin-offline/src/get-resources-from-html.js
+++ b/packages/gatsby-plugin-offline/src/get-resources-from-html.js
@@ -10,10 +10,8 @@ module.exports = htmlPath => {
     // load index.html to pull scripts/links necessary for proper offline reload
     html = fs.readFileSync(path.resolve(htmlPath))
   } catch (err) {
-    // ENOENT means the file doesn't exist, which is to be expected when trying
-    // to open 404.html if the user hasn't created a custom 404 page -- return
-    // an empty array.
-    if (err.code === `ENOENT`) {
+    const acceptableCodes = [`ENOENT`, `EISDIR`]
+    if (acceptableCodes.includes(err.code)) {
       return []
     } else {
       throw err

--- a/packages/gatsby-plugin-offline/src/get-resources-from-html.js
+++ b/packages/gatsby-plugin-offline/src/get-resources-from-html.js
@@ -10,6 +10,8 @@ module.exports = htmlPath => {
     // load index.html to pull scripts/links necessary for proper offline reload
     html = fs.readFileSync(path.resolve(htmlPath))
   } catch (err) {
+    // Return an empty array if the file doesn't exist yet or the file system
+    // is returning a directory instead for the 404.html
     const acceptableCodes = [`ENOENT`, `EISDIR`]
     if (acceptableCodes.includes(err.code)) {
       return []


### PR DESCRIPTION
I ran into an issue after upgrading to the RC0 with the `gatsby-offline-plugin`. The production build was returning an `EISDIR` error for the 404.html but I'm not too sure why. This not happening in dev builds.

You can see the branch that's causing this issue: https://github.com/BayPhillips/gatsby-blog/tree/gatsby-rc0

This happened on both my Windows 10 WSL (Ubuntu) as well as on CI with CircleCI. Happy to tweak whatever else in the PR.