### PR TITLE
[v2] fix recursiveOmitBy modifying originalValue

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -216,12 +216,14 @@ type InferInputOptions = {
 
 const recursiveOmitBy = (value, fn) => {
   if (_.isObject(value)) {
+    let newValue = {}
     if (_.isPlainObject(value)) {
-      value = _.omitBy(value, fn)
+      newValue = _.omitBy(value, fn)
     }
     _.each(value, (v, k) => {
-      value[k] = recursiveOmitBy(v, fn)
+      newValue[k] = recursiveOmitBy(v, fn)
     })
+    value = newValue
     if (_.isEmpty(value)) {
       // don't return empty objects - gatsby doesn't support these
       return null


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
When calling `recursiveOmitBy(value, ...)`, if `value` was an array
this method was actually modifying the original array instead of returning
a new one

*Note*: I tried to add a unit test in `infer-graphql-input-type-test.js` but I didn't find a way to create a type containing an array of type.

fixes #7970

