### PR TITLE
feat: add --prefix-paths option to gatsby serve cli

### DIFF
--- a/integration-tests/path-prefix/package.json
+++ b/integration-tests/path-prefix/package.json
@@ -19,12 +19,11 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build --prefix-paths",
-    "postbuild": "mv public blog && mkdir public && mv blog public/blog",
     "develop": "gatsby develop",
     "format": "prettier --write '**/*.js'",
     "test": "npm-run-all -s build start-server-and-test",
     "start-server-and-test": "start-server-and-test serve http://localhost:9000/blog cy:run",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve --prefix-paths",
     "cy:open": "cypress open",
     "cy:run": "cypress run --browser chrome"
   },

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -28,7 +28,7 @@ for more.
 At the root of a Gatsby site run `gatsby develop` to start the Gatsby
 development server.
 
-Options
+**Options**
 
 ```
   -H, --host    Set host. Defaults to localhost
@@ -45,11 +45,40 @@ to find out how you can set up an HTTPS development server using Gatsby.
 At the root of a Gatsby site run `gatsby build` to do a production build of a
 site.
 
+**Options**
+
+```
+  -prefix-paths               Build site with link paths prefixed (set prefix in your config).
+  -no-uglify                  Build site without uglifying JS bundles (for debugging).
+  -open-tracing-config-file   Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/
+```
+
 ### Serve
 
 At the root of a Gatsby site run `gatsby serve` to serve the production build of
 the site for testing.
 
+**Options**
+
+```
+  -H, --host      Set host. Defaults to localhost
+  -p, --port      Set port. Defaults to 8000
+  -o, --open      Open the site in your browser for you
+  -prefix-paths   Serve site with link paths prefixed (set prefix in your config).
+```
+
 ### Info
 
 At the root of a Gatsby site run `gatsby info` to get helpful environment information which will be required when reporting a bug.
+
+**Options**
+
+```
+  -C, --clipboard   Automagically copy environment information to clipboard
+```
+
+### Repl
+
+Get a node repl with context of Gatsby environment
+
+<!-- TODO: add repl documentation link when ready -->

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -28,7 +28,7 @@ for more.
 At the root of a Gatsby site run `gatsby develop` to start the Gatsby
 development server.
 
-**Options**
+#### Options
 
 ```
   -H, --host    Set host. Defaults to localhost
@@ -45,7 +45,7 @@ to find out how you can set up an HTTPS development server using Gatsby.
 At the root of a Gatsby site run `gatsby build` to do a production build of a
 site.
 
-**Options**
+#### Options
 
 ```
   --prefix-paths               Build site with link paths prefixed (set prefix in your config).
@@ -58,7 +58,7 @@ site.
 At the root of a Gatsby site run `gatsby serve` to serve the production build of
 the site for testing.
 
-**Options**
+#### Options
 
 ```
   -H, --host        Set host. Defaults to localhost
@@ -71,7 +71,7 @@ the site for testing.
 
 At the root of a Gatsby site run `gatsby info` to get helpful environment information which will be required when reporting a bug.
 
-**Options**
+#### Options
 
 ```
   -C, --clipboard   Automagically copy environment information to clipboard

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -48,9 +48,9 @@ site.
 **Options**
 
 ```
-  -prefix-paths               Build site with link paths prefixed (set prefix in your config).
-  -no-uglify                  Build site without uglifying JS bundles (for debugging).
-  -open-tracing-config-file   Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/
+  --prefix-paths               Build site with link paths prefixed (set prefix in your config).
+  --no-uglify                  Build site without uglifying JS bundles (for debugging).
+  --open-tracing-config-file   Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/
 ```
 
 ### Serve
@@ -64,7 +64,7 @@ the site for testing.
   -H, --host      Set host. Defaults to localhost
   -p, --port      Set port. Defaults to 8000
   -o, --open      Open the site in your browser for you
-  -prefix-paths   Serve site with link paths prefixed (set prefix in your config).
+  --prefix-paths   Serve site with link paths prefixed (set prefix in your config).
 ```
 
 ### Info

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -30,12 +30,12 @@ development server.
 
 #### Options
 
-```
-  -H, --host    Set host. Defaults to localhost
-  -p, --port    Set port. Defaults to 8000
-  -o, --open    Open the site in your browser for you
-  -S, --https   Use HTTPS
-```
+|     Option      | Description                                     |
+| :-------------: | ----------------------------------------------- |
+| `-H`, `--host`  | Set host. Defaults to localhost                 |
+| `-p`, `--port`  | Set port. Defaults to 8000                      |
+| `-o`, `--open`  | Open the site in your (default) browser for you |
+| `-S`, `--https` | Use HTTPS                                       |
 
 Follow the [Local HTTPS guide](https://www.gatsbyjs.org/docs/local-https/)
 to find out how you can set up an HTTPS development server using Gatsby.
@@ -47,11 +47,11 @@ site.
 
 #### Options
 
-```
-  --prefix-paths               Build site with link paths prefixed (set prefix in your config).
-  --no-uglify                  Build site without uglifying JS bundles (for debugging).
-  --open-tracing-config-file   Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/
-```
+|            Option            | Description                                                                                                 |
+| :--------------------------: | ----------------------------------------------------------------------------------------------------------- |
+|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                         |
+|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                     |
+| `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |
 
 ### Serve
 
@@ -60,12 +60,12 @@ the site for testing.
 
 #### Options
 
-```
-  -H, --host        Set host. Defaults to localhost
-  -p, --port        Set port. Defaults to 8000
-  -o, --open        Open the site in your browser for you
-  --prefix-paths    Serve site with link paths prefixed (set prefix in your config).
-```
+|      Option      | Description                                                                     |
+| :--------------: | ------------------------------------------------------------------------------- |
+|  `-H`, `--host`  | Set host. Defaults to localhost                                                 |
+|  `-p`, `--port`  | Set port. Defaults to 8000                                                      |
+|  `-o`, `--open`  | Open the site in your (default) browser for you                                 |
+| `--prefix-paths` | Serve site with link paths prefixed (set pathPrefix in your `gatsby-config.js`) |
 
 ### Info
 
@@ -73,9 +73,9 @@ At the root of a Gatsby site run `gatsby info` to get helpful environment inform
 
 #### Options
 
-```
-  -C, --clipboard   Automagically copy environment information to clipboard
-```
+|       Option        | Description                                             |
+| :-----------------: | ------------------------------------------------------- |
+| `-C`, `--clipboard` | Automagically copy environment information to clipboard |
 
 ### Repl
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -61,10 +61,10 @@ the site for testing.
 **Options**
 
 ```
-  -H, --host      Set host. Defaults to localhost
-  -p, --port      Set port. Defaults to 8000
-  -o, --open      Open the site in your browser for you
-  --prefix-paths   Serve site with link paths prefixed (set prefix in your config).
+  -H, --host        Set host. Defaults to localhost
+  -p, --port        Set port. Defaults to 8000
+  -o, --open        Open the site in your browser for you
+  --prefix-paths    Serve site with link paths prefixed (set prefix in your config).
 ```
 
 ### Info

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -65,7 +65,7 @@ the site for testing.
 |  `-H`, `--host`  | Set host. Defaults to localhost                                                 |
 |  `-p`, `--port`  | Set port. Defaults to 8000                                                      |
 |  `-o`, `--open`  | Open the site in your (default) browser for you                                 |
-| `--prefix-paths` | Serve site with link paths prefixed (set pathPrefix in your `gatsby-config.js`) |
+| `--prefix-paths` | Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js). |
 
 ### Info
 

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -98,7 +98,7 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`o`, {
           alias: `open`,
           type: `boolean`,
-          describe: `Open the site in your browser for you.`,
+          describe: `Open the site in your (default) browser for you.`,
         })
         .option(`S`, {
           alias: `https`,
@@ -140,7 +140,7 @@ function buildLocalCommands(cli, isLocalSite) {
       _.option(`prefix-paths`, {
         type: `boolean`,
         default: false,
-        describe: `Build site with link paths prefixed (set prefix in your config).`,
+        describe: `Build site with link paths prefixed (set pathPrefix in your gatsby-config.js).`,
       })
         .option(`no-uglify`, {
           type: `boolean`,
@@ -178,12 +178,12 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`o`, {
           alias: `open`,
           type: `boolean`,
-          describe: `Open the site in your browser for you.`,
+          describe: `Open the site in your (default) browser for you.`,
         })
         .option(`prefix-paths`, {
           type: `boolean`,
           default: false,
-          describe: `Serve site with link paths prefixed (set prefix in your config).`,
+          describe: `Serve site with link paths prefixed (set pathPrefix in your gatsby-config.js.`,
         }),
 
     handler: getCommandHandler(`serve`),

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -183,7 +183,7 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`prefix-paths`, {
           type: `boolean`,
           default: false,
-          describe: `Serve site with link paths prefixed (set pathPrefix in your gatsby-config.js.`,
+          describe: `Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js).`,
         }),
 
     handler: getCommandHandler(`serve`),

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -179,6 +179,11 @@ function buildLocalCommands(cli, isLocalSite) {
           alias: `open`,
           type: `boolean`,
           describe: `Open the site in your browser for you.`,
+        })
+        .option(`prefix-paths`, {
+          type: `boolean`,
+          default: false,
+          describe: `Serve site with link paths prefixed (set prefix in your config).`,
         }),
 
     handler: getCommandHandler(`serve`),

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -17,6 +17,7 @@ const { initCache } = require(`../utils/cache`)
 const report = require(`gatsby-cli/lib/reporter`)
 const getConfigFile = require(`./get-config-file`)
 const tracer = require(`opentracing`).globalTracer()
+const preferDefault = require(`./prefer-default`)
 
 // Show stack trace on unhandled promises.
 process.on(`unhandledRejection`, (reason, p) => {
@@ -40,7 +41,6 @@ const {
 // Otherwise leave commented out.
 // require(`./log-line-function`)
 
-const preferDefault = m => (m && m.default) || m
 
 type BootstrapArgs = {
   directory: string,

--- a/packages/gatsby/src/bootstrap/prefer-default.js
+++ b/packages/gatsby/src/bootstrap/prefer-default.js
@@ -1,0 +1,1 @@
+module.exports = m => (m && m.default) || m

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -3,27 +3,36 @@ const openurl = require(`opn`)
 const signalExit = require(`signal-exit`)
 const compression = require(`compression`)
 const express = require(`express`)
+const getConfigFile = require(`../bootstrap/get-config-file`)
+const preferDefault = require(`../bootstrap/prefer-default`)
 
-module.exports = program => {
-  let { port, open } = program
+module.exports = async program => {
+  let { prefixPaths, port, open } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 
+  let { pathPrefix } = await preferDefault(
+    getConfigFile(program.directory, `gatsby-config`)
+  )
+
+  pathPrefix = prefixPaths && pathPrefix ? pathPrefix : '/'
+
   const app = express()
-  app.use(compression())
-  app.use(express.static(`public`))
-  app.use((req, res, next) => {
+  const router = express.Router()
+  router.use(compression())
+  router.use(express.static(`public`))
+  router.use((req, res, next) => {
     if (req.accepts(`html`)) {
       res.status(404).sendFile(`404.html`, { root: `public` })
     } else {
       next()
     }
   })
+  app.use(pathPrefix, router)
 
   const server = app.listen(port, () => {
-    let openUrlString = `http://localhost:` + port
+    let openUrlString = `http://localhost:${port}${pathPrefix}`
     console.log(`gatsby serve running at:`, openUrlString)
     if (open) {
-      let openUrlString = `http://localhost:` + port
       console.log(`Opening browser...`)
       openurl(openUrlString)
     }

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -14,7 +14,7 @@ module.exports = async program => {
     getConfigFile(program.directory, `gatsby-config`)
   )
 
-  pathPrefix = prefixPaths && pathPrefix ? pathPrefix : '/'
+  pathPrefix = prefixPaths && pathPrefix ? pathPrefix : `/`
 
   const app = express()
   const router = express.Router()


### PR DESCRIPTION
This PR adds a prefix-paths option so we can use it in tests (and generally, because it's helpful for debugging/testing local builds).
    
I also spruced up some of the documentation