### PR TITLE
Fix data overwriting bug

### DIFF
--- a/docs/docs/testing-components-with-graphql.md
+++ b/docs/docs/testing-components-with-graphql.md
@@ -256,7 +256,7 @@ export default props => (
         }
       }
     `}
-    render={data => <Header data={data} {...props} />}
+    render={data => <Header {...props} data={data} />}
   />
 )
 ```
@@ -286,7 +286,7 @@ export const Header = props => (
         }
       }
     `}
-    render={data => <PureHeader data={data} {...props} />}
+    render={data => <PureHeader {...props} data={data} />}
   />
 )
 


### PR DESCRIPTION
So I hit a really weird bug in my project and with the help of @pieh we came to the conclusion that the order needs to be swapped as `{...props}` was overwriting the `data`