### PR TITLE
Added `state` alongside `pathname` to be passed to `shouldUpdateScroll`.

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -102,10 +102,11 @@ const navigate = (to, options = {}) => {
   })
 }
 
-function shouldUpdateScroll(prevRouterProps, { location: { pathname } }) {
+function shouldUpdateScroll(prevRouterProps, { location: { pathname, state } }) {
   const results = apiRunner(`shouldUpdateScroll`, {
     prevRouterProps,
     pathname,
+    state,
   })
   if (results.length > 0) {
     return results[0]

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -59,6 +59,7 @@ exports.onRouteUpdate = true
  * @param {object} $0
  * @param {object} $0.prevRouterProps The previous state of the router before the route change.
  * @param {object} $0.pathname The new pathname
+ * @param {object} $0.state The new location state
  */
 exports.shouldUpdateScroll = true
 


### PR DESCRIPTION
State seems like a perfect place to add custom values `shouldUpdateScroll` could feed upon.

Also found the necessity through building modals (follow up from https://github.com/gatsbyjs/gatsby/pull/8081). 

Gatsbygram has somewhat a global `shouldUpdateScroll` behavior for modals, but my project isn't all modals or not.

Actually, this all (this and previous PR) sparked up because I couldn't find a way in `shouldUpdateScroll` to check if I am opening a modal. Nor if I am closing it. 
That's why I sought for `replace` - the previous PR, because `replace` breaks out of scroll position handling, but replace wasn't triggerable through link...

In the middle of all this, I found about Link `state` and immediately thought that I can replace my current hacky `shouldUpdateScroll` behavior used for modals to a proper one... just to find out that I can get only the previous state, not current one.

Therefore, I have added `state` to `shouldUpdateScroll`. 

I was in a dilemma as to why only the `pathname` is getting passed, which I settled by sticking to your way of things - adding `state` alongside of `pathname`. 
As I thought to myself, that there is some kind of a reason for such specific whitelisting.

The other side of dilemma was to pass full `location` object to `shouldUpdateScroll`.