### PR TITLE
Remove archived gatsby-starter-simple-landing

### DIFF
--- a/docs/docs/gatsby-starters.md
+++ b/docs/docs/gatsby-starters.md
@@ -562,18 +562,6 @@ gatsby new my-blog https://github.com/gatsbyjs/gatsby-starter-blog#v2
   - Minimal UI and Styling -- made to customize.
   - Styled Components
 
-- [gatsby-starter-simple-landing](https://github.com/greglobinski/gatsby-starter-simple-landing)
-  [(demo)](https://gssl.greglobinski.com/)
-
-  Features:
-
-  - CSS-in-JS via [JSS](https://github.com/cssinjs/jss)
-  - easily restyled through theme object
-  - text content via Markdown files
-  - auto-generated sizes and types (png, webp) for background and hero images
-  - favicons generator
-  - webfonts with [webfontloader](https://github.com/typekit/webfontloader)
-
 - [gatsby-starter-typescript-plus](https://github.com/resir014/gatsby-starter-typescript-plus)
   [(demo)](https://gatsby-starter-typescript-plus.netlify.com/)
 


### PR DESCRIPTION
The [repo](https://github.com/greglobinski/gatsby-starter-simple-landing) is archived and the demo page is offline

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
