### PR TITLE
Make clicking title in docs behave like toggle button

### DIFF
--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -103,7 +103,9 @@ const SplitButton = ({
         isParentOfActiveItem,
         item,
         location,
-        onLinkClick,
+        onLinkClick: () => {
+          onLinkClick(item)
+        },
       })}
     </span>
     {/* @todo this should cover 100% of the item's height */}

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -235,7 +235,7 @@ class SidebarBody extends Component {
                 key={index}
                 level={0}
                 location={location}
-                onLinkClick={closeSidebar}
+                onLinkClick={this._toggleSection}
                 onSectionTitleClick={this._toggleSection}
                 openSectionHash={openSectionHash}
               />


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
This PR makes the behavior between clicking a title and the accompanying button the same.

Closes #7975 