### PR TITLE
Added a way to configure remark options.

### DIFF
--- a/examples/using-remark/gatsby-config.js
+++ b/examples/using-remark/gatsby-config.js
@@ -26,6 +26,11 @@ module.exports = {
     {
       resolve: `gatsby-transformer-remark`,
       options: {
+        gfm: true,
+        commonmark: true,
+        footnotes: true,
+        pedantic: true,
+        // blocks: ["h2"], Blocks option value can be provided here as an array.
         excerpt_separator: `<!-- end -->`,
         plugins: [
           {

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -79,7 +79,7 @@ module.exports = (
       gfm,
       commonmark,
       footnotes,
-      pedantic
+      pedantic,
     }
     if (_.isArray(blocks)) {
       remarkOptions.blocks = blocks

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -74,11 +74,17 @@ module.exports = (
 
   return new Promise((resolve, reject) => {
     // Setup Remark.
-    let remark = new Remark().data(`settings`, {
-      commonmark: true,
-      footnotes: true,
-      pedantic: true,
-    })
+    const { commonmark = true, footnotes = true, pedantic = true, gfm = true, blocks } = pluginOptions
+    const remarkOptions = {
+      gfm,
+      commonmark,
+      footnotes,
+      pedantic
+    }
+    if (_.isArray(blocks)) {
+      remarkOptions.blocks = blocks
+    }
+    let remark = new Remark().data(`settings`, remarkOptions)
 
     for (let plugin of pluginOptions.plugins) {
       const requiredPlugin = require(plugin.resolve)


### PR DESCRIPTION
With remark, now the following options can be provided:
- gfm
- commonmark
- footnotes
- pedantic
- blocks

The config can be provided in `gatsby-config.js` as below:
```js
  plugins: [
    {
      resolve: `gatsby-transformer-remark`,
      options: {
        gfm: false,
        commonmark: false,
        footnotes: false,
        pedantic: false,
        blocks: ["h2"],
     }
  },
// other plugins
```

Fixes #7992 