### PR TITLE
[docs] Add note about sourceInstanceName

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -59,6 +59,22 @@ You can query file nodes like the following:
 }
 ```
 
+To filter by the `name` you specified in the config, use `sourceInstanceName`:
+
+```graphql
+{
+  allFile(filter: { sourceInstanceName: { eq: "data" } }) {
+    edges {
+      node {
+        extension
+        dir
+        modifiedTime
+      }
+    }
+  }
+}
+```
+
 ## Helper functions
 
 `gatsby-source-filesystem` exports two helper functions:


### PR DESCRIPTION
The docs for `gatsby-source-filesystem` show how to setup multiple instances with different names. We should also show how to filter queries by those names, to aid discoverability of `sourceInstanceName`.