### PR TITLE
[v2] [cache-dir] Prefetch all component resources, not just JS

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-browser.js
@@ -35,8 +35,7 @@ exports.onServiceWorkerInstalled = ({ getResourceURLsForPathname }) => {
   // Loop over all resources and fetch the page component and JSON
   // to add it to the sw cache.
   prefetchedPathnames.forEach(path => {
-    const { jsUrl, dataUrl } = getResourceURLsForPathname(path)
-    fetch(jsUrl)
-    fetch(dataUrl)
+    const urls = getResourceURLsForPathname(path)
+    urls.forEach(url => fetch(url))
   })
 }

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -48,8 +48,10 @@ const fetchPageResourceMap = () => {
 }
 
 const createJsonURL = jsonName => `${__PATH_PREFIX__}/static/d/${jsonName}.json`
-const createComponentUrl = componentChunkName =>
-  `${__PATH_PREFIX__}${window.___chunkMapping[componentChunkName]}`
+const createComponentUrls = componentChunkName =>
+  window.___chunkMapping[componentChunkName].map(
+    chunk => __PATH_PREFIX__ + chunk
+  )
 
 const fetchResource = resourceName => {
   // Find resource
@@ -111,7 +113,7 @@ const fetchResource = resourceName => {
 
 const prefetchResource = resourceName => {
   if (resourceName.slice(0, 12) === `component---`) {
-    prefetchHelper(createComponentUrl(resourceName))
+    createComponentUrls(resourceName).forEach(url => prefetchHelper(url))
   } else {
     const url = createJsonURL(jsonDataPaths[resourceName])
     prefetchHelper(url)
@@ -242,12 +244,10 @@ const queue = {
   getResourceURLsForPathname: path => {
     const page = findPage(path)
     if (page) {
-      const jsUrl = createComponentUrl(page.componentChunkName)
-      const dataUrl = createJsonURL(jsonDataPaths[page.jsonName])
-      return {
-        jsUrl,
-        dataUrl,
-      }
+      return [
+        ...createComponentUrls(page.componentChunkName),
+        createJsonURL(jsonDataPaths[page.jsonName]),
+      ]
     } else {
       return null
     }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -226,14 +226,14 @@ module.exports = async (
                       assets[chunkGroup.name] = files.filter(
                         f => f.slice(-4) !== `.map`
                       )
-                      assetsMap[chunkGroup.name] =
-                        `/` +
-                        files.filter(
+                      assetsMap[chunkGroup.name] = files
+                        .filter(
                           f =>
-                            f.slice(-3) === `.js` &&
+                            f.slice(-4) !== `.map` &&
                             f.slice(0, chunkGroup.name.length) ===
                               chunkGroup.name
-                        )[0]
+                        )
+                        .map(filename => `/${filename}`)
                     }
                   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12208,6 +12208,15 @@ postcss-loader@^2.1.3:
     postcss-load-config "^2.0.0"
     schema-utils "^0.4.0"
 
+postcss-loader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-3.0.0.tgz#6b97943e47c72d845fa9e03f273773d4e8dd6c2d"
+  dependencies:
+    loader-utils "^1.1.0"
+    postcss "^7.0.0"
+    postcss-load-config "^2.0.0"
+    schema-utils "^1.0.0"
+
 postcss-merge-longhand@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-4.0.1.tgz#98cdebda7cc1bada4ae03c76ed1c44c97a574019"


### PR DESCRIPTION
I've changed `window.___chunkMapping` / `chunk-map.json` to be an array of files, rather than a string for just the JS, which allows us to easily prefetch any type of file built by Webpack. Example:

```json
{
  "app": ["/app-c22c4d2ffbb2798ab915.js"],
  "component---src-templates-blog-post-js": [
    "/component---src-templates-blog-post-js.4b26962d7d287b796eaa.css",
    "/component---src-templates-blog-post-js-6c36fc18984e69fb904e.js"
  ],
  "component---src-pages-404-js": [
    "/component---src-pages-404-js.2296b85c2e71c74e9bf5.css",
    "/component---src-pages-404-js-815b4e684231a00ba462.js"
  ],
  "component---src-pages-about-js": [
    "/component---src-pages-about-js.2296b85c2e71c74e9bf5.css",
    "/component---src-pages-about-js-4914e8e44c7f771c25d2.js"
  ],
  "component---src-pages-index-js": [
    "/component---src-pages-index-js.0c27dd12264f30094eb9.css",
    "/component---src-pages-index-js-0f8857af223ff70bf38a.js"
  ],
  "component---src-pages-my-files-js": [
    "/component---src-pages-my-files-js.2296b85c2e71c74e9bf5.css",
    "/component---src-pages-my-files-js-5b2747cd1f83dce341a2.js"
  ]
}
```

Fixes #7948