### PR TITLE
Fix up gatsbygram UI tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,9 @@
     "jest": true
   },
   "globals": {
-    "spyOn": true
+    "spyOn": true,
+    "cy": false,
+    "Cypress": false
   },
   "rules": {
     "no-console": "off",

--- a/examples/gatsbygram/cypress/integration/home-page-spec.js
+++ b/examples/gatsbygram/cypress/integration/home-page-spec.js
@@ -1,4 +1,8 @@
 describe(`The Home Page`, () => {
+  beforeEach(() => {
+    cy.visit(`/`)
+  })
+
   it(`successfully loads`, () => {
     cy.visit(`/`)
   })
@@ -45,8 +49,8 @@ describe(`The Home Page`, () => {
       cy.getTestElement(`post`)
         .first()
         .click()
-      cy.url().should("contain", post.id)
-      cy.getTestElement(`post-detail-avatar`).should(
+      cy.url().should(`contain`, post.id)
+      cy.getTestElement(`post-detail-avatar`, { timeout: 10000 }).should(
         `have.attr`,
         `src`,
         post.avatar
@@ -70,27 +74,24 @@ describe(`The Home Page`, () => {
     cy.fixture(`posts`).then(postsData => {
       const post1 = postsData[0]
       const post2 = postsData[1]
-      // wait for page to initialize
-      let routeChangePromise
-      setRouteChangePromise(cy, routeChangePromise)
-      cy.wrap(routeChangePromise)
 
       // open first post
       cy.getTestElement(`post`)
         .first()
         .click()
-      cy.url().should("contain", post1.id)
-      // click right arrow icon to go to 2nd post
-      setRouteChangePromise(cy, routeChangePromise)
-      cy.getTestElement(`next-post`).click()
-      cy.wrap(routeChangePromise)
-      cy.url().should("contain", post2.id)
+      cy.url().should(`contain`, post1.id)
 
-      // wait for page to transition
-      cy.wrap(routeChangePromise)
+      // click right arrow icon to go to 2nd post
+      cy.getTestElement(`next-post`, { timeout: 10000 }).click()
+      cy.url().should(`contain`, post2.id)
+
+      // wait for modal to update
+      cy.get(`[data-testid="previous-post"][data-postid="${post2.id}"]`, { timeout: 10000 })
+
       // press left arrow to go back to 1st post
       cy.getTestElement(`previous-post`).click()
-      cy.url().should("contain", post1.id)
+      cy.url().should(`contain`, post1.id)
+
       // close the post
       cy.getTestElement(`modal-close`).click()
     })
@@ -100,33 +101,29 @@ describe(`The Home Page`, () => {
     cy.fixture(`posts`).then(postsData => {
       const post1 = postsData[0]
       const post2 = postsData[1]
-      // wait for page to initialize
-      let routeChangePromise
-      setRouteChangePromise(cy, routeChangePromise)
-      cy.wrap(routeChangePromise)
 
       // open fist post
-      setRouteChangePromise(cy, routeChangePromise)
       cy.getTestElement(`post`)
         .first()
         // force, because sometimes the children cover
         // the outer element causing Cypress to complain
         .click({ force: true })
+      cy.url().should(`contain`, post1.id)
 
-      cy.url().should("contain", post1.id)
-
-      // wait for page to transition
-      cy.wrap(routeChangePromise)
+      // wait for modal to update
+      cy.get(`[data-testid="next-post"][data-postid="${post1.id}"]`, { timeout: 10000 })
 
       // press right arrow to go to 2nd post
-      setRouteChangePromise(cy, routeChangePromise)
       cy.get(`body`).type(`{rightarrow}`)
       cy.url().should("contain", post2.id)
-      // wait for page to transition
-      cy.wrap(routeChangePromise)
-      // press left arrow to go back to 1st post
+
+      // wait for modal to update
+      cy.get(`[data-testid="next-post"][data-postid="${post2.id}"]`, { timeout: 10000 })
+
+      // press left arrow to go back to 1srt post
       cy.get(`body`).type(`{leftarrow}`)
-      cy.url().should("contain", post1.id)
+      cy.url().should(`contain`, post1.id)
+
       // close the post
       cy.getTestElement(`modal-close`).click()
     })
@@ -134,16 +131,16 @@ describe(`The Home Page`, () => {
 
   it(`loads more posts when Load More button is clicked & on scroll`, () => {
     // initially loads 12 posts
-    cy.getTestElement(`post`).should("have.length", 12)
+    cy.getTestElement(`post`).should(`have.length`, 12)
 
     // loads 12 more posts when Load More button is clicked
     cy.getTestElement(`load-more`).click()
-    cy.getTestElement(`post`).should("have.length", 24)
+    cy.getTestElement(`post`).should(`have.length`, 24)
 
     // loads 12 more posts when scrolled to bottom
     // cy.getTestElement(`home-container`).scrollTo(`0%`, `99%`)
     cy.window().scrollTo(`bottom`)
-    cy.getTestElement(`post`).should("have.length", 36)
+    cy.getTestElement(`post`).should(`have.length`, 36)
 
     // let's go back to top
     cy.window().scrollTo(`top`)

--- a/examples/gatsbygram/cypress/support/commands.js
+++ b/examples/gatsbygram/cypress/support/commands.js
@@ -25,6 +25,6 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 // copied from here - https://github.com/cypress-io/cypress/issues/1212#issuecomment-360395261
-Cypress.Commands.add("getTestElement", (selector) => {
-  return cy.get(`[data-testid="${selector}"]`)
+Cypress.Commands.add("getTestElement", (selector, options = {}) => {
+  return cy.get(`[data-testid="${selector}"]`, options)
 })

--- a/examples/gatsbygram/src/components/modal.js
+++ b/examples/gatsbygram/src/components/modal.js
@@ -32,11 +32,13 @@ class GatsbyGramModal extends React.Component {
     mousetrap.unbind(`spacebar`)
   }
 
+  getIdFromUrl() { return this.props.location.pathname.split(`/`)[1] }
+
   findCurrentIndex() {
     let index
     index = findIndex(
       posts,
-      post => post.id === this.props.location.pathname.split(`/`)[1]
+      post => post.id === this.getIdFromUrl()
     )
 
     return index
@@ -94,6 +96,7 @@ class GatsbyGramModal extends React.Component {
           if (!posts) {
             posts = data.allPostsJson.edges.map(e => e.node)
           }
+          const postId = this.getIdFromUrl()
           return (
             <Modal
               isOpen={this.props.isOpen}
@@ -142,6 +145,7 @@ class GatsbyGramModal extends React.Component {
                 >
                   <CaretLeft
                     data-testid="previous-post"
+                    data-postid={postId}
                     css={{
                       cursor: `pointer`,
                       fontSize: `50px`,
@@ -153,6 +157,7 @@ class GatsbyGramModal extends React.Component {
                   {this.props.children}
                   <CaretRight
                     data-testid="next-post"
+                    data-postid={postId}
                     css={{
                       cursor: `pointer`,
                       fontSize: `50px`,


### PR DESCRIPTION
It's possible to reliably reproduce the test failures locally! With Cypress open (`cy:run`) you can go into the performance tab of the Chrome dev tools and enable CPU throttling. 4x throttling is enough to trigger the same errors that we're seeing on Travis.

The new `waitForRouteChange` API (#7763) seemed to be resolving before the modal had finished doing its work so I worked around it... 
