### PR TITLE
dont add data import for non static queries

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Doesn't add data import for non static queries 1`] = `
+"import staticQueryData from \\"public/static/d/4279313589.json\\";
+import React from 'react';
+import { StaticQuery } from \\"gatsby\\";
+
+const Test = () => React.createElement(StaticQuery, {
+  query: \\"4279313589\\",
+  render: data => React.createElement(\\"div\\", null, data.site.siteMetadata.title),
+  data: staticQueryData
+});
+
+export default Test;
+export const fragment = \\"2962815581\\";"
+`;
+
 exports[`Handles closing StaticQuery tag 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import React from 'react';

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
@@ -202,3 +202,33 @@ it(`Handles closing StaticQuery tag`, () => {
   )
   `)
 })
+
+it(`Doesn't add data import for non static queries`, () => {
+  matchesSnapshot(`
+  import React from 'react'
+  import { StaticQuery, graphql } from "gatsby"
+
+  const Test = () => (
+    <StaticQuery
+      query={graphql\`
+      {
+        site {
+          siteMetadata {
+            title
+          }
+        }
+      }
+      \`}
+      render={data => <div>{data.site.siteMetadata.title}</div>}
+    />
+  )
+
+  export default Test
+
+  export const fragment = graphql\`
+    fragment MarkdownNodeFragment on MarkdownRemark {
+      html
+    }
+  \`
+  `)
+})

--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -184,7 +184,16 @@ export default function({ types: t }) {
             // Replace the query with the hash of the query.
             path2.replaceWith(t.StringLiteral(queryHash))
 
-            path.traverse(nestedJSXVistor, { queryHash, query })
+            // modify StaticQuery elements and import data only if query is inside StaticQuery
+            if (
+              path2.parentPath?.parentPath?.parentPath?.node?.name?.name ===
+              `StaticQuery`
+            ) {
+              path2.parentPath.parentPath.parentPath.traverse(nestedJSXVistor, {
+                queryHash,
+                query,
+              })
+            }
 
             return null
           },


### PR DESCRIPTION
This copies from `file-parser.js`: https://github.com/gatsbyjs/gatsby/blob/e2f2ea1eeeaaf1b2fe5ccc95bcbd0f35a0374722/packages/gatsby/src/internal-plugins/query-runner/file-parser.js#L107-L110

to determine if query is inside `<StaticQuery>` component and make sure we won't add import and modify static query based on unrelated queries.

Fixes #7649