### PR TITLE
[sites-showcase] Adding target for external links

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -391,6 +391,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                   >
                     <a
                       href={data.sitesYaml.source_url}
+                      target="_blank"
                       css={{
                         ...styles.link,
                       }}
@@ -444,6 +445,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                 >
                   <a
                     href={data.sitesYaml.main_url}
+                    target="_blank"
                     css={{
                       border: 0,
                       borderRadius: presets.radius,
@@ -470,6 +472,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                         verticalAlign: `sub`,
                       }}
                     />
+                    {` `}
                     Visit site
                     {` `}
                   </a>

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -392,6 +392,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                     <a
                       href={data.sitesYaml.source_url}
                       target="_blank"
+                      rel="noopener noreferrer"
                       css={{
                         ...styles.link,
                       }}
@@ -446,6 +447,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                   <a
                     href={data.sitesYaml.main_url}
                     target="_blank"
+                    rel="noopener noreferrer"
                     css={{
                       border: 0,
                       borderRadius: presets.radius,


### PR DESCRIPTION
Personally I am used to showcase sites links to open a new tab (definitely for github pages that I might open and read later), also the icon on visit site is suggesting new tab ;)
I skipped the url under the title, and added a space between the icon and 'visit'.

Also note that upon closing this window, the sidebar filters are not retained. I think it's a proper bug.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
