### PR TITLE
Removed the call of withPrefix from prefetch. 

### DIFF
--- a/packages/gatsby/cache-dir/prefetch.js
+++ b/packages/gatsby/cache-dir/prefetch.js
@@ -45,8 +45,6 @@ function normalizePath(path) {
 }
 
 const prefetch = function(url) {
-  url = withPrefix(url)
-
   if (preFetched[url]) {
     return
   }


### PR DESCRIPTION
Duplicate path prefix was being added to prefetch URLs.

Fixes issue discussed in this [thread](https://github.com/gatsbyjs/gatsby/issues/7898#issuecomment-419006352).