### PR TITLE
feat(gatsby-source-filesystem): Added an 'ignore' property to the options to ignore more files.

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -35,6 +35,7 @@ module.exports = {
       options: {
         name: `data`,
         path: `${__dirname}/src/data/`,
+        ignore: `**/\.*`, // ignore files starting with a dot
       },
     },
   ],

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -35,11 +35,27 @@ module.exports = {
       options: {
         name: `data`,
         path: `${__dirname}/src/data/`,
-        ignore: `**/\.*`, // ignore files starting with a dot
+        ignore: [`**/\.*`], // ignore files starting with a dot
       },
     },
   ],
 }
+```
+
+## Options
+
+In addition to the name and path parameters you may pass an optional `ignore` array of file globs to ignore.
+
+They will be added to the following default list:
+
+```
+**/*.un~
+**/.gitignore
+**/.npmignore
+**/.babelrc
+**/yarn.lock
+**/node_modules
+../**/dist/**
 ```
 
 ## How to query

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -50,6 +50,7 @@ They will be added to the following default list:
 
 ```
 **/*.un~
+**/.DS_Store
 **/.gitignore
 **/.npmignore
 **/.babelrc

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -135,6 +135,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
       `**/yarn.lock`,
       `**/node_modules`,
       `../**/dist/**`,
+      ...(pluginOptions.ignore || []),
     ],
   })
 


### PR DESCRIPTION
One of my clients uses a markdown editor that saves `.~<filename>` temporary files in an auto-save context. These get eaten up by the gatsby-source-filesystem plugin and can cause issues.

This PR allows for an `ignore` array in the options to specify more regex's to ignore.

```
    {
      resolve: `gatsby-source-filesystem`,
      options: {
        path: `${__dirname}/src/packages/pages`,
        name: 'pages',
        ignore: [`**/\.*`],
      },
    },
```

I would argue that adding `**/\.*` to the default list of ignores (ignore dot files) would be a sane default, but that might be considered a breaking change?

I can amend this PR with that change / make a second PR if desired.