### PR TITLE
Sidebar position jumping on list item selection

### DIFF
--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -82,9 +82,8 @@ class SidebarBody extends Component {
         }
 
         state.expandAll = Object.entries(state.openSectionHash).every(k => k[1])
-
         this.setState(state, () => {
-          if (node) {
+          if (node && this.props.position) {
             node.scrollTop = this.props.position
           }
         })
@@ -209,9 +208,10 @@ class SidebarBody extends Component {
             // get proper scroll position
             const position = nativeEvent.target.scrollTop
             const { pathname } = location
+            const sidebarType = pathname.split(`/`)[1]
 
             requestAnimationFrame(() => {
-              onPositionChange(pathname, position)
+              onPositionChange(sidebarType, position)
             })
           }}
           ref={this.scrollRef}

--- a/www/src/components/sidebar/sticky-responsive-sidebar.js
+++ b/www/src/components/sidebar/sticky-responsive-sidebar.js
@@ -26,13 +26,17 @@ class StickyResponsiveSidebar extends Component {
 
   render() {
     const { open } = this.state
-    const SidebarComponent = this.props.enableScrollSync
-      ? ScrollSyncSidebar
-      : Sidebar
+    const {
+      enableScrollSync,
+      location: { pathname },
+    } = this.props
+    const SidebarComponent = enableScrollSync ? ScrollSyncSidebar : Sidebar
 
     const iconOffset = open ? 8 : -4
     const menuOpacity = open ? 1 : 0
     const menuOffset = open ? 0 : rhythm(10)
+
+    const sidebarType = pathname.split(`/`)[1]
 
     return (
       <ScrollPositionProvider>
@@ -52,7 +56,7 @@ class StickyResponsiveSidebar extends Component {
             <ScrollPositionConsumer>
               {({ positions, onPositionChange }) => (
                 <SidebarComponent
-                  position={positions[this.props.location.pathname]}
+                  position={positions[sidebarType]}
                   onPositionChange={onPositionChange}
                   closeSidebar={this._closeSidebar}
                   {...this.props}


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
This PR fixes the docs sidebar jumping on list item selection while maintaining position when switching between different sidebars (docs/tutorial/etc).

Closes #7422 