### PR TITLE
Travis config update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,81 +1,35 @@
 services:
   - docker
-
 os:
   - linux
-
 dist: trusty
 sudo: required
 
-jobs:
-    include:
-        - stage: Unit tests
-          if: type = pull_request
-          language: node_js
-          node_js:
-            - '6'
-            - '8'
-            - '10'
-          cache:
-            yarn: true
-          before_install:
-          - curl -o- -L https://yarnpkg.com/install.sh | bash
-          - export PATH=$HOME/.yarn/bin:$PATH
-          install:
-          - yarn run bootstrap
-          script:
-          - yarn test
+language: node_js
+node_js:
+  - '6'
+  - '8'
+  - '10'
 
-        - stage: Integration tests
-          if: type = pull_request
-          language: node_js
-          node_js:
-            - '6'
-            - '8'
-            - '10'
-          cache:
-            yarn: true
-          before_install:
-          - curl -o- -L https://yarnpkg.com/install.sh | bash
-          - export PATH=$HOME/.yarn/bin:$PATH
-          install:
-          - yarn run bootstrap
-          script:
-          - yarn test:integration
+matrix:
+  include:
+    - name: "Unit Tests"
+      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=test
+    - name: "Integration Tests"
+      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND='test:integration'
+    - name: "Develop UI Tests"
+      env: SRC_PATH='examples/gatsbygram' INSTALL_COMMAND='install' TEST_COMMAND=test
+    - name: "Production UI Tests"
+      env: SRC_PATH='integration-tests/production-runtime' INSTALL_COMMAND='install' TEST_COMMAND=test
 
-        - stage: Develop UI tests
-          language: node_js
-          node_js:
-            - '6'
-            - '8'
-            - '10'
-          cache:
-            yarn: true
-          before_install:
-          - curl -o- -L https://yarnpkg.com/install.sh | bash
-          - export PATH=$HOME/.yarn/bin:$PATH
-          - cd examples/gatsbygram
-          install:
-          - yarn
-          script:
-          - yarn test
-
-        - stage: Production UI tests
-          language: node_js
-          node_js:
-            - '6'
-            - '8'
-            - '10'
-          cache:
-            yarn: true
-          before_install:
-          - curl -o- -L https://yarnpkg.com/install.sh | bash
-          - export PATH=$HOME/.yarn/bin:$PATH
-          - cd integration-tests/production-runtime
-          install:
-          - yarn
-          script:
-          - yarn test
+cache:
+  yarn: true
+before_install:
+  - 'cd $SRC_PATH'
+install:
+  - 'yarn $INSTALL_COMMAND'
+script:
+  - 'yarn $TEST_COMMAND'
 
 # new pushes aren't working at the moment (the build times out processing showcase images)
 # the existing image works fine, and can be manually updated by running through the steps

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,41 @@ language: node_js
 
 matrix:
   include:
+    - name: "Lint"
+      env: SRC_PATH=. TEST_COMMAND='lint'
+      node_js:
+        - 'lts/*'
     - name: "Unit Tests on Node.js 6"
-      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=test
+      env: SRC_PATH=. TEST_COMMAND=jest
       node_js:
         - '6'
     - name: "Unit Tests on Node.js 8"
-      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=test
+      env: SRC_PATH=. TEST_COMMAND=jest
       node_js:
         - '8'
     - name: "Unit Tests on Node.js 10"
-      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=test
+      env: SRC_PATH=. TEST_COMMAND=jest
       node_js:
         - '10'
     - name: "Integration Tests"
-      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND='test:integration'
+      env: SRC_PATH=. TEST_COMMAND='test:integration'
+      node_js:
+        - 'lts/*'
     - name: "Develop UI Tests"
-      env: SRC_PATH='examples/gatsbygram' INSTALL_COMMAND='install' TEST_COMMAND='test'
+      env: SRC_PATH='examples/gatsbygram' TEST_COMMAND='test'
+      node_js:
+        - 'lts/*'
     - name: "Production UI Tests"
-      env: SRC_PATH='integration-tests/production-runtime' INSTALL_COMMAND='install' TEST_COMMAND='test'
+      env: SRC_PATH='integration-tests/production-runtime' TEST_COMMAND='test'
+      node_js:
+        - 'lts/*'
 
 cache:
   yarn: true
 before_install:
   - 'cd $SRC_PATH'
 install:
-  - 'yarn $INSTALL_COMMAND'
+  - yarn
 script:
   - 'yarn $TEST_COMMAND'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ services:
 os:
   - linux
 dist: trusty
-sudo: required
+ # use container-based build env for faster boot
+sudo: false
 language: node_js
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,31 +10,31 @@ language: node_js
 matrix:
   include:
     - name: "Lint"
-      env: SRC_PATH=. TEST_COMMAND='lint'
+      env: SRC_PATH=. INSTALL_COMMAND='install' TEST_COMMAND='lint'
       node_js:
         - 'lts/*'
     - name: "Unit Tests on Node.js 6"
-      env: SRC_PATH=. TEST_COMMAND=jest
+      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=jest
       node_js:
         - '6'
     - name: "Unit Tests on Node.js 8"
-      env: SRC_PATH=. TEST_COMMAND=jest
+      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=jest
       node_js:
         - '8'
     - name: "Unit Tests on Node.js 10"
-      env: SRC_PATH=. TEST_COMMAND=jest
+      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=jest
       node_js:
         - '10'
     - name: "Integration Tests"
-      env: SRC_PATH=. TEST_COMMAND='test:integration'
+      env: SRC_PATH=. INSTALL_COMMAND='install' TEST_COMMAND='test:integration'
       node_js:
         - 'lts/*'
     - name: "Develop UI Tests"
-      env: SRC_PATH='examples/gatsbygram' TEST_COMMAND='test'
+      env: SRC_PATH='examples/gatsbygram' INSTALL_COMMAND='install' TEST_COMMAND='test'
       node_js:
         - 'lts/*'
     - name: "Production UI Tests"
-      env: SRC_PATH='integration-tests/production-runtime' TEST_COMMAND='test'
+      env: SRC_PATH='integration-tests/production-runtime' INSTALL_COMMAND='install' TEST_COMMAND='test'
       node_js:
         - 'lts/*'
 
@@ -43,7 +43,7 @@ cache:
 before_install:
   - 'cd $SRC_PATH'
 install:
-  - yarn
+  - 'yarn $INSTALL_COMMAND'
 script:
   - 'yarn $TEST_COMMAND'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,28 @@ os:
   - linux
 dist: trusty
 sudo: required
-
 language: node_js
-node_js:
-  - '6'
-  - '8'
-  - '10'
 
 matrix:
   include:
-    - name: "Unit Tests"
+    - name: "Unit Tests on Node.js 6"
       env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=test
+      node_js:
+        - '6'
+    - name: "Unit Tests on Node.js 8"
+      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=test
+      node_js:
+        - '8'
+    - name: "Unit Tests on Node.js 10"
+      env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND=test
+      node_js:
+        - '10'
     - name: "Integration Tests"
       env: SRC_PATH=. INSTALL_COMMAND='run bootstrap' TEST_COMMAND='test:integration'
     - name: "Develop UI Tests"
-      env: SRC_PATH='examples/gatsbygram' INSTALL_COMMAND='install' TEST_COMMAND=test
+      env: SRC_PATH='examples/gatsbygram' INSTALL_COMMAND='install' TEST_COMMAND='test'
     - name: "Production UI Tests"
-      env: SRC_PATH='integration-tests/production-runtime' INSTALL_COMMAND='install' TEST_COMMAND=test
+      env: SRC_PATH='integration-tests/production-runtime' INSTALL_COMMAND='install' TEST_COMMAND='test'
 
 cache:
   yarn: true


### PR DESCRIPTION
Speed up Travis CI runs by setting jobs to run in parallel instead of sequentially.

This also splits linting out to a separate job from unit testing, and unit testing is now run on Node 6, 8 and 10.

Refs #7792 