### PR TITLE
fix: fix tag pages on blog/docs

### DIFF
--- a/docs/blog/2017-05-31-introduction-to-gatsby/index.md
+++ b/docs/blog/2017-05-31-introduction-to-gatsby/index.md
@@ -3,7 +3,7 @@ title: Introduction to Gatsby
 date: 2018-05-31
 author: Michelle Barker
 excerpt: "In case you haven’t heard about it, Gatsby is the latest hot thing in static site generators"
-tags: ["gatsby", "css", "graphql", "blog"]
+tags: ["css", "graphql", "blog"]
 canonicalLink: https://css-irl.info/introduction-to-gatsby/
 publishedAt: css-irl.info
 ---

--- a/docs/blog/2018-05-11-six-reasons-i-chose-gatsby/index.md
+++ b/docs/blog/2018-05-11-six-reasons-i-chose-gatsby/index.md
@@ -3,7 +3,7 @@ title: Six Reasons I Chose Gatsby
 date: 2018-05-11
 author: Ray Gesualdo
 excerpt: "Spoiler alert: I'm a big fan of Gatsby."
-tags: ["gatsby", "react", "graphql", "plugins"]
+tags: ["react", "graphql", "plugins"]
 canonicalLink: https://www.raygesualdo.com/posts/six-reasons-i-chose-gatsby/
 publishedAt: raygesualdo.com
 ---

--- a/docs/blog/2018-06-16-announcing-gatsby-v2-beta-launch/index.md
+++ b/docs/blog/2018-06-16-announcing-gatsby-v2-beta-launch/index.md
@@ -2,7 +2,7 @@
 title: Announcing Gatsby v2 beta launch!
 date: "2018-06-16"
 author: "Mike Allanson"
-tags: ["v2", "gatsby"]
+tags: ["v2"]
 image: "astronaut-v2.jpg"
 ---
 

--- a/docs/blog/2018-08-09-swag-store/index.md
+++ b/docs/blog/2018-08-09-swag-store/index.md
@@ -3,7 +3,7 @@ title: Free Swag for Gatsby Contributors
 date: "2018-08-09"
 image: images/gatsby-swag.jpg
 author: Jason Lengstorf
-tags: ["collaboration", "gatsby", "community"]
+tags: ["collaboration", "community"]
 ---
 
 Today, we’re _so excited_ to announce the launch of the [Gatsby Swag Store][store]! If you’ve been following along [on Twitter][twitter], you may have seen the news a little while back.

--- a/docs/blog/2018-08-11-gatsby-pair-programming/index.md
+++ b/docs/blog/2018-08-11-gatsby-pair-programming/index.md
@@ -3,7 +3,7 @@ title: My experience doing pair programming with the Gatsby team and why you sho
 date: "2018-08-11"
 image: images/screenshot.jpg
 author: Horacio Herrera
-tags: ["collaboration", "gatsby", "community"]
+tags: ["collaboration", "community"]
 ---
 
 I love pair programming. This is one of the practices we do in our trainings at [ReactJS Academy](https://reactjs.academy?utm_source=social&utm_medium=medium&utm_campaign=horacio-gatsby-post&utm_term=reactjs-academy), and we do it regularly at [LeanJS](https://leanjs.com?utm_source=social&utm_medium=medium&utm_campaign=horacio-gatsby-post&utm_term=leanjs).

--- a/docs/blog/2018-08-13-using-decoupled-drupal-with-gatsby/index.md
+++ b/docs/blog/2018-08-13-using-decoupled-drupal-with-gatsby/index.md
@@ -2,7 +2,7 @@
 title: Using Decoupled Drupal with Gatsby
 date: "2018-08-13"
 author: Shannon Soper
-tags: ["cms", "gatsby", "drupal"]
+tags: ["cms", "drupal"]
 ---
 
 ## Why use Drupal + Gatsby together?

--- a/docs/blog/2018-1-18-strapi-and-gatsby/index.md
+++ b/docs/blog/2018-1-18-strapi-and-gatsby/index.md
@@ -2,7 +2,7 @@
 title: "Building a static blog using Gatsby and Strapi"
 date: "2018-01-18"
 author: "Pierre Burgy"
-tags: ["gatsby", "strapi"]
+tags: ["strapi"]
 ---
 
 ## Introduction

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -203,7 +203,7 @@ exports.createPages = ({ graphql, actions }) => {
 
       _.uniq(_.flatten(tagLists)).forEach(tag => {
         createPage({
-          path: `/blog/tags/${_.kebabCase(tag)}/`,
+          path: `/blog/tags/${_.kebabCase(tag.toLowerCase())}/`,
           component: tagTemplate,
           context: {
             tag,

--- a/www/src/components/tags-section.js
+++ b/www/src/components/tags-section.js
@@ -9,7 +9,7 @@ const TagsSection = ({ tags }) => {
     const divider = i < tags.length - 1 && <span>{` | `}</span>
     return (
       <span key={tag}>
-        <Link to={`/blog/tags/${_.kebabCase(tag)}`}>{tag}</Link>
+        <Link to={`/blog/tags/${_.kebabCase(tag.toLowerCase())}`}>{tag}</Link>
         {divider}
       </span>
     )


### PR DESCRIPTION
This PR introduces the following fixes:

- Duplicate tags are largely eliminated on /blog/tags (e.g. React vs. react, JAMstack vs. jamstack, etc.)
- Only tags tied to blog posts are shown (e.g. fixes https://next.gatsbyjs.org/blog/tags/firebase/)
- Removes redundant gatsby tags (note: this was manual and not programmatic)

I feel like the toLowerCase() and kebabCase mix is a little janky. In the past, I've solved this by adding a custom slug resolver, but it's a bit harder to do with tags. That said, other approaches more than welcome :)