### PR TITLE
[v2] [Babel] Add decoratorsBeforeExport option where it was missed

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
+++ b/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
@@ -20,7 +20,12 @@ async function onCreateNode({ node, getNode, actions, loadNodeContent }) {
       `jsx`,
       `doExpressions`,
       `objectRestSpread`,
-      `decorators`,
+      [
+        `decorators`,
+        {
+          decoratorsBeforeExport: true,
+        },
+      ],
       `classProperties`,
       `exportExtensions`,
       `asyncGenerators`,

--- a/packages/gatsby-transformer-javascript-static-exports/src/gatsby-node.js
+++ b/packages/gatsby-transformer-javascript-static-exports/src/gatsby-node.js
@@ -26,7 +26,12 @@ async function onCreateNode({
       `flow`,
       `doExpressions`,
       `objectRestSpread`,
-      `decorators`,
+      [
+        `decorators`,
+        {
+          decoratorsBeforeExport: true,
+        },
+      ],
       `classProperties`,
       `classPrivateProperties`,
       `classPrivateMethods`,


### PR DESCRIPTION
I forgot to add this to all the files where the `decorators` plugin is used