### PR TITLE
fix: babel options

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/babelrc.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/babelrc.js.snap
@@ -5,7 +5,6 @@ Object {
   "stages": Object {
     "build-html": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },
@@ -19,7 +18,6 @@ Object {
     },
     "build-javascript": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },
@@ -33,7 +31,6 @@ Object {
     },
     "develop": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },
@@ -47,7 +44,6 @@ Object {
     },
     "develop-html": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },
@@ -68,7 +64,6 @@ Object {
   "stages": Object {
     "build-html": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },
@@ -82,7 +77,6 @@ Object {
     },
     "build-javascript": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },
@@ -96,7 +90,6 @@ Object {
     },
     "develop": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },
@@ -110,7 +103,6 @@ Object {
     },
     "develop-html": Object {
       "options": Object {
-        "babelrc": false,
         "cacheDirectory": true,
         "sourceType": "unambiguous",
       },

--- a/packages/gatsby/src/redux/reducers/babelrc.js
+++ b/packages/gatsby/src/redux/reducers/babelrc.js
@@ -8,7 +8,6 @@ module.exports = (
         presets: [],
         options: {
           cacheDirectory: true,
-          babelrc: false,
           sourceType: `unambiguous`,
         },
       },
@@ -17,7 +16,6 @@ module.exports = (
         presets: [],
         options: {
           cacheDirectory: true,
-          babelrc: false,
           sourceType: `unambiguous`,
         },
       },
@@ -26,7 +24,6 @@ module.exports = (
         presets: [],
         options: {
           cacheDirectory: true,
-          babelrc: false,
           sourceType: `unambiguous`,
         },
       },
@@ -35,7 +32,6 @@ module.exports = (
         presets: [],
         options: {
           cacheDirectory: true,
-          babelrc: false,
           sourceType: `unambiguous`,
         },
       },


### PR DESCRIPTION
we don't need to disable babelrc lookup now that we are using the babel apis

Also i accidentally commited this directly to master and then reverted it SORRY (i'm tired)!