### PR TITLE
[gatsby-plugin-typescript] fixed reference to babel docs in README

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -20,7 +20,8 @@ plugins: [`gatsby-plugin-typescript`]
 
 ## Caveats
 
-This plugin uses [`babel-plugin-transform-typescript`](https://new.babeljs.io/docs/en/next/babel-plugin-transform-typescript.html) to transpile typescript. It does _not do type checking_. Also since the TypeScript
+This plugin uses [`babel-plugin-transform-typescript`](https://babeljs.io/docs/en/babel-plugin-transform-typescript.html)
+to transpile typescript. It does _not do type checking_. Also since the TypeScript
 compiler is not involved, the following applies:
 
 > Does not support namespaces.
@@ -36,7 +37,7 @@ compiler is not involved, the following applies:
 > to using export default and export const,
 > and import x, {y} from "z".
 
-https://new.babeljs.io/docs/en/next/babel-plugin-transform-typescript.html
+https://babeljs.io/docs/en/babel-plugin-transform-typescript.html
 
 ## Type checking
 


### PR DESCRIPTION
Updated old Babel docs link to the new one, now that Babel v7 is out.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
