### PR TITLE
docs/add-custom-webpack-config.md: example of modifying babel loader

### DIFF
--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -91,3 +91,45 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
 ```
 
 You can always find more information on _resolve_ and other options in the official [Webpack docs](https://webpack.js.org/concepts/).
+
+### Modifying the babel loader
+
+You need this if you want to do things like transpile parts of `node_modules`.
+
+```js
+exports.onCreateWebpackConfig = ({ actions, loaders, getConfig }) => {
+  const config = getConfig();
+
+  config.module.rules = [
+    // Omit the default rule where test === '\.jsx?$'
+    ...config.module.rules.filter(
+      rule => String(rule.test) !== String(/\.jsx?$/),
+    ),
+
+    // Recreate it with custom exclude filter
+    {
+      // Called without any arguments, `loaders.js` will return an
+      // object like:
+      // {
+      //   options: undefined,
+      //   loader: '/path/to/node_modules/gatsby/dist/utils/babel-loader.js',
+      // }
+      // Unless you're replacing Babel with a different transpiler, you probably
+      // want this so that Gatsby will apply its required Babel
+      // presets/plugins.  This will also merge in your configuration from
+      // `babel.config.js`.
+      ...loaders.js(),
+
+      test: /\.jsx?$/,
+
+      // Exclude all node_modules from transpilation, except for 'swiper' and 'dom7'
+      exclude: modulePath =>
+        /node_modules/.test(modulePath) &&
+        !/node_modules\/(swiper|dom7)/.test(modulePath),
+    },
+  ];
+
+  // This will completely replace the webpack config with the modified object.
+  actions.replaceWebpackConfig(config);
+};
+```


### PR DESCRIPTION
There used to be an [example of how to do this](https://www.gatsbyjs.org/docs/add-custom-webpack-config/#modifying-the-babel-loader) in v1 and people are having trouble migrating without it.

It would be nice if there was a proper equivalent of v1's `config.removeLoader("js")` so that it's not necessary to filter by the `test` rule.

Ref: https://github.com/gatsbyjs/gatsby/issues/7634

