### PR TITLE
[gatsby-plugin-offline] Fix README

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -22,7 +22,7 @@ plugins: [`gatsby-plugin-offline`]
 ## Overriding options
 
 When adding this plugin to your `gatsby-config.js`, you can pass in options to
-override the default sw-precache config.
+override the default Workbox config.
 
 The default config is as follows. Warning, you can break the offline support
 and AppCache setup by changing these options so tread carefully.

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -22,7 +22,7 @@ plugins: [`gatsby-plugin-offline`]
 ## Overriding options
 
 When adding this plugin to your `gatsby-config.js`, you can pass in options to
-override the default Workbox config.
+override the default [Workbox](https://developers.google.com/web/tools/workbox/modules/workbox-build) config.
 
 The default config is as follows. Warning, you can break the offline support
 and AppCache setup by changing these options so tread carefully.


### PR DESCRIPTION
I changed README. sw-precache is replaced by Workbox. (#7605 )