### PR TITLE
Update for gatsby-plugin-typescript README.md

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -15,7 +15,10 @@ Provides drop-in support for TypeScript and TSX.
 `gatsby-config.js`
 
 ```javascript
-plugins: [`gatsby-plugin-typescript`]
+module.exports = {
+  // ...,
+  plugins: [...`gatsby-plugin-typescript`],
+}
 ```
 
 ## Caveats


### PR DESCRIPTION
I was looking at another plugin's explanation on how to add the plugin, which handled it a bit better than this README - so I added some extra bits.