### PR TITLE
specify gatsby-source-graphql dependencies

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -11,7 +11,8 @@
     "apollo-link": "1.2.1",
     "apollo-link-http": "^1.5.4",
     "graphql": "^0.13.2",
-    "graphql-tools": "^3.0.4"
+    "graphql-tools": "^3.0.4",
+    "node-fetch": "^1.7.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -12,7 +12,9 @@
     "apollo-link-http": "^1.5.4",
     "graphql": "^0.13.2",
     "graphql-tools": "^3.0.4",
-    "node-fetch": "^1.7.3"
+    "invariant": "^2.2.4",
+    "node-fetch": "^1.7.3",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11044,7 +11044,7 @@ node-fetch@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0.tgz#982bba43ecd4f2922a29cc186a6bbb0bb73fcba6"
 
-node-fetch@^1.0.1:
+node-fetch@^1.0.1, node-fetch@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:


### PR DESCRIPTION
closes #8011 

@pieh I haven't added the other dependencies, just `node-fetch`. Let me know if you want the others too.