### PR TITLE
[v2] [gatsby-plugin-offline] Use a local copy of Workbox by default

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -29,6 +29,7 @@ and AppCache setup by changing these options so tread carefully.
 
 ```javascript
 const options = {
+  importWorkboxFrom: `local`,
   globDirectory: rootDir,
   globPatterns,
   modifyUrlPrefix: {

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -73,6 +73,7 @@ exports.onPostBuild = (args, pluginOptions) => {
   })
 
   const options = {
+    importWorkboxFrom: `local`,
     globDirectory: rootDir,
     globPatterns,
     modifyUrlPrefix: {


### PR DESCRIPTION
Fixes #8037