### PR TITLE
Make sure include the path to the js file not css

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -230,8 +230,7 @@ module.exports = async (
                         `/` +
                         files.filter(
                           f =>
-                            f.slice(-4) !== `.css` &&
-                            f.slice(-4) !== `.map` &&
+                            f.slice(-3) !== `.js` &&
                             f.slice(0, chunkGroup.name.length) ===
                               chunkGroup.name
                         )[0]

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -230,6 +230,7 @@ module.exports = async (
                         `/` +
                         files.filter(
                           f =>
+                            f.slice(-4) !== `.css` &&
                             f.slice(-4) !== `.map` &&
                             f.slice(0, chunkGroup.name.length) ===
                               chunkGroup.name


### PR DESCRIPTION
It'd be ideal to prefetch the css files as well but we'll skip that for
now as there's generally relatively few css chunks and they'll get
loaded when we hover on a link, etc.

I'll create an issue about adding support for it.


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->