### PR TITLE
[v2] Fix [gatsby-plugin-styled-jsx] when not specifying plugins

### DIFF
--- a/examples/using-styled-jsx/package.json
+++ b/examples/using-styled-jsx/package.json
@@ -5,10 +5,10 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "gatsby": "next",
-    "gatsby-plugin-styled-jsx": "^2.0.0",
+    "gatsby-plugin-styled-jsx": "^3.0.1-rc.3",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "styled-jsx": "^2.2.5"
+    "styled-jsx": "^3.0.2"
   },
   "license": "MIT",
   "main": "n/a",

--- a/packages/gatsby-plugin-styled-jsx/README.md
+++ b/packages/gatsby-plugin-styled-jsx/README.md
@@ -26,3 +26,18 @@ plugins: [
   },
 ]
 ```
+
+[Configuration options for `styled-jsx`](https://github.com/zeit/styled-jsx#configuration-options) can also be specified:
+
+```js
+plugins: [
+  {
+    resolve: `gatsby-plugin-styled-jsx`,
+    options: {
+      optimizeForSpeed: true,
+      sourceMaps: false,
+      vendorPrefixes: true,
+    },
+  },
+]
+```

--- a/packages/gatsby-plugin-styled-jsx/package.json
+++ b/packages/gatsby-plugin-styled-jsx/package.json
@@ -24,7 +24,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": ">2.0.0-alpha",
-    "styled-jsx": "^2.2.1"
+    "styled-jsx": "^3.0.2"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx",
   "scripts": {

--- a/packages/gatsby-plugin-styled-jsx/src/gatsby-node.js
+++ b/packages/gatsby-plugin-styled-jsx/src/gatsby-node.js
@@ -1,9 +1,18 @@
-// Add babel plugin
-exports.onCreateBabelConfig = ({ actions }, { jsxPlugins }) => {
+exports.onCreateBabelConfig = ({ actions }, pluginOptions) => {
+  const {
+    jsxPlugins: plugins,
+    optimizeForSpeed,
+    sourceMaps,
+    vendorPrefixes,
+  } = pluginOptions
+
   actions.setBabelPlugin({
     name: `styled-jsx/babel`,
     options: {
-      plugins: jsxPlugins || [],
+      optimizeForSpeed,
+      sourceMaps,
+      vendorPrefixes,
+      ...(plugins ? { plugins } : {}),
     },
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,7 +2543,7 @@ babel-plugin-syntax-function-bind@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz#48c495f177bdf31a981e732f55adc0bdd2601f46"
 
-babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+babel-plugin-syntax-jsx@6.18.0, babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
@@ -3083,7 +3083,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@6.26.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -4612,7 +4612,7 @@ convert-hrtime@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-hrtime/-/convert-hrtime-2.0.0.tgz#19bfb2c9162f9e11c2f04c2c79de2b7e8095c627"
 
-convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.3.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+convert-source-map@1.5.1, convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.3.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -9943,6 +9943,14 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
+loader-utils@1.1.0, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
 loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
@@ -9951,14 +9959,6 @@ loader-utils@^0.2.16:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
-
-loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -14481,6 +14481,10 @@ source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, sourc
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+source-map@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -14783,7 +14787,7 @@ strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
-string-hash@^1.1.1:
+string-hash@1.1.3, string-hash@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
 
@@ -14959,6 +14963,19 @@ style-loader@^0.21.0:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
+styled-jsx@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.0.2.tgz#8fd439a96602e890700092aec1af0b24123cd878"
+  dependencies:
+    babel-plugin-syntax-jsx "6.18.0"
+    babel-types "6.26.0"
+    convert-source-map "1.5.1"
+    loader-utils "1.1.0"
+    source-map "0.7.3"
+    string-hash "1.1.3"
+    stylis "3.5.3"
+    stylis-rule-sheet "0.0.10"
+
 stylehacks@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.0.tgz#64b323951c4a24e5fc7b2ec06c137bf32d155e8a"
@@ -14994,6 +15011,14 @@ styletron-standard@^1.0.6:
   resolved "https://registry.yarnpkg.com/styletron-standard/-/styletron-standard-1.0.6.tgz#f38a21d888ccee143a7c263e86d525f1eef2df7d"
   dependencies:
     inline-style-prefixer "^4.0.0"
+
+stylis-rule-sheet@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
 
 stylus-loader@^3.0.1:
   version "3.0.2"


### PR DESCRIPTION
Previously, the build would fail when using `gatsby-plugin-styled-jsx` without specifying any plugins - seemingly due to an unreported bug with the upstream `styled-jsx` module. This works around that bug by only setting the `plugins` option *at all* if it's not empty, rather than setting it to an empty array.

Other changes:

- Update dependencies in the example
- Update the peer dependency for `styled-jsx` in `gatsby-plugin-styled-jsx` from v2 to v3
- Allow specifying standard options for `styled-jsx`, and briefly document these