### PR TITLE
[www] Fix header background for paginated "Blog" pages

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -181,7 +181,7 @@ exports.createPages = ({ graphql, actions }) => {
 
       Array.from({ length: numPages }).forEach((_, i) => {
         createPage({
-          path: i === 0 ? `/blog` : `/blog/${i + 1}`,
+          path: i === 0 ? `/blog` : `/blog/page/${i + 1}`,
           component: slash(blogListTemplate),
           context: {
             limit: postsPerPage,

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -30,7 +30,7 @@ const NavItem = ({ linkTo, children }) => (
 
 const Navigation = ({ pathname }) => {
   const isHomepage = pathname === `/`
-  const isBlog = pathname === `/blog/`
+  const isBlog = pathname === `/blog/` || pathname.indexOf(`/blog/page/`) === 0
 
   const socialIconsStyles = {
     ...styles.navItem,

--- a/www/src/components/pagination/index.js
+++ b/www/src/components/pagination/index.js
@@ -8,16 +8,16 @@ import { options, rhythm } from "../../utils/typography"
 
 class Pagination extends React.Component {
   changePage = e => {
-    navigate(`/blog/page/${e.target.value}`)
+    navigate(e.target.value ? `/blog/page/${e.target.value}` : `/blog/`)
   }
   render() {
     const { numPages, currentPage } = this.props.context
     const isFirst = currentPage === 1
     const isLast = currentPage === numPages
     const prevPageNum =
-      currentPage - 1 === 1 ? `` : (currentPage - 1).toString()
+      currentPage - 1 === 1 ? `` : `page/${(currentPage - 1).toString()}`
     const nextPageNum = (currentPage + 1).toString()
-    const prevPageLink = isFirst ? null : `/blog/page/${prevPageNum}`
+    const prevPageLink = isFirst ? null : `/blog/${prevPageNum}`
     const nextPageLink = isLast ? null : `/blog/page/${nextPageNum}`
 
     const prevNextLinkStyles = {

--- a/www/src/components/pagination/index.js
+++ b/www/src/components/pagination/index.js
@@ -8,7 +8,7 @@ import { options, rhythm } from "../../utils/typography"
 
 class Pagination extends React.Component {
   changePage = e => {
-    navigate(`/blog/${e.target.value}`)
+    navigate(`/blog/page/${e.target.value}`)
   }
   render() {
     const { numPages, currentPage } = this.props.context
@@ -17,8 +17,8 @@ class Pagination extends React.Component {
     const prevPageNum =
       currentPage - 1 === 1 ? `` : (currentPage - 1).toString()
     const nextPageNum = (currentPage + 1).toString()
-    const prevPageLink = isFirst ? null : `/blog/${prevPageNum}`
-    const nextPageLink = isLast ? null : `/blog/${nextPageNum}`
+    const prevPageLink = isFirst ? null : `/blog/page/${prevPageNum}`
+    const nextPageLink = isLast ? null : `/blog/page/${nextPageNum}`
 
     const prevNextLinkStyles = {
       "&&": {


### PR DESCRIPTION
Resolves #8041 by changing the URLs for "paginated blog index pages" from e.g. `/blog/2` to `/blog/page/2`, and updating the condition defining wether to render the header with a grey or white background accordingly.

I chose to change the URLs for "paginated blog index pages" instead of fiddling around with a more complex condition/regex. That condition would have had to differentiate among e.g. `/blog/2` (a paginated page, w/ gray header bg) and e.g. `/blog/2018-07-17-announcing-gatsby-preview/` (a blog article, w/ white header bg) — while this certainly would have been possible, it still felt a little fragile.

The URL change comes with the side effect of making the "paginated blog index page" URLs a little more meaningful.