### PR TITLE
[www] A couple of main navigation improvements (following up on #7933 (active nav state))

### DIFF
--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -5,6 +5,7 @@ import { rhythm, scale, options } from "../utils/typography"
 
 const Banner = ({ children, background }) => {
   const backgroundColor = background ? background : colors.gatsby
+  const horizontalPadding = rhythm(1 / 2)
 
   return (
     <div
@@ -14,7 +15,7 @@ const Banner = ({ children, background }) => {
         height: presets.bannerHeight,
         position: `fixed`,
         width: `100%`,
-        zIndex: `3`,
+        zIndex: 3,
       }}
     >
       <div
@@ -23,7 +24,7 @@ const Banner = ({ children, background }) => {
           display: `flex`,
           height: presets.bannerHeight,
           overflowX: `auto`,
-          maskImage: `linear-gradient(to right, transparent, ${backgroundColor} 4%, ${backgroundColor} 96%, transparent)`,
+          maskImage: `linear-gradient(to right, transparent, ${backgroundColor} ${horizontalPadding}, ${backgroundColor} 96%, transparent)`,
         }}
       >
         <div
@@ -31,8 +32,8 @@ const Banner = ({ children, background }) => {
             color: colors.ui.bright,
             fontFamily: options.headerFontFamily.join(`,`),
             fontSize: scale(-1 / 5).fontSize,
-            paddingLeft: rhythm(1 / 2),
-            paddingRight: rhythm(1 / 2),
+            paddingLeft: horizontalPadding,
+            paddingRight: horizontalPadding,
             WebkitFontSmoothing: `antialiased`,
             whiteSpace: `nowrap`,
           }}

--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -1,25 +1,47 @@
 import React from "react"
 
-import { colors } from "../utils/presets"
+import presets, { colors } from "../utils/presets"
 import { rhythm, scale, options } from "../utils/typography"
 
-const Banner = ({ children, background }) => (
-  <div
-    className="banner"
-    css={{
-      backgroundColor: background ? background : colors.gatsby,
-      color: colors.ui.bright,
-      fontFamily: options.headerFontFamily.join(`,`),
-      fontSize: scale(-1 / 5).fontSize,
-      padding: rhythm(1 / 2),
-      position: `fixed`,
-      WebkitFontSmoothing: `antialiased`,
-      width: `100%`,
-      zIndex: `3`,
-    }}
-  >
-    {children}
-  </div>
-)
+const Banner = ({ children, background }) => {
+  const backgroundColor = background ? background : colors.gatsby
+
+  return (
+    <div
+      className="banner"
+      css={{
+        backgroundColor: backgroundColor,
+        height: presets.bannerHeight,
+        position: `fixed`,
+        width: `100%`,
+        zIndex: `3`,
+      }}
+    >
+      <div
+        css={{
+          alignItems: `center`,
+          display: `flex`,
+          height: presets.bannerHeight,
+          overflowX: `auto`,
+          maskImage: `linear-gradient(to right, transparent, ${backgroundColor} 4%, ${backgroundColor} 96%, transparent)`,
+        }}
+      >
+        <div
+          css={{
+            color: colors.ui.bright,
+            fontFamily: options.headerFontFamily.join(`,`),
+            fontSize: scale(-1 / 5).fontSize,
+            paddingLeft: rhythm(1 / 2),
+            paddingRight: rhythm(1 / 2),
+            WebkitFontSmoothing: `antialiased`,
+            whiteSpace: `nowrap`,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 export default Banner

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -58,14 +58,11 @@ export default ({ pathname }) => {
   if (isHomepage) {
     styles.backgroundColor = `rgba(255,255,255,0)`
     styles.borderBottomColor = `transparent`
-    styles[presets.Tablet] = {
-      position: isHomepage || isBlog ? `absolute` : `fixed`,
-    }
   } else if (isBlog) {
     styles.backgroundColor = `#fff`
     styles[presets.Tablet] = {
       borderBottomColor: `transparent`,
-      position: isHomepage || isBlog ? `absolute` : `fixed`,
+      position: `absolute`,
       backgroundColor: colors.ui.whisper,
     }
   }

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -30,8 +30,7 @@ const navItemStyles = {
 }
 
 const activeNavItemStyles = {
-  // fontWeight: 600,
-  borderBottomColor: `#663399`,
+  borderBottomColor: colors.gatsby,
 }
 
 const assignActiveStyles = ({ isPartiallyCurrent }) =>

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -5,162 +5,130 @@ import TwitterIcon from "react-icons/lib/fa/twitter"
 import SearchForm from "../components/search-form"
 import DiscordIcon from "../components/discord"
 import logo from "../logo.svg"
-import typography, { rhythm, scale } from "../utils/typography"
+import typography, { rhythm, scale, options } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
 import { vP, vPHd, vPVHd, vPVVHd } from "./gutters"
 
-const navItemStyles = {
-  ...scale(-1 / 3),
-  boxSizing: `border-box`,
-  color: `inherit`,
-  textDecoration: `none`,
-  textTransform: `uppercase`,
-  letterSpacing: `0.03em`,
-  lineHeight: `calc(${presets.headerHeight} - 6px)`,
-  position: `relative`,
-  top: 0,
-  transition: `color .15s ease-out`,
-  "&:hover": {
-    opacity: 0.8,
-  },
-  display: `flex`,
-  alignItems: `center`,
-  justifyContent: `center`,
-  borderBottom: `2px solid transparent`,
-}
+// what we need to nudge down the navItems to sit
+// on the baseline of the logo's wordmark
+const navItemTopOffset = `0.6rem`
+const navItemHorizontalSpacing = rhythm(1 / 3)
 
-const activeNavItemStyles = {
-  borderBottomColor: colors.gatsby,
-}
+const iconColor = colors.lilac
+const iconColorHomepage = colors.ui.light
 
 const assignActiveStyles = ({ isPartiallyCurrent }) =>
-  isPartiallyCurrent ? { style: activeNavItemStyles } : {}
+  isPartiallyCurrent ? { style: styles.navItem.active } : {}
 
 const NavItem = ({ linkTo, children }) => (
-  <li
-    css={{
-      display: `inline-block`,
-      margin: 0,
-      padding: `6px ${rhythm(1 / 4)} 0 ${rhythm(1 / 2)}`,
-    }}
-  >
-    <Link to={linkTo} getProps={assignActiveStyles} css={navItemStyles}>
+  <li css={styles.li}>
+    <Link to={linkTo} getProps={assignActiveStyles} css={styles.navItem}>
       {children}
     </Link>
   </li>
 )
 
-export default ({ pathname }) => {
+const Navigation = ({ pathname }) => {
   const isHomepage = pathname === `/`
   const isBlog = pathname === `/blog/`
 
-  let styles = {}
-  if (isHomepage) {
-    styles.backgroundColor = `rgba(255,255,255,0)`
-    styles.borderBottomColor = `transparent`
-  } else if (isBlog) {
-    styles.backgroundColor = `#fff`
-    styles[presets.Tablet] = {
-      borderBottomColor: `transparent`,
-      position: `absolute`,
-      backgroundColor: colors.ui.whisper,
-    }
-  }
   const socialIconsStyles = {
-    color: colors.lilac,
-    padding: `6px ${rhythm(1 / 4)} 0 ${rhythm(1 / 2)}`,
+    ...styles.navItem,
+    ...styles.socialIconItem,
     [presets.Phablet]: {
-      color: isHomepage ? colors.ui.light : false,
+      color: isHomepage ? iconColorHomepage : false,
+      "&:hover": {
+        color: isHomepage ? colors.ui.bright : colors.gatsby,
+      },
     },
   }
-  const gutters = isHomepage
-    ? {
-        paddingLeft: vP,
-        paddingRight: vP,
-        paddingTop: rhythm(1.5),
-        [presets.Hd]: {
-          paddingLeft: vPHd,
-          paddingRight: vPHd,
-        },
-        [presets.VHd]: {
-          paddingLeft: vPVHd,
-          paddingRight: vPVHd,
-        },
-        [presets.VVHd]: {
-          paddingLeft: vPVVHd,
-          paddingRight: vPVVHd,
-        },
-      }
-    : {}
+
+  const SocialNavItem = ({ href, title, children, overrideCSS }) => (
+    <a
+      href={href}
+      title={title}
+      css={{
+        ...socialIconsStyles,
+        ...overrideCSS,
+      }}
+    >
+      {children}
+    </a>
+  )
 
   return (
     <div
       role="navigation"
       className="navigation"
       css={{
-        borderBottom: `1px solid ${colors.ui.light}`,
-        backgroundColor: `rgba(255,255,255,0.975)`,
+        backgroundColor: isHomepage ? `transparent` : `rgba(255,255,255,0.975)`,
         position: isHomepage ? `absolute` : `relative`,
         height: presets.headerHeight,
-        zIndex: 2,
         left: 0,
         right: 0,
-        top: presets.bannerHeight,
+        top: isHomepage
+          ? `calc(${presets.bannerHeight} + ${rhythm(
+              options.blockMarginBottom
+            )})`
+          : presets.bannerHeight,
+        zIndex: 2,
+        "&:after": {
+          content: ` `,
+          position: `absolute`,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          width: `100%`,
+          height: 1,
+          zIndex: -1,
+          background: isHomepage ? `transparent` : colors.ui.light,
+        },
+        // use this to test if the header items are properly aligned to the logo
+        // wordmark
+        // "&:before": {
+        //   content: ` `,
+        //   position: `absolute`,
+        //   bottom: `1.25rem`,
+        //   left: 0,
+        //   right: 0,
+        //   width: `100%`,
+        //   height: 1,
+        //   zIndex: 10,
+        //   background: `red`,
+        // },
         [presets.Tablet]: {
           position: isHomepage || isBlog ? `absolute` : `fixed`,
+          backgroundColor: isBlog ? colors.ui.whisper : false,
         },
-        ...styles,
       }}
     >
       <div
         css={{
-          //maxWidth: rhythm(presets.maxWidth),
-          margin: `0 auto`,
-          paddingLeft: rhythm(3 / 4),
-          paddingRight: rhythm(3 / 4),
-          ...gutters,
-          fontFamily: typography.options.headerFontFamily.join(`,`),
-          display: `flex`,
-          alignItems: `center`,
-          width: `100%`,
-          height: `100%`,
+          ...styles.containerInner,
+          ...(isHomepage
+            ? {
+                paddingLeft: vP,
+                paddingRight: vP,
+                [presets.Hd]: {
+                  paddingLeft: vPHd,
+                  paddingRight: vPHd,
+                },
+                [presets.VHd]: {
+                  paddingLeft: vPVHd,
+                  paddingRight: vPVHd,
+                },
+                [presets.VVHd]: {
+                  paddingLeft: vPVVHd,
+                  paddingRight: vPVVHd,
+                },
+              }
+            : {}),
         }}
       >
-        <Link
-          to="/"
-          css={{
-            alignItems: `center`,
-            color: `inherit`,
-            display: `flex`,
-            textDecoration: `none`,
-            marginRight: rhythm(1 / 2),
-          }}
-        >
-          <img
-            src={logo}
-            css={{
-              width: 106,
-              margin: 0,
-            }}
-            alt=""
-          />
+        <Link to="/" css={styles.logoLink}>
+          <img src={logo} css={styles.logo} alt="" />
         </Link>
-        <ul
-          css={{
-            display: `none`,
-            [presets.Tablet]: {
-              display: `flex`,
-              alignItems: `center`,
-              margin: 0,
-              listStyle: `none`,
-              flexGrow: 1,
-              overflowX: `auto`,
-              maskImage: `linear-gradient(to right, transparent, white ${rhythm(
-                1 / 8
-              )}, white 98%, transparent)`,
-            },
-          }}
-        >
+        <ul css={styles.navContainer}>
           <NavItem linkTo="/docs/">Docs</NavItem>
           <NavItem linkTo="/tutorial/">Tutorial</NavItem>
           <NavItem linkTo="/plugins/">Plugins</NavItem>
@@ -168,39 +136,30 @@ export default ({ pathname }) => {
           <NavItem linkTo="/blog/">Blog</NavItem>
           <NavItem linkTo="/showcase/">Showcase</NavItem>
           {false ? (
-            <li
-              css={{
-                display: `inline-block`,
-                margin: 0,
-              }}
-            >
-              <Link to="/community/" css={navItemStyles} state={{ filter: `` }}>
+            <li css={styles.li}>
+              <Link
+                to="/community/"
+                css={styles.navItem}
+                state={{ filter: `` }}
+              >
                 Community
               </Link>
             </li>
           ) : null}
         </ul>
-        <div
-          css={{
-            display: `flex`,
-            marginLeft: `auto`,
-          }}
-        >
+        <div css={styles.searchAndSocialContainer}>
           <SearchForm
             key="SearchForm"
-            iconStyles={{ ...socialIconsStyles }}
+            iconColor={isHomepage ? iconColorHomepage : iconColor}
             isHomepage={isHomepage}
+            offsetVertical="-0.2175rem"
           />
-          <a
+          <SocialNavItem
             href="https://github.com/gatsbyjs/gatsby"
             title="GitHub"
-            css={{
-              ...navItemStyles,
-              ...socialIconsStyles,
-            }}
           >
             <GithubIcon style={{ verticalAlign: `text-top` }} />
-          </a>
+          </SocialNavItem>
           <div
             css={{
               display: `none`,
@@ -208,40 +167,111 @@ export default ({ pathname }) => {
               [presets.Hd]: { display: `flex` },
             }}
           >
-            <a
+            <SocialNavItem
               href="https://discord.gg/0ZcbPKXt5bVoxkfV"
               title="Discord"
-              css={{
-                ...navItemStyles,
-                ...socialIconsStyles,
-              }}
             >
               <DiscordIcon overrideCSS={{ verticalAlign: `text-top` }} />
-            </a>
-            <a
+            </SocialNavItem>
+            <SocialNavItem
               href="https://twitter.com/gatsbyjs"
               title="@gatsbyjs"
-              css={{
-                ...navItemStyles,
-                ...socialIconsStyles,
-              }}
             >
               <TwitterIcon style={{ verticalAlign: `text-top` }} />
-            </a>
+            </SocialNavItem>
           </div>
-          <a
+          <SocialNavItem
             href="https://www.gatsbyjs.com"
             title="gatsbyjs.com"
-            css={{
-              ...navItemStyles,
-              ...socialIconsStyles,
-              paddingRight: 0,
-            }}
+            overrideCSS={{ paddingRight: 0 }}
           >
             .com
-          </a>
+          </SocialNavItem>
         </div>
       </div>
     </div>
   )
 }
+
+const styles = {
+  li: {
+    display: `block`,
+    margin: 0,
+    marginLeft: navItemHorizontalSpacing,
+    marginRight: navItemHorizontalSpacing,
+  },
+  navContainer: {
+    display: `none`,
+    [presets.Tablet]: {
+      alignSelf: `flex-end`,
+      display: `flex`,
+      flexGrow: 1,
+      margin: 0,
+      marginLeft: rhythm(1 / 4),
+      listStyle: `none`,
+      maskImage: `linear-gradient(to right, transparent, white ${rhythm(
+        1 / 8
+      )}, white 98%, transparent)`,
+      overflowX: `auto`,
+    },
+  },
+  containerInner: {
+    margin: `0 auto`,
+    paddingLeft: rhythm(3 / 4),
+    paddingRight: rhythm(3 / 4),
+    fontFamily: typography.options.headerFontFamily.join(`,`),
+    display: `flex`,
+    alignItems: `center`,
+    width: `100%`,
+    height: `100%`,
+  },
+  navItem: {
+    ...scale(-1 / 3),
+    borderBottom: `0.125rem solid transparent`,
+    color: `inherit`,
+    display: `block`,
+    letterSpacing: `0.03em`,
+    lineHeight: `calc(${presets.headerHeight} - ${navItemTopOffset})`,
+    position: `relative`,
+    textDecoration: `none`,
+    textTransform: `uppercase`,
+    top: 0,
+    transition: `color ${presets.animation.speedDefault} ${
+      presets.animation.curveDefault
+    }`,
+    zIndex: 1,
+    "&:hover": {
+      color: colors.gatsby,
+    },
+    active: {
+      borderBottomColor: colors.gatsby,
+      color: colors.gatsby,
+    },
+  },
+  socialIconItem: {
+    color: iconColor,
+    paddingLeft: navItemHorizontalSpacing,
+    paddingRight: navItemHorizontalSpacing,
+  },
+  searchAndSocialContainer: {
+    alignSelf: `flex-end`,
+    display: `flex`,
+    marginLeft: `auto`,
+  },
+  logo: {
+    height: 28,
+    margin: 0,
+    [presets.Tablet]: {
+      height: `1.55rem`,
+    },
+  },
+  logoLink: {
+    alignItems: `center`,
+    color: `inherit`,
+    display: `flex`,
+    marginRight: rhythm(1 / 2),
+    textDecoration: `none`,
+  },
+}
+
+export default Navigation

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -104,11 +104,11 @@ export default ({ pathname }) => {
         borderBottom: `1px solid ${colors.ui.light}`,
         backgroundColor: `rgba(255,255,255,0.975)`,
         position: isHomepage ? `absolute` : `relative`,
-        // height: presets.headerHeight,
-        zIndex: `2`,
+        height: presets.headerHeight,
+        zIndex: 2,
         left: 0,
         right: 0,
-        top: `calc(${presets.bannerHeight} - 1px)`,
+        top: presets.bannerHeight,
         [presets.Tablet]: {
           position: isHomepage || isBlog ? `absolute` : `fixed`,
         },
@@ -170,20 +170,18 @@ export default ({ pathname }) => {
           <NavItem linkTo="/features/">Features</NavItem>
           <NavItem linkTo="/blog/">Blog</NavItem>
           <NavItem linkTo="/showcase/">Showcase</NavItem>
-          {
-            false ? 
-              <li
-                css={{
-                  display: `inline-block`,
-                  margin: 0,
-                }}
-              >
-                <Link to="/community/" css={navItemStyles} state={{ filter: `` }}>
-                  Community
-                </Link>
-              </li> :
-              null
-          }
+          {false ? (
+            <li
+              css={{
+                display: `inline-block`,
+                margin: 0,
+              }}
+            >
+              <Link to="/community/" css={navItemStyles} state={{ filter: `` }}>
+                Community
+              </Link>
+            </li>
+          ) : null}
         </ul>
         <div
           css={{

--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -8,7 +8,7 @@ class PageWithPluginSearchBar extends Component {
     const searchbarWidth = rhythm(17)
 
     const styles = {
-      height: `calc(100vh - ${presets.headerHeight} + 1px)`,
+      height: `calc(100vh - ${presets.headerHeight})`,
       width: `100vw`,
       padding: rhythm(3 / 4),
       zIndex: 1,

--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -298,7 +298,7 @@ class SearchForm extends Component {
   }
   render() {
     const { focussed } = this.state
-    const { iconStyles, isHomepage } = this.props
+    const { iconColor, isHomepage, offsetVertical } = this.props
     return (
       <form
         css={{
@@ -308,42 +308,44 @@ class SearchForm extends Component {
           alignItems: `center`,
           marginLeft: rhythm(1 / 2),
           marginBottom: 0,
+          marginTop: offsetVertical ? offsetVertical : false,
         }}
         className="searchWrap"
         onMouseOver={() => this.loadAlgoliaJS()}
         onClick={() => this.loadAlgoliaJS()}
         onSubmit={e => e.preventDefault()}
       >
-        <label css={{ position: `relative` }}>
+        <label
+          css={{
+            position: `relative`,
+          }}
+        >
           <input
             id="doc-search"
             css={{
               appearance: `none`,
               backgroundColor: `transparent`,
               border: 0,
-              borderRadius: presets.radiusLg,
-              color: colors.gatsby,
+              borderRadius: presets.radius,
+              color: colors.lilac,
               paddingTop: rhythm(1 / 8),
               paddingRight: rhythm(1 / 4),
               paddingBottom: rhythm(1 / 8),
-              paddingLeft: rhythm(1),
+              paddingLeft: rhythm(5 / 4),
               overflow: `hidden`,
               width: rhythm(1),
               transition: `width ${speedDefault} ${curveDefault}, background-color ${speedDefault} ${curveDefault}`,
               ":focus": {
-                outline: 0,
                 backgroundColor: colors.ui.light,
-                borderRadius: presets.radiusLg,
+                color: colors.gatsby,
+                outline: 0,
                 width: rhythm(5),
-                transition: `width ${speedDefault} ${curveDefault}, background-color ${speedDefault} ${curveDefault}`,
               },
               [presets.Desktop]: {
                 backgroundColor: !isHomepage && `#fff`,
-                color: colors.gatsby,
                 width: !isHomepage && rhythm(3.5),
                 ":focus": {
                   backgroundColor: colors.ui.light,
-                  color: colors.gatsby,
                 },
               },
               [presets.Hd]: {
@@ -364,18 +366,17 @@ class SearchForm extends Component {
           />
           <SearchIcon
             overrideCSS={{
-              ...iconStyles,
-              fill: focussed && colors.gatsby,
+              fill: focussed ? colors.gatsby : colors.lilac,
               position: `absolute`,
-              left: `5px`,
+              left: rhythm(1 / 4),
               top: `50%`,
-              width: `16px`,
-              height: `16px`,
+              width: `1rem`,
+              height: `1rem`,
               pointerEvents: `none`,
               transition: `fill ${speedDefault} ${curveDefault}`,
-              transform: `translateY(-50%)`,
-              [presets.Hd]: {
-                fill: focussed && isHomepage && colors.gatsby,
+              transform: `translateY(-55%)`,
+              [presets.Phablet]: {
+                fill: focussed ? colors.gatsby : isHomepage ? iconColor : false,
               },
             }}
           />
@@ -386,6 +387,7 @@ class SearchForm extends Component {
 }
 SearchForm.propTypes = {
   isHomepage: PropTypes.bool,
-  iconStyles: PropTypes.object,
+  iconColor: PropTypes.string,
+  offsetVertical: PropTypes.string,
 }
 export default SearchForm

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -218,8 +218,8 @@ class SidebarBody extends Component {
           css={{
             ...styles.sidebarScrollContainer,
             height: itemList[0].disableExpandAll
-              ? `calc(100%)`
-              : `calc(100% - ${presets.sidebarUtilityHeight} + 1px)`,
+              ? `100%`
+              : `calc(100% - ${presets.sidebarUtilityHeight})`,
             [presets.Tablet]: {
               ...styles.sidebarScrollContainerTablet,
             },

--- a/www/src/components/sidebar/sticky-responsive-sidebar.js
+++ b/www/src/components/sidebar/sticky-responsive-sidebar.js
@@ -107,9 +107,7 @@ const styles = {
     width: 320,
     zIndex: 10,
     [presets.Tablet]: {
-      height: `calc(100vh - ${presets.headerHeight} - ${
-        presets.bannerHeight
-      } + 1px)`,
+      height: `calc(100vh - ${presets.headerHeight} - ${presets.bannerHeight})`,
       maxWidth: `none`,
       opacity: `1 !important`,
       pointerEvents: `auto`,

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -18,7 +18,7 @@ class Plugins extends Component {
               display: `flex`,
               minHeight: `calc(100vh - (${presets.headerHeight} + ${
                 presets.bannerHeight
-              } - 1px))`,
+              }))`,
             }}
           >
             <div
@@ -60,7 +60,7 @@ class Plugins extends Component {
                 }}
               >
                 Please use the search bar to find plugins that will make your
-                blazing fast site even more awesome. If you'd like to create
+                blazing fast site even more awesome. If you{`'`}d like to create
                 your own plugin, see the
                 {` `}
                 <Link to="/docs/plugin-authoring/">Plugin Authoring</Link> page

--- a/www/src/utils/colors.js
+++ b/www/src/utils/colors.js
@@ -78,9 +78,9 @@ const colors = {
     light: gray(80, 270),
   },
   code: {
-    bg: '#fdfaf6',
-    border: '#faede5',
-    text: '#866c5b',
+    bg: `#fdfaf6`,
+    border: `#faede5`,
+    text: `#866c5b`,
     remove: `#e45c5c`,
     add: `#4a9c59`,
   },

--- a/www/src/utils/presets.js
+++ b/www/src/utils/presets.js
@@ -35,6 +35,6 @@ module.exports = {
   },
   logoOffset: 1.8,
   headerHeight: `3.5rem`,
-  bannerHeight: `2.55rem`,
+  bannerHeight: `2.5rem`,
   sidebarUtilityHeight: `2.5rem`,
 }

--- a/www/src/views/shared/styles.js
+++ b/www/src/views/shared/styles.js
@@ -104,8 +104,15 @@ const styles = {
     },
   },
   sticky: {
-    paddingTop: rhythm(options.blockMarginBottom),
     position: `sticky`,
+    // We need the -1px here to work around a weird issue on Chrome
+    // where the sticky element is consistently positioned 1px too far down,
+    // leaving a nasty gap that the page content peeks through.
+    // FWIW the problem is only present on the "Site Showcase" index page,
+    // not the "Starter Showcase" index page; if the "Featured Sites" block
+    // is removed, the problem goes away. I tried removing elements in the
+    // "Featured Sites" content block, but no success—only removing the entire block
+    // resolves the issue.
     top: `calc(${presets.bannerHeight} - 1px)`,
     [presets.Desktop]: {
       top: `calc(${presets.headerHeight} + ${presets.bannerHeight} - 1px)`,

--- a/www/src/views/showcase/filtered-showcase.js
+++ b/www/src/views/showcase/filtered-showcase.js
@@ -6,7 +6,7 @@ import styles from "../shared/styles"
 import ShowcaseList from "./showcase-list"
 import Filters from "./filters"
 import SearchIcon from "../../components/search-icon"
-import { options, rhythm, scale } from "../../utils/typography"
+import { rhythm, scale } from "../../utils/typography"
 import presets, { colors } from "../../utils/presets"
 import URLQuery from "../../components/url-query"
 
@@ -135,7 +135,6 @@ class FilteredShowcase extends Component {
                     background: `rgba(255,255,255,0.98)`,
                     paddingLeft: `${rhythm(3 / 4)}`,
                     paddingRight: `${rhythm(3 / 4)}`,
-                    paddingBottom: rhythm(options.blockMarginBottom),
                     zIndex: 1,
                     borderBottom: `1px solid ${colors.ui.light}`,
                   }}

--- a/www/src/views/showcase/filters.js
+++ b/www/src/views/showcase/filters.js
@@ -44,7 +44,7 @@ const Filters = ({
       css={{
         display: `flex`,
         flexDirection: `column`,
-        height: `calc(100% - ${presets.headerHeight} + 1px)`,
+        height: `calc(100% - ${presets.headerHeight})`,
         paddingLeft: rhythm(3 / 4),
       }}
     >

--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -4,7 +4,6 @@ import Helmet from "react-helmet"
 import FeaturedSites from "./featured-sites"
 import FilteredShowcase from "./filtered-showcase"
 import Layout from "../../components/layout"
-import presets from "../../utils/presets"
 
 class ShowcaseView extends Component {
   showcase = React.createRef()
@@ -21,15 +20,7 @@ class ShowcaseView extends Component {
           featured={data.featured.edges}
           showcase={this.showcase}
         />
-        <div
-          id="showcase"
-          css={{
-            position: `relative`,
-            top: `calc(-${presets.headerHeight} + 1px)`,
-            height: 1,
-          }}
-          ref={this.showcase}
-        />
+        <div id="showcase" css={{ height: 0 }} ref={this.showcase} />
         <FilteredShowcase data={data} />
       </Layout>
     )

--- a/www/src/views/starter-showcase/filtered-showcase.js
+++ b/www/src/views/starter-showcase/filtered-showcase.js
@@ -201,7 +201,6 @@ export default class FilteredShowcase extends Component {
               background: `rgba(255,255,255,0.98)`,
               paddingLeft: `${rhythm(3 / 4)}`,
               paddingRight: `${rhythm(3 / 4)}`,
-              paddingBottom: rhythm(options.blockMarginBottom),
               zIndex: 1,
               borderBottom: `1px solid ${colors.ui.light}`,
             }}


### PR DESCRIPTION
This PR mainly takes care of making sure that the header items (nav items, Algolia search input, social links) line up nicely with the logo wordmark again. It also resolves the issue where the "Docs/Tutorial/Features" sidebar would overlap the 2px bottom border of the active nav item state, and brings back the header search input icon.

To enable the above without hacking those fixes in, I refactored the corresponding components in an effort to make things at least a little clearer and simpler. It's not squeaky clean and completely magic-number-free, but IMO quite a bit easier to grasp what's going on.

Peep these videos to see a comparison to the current next.gatsbyjs.org as well as gatsbyjs.org:

* https://www.dropbox.com/s/cx15igtrwtj4rk8/active-nav-state.mov?dl=0
* https://www.dropbox.com/s/90k64vdn7iz6s1i/active-nav-state-2.mov?dl=0

---

Along the way, I slightly touched the banner component to allow any amount of (one-line, scrolling overflow) copy:

<img width="386" alt="bildschirmfoto 2018-09-08 um 02 41 53" src="https://user-images.githubusercontent.com/21834/45256574-8b673d80-b398-11e8-8e5f-355809a74217.png">

<img width="385" alt="bildschirmfoto 2018-09-08 um 02 42 17" src="https://user-images.githubusercontent.com/21834/45256576-8e622e00-b398-11e8-807b-5110464f429d.png">

This PR is powered by [Alice](https://www.youtube.com/watch?v=QUMuDWDVd20) and [Omni Trio](https://www.youtube.com/watch?v=xMYb_mC-CKw).