### PR TITLE
[transformer-remark] Fix hardcoded field used in table of contents

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -58,6 +58,29 @@ A sample GraphQL query to get MarkdownRemark nodes:
 }
 ```
 
+### Getting table of contents
+
+Using the following GraphQL query you'll be able to get the table of contents
+
+```graphql
+{
+  allMarkdownRemark {
+    edges {
+      node {
+        html
+        tableOfContents(pathToSlugField: "frontmatter.path")
+        frontmatter {
+          # Assumes you're using path in your frontmatter.
+          path
+        }
+      }
+    }
+  }
+}
+```
+
+By default the tableOfContents is using the field `slug` to generate URLs. You can however provide another field using the pathToSlugField parameter. **Note** that providing a non existing field will cause the result to be null.
+
 ## Troubleshooting
 
 ### Excerpts for non-latin languages

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -230,7 +230,7 @@ module.exports = (
       }
     }
 
-    async function getTableOfContents(markdownNode, field) {
+    async function getTableOfContents(markdownNode, pathToSlugField) {
       const cachedToc = await cache.get(tableOfContentsCacheKey(markdownNode))
       if (cachedToc) {
         return cachedToc
@@ -242,11 +242,11 @@ module.exports = (
         if (tocAst.map) {
           const addSlugToUrl = function(node) {
             if (node.url) {
-              if (!markdownNode.fields || markdownNode.fields[field] === undefined) {
-                console.warn(`Skipping TableOfContents. Field '${field}' missing from markdown node`)
+              if (_.get(markdownNode, pathToSlugField) === undefined) {
+                console.warn(`Skipping TableOfContents. Field '${pathToSlugField}' missing from markdown node`)
                 return null
               }
-              node.url = [pathPrefix, markdownNode.fields[field], node.url]
+              node.url = [pathPrefix, _.get(markdownNode, pathToSlugField), node.url]
                 .join(`/`)
                 .replace(/\/\//g, `/`)
             }
@@ -413,13 +413,13 @@ module.exports = (
       tableOfContents: {
         type: GraphQLString,
         args: {
-          field: {
+          pathToSlugField: {
             type: GraphQLString,
-            defaultValue: `slug`,
+            defaultValue: `fields.slug`,
           },
         },
-        resolve(markdownNode, { field }) {
-          return getTableOfContents(markdownNode, field)
+        resolve(markdownNode, { pathToSlugField }) {
+          return getTableOfContents(markdownNode, pathToSlugField)
         },
       },
       // TODO add support for non-latin languages https://github.com/wooorm/remark/issues/251#issuecomment-296731071


### PR DESCRIPTION
Fixes #4038

[plugin-transformer-remark] Add an optional field for, untill now a hardcoded field used in the table of contents urls generation.
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
