### PR TITLE
[v2] [gatsby-plugin-offline] [cache-dir] Fix bugs with mismatching actual/canonical paths

### DIFF
--- a/packages/gatsby/cache-dir/load-directly-or-404.js
+++ b/packages/gatsby/cache-dir/load-directly-or-404.js
@@ -19,7 +19,7 @@ export default function(resources, path, replaceOnSuccess = false) {
         `Found no-cache=1 while attempting to load a page directly; ` +
           `this is likely due to a bug in Gatsby, or a misconfiguration in your project.`
       )
-      reject()
+      return reject()
     }
 
     // Append the appropriate query to the URL.

--- a/packages/gatsby/cache-dir/load-directly-or-404.js
+++ b/packages/gatsby/cache-dir/load-directly-or-404.js
@@ -10,9 +10,17 @@
  * 4. If the fetch failed (generally meaning we're offline), then navigate anyways to show
  * either the browser's offline page or whatever the server error is.
  */
-export default function(resources, path) {
-  return new Promise(resolve => {
+export default function(resources, path, replaceOnSuccess = false) {
+  return new Promise((resolve, reject) => {
     const url = new URL(window.location.origin + path)
+
+    if (url.search.match(/\?(.*&)?no-cache=1(&|$)/)) {
+      console.log(
+        `Found no-cache=1 while attempting to load a page directly; ` +
+          `this is likely due to a bug in Gatsby, or a misconfiguration in your project.`
+      )
+      reject()
+    }
 
     // Append the appropriate query to the URL.
     if (url.search) {
@@ -32,7 +40,11 @@ export default function(resources, path) {
             // Redirect there if there isn't a 404. If a different HTTP
             // error occurs, the appropriate error message will be
             // displayed after loading the page directly.
-            window.location.replace(url)
+            if (replaceOnSuccess) {
+              window.location.replace(url)
+            } else {
+              window.location = url
+            }
           } else {
             // If a 404 occurs, show the custom 404 page.
             resolve()

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -85,9 +85,9 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     window.page.path !== window.location.pathname &&
     window.page.path !== `/offline-plugin-app-shell-fallback/`
   ) {
-    const url = new URL(window.location)
-    url.pathname = window.page.path
-    navigate(url, { replace: true })
+    navigate(window.page.path + window.location.search + window.location.hash, {
+      replace: true,
+    })
   }
 
   loader

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -1,7 +1,7 @@
 import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
 import React, { createElement } from "react"
 import ReactDOM from "react-dom"
-import { Router } from "@reach/router"
+import { Router, navigate } from "@reach/router"
 import { ScrollContext } from "gatsby-react-router-scroll"
 import domReady from "domready"
 import {
@@ -80,6 +80,16 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     }
   }
 
+  if (
+    window.page.path &&
+    window.page.path !== window.location.pathname &&
+    window.page.path !== `/offline-plugin-app-shell-fallback/`
+  ) {
+    const url = new URL(window.location)
+    url.pathname = window.page.path
+    navigate(url, { replace: true })
+  }
+
   loader
     .getResourcesForPathname(window.location.pathname)
     .then(() => {
@@ -87,7 +97,13 @@ apiRunnerAsync(`onClientEntry`).then(() => {
         return loader
           .getResourcesForPathname(`/404.html`)
           .then(resources =>
-            loadDirectlyOr404(resources, window.location.pathname)
+            loadDirectlyOr404(
+              resources,
+              window.location.pathname +
+                window.location.search +
+                window.location.hash,
+              true
+            )
           )
       }
     })


### PR DESCRIPTION
Changelog:

- Add back the check in `load-directly-or-404.js` - @KyleAMathews was correct that this should be unnecessary, however a lot of the recent bugs were due to behaviour surrounding the new `no-cache=1` so it might help if others are discovered later.
- Set the correct pathname without loading from the server if it mismatches the canonical path - this allows Gatsby to find the resources for the page, even if the server is serving it at a different location (e.g. lowercase when it should be uppercase)
- Replace the URL if `loadDirectlyOr404` succeeds upon initially trying to load the page, for correct history.
  - Not sure yet if this fixes #7261 since my manual tests didn't include reloading before pressing back etc, but it works correctly for all the tests I've performed.

<details>
<summary>Click to see manual tests</summary>

```
configurations:

- 1) online without gatsby-plugin-offline
- 2) online with gatsby-plugin-offline
- 3) offline with gatsby-plugin-offline
- 4) online in develop

- x.1) with a custom 404 page
- x.2) without a custom 404 page


tests:

- 1) 404s are handled correctly from internal links - custom 404 or server 404
  if custom is unavailable, or offline error, but no blank pages

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 2) 404s are handled correctly when entering a URL directly - as above, and
  the URL fetched contains the original query parameters (not just no-cache=1)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 3A) back button works properly after internal link 404 (navigates to the
  expected page)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 3B) back button works properly after external link 404 (navigates to the
  expected page)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 4) pages which fail to load display a native offline error (no blank pages)

  requires: [3.1, 3.2]
  passed:   [3.1, 3.2]

- 5) the service worker remains installed after a 404/offline error

  requires: [3.1, 3.2]
  passed:   [3.1, 3.2]

- 6) Netlify CMS /admin/ loads or displays an offline error (no 404/blank page)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 7) going to a page by entering the URL directly works

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 4.1, 4.2]

- 8) clicking the "mismatching canonical URL" link works with JS, and goes
  backwards and forwards correctly (or shows offline)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2]

- 9) directly entering the mismatching canonical URL works with JS, and goes
  backwards and forwards correctly (or shows offline)

  requires: [1.1, 1.2, 2.1, 2.2, 3.1, 3.2]
  passed:   [1.1, 1.2, 2.1, 2.2, 3.1, 3.2]

- 10) going to a page with a mismatching canonical URL always shows a 404 in
  development

  requires: [4.1, 4.2]
  passed:   [4.1, 4.2]
```
</details>

Fixes #7760