### PR TITLE
feature: Add support for all options for transformer-excel.

### DIFF
--- a/packages/gatsby-transformer-excel/README.md
+++ b/packages/gatsby-transformer-excel/README.md
@@ -28,7 +28,9 @@ module.exports = {
 }
 ```
 
-You can see an example project at https://github.com/gatsbyjs/gatsby/tree/master/examples/using-excel.
+This plugin allows you to pass any available options used by the underlying library's function. [Click here](https://github.com/SheetJS/js-xlsx#json) to view the full list of options.
+
+You can see an example project at [https://github.com/gatsbyjs/gatsby/tree/master/examples/using-excel](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-excel).
 
 ## Parsing algorithm
 
@@ -71,7 +73,7 @@ the following nodes would be created:
 
 ## How to query
 
-You'd be able to query your letters like:
+Using the same `letters.xlsx` example from above, you'd be able to query your letters like:
 
 ```graphql
 {
@@ -123,11 +125,15 @@ module.exports = {
     {
       resolve: `gatsby-transformer-excel`,
       options: {
-        rawOutput: false,
+        raw: false,
       },
     },
   ],
 }
 ```
+
+*NOTE 1*: A previous version of this library used the attribute name `rawOutput`. This name still works, but is an alias for the correct attribute `raw`. If both attributes are specified, the value for `raw` takes precedence.
+
+*NOTE 2*: If you don't specify the `raw` or `rawOutput` option, a value of `true` will be used in the underlying js-xlsx function. This is opposite the library's [default value of false](https://github.com/SheetJS/js-xlsx#json).
 
 This will make sure, that all field types are converted to strings.

--- a/packages/gatsby-transformer-excel/src/gatsby-node.js
+++ b/packages/gatsby-transformer-excel/src/gatsby-node.js
@@ -12,7 +12,7 @@ function _loadNodeContent(fileNode, fallback) {
 
 async function onCreateNode(
   { node, actions, loadNodeContent, createNodeId },
-  options
+  options = {}
 ) {
   const { createNode, createParentChildLink } = actions
   const extensions = `xls|xlsx|xlsm|xlsb|xml|xlw|xlc|csv|txt|dif|sylk|slk|prn|ods|fods|uos|dbf|wks|123|wq1|qpw|htm|html`.split(
@@ -23,13 +23,20 @@ async function onCreateNode(
   }
   // Load binary string
   const content = await _loadNodeContent(node, loadNodeContent)
+
+  // accept *all* options to pass to the sheet_to_json function
+  // alias legacy `rawOutput` to correct `raw` attribute
+  // NOTE: the default of true for `raw` is opposite the library's default
+  const xlsxOptions = _.defaults(options, { 'raw': options.rawOutput }, { 'raw': true })
+  delete xlsxOptions.rawOutput
+  delete xlsxOptions.plugins
+  console.log(`JSON after updates is: ${JSON.stringify(xlsxOptions)}`)
+
   // Parse
   let wb = XLSX.read(content, { type: `binary`, cellDates: true })
   wb.SheetNames.forEach((n, idx) => {
     let ws = wb.Sheets[n]
-    let parsedContent = XLSX.utils.sheet_to_json(ws, {
-      raw: options && `rawOutput` in options ? options.rawOutput : true,
-    })
+    let parsedContent = XLSX.utils.sheet_to_json(ws, xlsxOptions)
 
     if (_.isArray(parsedContent)) {
       const csvArray = parsedContent.map((obj, i) => {

--- a/packages/gatsby-transformer-excel/src/gatsby-node.js
+++ b/packages/gatsby-transformer-excel/src/gatsby-node.js
@@ -30,7 +30,6 @@ async function onCreateNode(
   const xlsxOptions = _.defaults(options, { 'raw': options.rawOutput }, { 'raw': true })
   delete xlsxOptions.rawOutput
   delete xlsxOptions.plugins
-  console.log(`JSON after updates is: ${JSON.stringify(xlsxOptions)}`)
 
   // Parse
   let wb = XLSX.read(content, { type: `binary`, cellDates: true })


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Closes #7767 . Add support for all options available in [js-xlsx](https://github.com/SheetJS/js-xlsx#json).

**As noted in the comments**: I left the existing default value for `raw` to `true`, even though the default value in the library's `sheet_to_json` attribute is `false`. This is a one-liner if we want to change and bring the default in our plugin inline with js-xlsx.