### PR TITLE
Added WPCOM authentication header to first request

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -73,7 +73,7 @@ Mama Route URL: ${url}
     
     if (_hostingWPCOM && _accessToken) {
       options.headers = {
-        Authorization: `Bearer ${_accessToken}`
+        Authorization: `Bearer ${_accessToken}`,
       }
     }
     

--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -64,12 +64,19 @@ Mama Route URL: ${url}
       method: `get`,
       url: url,
     }
-    if (_auth) {
+    if (_auth && (_auth.htaccess_user || _auth.htaccess_pass)) {
       options.auth = {
         username: _auth.htaccess_user,
         password: _auth.htaccess_pass,
       }
     }
+    
+    if (_hostingWPCOM && _accessToken) {
+      options.headers = {
+        Authorization: `Bearer ${_accessToken}`
+      }
+    }
+    
     allRoutes = await axios(options)
   } catch (e) {
     httpExceptionHandler(e)


### PR DESCRIPTION
When hosted on a WPCOM private blog, the first request fetching the valid routes from the API must be authenticated. I fixed this by attaching the Authorization header along with the Bearer auth token we got.

Also, having an auth set when doing this request did not work. Removing the options.auth when unnecessary (i.e. when no credentials are actually passed) worked.