### PR TITLE
Overall typography edits - starter showcase #6719

### DIFF
--- a/www/src/views/shared/styles.js
+++ b/www/src/views/shared/styles.js
@@ -1,4 +1,4 @@
-import typography, { options, rhythm } from "../../utils/typography"
+import typography, { options, rhythm, scale } from "../../utils/typography"
 import presets, { colors } from "../../utils/presets"
 import { style } from "glamor"
 import hex2rgba from "hex2rgba"
@@ -143,6 +143,13 @@ const styles = {
   noLinkUnderline: {
     borderBottom: `none !important`, // i know i know
     boxShadow: `none !important`, // but people really want this
+  },
+  meta: {
+    ...scale(-1 / 5),
+    alignItems: `baseline`,
+    "&&": {
+      color: colors.gray.bright,
+    },
   },
   searchInput: {
     appearance: `none`,

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -78,13 +78,9 @@ const ShowcaseList = ({ items, count }) => {
               </Link>
               <div
                 css={{
-                  ...scale(-2 / 5),
+                  ...styles.meta,
                   display: `flex`,
                   justifyContent: `space-between`,
-                  alignItems: `baseline`,
-                  "&&": {
-                    color: `#9B9B9B`,
-                  },
                 }}
                 className="meta"
               >

--- a/www/src/views/starter-showcase/showcase-list.js
+++ b/www/src/views/starter-showcase/showcase-list.js
@@ -4,7 +4,8 @@ import Img from "gatsby-image"
 import FaExtLink from "react-icons/lib/fa/external-link"
 import FaGithub from "react-icons/lib/fa/github"
 import FaClipboard from "react-icons/lib/fa/clipboard"
-import { /* options, rhythm, */ scale, rhythm } from "../../utils/typography"
+import MdStar from "react-icons/lib/md/star"
+import { /* rhythm, */ scale, rhythm, options } from "../../utils/typography"
 import presets, { colors } from "../../utils/presets"
 import copyToClipboard from "../../utils/copy-to-clipboard"
 import styles from "../shared/styles"
@@ -48,6 +49,7 @@ const ShowcaseList = ({ urlState, items, imgs, count, sortRecent }) => {
   return (
     <div
       css={{
+        fontFamily: options.headerFontFamily.join(`,`),
         display: `flex`,
         flexWrap: `wrap`,
         padding: rhythm(3 / 4),
@@ -136,14 +138,27 @@ const ShowcaseList = ({ urlState, items, imgs, count, sortRecent }) => {
               </Link>
               <div
                 css={{
-                  ...scale(-2 / 5),
-                  color: `#9B9B9B`,
+                  ...scale(-1 / 6),
+                  color: colors.gray.bright,
                   fontWeight: `normal`,
+                  marginTop: rhythm(options.blockMarginBottom),
                 }}
               >
                 <div css={{ display: `flex`, justifyContent: `space-between` }}>
-                  {repo.owner && repo.owner.login} /
-                  <span>
+                  <span css={{ color: colors.gray.dark }}>
+                    {repo.owner && repo.owner.login} /
+                  </span>
+                  <span
+                    css={{
+                      "> a": {
+                        paddingLeft: 5,
+                        "&:hover": {
+                          background: `none`,
+                          color: colors.gatsby,
+                        },
+                      },
+                    }}
+                  >
                     <a
                       href="#copy-to-clipboard"
                       onClick={() =>
@@ -196,9 +211,12 @@ const ShowcaseList = ({ urlState, items, imgs, count, sortRecent }) => {
                 </div>
                 <div css={{ display: `flex`, justifyContent: `space-between` }}>
                   <div css={{ display: `inline-block` }}>
-                    <span role="img" aria-label="star">
-                      ⭐
-                    </span>
+                    <MdStar
+                      style={{
+                        color: colors.accent,
+                        verticalAlign: "text-top",
+                      }}
+                    />
                     {stars}
                   </div>
                   <div css={{ display: `inline-block` }}>

--- a/www/src/views/starter-showcase/showcase-list.js
+++ b/www/src/views/starter-showcase/showcase-list.js
@@ -138,9 +138,7 @@ const ShowcaseList = ({ urlState, items, imgs, count, sortRecent }) => {
               </Link>
               <div
                 css={{
-                  ...scale(-1 / 6),
-                  color: colors.gray.bright,
-                  fontWeight: `normal`,
+                  ...styles.meta,
                   marginTop: rhythm(options.blockMarginBottom),
                 }}
               >


### PR DESCRIPTION
Closes #6719

Change:
![screen shot 2018-08-28 at 5 30 34 pm](https://user-images.githubusercontent.com/3461087/44755017-fdfb3200-aae9-11e8-8e99-d030b2c9fc8e.png)

Prev:
![screen shot 2018-08-28 at 5 40 15 pm](https://user-images.githubusercontent.com/3461087/44755019-005d8c00-aaea-11e8-80bd-9253ab3bbc7b.png)

@fk, @shannonbux i believe i've addressed everything for the starter showcase index. I'd like to propose that it makes more sense for the index page to be addressed here, and the starter page type changes to be folded into the other detail page main issue: #6709. 