### PR TITLE
[www] Consolidate site- and starter-showcase list view

### DIFF
--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -53,9 +53,7 @@ export const showcaseQuery = graphql`
           childScreenshot {
             screenshotFile {
               childImageSharp {
-                fixed(width: 282, height: 211) {
-                  ...GatsbyImageSharpFixed_noBase64
-                }
+                ...ShowcaseThumbnailFragment_item
               }
             }
           }

--- a/www/src/pages/starter-showcase.js
+++ b/www/src/pages/starter-showcase.js
@@ -21,9 +21,7 @@ export const showcaseQuery = graphql`
         node {
           name
           childImageSharp {
-            fluid(maxWidth: 280, maxHeight: 230) {
-              ...GatsbyImageSharpFluid
-            }
+            ...ShowcaseThumbnailFragment_item
           }
         }
       }

--- a/www/src/views/shared/thumbnail.js
+++ b/www/src/views/shared/thumbnail.js
@@ -1,0 +1,67 @@
+import React from "react"
+import { Link, graphql } from "gatsby"
+import Img from "gatsby-image"
+
+import styles from "./styles"
+import presets from "../../utils/presets"
+
+const ThumbnailLink = ({ slug, image, title, children }) => {
+  let screenshot = false
+
+  // site showcase
+  if (image.screenshotFile) {
+    screenshot = image.screenshotFile.childImageSharp.fixed
+  } else {
+    // starter showcase
+    screenshot = image.childImageSharp.fixed
+  }
+
+  return (
+    <Link
+      to={slug}
+      state={{ isModal: true }}
+      {...styles.withTitleHover}
+      css={{
+        "&&": {
+          borderBottom: `none`,
+          boxShadow: `none`,
+          transition: `all ${presets.animation.speedDefault} ${
+            presets.animation.curveDefault
+          }`,
+          "&:hover": { ...styles.screenshotHover },
+          "&:hover ~ .meta > .featured-site": {
+            transform: `translateY(-3px)`,
+          },
+        },
+      }}
+    >
+      {screenshot ? (
+        <Img
+          fixed={screenshot}
+          alt={`Screenshot of ${title}`}
+          css={{ ...styles.screenshot }}
+        />
+      ) : (
+        <div
+          css={{
+            width: 320,
+            backgroundColor: `#d999e7`,
+          }}
+        >
+          missing
+        </div>
+      )}
+      {children}
+    </Link>
+  )
+}
+
+export default ThumbnailLink
+
+export const showcaseThumbnailFragment = graphql`
+  fragment ShowcaseThumbnailFragment_item on ImageSharp {
+    fixed(width: 282, height: 211) {
+      ...GatsbyImageSharpFixed_noBase64
+    }
+  }
+`

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -1,13 +1,13 @@
 import React from "react"
 import { Link } from "gatsby"
-import Img from "gatsby-image"
 
 import styles from "../shared/styles"
+import ThumbnailLink from "../shared/thumbnail"
 import qs from "qs"
 
 import ShowcaseItemCategories from "./showcase-item-categories"
-import { rhythm, scale } from "../../utils/typography"
-import presets, { colors } from "../../utils/presets"
+import { rhythm } from "../../utils/typography"
+import { colors } from "../../utils/presets"
 
 import GithubIcon from "react-icons/lib/go/mark-github"
 import FeaturedIcon from "../../assets/featured-sites-icons--white.svg"
@@ -31,50 +31,15 @@ const ShowcaseList = ({ items, count }) => {
                 ...styles.showcaseItem,
               }}
             >
-              <Link
-                to={node.fields.slug}
-                state={{ isModal: true }}
-                {...styles.withTitleHover}
-                css={{
-                  "&&": {
-                    borderBottom: `none`,
-                    boxShadow: `none`,
-                    transition: `all ${presets.animation.speedDefault} ${
-                      presets.animation.curveDefault
-                    }`,
-                    "&:hover": {
-                      ...styles.screenshotHover,
-                    },
-                    "&:hover ~ .meta > .featured-site": {
-                      transform: `translateY(-3px)`,
-                    },
-                  },
-                }}
+              <ThumbnailLink
+                slug={node.fields.slug}
+                image={node.childScreenshot}
+                title={node.title}
               >
-                {node.childScreenshot ? (
-                  <Img
-                    fixed={
-                      node.childScreenshot.screenshotFile.childImageSharp.fixed
-                    }
-                    alt={`Screenshot of ${node.title}`}
-                    css={{
-                      ...styles.screenshot,
-                    }}
-                  />
-                ) : (
-                  <div
-                    css={{
-                      width: 320,
-                      backgroundColor: `#d999e7`,
-                    }}
-                  >
-                    missing
-                  </div>
-                )}
                 <div>
                   <span className="title">{node.title}</span>
                 </div>
-              </Link>
+              </ThumbnailLink>
               <div
                 css={{
                   ...styles.meta,

--- a/www/src/views/starter-showcase/showcase-list.js
+++ b/www/src/views/starter-showcase/showcase-list.js
@@ -1,14 +1,13 @@
-import React /* { Component } */ from "react"
-import { Link } from "gatsby"
-import Img from "gatsby-image"
+import React from "react"
 import FaExtLink from "react-icons/lib/fa/external-link"
 import FaGithub from "react-icons/lib/fa/github"
 import FaClipboard from "react-icons/lib/fa/clipboard"
 import MdStar from "react-icons/lib/md/star"
-import { /* rhythm, */ scale, rhythm, options } from "../../utils/typography"
+import { rhythm, options } from "../../utils/typography"
 import presets, { colors } from "../../utils/presets"
 import copyToClipboard from "../../utils/copy-to-clipboard"
 import styles from "../shared/styles"
+import ThumbnailLink from "../shared/thumbnail"
 
 const ShowcaseList = ({ urlState, items, imgs, count, sortRecent }) => {
   if (!items.length) {
@@ -75,6 +74,7 @@ const ShowcaseList = ({ urlState, items, imgs, count, sortRecent }) => {
         const minorVersion = match ? match[0] : gatsbyVersion // default to version if no match
         const isGatsbyVersionWarning = !/(2..+|next|latest)/g.test(minorVersion) // either 2.x or next or latest
         const imgsharp = imgsFilter(imgs, stub)
+
         const repo = githubData.repoMetadata
         const { pushed_at } = repo
         return (
@@ -87,59 +87,14 @@ const ShowcaseList = ({ urlState, items, imgs, count, sortRecent }) => {
               }}
               {...styles.withTitleHover}
             >
-              <Link
-                to={`/starters/${stub}`}
-                state={{ isModal: true }}
-                css={{
-                  "&&": {
-                    borderBottom: `none`,
-                    boxShadow: `none`,
-                    transition: `all ${presets.animation.speedDefault} ${
-                      presets.animation.curveDefault
-                    }`,
-                    "&:hover": {
-                      ...styles.screenshotHover,
-                      // manual patch for hover
-                      boxShadow: `0 8px 20px rgba(157,124,191,0.5)`,
-                      transform: `translateY(-3px)`,
-                    },
-                  },
-                }}
-              >
-                <div
-                  className="gatsby-image-wrapper"
-                  css={{
-                    transition: `all ${presets.animation.speedDefault} ${
-                      presets.animation.curveDefault
-                    }`,
-                  }}
-                >
-                  {imgsharp ? (
-                    <Img
-                      fluid={imgsharp.childImageSharp.fluid}
-                      alt={`Screenshot of ${imgsharp.name}`}
-                      css={{
-                        ...styles.screenshot,
-                        marginBottom: 0,
-                      }}
-                    />
-                  ) : (
-                    <div
-                      css={{
-                        // height: 230,
-                        width: 320,
-                        backgroundColor: `#d999e7`,
-                      }}
-                    >
-                      missing
-                    </div>
-                  )}
-                </div>
-              </Link>
+              <ThumbnailLink
+                slug={`/starters/${stub}`}
+                image={imgsharp}
+                title={imgsharp.name}
+              />
               <div
                 css={{
                   ...styles.meta,
-                  marginTop: rhythm(options.blockMarginBottom),
                 }}
               >
                 <div css={{ display: `flex`, justifyContent: `space-between` }}>


### PR DESCRIPTION
This consolidates site- and starter-showcase list view "thumbnail links" via adding a new component `src/views/shared/thumbnail.js`. Also adds a fragment for the thumbnail image itself (before this, starter images were `fluid`, and site showcase images were `fixed`, now we consistently use `fixed`).

Fixes the starter showcase list view thumbnail link UI glitch #7978 and hopefully makes things like #7950 a little easier to implement for both site and starter showcase.