### PR TITLE
[gatsby-source-contentful] Support non localize fields from contentful

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -165,17 +165,16 @@ describe(`Gets field value based on current locale`, () => {
       })
     ).toBe(field[`de`])
   })
-  it(`Falls back to default locale on a non localized field without locale fallbacks`, () => {
+  it(`returns null if passed a locale that doesn't have a field on a localized field`, () => {
     expect(
       normalize.getLocalizedField({
         field,
-        localesFallback: { "es-ES": null, "de": null },
+        localesFallback: { "es-ES": null, de: null },
         locale: {
-          code: `es-ES`,
+          code: `es-US`,
         },
-        defaultLocale: `en-US`,
       })
-    ).toBe(field[`en-US`])
+    ).toEqual(null)
   })
   it(`returns null if passed a locale that doesn't have a field nor a fallbackCode`, () => {
     expect(

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -11,7 +11,7 @@ const digest = str =>
 const typePrefix = `Contentful`
 const makeTypeName = type => _.upperFirst(_.camelCase(`${typePrefix} ${type}`))
 
-const getLocalizedField = ({ field, locale, localesFallback, defaultLocale }) => {
+const getLocalizedField = ({ field, locale, localesFallback }) => {
   if (!_.isUndefined(field[locale.code])) {
     return field[locale.code]
   } else if (
@@ -20,7 +20,7 @@ const getLocalizedField = ({ field, locale, localesFallback, defaultLocale }) =>
   ) {
     return getLocalizedField({
       field,
-      locale: { code: localesFallback[locale.code] || defaultLocale },
+      locale: { code: localesFallback[locale.code] },
       localesFallback,
     })
   } else {
@@ -35,8 +35,8 @@ const buildFallbackChain = locales => {
   )
   return localesFallback
 }
-const makeGetLocalizedField = ({ locale, localesFallback, defaultLocale }) => field =>
-  getLocalizedField({ field, locale, localesFallback, defaultLocale })
+const makeGetLocalizedField = ({ locale, localesFallback }) => field =>
+  getLocalizedField({ field, locale, localesFallback })
 
 exports.getLocalizedField = getLocalizedField
 exports.buildFallbackChain = buildFallbackChain
@@ -247,7 +247,13 @@ exports.createContentTypeNodes = ({
     // First create nodes for each of the entries of that content type
     const entryNodes = entries.map(entryItem => {
       // Get localized fields.
-      const entryItemFields = _.mapValues(entryItem.fields, v => getField(v))
+      const entryItemFields = _.mapValues(entryItem.fields, (v, k) => {
+        const fieldProps = contentTypeItem.fields.find(field => field.id === k)
+        if (!fieldProps.localized) {
+          return v[defaultLocale]
+        }
+        return getField(v)
+      })
 
       // Prefix any conflicting fields
       // https://github.com/gatsbyjs/gatsby/pull/1084#pullrequestreview-41662888


### PR DESCRIPTION
Reverted some changes for default locale. 

Better to make the decision if a field is localized before we run `getLocalizedField()`. As assets are always localized we do not need to add any extra check for that.