### PR TITLE
[gatsby-plugin-catch-links]: `${origin}/${destination}` URL bug fix

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,4 +21,5 @@ module.exports = {
   moduleNameMapper: {
     "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,
   },
+  testURL: `http://localhost:8000`,
 }

--- a/packages/gatsby-plugin-catch-links/package.json
+++ b/packages/gatsby-plugin-catch-links/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0"
+    "babel-runtime": "^6.26.0",
+    "escape-string-regexp": "^1.0.5"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -1,0 +1,184 @@
+const pathPrefix = `/pathPrefix`
+
+import * as catchLinks from '../catch-links'
+
+beforeAll(() => {
+    // Set the base URL we will be testing against to http://localhost:8000/pathPrefix
+    window.history.pushState({}, `APP Url`, `${pathPrefix}`)
+})
+
+afterAll(() => {
+    window.history.back()
+})
+
+describe(`catchLinks`, () => {
+    it(`creates a click event on the window`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+})
+
+describe(`the click event`, () => {
+    it(`checks if the user might be forcing navigation`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`checks if we clicked on an anchor`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`checks if the document author might be forcing navigation`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`checks if the destination/origin URLs have matching origins`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`checks if the destination/origin URLs have matching top level paths`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`checks if the destination URL wants to scroll the page with a hash anchor`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`routes the destination href through gatsby`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+})
+
+describe(`a user may be forcing navigation if`, () => {
+    // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#Return_value
+    describe(`the "main" button was not clicked`, () => {
+        test(`"auxiliary" button`, () => {
+            const event = { button: 1 }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+        test(`"secondary" button`, () => {
+            const event = { button: 2 }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+        test(`"fourth" button`, () => {
+            const event = { button: 3 }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+        test(`"fifth" button`, () => {
+            const event = { button: 4 }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+    })
+    describe(`the user is holding down a modifier key`, () => {
+        test(`alt key`, () => {
+            const event = { altKey: true }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+        test(`control key`, () => {
+            const event = { ctrlKey: true }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+        test(`meta key`, () => {
+            const event = { metaKey: true }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+        test(`shift key`, () => {
+            const event = { shiftKey: true }
+
+            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+        })
+    })
+    test(`the default behavior was prevented elsewhere`, () => {
+        const event = { defaultPrevented: true }
+
+        expect(catchLinks.navigationWasHandledElsewhere(event)).toBe(true)
+    })
+})
+
+describe(`the clicked element`, () => {
+    it(`must be an anchor tag`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+})
+
+describe(`the author might be forcing navigation`, () => {
+    test(`if the clicked anchor is a download link`, () => {
+        const testAnchor = document.createElement(`a`)
+        testAnchor.setAttribute(`download`, ``)
+
+        expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
+    })
+    describe(`if the clicked anchor does not target _self`, () => {
+        const separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
+
+        test(`target=_blank`, () => {
+            const testAnchor = document.createElement(`a`)
+            testAnchor.setAttribute(`target`, `_blank`)
+
+            expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
+        })
+        test(`target=_parent`, () => {
+            const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
+            testAnchor.setAttribute(`target`, `_parent`)
+
+            expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
+        })
+        test(`target=_top`, () => {
+            const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
+            testAnchor.setAttribute(`target`, `_top`)
+
+            expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
+        })
+
+        separateBrowsingContext.remove()
+    })
+})
+
+describe(`anchor target attribute looks like _self if`, () => {
+    const separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
+
+    it(`is not set`, () => {
+        const testAnchor = document.createElement(`a`)
+
+        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+    })
+    it(`is set to _self`, () => {
+        const testAnchor = document.createElement(`a`)
+        testAnchor.setAttribute(`target`, `_self`)
+
+        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+    })
+    it(`is set to _parent, but window = window.parent`, () => {
+        const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
+        testAnchor.setAttribute(`target`, `_parent`)
+
+        document.body.appendChild(testAnchor)
+
+        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+
+        testAnchor.remove()
+    })
+    it(`is set to _top, but window = window.top`, () => {
+        const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
+        testAnchor.setAttribute(`target`, `_top`)
+
+        document.body.appendChild(testAnchor)
+
+        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+
+        testAnchor.remove()
+    })
+
+    separateBrowsingContext.remove()
+})
+
+describe(`navigation is routed through gatsby if the destination href`, () => {
+    it(`shares the same origin and`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`shares the same top level path and`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+    it(`is not a hash anchor for the current page`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+})

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -183,13 +183,83 @@ describe(`anchor target attribute looks like _self if`, () => {
 })
 
 describe(`navigation is routed through gatsby if the destination href`, () => {
-    it(`shares the same origin and`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
+    // We're going to manually set up the event listener here
+    let hrefHandler
+    let eventDestroyer
+
+    beforeAll(() => {
+        hrefHandler = jest.fn()
+        eventDestroyer = catchLinks.default(window, hrefHandler)
     })
-    it(`shares the same top level path and`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
+
+    afterAll(() => {
+        eventDestroyer()
+    })
+
+    it(`shares the same origin and top path`, (done) => {
+        const sameOriginAndTopPath = document.createElement(`a`)
+        sameOriginAndTopPath.setAttribute(`href`, `${window.location.href}/someSubPath`)
+        document.body.appendChild(sameOriginAndTopPath)
+        
+        // create the click event we'll be using for testing
+        const clickEvent = new MouseEvent(`click`, {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        })
+    
+        hrefHandler.mockImplementation(() => {
+            expect(hrefHandler).toHaveBeenCalledWith(`${sameOriginAndTopPath.pathname}`)
+
+            sameOriginAndTopPath.remove()
+
+            done()
+        })
+        
+        sameOriginAndTopPath.dispatchEvent(clickEvent)
     })
     it(`is not a hash anchor for the current page`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
+        const withAnchor = document.createElement(`a`)
+        withAnchor.setAttribute(`href`, `${window.location.href}/someSubPath#inside`)
+        document.body.appendChild(withAnchor)
+        
+        // create the click event we'll be using for testing
+        const clickEvent = new MouseEvent(`click`, {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        })
+    
+        hrefHandler.mockImplementation(() => {
+            expect(hrefHandler).toHaveBeenCalledWith(`${withAnchor.pathname}${withAnchor.hash}`)
+
+            withAnchor.remove()
+            
+            done()
+        })
+        
+        withAnchor.dispatchEvent(clickEvent)
+    })
+    it(`has a URL "search" portion`, (done) => {
+        const withSearch = document.createElement(`a`)
+        withSearch.setAttribute(`href`, `${window.location.href}${pathPrefix}/subPath?q=find+me#inside`)
+        document.body.appendChild(withSearch)
+        
+        // create the click event we'll be using for testing
+        const clickEvent = new MouseEvent(`click`, {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        })
+    
+        hrefHandler.mockImplementation(() => {
+            expect(hrefHandler).toHaveBeenCalledWith(`${withSearch.pathname}${withSearch.search}${withSearch.hash}`)
+
+            withSearch.remove()
+            
+            done()
+        })
+        
+        withSearch.dispatchEvent(clickEvent)
     })
 })

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -8,6 +8,7 @@ beforeAll(() => {
 })
 
 afterAll(() => {
+    // Set history back to http://localhost:8000
     window.history.back()
 })
 

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -17,7 +17,7 @@ describe(`catchLinks`, () => {
   let handler
 
   beforeAll(() => {
-    mockedAEH = jest.spyOn(window, "addEventListener")
+    mockedAEH = jest.spyOn(window, `addEventListener`)
     mockedAEH.mockImplementation((_, eventHandler) => (handler = eventHandler))
   })
 
@@ -111,10 +111,53 @@ describe(`a user may be forcing navigation if`, () => {
 
 describe(`the clicked element`, () => {
   it(`must be an anchor tag`, done => {
-    done.fail(`NOT IMPLEMENTED YET`)
+    const testAnchor = document.createElement(`a`)
+    document.body.appendChild(testAnchor)
+
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    })
+
+    const handler = event => {
+      expect(catchLinks.findClosestAnchor(event.target)).toBe(testAnchor)
+
+      testAnchor.remove()
+      window.removeEventListener(`click`, handler)
+
+      done()
+    }
+    window.addEventListener(`click`, handler)
+
+    testAnchor.dispatchEvent(clickEvent)
   })
-  it(`could be inside of an element`, done => {
-    done.fail(`NOT IMPLEMENTED YET`)
+  it(`could be inside of an anchor`, done => {
+    const testAnchor = document.createElement(`a`)
+    const clickTarget = document.createElement(`span`)
+
+    testAnchor.appendChild(clickTarget)
+    document.body.appendChild(testAnchor)
+
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    })
+
+    const handler = event => {
+      expect(catchLinks.findClosestAnchor(event.target)).toBe(testAnchor)
+
+      testAnchor.remove()
+      window.removeEventListener(`click`, handler)
+
+      done()
+    }
+    window.addEventListener(`click`, handler)
+
+    clickTarget.dispatchEvent(clickEvent)
   })
 })
 

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -1,265 +1,309 @@
 const pathPrefix = `/pathPrefix`
 
-import * as catchLinks from '../catch-links'
+import * as catchLinks from "../catch-links"
 
 beforeAll(() => {
-    // Set the base URL we will be testing against to http://localhost:8000/pathPrefix
-    window.history.pushState({}, `APP Url`, `${pathPrefix}`)
+  // Set the base URL we will be testing against to http://localhost:8000/pathPrefix
+  window.history.pushState({}, `APP Url`, `${pathPrefix}`)
 })
 
 afterAll(() => {
-    // Set history back to http://localhost:8000
-    window.history.back()
+  // Set history back to http://localhost:8000
+  window.history.back()
 })
 
 describe(`catchLinks`, () => {
-    it(`creates a click event`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
+  let mockedAEH
+  let handler
+
+  beforeAll(() => {
+    mockedAEH = jest.spyOn(window, "addEventListener")
+    mockedAEH.mockImplementation((_, eventHandler) => (handler = eventHandler))
+  })
+
+  afterAll(() => {
+    mockedAEH.mockRestore()
+  })
+
+  let eventDestroyer
+
+  beforeAll(() => {
+    eventDestroyer = catchLinks.default(window, href => {})
+  })
+
+  afterAll(() => {
+    eventDestroyer()
+  })
+
+  it(`creates a click event`, () => {
+    expect(mockedAEH).toHaveBeenCalledWith(`click`, expect.any(Function))
+  })
+  it(`uses an instance of the handler returned by routeThroughBrowserOrApp`, () => {
+    expect(handler.toString()).toEqual(
+      catchLinks.routeThroughBrowserOrApp(jest.fn()).toString()
+    )
+  })
 })
 
+// https://github.com/facebook/jest/issues/936
 describe(`the click event`, () => {
-    it(`checks if the user might be forcing navigation`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
-    it(`checks if we clicked on an anchor`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
-    it(`checks if the document author might be forcing navigation`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
-    it(`checks if the destination/origin URLs have matching origins`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
-    it(`checks if the destination/origin URLs have matching top level paths`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
-    it(`checks if the destination URL wants to scroll the page with a hash anchor`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
-    it(`routes the destination href through gatsby`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
+  it(`checks if the user might be forcing navigation`, () => {})
+  it(`checks if we clicked on an anchor`, () => {})
+  it(`checks if the document author might be forcing navigation`, () => {})
+  it(`checks if the destination/origin URLs have matching origins`, () => {})
+  it(`checks if the destination/origin URLs have matching top level paths`, () => {})
+  it(`checks if the destination URL wants to scroll the page with a hash anchor`, () => {})
+  it(`routes the destination href through gatsby`, () => {})
 })
 
 describe(`a user may be forcing navigation if`, () => {
-    // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#Return_value
-    describe(`the "main" button was not clicked`, () => {
-        test(`"auxiliary" button`, () => {
-            const event = { button: 1 }
+  // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#Return_value
+  describe(`the "main" button was not clicked`, () => {
+    test(`"auxiliary" button`, () => {
+      const event = { button: 1 }
 
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
-        test(`"secondary" button`, () => {
-            const event = { button: 2 }
-
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
-        test(`"fourth" button`, () => {
-            const event = { button: 3 }
-
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
-        test(`"fifth" button`, () => {
-            const event = { button: 4 }
-
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
     })
-    describe(`the user is holding down a modifier key`, () => {
-        test(`alt key`, () => {
-            const event = { altKey: true }
+    test(`"secondary" button`, () => {
+      const event = { button: 2 }
 
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
-        test(`control key`, () => {
-            const event = { ctrlKey: true }
-
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
-        test(`meta key`, () => {
-            const event = { metaKey: true }
-
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
-        test(`shift key`, () => {
-            const event = { shiftKey: true }
-
-            expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
-        })
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
     })
-    test(`the default behavior was prevented elsewhere`, () => {
-        const event = { defaultPrevented: true }
+    test(`"fourth" button`, () => {
+      const event = { button: 3 }
 
-        expect(catchLinks.navigationWasHandledElsewhere(event)).toBe(true)
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
     })
+    test(`"fifth" button`, () => {
+      const event = { button: 4 }
+
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+    })
+  })
+  describe(`the user is holding down a modifier key`, () => {
+    test(`alt key`, () => {
+      const event = { altKey: true }
+
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+    })
+    test(`control key`, () => {
+      const event = { ctrlKey: true }
+
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+    })
+    test(`meta key`, () => {
+      const event = { metaKey: true }
+
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+    })
+    test(`shift key`, () => {
+      const event = { shiftKey: true }
+
+      expect(catchLinks.userIsForcingNavigation(event)).toBe(true)
+    })
+  })
+  test(`the default behavior was prevented elsewhere`, () => {
+    const event = { defaultPrevented: true }
+
+    expect(catchLinks.navigationWasHandledElsewhere(event)).toBe(true)
+  })
 })
 
 describe(`the clicked element`, () => {
-    it(`must be an anchor tag`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
+  it(`must be an anchor tag`, done => {
+    done.fail(`NOT IMPLEMENTED YET`)
+  })
+  it(`could be inside of an element`, done => {
+    done.fail(`NOT IMPLEMENTED YET`)
+  })
 })
 
 describe(`the author might be forcing navigation`, () => {
-    test(`if the clicked anchor is a download link`, () => {
-        const testAnchor = document.createElement(`a`)
-        testAnchor.setAttribute(`download`, ``)
+  test(`if the clicked anchor is a download link`, () => {
+    const testAnchor = document.createElement(`a`)
+    testAnchor.setAttribute(`download`, ``)
 
-        expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
-    })
-    describe(`if the clicked anchor does not target _self`, () => {
-        let separateBrowsingContext
-    
-        beforeAll(() => {
-            separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
-        })
-        afterAll(() => {
-            separateBrowsingContext.remove()
-        })
-
-        test(`target=_blank`, () => {
-            const testAnchor = document.createElement(`a`)
-            testAnchor.setAttribute(`target`, `_blank`)
-
-            expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
-        })
-        test(`target=_parent`, () => {
-            const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
-            testAnchor.setAttribute(`target`, `_parent`)
-
-            expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
-        })
-        test(`target=_top`, () => {
-            const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
-            testAnchor.setAttribute(`target`, `_top`)
-
-            expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
-        })
-    })
-})
-
-describe(`anchor target attribute looks like _self if`, () => {
+    expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
+  })
+  describe(`if the clicked anchor does not target _self`, () => {
     let separateBrowsingContext
 
     beforeAll(() => {
-        separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
+      separateBrowsingContext = document.body.appendChild(
+        document.createElement(`iframe`)
+      )
     })
     afterAll(() => {
-        separateBrowsingContext.remove()
+      separateBrowsingContext.remove()
     })
 
-    it(`is not set`, () => {
-        const testAnchor = document.createElement(`a`)
+    test(`target=_blank`, () => {
+      const testAnchor = document.createElement(`a`)
+      testAnchor.setAttribute(`target`, `_blank`)
 
-        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+      expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
     })
-    it(`is set to _self`, () => {
-        const testAnchor = document.createElement(`a`)
-        testAnchor.setAttribute(`target`, `_self`)
+    test(`target=_parent`, () => {
+      const testAnchor = separateBrowsingContext.contentDocument.createElement(
+        `a`
+      )
+      testAnchor.setAttribute(`target`, `_parent`)
 
-        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+      expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
     })
-    it(`is set to _parent, but window = window.parent`, () => {
-        const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
-        testAnchor.setAttribute(`target`, `_parent`)
+    test(`target=_top`, () => {
+      const testAnchor = separateBrowsingContext.contentDocument.createElement(
+        `a`
+      )
+      testAnchor.setAttribute(`target`, `_top`)
 
-        document.body.appendChild(testAnchor)
-
-        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
-
-        testAnchor.remove()
+      expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
     })
-    it(`is set to _top, but window = window.top`, () => {
-        const testAnchor = separateBrowsingContext.contentDocument.createElement(`a`)
-        testAnchor.setAttribute(`target`, `_top`)
+  })
+})
 
-        document.body.appendChild(testAnchor)
+describe(`anchor target attribute looks like _self if`, () => {
+  let separateBrowsingContext
 
-        expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+  beforeAll(() => {
+    separateBrowsingContext = document.body.appendChild(
+      document.createElement(`iframe`)
+    )
+  })
+  afterAll(() => {
+    separateBrowsingContext.remove()
+  })
 
-        testAnchor.remove()
-    })
+  it(`is not set`, () => {
+    const testAnchor = document.createElement(`a`)
+
+    expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+  })
+  it(`is set to _self`, () => {
+    const testAnchor = document.createElement(`a`)
+    testAnchor.setAttribute(`target`, `_self`)
+
+    expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+  })
+  it(`is set to _parent, but window = window.parent`, () => {
+    const testAnchor = separateBrowsingContext.contentDocument.createElement(
+      `a`
+    )
+    testAnchor.setAttribute(`target`, `_parent`)
+
+    document.body.appendChild(testAnchor)
+
+    expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+
+    testAnchor.remove()
+  })
+  it(`is set to _top, but window = window.top`, () => {
+    const testAnchor = separateBrowsingContext.contentDocument.createElement(
+      `a`
+    )
+    testAnchor.setAttribute(`target`, `_top`)
+
+    document.body.appendChild(testAnchor)
+
+    expect(catchLinks.anchorsTargetIsEquivalentToSelf(testAnchor)).toBe(true)
+
+    testAnchor.remove()
+  })
 })
 
 describe(`navigation is routed through gatsby if the destination href`, () => {
-    // We're going to manually set up the event listener here
-    let hrefHandler
-    let eventDestroyer
+  // We're going to manually set up the event listener here
+  let hrefHandler
+  let eventDestroyer
 
-    beforeAll(() => {
-        hrefHandler = jest.fn()
-        eventDestroyer = catchLinks.default(window, hrefHandler)
+  beforeAll(() => {
+    hrefHandler = jest.fn()
+    eventDestroyer = catchLinks.default(window, hrefHandler)
+  })
+
+  afterAll(() => {
+    eventDestroyer()
+  })
+
+  it(`shares the same origin and top path`, done => {
+    const sameOriginAndTopPath = document.createElement(`a`)
+    sameOriginAndTopPath.setAttribute(
+      `href`,
+      `${window.location.href}/someSubPath`
+    )
+    document.body.appendChild(sameOriginAndTopPath)
+
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
     })
 
-    afterAll(() => {
-        eventDestroyer()
+    hrefHandler.mockImplementation(() => {
+      expect(hrefHandler).toHaveBeenCalledWith(
+        `${sameOriginAndTopPath.pathname}`
+      )
+
+      sameOriginAndTopPath.remove()
+
+      done()
     })
 
-    it(`shares the same origin and top path`, (done) => {
-        const sameOriginAndTopPath = document.createElement(`a`)
-        sameOriginAndTopPath.setAttribute(`href`, `${window.location.href}/someSubPath`)
-        document.body.appendChild(sameOriginAndTopPath)
-        
-        // create the click event we'll be using for testing
-        const clickEvent = new MouseEvent(`click`, {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-        })
-    
-        hrefHandler.mockImplementation(() => {
-            expect(hrefHandler).toHaveBeenCalledWith(`${sameOriginAndTopPath.pathname}`)
+    sameOriginAndTopPath.dispatchEvent(clickEvent)
+  })
+  it(`is not a hash anchor for the current page`, done => {
+    const withAnchor = document.createElement(`a`)
+    withAnchor.setAttribute(
+      `href`,
+      `${window.location.href}/someSubPath#inside`
+    )
+    document.body.appendChild(withAnchor)
 
-            sameOriginAndTopPath.remove()
-
-            done()
-        })
-        
-        sameOriginAndTopPath.dispatchEvent(clickEvent)
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
     })
-    it(`is not a hash anchor for the current page`, (done) => {
-        const withAnchor = document.createElement(`a`)
-        withAnchor.setAttribute(`href`, `${window.location.href}/someSubPath#inside`)
-        document.body.appendChild(withAnchor)
-        
-        // create the click event we'll be using for testing
-        const clickEvent = new MouseEvent(`click`, {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-        })
-    
-        hrefHandler.mockImplementation(() => {
-            expect(hrefHandler).toHaveBeenCalledWith(`${withAnchor.pathname}${withAnchor.hash}`)
 
-            withAnchor.remove()
-            
-            done()
-        })
-        
-        withAnchor.dispatchEvent(clickEvent)
-    })
-    it(`has a URL "search" portion`, (done) => {
-        const withSearch = document.createElement(`a`)
-        withSearch.setAttribute(`href`, `${window.location.href}${pathPrefix}/subPath?q=find+me#inside`)
-        document.body.appendChild(withSearch)
-        
-        // create the click event we'll be using for testing
-        const clickEvent = new MouseEvent(`click`, {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-        })
-    
-        hrefHandler.mockImplementation(() => {
-            expect(hrefHandler).toHaveBeenCalledWith(`${withSearch.pathname}${withSearch.search}${withSearch.hash}`)
+    hrefHandler.mockImplementation(() => {
+      expect(hrefHandler).toHaveBeenCalledWith(
+        `${withAnchor.pathname}${withAnchor.hash}`
+      )
 
-            withSearch.remove()
-            
-            done()
-        })
-        
-        withSearch.dispatchEvent(clickEvent)
+      withAnchor.remove()
+
+      done()
     })
+
+    withAnchor.dispatchEvent(clickEvent)
+  })
+  it(`has a URL "search" portion`, done => {
+    const withSearch = document.createElement(`a`)
+    withSearch.setAttribute(
+      `href`,
+      `${window.location.href}${pathPrefix}/subPath?q=find+me#inside`
+    )
+    document.body.appendChild(withSearch)
+
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    })
+
+    hrefHandler.mockImplementation(() => {
+      expect(hrefHandler).toHaveBeenCalledWith(
+        `${withSearch.pathname}${withSearch.search}${withSearch.hash}`
+      )
+
+      withSearch.remove()
+
+      done()
+    })
+
+    withSearch.dispatchEvent(clickEvent)
+  })
 })

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -12,7 +12,7 @@ afterAll(() => {
 })
 
 describe(`catchLinks`, () => {
-    it(`creates a click event on the window`, (done) => {
+    it(`creates a click event`, (done) => {
         done.fail(`NOT IMPLEMENTED YET`)
     })
 })

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -45,7 +45,7 @@ describe(`catchLinks`, () => {
   })
 })
 
-// https://github.com/facebook/jest/issues/936
+// https://github.com/facebook/jest/issues/936#issuecomment-214939935
 describe(`the click event`, () => {
   it(`checks if the user might be forcing navigation`, () => {})
   it(`checks if we clicked on an anchor`, () => {})

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -109,7 +109,14 @@ describe(`the author might be forcing navigation`, () => {
         expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
     })
     describe(`if the clicked anchor does not target _self`, () => {
-        const separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
+        let separateBrowsingContext
+    
+        beforeAll(() => {
+            separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
+        })
+        afterAll(() => {
+            separateBrowsingContext.remove()
+        })
 
         test(`target=_blank`, () => {
             const testAnchor = document.createElement(`a`)
@@ -129,13 +136,18 @@ describe(`the author might be forcing navigation`, () => {
 
             expect(catchLinks.authorIsForcingNavigation(testAnchor)).toBe(true)
         })
-
-        separateBrowsingContext.remove()
     })
 })
 
 describe(`anchor target attribute looks like _self if`, () => {
-    const separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
+    let separateBrowsingContext
+
+    beforeAll(() => {
+        separateBrowsingContext = document.body.appendChild(document.createElement(`iframe`))
+    })
+    afterAll(() => {
+        separateBrowsingContext.remove()
+    })
 
     it(`is not set`, () => {
         const testAnchor = document.createElement(`a`)
@@ -168,8 +180,6 @@ describe(`anchor target attribute looks like _self if`, () => {
 
         testAnchor.remove()
     })
-
-    separateBrowsingContext.remove()
 })
 
 describe(`navigation is routed through gatsby if the destination href`, () => {

--- a/packages/gatsby-plugin-catch-links/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/gatsby-browser.js
@@ -1,0 +1,5 @@
+describe(`gatsby-plugin-catch-links`, () => {
+    it(`calls catchLinks in gatsby-browser's onClientEntry API`, (done) => {
+        done.fail(`NOT IMPLEMENTED YET`)
+    })
+})

--- a/packages/gatsby-plugin-catch-links/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/gatsby-browser.js
@@ -1,5 +1,20 @@
+import { onClientEntry } from "../gatsby-browser"
+import * as catchLinks from "../catch-links"
+
 describe(`gatsby-plugin-catch-links`, () => {
-    it(`calls catchLinks in gatsby-browser's onClientEntry API`, (done) => {
-        done.fail(`NOT IMPLEMENTED YET`)
-    })
+  let mockedCatchLinks
+
+  beforeAll(() => {
+    mockedCatchLinks = jest.spyOn(catchLinks, `default`)
+  })
+
+  afterAll(() => {
+    mockedCatchLinks.mockRestore()
+  })
+
+  it(`calls catchLinks in gatsby-browser's onClientEntry API`, () => {
+    onClientEntry()
+
+    expect(mockedCatchLinks).toHaveBeenCalledWith(window, expect.any(Function))
+  })
 })

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -119,8 +119,9 @@ export default function(root, cb) {
     var re = new RegExp(`^${origin.host}${withPrefix(`/`)}`)
     if (!re.test(`${destination.host}${destination.pathname}`)) return true
 
-    // Don't catch links pointed to the same page but with a hash.
-    if (destination.pathname === origin.pathname && destination.hash !== ``) {
+    // Don't catch links pointed at what look like file extensions (other than
+    // .htm/html extensions).
+    if (destination.pathname.search(/^.*\.((?!htm)[a-z0-9]{1,5})$/i) !== -1) {
       return true
     }
 
@@ -129,9 +130,8 @@ export default function(root, cb) {
       return true
     }
 
-    // Don't catch links pointed at what look like file extensions (other than
-    // .htm/html extensions).
-    if (destination.pathname.search(/^.*\.((?!htm)[a-z0-9]{1,5})$/i) !== -1) {
+    // Don't catch links pointed to the same page but with a hash.
+    if (destination.hash !== ``) {
       return true
     }
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -10,9 +10,9 @@ export const userIsForcingNavigation = event => (
   event.defaultPrevented
 )
 
-export const findClosestAnchor = event => {
+export const findClosestAnchor = node => {
   for (
-    var node = event.target; 
+    ; 
     node.parentNode; 
     node = node.parentNode
   ) {
@@ -123,10 +123,10 @@ export const hashShouldBeFollowed = (origin, destination) => (
 )
 
 export default function(root, cb) {
-  root.addEventListener(`click`, function(ev) {
-    if ( userIsForcingNavigation(ev) ) return true
+  root.addEventListener(`click`, function(event) {
+    if ( userIsForcingNavigation(event) ) return true
 
-    const clickedAnchor = findClosestAnchor(ev)
+    const clickedAnchor = findClosestAnchor(event.target)
     if (clickedAnchor == null) return true
 
     if( authorIsForcingNavigation(clickedAnchor) ) return true
@@ -151,7 +151,7 @@ export default function(root, cb) {
 
     if ( hashShouldBeFollowed(origin, destination) ) return true
 
-    ev.preventDefault()
+    event.preventDefault()
 
     cb(`${destination.pathname}${destination.search}${destination.hash}`)
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -9,48 +9,56 @@ export const userIsForcingNavigation = event => (
   event.defaultPrevented
 )
 
+export const findClosestAnchor = event => {
+  for (
+    var node = event.target; 
+    node.parentNode; 
+    node = node.parentNode
+  ) {
+    if (node.nodeName.toLowerCase() === `a`) {
+      return node
+    }
+  }
+
+  return null
+}
+
 module.exports = function(root, cb) {
   root.addEventListener(`click`, function(ev) {
     if ( userIsForcingNavigation(ev) ) return true
 
-    var anchor = null
-    for (var n = ev.target; n.parentNode; n = n.parentNode) {
-      if (n.nodeName === `A`) {
-        anchor = n
-        break
-      }
-    }
-    if (!anchor) return true
+    const targetAnchor = findClosestAnchor(ev)
+    if (targetAnchor == null) return true
 
     // Don't catch links where a target (other than self) is set
     // e.g. _blank.
-    if (anchor.target && anchor.target.toLowerCase() !== `_self`) return true
+    if (targetAnchor.target && targetAnchor.target.toLowerCase() !== `_self`) return true
 
     // Don't catch links pointed to the same page but with a hash.
-    if (anchor.pathname === window.location.pathname && anchor.hash !== ``) {
+    if (targetAnchor.pathname === window.location.pathname && targetAnchor.hash !== ``) {
       return true
     }
 
     // Dynamically created anchor links (href="#my-anchor") do not always have pathname on IE
-    if (anchor.pathname === ``) {
+    if (targetAnchor.pathname === ``) {
       return true
     }
 
     // Don't catch links pointed at what look like file extensions (other than
     // .htm/html extensions).
-    if (anchor.pathname.search(/^.*\.((?!htm)[a-z0-9]{1,5})$/i) !== -1) {
+    if (targetAnchor.pathname.search(/^.*\.((?!htm)[a-z0-9]{1,5})$/i) !== -1) {
       return true
     }
 
     // IE clears the host value if the anchor href changed after creation, e.g.
     // in React. Creating a new anchor element to ensure host value is present
     var a1 = document.createElement(`a`)
-    a1.href = anchor.href
+    a1.href = targetAnchor.href
 
     // In IE, the default port is included in the anchor host but excluded from
     // the location host.  This affects the ability to directly compare
     // location host to anchor host.  For example: http://example.com would
-    // have a location.host of 'example.com' and an anchor.host of
+    // have a location.host of 'example.com' and an targetAnchor.host of
     // 'example.com:80' Creating anchor from the location.href to normalize the
     // host value.
     var a2 = document.createElement(`a`)
@@ -75,7 +83,7 @@ module.exports = function(root, cb) {
 
     ev.preventDefault()
 
-    cb(anchor.getAttribute(`href`))
+    cb(targetAnchor.getAttribute(`href`))
     return false
   })
 }

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -116,8 +116,8 @@ export default function(root, cb) {
     // href="https://example.com/not-my-app"> the plugin won't catch it and
     // will navigate to an external link instead of doing a pushState resulting
     // in `https://example.com/myapp/https://example.com/not-my-app`
-    var re = new RegExp(`^${origin.host}${withPrefix(`/`)}`)
-    if (!re.test(`${destination.host}${destination.pathname}`)) return true
+    var re = new RegExp(`^${withPrefix(`/`)}`)
+    if (!re.test(`${destination.pathname}`)) return true
 
     // Don't catch links pointed at what look like file extensions (other than
     // .htm/html extensions).

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -1,17 +1,17 @@
 import { withPrefix } from "gatsby-link"
 
+export const userIsForcingNavigation = event => (
+  event.button !== 0 ||
+  event.altKey ||
+  event.ctrlKey ||
+  event.metaKey ||
+  event.shiftKey ||
+  event.defaultPrevented
+)
+
 module.exports = function(root, cb) {
   root.addEventListener(`click`, function(ev) {
-    if (
-      ev.button !== 0 ||
-      ev.altKey ||
-      ev.ctrlKey ||
-      ev.metaKey ||
-      ev.shiftKey ||
-      ev.defaultPrevented
-    ) {
-      return true
-    }
+    if ( userIsForcingNavigation(ev) ) return true
 
     var anchor = null
     for (var n = ev.target; n.parentNode; n = n.parentNode) {

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -108,6 +108,17 @@ export default function(root, cb) {
 
     if ( urlsAreOnSameOrigin(origin, destination) === false ) return true
 
+    // For when pathPrefix is used in an app and there happens to be a link
+    // pointing to the same domain but outside of the app's pathPrefix. For
+    // example, a Gatsby app lives at https://example.com/myapp/, with the
+    // pathPrefix set to `/myapp`. When adding an absolute link to the same
+    // domain but outside of the /myapp path, for example, <a
+    // href="https://example.com/not-my-app"> the plugin won't catch it and
+    // will navigate to an external link instead of doing a pushState resulting
+    // in `https://example.com/myapp/https://example.com/not-my-app`
+    var re = new RegExp(`^${origin.host}${withPrefix(`/`)}`)
+    if (!re.test(`${destination.host}${destination.pathname}`)) return true
+
     // Don't catch links pointed to the same page but with a hash.
     if (destination.pathname === origin.pathname && destination.hash !== ``) {
       return true
@@ -123,17 +134,6 @@ export default function(root, cb) {
     if (destination.pathname.search(/^.*\.((?!htm)[a-z0-9]{1,5})$/i) !== -1) {
       return true
     }
-
-    // For when pathPrefix is used in an app and there happens to be a link
-    // pointing to the same domain but outside of the app's pathPrefix. For
-    // example, a Gatsby app lives at https://example.com/myapp/, with the
-    // pathPrefix set to `/myapp`. When adding an absolute link to the same
-    // domain but outside of the /myapp path, for example, <a
-    // href="https://example.com/not-my-app"> the plugin won't catch it and
-    // will navigate to an external link instead of doing a pushState resulting
-    // in `https://example.com/myapp/https://example.com/not-my-app`
-    var re = new RegExp(`^${origin.host}${withPrefix(`/`)}`)
-    if (!re.test(`${destination.host}${destination.pathname}`)) return true
 
     // TODO: add a check for absolute internal links in a callback or here,
     // or always pass only `${destination.pathname}${destination.hash}`

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -25,7 +25,7 @@ export const findClosestAnchor = node => {
 }
 
 export const anchorsTargetIsEquivalentToSelf = anchor => (
-  /* If not target attribute is present it's treated as _self */
+  /* If target attribute is not present it's treated as _self */
   anchor.hasAttribute(`target`) === false ||
 
   /**

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -23,25 +23,35 @@ export const findClosestAnchor = event => {
   return null
 }
 
-export const authorIsForcingNavigation = anchor => {
-  // Don't catch links where a target (other than self) is set
-  // e.g. _blank.
-  if (anchor.target && anchor.target.toLowerCase() !== `_self`) return true
+export const authorIsForcingNavigation = anchor => (
+  /**
+   * HTML5 attribute that informs the browser to handle the 
+   * href as a downloadable file
+   */
+  anchor.hasAttribute(`download`) === true ||
 
-  // HTML5 attribute that informs the browser to handle the href 
-  // as a downloadable file
-  if (anchor.hasAttribute(`download`)) return true
+  /**
+   * Only catch target=_self anchors
+   */
+  anchor.hasAttribute(`target`) === false ||
 
-  return false
-}
+  /* Assumption: some browsers use null for default attribute values */
+  anchor.target == null ||
 
-export const urlsAreOnSameOrigin = (origin, destination) => {
-  // https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
-  return (
-    origin.protocol === destination.protocol &&
-    origin.host === destination.host /* This includes both hostname and port */
-  )
-}
+  /**
+   * The browser defaults to _self, but, not all browsers set 
+   * a.target to the string value `_self` by default
+   */
+  [`_self`, ``].indexOf(anchor.target) === -1
+)
+
+// https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
+export const urlsAreOnSameOrigin = (origin, destination) => (
+  origin.protocol === destination.protocol &&
+
+   /* a.host includes both hostname and port in the expected format host:port */
+  origin.host === destination.host
+)
 
 export default function(root, cb) {
   root.addEventListener(`click`, function(ev) {

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -146,13 +146,10 @@ export default function(root, cb) {
       return true
     }
 
-    // TODO: add a check for absolute internal links in a callback or here,
-    // or always pass only `${destination.pathname}${destination.hash}`
-    // to avoid `https://example.com/myapp/https://example.com/myapp/here` navigation
-
     ev.preventDefault()
 
-    cb(destination.getAttribute(`href`))
+    cb(`${destination.pathname}${destination.search}${destination.hash}`)
+
     return false
   })
 }

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -109,6 +109,19 @@ export const pathIsNotHandledByApp = destination => {
   )
 }
 
+export const hashShouldBeFollowed = (origin, destination) => (
+  destination.hash !== `` && (
+    /**
+     * Dynamically created anchor links (href="#my-anchor") do not always 
+     * have pathname on IE 
+     */
+    destination.pathname === `` ||
+
+    /* Don't catch links pointed to the same page but with a hash. */
+    destination.pathname === origin.pathname
+  )
+)
+
 export default function(root, cb) {
   root.addEventListener(`click`, function(ev) {
     if ( userIsForcingNavigation(ev) ) return true
@@ -136,15 +149,7 @@ export default function(root, cb) {
 
     if ( pathIsNotHandledByApp(destination) ) return true
 
-    // Dynamically created anchor links (href="#my-anchor") do not always have pathname on IE
-    if (destination.pathname === ``) {
-      return true
-    }
-
-    // Don't catch links pointed to the same page but with a hash.
-    if (destination.hash !== ``) {
-      return true
-    }
+    if ( hashShouldBeFollowed(origin, destination) ) return true
 
     ev.preventDefault()
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -23,26 +23,56 @@ export const findClosestAnchor = event => {
   return null
 }
 
-export const authorIsForcingNavigation = anchor => (
-  /**
-   * HTML5 attribute that informs the browser to handle the 
-   * href as a downloadable file
-   */
-  anchor.hasAttribute(`download`) === true ||
-
-  /**
-   * Only catch target=_self anchors
-   */
+export const anchorsTargetIsEquivalentToSelf = anchor => (
+  /* If not target attribute is present it's treated as _self */
   anchor.hasAttribute(`target`) === false ||
-
-  /* Assumption: some browsers use null for default attribute values */
-  anchor.target == null ||
 
   /**
    * The browser defaults to _self, but, not all browsers set 
    * a.target to the string value `_self` by default
    */
-  [`_self`, ``].indexOf(anchor.target) === -1
+
+  /** 
+   * Assumption: some browsers use null/undefined for default 
+   * attribute values 
+   */
+  anchor.target == null ||
+
+  /** 
+   * Some browsers use the empty string to mean _self, check 
+   * for actual `_self` 
+   */
+  [`_self`, ``].indexOf(anchor.target) !== -1 ||
+
+  /**
+   * As per https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target
+   */
+  (
+    anchor.target === `_parent` && (
+      !window.parent || 
+      window.parent === window
+    )
+  ) || 
+  (
+    anchor.target === `_top` && (
+      !window.top || 
+      window.top === window
+    )
+  )
+)
+
+export const authorIsForcingNavigation = anchor => (
+  /**
+   * HTML5 attribute that informs the browser to handle the 
+   * href as a downloadable file; let the browser handle it
+   */
+  anchor.hasAttribute(`download`) === true ||
+
+  /**
+   * Let the browser handle anything that doesn't look like a 
+   * target="_self" anchor
+   */
+  anchorsTargetIsEquivalentToSelf(anchor) === false
 )
 
 // https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -163,5 +163,9 @@ export const routeThroughBrowserOrApp = hrefHandler => event => {
 }
 
 export default function(root, cb) {
-  root.addEventListener(`click`, routeThroughBrowserOrApp(cb))
+  const clickHandler = routeThroughBrowserOrApp(cb)
+
+  root.addEventListener(`click`, clickHandler)
+
+  return () => root.removeEventListener(`click`, clickHandler)
 }

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -127,7 +127,7 @@ export default function(root, cb) {
     if ( userIsForcingNavigation(event) ) return true
 
     const clickedAnchor = findClosestAnchor(event.target)
-    if (clickedAnchor == null) return true
+    if ( clickedAnchor == null ) return true
 
     if( authorIsForcingNavigation(clickedAnchor) ) return true
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -53,13 +53,13 @@ export const anchorsTargetIsEquivalentToSelf = anchor => (
    */
   (
     anchor.target === `_parent` && (
-      !anchor.ownerDocument.defaultView.parent || 
+      !anchor.ownerDocument.defaultView.parent || // Assumption: This can be falsey
       anchor.ownerDocument.defaultView.parent === anchor.ownerDocument.defaultView
     )
   ) || 
   (
     anchor.target === `_top` && (
-      !anchor.ownerDocument.defaultView.top || 
+      !anchor.ownerDocument.defaultView.top || // Assumption: This can be falsey
       anchor.ownerDocument.defaultView.top === anchor.ownerDocument.defaultView
     )
   )

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -6,7 +6,10 @@ export const userIsForcingNavigation = event => (
   event.altKey ||
   event.ctrlKey ||
   event.metaKey ||
-  event.shiftKey ||
+  event.shiftKey
+)
+
+export const navigationWasHandledElsewhere = event => (
   event.defaultPrevented
 )
 
@@ -124,6 +127,8 @@ export const hashShouldBeFollowed = (origin, destination) => (
 
 export const routeThroughBrowserOrApp = hrefHandler => event => {
   if ( userIsForcingNavigation(event) ) return true
+
+  if ( navigationWasHandledElsewhere(event) ) return true
 
   const clickedAnchor = findClosestAnchor(event.target)
   if ( clickedAnchor == null ) return true

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -23,6 +23,18 @@ export const findClosestAnchor = event => {
   return null
 }
 
+export const authorIsForcingNavigation = anchor => {
+  // Don't catch links where a target (other than self) is set
+  // e.g. _blank.
+  if (anchor.target && anchor.target.toLowerCase() !== `_self`) return true
+
+  // HTML5 attribute that informs the browser to handle the href 
+  // as a downloadable file
+  if (anchor.hasAttribute(`download`)) return true
+
+  return false
+}
+
 module.exports = function(root, cb) {
   root.addEventListener(`click`, function(ev) {
     if ( userIsForcingNavigation(ev) ) return true
@@ -30,9 +42,7 @@ module.exports = function(root, cb) {
     const targetAnchor = findClosestAnchor(ev)
     if (targetAnchor == null) return true
 
-    // Don't catch links where a target (other than self) is set
-    // e.g. _blank.
-    if (targetAnchor.target && targetAnchor.target.toLowerCase() !== `_self`) return true
+    if( authorIsForcingNavigation(targetAnchor) ) return true
 
     // Don't catch links pointed to the same page but with a hash.
     if (targetAnchor.pathname === window.location.pathname && targetAnchor.hash !== ``) {

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -50,14 +50,14 @@ export const anchorsTargetIsEquivalentToSelf = anchor => (
    */
   (
     anchor.target === `_parent` && (
-      !window.parent || 
-      window.parent === window
+      !anchor.ownerDocument.defaultView.parent || 
+      anchor.ownerDocument.defaultView.parent === anchor.ownerDocument.defaultView
     )
   ) || 
   (
     anchor.target === `_top` && (
-      !window.top || 
-      window.top === window
+      !anchor.ownerDocument.defaultView.top || 
+      anchor.ownerDocument.defaultView.top === anchor.ownerDocument.defaultView
     )
   )
 )

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -35,6 +35,14 @@ export const authorIsForcingNavigation = anchor => {
   return false
 }
 
+export const urlsAreOnSameOrigin = (origin, destination) => {
+  // https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
+  return (
+    origin.protocol === destination.protocol &&
+    origin.host === destination.host /* This includes both hostname and port */
+  )
+}
+
 export default function(root, cb) {
   root.addEventListener(`click`, function(ev) {
     if ( userIsForcingNavigation(ev) ) return true
@@ -58,7 +66,7 @@ export default function(root, cb) {
     const origin = document.createElement(`a`)
     origin.href = window.location.href
 
-    if (destination.host !== origin.host) return true
+    if ( urlsAreOnSameOrigin(origin, destination) === false ) return true
 
     // Don't catch links pointed to the same page but with a hash.
     if (destination.pathname === origin.pathname && destination.hash !== ``) {

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -47,15 +47,15 @@ export default function(root, cb) {
   root.addEventListener(`click`, function(ev) {
     if ( userIsForcingNavigation(ev) ) return true
 
-    const targetAnchor = findClosestAnchor(ev)
-    if (targetAnchor == null) return true
+    const clickedAnchor = findClosestAnchor(ev)
+    if (clickedAnchor == null) return true
 
-    if( authorIsForcingNavigation(targetAnchor) ) return true
+    if( authorIsForcingNavigation(clickedAnchor) ) return true
 
     // IE clears the host value if the anchor href changed after creation, e.g.
     // in React. Creating a new anchor element to ensure host value is present
     const destination = document.createElement(`a`)
-    destination.href = targetAnchor.href
+    destination.href = clickedAnchor.href
 
     // In IE, the default port is included in the anchor host but excluded from
     // the location host.  This affects the ability to directly compare

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -35,7 +35,7 @@ export const authorIsForcingNavigation = anchor => {
   return false
 }
 
-module.exports = function(root, cb) {
+export default function(root, cb) {
   root.addEventListener(`click`, function(ev) {
     if ( userIsForcingNavigation(ev) ) return true
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -1,3 +1,4 @@
+import escapeStringRegexp from "escape-string-regexp"
 import { withPrefix } from "gatsby-link"
 
 export const userIsForcingNavigation = event => (
@@ -116,7 +117,7 @@ export default function(root, cb) {
     // href="https://example.com/not-my-app"> the plugin won't catch it and
     // will navigate to an external link instead of doing a pushState resulting
     // in `https://example.com/myapp/https://example.com/not-my-app`
-    var re = new RegExp(`^${withPrefix(`/`)}`)
+    var re = new RegExp(`^${escapeStringRegexp(withPrefix(`/`))}`)
     if (!re.test(`${destination.pathname}`)) return true
 
     // Don't catch links pointed at what look like file extensions (other than


### PR DESCRIPTION
Issues this PR (Possibly) Address
---

https://github.com/gatsbyjs/gatsby/issues/3370
https://github.com/gatsbyjs/gatsby/issues/3546
https://github.com/gatsbyjs/gatsby/issues/3715
https://github.com/gatsbyjs/gatsby/issues/4964
https://github.com/gatsbyjs/gatsby/issues/7033

Comments
---

The bug was being caused by us not escaping the string based regular expression we were creating that compares a pathPrefix-ed URL against the currently clicked link's URL.

The rest of the work in this ticket was me breaking up the logic of that window click event handler into functions following certain themes: checking the event, checking the links attributes, checking the URL in distinct chunks (protocol + host [same origin policy], pathname, hash) etc... 

I'm also handling some edge cases here that weren't handled before (checking the protocol, target=_parent and target=_top when the window is the topmost one, etc...).

I tested my code against a local version of GatsbyJS' documentation website, where I first noticed the issue. Currently, if you visit the [life-cycle apis documentation](https://www.gatsbyjs.org/docs/gatsby-lifecycle-apis/) and try to click on "onPreBootstrap" or any of the other API calls, the bug will surface. The links work as expected with the code from this PR.

Thanks to @octalmage and @m-allanson for help during the testing of the code, they were a big help in getting those tests written as I was less experienced in those matters at the time.