### PR TITLE
[docs] Plugin Authoring doc: publishing info

### DIFF
--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -9,6 +9,7 @@ You may be looking to build a plugin that doesn't exist yet, or you may just be 
 3.  expected files in a plugin package
 4.  defining a local (unpublished) plugin for your own use case
 5.  what a plugin is _not_
+6.  how to publish your plugin to the library
 
 ## Core Concepts
 
@@ -64,3 +65,20 @@ Like all `gatsby-*` files, the code is not processed by Babel. If you want
 to use JavaScript syntax which isn't supported by your version of Node.js, you
 can place the files in a `src` subfolder and build them to the plugin folder
 root.
+
+## Publishing a plugin to the library
+
+In order to add your plugin to the [Plugin Library], you need to simply publish a package to NPM (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages)) with the [required files](#what-files-does-gatsby-look-for-in-a-plugin) and **include a `keywords` field** to `package.json` containing `gatsby` and `gatsby-plugin`.
+
+After doing so, Algolia will take up to 12 hours to add it to the library search index (the exact time necessary is still unknown), and wait for the daily rebuild of https://gatsbyjs.org to automatically include your plugin page to the website. Then, all you have to do is share your wonderful plugin with the community!
+
+**NOTE:** You can include other _relevant_ keywords to your `package.json` file to help interested users in finding it. As an example, a  Markdown MathJax transformer would include:
+```
+"keywords": [
+  "gatsby",
+  "gatsby-plugin",
+  "gatsby-transformer-plugin",
+  "mathjax",
+  "markdown",
+]
+```

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -68,7 +68,7 @@ root.
 
 ## Publishing a plugin to the library
 
-In order to add your plugin to the [Plugin Library], you need to simply publish a package to NPM (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages)) with the [required files](#what-files-does-gatsby-look-for-in-a-plugin) and **include a `keywords` field** to `package.json` containing `gatsby` and `gatsby-plugin`.
+In order to add your plugin to the [Plugin Library], you need to publish a package to npm (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages)) with the [required files](#what-files-does-gatsby-look-for-in-a-plugin) and **include a `keywords` field** to `package.json` containing `gatsby` and `gatsby-plugin`.
 
 After doing so, Algolia will take up to 12 hours to add it to the library search index (the exact time necessary is still unknown), and wait for the daily rebuild of https://gatsbyjs.org to automatically include your plugin page to the website. Then, all you have to do is share your wonderful plugin with the community!
 

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -8,8 +8,7 @@ You may be looking to build a plugin that doesn't exist yet, or you may just be 
 2.  naming conventions for the plugin title
 3.  expected files in a plugin package
 4.  defining a local (unpublished) plugin for your own use case
-5.  what a plugin is _not_
-6.  how to publish your plugin to the library
+5.  how to publish your plugin to the library
 
 ## Core Concepts
 


### PR DESCRIPTION
I've added a couple of paragraphs under a new H2 for _Publishing a plugin to the library_ to help with #4673 .

Instead of just adding a tiny note on how much time Algolia would take to add the page to the library, based on my previous experience, I thought it was best to create a new section on publishing as it could be a bit confusing for beginners (in the very least, it was for me). The wording is still probably a bit off, feel free to suggest changes 😄 

**PS:** In the first section of this page we say we'll review "what a plugin is _not_", but I don't this in any explicit way here... what was your line of thought in including this?

closes #4673 