### PR TITLE
[gatsby-source-contentful] Added support for non localized fields without use of fallback locales

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -161,10 +161,21 @@ describe(`Gets field value based on current locale`, () => {
         localesFallback,
         locale: {
           code: `gsw_CH`,
-          fallbackCode: `de`,
         },
       })
     ).toBe(field[`de`])
+  })
+  it(`Falls back to default locale on a non localized field without locale fallbacks`, () => {
+    expect(
+      normalize.getLocalizedField({
+        field,
+        localesFallback: { "es-ES": null, "de": null },
+        locale: {
+          code: `es-ES`,
+        },
+        defaultLocale: `en-US`,
+      })
+    ).toBe(field[`en-US`])
   })
   it(`returns null if passed a locale that doesn't have a field nor a fallbackCode`, () => {
     expect(
@@ -173,7 +184,6 @@ describe(`Gets field value based on current locale`, () => {
         localesFallback,
         locale: {
           code: `es-US`,
-          fallbackCode: `null`,
         },
       })
     ).toEqual(null)

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -11,7 +11,7 @@ const digest = str =>
 const typePrefix = `Contentful`
 const makeTypeName = type => _.upperFirst(_.camelCase(`${typePrefix} ${type}`))
 
-const getLocalizedField = ({ field, locale, localesFallback }) => {
+const getLocalizedField = ({ field, locale, localesFallback, defaultLocale }) => {
   if (!_.isUndefined(field[locale.code])) {
     return field[locale.code]
   } else if (
@@ -20,7 +20,7 @@ const getLocalizedField = ({ field, locale, localesFallback }) => {
   ) {
     return getLocalizedField({
       field,
-      locale: { code: localesFallback[locale.code] },
+      locale: { code: localesFallback[locale.code] || defaultLocale },
       localesFallback,
     })
   } else {
@@ -35,8 +35,8 @@ const buildFallbackChain = locales => {
   )
   return localesFallback
 }
-const makeGetLocalizedField = ({ locale, localesFallback }) => field =>
-  getLocalizedField({ field, locale, localesFallback })
+const makeGetLocalizedField = ({ locale, localesFallback, defaultLocale }) => field =>
+  getLocalizedField({ field, locale, localesFallback, defaultLocale })
 
 exports.getLocalizedField = getLocalizedField
 exports.buildFallbackChain = buildFallbackChain


### PR DESCRIPTION
Fixes for #2937, default locale is added to support a contentful setup where fallback locales are not used. 

### Test case
A content model existing of 2 fields (the environment is setup without having any fallbacks.
- Name (localized)
- slug (not localized)

### Result from graphQL query
```
{
  "data": {
    "allContentfulPage": {
      "edges": [
        {
          "node": {
            "name": "Page A",
            "node_locale": "en-US",
            "slug": "/"
          }
        },
        {
          "node": {
            "name": "Page B",
            "node_locale": "es-ES",
            "slug": null
          }
        },
      ]
    }
  }
}
```

### Expected Result

```
{
  "data": {
    "allContentfulPage": {
      "edges": [
        {
          "node": {
            "name": "Page A",
            "node_locale": "en-US",
            "slug": "/"
          }
        },
        {
          "node": {
            "name": "Page B",
            "node_locale": "es-ES",
            "slug": "/"
          }
        },
      ]
    }
  }
}
```