### PR TITLE
 Drop shadow on detail page of starter showcase #6766

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -7,6 +7,7 @@ import qs from "qs"
 
 import presets, { colors } from "../utils/presets"
 import { options, scale, rhythm } from "../utils/typography"
+import sharedStyles from "../views/shared/styles"
 import { Link, StaticQuery, graphql } from "gatsby"
 import Layout from "../components/layout"
 import ShareMenu from "../components/share-menu"
@@ -492,7 +493,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                   css={{
                     boxShadow: isModal
                       ? false
-                      : `0 4px 10px ${hex2rgba(colors.gatsby, 0.1)}`,
+                      : sharedStyles.screenshot.boxShadow,
                   }}
                 />
               </div>

--- a/www/src/templates/template-starter-showcase.js
+++ b/www/src/templates/template-starter-showcase.js
@@ -9,6 +9,7 @@ import Layout from "../components/layout"
 import ShareMenu from "../components/share-menu"
 import presets, { colors } from "../utils/presets"
 import { /*typography, */ rhythm, scale, options } from "../utils/typography"
+import sharedStyles from "../views/shared/styles"
 import MdLaunch from "react-icons/lib/md/launch"
 import GithubIcon from "react-icons/lib/fa/github"
 
@@ -272,7 +273,7 @@ class StarterTemplate extends React.Component {
                   fluid={imageSharp.childImageSharp.fluid}
                   alt={`Screenshot of ${imageSharp.name}`}
                   css={{
-                    ...styles.screenshot,
+                    ...sharedStyles.screenshot,
                   }}
                 />
               )}


### PR DESCRIPTION
closes #6766

I believe this is what you were asking for, to differentiate between screenshot and background. Might get adjusted later as Flo makes tweaks to the detail page mockups though.

(cc @fk)

![screen shot 2018-08-28 at 3 31 02 pm](https://user-images.githubusercontent.com/3461087/44749262-9fc55380-aad7-11e8-85f2-5eef2a17f20d.png)

