### PR TITLE
(fix) Use SSR in 'build-javascript' stage (gatsby-plugin-styled-components).

### DIFF
--- a/packages/gatsby-plugin-styled-components/src/gatsby-node.js
+++ b/packages/gatsby-plugin-styled-components/src/gatsby-node.js
@@ -8,12 +8,11 @@ try {
 }
 
 exports.onCreateBabelConfig = ({ stage, actions }, pluginOptions) => {
+  const ssr = stage === `build-html` || stage === `build-javascript`
+
   actions.setBabelPlugin({
     name: `babel-plugin-styled-components`,
     stage,
-    options: {
-      ...pluginOptions,
-      ssr: stage === `build-html`,
-    },
+    options: { ...pluginOptions, ssr },
   })
 }


### PR DESCRIPTION
Fixes #5993.

Until this PR is merged, one can correct the issue by simply placing the following in `gatsby-node.js`:

```javascript
exports.onCreateBabelConfig = ({ stage, actions }, pluginOptions) => {
  const ssr = stage === `build-html` || stage === `build-javascript`

  actions.setBabelPlugin({
    name: `babel-plugin-styled-components`,
    stage,
    options: { ...pluginOptions, ssr },
  })
}
```