### PR TITLE
fix: remove some warnings on promises

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -150,6 +150,8 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
         currentState = fsMachine.transition(currentState.value, `EMIT_FS_EVENT`)
         createNode(fileNode)
       }
+
+      return null
     })
     return fileNodePromise
   }

--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -159,6 +159,8 @@ const updateStateAndRunQueries = isFirstRun => {
       `)
     }
     runQueuedQueries()
+
+    return null
   })
 }
 


### PR DESCRIPTION
When using `gatsby-source-filesystem` we can see some warnings in the terminal thrown by the `bluebird` dep.

It can be reproduce by using the `gatsby-starter-blog` starter (in v2).

```shell
$ gatsby build
success open and validate gatsby-config — 0.015 s
success load plugins — 0.298 s
success onPreInit — 0.818 s
success delete html and css files from previous builds — 0.008 s
success initialize cache — 0.010 s
success copy gatsby files — 2.584 s
success onPreBootstrap — 0.266 s
⠂ source and transform nodes(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
⠄ source and transform nodes(node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby-source-filesystem/gatsby-node.js:141:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
success source and transform nodes — 0.151 s
success building schema — 1.550 s
⠁ (node:23505) Warning: a promise was created in a handler at my/gatsby/project/gatsby-node.js:38:11 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
success createPages — 0.105 s
success createPagesStatefully — 0.047 s
success onPreExtractQueries — 0.003 s
success update schema — 0.217 s
⠁ (node:23505) Warning: a promise was created in a handler at my/gatsby/project/node_modules/gatsby/dist/internal-plugins/query-runner/query-watcher.js:148:5 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (my/gatsby/project/node_modules/bluebird/js/release/promise.js:79:10)
success extract queries from components — 0.199 s
success run graphql queries — 0.743 s — 7/7 9.45 queries/second
Generating image thumbnails [==============================] 7/7 0.4 secs 100%
success write out page data — 0.091 s
success write out redirect data — 0.068 s
⠂ onPostBootstrapdone generating icons for manifest
success onPostBootstrap — 0.557 s

info bootstrap finished - 10.144 s

success Building production JavaScript and CSS bundles — 61.710 s
success Building static HTML for pages — 2.603 s — 7/7 5.20 pages/second
Generated public/sw.js, which will precache 13 files, totaling 292493 bytes.
info Done building in 75.469 sec
✨  Done in 75.91s.
```