### PR TITLE
[www] Pin gatsby-remark-prismjs@3.0.0-beta.6

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -34,7 +34,7 @@
     "gatsby-remark-copy-linked-files": "next",
     "gatsby-remark-graphviz": "next",
     "gatsby-remark-images": "next",
-    "gatsby-remark-prismjs": "next",
+    "gatsby-remark-prismjs": "3.0.0-beta.6",
     "gatsby-remark-responsive-iframe": "next",
     "gatsby-remark-smartypants": "next",
     "gatsby-source-filesystem": "^2.0.1-rc.1",


### PR DESCRIPTION
We currently have major issues with line highlights in `JSX` code blocks, see #8058.

I poked around a bit and (to my own surprise 🎉😅) managed to find out that those problems were introduced with #7342 and `gatsby-remark-prismjs@3.0.0-beta.7`.

This PR pins `www` to use `gatsby-remark-prismjs@3.0.0-beta.6` which restores the expected line highlight behavior—e.g. for https://next.gatsbyjs.org/tutorial/part-three/:

![image](https://user-images.githubusercontent.com/21834/45396871-d6ee4580-b63d-11e8-8f4c-e23b2d670c4d.png)

![image](https://user-images.githubusercontent.com/21834/45396931-0f8e1f00-b63e-11e8-8c06-0c622def0738.png)

While this PR makes `www` loose the good things of `beta.7` (which indeed does resolve issues with false highlighting of keywords in JSX plaintext—see https://github.com/gatsbyjs/gatsby/pull/7342#issuecomment-420477709 for a tiny bit of context that I can provide) in favor of fixing line highlighting, which is rather crucial to have a good experience following the tutorial and other code examples.