### PR TITLE
[v2] Properly serve static files

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -131,7 +131,7 @@ async function startServer(program) {
     res.end()
   })
 
-  app.use(express.static(__dirname + `/public`))
+  app.use(express.static(`public`))
 
   app.use(
     require(`webpack-dev-middleware`)(compiler, {
@@ -157,33 +157,6 @@ async function startServer(program) {
       req.pipe(request(proxiedUrl)).pipe(res)
     })
   }
-
-  // Check if the file exists in the public folder.
-  app.get(`*`, (req, res, next) => {
-    // Load file but ignore errors.
-    res.sendFile(
-      directoryPath(`/public${decodeURIComponent(req.path)}`),
-      err => {
-        // No err so a file was sent successfully.
-        if (!err || !err.path) {
-          next()
-        } else if (err) {
-          // There was an error. Let's check if the error was because it
-          // couldn't find an HTML file. We ignore these as we want to serve
-          // all HTML from our single empty SSR html file.
-          const parsedPath = parsePath(err.path)
-          if (
-            parsedPath.extname === `` ||
-            parsedPath.extname.startsWith(`.html`)
-          ) {
-            next()
-          } else {
-            res.status(404).end()
-          }
-        }
-      }
-    )
-  })
 
   // Render an HTML page and serve it.
   app.use((req, res, next) => {


### PR DESCRIPTION
Issue #2352 brought to my attention that `express.static` wasn't serving any static files, leaving all the heavy lifting to lines 161-187.

This is due to the fact that `__dirname` is the local filename, not the project root.

Actually, express uses the place from where the node process is called (usually the project root) as the actual root for serving static files, so I just went ahead and removed it.

Before, having a public folder like:
```
static/
  my-custom-folder/
    - index.html
```
Would raise 404 for `/my-custom-folder`, but not for `/my-custom-folder/index.html` or `/my-custom-folder/`.

Now, when accessing `/my-custom-folder`, we're getting redirected to `/my-custom-folder/`, as one might expect.

Edit: this was originally intended to go with v2, but I guess we can hotfix it down to v1 as well?

Closes #2352 
Closes freeCodeCamp/freeCodeCamp#18093