### PR TITLE
chore: Upgrade lodash to current version.

### DIFF
--- a/examples/client-only-paths/package.json
+++ b/examples/client-only-paths/package.json
@@ -6,7 +6,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "gatsby": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-transition-group": "^2.4.0",

--- a/examples/gatsbygram/package.json
+++ b/examples/gatsbygram/package.json
@@ -19,7 +19,7 @@
     "gatsby-transformer-sharp": "next",
     "glamor": "^2.20.40",
     "instagram-screen-scrape": "^2.0.0",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
     "mousetrap": "^1.6.0",
     "progress": "^2.0.0",

--- a/examples/hn/package.json
+++ b/examples/hn/package.json
@@ -9,7 +9,7 @@
     "gatsby": "next",
     "gatsby-plugin-manifest": "next",
     "gatsby-source-hacker-news": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "slash": "^2.0.0"

--- a/examples/no-plugins/package.json
+++ b/examples/no-plugins/package.json
@@ -6,7 +6,7 @@
   "author": "Scotty Eckenthal <scott.eckenthal@gmail.com>",
   "dependencies": {
     "gatsby": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "slash": "^1.0.0"

--- a/examples/no-trailing-slashes/package.json
+++ b/examples/no-trailing-slashes/package.json
@@ -8,7 +8,7 @@
     "gatsby": "next",
     "gatsby-plugin-google-analytics": "next",
     "gatsby-plugin-offline": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "slash": "^1.0.0"

--- a/examples/using-asciidoc/package.json
+++ b/examples/using-asciidoc/package.json
@@ -10,7 +10,7 @@
     "gatsby-plugin-offline": "next",
     "gatsby-plugin-typography": "next",
     "gatsby-source-filesystem": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-typography": "^0.16.13",

--- a/examples/using-contentful/package.json
+++ b/examples/using-contentful/package.json
@@ -12,7 +12,7 @@
     "gatsby-plugin-typography": "next",
     "gatsby-source-contentful": "next",
     "gatsby-transformer-remark": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-typography": "^0.16.3",

--- a/examples/using-drupal/package.json
+++ b/examples/using-drupal/package.json
@@ -16,7 +16,7 @@
     "gatsby-transformer-sharp": "next",
     "glamor": "^2.20.40",
     "gray-percentage": "^2.0.0",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-icons": "^2.2.7",

--- a/examples/using-emotion-prismjs/package.json
+++ b/examples/using-emotion-prismjs/package.json
@@ -18,7 +18,7 @@
     "gatsby-remark-prismjs": "next",
     "gatsby-source-filesystem": "next",
     "gatsby-transformer-remark": "next",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "prismjs": "^1.14.0",
     "prop-types": "^15.6.0",
     "react": "^16.4.0",

--- a/examples/using-glamor/package.json
+++ b/examples/using-glamor/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-offline": "next",
     "gatsby-plugin-typography": "^2.0.1-11",
     "glamor": "^2.20.40",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-typography": "^0.16.13",

--- a/examples/using-prefetching-preloading-modules/package.json
+++ b/examples/using-prefetching-preloading-modules/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-react-helmet": "next",
     "gatsby-plugin-styled-components": "next",
     "gatsby-plugin-typography": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-helmet": "^5.2.0",

--- a/examples/using-remark/package.json
+++ b/examples/using-remark/package.json
@@ -26,7 +26,7 @@
     "gatsby-transformer-sharp": "next",
     "gatsby-transformer-yaml": "next",
     "glamor": "^2.20.40",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "lodash-id": "^0.14.0",
     "lodash-webpack-plugin": "^0.11.5",
     "prismjs": "^1.13.0",

--- a/examples/using-styled-components/package.json
+++ b/examples/using-styled-components/package.json
@@ -12,7 +12,7 @@
     "gatsby-plugin-react-helmet": "next",
     "gatsby-plugin-styled-components": "next",
     "gatsby-plugin-typography": "next",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-helmet": "^5.2.0",

--- a/examples/using-wordpress/package.json
+++ b/examples/using-wordpress/package.json
@@ -14,7 +14,7 @@
     "gatsby-source-wordpress": "next",
     "gatsby-transformer-sharp": "next",
     "glamor": "^2.20.40",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.10",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0",

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -21,7 +21,7 @@
     "fs-exists-cached": "^1.0.0",
     "fs-extra": "^4.0.1",
     "hosted-git-info": "^2.6.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "opentracing": "^0.14.3",
     "pretty-error": "^2.1.1",
     "resolve-cwd": "^2.0.0",

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -15,7 +15,7 @@
     "configstore": "^3.1.0",
     "fs-extra": "^4.0.1",
     "is-absolute": "^0.2.6",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "yargs": "^8.0.2"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -16,7 +16,7 @@
     "@babel/runtime": "^7.0.0",
     "fs-extra": "^4.0.2",
     "kebab-hash": "^0.1.2",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "webpack-assets-manifest": "^3.0.2"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -23,7 +23,7 @@
     "chokidar": "^1.7.0",
     "fs-exists-cached": "^1.0.0",
     "glob": "^7.1.1",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "parse-filepath": "^1.0.1",
     "slash": "^1.0.0"
   },

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -14,7 +14,7 @@
     "imagemin": "^6.0.0",
     "imagemin-pngquant": "^6.0.0",
     "imagemin-webp": "^4.1.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "mini-svg-data-uri": "^1.0.0",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -11,7 +11,7 @@
     "cheerio": "^1.0.0-rc.2",
     "fs-extra": "^4.0.1",
     "is-relative-url": "^2.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "path-is-inside": "^1.0.2",
     "probe-image-size": "^4.0.0",
     "unist-util-visit": "^1.3.0"

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.18.0",
     "cheerio": "^1.0.0-rc.2",
     "is-relative-url": "^2.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "sharp": "^0.20.2",
     "unist-util-select": "^1.5.0"
   },

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "cheerio": "^1.0.0-rc.2",
     "is-relative-url": "^2.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "slash": "^1.0.0",
     "unist-util-select": "^1.5.0",
     "unist-util-visit-parents": "^2.0.1"

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",
     "cheerio": "^1.0.0-rc.2",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "unist-util-visit": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -17,7 +17,7 @@
     "gatsby-plugin-sharp": "^2.0.0-rc.3",
     "is-online": "^7.0.0",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "qs": "^6.4.0"
   },
   "devDependencies": {

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -11,7 +11,7 @@
     "axios": "^0.18.0",
     "bluebird": "^3.5.0",
     "gatsby-source-filesystem": "^2.0.1-rc.2",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "axios": "^0.18.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -6,7 +6,7 @@
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "bundleDependencies": false,
+  "bundledDependencies": [],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "axios": "^0.18.0",
@@ -14,7 +14,7 @@
     "deep-map": "^1.5.0",
     "deep-map-keys": "^1.2.0",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.10"
   },
   "deprecated": false,
   "devDependencies": {

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "mongodb": "^2.2.30",
     "query-string": "^6.1.0"
   },

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -6,7 +6,7 @@
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "bundleDependencies": false,
+  "bundledDependencies": [],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "axios": "^0.18.0",
@@ -16,7 +16,7 @@
     "deep-map-keys": "^1.2.0",
     "gatsby-source-filesystem": "^2.0.1-rc.2",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "minimatch": "^3.0.4",
     "qs": "^6.4.0"
   },

--- a/packages/gatsby-transformer-documentationjs/README.md
+++ b/packages/gatsby-transformer-documentationjs/README.md
@@ -5,7 +5,7 @@ Uses [Documentation.js](http://documentation.js.org/) to extract code metadata
 and can be added to this plugin as well).
 
 It's used on gatsbyjs.org and can be seen in use on several pages there e.g.
-https://www.gatsbyjs.org/docs/node-apis/
+[https://www.gatsbyjs.org/docs/node-apis/](https://www.gatsbyjs.org/docs/node-apis/)
 
 ## Install
 

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -18,7 +18,7 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "cross-env": "^5.1.4",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.10"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen#readme",
   "keywords": [

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -12,7 +12,7 @@
     "gray-matter": "^4.0.0",
     "hast-util-raw": "^2.0.2",
     "hast-util-to-html": "^3.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "mdast-util-to-hast": "^3.0.0",
     "mdast-util-toc": "^2.0.1",
     "remark": "^9.0.0",

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "xml-parser": "^1.2.1"
   },
   "devDependencies": {

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "js-yaml": "3.11.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "unist-util-select": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -81,7 +81,7 @@
     "json-loader": "^0.5.7",
     "json-stringify-safe": "^5.0.1",
     "kebab-hash": "^0.1.2",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "md5": "^2.2.1",
     "md5-file": "^3.1.1",
     "mime": "^2.2.0",

--- a/scripts/site-up-checker/package.json
+++ b/scripts/site-up-checker/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "discord.js": "^11.1.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "request": "^2.81.0",
     "request-promise": "^4.2.0",
     "webhook-discord": "^2.0.6"

--- a/www/package.json
+++ b/www/package.json
@@ -49,7 +49,7 @@
     "graphql-request": "1.6.0",
     "gray-percentage": "^2.0.0",
     "hex2rgba": "^0.0.1",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "mitt": "^1.1.3",
     "mousetrap": "^1.6.1",
     "parse-filepath": "^1.0.2",

--- a/www/src/data/StarterShowcase/generatedGithubData/gatsby-advanced-starter.json
+++ b/www/src/data/StarterShowcase/generatedGithubData/gatsby-advanced-starter.json
@@ -24,7 +24,7 @@
     "gatsby-remark-responsive-iframe": "^1.4.16",
     "gatsby-source-filesystem": "^1.5.16",
     "gatsby-transformer-remark": "^1.7.30",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "lodash-webpack-plugin": "^0.11.4",
     "react": "^16.2.0",
     "react-disqus-comments": "^1.1.1",

--- a/www/src/data/StarterShowcase/generatedGithubData/gatsby-starter-forty.json
+++ b/www/src/data/StarterShowcase/generatedGithubData/gatsby-starter-forty.json
@@ -16,7 +16,7 @@
     "gatsby-source-filesystem": "^1.5.27",
     "gatsby-transformer-remark": "^1.7.37",
     "gatsby-transformer-sharp": "^1.6.22",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.10"
   },
   "homepage": "https://github.com/ChangoMan/gatsby-starter-forty",
   "keywords": [

--- a/www/src/data/StarterShowcase/generatedGithubData/gatsby-typescript-starter.json
+++ b/www/src/data/StarterShowcase/generatedGithubData/gatsby-typescript-starter.json
@@ -53,7 +53,7 @@
     "gatsby-transformer-sharp": "latest",
     "graphql-code-generator": "^0.5.2",
     "gray-matter": "^2.1.1",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-helmet": "5.0.3",


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Closes #8035 Upgrade lodash to current version in all packages. Addresses security vulnerability and standardizes everything to same version of lodash.

*NOTE* - I know this is a big change in terms of the number of packages affected (almost all). Let me know if you want me to break to out into smaller separate PRs.