### PR TITLE
Add CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+workflows:
+  version: 2
+  main:
+    jobs:
+      - unit-node6
+      - unit-node8
+      - unit-node10
+      - lint
+      - integration
+      - ui
+      - prod_ui
+
+
+version: 2
+jobs:
+  unit-node6:
+    docker:
+      - image: circleci/node:6
+    steps:
+      - checkout
+      - run:
+          name: "Unit test with Node.js 6"
+          command: |
+            yarn run bootstrap
+            yarn jest -w 1
+
+  unit-node8:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - run:
+          name: "Unit test with Node.js 8"
+          command: |
+            yarn run bootstrap
+            yarn jest -w 1
+
+  unit-node10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run:
+          name: "Unit test with Node.js 10"
+          command: |
+            yarn run bootstrap
+            yarn jest -w 1
+
+  lint:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - run:
+          name: "Lint Code"
+          command: |
+            yarn install
+            yarn lint
+
+  integration:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - run:
+          name: "Integration Tests"
+          command: |
+            yarn install
+            yarn test:integration
+
+  ui:
+    docker:
+      - image: circleci/node:8-browsers
+    steps:
+      - checkout
+      - run:
+          name: "UI Tests"
+          command: |
+            cd examples/gatsbygram
+            yarn install
+            yarn test
+
+  prod_ui:
+    docker:
+      - image: circleci/node:8-browsers
+    steps:
+      - checkout
+      - run:
+          name: "UI Tests"
+          command: |
+            cd integration-tests/production-runtime
+            yarn install
+            yarn test


### PR DESCRIPTION
Fixes #7792 

Hey everyone,

In the Issue above I noticed there was some interest in getting Gatsby up and running on CircleCI. So in the spirit of open source here's a PR.

This PR creates a CircleCI config that tries to mimic what currently happens in the Travis CI build as much as possible.

Here's [an example](https://circleci.com/workflow-run/5764a7ca-6b39-4b25-897e-aad7dfe549cc) of a CircleCI build running for this project from my fork. So far the builds seem to be between 6-7 minutes total.

What's missing? Obviously I don't have access to any build secrets that might be needed for any deployments or anything like that. A CircleCI account would have to be made for Gatsby (you sign up with GitHub) and then any secrets can be added as private environment variables. Also the commented out Docker code in the Travis CI config can be added as well though I didn't include it here.

I'm happy to answer any questions or help with any tweaks to get this PR merged if you choose to do so.