### PR TITLE
[gatsyb-source-filesystem] ignore .DS_Store file

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -129,6 +129,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
   const watcher = chokidar.watch(pluginOptions.path, {
     ignored: [
       `**/*.un~`,
+      `**/.DS_Store`,
       `**/.gitignore`,
       `**/.npmignore`,
       `**/.babelrc`,


### PR DESCRIPTION
It's really annoying, BTW, I think we can add an extra `ignore` options to source more specific files except the default list