### PR TITLE
[v2] [gatsby-plugin-offline] Skip cache-busting CSS

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -87,8 +87,8 @@ exports.onPostBuild = (args, pluginOptions) => {
     navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
     navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
     cacheId: `gatsby-plugin-offline`,
-    // Don't cache-bust JS files and anything in the static directory
-    dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,
+    // Don't cache-bust JS or CSS files, and anything in the static directory
+    dontCacheBustUrlsMatching: /(.*\.js$|.*\.css$|\/static\/)/,
     runtimeCaching: [
       {
         // Add runtime caching of various page resources.


### PR DESCRIPTION
Generated CSS files have a unique filename like JS files, so we don't need to cache-bust these. I've also modified the regex for JS files to ensure there's a dot before the js extension, to prevent possible edge cases.