### PR TITLE
Replace waits with command timeouts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,9 @@
     "jest": true
   },
   "globals": {
-    "spyOn": true
+    "spyOn": true,
+    "cy": true,
+    "Cypress": true
   },
   "rules": {
     "no-console": "off",

--- a/examples/gatsbygram/cypress/integration/home_page_spec.js
+++ b/examples/gatsbygram/cypress/integration/home_page_spec.js
@@ -64,20 +64,16 @@ describe(`The Home Page`, () => {
     cy.fixture(`posts`).then(postsData => {
       const post1 = postsData[0]
       const post2 = postsData[1]
-      // wait for page to initialize
-      cy.wait(200)
       // open first post
-      cy.getTestElement(`post`)
+      cy.getTestElement(`post`, {timeout: 10000})
         .first()
         .click()
       cy.url().should("contain", post1.id)
       // click right arrow icon to go to 2nd post
       cy.getTestElement(`next-post`).click()
-      cy.url().should("contain", post2.id)
-      // wait for page to transition
-      cy.wait(200)
+      cy.url({timeout: 10000}).should("contain", post2.id)
       // press left arrow to go back to 1st post
-      cy.getTestElement(`previous-post`).click()
+      cy.getTestElement(`previous-post`, {timeout: 10000}).click()
       cy.url().should("contain", post1.id)
       // close the post
       cy.getTestElement(`modal-close`).click()
@@ -88,25 +84,19 @@ describe(`The Home Page`, () => {
     cy.fixture(`posts`).then(postsData => {
       const post1 = postsData[0]
       const post2 = postsData[1]
-      // wait for page to initialize
-      cy.wait(200)
       // open fist post
-      cy.getTestElement(`post`)
+      cy.getTestElement(`post`, {timeout: 10000})
         .first()
         // force, because sometimes the children cover
         // the outer element causing Cypress to complain
         .click({ force: true })
-      cy.url().should("contain", post1.id)
-      // wait for page to transition
-      cy.wait(200)
+      cy.url({timeout: 10000}).should("contain", post1.id)
       // press right arrow to go to 2nd post
-      cy.get(`body`).type(`{rightarrow}`)
-      cy.url().should("contain", post2.id)
-      // wait for page to transition
-      cy.wait(200)
+      cy.get(`body`, {timeout: 10000}).type(`{rightarrow}`)
+      cy.url({timeout: 10000}).should("contain", post2.id)
       // press left arrow to go back to 1st post
-      cy.get(`body`).type(`{leftarrow}`)
-      cy.url().should("contain", post1.id)
+      cy.get(`body`, {timeout: 10000}).type(`{leftarrow}`)
+      cy.url({timeout: 10000}).should("contain", post1.id)
       // close the post
       cy.getTestElement(`modal-close`).click()
     })

--- a/examples/gatsbygram/cypress/support/commands.js
+++ b/examples/gatsbygram/cypress/support/commands.js
@@ -25,6 +25,6 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 // copied from here - https://github.com/cypress-io/cypress/issues/1212#issuecomment-360395261
-Cypress.Commands.add("getTestElement", (selector) => {
-  return cy.get(`[data-testid="${selector}"]`)
+Cypress.Commands.add("getTestElement", (selector, options = {}) => {
+  return cy.get(`[data-testid="${selector}"]`, options)
 })


### PR DESCRIPTION
Will this fix the occasionally failing tests? Cypress should continue as soon as an assertion with a timeout is met, this bumps up the default timeout around areas where `wait` was being used.

