### PR TITLE
fix `gatsby new` command for v2 official starters

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -38,19 +38,19 @@ If you'd like to get started with Gatsby v2 you're in luck, there's a v2 edition
 `gatsby-starter-default` with v2:
 
 ```
-gatsby new my-default-project https://github.com/gatsbyjs/gatsby-starter-default#v2
+gatsby new my-default-project https://github.com/gatsbyjs/gatsby-starter-default\#v2
 ```
 
 `gatsby-starter-hello-world` with v2:
 
 ```
-gatsby new my-hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world#v2
+gatsby new my-hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world\#v2
 ```
 
 `gatsby-starter-blog` with v2:
 
 ```
-gatsby new my-blog https://github.com/gatsbyjs/gatsby-starter-blog#v2
+gatsby new my-blog https://github.com/gatsbyjs/gatsby-starter-blog\#v2
 ```
 
 ## Community starters


### PR DESCRIPTION
`gatsby new my-project https://github.com/gatsbyjs/gatsby-starter-default#v2` was returning the error:  `zsh: no matches found: https://github.com/gatsbyjs/gatsby-starter-default#v2`

adding `\` before the branch name corrected the error for me on the 3 official starters