### PR TITLE
docs: add a title to code snippets in the first part of the tutorial

### DIFF
--- a/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
+++ b/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
@@ -93,7 +93,7 @@ After installing each of these functional plugins, we'll edit
 `gatsby-config.js`, which Gatsby loads at build-time to implement the exposed
 functionality of the specified plugins.
 
-```javascript{6-9}
+```javascript{6-9}:title=gatsby-config.js
 module.exports = {
   siteMetadata: {
     title: `Your Name - Blog`,
@@ -127,7 +127,7 @@ into our `gatsby-config.js`, like so:
 yarn add gatsby-source-filesystem
 ```
 
-```javascript{6-12}
+```javascript{6-12}:title=gatsby-config.js
 module.exports = {
   // previous configuration
   plugins: [
@@ -178,7 +178,7 @@ yarn add gatsby-transformer-remark
 
 and editing `gatsby-config.js`
 
-```javascript{13-18}
+```javascript{13-18}:title=gatsby-config.js
 module.exports = {
   // previous setup
   plugins: [
@@ -220,7 +220,7 @@ for blog posts is to name the folder something like `MM-DD-YYYY-title`, e.g.
 The content of this Markdown file will be our blog post, authored in Markdown
 (of course!). Here's what it'll look like:
 
-```markdown
+```markdown:title=src/pages/07-12-2017-getting-started/index.md
 ---
 path: "/hello-world"
 date: "2017-07-12T17:12:33.962Z"
@@ -252,7 +252,7 @@ write our template in... you guessed it, React! (Or
 We'll want to create the file `src/templates/blog-post.js` (please create the
 `src/templates` folder if it does not yet exist!).
 
-```javascript
+```javascript:title=src/templates/blog-post.js
 import React from "react"
 import Helmet from "react-helmet"
 
@@ -294,7 +294,7 @@ very simply the pieces of data that we want to display for our blog post. Each
 piece of data our query selects will be injected via the `data` property we
 specified earlier.
 
-```javascript{21-32}
+```javascript{23-32}:title=src/templates/blog-post.js
 import React from "react"
 import Helmet from "react-helmet"
 import { graphql } from "gatsby"
@@ -376,11 +376,11 @@ level as `gatsby-config.js`. Each export found in this file will be parsed by
 Gatsby, as detailed in its [Node API specification][node-spec]. However, we only
 care about one particular API in this instance, `createPages`.
 
-```javascript
+```javascript:title=gatsby-node.js
 const path = require("path")
 
-exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ actions, graphql }) => {
+  const { createPage } = actions
 
   const blogPostTemplate = path.resolve(`src/templates/blog-post.js`)
 }
@@ -389,20 +389,20 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
 Nothing super complex yet! We're using the `createPages` API (which Gatsby will
 call at build time with injected parameters). We're also grabbing the _path_ to
 our blogPostTemplate we created earlier. Finally, we're using the `createPage`
-action creator/function made available in boundActionCreators. Gatsby uses Redux
-internally to manage its state, and `boundActionCreators` are simply the exposed
+action creator/function made available in actions. Gatsby uses Redux
+internally to manage its state, and `actions` are simply the exposed
 action creators of Gatsby, of which `createPage` is one of the action creators!
 For the full list of exposed action creators, check out [Gatsby's
-documentation][gatsby-bound-action-creators]. We can now construct the GraphQL
+documentation][gatsby-actions]. We can now construct the GraphQL
 query, which will fetch all of our Markdown posts.
 
 ### Querying for posts
 
-```javascript{8-31}
+```javascript{8-31}:title=gatsby-node.js
 const path = require("path")
 
-exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ actions, graphql }) => {
+  const { createPage } = actions
 
   const blogPostTemplate = path.resolve(`src/templates/blog-post.js`)
 
@@ -447,11 +447,11 @@ pages (with the `createPage` action creator). Let's do that!
 
 ### Creating the pages
 
-```javascript{32-39}
+```javascript{28-34}:title=gatsby-node.js
 const path = require("path")
 
-exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+exports.createPages = ({ actions, graphql }) => {
+  const { createPage } = actions
 
   const blogPostTemplate = path.resolve(`src/templates/blog-post.js`)
 
@@ -531,7 +531,7 @@ component!) will get a corresponding static HTML file. For instance, if we
 create `src/pages/tags.js`, the path `http://localhost:8000/tags/` will be
 available within the browser and the statically generated site.
 
-```javascript
+```javascript:title=src/pages/index.js
 import React from "react"
 import { Link, graphql } from "gatsby"
 import Helmet from "react-helmet"
@@ -649,7 +649,7 @@ Now go build something great.
 [frontmatter]: https://jekyllrb.com/docs/frontmatter/
 [learn-graphql]: https://www.howtographql.com
 [node-spec]: /docs/node-apis/
-[gatsby-bound-action-creators]: /docs/bound-action-creators/
+[gatsby-actions]: /docs/actions/
 [styled-components]: https://github.com/styled-components/styled-components
 [yarn]: https://yarnpkg.com/en/
 [source-code]: https://github.com/dschau/gatsby-blog-starter-kit

--- a/docs/blog/author.yaml
+++ b/docs/blog/author.yaml
@@ -3,7 +3,7 @@
   avatar: avatars/kyle-mathews.jpeg
   twitter: "@kylemathews"
 - id: Dustin Schau
-  bio: Consultant @ Object Partners, Inc. Likes all things front-end, and travel. And other things too. Blogs at dustinschau.com/blog.
+  bio: Software Engineer @ GatsbyJS. Likes all things front-end, and travel. And other things too. Blogs at blog.dustinschau.com.
   avatar: avatars/dustin-schau.jpeg
   twitter: "@schaudustin"
 - id: Kostas Bariotis

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -39,7 +39,7 @@ Let’s take a look at the code that powers the homepage.
 
 Open up the `/src` directory in your code editor. Inside is a single directory: `/pages`.
 
-Open the file at `/src/pages/index.js`. The code in this file creates a component that contains a single div, and some text — appropriately, “Hello world!”
+Open the file at `src/pages/index.js`. The code in this file creates a component that contains a single div, and some text — appropriately, “Hello world!”
 
 ### ✋ Make changes to the “Hello World” homepage
 
@@ -52,9 +52,9 @@ Open the file at `/src/pages/index.js`. The code in this file creates a componen
 
 > 💡 Gatsby uses **hot reloading** to speed up your development process. Essentially, when you’re running a Gatsby development server, the Gatsby site files are being “watched” in the background — any time you save a file, your changes will be immediately reflected in the browser. You don’t need to hard refresh the page, or restart the development server — your changes just appear.
 
-2.  Let’s make our changes a little more visible. Try replacing the code in `/src/pages/index.js` with the code below, and save again. You’ll see changes to the text; The text color will be purple, and the font size will be larger.
+2.  Let’s make our changes a little more visible. Try replacing the code in `src/pages/index.js` with the code below, and save again. You’ll see changes to the text; The text color will be purple, and the font size will be larger.
 
-```jsx
+```jsx:title=src/pages/index.js
 import React from "react"
 
 export default () => (
@@ -66,7 +66,7 @@ export default () => (
 
 3.  Remove the font size styling. Change the “Hello Gatsby!” text to a level-one header. Add a paragraph beneath the header.
 
-```jsx{4-6}
+```jsx{4-6}:title=src/pages/index.js
 import React from "react"
 
 export default () => (
@@ -99,9 +99,9 @@ export default () => (
 
 _If you’re familiar with React and JSX, feel free to skip this section._ If you haven’t worked with the React framework before, you may be wondering what HTML is doing in a JavaScript function. Or why we’re importing `react` on the first line but seemingly not using it anywhere. This hybrid “HTML-in-JS” is actually a syntax extension of JavaScript, for React, called JSX. You can follow along this tutorial without prior experience with React, but if you’re curious, here’s a brief primer…
 
-Consider the original contents of the `/src/pages/index.js` file:
+Consider the original contents of the `src/pages/index.js` file:
 
-```jsx
+```jsx:title=src/pages/index.js
 import React from "react"
 
 export default () => <div>Hello world!</div>
@@ -109,7 +109,7 @@ export default () => <div>Hello world!</div>
 
 In pure JavaScript, it looks more like this:
 
-```javascript
+```javascript:title=src/pages/index.js
 import React from "react"
 
 export default () => React.createElement("div", null, "Hello world!")
@@ -152,13 +152,13 @@ limited to the building blocks the browser provides e.g. `<button />`, you can e
 
 ### ✋ Using page components
 
-Any React component defined in `/src/pages/*.js` will automatically become a page. Let’s see this in action.
+Any React component defined in `src/pages/*.js` will automatically become a page. Let’s see this in action.
 
-We already have a `/src/pages/index.js` file that came with the “Hello World” starter. Let’s create an about page.
+We already have a `src/pages/index.js` file that came with the “Hello World” starter. Let’s create an about page.
 
-1.  Create a new file at `/src/pages/about.js`, copy the following code into the new file, and save.
+1.  Create a new file at `src/pages/about.js`, copy the following code into the new file, and save.
 
-```jsx
+```jsx:title=src/pages/about.js
 import React from "react"
 
 export default () => (
@@ -173,16 +173,16 @@ export default () => (
 
 ![New about page](05-about-page.png)
 
-Just by putting a React component in the `/src/pages/about.js` file, we now have a page accessible at `/about`.
+Just by putting a React component in the `src/pages/about.js` file, we now have a page accessible at `/about`.
 
 ### ✋ Using sub-components
 
 Let’s say the homepage and the about page both got quite large, and we were rewriting a lot of things. We can use sub-components to break the UI into reusable pieces. Both of our pages have `<h1>` headers — let’s create a component that will describe a `Header`.
 
-1.  Create a new directory at `/src/components`, and a file within that directory called `header.js`.
-2.  Add the following code to the new `/src/components/header.js` file.
+1.  Create a new directory at `src/components`, and a file within that directory called `header.js`.
+2.  Add the following code to the new `src/components/header.js` file.
 
-```jsx
+```jsx:title=src/components/header.js
 import React from "react"
 
 export default () => <h1>This is a header.</h1>
@@ -190,7 +190,7 @@ export default () => <h1>This is a header.</h1>
 
 3.  Modify the `about.js` file to import the `Header` component. Replace the `h1` markup with `<Header />`:
 
-```jsx{2,6}
+```jsx{2,6}:title=src/pages/about.js
 import React from "react"
 import Header from "../components/header"
 
@@ -206,17 +206,17 @@ export default () => (
 
 In the browser, the “About Gatsby” header text should now be replaced with “This is a header.” But we don’t want the “About” page to say “This is a header.” We want it to say, “About Gatsby”.
 
-4.  Head back to `/src/components/header.js`, and make the following change:
+4.  Head back to `src/components/header.js`, and make the following change:
 
-```jsx{3}
+```jsx{3}:title=src/components/header.js
 import React from "react"
 
 export default props => <h1>{props.headerText}</h1>
 ```
 
-5.  Head back to `/src/pages/about.js` and make the following change:
+5.  Head back to `src/pages/about.js` and make the following change:
 
-```jsx{6}
+```jsx{6}:title=src/pages/about.js
 import React from "react"
 import Header from "../components/header"
 
@@ -258,9 +258,9 @@ If we had passed another prop to our `<Header />` component, like so...
 
 ...we would have been able to also access the `arbitraryPhrase` prop: `{props.arbitraryPhrase}`.
 
-6.  To emphasize how this makes our components reusable, let’s add an extra `<Header />` component to the about page. Add the following code to the `/src/pages/about.js` file, and save.
+6.  To emphasize how this makes our components reusable, let’s add an extra `<Header />` component to the about page. Add the following code to the `src/pages/about.js` file, and save.
 
-```jsx{7}
+```jsx{7}:title=src/pages/about.js
 import React from "react"
 import Header from "../components/header"
 
@@ -289,9 +289,9 @@ You'll often want to link between pages -- Let's look at routing in a Gatsby sit
 
 ### ✋ Using the `<Link />` component
 
-1.  Open the index page component (`/src/pages/index.js`). Import the `<Link />` component from Gatsby. Add a `<Link />` component below the header, and give it a `to` property, with the value of `"/contact/"` for the pathname:
+1.  Open the index page component (`src/pages/index.js`). Import the `<Link />` component from Gatsby. Add a `<Link />` component below the header, and give it a `to` property, with the value of `"/contact/"` for the pathname:
 
-```jsx{2,7}
+```jsx{2,7}:title=src/pages/index.js
 import React from "react"
 import { Link } from "gatsby"
 import Header from "../components/header"
@@ -316,7 +316,7 @@ When you click the new "Contact" link on the homepage, you should see...
 
 2.  Let's create a page component for our new " Contact" page at `src/pages/contact.js`, and have it link back to the homepage:
 
-```jsx
+```jsx:title=src/pages/contact.js
 import React from "react"
 import { Link } from "gatsby"
 import Header from "../components/header"

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -55,6 +55,7 @@ module.exports = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
+          'gatsby-remark-code-titles',
           {
             resolve: `gatsby-remark-images`,
             options: {

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -55,7 +55,7 @@ module.exports = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
-          'gatsby-remark-code-titles',
+          `gatsby-remark-code-titles`,
           {
             resolve: `gatsby-remark-images`,
             options: {

--- a/www/package.json
+++ b/www/package.json
@@ -28,6 +28,7 @@
     "gatsby-plugin-twitter": "next",
     "gatsby-plugin-typography": "^2.2.0-rc.3",
     "gatsby-remark-autolink-headers": "next",
+    "gatsby-remark-code-titles": "^1.0.2",
     "gatsby-remark-copy-linked-files": "next",
     "gatsby-remark-images": "next",
     "gatsby-remark-prismjs": "next",

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -1,6 +1,7 @@
 import React from "react"
 import Helmet from "react-helmet"
 import { graphql } from "gatsby"
+import { MIN_DEFAULT_MEDIA_QUERY } from "typography-breakpoint-constants"
 
 import Layout from "../components/layout"
 import { itemListDocs, itemListTutorial } from "../utils/sidebar/item-list"
@@ -8,7 +9,8 @@ import MarkdownPageFooter from "../components/markdown-page-footer"
 import DocSearchContent from "../components/docsearch-content"
 
 import Container from "../components/container"
-import colors from "../utils/colors"
+import presets, { colors } from "../utils/presets"
+import { rhythm, options } from "../utils/typography"
 
 import docsHierarchy from "../data/sidebars/doc-links.yaml"
 
@@ -88,19 +90,22 @@ class DocsTemplate extends React.Component {
                 css={{
                   "> .gatsby-code-title": {
                     backgroundColor: colors.gatsby,
-                    borderTopLeftRadius: 8,
-                    borderTopRightRadius: 8,
+                    borderTopLeftRadius: presets.radiusLg,
+                    borderTopRightRadius: presets.radiusLg,
                     color: `white`,
-                    fontFamily:
-                      `Space Mono, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace`,
+                    fontFamily: options.monospaceFontFamily.join(`,`),
                     fontSize: 14,
-                    marginLeft: `-1.05rem`,
-                    marginRight: `-1.05rem`,
-                    padding: `0.5rem 1.05rem`,
-                    "@media only screen and (min-width: 980px)": {
-                      padding: `1rem 1.575rem`,
-                      marginLeft: `-1.575rem`,
-                      marginRight: `-1.575rem`,
+                    marginLeft: rhythm(-options.blockMarginBottom),
+                    marginRight: rhythm(-options.blockMarginBottom),
+                    padding: `${rhythm(options.blockMarginBottom / 2)} ${rhythm(
+                      options.blockMarginBottom
+                    )}`,
+                    [MIN_DEFAULT_MEDIA_QUERY]: {
+                      marginLeft: rhythm(-options.blockMarginBottom * 1.5),
+                      marginRight: rhythm(-options.blockMarginBottom * 1.5),
+                      padding: `${rhythm(options.blockMarginBottom)} ${rhythm(
+                        options.blockMarginBottom * 1.5
+                      )}`,
                     },
                   },
                 }}

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -10,7 +10,7 @@ import DocSearchContent from "../components/docsearch-content"
 
 import Container from "../components/container"
 import presets, { colors } from "../utils/presets"
-import { rhythm, options } from "../utils/typography"
+import { options, rhythm, scale } from "../utils/typography"
 
 import docsHierarchy from "../data/sidebars/doc-links.yaml"
 
@@ -94,7 +94,7 @@ class DocsTemplate extends React.Component {
                     borderTopRightRadius: presets.radiusLg,
                     color: `white`,
                     fontFamily: options.monospaceFontFamily.join(`,`),
-                    fontSize: 14,
+                    ...scale(-1 / 5),
                     marginLeft: rhythm(-options.blockMarginBottom),
                     marginRight: rhythm(-options.blockMarginBottom),
                     padding: `${rhythm(options.blockMarginBottom / 2)} ${rhythm(

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -8,6 +8,7 @@ import MarkdownPageFooter from "../components/markdown-page-footer"
 import DocSearchContent from "../components/docsearch-content"
 
 import Container from "../components/container"
+import colors from '../utils/colors';
 
 import docsHierarchy from "../data/sidebars/doc-links.yaml"
 
@@ -84,6 +85,24 @@ class DocsTemplate extends React.Component {
                 {page.frontmatter.title}
               </h1>
               <div
+                css={{
+                  '> .gatsby-code-title': {
+                    backgroundColor: colors.gatsby,
+                    borderTopLeftRadius: 8,
+                    borderTopRightRadius: 8,
+                    color: 'white',
+                    fontFamily: 'Space Mono, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace',
+                    fontSize: 14,
+                    marginLeft: '-1.05rem',
+                    marginRight: '-1.05rem',
+                    padding: '0.5rem 1.05rem',
+                    '@media only screen and (min-width: 980px)': {
+                      padding: '1rem 1.575rem',
+                      marginLeft: '-1.575rem',
+                      marginRight: '-1.575rem',
+                    }
+                  }
+                }}
                 dangerouslySetInnerHTML={{
                   __html: html,
                 }}

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -1,7 +1,6 @@
 import React from "react"
 import Helmet from "react-helmet"
 import { graphql } from "gatsby"
-import { MIN_DEFAULT_MEDIA_QUERY } from "typography-breakpoint-constants"
 
 import Layout from "../components/layout"
 import { itemListDocs, itemListTutorial } from "../utils/sidebar/item-list"
@@ -9,8 +8,6 @@ import MarkdownPageFooter from "../components/markdown-page-footer"
 import DocSearchContent from "../components/docsearch-content"
 
 import Container from "../components/container"
-import presets, { colors } from "../utils/presets"
-import { options, rhythm, scale } from "../utils/typography"
 
 import docsHierarchy from "../data/sidebars/doc-links.yaml"
 
@@ -87,28 +84,6 @@ class DocsTemplate extends React.Component {
                 {page.frontmatter.title}
               </h1>
               <div
-                css={{
-                  "> .gatsby-code-title": {
-                    backgroundColor: colors.gatsby,
-                    borderTopLeftRadius: presets.radiusLg,
-                    borderTopRightRadius: presets.radiusLg,
-                    color: `white`,
-                    fontFamily: options.monospaceFontFamily.join(`,`),
-                    ...scale(-1 / 5),
-                    marginLeft: rhythm(-options.blockMarginBottom),
-                    marginRight: rhythm(-options.blockMarginBottom),
-                    padding: `${rhythm(options.blockMarginBottom / 2)} ${rhythm(
-                      options.blockMarginBottom
-                    )}`,
-                    [MIN_DEFAULT_MEDIA_QUERY]: {
-                      marginLeft: rhythm(-options.blockMarginBottom * 1.5),
-                      marginRight: rhythm(-options.blockMarginBottom * 1.5),
-                      padding: `${rhythm(options.blockMarginBottom)} ${rhythm(
-                        options.blockMarginBottom * 1.5
-                      )}`,
-                    },
-                  },
-                }}
                 dangerouslySetInnerHTML={{
                   __html: html,
                 }}

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -8,7 +8,7 @@ import MarkdownPageFooter from "../components/markdown-page-footer"
 import DocSearchContent from "../components/docsearch-content"
 
 import Container from "../components/container"
-import colors from '../utils/colors';
+import colors from "../utils/colors"
 
 import docsHierarchy from "../data/sidebars/doc-links.yaml"
 
@@ -86,22 +86,23 @@ class DocsTemplate extends React.Component {
               </h1>
               <div
                 css={{
-                  '> .gatsby-code-title': {
+                  "> .gatsby-code-title": {
                     backgroundColor: colors.gatsby,
                     borderTopLeftRadius: 8,
                     borderTopRightRadius: 8,
-                    color: 'white',
-                    fontFamily: 'Space Mono, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace',
+                    color: `white`,
+                    fontFamily:
+                      `Space Mono, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace`,
                     fontSize: 14,
-                    marginLeft: '-1.05rem',
-                    marginRight: '-1.05rem',
-                    padding: '0.5rem 1.05rem',
-                    '@media only screen and (min-width: 980px)': {
-                      padding: '1rem 1.575rem',
-                      marginLeft: '-1.575rem',
-                      marginRight: '-1.575rem',
-                    }
-                  }
+                    marginLeft: `-1.05rem`,
+                    marginRight: `-1.05rem`,
+                    padding: `0.5rem 1.05rem`,
+                    "@media only screen and (min-width: 980px)": {
+                      padding: `1rem 1.575rem`,
+                      marginLeft: `-1.575rem`,
+                      marginRight: `-1.575rem`,
+                    },
+                  },
                 }}
                 dangerouslySetInnerHTML={{
                   __html: html,

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -232,6 +232,19 @@ const _options = {
         borderRadius: `${presets.radius}px`,
         overflow: `hidden`,
       },
+      ".gatsby-code-title": {
+        backgroundColor: colors.gatsby,
+        borderTopLeftRadius: `${presets.radiusLg}px`,
+        borderTopRightRadius: `${presets.radiusLg}px`,
+        color: `white`,
+        fontFamily: options.monospaceFontFamily.join(`,`),
+        ...scale(-1 / 5),
+        marginLeft: rhythm(-options.blockMarginBottom),
+        marginRight: rhythm(-options.blockMarginBottom),
+        padding: `${rhythm(options.blockMarginBottom / 2)} ${rhythm(
+          options.blockMarginBottom
+        )}`,
+      },
       "@media (max-width:634px)": {
         ".gatsby-highlight, .gatsby-resp-image-link": {
           borderRadius: 0,
@@ -267,7 +280,7 @@ const _options = {
         },
       },
       [MIN_DEFAULT_MEDIA_QUERY]: {
-        ".gatsby-highlight, .post .gatsby-resp-iframe-wrapper, .post .gatsby-resp-image-link": {
+        ".gatsby-highlight, .post .gatsby-resp-iframe-wrapper, .post .gatsby-resp-image-link, .gatsby-code-title": {
           marginLeft: rhythm(-options.blockMarginBottom * 1.5),
           marginRight: rhythm(-options.blockMarginBottom * 1.5),
         },
@@ -282,6 +295,11 @@ const _options = {
           paddingLeft: `${rhythm(((options.blockMarginBottom * 1.5) / 5) * 4)}`,
           borderLeftWidth: `${rhythm(
             ((options.blockMarginBottom * 1.5) / 5) * 1
+          )}`,
+        },
+        ".gatsby-code-title": {
+          padding: `${rhythm(options.blockMarginBottom)} ${rhythm(
+            options.blockMarginBottom * 1.5
           )}`,
         },
       },


### PR DESCRIPTION
Addresses #5608

Note: there is more to do here, i.e. actually copy these titles over to relevant tutorial pages, but I think this is a start.

Here's what it ends up looking like.

![screen shot 2018-09-04 at 10 25 52 am](https://user-images.githubusercontent.com/3924690/45043523-fc25f700-b032-11e8-9676-b282e81d9470.png)


Will want to fix/externalize the padding/media query stuff. That feels a little janky.