### PR TITLE
feat: add a copy-all script to gatsby-dev-cli

### DIFF
--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -57,3 +57,7 @@ https://github.com/gatsbyjs/gatsby/blob/master/scripts/publish-site.sh.
 
 Don't output anything except for a quit message when used together with
 `--scan-once`.
+
+#### `--copy-all`
+
+Copy all modules/files in the gatsby source repo in packages/

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -70,8 +70,8 @@ if (argv.copyAll) {
   packages = fs.readdirSync(path.join(gatsbyLocation, `packages`))
 } else {
   const { dependencies } = JSON.parse(fs.readFileSync(path.join(gatsbyLocation, `packages/gatsby/package.json`)))
-  const extraGatsbyPackages = Object.keys(dependencies).filter(d => d.startsWith(`gatsby`) && d !== `gatsby-plugin-page-creator`)
-  packages = packages.filter(p => p.startsWith(`gatsby`)).concat(extraGatsbyPackages)
+  const extraGatsbyPackages = Object.keys(dependencies).filter(d => d !== `gatsby-plugin-page-creator`)
+  packages = packages.concat(extraGatsbyPackages).filter(p => p.startsWith(`gatsby`))
 }
 
 if (!argv.packages && _.isEmpty(packages)) {

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -70,8 +70,7 @@ if (argv.copyAll) {
   packages = fs.readdirSync(path.join(gatsbyLocation, `packages`))
 } else {
   const { dependencies } = JSON.parse(fs.readFileSync(path.join(gatsbyLocation, `packages/gatsby/package.json`)))
-  const extraGatsbyPackages = Object.keys(dependencies).filter(d => d !== `gatsby-plugin-page-creator`)
-  packages = packages.concat(extraGatsbyPackages).filter(p => p.startsWith(`gatsby`))
+  packages = packages.concat(Object.keys(dependencies)).filter(p => p.startsWith(`gatsby`))
 }
 
 if (!argv.packages && _.isEmpty(packages)) {

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -40,11 +40,6 @@ if (!havePackageJsonFile) {
   process.exit()
 }
 
-const localPkg = JSON.parse(fs.readFileSync(`package.json`))
-let packages = Object.keys(
-  _.merge({}, localPkg.dependencies, localPkg.devDependencies)
-)
-
 const pathToRepo = argv.setPathToRepo
 if (pathToRepo) {
   console.log(`Saving path to your Gatsby repo`)
@@ -65,6 +60,11 @@ gatsby-dev --set-path-to-repo /path/to/my/cloned/version/gatsby
   )
   process.exit()
 }
+
+const localPkg = JSON.parse(fs.readFileSync(`package.json`))
+let packages = Object.keys(
+  _.merge({}, localPkg.dependencies, localPkg.devDependencies)
+)
 
 if (argv.copyAll) {
   packages = fs.readdirSync(path.join(gatsbyLocation, `packages`))

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -69,7 +69,9 @@ let packages = Object.keys(
 if (argv.copyAll) {
   packages = fs.readdirSync(path.join(gatsbyLocation, `packages`))
 } else {
-  packages = packages.filter(p => p.startsWith(`gatsby`))
+  const { dependencies } = JSON.parse(fs.readFileSync(path.join(gatsbyLocation, `packages/gatsby/package.json`)))
+  const extraGatsbyPackages = Object.keys(dependencies).filter(d => d.startsWith(`gatsby`) && d !== `gatsby-plugin-page-creator`)
+  packages = packages.filter(p => p.startsWith(`gatsby`)).concat(extraGatsbyPackages)
 }
 
 if (!argv.packages && _.isEmpty(packages)) {

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -67,9 +67,9 @@ gatsby-dev --set-path-to-repo /path/to/my/cloned/version/gatsby
 }
 
 if (argv.copyAll) {
-  packages = fs.readdirSync(path.join(gatsbyLocation, 'packages'));
+  packages = fs.readdirSync(path.join(gatsbyLocation, `packages`))
 } else {
-  packages = packages.filter(p => p.startsWith(`gatsby`));
+  packages = packages.filter(p => p.startsWith(`gatsby`))
 }
 
 if (!argv.packages && _.isEmpty(packages)) {

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -31,6 +31,7 @@ function watch(root, packages, { scanOnce, quiet }) {
     const ignoreRegs = [
       /[/\\]node_modules[/\\]/i,
       /\.git/i,
+      /\.DS_Store/,
       new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`),
     ]
 


### PR DESCRIPTION
This adds a copy-all option to gatsby-dev-cli to copy over _all_ packages in source gatsby project packages/ folder, rather than just the ones that begin with gatsby- and that are _in_ the current project.

Note: there is probably a way to be smarter about this. Grab all packages, but then diff with any that have "local" changes? i.e. that way we're not testing _everything_ but just the contents of the PR. That could be less prone to breaking and perhaps better over all, but wanted to add this option anyways since it could be valuable.

Also see #7936 for the conversation as to why this is needed.