### PR TITLE
Added handling of  property.

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -104,6 +104,7 @@ class GatsbyLink extends React.Component {
       ref: $ref,
       innerRef: $innerRef,
       state,
+      replace,
       /* eslint-enable no-unused-vars */
       ...rest
     } = this.props
@@ -153,7 +154,7 @@ class GatsbyLink extends React.Component {
 
             // Make sure the necessary scripts and data are
             // loaded before continuing.
-            navigate(prefixedTo, { state })
+            navigate(prefixedTo, { state, replace })
           }
 
           return true
@@ -169,6 +170,7 @@ GatsbyLink.propTypes = {
   innerRef: PropTypes.func,
   onClick: PropTypes.func,
   to: PropTypes.string.isRequired,
+  replace: PropTypes.bool,
 }
 
 // eslint-disable-next-line react/display-name


### PR DESCRIPTION
Reach Router has it.
React Router has it.
Probably any other router out there has it too.

A need arose for me to have such functionality, was surprised it doesn't exist, so, I made one.
The need for me is opening/closing modals, not really looking for them to be stored in history.

I'm not sure if this won't have to be changed once https://github.com/reach/router/issues/119 lands, but in the same fashion as scroll behavior has been fixed for now, made the quick-fix here.