### PR TITLE
Site Showcase - new featured sites and edited tags

### DIFF
--- a/docs/docs/site-showcase-submissions.md
+++ b/docs/docs/site-showcase-submissions.md
@@ -58,8 +58,6 @@ Categories currently include both _type of site_ (structure) and the _content of
 - eCommerce
 - Education
 - Gallery
-- Landing
-- Marketing
 - Portfolio
 - (feel free to create new ones after checking to make sure the tag you want doesn't already exist)
 
@@ -68,13 +66,12 @@ Categories currently include both _type of site_ (structure) and the _content of
 A few notes on site content: a common question is this: "aren't all Gatsby sites technically in the "web dev" category?" Well, no because this category means the _content_ of the site has to be about web development, like [ReactJS](https://reactjs.org/). Also, the difference between technology and web dev is like this. [Cardiogram](https://cardiogr.am/) is technology, while [ReactJS](https://reactjs.org/) is web dev.
 
 - Agency
-- Corporate
 - Cinema
-- Creative
 - Education
 - Entertainment
 - Finance
 - Food
+- Health & Wellness
 - Healthcare
 - Hosting
 - Gallery
@@ -86,11 +83,9 @@ A few notes on site content: a common question is this: "aren't all Gatsby sites
 - News
 - Nonprofit
 - Open Source
-- Personal
 - Photography
 - Podcast
 - Real Estate
-- Retail
 - Science
 - Technology
 - Web Dev

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -14,7 +14,6 @@
     shopping experience.
   categories:
     - eCommerce
-    - Clothing
     - Fashion
     - Featured
   featured: true
@@ -769,7 +768,6 @@
   url: "https://meetfabric.com/"
   featured: false
   categories:
-    - Corporate
     - Marketing
     - Insurance
 - title: Nexit
@@ -882,7 +880,6 @@
   url: "https://simply.co.za/"
   featured: false
   categories:
-    - Corporate
     - Marketing
     - Insurance
 - title: Storybook
@@ -1464,7 +1461,6 @@
   categories:
     - Blog
     - Education
-    - Careers
     - Personal Development
   built_by: "Stephanie Langers (content), Adrian Wenke (development)"
   built_by_url: "https://twitter.com/AdrianWenke"
@@ -1479,7 +1475,6 @@
   categories:
     - Technology
     - Finance
-    - Corporate
     - Marketing
   built_by: Bejamas.io
   built_by_url: "https://bejamas.io/"
@@ -1863,7 +1858,6 @@
   url: "https://www.unow.fr/"
   categories:
     - Education
-    - Corporate
     - Marketing
   featured: false
 - title: Peter Hironaka
@@ -1889,11 +1883,11 @@
   featured: false
 - title: Haacht Brewery
   description: |
-    Corporate wesbite for Haacht Brewery. Designed and Developed by Gafas.
+    Corporate website for Haacht Brewery. Designed and Developed by Gafas.
   main_url: "https://haacht.com/en/"
   url: "https://haacht.com"
   categories:
-    - Corporate
+    - Brewery
   built_by: Gafas
   built_by_url: "https://gafas.be"
   featured: false
@@ -2380,7 +2374,6 @@
     - Technology
     - Tool
     - Software
-    - Corporate
     - Help
     - Services
     - Travel

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -169,7 +169,6 @@
     Fully automatic time tracking. For those who trade in time.
   categories:
     - Time Tracking
-    - Tool
     - Featured
   built_by: Timm Stokke
   built_by_url: "https://timm.stokke.me"
@@ -182,7 +181,6 @@
     platforms.
   categories:
     - Technology
-    - Tool
     - Documentation
     - Featured
   featured: true
@@ -195,7 +193,6 @@
   categories:
     - API
     - Technology
-    - Tool
     - Documentation
     - Featured
   featured: true
@@ -1195,7 +1192,6 @@
     - Documentation
     - Bot
     - Community
-    - Tool
   built_by: Sankarsan Kampa
   built_by_url: "https://sankarsankampa.com"
 - title: upGizmo
@@ -1769,7 +1765,6 @@
   url: "http://html2canvas.hertzen.com/"
   source_url: "https://github.com/niklasvh/html2canvas/tree/master/www"
   categories:
-    - Tool
     - JavaScript
     - Documentation
   built_by: Niklas von Hertzen
@@ -1783,7 +1778,6 @@
   categories:
     - CMS
     - API
-    - Tool
   featured: false
 - title: Half Electronics
   description: |
@@ -2211,7 +2205,6 @@
     the blockchain.
   categories:
     - Technology
-    - Tool
     - Bank
   built_by: Axel Fuhrmann
   built_by_url: "https://axelfuhrmann.com/"
@@ -2223,7 +2216,6 @@
     Explorer React Native packages and examples effortlessly.
   categories:
     - React Native
-    - Tool
   featured: false
 - title: 500Tech
   main_url: "https://500tech.com/"
@@ -2299,7 +2291,6 @@
   categories:
     - API
     - Technology
-    - Tool
     - Travel
     - Bot
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2278,8 +2278,7 @@
     - JavaScript
     - Grid
     - Productivity
-    - UI
-    - UX
+    - User Experience
   built_by: Dave Geddes
   built_by_url: https://twitter.com/geddski
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2327,7 +2327,6 @@
     - CSS
     - JavaScript
     - Grid
-    - Flexbox
     - PWA
     - Productivity
     - UI

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1597,7 +1597,6 @@
   source_url: "https://github.com/janosh/ocean-artup"
   categories:
     - Science
-    - Research
     - Education
     - Blog
   built_by: Janosh Riebesell
@@ -1653,7 +1652,6 @@
   main_url: "https://beta.bom.gov.au/"
   categories:
     - Meteorology
-    - Research
     - Services
   featured: false
 - title: Curbside
@@ -1755,7 +1753,6 @@
   main_url: "http://oira.ua.edu/"
   url: "http://oira.ua.edu/"
   categories:
-    - Research
     - Data
   featured: false
 - title: Trintellix
@@ -2196,7 +2193,6 @@
     make sense of the findings.
   categories:
     - User Experience
-    - Research
     - Design
   built_by: Just Ask Users
   built_by_url: "https://justaskusers.com/"

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1698,7 +1698,6 @@
   categories:
     - Scheduling
     - Documentation
-    - Messaging
     - Billing
     - Services
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -168,7 +168,7 @@
   description: |
     Fully automatic time tracking. For those who trade in time.
   categories:
-    - Time Tracking
+    - Productivity
     - Featured
   built_by: Timm Stokke
   built_by_url: "https://timm.stokke.me"

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -425,7 +425,7 @@
   source_url: "https://github.com/hiooyUI/hiooyui.github.io"
   featured: false
   categories:
-    - Retail
+    - eCommerce
 - title: Steve Meredith's Portfolio
   main_url: "http://www.stevemeredith.com/"
   url: "http://www.stevemeredith.com/"
@@ -1335,7 +1335,7 @@
   url: "https://www.prideofthemeadows.com/"
   featured: false
   categories:
-    - Retail
+    - eCommerce
     - Food
     - Blog
 - title: Michael Uloth
@@ -1702,7 +1702,6 @@
   url: "https://join.hubba.com/"
   categories:
     - eCommerce
-    - Retail
   featured: false
 - title: HyperPlay
   description: |

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1738,7 +1738,7 @@
   categories:
     - Loans
     - Credits
-    - Online Banking
+    - Bank
     - Nonprofit
   featured: false
 - title: Open FDA

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1775,7 +1775,6 @@
   url: "https://us.trintellix.com/"
   categories:
     - Health & Wellness
-    - Help
   featured: false
 - title: The Telegraph Premium
   description: |
@@ -2343,7 +2342,6 @@
     - API
     - Technology
     - Tool
-    - Help
     - Services
     - Travel
     - Bot

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1642,7 +1642,6 @@
   url: "https://partners.patreon.com/"
   main_url: "https://partners.patreon.com/"
   categories:
-    - Resources
     - Directory
   featured: false
 - title: Bureau Of Meteorology (beta)

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -172,7 +172,6 @@
   description: |
     Fully automatic time tracking. For those who trade in time.
   categories:
-    - Software
     - Time Tracking
     - Tool
     - Featured
@@ -188,7 +187,6 @@
   categories:
     - Technology
     - Tool
-    - Software
     - Documentation
     - Featured
   featured: true
@@ -202,7 +200,6 @@
     - API
     - Technology
     - Tool
-    - Software
     - Documentation
     - Featured
   featured: true
@@ -1209,7 +1206,6 @@
     - Bot
     - Community
     - Services
-    - Software
     - Tool
   built_by: Sankarsan Kampa
   built_by_url: "https://sankarsankampa.com"
@@ -1676,7 +1672,6 @@
   url: "https://curbside.com/"
   categories:
     - Mobile Commerce
-    - Software
   featured: false
 - title: Mux Video
   description: |
@@ -2193,7 +2188,6 @@
     Bootstrap, To get in touch with people looking for full stack developer.
   categories:
     - Portfolio
-    - Software
     - Web Dev
     - Personal
   built_by: Mahipat Jadav
@@ -2261,7 +2255,6 @@
     - Technology
     - Tool
     - Bank
-    - Software
   built_by: Axel Fuhrmann
   built_by_url: "https://axelfuhrmann.com/"
   featured: false
@@ -2272,7 +2265,6 @@
     Explorer React Native packages and examples effortlessly.
   categories:
     - React Native
-    - Software
     - Tool
   featured: false
 - title: 500Tech
@@ -2352,7 +2344,6 @@
     - API
     - Technology
     - Tool
-    - Software
     - Help
     - Services
     - Travel

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -26,7 +26,6 @@
   categories:
     - Blog
     - Gallery
-    - Projects
     - Featured
   featured: true
 - title: Braun

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1777,7 +1777,6 @@
   source_url: "https://github.com/niklasvh/html2canvas/tree/master/www"
   categories:
     - Tool
-    - Screenshots
     - JavaScript
     - Documentation
   built_by: Niklas von Hertzen

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1748,7 +1748,6 @@
   categories:
     - API
     - Data
-    - Reports
   featured: false
 - title: Office of Institutional Research and Assessment
   description: |

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -726,7 +726,6 @@
   gatsby_version: V1
   categories:
     - Blog
-    - Personal
   built_by: Jason Lengstorf
   built_by_url: "https://github.com/jlengstorf"
 - title: Mannequin.io
@@ -802,7 +801,6 @@
     broad and unique user needs.
   categories:
     - Portfolio
-    - Personal
 - title: Preston Richey Portfolio / Blog
   main_url: "https://prestonrichey.com/"
   url: "https://prestonrichey.com/"
@@ -1925,7 +1923,6 @@
   categories:
     - Blog
     - Portfolio
-    - Personal
     - Fashion
   featured: false
 - title: Lifestone Church
@@ -1945,7 +1942,6 @@
   categories:
     - Portfolio
     - Open Source
-    - Personal
     - Web Dev
   built_by: Artem Sapegin
   built_by_url: "https://github.com/sapegin"
@@ -2005,7 +2001,6 @@
     - Portfolio
     - Web Dev
     - Design
-    - Personal
   built_by: Max McKinney
   featured: false
 - title: Stickyard
@@ -2066,7 +2061,6 @@
   categories:
     - Blog
     - Web Dev
-    - Personal
   built_by: Matt Ferderer
   built_by_url: "https://twitter.com/mattferderer"
   featured: false
@@ -2172,7 +2166,6 @@
   categories:
     - Portfolio
     - Web Dev
-    - Personal
   built_by: Mahipat Jadav
   built_by_url: "https://mojaave.com/"
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -78,7 +78,6 @@
   main_url: "https://gm.capitalone.com/"
   url: "https://gm.capitalone.com/"
   categories:
-    - Rewards
     - Credit Card
     - Featured
   featured: true

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -228,7 +228,6 @@
   url: "https://slite.com/"
   featured: false
   categories:
-    - Landing
     - Marketing
     - Technology
 - title: GraphCMS
@@ -236,7 +235,6 @@
   url: "https://graphcms.com/"
   featured: false
   categories:
-    - Landing
     - Marketing
     - Technology
 - title: Bottender Docs
@@ -353,7 +351,6 @@
   url: "https://www.oncallogy.com/"
   featured: false
   categories:
-    - Landing
     - Marketing
     - Healthcare
 - title: Ryan Wiemer's Portfolio
@@ -601,7 +598,6 @@
   url: "https://doopoll.co/"
   featured: false
   categories:
-    - Landing
     - Marketing
     - Technology
 - title: ERC dEX
@@ -1579,7 +1575,6 @@
   main_url: "https://insomnia.rest/"
   url: "https://insomnia.rest/"
   categories:
-    - Landing
     - Blog
   built_by: Gregory Schier
   built_by_url: "https://schier.co"
@@ -1590,7 +1585,6 @@
   main_url: "http://www.amanhimself.me/"
   url: "http://www.amanhimself.me/"
   categories:
-    - Landing
     - Web Dev
     - Portfolio
   built_by: Aman Mittal
@@ -1723,7 +1717,8 @@
   main_url: "https://hyperplay.leagueoflegends.com/"
   url: "https://hyperplay.leagueoflegends.com/"
   categories:
-    - Landing
+    - Video Games
+    - Music
   featured: false
 - title: Bad Credit Loans
   description: |
@@ -1782,7 +1777,6 @@
   main_url: "https://premium.telegraph.co.uk/"
   url: "https://premium.telegraph.co.uk/"
   categories:
-    - Landing
     - Newspaper
     - Subscription
   featured: false
@@ -1911,7 +1905,6 @@
   main_url: "https://otsimo.com/en/"
   url: "https://otsimo.com/en/"
   categories:
-    - Landing
     - Blog
     - Education
   featured: false
@@ -1923,7 +1916,6 @@
   main_url: "https://mattbag.github.io"
   url: "https://mattbag.github.io"
   categories:
-    - Landing
     - Portfolio
   featured: false
 - title: Lisa Ye's Blog
@@ -1952,7 +1944,6 @@
   main_url: "https://sapegin.me/"
   url: "https://sapegin.me/"
   categories:
-    - Landing
     - Portfolio
     - Open Source
     - Personal
@@ -1986,7 +1977,6 @@
   main_url: "https://www.novatics.com.br"
   url: "https://www.novatics.com.br"
   categories:
-    - Landing
     - Portfolio
     - Technology
     - Web Dev
@@ -2016,7 +2006,6 @@
     - Portfolio
     - Web Dev
     - Design
-    - Landing
     - Personal
   built_by: Max McKinney
   featured: false
@@ -2036,7 +2025,6 @@
   main_url: "https://agatamilik.pl"
   url: "https://agatamilik.pl"
   categories:
-    - Landing
     - Marketing
     - Healthcare
   built_by: Piotr Fedorczyk
@@ -2066,7 +2054,6 @@
   categories:
     - Marketing
     - Technology
-    - Landing
   built_by: Papertrail.io
   built_by_url: "https://www.papertrail.io"
   featured: false
@@ -2129,7 +2116,6 @@
     designers, ux designers, ui designers.
   categories:
     - Blog
-    - Landing
   built_by: Linton Ye
   built_by_url: "https://twitter.com/lintonye"
 - title: Devol’s Dance
@@ -2140,7 +2126,6 @@
     robotics, AI, and automation.
   categories:
     - Marketing
-    - Landing
     - Technology
   built_by: Corey Ward
   built_by_url: "http://www.coreyward.me/"
@@ -2208,7 +2193,6 @@
   description: |
     Mini site for 2018 edition of Traffic Design’s Biennale
   categories:
-    - Landing
     - Nonprofit
     - Gallery
   built_by: Piotr Fedorczyk

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -133,7 +133,6 @@
     - Technology
     - Web Dev
     - Agency
-    - Creative
     - Marketing
     - Featured
   built_by: Bejamas
@@ -266,7 +265,6 @@
   featured: false
   categories:
     - Portfolio
-    - Creative
 - title: Hack Club
   main_url: "https://hackclub.com/"
   url: "https://hackclub.com/"
@@ -304,7 +302,6 @@
   featured: false
   categories:
     - Portfolio
-    - Creative
     - Web Dev
 - title: unrealcpp
   main_url: "https://unrealcpp.com/"
@@ -392,7 +389,7 @@
   source_url: "https://github.com/dvzrd/gatsby-sfiction"
   featured: false
   categories:
-    - Creative
+    - Fiction
 - title: Digital Psychology
   main_url: "http://digitalpsychology.io/"
   url: "http://digitalpsychology.io/"
@@ -575,7 +572,6 @@
     integrated design and marketing strategies to improve sales, increase brand
     engagement, generate leads and achieve goals.
   categories:
-    - Creative
     - Design
     - Featured
     - Marketing
@@ -668,7 +664,6 @@
   featured: false
   categories:
     - Agency
-    - Creative
 - title: heml.io
   main_url: "https://heml.io/"
   url: "https://heml.io/"
@@ -702,7 +697,6 @@
     project that you want to collaborate on. Or if you just want to say hello,
     that’s cool too.
   categories:
-    - Creative
     - Portfolio
   built_by: Kris Hedstrom
   built_by_url: "https://k-create.com/"
@@ -851,7 +845,6 @@
   featured: false
   categories:
     - Agency
-    - Creative
 - title: Sean Coker's Blog
   main_url: "https://sean.is/"
   url: "https://sean.is/"
@@ -898,7 +891,6 @@
   categories:
     - Portfolio
     - Web Dev
-    - Creative
 - title: VisitGemer
   main_url: "https://visitgemer.sk/"
   url: "https://visitgemer.sk/"
@@ -1013,7 +1005,6 @@
   source_url: "https://github.com/michelemazzucco/michelemazzucco.it"
   featured: false
   categories:
-    - Creative
     - Portfolio
 - title: Orbit FM Podcasts
   main_url: "https://www.orbit.fm/"
@@ -1151,7 +1142,6 @@
   featured: false
   categories:
     - Web Dev
-    - Creative
     - Agency
 - title: Marmelab
   main_url: "https://marmelab.com/en/"
@@ -1165,7 +1155,6 @@
   url: "http://thefmg.com/"
   featured: false
   categories:
-    - Creative
     - Entertainment
     - News
 - title: Cool Hunting
@@ -1239,7 +1228,6 @@
   categories:
     - Portfolio
     - Web Dev
-    - Creative
 - title: Philipp Czernitzki - Blog/Website
   main_url: "http://philippczernitzki.me/"
   url: "http://philippczernitzki.me/"
@@ -1383,7 +1371,6 @@
     - Marketing
     - Portfolio
     - Agency
-    - Creative
     - Featured
   built_by: Spacetime
   built_by_url: "https://www.heyspacetime.com/"
@@ -1499,7 +1486,6 @@
   categories:
     - Portfolio
     - Web Dev
-    - Creative
   built_by: Matthias Kretschmann
   built_by_url: "https://matthiaskretschmann.com/"
 - title: Iron Cove Solutions
@@ -1649,7 +1635,6 @@
   categories:
     - Agency
     - Blog
-    - Creative
     - Design
     - Web Dev
     - SEO
@@ -1848,7 +1833,6 @@
   featured: false
   description: "I DRINK COFFEE, WRITE CODE AND IMPROVE MY DEVELOPMENT SKILLS EVERY DAY."
   categories:
-    - Creative
     - Design
     - Web Dev
   built_by: Frithir
@@ -2153,7 +2137,6 @@
   categories:
     - Blog
     - Landing
-    - Creative
   built_by: Linton Ye
   built_by_url: "https://twitter.com/lintonye"
 - title: Devol’s Dance
@@ -2235,7 +2218,6 @@
     Mini site for 2018 edition of Traffic Design’s Biennale
   categories:
     - Landing
-    - Creative
     - Nonprofit
     - Gallery
   built_by: Piotr Fedorczyk
@@ -2342,7 +2324,6 @@
     - Web Dev
     - Design
     - Portfolio
-    - Creative
   built_by: Peter Kroyer
   built_by_url: https://www.peterkroyer.at/
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -89,7 +89,6 @@
   url: "https://housemanager.calstate.aaa.com/"
   categories:
     - Home
-    - Services
     - Featured
   featured: true
 - title: Life Without Barriers | Foster Care
@@ -1197,7 +1196,6 @@
     - Documentation
     - Bot
     - Community
-    - Services
     - Tool
   built_by: Sankarsan Kampa
   built_by_url: "https://sankarsankampa.com"
@@ -1650,7 +1648,6 @@
   main_url: "https://beta.bom.gov.au/"
   categories:
     - Meteorology
-    - Services
   featured: false
 - title: Curbside
   description: |
@@ -1680,7 +1677,6 @@
   categories:
     - Event
     - Community
-    - Services
   featured: false
 - title: Kalix
   description: >
@@ -1692,7 +1688,6 @@
     - Scheduling
     - Documentation
     - Billing
-    - Services
   featured: false
 - title: Hubba
   description: |
@@ -2307,7 +2302,6 @@
     - API
     - Technology
     - Tool
-    - Services
     - Travel
     - Bot
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2309,7 +2309,6 @@
     - CSS
     - JavaScript
     - Grid
-    - PWA
     - Productivity
     - UI
     - UX

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1,237 +1,425 @@
 - title: ReactJS
-  main_url: 'https://reactjs.org/'
-  url: 'https://reactjs.org/'
-  source_url: 'https://github.com/reactjs/reactjs.org'
+  main_url: "https://reactjs.org/"
+  url: "https://reactjs.org/"
+  source_url: "https://github.com/reactjs/reactjs.org"
   featured: true
   categories:
     - Web Dev
     - Featured
-- title: NEON
-  main_url: 'http://neonrated.com/'
-  url: 'http://neonrated.com/'
+- title: Stitch Fix
+  main_url: "https://www.stitchfix.com/"
+  url: "https://www.stitchfix.com/"
+  description: >
+    Stitch Fix is an online styling service that delivers a truly personalized
+    shopping experience.
+  categories:
+    - eCommerce
+    - Clothing
+    - Fashion
+    - Featured
   featured: true
+- title: Airbnb Engineering & Data Science
+  description: >
+    Creative engineers and data scientists building a world where you can belong
+    anywhere
+  main_url: "https://airbnb.io/"
+  url: "https://airbnb.io/"
+  categories:
+    - Blog
+    - Gallery
+    - Projects
+    - Featured
+  featured: true
+- title: Braun
+  description: >
+    Braun offers high performance hair removal and hair care products, including dryers, straighteners, shavers, and more.
+  main_url: "https://ca.braun.com/en-ca"
+  url: "https://ca.braun.com/en-ca"
+  categories:
+    - eCommerce
+    - Featured
+  featured: true
+- title: NYC Pride 2019 | WorldPride NYC | Stonewall50
+  main_url: "https://2019-worldpride-stonewall50.nycpride.org/"
+  url: "https://2019-worldpride-stonewall50.nycpride.org/"
+  featured: true
+  description: >-
+    Join us in 2019 for NYC Pride, as we welcome WorldPride and mark the 50th
+    Anniversary of the Stonewall Uprising and a half-century of LGBTQ+
+    liberation.
+  categories:
+    - Education
+    - Marketing
+    - Nonprofit
+    - Featured
+  built_by: Canvas United
+  built_by_url: "https://www.canvasunited.com/"
+- title: The State of European Tech
+  main_url: "https://2017.stateofeuropeantech.com/"
+  url: "https://2017.stateofeuropeantech.com/"
+  featured: true
+  categories:
+    - Technology
+    - Featured
+  plugins: "gatsby-plugin-react-helmet, gatsby-plugin-react-next"
+  built_by: Studio Lovelock
+  built_by_url: "http://www.studiolovelock.com/"
+- title: Cajun Bowfishing
+  main_url: "https://cajunbowfishing.com/"
+  url: "https://cajunbowfishing.com/"
+  featured: true
+  categories:
+    - eCommerce
+    - Sports
+    - Featured
+  built_by: Escalade Sports
+  built_by_url: "http://escaladesports.com/"
+- title: GM Capital One
+  description: |
+    Introducing the new online experience for your GM Rewards Credit Card
+  main_url: "https://gm.capitalone.com/"
+  url: "https://gm.capitalone.com/"
+  categories:
+    - Rewards
+    - Credit Card
+    - Featured
+  featured: true
+- title: House Manager
+  description: >
+    Home service membership that offers proactive and on-demand maintenance for
+    homeowners
+  main_url: "https://housemanager.calstate.aaa.com/"
+  url: "https://housemanager.calstate.aaa.com/"
+  categories:
+    - Home
+    - Services
+    - Featured
+  featured: true
+- title: Life Without Barriers | Foster Care
+  main_url: "https://www.lwb.org.au/foster-care"
+  url: "https://www.lwb.org.au/foster-care"
+  featured: true
+  description: >-
+    We are urgently seeking foster carers all across Australia. Can you open
+    your heart and your home to a child in need? There are different types of
+    foster care that can suit you. We offer training and 24/7 support.
+  categories:
+    - Charity
+    - Nonprofit
+    - Education
+    - Documentation
+    - Marketing
+    - Featured
+  built_by: LWB Digital Team
+  built_by_url: "https://twitter.com/LWBAustralia"
+- title: Figma
+  main_url: "https://www.figma.com/"
+  url: "https://www.figma.com/"
+  featured: true
+  categories:
+    - Marketing
+    - Design
+    - Featured
+  built_by: Corey Ward
+  built_by_url: "http://www.coreyward.me/"
+- title: Bejamas - JAM Experts for hire
+  main_url: "https://bejamas.io/"
+  url: "https://bejamas.io/"
+  featured: true
+  description: >-
+    We help agencies and companies with JAMStack tools. This includes web
+    development using Static Site Generators, Headless CMS, CI / CD and CDN
+    setup.
+  categories:
+    - Technology
+    - Web Dev
+    - Agency
+    - Creative
+    - Marketing
+    - Featured
+  built_by: Bejamas
+  built_by_url: "https://bejamas.io/"
+- title: The State of JavaScript
+  description: >
+    Data from over 20,000 developers, asking them questions on topics ranging
+    from front-end frameworks and state management, to build tools and testing
+    libraries.
+  main_url: "https://stateofjs.com/"
+  url: "https://stateofjs.com/"
+  source_url: "https://github.com/StateOfJS/StateOfJS"
+  categories:
+    - Data
+    - JavaScript
+    - Statistics
+    - Featurd
+  built_by: StateOfJS
+  built_by_url: "https://github.com/StateOfJS/StateOfJS/graphs/contributors"
+  featured: true
+- title: DesignSystems.com
+  main_url: "https://www.designsystems.com/"
+  url: "https://www.designsystems.com/"
+  description: |
+    A resource for learning, creating and evangelizing design systems.
+  categories:
+    - Design
+    - Blog
+    - Technology
+    - Featured
+  built_by: Corey Ward
+  built_by_url: "http://www.coreyward.me/"
+  featured: true
+- title: Timely
+  main_url: "https://timelyapp.com/"
+  url: "https://timelyapp.com/"
+  description: |
+    Fully automatic time tracking. For those who trade in time.
+  categories:
+    - Software
+    - Time Tracking
+    - Tool
+    - Featured
+  built_by: Timm Stokke
+  built_by_url: "https://timm.stokke.me"
+  featured: true
+- title: Snap Kit
+  main_url: "https://kit.snapchat.com/"
+  url: "https://kit.snapchat.com/"
+  description: >
+    Snap Kit lets developers integrate some of Snapchat’s best features across
+    platforms.
+  categories:
+    - Technology
+    - Tool
+    - Software
+    - Documentation
+    - Featured
+  featured: true
+- title: SendGrid
+  main_url: "https://sendgrid.com/docs/"
+  url: "https://sendgrid.com/docs/"
+  description: >
+    SendGrid delivers your transactional and marketing emails through the
+    world's largest cloud-based email delivery platform.
+  categories:
+    - API
+    - Technology
+    - Tool
+    - Software
+    - Documentation
+    - Featured
+  featured: true
+- title: KNW Photography
+  main_url: "https://www.knw.io/"
+  url: "https://www.knw.io/galleries/"
+  source_url: "https://github.com/ryanwiemer/knw"
+  featured: true
+  description: >-
+    Hi there! I’m Kirsten and I’m currently living in Oakland with my husband
+    and fluffy pup Birch. I’ve always been an excessive photo taker and decided
+    to turn my love for taking photos into a career.
+  categories:
+    - Photography
+    - Portfolio
+    - Featured
+- title: NEON
+  main_url: "http://neonrated.com/"
+  url: "http://neonrated.com/"
+  featured: false
   categories:
     - Gallery
     - Cinema
-    - Featured
-- title: The State of European Tech
-  main_url: 'https://2017.stateofeuropeantech.com/'
-  url: 'https://2017.stateofeuropeantech.com/'
-  featured: true
-  categories:
-    - Featured
-    - Technology
-  plugins: 'gatsby-plugin-react-helmet, gatsby-plugin-react-next'
-  built_by: Studio Lovelock
-  built_by_url: 'http://www.studiolovelock.com/'
 - title: Slite
-  main_url: 'https://slite.com/'
-  url: 'https://slite.com/'
-  featured: true
+  main_url: "https://slite.com/"
+  url: "https://slite.com/"
+  featured: false
   categories:
     - Landing
     - Marketing
     - Technology
-    - Featured
 - title: GraphCMS
-  main_url: 'https://graphcms.com/'
-  url: 'https://graphcms.com/'
-  featured: true
+  main_url: "https://graphcms.com/"
+  url: "https://graphcms.com/"
+  featured: false
   categories:
     - Landing
     - Marketing
     - Technology
 - title: Bottender Docs
-  main_url: 'https://bottender.js.org/'
-  url: 'https://bottender.js.org/'
-  source_url: 'https://github.com/bottenderjs/bottenderjs.github.io'
-  featured: true
+  main_url: "https://bottender.js.org/"
+  url: "https://bottender.js.org/"
+  source_url: "https://github.com/bottenderjs/bottenderjs.github.io"
+  featured: false
   categories:
     - Documentation
     - Web Dev
     - Open Source
-    - Featured
 - title: Cardiogram
-  main_url: 'https://cardiogr.am/'
-  url: 'https://cardiogr.am/'
-  featured: true
+  main_url: "https://cardiogr.am/"
+  url: "https://cardiogr.am/"
+  featured: false
   categories:
     - Marketing
     - Technology
-    - Featured
 - title: Etcetera Design
-  main_url: 'https://etcetera.design/'
-  url: 'https://etcetera.design/'
-  source_url: 'https://github.com/etceteradesign/website'
-  featured: true
+  main_url: "https://etcetera.design/"
+  url: "https://etcetera.design/"
+  source_url: "https://github.com/etceteradesign/website"
+  featured: false
   categories:
     - Portfolio
     - Creative
-    - Featured
 - title: Hack Club
-  main_url: 'https://hackclub.com/'
-  url: 'https://hackclub.com/'
-  source_url: 'https://github.com/hackclub/site'
-  featured: true
+  main_url: "https://hackclub.com/"
+  url: "https://hackclub.com/"
+  source_url: "https://github.com/hackclub/site"
+  featured: false
   categories:
     - Education
     - Web Dev
-    - Featured
 - title: Matthias Jordan Portfolio
-  main_url: 'https://iammatthias.com/'
-  url: 'https://iammatthias.com/'
-  source_url: 'https://github.com/iammatthias/net'
-  featured: true
+  main_url: "https://iammatthias.com/"
+  url: "https://iammatthias.com/"
+  source_url: "https://github.com/iammatthias/net"
+  featured: false
   categories:
     - Photography
     - Portfolio
-    - Featured
 - title: Investment Calculator
-  main_url: 'https://investmentcalculator.io/'
-  url: 'https://investmentcalculator.io/'
-  featured: true
+  main_url: "https://investmentcalculator.io/"
+  url: "https://investmentcalculator.io/"
+  featured: false
   categories:
     - Education
-    - Featured
     - Finance
 - title: CSS Grid Playground by MozillaDev
-  main_url: 'https://mozilladevelopers.github.io/playground/'
-  url: 'https://mozilladevelopers.github.io/playground/'
-  source_url: 'https://github.com/MozillaDevelopers/playground'
-  featured: true
+  main_url: "https://mozilladevelopers.github.io/playground/"
+  url: "https://mozilladevelopers.github.io/playground/"
+  source_url: "https://github.com/MozillaDevelopers/playground"
+  featured: false
   categories:
     - Education
     - Web Dev
-    - Featured
 - title: Piotr Fedorczyk Portfolio
-  main_url: 'https://piotrf.pl/'
-  url: 'https://piotrf.pl/'
-  featured: true
+  main_url: "https://piotrf.pl/"
+  url: "https://piotrf.pl/"
+  featured: false
   categories:
     - Portfolio
     - Creative
     - Web Dev
-    - Featured
 - title: unrealcpp
-  main_url: 'https://unrealcpp.com/'
-  url: 'https://unrealcpp.com/'
-  source_url: 'https://github.com/Harrison1/unrealcpp-com'
-  featured: true
+  main_url: "https://unrealcpp.com/"
+  url: "https://unrealcpp.com/"
+  source_url: "https://github.com/Harrison1/unrealcpp-com"
+  featured: false
   categories:
     - Blog
     - Web Dev
-    - Featured
 - title: Andy Slezak
-  main_url: 'https://www.aslezak.com/'
-  url: 'https://www.aslezak.com/'
-  source_url: 'https://github.com/amslezak'
-  featured: true
+  main_url: "https://www.aslezak.com/"
+  url: "https://www.aslezak.com/"
+  source_url: "https://github.com/amslezak"
+  featured: false
   categories:
     - Web Dev
     - Portfolio
-    - Featured
 - title: Deliveroo.Design
-  main_url: 'https://www.deliveroo.design/'
-  url: 'https://www.deliveroo.design/'
-  featured: true
+  main_url: "https://www.deliveroo.design/"
+  url: "https://www.deliveroo.design/"
+  featured: false
   categories:
     - Food
     - Marketing
-    - Featured
 - title: Dona Rita
-  main_url: 'https://www.donarita.co.uk/'
-  url: 'https://www.donarita.co.uk/'
-  source_url: 'https://github.com/peduarte/dona-rita-website'
-  featured: true
+  main_url: "https://www.donarita.co.uk/"
+  url: "https://www.donarita.co.uk/"
+  source_url: "https://github.com/peduarte/dona-rita-website"
+  featured: false
   categories:
     - Food
     - Marketing
-    - Featured
 - title: Fröhlich ∧ Frei
-  main_url: 'https://www.froehlichundfrei.de/'
-  url: 'https://www.froehlichundfrei.de/'
-  featured: true
+  main_url: "https://www.froehlichundfrei.de/"
+  url: "https://www.froehlichundfrei.de/"
+  featured: false
   categories:
     - Web Dev
     - Blog
     - Open Source
 - title: How to GraphQL
-  main_url: 'https://www.howtographql.com/'
-  url: 'https://www.howtographql.com/'
-  source_url: 'https://github.com/howtographql/howtographql'
-  featured: true
+  main_url: "https://www.howtographql.com/"
+  url: "https://www.howtographql.com/"
+  source_url: "https://github.com/howtographql/howtographql"
+  featured: false
   categories:
     - Documentation
     - Web Dev
     - Open Source
-    - Featured
 - title: OnCallogy
-  main_url: 'https://www.oncallogy.com/'
-  url: 'https://www.oncallogy.com/'
-  featured: true
+  main_url: "https://www.oncallogy.com/"
+  url: "https://www.oncallogy.com/"
+  featured: false
   categories:
     - Landing
     - Marketing
-    - Featured
     - Healthcare
 - title: Ryan Wiemer's Portfolio
-  main_url: 'https://www.ryanwiemer.com/'
-  url: 'https://www.ryanwiemer.com/knw-photography/'
-  source_url: 'https://github.com/ryanwiemer/rw'
-  featured: true
+  main_url: "https://www.ryanwiemer.com/"
+  url: "https://www.ryanwiemer.com/knw-photography/"
+  source_url: "https://github.com/ryanwiemer/rw"
+  featured: false
   categories:
     - Portfolio
     - Web Dev
-    - Featured
 - title: Ventura Digitalagentur Köln
-  main_url: 'https://www.ventura-digital.de/'
-  url: 'https://www.ventura-digital.de/'
-  featured: true
+  main_url: "https://www.ventura-digital.de/"
+  url: "https://www.ventura-digital.de/"
+  featured: false
   categories:
     - Agency
     - Marketing
     - Featured
 - title: Azer Koçulu
-  main_url: 'http://azer.bike/'
-  url: 'http://azer.bike/photography'
+  main_url: "http://azer.bike/"
+  url: "http://azer.bike/photography"
   featured: false
   categories:
     - Portfolio
     - Photography
     - Web Dev
 - title: Damir.io
-  main_url: 'http://damir.io/'
-  url: 'http://damir.io/'
-  source_url: 'https://github.com/dvzrd/gatsby-sfiction'
+  main_url: "http://damir.io/"
+  url: "http://damir.io/"
+  source_url: "https://github.com/dvzrd/gatsby-sfiction"
   featured: false
   categories:
     - Creative
 - title: Digital Psychology
-  main_url: 'http://digitalpsychology.io/'
-  url: 'http://digitalpsychology.io/'
-  source_url: 'https://github.com/danistefanovic/digitalpsychology.io'
+  main_url: "http://digitalpsychology.io/"
+  url: "http://digitalpsychology.io/"
+  source_url: "https://github.com/danistefanovic/digitalpsychology.io"
   featured: false
   categories:
     - Education
     - Library
 - title: GRANDstack
-  main_url: 'http://grandstack.io/'
-  url: 'http://grandstack.io/'
+  main_url: "http://grandstack.io/"
+  url: "http://grandstack.io/"
   featured: false
   categories:
     - Open Source
     - Web Dev
 - title: Théâtres Parisiens
-  main_url: 'http://theatres-parisiens.fr/'
-  url: 'http://theatres-parisiens.fr/'
-  source_url: 'https://github.com/phacks/theatres-parisiens'
+  main_url: "http://theatres-parisiens.fr/"
+  url: "http://theatres-parisiens.fr/"
+  source_url: "https://github.com/phacks/theatres-parisiens"
   featured: false
   categories:
     - Education
     - Entertainment
 - title: William Owen UK Portfolio / Blog
-  main_url: 'http://william-owen.co.uk/'
-  url: 'http://william-owen.co.uk/'
+  main_url: "http://william-owen.co.uk/"
+  url: "http://william-owen.co.uk/"
   featured: false
   description: >-
     Over 20 years experience delivering customer-facing websites, internet-based
@@ -241,30 +429,30 @@
     - Portfolio
     - Blog
   built_by: William Owen
-  built_by_url: 'https://twitter.com/twilowen'
+  built_by_url: "https://twitter.com/twilowen"
 - title: A4 纸网
-  main_url: 'http://www.a4z.cn/'
-  url: 'http://www.a4z.cn/price'
-  source_url: 'https://github.com/hiooyUI/hiooyui.github.io'
+  main_url: "http://www.a4z.cn/"
+  url: "http://www.a4z.cn/price"
+  source_url: "https://github.com/hiooyUI/hiooyui.github.io"
   featured: false
   categories:
     - Retail
 - title: Steve Meredith's Portfolio
-  main_url: 'http://www.stevemeredith.com/'
-  url: 'http://www.stevemeredith.com/'
+  main_url: "http://www.stevemeredith.com/"
+  url: "http://www.stevemeredith.com/"
   featured: false
   categories:
     - Portfolio
 - title: Sourcegraph
-  main_url: 'https://about.sourcegraph.com/'
-  url: 'https://about.sourcegraph.com/'
+  main_url: "https://about.sourcegraph.com/"
+  url: "https://about.sourcegraph.com/"
   featured: false
   categories:
     - Web Dev
 - title: API Platform
-  main_url: 'https://api-platform.com/'
-  url: 'https://api-platform.com/'
-  source_url: 'https://github.com/api-platform/website'
+  main_url: "https://api-platform.com/"
+  url: "https://api-platform.com/"
+  source_url: "https://github.com/api-platform/website"
   featured: false
   categories:
     - Documentation
@@ -272,8 +460,8 @@
     - Open Source
     - Library
 - title: Artivest
-  main_url: 'https://artivest.co/'
-  url: 'https://artivest.co/what-we-do/for-advisors-and-investors/'
+  main_url: "https://artivest.co/"
+  url: "https://artivest.co/what-we-do/for-advisors-and-investors/"
   featured: false
   categories:
     - Marketing
@@ -281,35 +469,35 @@
     - Documentation
     - Finance
 - title: The Audacious Project
-  main_url: 'https://audaciousproject.org/'
-  url: 'https://audaciousproject.org/'
+  main_url: "https://audaciousproject.org/"
+  url: "https://audaciousproject.org/"
   featured: false
   categories:
     - Nonprofit
 - title: Dustin Schau's Blog
-  main_url: 'https://blog.dustinschau.com/'
-  url: 'https://blog.dustinschau.com/'
-  source_url: 'https://github.com/dschau/blog'
+  main_url: "https://blog.dustinschau.com/"
+  url: "https://blog.dustinschau.com/"
+  source_url: "https://github.com/dschau/blog"
   featured: false
   categories:
     - Blog
     - Web Dev
 - title: FloydHub's Blog
-  main_url: 'https://blog.floydhub.com/'
-  url: 'https://blog.floydhub.com/'
+  main_url: "https://blog.floydhub.com/"
+  url: "https://blog.floydhub.com/"
   featured: false
   categories:
     - Technology
     - Blog
 - title: iContract Blog
-  main_url: 'https://blog.icontract.co.uk/'
-  url: 'http://blog.icontract.co.uk/'
+  main_url: "https://blog.icontract.co.uk/"
+  url: "http://blog.icontract.co.uk/"
   featured: false
   categories:
     - Blog
 - title: BRIIM
-  main_url: 'https://bri.im/'
-  url: 'https://bri.im/'
+  main_url: "https://bri.im/"
+  url: "https://bri.im/"
   featured: false
   description: >-
     BRIIM is a movement to enable JavaScript enthusiasts and web developers in
@@ -321,9 +509,9 @@
     - Web Dev
     - Technology
 - title: Caddy Smells Like Trees
-  main_url: 'https://caddysmellsliketrees.ru/'
-  url: 'https://caddysmellsliketrees.ru/'
-  source_url: 'https://github.com/podabed/caddysmellsliketrees.github.io'
+  main_url: "https://caddysmellsliketrees.ru/"
+  url: "https://caddysmellsliketrees.ru/"
+  source_url: "https://github.com/podabed/caddysmellsliketrees.github.io"
   featured: false
   description: >-
     We play soul-searching songs for every day. They are merging in our forests
@@ -332,25 +520,25 @@
   categories:
     - Music
 - title: Calpa's Blog
-  main_url: 'https://calpa.me/'
-  url: 'https://calpa.me/'
-  source_url: 'https://github.com/calpa/blog'
+  main_url: "https://calpa.me/"
+  url: "https://calpa.me/"
+  source_url: "https://github.com/calpa/blog"
   featured: false
   categories:
     - Blog
     - Web Dev
 - title: Chocolate Free
-  main_url: 'https://chocolate-free.com/'
-  url: 'https://chocolate-free.com/'
-  source_url: 'https://github.com/Khaledgarbaya/chocolate-free-website'
+  main_url: "https://chocolate-free.com/"
+  url: "https://chocolate-free.com/"
+  source_url: "https://github.com/Khaledgarbaya/chocolate-free-website"
   featured: false
   description: "A full time foodie \U0001F60D a forever Parisian \"patisserie\" lover and \U0001F382 \U0001F369 \U0001F370 \U0001F36A explorer and finally an under construction #foodblogger #foodblog"
   categories:
     - Blog
     - Food
 - title: Code Bushi
-  main_url: 'https://codebushi.com/'
-  url: 'https://codebushi.com/'
+  main_url: "https://codebushi.com/"
+  url: "https://codebushi.com/"
   featured: false
   description: >-
     Web development resources, trends, & techniques to elevate your coding
@@ -360,28 +548,28 @@
     - Open Source
     - Blog
   built_by: Hunter Chang
-  built_by_url: 'https://hunterchang.com/'
+  built_by_url: "https://hunterchang.com/"
 - title: Daniel Hollcraft
-  main_url: 'https://danielhollcraft.com/'
-  url: 'https://danielhollcraft.com/'
-  source_url: 'https://github.com/danielbh/danielhollcraft.com'
+  main_url: "https://danielhollcraft.com/"
+  url: "https://danielhollcraft.com/"
+  source_url: "https://github.com/danielbh/danielhollcraft.com"
   featured: false
   categories:
     - Web Dev
     - Blog
     - Portfolio
 - title: Darren Britton's Portfolio
-  main_url: 'https://darrenbritton.com/'
-  url: 'https://darrenbritton.com/'
-  source_url: 'https://github.com/darrenbritton/darrenbritton.github.io'
+  main_url: "https://darrenbritton.com/"
+  url: "https://darrenbritton.com/"
+  source_url: "https://github.com/darrenbritton/darrenbritton.github.io"
   featured: false
   categories:
     - Web Dev
     - Portfolio
 - title: Dave Lindberg Marketing & Design
-  url: 'https://davelindberg.com/'
-  main_url: 'https://davelindberg.com/'
-  source_url: 'https://github.com/Dave-Lindberg/dl-gatsby'
+  url: "https://davelindberg.com/"
+  main_url: "https://davelindberg.com/"
+  source_url: "https://github.com/Dave-Lindberg/dl-gatsby"
   featured: false
   description: >-
     My work revolves around solving problems for people in business, using
@@ -395,45 +583,45 @@
     - SEO
     - Portfolio
 - title: Design Systems Weekly
-  main_url: 'https://designsystems.email/'
-  url: 'https://designsystems.email/'
+  main_url: "https://designsystems.email/"
+  url: "https://designsystems.email/"
   featured: false
   categories:
     - Education
     - Web Dev
 - title: Dalbinaco's Website
-  main_url: 'https://dlbn.co/en/'
-  url: 'https://dlbn.co/en/'
-  source_url: 'https://github.com/dalbinaco/dlbn.co'
+  main_url: "https://dlbn.co/en/"
+  url: "https://dlbn.co/en/"
+  source_url: "https://github.com/dalbinaco/dlbn.co"
   featured: false
   categories:
     - Portfolio
     - Web Dev
 - title: mParticle's Documentation
-  main_url: 'https://docs.mparticle.com/'
-  url: 'https://docs.mparticle.com/'
+  main_url: "https://docs.mparticle.com/"
+  url: "https://docs.mparticle.com/"
   featured: false
   categories:
     - Web Dev
     - Documentation
 - title: Doopoll
-  main_url: 'https://doopoll.co/'
-  url: 'https://doopoll.co/'
+  main_url: "https://doopoll.co/"
+  url: "https://doopoll.co/"
   featured: false
   categories:
     - Landing
     - Marketing
     - Technology
 - title: ERC dEX
-  main_url: 'https://ercdex.com/'
-  url: 'https://ercdex.com/aqueduct'
+  main_url: "https://ercdex.com/"
+  url: "https://ercdex.com/aqueduct"
   featured: false
   categories:
     - Marketing
 - title: Fabian Schultz' Portfolio
-  main_url: 'https://fabianschultz.com/'
-  url: 'https://fabianschultz.com/'
-  source_url: 'https://github.com/fabe/site'
+  main_url: "https://fabianschultz.com/"
+  url: "https://fabianschultz.com/"
+  source_url: "https://github.com/fabe/site"
   featured: false
   description: >-
     Hello, I’m Fabian — a product designer and developer based in Potsdam,
@@ -444,66 +632,65 @@
     - Portfolio
     - Web Dev
   built_by: Fabian Schultz
-  built_by_url: 'https://fabianschultz.com/'
+  built_by_url: "https://fabianschultz.com/"
 - title: Formidable
-  main_url: 'https://formidable.com/'
-  url: 'https://formidable.com/'
-  featured: true
+  main_url: "https://formidable.com/"
+  url: "https://formidable.com/"
+  featured: false
   categories:
     - Web Dev
     - Agency
     - Open Source
-    - Featured
 - title: Gatsby Manor
-  main_url: 'https://gatsbymanor.com/'
-  url: 'https://gatsbymanor.com/themes'
+  main_url: "https://gatsbymanor.com/"
+  url: "https://gatsbymanor.com/themes"
   featured: false
   categories:
     - Web Dev
 - title: The freeCodeCamp Guide
-  main_url: 'https://guide.freecodecamp.org/'
-  url: 'https://guide.freecodecamp.org/'
-  source_url: 'https://github.com/freeCodeCamp/guide'
+  main_url: "https://guide.freecodecamp.org/"
+  url: "https://guide.freecodecamp.org/"
+  source_url: "https://github.com/freeCodeCamp/guide"
   featured: false
   categories:
     - Web Dev
     - Documentation
 - title: High School Hackathons
-  main_url: 'https://hackathons.hackclub.com/'
-  url: 'https://hackathons.hackclub.com/'
-  source_url: 'https://github.com/hackclub/hackathons'
+  main_url: "https://hackathons.hackclub.com/"
+  url: "https://hackathons.hackclub.com/"
+  source_url: "https://github.com/hackclub/hackathons"
   featured: false
   categories:
     - Education
     - Web Dev
 - title: Hapticmedia
-  main_url: 'https://hapticmedia.fr/en/'
-  url: 'https://hapticmedia.fr/en/'
+  main_url: "https://hapticmedia.fr/en/"
+  url: "https://hapticmedia.fr/en/"
   featured: false
   categories:
     - Agency
     - Creative
 - title: heml.io
-  main_url: 'https://heml.io/'
-  url: 'https://heml.io/'
-  source_url: 'https://github.com/SparkPost/heml.io'
+  main_url: "https://heml.io/"
+  url: "https://heml.io/"
+  source_url: "https://github.com/SparkPost/heml.io"
   featured: false
   categories:
     - Documentation
     - Web Dev
     - Open Source
 - title: Juliette Pretot's Portfolio
-  main_url: 'https://juliette.sh/'
-  url: 'https://juliette.sh/'
+  main_url: "https://juliette.sh/"
+  url: "https://juliette.sh/"
   featured: false
   categories:
     - Web Dev
     - Portfolio
     - Blog
 - title: Kris Hedstrom's Portfolio
-  main_url: 'https://k-create.com/'
-  url: 'https://k-create.com/portfolio/'
-  source_url: 'https://github.com/kristofferh/kristoffer'
+  main_url: "https://k-create.com/"
+  url: "https://k-create.com/portfolio/"
+  source_url: "https://github.com/kristofferh/kristoffer"
   featured: false
   description: >-
     Hey. I’m Kris. I’m an interactive designer / developer. I grew up in Umeå,
@@ -519,35 +706,35 @@
     - Creative
     - Portfolio
   built_by: Kris Hedstrom
-  built_by_url: 'https://k-create.com/'
+  built_by_url: "https://k-create.com/"
 - title: knpw.rs
-  main_url: 'https://knpw.rs/'
-  url: 'https://knpw.rs/'
-  source_url: 'https://github.com/knpwrs/knpw.rs'
+  main_url: "https://knpw.rs/"
+  url: "https://knpw.rs/"
+  source_url: "https://github.com/knpwrs/knpw.rs"
   featured: false
   categories:
     - Blog
     - Web Dev
 - title: Kostas Bariotis' Blog
-  main_url: 'https://kostasbariotis.com/'
-  url: 'https://kostasbariotis.com/'
-  source_url: 'https://github.com/kbariotis/kostasbariotis.com'
+  main_url: "https://kostasbariotis.com/"
+  url: "https://kostasbariotis.com/"
+  source_url: "https://github.com/kbariotis/kostasbariotis.com"
   featured: false
   categories:
     - Blog
     - Portfolio
     - Web Dev
 - title: LaserTime Clinic
-  main_url: 'https://lasertime.ru/'
-  url: 'https://lasertime.ru/'
-  source_url: 'https://github.com/oleglegun/lasertime'
+  main_url: "https://lasertime.ru/"
+  url: "https://lasertime.ru/"
+  source_url: "https://github.com/oleglegun/lasertime"
   featured: false
   categories:
     - Marketing
 - title: Jason Lengstorf
-  main_url: 'https://lengstorf.com'
-  url: 'https://lengstorf.com'
-  source_url: 'https://github.com/jlengstorf/lengstorf.com'
+  main_url: "https://lengstorf.com"
+  url: "https://lengstorf.com"
+  source_url: "https://github.com/jlengstorf/lengstorf.com"
   featured: false
   date_added: Apr 10
   gatsby_version: V1
@@ -555,20 +742,20 @@
     - Blog
     - Personal
   built_by: Jason Lengstorf
-  built_by_url: 'https://github.com/jlengstorf'
+  built_by_url: "https://github.com/jlengstorf"
 - title: Mannequin.io
-  main_url: 'https://mannequin.io/'
-  url: 'https://mannequin.io/'
-  source_url: 'https://github.com/LastCallMedia/Mannequin/tree/master/site'
+  main_url: "https://mannequin.io/"
+  url: "https://mannequin.io/"
+  source_url: "https://github.com/LastCallMedia/Mannequin/tree/master/site"
   featured: false
   categories:
     - Open Source
     - Web Dev
     - Documentation
 - title: manu.ninja
-  main_url: 'https://manu.ninja/'
-  url: 'https://manu.ninja/'
-  source_url: 'https://github.com/Lorti/manu.ninja'
+  main_url: "https://manu.ninja/"
+  url: "https://manu.ninja/"
+  source_url: "https://github.com/Lorti/manu.ninja"
   featured: false
   description: >-
     manu.ninja is the personal blog of Manuel Wieser, where he talks about
@@ -578,41 +765,40 @@
     - Technology
     - Web Dev
 - title: Fabric
-  main_url: 'https://meetfabric.com/'
-  url: 'https://meetfabric.com/'
-  featured: true
+  main_url: "https://meetfabric.com/"
+  url: "https://meetfabric.com/"
+  featured: false
   categories:
     - Corporate
     - Marketing
-    - Featured
     - Insurance
 - title: Nexit
-  main_url: 'https://nexit.sk/'
-  url: 'https://nexit.sk/references'
+  main_url: "https://nexit.sk/"
+  url: "https://nexit.sk/references"
   featured: false
   categories:
     - Web Dev
 - title: Nortcast
-  main_url: 'https://nortcast.com/'
-  url: 'https://nortcast.com/'
+  main_url: "https://nortcast.com/"
+  url: "https://nortcast.com/"
   featured: false
   categories:
     - Technology
     - Entertainment
     - Podcast
 - title: openFDA
-  main_url: 'https://open.fda.gov/'
-  url: 'https://open.fda.gov/'
-  source_url: 'https://github.com/FDA/open.fda.gov'
+  main_url: "https://open.fda.gov/"
+  url: "https://open.fda.gov/"
+  source_url: "https://github.com/FDA/open.fda.gov"
   featured: false
   categories:
     - Government
     - Open Source
     - Web Dev
 - title: NYC Planning Labs (New York City Department of City Planning)
-  main_url: 'https://planninglabs.nyc/'
-  url: 'https://planninglabs.nyc/about/'
-  source_url: 'https://github.com/NYCPlanning/'
+  main_url: "https://planninglabs.nyc/"
+  url: "https://planninglabs.nyc/about/"
+  source_url: "https://github.com/NYCPlanning/"
   featured: false
   description: >-
     We work with New York City's Urban Planners to deliver impactful, modern
@@ -621,9 +807,9 @@
     - Open Source
     - Government
 - title: Pravdomil
-  main_url: 'https://pravdomil.com/'
-  url: 'https://pravdomil.com/'
-  source_url: 'https://github.com/pravdomil/pravdomil.com'
+  main_url: "https://pravdomil.com/"
+  url: "https://pravdomil.com/"
+  source_url: "https://github.com/pravdomil/pravdomil.com"
   featured: false
   description: >-
     I’ve been working both as a product designer and frontend developer for over
@@ -633,26 +819,26 @@
     - Portfolio
     - Personal
 - title: Preston Richey Portfolio / Blog
-  main_url: 'https://prestonrichey.com/'
-  url: 'https://prestonrichey.com/'
-  source_url: 'https://github.com/prichey/prestonrichey.com'
+  main_url: "https://prestonrichey.com/"
+  url: "https://prestonrichey.com/"
+  source_url: "https://github.com/prichey/prestonrichey.com"
   featured: false
   categories:
     - Web Dev
     - Portfolio
     - Blog
 - title: Landing page of Put.io
-  main_url: 'https://put.io/'
-  url: 'https://put.io/'
+  main_url: "https://put.io/"
+  url: "https://put.io/"
   featured: false
   categories:
     - eCommerce
     - Technology
 - title: The Rick and Morty API
-  main_url: 'https://rickandmortyapi.com/'
-  url: 'https://rickandmortyapi.com/'
+  main_url: "https://rickandmortyapi.com/"
+  url: "https://rickandmortyapi.com/"
   built_by: Axel Fuhrmann
-  built_by_url: 'https://axelfuhrmann.com/'
+  built_by_url: "https://axelfuhrmann.com/"
   featured: false
   categories:
     - Web Dev
@@ -661,84 +847,84 @@
     - Open Source
     - API
 - title: Santa Compañía Creativa
-  main_url: 'https://santacc.es/'
-  url: 'https://santacc.es/'
-  source_url: 'https://github.com/DesarrolloWebSantaCC/santacc-web'
+  main_url: "https://santacc.es/"
+  url: "https://santacc.es/"
+  source_url: "https://github.com/DesarrolloWebSantaCC/santacc-web"
   featured: false
   categories:
     - Agency
     - Creative
 - title: Sean Coker's Blog
-  main_url: 'https://sean.is/'
-  url: 'https://sean.is/'
+  main_url: "https://sean.is/"
+  url: "https://sean.is/"
   featured: false
   categories:
     - Blog
     - Portfolio
     - Web Dev
 - title: Segment's Blog
-  main_url: 'https://segment.com/blog/'
-  url: 'https://segment.com/blog/'
+  main_url: "https://segment.com/blog/"
+  url: "https://segment.com/blog/"
   featured: false
   categories:
     - Web Dev
     - Blog
 - title: Several Levels
-  main_url: 'https://severallevels.io/'
-  url: 'https://severallevels.io/'
-  source_url: 'https://github.com/Harrison1/several-levels'
+  main_url: "https://severallevels.io/"
+  url: "https://severallevels.io/"
+  source_url: "https://github.com/Harrison1/several-levels"
   featured: false
   categories:
     - Agency
     - Web Dev
 - title: Simply
-  main_url: 'https://simply.co.za/'
-  url: 'https://simply.co.za/'
+  main_url: "https://simply.co.za/"
+  url: "https://simply.co.za/"
   featured: false
   categories:
     - Corporate
     - Marketing
     - Insurance
 - title: Storybook
-  main_url: 'https://storybook.js.org/'
-  url: 'https://storybook.js.org/'
-  source_url: 'https://github.com/storybooks/storybook'
+  main_url: "https://storybook.js.org/"
+  url: "https://storybook.js.org/"
+  source_url: "https://github.com/storybooks/storybook"
   featured: false
   categories:
     - Web Dev
     - Open Source
 - title: Vibert Thio's Portfolio
-  main_url: 'https://vibertthio.com/portfolio/'
-  url: 'https://vibertthio.com/portfolio/projects/'
-  source_url: 'https://github.com/vibertthio/portfolio'
+  main_url: "https://vibertthio.com/portfolio/"
+  url: "https://vibertthio.com/portfolio/projects/"
+  source_url: "https://github.com/vibertthio/portfolio"
   featured: false
   categories:
     - Portfolio
     - Web Dev
     - Creative
 - title: VisitGemer
-  main_url: 'https://visitgemer.sk/'
-  url: 'https://visitgemer.sk/'
+  main_url: "https://visitgemer.sk/"
+  url: "https://visitgemer.sk/"
   featured: false
   categories:
     - Marketing
 - title: Beach Hut Poole
-  main_url: 'https://www.beachhutpoole.co.uk/'
-  url: 'https://www.beachhutpoole.co.uk/'
+  main_url: "https://www.beachhutpoole.co.uk/"
+  url: "https://www.beachhutpoole.co.uk/"
   featured: false
   categories:
     - Travel
     - Marketing
 - title: Bricolage.io
-  main_url: 'https://www.bricolage.io/'
-  url: 'https://www.bricolage.io/'
-  source_url: 'https://github.com/KyleAMathews/blog'
+  main_url: "https://www.bricolage.io/"
+  url: "https://www.bricolage.io/"
+  source_url: "https://github.com/KyleAMathews/blog"
   featured: false
   categories:
     - Blog
 - title: Charles Pinnix Website
-  main_url: 'https://www.charlespinnix.com/'
-  url: 'https://www.charlespinnix.com/'
+  main_url: "https://www.charlespinnix.com/"
+  url: "https://www.charlespinnix.com/"
   featured: false
   description: >-
     I’m a senior front end engineer with 8 years of experience building websites
@@ -754,187 +940,174 @@
     - Portfolio
     - Web Dev
 - title: Charlie Harrington's Blog
-  main_url: 'https://www.charlieharrington.com/'
-  url: 'https://www.charlieharrington.com/'
-  source_url: 'https://github.com/whatrocks/blog'
+  main_url: "https://www.charlieharrington.com/"
+  url: "https://www.charlieharrington.com/"
+  source_url: "https://github.com/whatrocks/blog"
   featured: false
   categories:
     - Blog
     - Web Dev
     - Music
 - title: Developer Ecosystem
-  main_url: 'https://www.developerecosystem.com/'
-  url: 'https://www.developerecosystem.com/'
+  main_url: "https://www.developerecosystem.com/"
+  url: "https://www.developerecosystem.com/"
   featured: false
   categories:
     - Blog
     - Web Dev
 - title: Gabriel Adorf's Portfolio
-  main_url: 'https://www.gabrieladorf.com/'
-  url: 'https://www.gabrieladorf.com/'
-  source_url: 'https://github.com/gabdorf/gabriel-adorf-portfolio'
+  main_url: "https://www.gabrieladorf.com/"
+  url: "https://www.gabrieladorf.com/"
+  source_url: "https://github.com/gabdorf/gabriel-adorf-portfolio"
   featured: false
   categories:
     - Portfolio
     - Web Dev
 - title: greglobinski.com
-  main_url: 'https://www.greglobinski.com/'
-  url: 'https://www.greglobinski.com/'
-  source_url: 'https://github.com/greglobinski/www.greglobinski.com'
+  main_url: "https://www.greglobinski.com/"
+  url: "https://www.greglobinski.com/"
+  source_url: "https://github.com/greglobinski/www.greglobinski.com"
   featured: false
   categories:
     - Portfolio
     - Web Dev
 - title: I am Putra
-  main_url: 'https://www.iamputra.com/'
-  url: 'https://www.iamputra.com/'
+  main_url: "https://www.iamputra.com/"
+  url: "https://www.iamputra.com/"
   featured: false
   categories:
     - Portfolio
     - Web Dev
     - Blog
 - title: In Sowerby Bridge
-  main_url: 'https://www.insowerbybridge.co.uk/'
-  url: 'https://www.insowerbybridge.co.uk/'
+  main_url: "https://www.insowerbybridge.co.uk/"
+  url: "https://www.insowerbybridge.co.uk/"
   featured: false
   categories:
     - Marketing
     - Government
 - title: JavaScript Stuff
-  main_url: 'https://www.javascriptstuff.com/'
-  url: 'https://www.javascriptstuff.com/'
+  main_url: "https://www.javascriptstuff.com/"
+  url: "https://www.javascriptstuff.com/"
   featured: false
   categories:
     - Education
     - Web Dev
     - Library
-- title: KNW Photography
-  main_url: 'https://www.knw.io/'
-  url: 'https://www.knw.io/galleries/'
-  source_url: 'https://github.com/ryanwiemer/knw'
-  featured: false
-  description: >-
-    Hi there! I’m Kirsten and I’m currently living in Oakland with my husband
-    and fluffy pup Birch. I’ve always been an excessive photo taker and decided
-    to turn my love for taking photos into a career.
-  categories:
-    - Photography
-    - Portfolio
 - title: Ledgy
-  main_url: 'https://www.ledgy.com/'
-  url: 'https://github.com/morloy/ledgy.com'
+  main_url: "https://www.ledgy.com/"
+  url: "https://github.com/morloy/ledgy.com"
   featured: false
   categories:
     - Marketing
     - Finance
 - title: Alec Lomas's Portfolio / Blog
-  main_url: 'https://www.lowmess.com/'
-  url: 'https://www.lowmess.com/'
-  source_url: 'https://github.com/lowmess/lowmess'
+  main_url: "https://www.lowmess.com/"
+  url: "https://www.lowmess.com/"
+  source_url: "https://github.com/lowmess/lowmess"
   featured: false
   categories:
     - Web Dev
     - Blog
     - Portfolio
 - title: Michele Mazzucco's Portfolio
-  main_url: 'https://www.michelemazzucco.it/'
-  url: 'https://www.michelemazzucco.it/'
-  source_url: 'https://github.com/michelemazzucco/michelemazzucco.it'
+  main_url: "https://www.michelemazzucco.it/"
+  url: "https://www.michelemazzucco.it/"
+  source_url: "https://github.com/michelemazzucco/michelemazzucco.it"
   featured: false
   categories:
     - Creative
     - Portfolio
 - title: Orbit FM Podcasts
-  main_url: 'https://www.orbit.fm/'
-  url: 'https://www.orbit.fm/'
-  source_url: 'https://github.com/agarrharr/orbit.fm'
+  main_url: "https://www.orbit.fm/"
+  url: "https://www.orbit.fm/"
+  source_url: "https://github.com/agarrharr/orbit.fm"
   featured: false
   categories:
     - Podcast
 - title: Prosecco Springs
-  main_url: 'https://www.proseccosprings.com/'
-  url: 'https://www.proseccosprings.com/'
+  main_url: "https://www.proseccosprings.com/"
+  url: "https://www.proseccosprings.com/"
   featured: false
   categories:
     - Food
     - Blog
     - Marketing
 - title: Verious
-  main_url: 'https://www.verious.io/'
-  url: 'https://www.verious.io/'
-  source_url: 'https://github.com/cpinnix/verious'
+  main_url: "https://www.verious.io/"
+  url: "https://www.verious.io/"
+  source_url: "https://github.com/cpinnix/verious"
   featured: false
   categories:
     - Web Dev
 - title: Whittle School
-  main_url: 'https://www.whittleschool.org/en/'
-  url: 'https://www.whittleschool.org/en/'
+  main_url: "https://www.whittleschool.org/en/"
+  url: "https://www.whittleschool.org/en/"
   featured: false
   categories:
     - Education
 - title: Yisela
-  main_url: 'https://www.yisela.com/'
-  url: 'https://www.yisela.com/tetris-against-trauma-gaming-as-therapy/'
+  main_url: "https://www.yisela.com/"
+  url: "https://www.yisela.com/tetris-against-trauma-gaming-as-therapy/"
   featured: false
   categories:
     - Blog
 - title: YouFoundRon.com
-  main_url: 'https://www.youfoundron.com/'
-  url: 'https://www.youfoundron.com/'
-  source_url: 'https://github.com/rongierlach/yfr-dot-com'
+  main_url: "https://www.youfoundron.com/"
+  url: "https://www.youfoundron.com/"
+  source_url: "https://github.com/rongierlach/yfr-dot-com"
   featured: false
   categories:
     - Portfolio
     - Web Dev
     - Blog
 - title: yerevancoder
-  main_url: 'https://yerevancoder.com/'
-  url: 'https://forum.yerevancoder.com/categories'
-  source_url: 'https://github.com/yerevancoder/yerevancoder.github.io'
+  main_url: "https://yerevancoder.com/"
+  url: "https://forum.yerevancoder.com/categories"
+  source_url: "https://github.com/yerevancoder/yerevancoder.github.io"
   featured: false
   categories:
     - Blog
     - Web Dev
 - title: EaseCentral
-  main_url: 'https://www.easecentral.com/'
-  url: 'https://www.easecentral.com/'
+  main_url: "https://www.easecentral.com/"
+  url: "https://www.easecentral.com/"
   featured: false
   categories:
     - Marketing
     - Healthcare
 - title: Policygenius
-  main_url: 'https://www.policygenius.com/'
-  url: 'https://www.policygenius.com/'
+  main_url: "https://www.policygenius.com/"
+  url: "https://www.policygenius.com/"
   featured: false
   categories:
     - Marketing
     - Healthcare
 - title: Moteefe
-  main_url: 'http://www.moteefe.com/'
-  url: 'http://www.moteefe.com/'
+  main_url: "http://www.moteefe.com/"
+  url: "http://www.moteefe.com/"
   featured: false
   categories:
     - Marketing
     - Agency
     - Technology
 - title: Athelas
-  main_url: 'http://www.athelas.com/'
-  url: 'http://www.athelas.com/'
-  featured: true
+  main_url: "http://www.athelas.com/"
+  url: "http://www.athelas.com/"
+  featured: false
   categories:
     - Marketing
     - Healthcare
-    - Featured
 - title: Pathwright
-  main_url: 'http://www.pathwright.com/'
-  url: 'http://www.pathwright.com/'
+  main_url: "http://www.pathwright.com/"
+  url: "http://www.pathwright.com/"
   featured: false
   categories:
     - Marketing
     - Education
 - title: pi-top
-  main_url: 'http://www.pi-top.com/'
-  url: 'http://www.pi-top.com/'
+  main_url: "http://www.pi-top.com/"
+  url: "http://www.pi-top.com/"
   featured: false
   categories:
     - Marketing
@@ -942,88 +1115,86 @@
     - Technology
     - eCommerce
 - title: Troops
-  main_url: 'http://www.troops.ai/'
-  url: 'http://www.troops.ai/'
+  main_url: "http://www.troops.ai/"
+  url: "http://www.troops.ai/"
   featured: false
   categories:
     - Marketing
     - Technology
 - title: ClearBrain
-  main_url: 'https://clearbrain.com/'
-  url: 'https://clearbrain.com/'
+  main_url: "https://clearbrain.com/"
+  url: "https://clearbrain.com/"
   featured: false
   categories:
     - Marketing
     - Technology
 - title: Lucid
-  main_url: 'https://www.golucid.co/'
-  url: 'https://www.golucid.co/'
-  featured: true
+  main_url: "https://www.golucid.co/"
+  url: "https://www.golucid.co/"
+  featured: false
   categories:
     - Marketing
     - Technology
-    - Featured
 - title: Bench
-  main_url: 'http://www.bench.co/'
-  url: 'http://www.bench.co/'
+  main_url: "http://www.bench.co/"
+  url: "http://www.bench.co/"
   featured: false
   categories:
     - Marketing
 - title: Union Plus Credit Card
-  main_url: 'http://www.unionpluscard.com'
-  url: 'https://unionplus.capitalone.com/'
+  main_url: "http://www.unionpluscard.com"
+  url: "https://unionplus.capitalone.com/"
   featured: false
   categories:
     - Marketing
     - Finance
 - title: Gin Lane
-  main_url: 'http://www.ginlane.com/'
-  url: 'https://www.ginlane.com/'
+  main_url: "http://www.ginlane.com/"
+  url: "https://www.ginlane.com/"
   featured: false
   categories:
     - Web Dev
     - Creative
     - Agency
 - title: Marmelab
-  main_url: 'https://marmelab.com/en/'
-  url: 'https://marmelab.com/en/'
+  main_url: "https://marmelab.com/en/"
+  url: "https://marmelab.com/en/"
   featured: false
   categories:
     - Web Dev
     - Agency
 - title: Fusion Media Group
-  main_url: 'http://thefmg.com/'
-  url: 'http://thefmg.com/'
-  featured: true
+  main_url: "http://thefmg.com/"
+  url: "http://thefmg.com/"
+  featured: false
   categories:
     - Creative
     - Entertainment
     - News
-    - Featured
 - title: Cool Hunting
-  main_url: 'http://www.coolhunting.com/'
-  url: 'http://www.coolhunting.com/'
+  main_url: "http://www.coolhunting.com/"
+  url: "http://www.coolhunting.com/"
   featured: false
   categories:
     - Magazine
 - title: Dovetail
-  main_url: 'https://dovetailapp.com/'
-  url: 'https://dovetailapp.com/'
+  main_url: "https://dovetailapp.com/"
+  url: "https://dovetailapp.com/"
   featured: false
   categories:
     - Marketing
     - Technology
 - title: GraphQL College
-  main_url: 'https://www.graphql.college/'
-  url: 'https://www.graphql.college/'
-  source_url: 'https://github.com/GraphQLCollege/graphql-college'
+  main_url: "https://www.graphql.college/"
+  url: "https://www.graphql.college/"
+  source_url: "https://github.com/GraphQLCollege/graphql-college"
   featured: false
   categories:
     - Web Dev
     - Education
 - title: F1 Vision
-  main_url: 'https://www.f1vision.com/'
-  url: 'https://www.f1vision.com/'
+  main_url: "https://www.f1vision.com/"
+  url: "https://www.f1vision.com/"
   featured: false
   categories:
     - Marketing
@@ -1031,18 +1202,18 @@
     - Technology
     - eCommerce
 - title: Yuuniworks Portfolio / Blog
-  main_url: 'https://www.yuuniworks.com/'
-  url: 'https://www.yuuniworks.com/'
-  source_url: 'https://github.com/junkboy0315/yuuni-web'
+  main_url: "https://www.yuuniworks.com/"
+  url: "https://www.yuuniworks.com/"
+  source_url: "https://github.com/junkboy0315/yuuni-web"
   featured: false
   categories:
     - Portfolio
     - Web Dev
     - Blog
 - title: The Bastion Bot
-  main_url: 'https://bastionbot.org/'
-  url: 'https://bastionbot.org/'
-  source_url: 'https://github.com/TheBastionBot/Bastion-Website'
+  main_url: "https://bastionbot.org/"
+  url: "https://bastionbot.org/"
+  source_url: "https://github.com/TheBastionBot/Bastion-Website"
   description: Give awesome perks to your Discord server!
   featured: false
   categories:
@@ -1055,51 +1226,51 @@
     - Software
     - Tool
   built_by: Sankarsan Kampa
-  built_by_url: 'https://sankarsankampa.com'
+  built_by_url: "https://sankarsankampa.com"
 - title: upGizmo
-  main_url: 'https://www.upgizmo.com/'
-  url: 'https://www.upgizmo.com/'
+  main_url: "https://www.upgizmo.com/"
+  url: "https://www.upgizmo.com/"
   featured: false
   categories:
     - News
     - Technology
 - title: Smakosh
-  main_url: 'https://smakosh.com/'
-  url: 'https://smakosh.com/'
-  source_url: 'https://github.com/smakosh/smakosh.com'
+  main_url: "https://smakosh.com/"
+  url: "https://smakosh.com/"
+  source_url: "https://github.com/smakosh/smakosh.com"
   featured: false
   categories:
     - Portfolio
     - Web Dev
     - Creative
 - title: Philipp Czernitzki - Blog/Website
-  main_url: 'http://philippczernitzki.me/'
-  url: 'http://philippczernitzki.me/'
+  main_url: "http://philippczernitzki.me/"
+  url: "http://philippczernitzki.me/"
   featured: false
   categories:
     - Portfolio
     - Web Dev
     - Blog
 - title: WebGazer
-  main_url: 'https://www.webgazer.io/'
-  url: 'https://www.webgazer.io/'
+  main_url: "https://www.webgazer.io/"
+  url: "https://www.webgazer.io/"
   featured: false
   categories:
     - Marketing
     - Web Dev
     - Technology
 - title: Joe Seifi's Blog
-  main_url: 'http://seifi.org/'
-  url: 'http://seifi.org/'
+  main_url: "http://seifi.org/"
+  url: "http://seifi.org/"
   featured: false
   categories:
     - Portfolio
     - Web Dev
     - Blog
 - title: Bartosz Dominiak Blog/Portfolio
-  main_url: 'http://bartoszdominiak.com/'
-  url: 'http://bartoszdominiak.com/'
-  source_url: 'https://github.com/bartdominiak/blog'
+  main_url: "http://bartoszdominiak.com/"
+  url: "http://bartoszdominiak.com/"
+  source_url: "https://github.com/bartdominiak/blog"
   featured: false
   categories:
     - Portfolio
@@ -1146,12 +1317,12 @@
 - title: Steven Natera's blog
   featured: false
 - title: LekoArts
-  main_url: 'https://www.lekoarts.de'
-  url: 'https://www.lekoarts.de'
-  source_url: 'https://github.com/LeKoArts/portfolio'
+  main_url: "https://www.lekoarts.de"
+  url: "https://www.lekoarts.de"
+  source_url: "https://github.com/LeKoArts/portfolio"
   featured: false
   built_by: LekoArts
-  built_by_url: 'https://github.com/LeKoArts'
+  built_by_url: "https://github.com/LeKoArts"
   description: >-
     Hi, I'm Lennart — a self-taught and passionate graphic/web designer &
     frontend developer based in Darmstadt, Germany. I love it to realize complex
@@ -1166,36 +1337,36 @@
   featured: false
 - title: Hallingdata
   featured: false
-- title: '@swyx (source)'
+- title: "@swyx (source)"
   featured: false
 - title: 伊撒尔の窝
   featured: false
 - title: 杨二小的博客
-  main_url: 'https://blog.yangerxiao.com/'
-  url: 'https://blog.yangerxiao.com/'
-  source_url: 'https://github.com/zerosoul/blog.yangerxiao.com'
+  main_url: "https://blog.yangerxiao.com/"
+  url: "https://blog.yangerxiao.com/"
+  source_url: "https://github.com/zerosoul/blog.yangerxiao.com"
   featured: false
   categories:
     - Blog
     - Portfolio
 - title: mottox2 blog
-  main_url: 'https://mottox2.com'
-  url: 'https://mottox2.com'
+  main_url: "https://mottox2.com"
+  url: "https://mottox2.com"
   featured: false
   categories:
     - Blog
     - Portfolio
 - title: Pride of the Meadows
-  main_url: 'https://www.prideofthemeadows.com/'
-  url: 'https://www.prideofthemeadows.com/'
+  main_url: "https://www.prideofthemeadows.com/"
+  url: "https://www.prideofthemeadows.com/"
   featured: false
   categories:
     - Retail
     - Food
     - Blog
 - title: Michael Uloth
-  main_url: 'https://www.michaeluloth.com'
-  url: 'https://www.michaeluloth.com'
+  main_url: "https://www.michaeluloth.com"
+  url: "https://www.michaeluloth.com"
   featured: false
   description: Michael Uloth is an opera singer and web developer based in Toronto.
   categories:
@@ -1203,24 +1374,10 @@
     - Music
     - Web Dev
   built_by: Michael Uloth
-  built_by_url: 'https://www.michaeluloth.com'
-- title: NYC Pride 2019 | WorldPride NYC | Stonewall50
-  main_url: 'https://2019-worldpride-stonewall50.nycpride.org/'
-  url: 'https://2019-worldpride-stonewall50.nycpride.org/'
-  featured: false
-  description: >-
-    Join us in 2019 for NYC Pride, as we welcome WorldPride and mark the 50th
-    Anniversary of the Stonewall Uprising and a half-century of LGBTQ+
-    liberation.
-  categories:
-    - Education
-    - Marketing
-    - Nonprofit
-  built_by: Canvas United
-  built_by_url: 'https://www.canvasunited.com/'
+  built_by_url: "https://www.michaeluloth.com"
 - title: Spacetime
-  main_url: 'https://www.heyspacetime.com/'
-  url: 'https://www.heyspacetime.com/'
+  main_url: "https://www.heyspacetime.com/"
+  url: "https://www.heyspacetime.com/"
   featured: false
   description: >-
     Spacetime is a Dallas-based digital experience agency specializing in web,
@@ -1232,22 +1389,22 @@
     - Creative
     - Featured
   built_by: Spacetime
-  built_by_url: 'https://www.heyspacetime.com/'
+  built_by_url: "https://www.heyspacetime.com/"
 - title: Eric Jinks
-  main_url: 'https://ericjinks.com/'
-  url: 'https://ericjinks.com/'
+  main_url: "https://ericjinks.com/"
+  url: "https://ericjinks.com/"
   featured: false
-  description: 'Software engineer / web developer from the Gold Coast, Australia.'
+  description: "Software engineer / web developer from the Gold Coast, Australia."
   categories:
     - Portfolio
     - Blog
     - Web Dev
     - Technology
   built_by: Eric Jinks
-  built_by_url: 'https://ericjinks.com/'
+  built_by_url: "https://ericjinks.com/"
 - title: GaiAma - We are wildlife
-  main_url: 'https://www.gaiama.org/'
-  url: 'https://www.gaiama.org/'
+  main_url: "https://www.gaiama.org/"
+  url: "https://www.gaiama.org/"
   featured: false
   description: >-
     We founded the GaiAma conservation organization to protect wildlife in Perú
@@ -1257,12 +1414,12 @@
     - Nonprofit
     - Marketing
     - Blog
-  source_url: 'https://github.com/GaiAma/gaiama.org'
+  source_url: "https://github.com/GaiAma/gaiama.org"
   built_by: GaiAma
-  built_by_url: 'https://www.gaiama.org/'
+  built_by_url: "https://www.gaiama.org/"
 - title: Healthcare Logic
-  main_url: 'https://www.healthcarelogic.com/'
-  url: 'https://www.healthcarelogic.com/'
+  main_url: "https://www.healthcarelogic.com/"
+  url: "https://www.healthcarelogic.com/"
   featured: false
   description: >-
     Revolutionary technology that empowers clinical and managerial leaders to
@@ -1272,23 +1429,23 @@
     - Healthcare
     - Technology
   built_by: Thrive
-  built_by_url: 'https://thriveweb.com.au/'
+  built_by_url: "https://thriveweb.com.au/"
 - title: Localgov.fyi
-  main_url: 'https://localgov.fyi/'
-  url: 'https://localgov.fyi/'
+  main_url: "https://localgov.fyi/"
+  url: "https://localgov.fyi/"
   featured: false
   description: Finding local government services made easier.
   categories:
     - Directory
     - Government
     - Technology
-  source_url: 'https://github.com/WeOpenly/localgov.fyi'
+  source_url: "https://github.com/WeOpenly/localgov.fyi"
   built_by: Openly
-  built_by_url: 'https://weopenly.com/'
+  built_by_url: "https://weopenly.com/"
 - title: Kata.ai Documentation
-  main_url: 'https://docs.kata.ai/'
-  url: 'https://docs.kata.ai/'
-  source_url: 'https://github.com/kata-ai/kata-platform-docs'
+  main_url: "https://docs.kata.ai/"
+  url: "https://docs.kata.ai/"
+  source_url: "https://github.com/kata-ai/kata-platform-docs"
   featured: false
   description: >-
     Documentation website for the Kata Platform, an all-in-one platform for
@@ -1297,8 +1454,8 @@
     - Documentation
     - Technology
 - title: goalgetters
-  main_url: 'https://goalgetters.space/'
-  url: 'https://goalgetters.space/'
+  main_url: "https://goalgetters.space/"
+  url: "https://goalgetters.space/"
   featured: false
   description: >-
     goalgetters is a source of inspiration for people who want to change their
@@ -1309,43 +1466,11 @@
     - Education
     - Careers
     - Personal Development
-  built_by: 'Stephanie Langers (content), Adrian Wenke (development)'
-  built_by_url: 'https://twitter.com/AdrianWenke'
-- title: Life Without Barriers | Foster Care
-  main_url: 'https://www.lwb.org.au/foster-care'
-  url: 'https://www.lwb.org.au/foster-care'
-  featured: false
-  description: >-
-    We are urgently seeking foster carers all across Australia. Can you open
-    your heart and your home to a child in need? There are different types of
-    foster care that can suit you. We offer training and 24/7 support.
-  categories:
-    - Charity
-    - Nonprofit
-    - Education
-    - Documentation
-    - Marketing
-  built_by: LWB Digital Team
-  built_by_url: 'https://twitter.com/LWBAustralia'
-- title: Bejamas - JAM Experts for hire
-  main_url: 'https://bejamas.io/'
-  url: 'https://bejamas.io/'
-  featured: false
-  description: >-
-    We help agencies and companies with JAMStack tools. This includes web
-    development using Static Site Generators, Headless CMS, CI / CD and CDN
-    setup.
-  categories:
-    - Technology
-    - Web Dev
-    - Agency
-    - Creative
-    - Marketing
-  built_by: Bejamas
-  built_by_url: 'https://bejamas.io/'
+  built_by: "Stephanie Langers (content), Adrian Wenke (development)"
+  built_by_url: "https://twitter.com/AdrianWenke"
 - title: Zensum
-  main_url: 'https://zensum.se/'
-  url: 'https://zensum.se/'
+  main_url: "https://zensum.se/"
+  url: "https://zensum.se/"
   featured: false
   description: >-
     Borrow money quickly and safely through Zensum. We compare Sweden's leading
@@ -1357,10 +1482,10 @@
     - Corporate
     - Marketing
   built_by: Bejamas.io
-  built_by_url: 'https://bejamas.io/'
+  built_by_url: "https://bejamas.io/"
 - title: StatusHub - Easy to use Hosted Status Page Service
-  main_url: 'https://statushub.com/'
-  url: 'https://statushub.com/'
+  main_url: "https://statushub.com/"
+  url: "https://statushub.com/"
   featured: false
   description: >-
     Set up your very own service status page in minutes with StatusHub. Allow
@@ -1369,11 +1494,11 @@
     - Technology
     - Marketing
   built_by: Bejamas.io
-  built_by_url: 'https://bejamas.io/'
+  built_by_url: "https://bejamas.io/"
 - title: Matthias Kretschmann Portfolio
-  main_url: 'https://matthiaskretschmann.com/'
-  url: 'https://matthiaskretschmann.com/'
-  source_url: 'https://github.com/kremalicious/portfolio'
+  main_url: "https://matthiaskretschmann.com/"
+  url: "https://matthiaskretschmann.com/"
+  source_url: "https://github.com/kremalicious/portfolio"
   featured: false
   description: Portfolio of designer & developer Matthias Kretschmann.
   categories:
@@ -1381,19 +1506,10 @@
     - Web Dev
     - Creative
   built_by: Matthias Kretschmann
-  built_by_url: 'https://matthiaskretschmann.com/'
-- title: Cajun Bowfishing
-  main_url: 'https://cajunbowfishing.com/'
-  url: 'https://cajunbowfishing.com/'
-  featured: false
-  categories:
-    - eCommerce
-    - Sports
-  built_by: Escalade Sports
-  built_by_url: 'http://escaladesports.com/'
+  built_by_url: "https://matthiaskretschmann.com/"
 - title: Iron Cove Solutions
-  main_url: 'https://ironcovesolutions.com/'
-  url: 'https://ironcovesolutions.com/'
+  main_url: "https://ironcovesolutions.com/"
+  url: "https://ironcovesolutions.com/"
   description: >-
     Iron Cove Solutions is a cloud based consulting firm. We help companies
     deliver a return on cloud usage by applying best practices
@@ -1401,23 +1517,23 @@
     - Technology
     - Web Dev
   built_by: Iron Cove Solutions
-  built_by_url: 'https://ironcovesolutions.com/'
+  built_by_url: "https://ironcovesolutions.com/"
   featured: false
 - title: Eventos orellana
   description: >-
     Somos una empresa dedicada a brindar asesoría personalizada y profesional
     para la elaboración y coordinación de eventos sociales y empresariales.
-  main_url: 'https://eventosorellana.com/'
-  url: 'https://eventosorellana.com/'
+  main_url: "https://eventosorellana.com/"
+  url: "https://eventosorellana.com/"
   featured: false
   categories:
     - Gallery
   built_by: Codedebug
-  built_by_url: 'https://codedebug.co/'
+  built_by_url: "https://codedebug.co/"
 - title: Moetez Chaabene Portfolio / Blog
-  main_url: 'https://moetez.me/'
-  url: 'https://moetez.me/'
-  source_url: 'https://github.com/moetezch/moetez.me'
+  main_url: "https://moetez.me/"
+  url: "https://moetez.me/"
+  source_url: "https://github.com/moetezch/moetez.me"
   featured: false
   description: Portfolio of Moetez Chaabene
   categories:
@@ -1425,125 +1541,116 @@
     - Web Dev
     - Blog
   built_by: Moetez Chaabene
-  built_by_url: 'https://twitter.com/moetezch'
+  built_by_url: "https://twitter.com/moetezch"
 - title: Nikita
   description: >-
     Automation of system deployments in Node.js for applications and
     infrastructures.
-  main_url: 'https://nikita.js.org/'
-  url: 'https://nikita.js.org/'
-  source_url: 'https://github.com/adaltas/node-nikita'
+  main_url: "https://nikita.js.org/"
+  url: "https://nikita.js.org/"
+  source_url: "https://github.com/adaltas/node-nikita"
   categories:
     - Documentation
     - Open Source
     - Technology
   built_by: David Worms
-  built_by_url: 'http://www.adaltas.com'
+  built_by_url: "http://www.adaltas.com"
   featured: false
 - title: Gourav Sood Blog & Portfolio
-  main_url: 'https://www.gouravsood.com/'
-  url: 'https://www.gouravsood.com/'
+  main_url: "https://www.gouravsood.com/"
+  url: "https://www.gouravsood.com/"
   featured: false
   categories:
     - Blog
     - Portfolio
     - Salesforce
   built_by: Gourav Sood
-  built_by_url: 'https://www.gouravsood.com/'
-- title: Figma
-  main_url: 'https://www.figma.com/'
-  url: 'https://www.figma.com/'
-  featured: false
-  categories:
-    - Marketing
-    - Design
-  built_by: Corey Ward
-  built_by_url: 'http://www.coreyward.me/'
+  built_by_url: "https://www.gouravsood.com/"
 - title: Jonas Tebbe Portfolio
   description: |
     Hey, I’m Jonas and I create digital products.
-  main_url: 'https://jonastebbe.com'
-  url: 'https://jonastebbe.com'
+  main_url: "https://jonastebbe.com"
+  url: "https://jonastebbe.com"
   categories:
     - Portfolio
   built_by: Jonas Tebbe
-  built_by_url: 'http://twitter.com/jonastebbe'
+  built_by_url: "http://twitter.com/jonastebbe"
   featured: false
 - title: Parker Sarsfield Portfolio
   description: |
     I'm Parker, a software engineer and sneakerhead.
-  main_url: 'https://parkersarsfield.com'
-  url: 'https://parkersarsfield.com'
+  main_url: "https://parkersarsfield.com"
+  url: "https://parkersarsfield.com"
   categories:
     - Blog
     - Portfolio
   built_by: Parker Sarsfield
-  built_by_url: 'https://parkersarsfield.com'
+  built_by_url: "https://parkersarsfield.com"
 - title: Front-end web development with Greg
   description: |
     JavaScript, GatsbyJS, ReactJS, CSS in JS... Let's learn some stuff together.
-  main_url: 'https://dev.greglobinski.com'
-  url: 'https://dev.greglobinski.com'
+  main_url: "https://dev.greglobinski.com"
+  url: "https://dev.greglobinski.com"
   categories:
     - Blog
     - Web Dev
   built_by: Greg Lobinski
-  built_by_url: 'https://github.com/greglobinski'
+  built_by_url: "https://github.com/greglobinski"
 - title: Insomnia
   description: |
     Desktop HTTP and GraphQL client for developers
-  main_url: 'https://insomnia.rest/'
-  url: 'https://insomnia.rest/'
+  main_url: "https://insomnia.rest/"
+  url: "https://insomnia.rest/"
   categories:
     - Landing
     - Blog
   built_by: Gregory Schier
-  built_by_url: 'https://schier.co'
+  built_by_url: "https://schier.co"
   featured: false
 - title: Timeline Theme Portfolio
   description: |
     I'm Aman Mittal, a software developer.
-  main_url: 'http://www.amanhimself.me/'
-  url: 'http://www.amanhimself.me/'
+  main_url: "http://www.amanhimself.me/"
+  url: "http://www.amanhimself.me/"
   categories:
     - Landing
     - Web Dev
     - Portfolio
   built_by: Aman Mittal
-  built_by_url: 'http://www.amanhimself.me/'
+  built_by_url: "http://www.amanhimself.me/"
 - title: Ocean artUp
   description: >
     Science outreach site built using styled-components and Contentful. It
     presents the research project "Ocean artUp" funded by an Advanced Grant of
     the European Research Council to explore the possible benefits of artificial
     uplift of nutrient-rich deep water to the ocean’s sunlit surface layer.
-  main_url: 'https://ocean-artup.eu'
-  url: 'https://ocean-artup.eu'
-  source_url: 'https://github.com/janosh/ocean-artup'
+  main_url: "https://ocean-artup.eu"
+  url: "https://ocean-artup.eu"
+  source_url: "https://github.com/janosh/ocean-artup"
   categories:
     - Science
     - Research
     - Education
     - Blog
   built_by: Janosh Riebesell
-  built_by_url: 'https://janosh.io'
+  built_by_url: "https://janosh.io"
   featured: false
 - title: Ryan Fitzgerald
   description: |
     Personal portfolio and blog for Ryan Fitzgerald
-  main_url: 'https://ryanfitzgerald.ca/'
-  url: 'https://ryanfitzgerald.ca/'
+  main_url: "https://ryanfitzgerald.ca/"
+  url: "https://ryanfitzgerald.ca/"
   categories:
     - Web Dev
     - Portfolio
   built_by: Ryan Fitzgerald
-  built_by_url: 'https://github.com/RyanFitzgerald'
+  built_by_url: "https://github.com/RyanFitzgerald"
   featured: false
 - title: Kaizen
   description: |
     Content Marketing, PR & SEO Agency in London
-  main_url: 'https://www.kaizen.co.uk/'
-  url: 'https://www.kaizen.co.uk/'
+  main_url: "https://www.kaizen.co.uk/"
+  url: "https://www.kaizen.co.uk/"
   categories:
     - Agency
     - Blog
@@ -1552,13 +1659,13 @@
     - Web Dev
     - SEO
   built_by: Bogdan Stanciu
-  built_by_url: 'https://github.com/b0gd4n'
+  built_by_url: "https://github.com/b0gd4n"
   featured: false
 - title: HackerOne Platform Documentation
   description: |
     HackerOne's Product Documentation Center!
-  url: 'https://docs.hackerone.com/'
-  main_url: 'https://docs.hackerone.com/'
+  url: "https://docs.hackerone.com/"
+  main_url: "https://docs.hackerone.com/"
   categories:
     - Documentation
     - Security
@@ -1566,8 +1673,8 @@
 - title: Patreon Partners
   description: |
     Resources and products to help you do more with Patreon.
-  url: 'https://partners.patreon.com/'
-  main_url: 'https://partners.patreon.com/'
+  url: "https://partners.patreon.com/"
+  main_url: "https://partners.patreon.com/"
   categories:
     - Resources
     - Directory
@@ -1575,8 +1682,8 @@
 - title: Bureau Of Meteorology (beta)
   description: |
     Help shape the future of Bureau services
-  url: 'https://beta.bom.gov.au/'
-  main_url: 'https://beta.bom.gov.au/'
+  url: "https://beta.bom.gov.au/"
+  main_url: "https://beta.bom.gov.au/"
   categories:
     - Meteorology
     - Research
@@ -1585,8 +1692,8 @@
 - title: Curbside
   description: |
     Connecting Stores with Mobile Customers
-  main_url: 'https://curbside.com/'
-  url: 'https://curbside.com/'
+  main_url: "https://curbside.com/"
+  url: "https://curbside.com/"
   categories:
     - Mobile Commerce
     - Software
@@ -1594,8 +1701,8 @@
 - title: Mux Video
   description: |
     API to video hosting and streaming
-  main_url: 'https://mux.com/'
-  url: 'https://mux.com/'
+  main_url: "https://mux.com/"
+  url: "https://mux.com/"
   categories:
     - Video
     - Hosting
@@ -1606,8 +1713,8 @@
   description: >
     The easiest way for event organizers to instantly connect people, build a
     community of attendees and exhibitors, and increase revenue over time
-  main_url: 'https://www.swapcard.com/'
-  url: 'https://www.swapcard.com/'
+  main_url: "https://www.swapcard.com/"
+  url: "https://www.swapcard.com/"
   categories:
     - Event
     - Community
@@ -1617,8 +1724,8 @@
   description: >
     Kalix is perfect for healthcare professionals starting out in private
     practice, to those with an established clinic.
-  main_url: 'https://www.kalixhealth.com/'
-  url: 'https://www.kalixhealth.com/'
+  main_url: "https://www.kalixhealth.com/"
+  url: "https://www.kalixhealth.com/"
   categories:
     - Scheduling
     - Documentation
@@ -1629,36 +1736,25 @@
 - title: Hubba
   description: |
     Buy wholesale products from thousands of independent, verified Brands.
-  main_url: 'https://join.hubba.com/'
-  url: 'https://join.hubba.com/'
+  main_url: "https://join.hubba.com/"
+  url: "https://join.hubba.com/"
   categories:
     - eCommerce
     - Retail
   featured: false
-- title: Airbnb Engineering & Data Science
-  description: >
-    Creative engineers and data scientists building a world where you can belong
-    anywhere
-  main_url: 'https://airbnb.io/'
-  url: 'https://airbnb.io/'
-  categories:
-    - Blog
-    - Gallery
-    - Projects
-  featured: false
 - title: HyperPlay
   description: |
     In Asean's 1st Ever LOL Esports X Music Festival
-  main_url: 'https://hyperplay.leagueoflegends.com/'
-  url: 'https://hyperplay.leagueoflegends.com/'
+  main_url: "https://hyperplay.leagueoflegends.com/"
+  url: "https://hyperplay.leagueoflegends.com/"
   categories:
     - Landing
   featured: false
 - title: Bad Credit Loans
   description: |
     Get the funds you need, from $250-$5,000
-  main_url: 'https://www.creditloan.com/'
-  url: 'https://www.creditloan.com/'
+  main_url: "https://www.creditloan.com/"
+  url: "https://www.creditloan.com/"
   categories:
     - Loans
     - Credits
@@ -1668,8 +1764,8 @@
     Member-owned, not-for-profit, co-operative whose members receive financial
     benefits in the form of lower loan rates, higher savings rates, and lower
     fees than banks.
-  main_url: 'https://fcfcu.com/'
-  url: 'https://fcfcu.com/'
+  main_url: "https://fcfcu.com/"
+  url: "https://fcfcu.com/"
   categories:
     - Loans
     - Credits
@@ -1681,8 +1777,8 @@
     Provides APIs and raw download access to a number of high-value, high
     priority and scalable structured datasets, including adverse events, drug
     product labeling, and recall enforcement reports.
-  main_url: 'https://open.fda.gov/'
-  url: 'https://open.fda.gov/'
+  main_url: "https://open.fda.gov/"
+  url: "https://open.fda.gov/"
   categories:
     - API
     - Datasets
@@ -1691,36 +1787,17 @@
 - title: Office of Institutional Research and Assessment
   description: |
     Good Data, Good Decisions
-  main_url: 'http://oira.ua.edu/'
-  url: 'http://oira.ua.edu/'
+  main_url: "http://oira.ua.edu/"
+  url: "http://oira.ua.edu/"
   categories:
     - Research
     - Data
   featured: false
-- title: GM Capital One
-  description: |
-    Introducing the new online experience for your GM Rewards Credit Card
-  main_url: 'https://gm.capitalone.com/'
-  url: 'https://gm.capitalone.com/'
-  categories:
-    - Rewards
-    - Credit Card
-  featured: false
-- title: House Manager
-  description: >
-    Home service membership that offers proactive and on-demand maintenance for
-    homeowners
-  main_url: 'https://housemanager.calstate.aaa.com/'
-  url: 'https://housemanager.calstate.aaa.com/'
-  categories:
-    - Home
-    - Services
-  featured: false
 - title: Trintellix
   description: |
     It may help make a difference for your depression (MDD).
-  main_url: 'https://us.trintellix.com/'
-  url: 'https://us.trintellix.com/'
+  main_url: "https://us.trintellix.com/"
+  url: "https://us.trintellix.com/"
   categories:
     - Health
     - Help
@@ -1728,8 +1805,8 @@
 - title: The Telegraph Premium
   description: |
     Exclusive stories from award-winning journalists
-  main_url: 'https://premium.telegraph.co.uk/'
-  url: 'https://premium.telegraph.co.uk/'
+  main_url: "https://premium.telegraph.co.uk/"
+  url: "https://premium.telegraph.co.uk/"
   categories:
     - Landing
     - Newspaper
@@ -1738,37 +1815,22 @@
 - title: html2canvas
   description: |
     Screenshots with JavaScript
-  main_url: 'http://html2canvas.hertzen.com/'
-  url: 'http://html2canvas.hertzen.com/'
-  source_url: 'https://github.com/niklasvh/html2canvas/tree/master/www'
+  main_url: "http://html2canvas.hertzen.com/"
+  url: "http://html2canvas.hertzen.com/"
+  source_url: "https://github.com/niklasvh/html2canvas/tree/master/www"
   categories:
     - Tool
     - Screenshots
     - JavaScript
     - Documentation
   built_by: Niklas von Hertzen
-  built_by_url: 'http://hertzen.com/'
-  featured: false
-- title: The State of JavaScript 2017
-  description: >
-    Data from over 20,000 developers, asking them questions on topics ranging
-    from front-end frameworks and state management, to build tools and testing
-    libraries.
-  main_url: 'https://stateofjs.com/'
-  url: 'https://stateofjs.com/'
-  source_url: 'https://github.com/StateOfJS/StateOfJS'
-  categories:
-    - Data
-    - JavaScript
-    - Statistics
-  built_by: StateOfJS
-  built_by_url: 'https://github.com/StateOfJS/StateOfJS/graphs/contributors'
+  built_by_url: "http://hertzen.com/"
   featured: false
 - title: Dato CMS
   description: |
     The API-based CMS your editors will love
-  main_url: 'https://www.datocms.com/'
-  url: 'https://www.datocms.com/'
+  main_url: "https://www.datocms.com/"
+  url: "https://www.datocms.com/"
   categories:
     - CMS
     - API
@@ -1777,28 +1839,28 @@
 - title: Half Electronics
   description: |
     Personal website
-  main_url: 'https://www.halfelectronic.com/'
-  url: 'https://www.halfelectronic.com/'
+  main_url: "https://www.halfelectronic.com/"
+  url: "https://www.halfelectronic.com/"
   categories:
     - Blog
     - Electronics
   built_by: Fernando Poumian
-  built_by_url: 'https://github.com/fpoumian/halfelectronic.com'
+  built_by_url: "https://github.com/fpoumian/halfelectronic.com"
   featured: false
 - title: Frithir Software Development
-  main_url: 'https://frithir.com/'
-  url: 'https://frithir.com/'
+  main_url: "https://frithir.com/"
+  url: "https://frithir.com/"
   featured: false
-  description: 'I DRINK COFFEE, WRITE CODE AND IMPROVE MY DEVELOPMENT SKILLS EVERY DAY.'
+  description: "I DRINK COFFEE, WRITE CODE AND IMPROVE MY DEVELOPMENT SKILLS EVERY DAY."
   categories:
     - Creative
     - Design
     - Web Dev
   built_by: Frithir
-  built_by_url: 'https://Frithir.com/'
+  built_by_url: "https://Frithir.com/"
 - title: Unow
-  main_url: 'https://www.unow.fr/'
-  url: 'https://www.unow.fr/'
+  main_url: "https://www.unow.fr/"
+  url: "https://www.unow.fr/"
   categories:
     - Education
     - Corporate
@@ -1807,44 +1869,44 @@
 - title: Peter Hironaka
   description: |
     Freelance Web Developer based in Los Angeles.
-  main_url: 'https://peterhironaka.com/'
-  url: 'https://peterhironaka.com/'
+  main_url: "https://peterhironaka.com/"
+  url: "https://peterhironaka.com/"
   categories:
     - Portfolio
     - Web Dev
   built_by: Peter Hironaka
-  built_by_url: 'https://github.com/PHironaka'
+  built_by_url: "https://github.com/PHironaka"
   featured: false
 - title: Michael McQuade
   description: |
     Personal website and blog for Michael McQuade
-  main_url: 'https://giraffesyo.io'
-  url: 'https://giraffesyo.io'
+  main_url: "https://giraffesyo.io"
+  url: "https://giraffesyo.io"
   categories:
     - Blog
   built_by: Michael McQuade
-  built_by_url: 'https://github.com/giraffesyo'
+  built_by_url: "https://github.com/giraffesyo"
   featured: false
 - title: Haacht Brewery
   description: |
     Corporate wesbite for Haacht Brewery. Designed and Developed by Gafas.
-  main_url: 'https://haacht.com/en/'
-  url: 'https://haacht.com'
+  main_url: "https://haacht.com/en/"
+  url: "https://haacht.com"
   categories:
     - Corporate
   built_by: Gafas
-  built_by_url: 'https://gafas.be'
+  built_by_url: "https://gafas.be"
   featured: false
 - title: StoutLabs
   description: |
     Portfolio of Daniel Stout, freelance web dev in East Tennessee.
-  main_url: 'https://www.stoutlabs.com/'
-  url: 'https://www.stoutlabs.com/'
+  main_url: "https://www.stoutlabs.com/"
+  url: "https://www.stoutlabs.com/"
   categories:
     - Web Dev
     - Portfolio
   built_by: Daniel Stout
-  built_by_url: 'https://github.com/stoutlabs'
+  built_by_url: "https://github.com/stoutlabs"
   featured: false
 - title: Chicago Ticket Outcomes By Neighborhood
   description: |
@@ -1856,7 +1918,7 @@
   url: >-
     https://projects.propublica.org/graphics/il/il-city-sticker-tickets-maps/ticket-status/?initialWidth=782
   built_by: David Eads
-  built_by_url: 'https://github.com/eads'
+  built_by_url: "https://github.com/eads"
   featured: false
 - title: Chicago South Side Traffic Ticketing rates
   description: |
@@ -1868,14 +1930,14 @@
     - Nonprofit
     - Visualization
   built_by: David Eads
-  built_by_url: 'https://github.com/eads'
+  built_by_url: "https://github.com/eads"
   featured: false
 - title: Otsimo
   description: >
     Otsimo is a special education application for children with autism, down
     syndrome and other developmental disabilities.
-  main_url: 'https://otsimo.com/en/'
-  url: 'https://otsimo.com/en/'
+  main_url: "https://otsimo.com/en/"
+  url: "https://otsimo.com/en/"
   categories:
     - Landing
     - Blog
@@ -1886,8 +1948,8 @@
     Mostly the result of playing with Gatsby and learning about react and
     graphql. Using the screenshot plugin to showcase the work done for my
     company in the last 2 years, and a good amount of other experiments.
-  main_url: 'https://mattbag.github.io'
-  url: 'https://mattbag.github.io'
+  main_url: "https://mattbag.github.io"
+  url: "https://mattbag.github.io"
   categories:
     - Landing
     - Portfolio
@@ -1895,8 +1957,8 @@
 - title: Lisa Ye's Blog
   description: |
     Simple blog/portofolio for a fashion designer. Gatsby_v2 + Netlify cms
-  main_url: 'https://lisaye.netlify.com/'
-  url: 'https://lisaye.netlify.com/'
+  main_url: "https://lisaye.netlify.com/"
+  url: "https://lisaye.netlify.com/"
   categories:
     - Blog
     - Portfolio
@@ -1904,9 +1966,9 @@
     - Fashion
   featured: false
 - title: Lifestone Church
-  main_url: 'https://www.lifestonechurch.net/'
-  url: 'https://www.lifestonechurch.net/'
-  source_url: 'https://github.com/lifestonechurch/lifestonechurch.net'
+  main_url: "https://www.lifestonechurch.net/"
+  url: "https://www.lifestonechurch.net/"
+  source_url: "https://github.com/lifestonechurch/lifestonechurch.net"
   featured: false
   categories:
     - Marketing
@@ -1915,8 +1977,8 @@
   description: >
     Little homepage of Artem Sapegin, a frontend developer, passionate
     photographer, coffee drinker and crazy dogs’ owner.
-  main_url: 'https://sapegin.me/'
-  url: 'https://sapegin.me/'
+  main_url: "https://sapegin.me/"
+  url: "https://sapegin.me/"
   categories:
     - Landing
     - Portfolio
@@ -1924,12 +1986,12 @@
     - Personal
     - Web Dev
   built_by: Artem Sapegin
-  built_by_url: 'https://github.com/sapegin'
+  built_by_url: "https://github.com/sapegin"
   featured: false
 - title: SparkPost Developers
-  main_url: 'https://developers.sparkpost.com/'
-  url: 'https://developers.sparkpost.com/'
-  source_url: 'https://github.com/SparkPost/developers.sparkpost.com'
+  main_url: "https://developers.sparkpost.com/"
+  url: "https://developers.sparkpost.com/"
+  source_url: "https://github.com/SparkPost/developers.sparkpost.com"
   categories:
     - Documentation
     - API
@@ -1938,19 +2000,19 @@
   description: >
     The portfolio blog of Malik Browne, a full stack engineer, foodie, and avid
     blogger/YouTuber.
-  main_url: 'https://www.malikbrowne.com/about'
-  url: 'https://www.malikbrowne.com'
+  main_url: "https://www.malikbrowne.com/about"
+  url: "https://www.malikbrowne.com"
   categories:
     - Blog
     - Portfolio
   built_by: Malik Browne
-  built_by_url: 'https://twitter.com/milkstarz'
+  built_by_url: "https://twitter.com/milkstarz"
   featured: false
 - title: Novatics
   description: |
     Digital products that inspire and make a difference
-  main_url: 'https://www.novatics.com.br'
-  url: 'https://www.novatics.com.br'
+  main_url: "https://www.novatics.com.br"
+  url: "https://www.novatics.com.br"
   categories:
     - Landing
     - Portfolio
@@ -1958,13 +2020,13 @@
     - Digital Products
     - Web Dev
   built_by: Novatics
-  built_by_url: 'https://github.com/Novatics'
+  built_by_url: "https://github.com/Novatics"
   featured: false
 - title: I migliori by Vivigratis
   description: |
     Product review website
-  main_url: 'https://imigliori.vivigratis.com/'
-  url: 'https://imigliori.vivigratis.com/'
+  main_url: "https://imigliori.vivigratis.com/"
+  url: "https://imigliori.vivigratis.com/"
   categories:
     - Blog
     - Travel
@@ -1977,8 +2039,8 @@
   description: >
     I’m a developer and designer with a focus in web technologies. I build cars
     on the side.
-  main_url: 'https://maxmckinney.com/'
-  url: 'https://maxmckinney.com/'
+  main_url: "https://maxmckinney.com/"
+  url: "https://maxmckinney.com/"
   categories:
     - Portfolio
     - Web Dev
@@ -1990,9 +2052,9 @@
 - title: Stickyard
   description: |
     Make your React component sticky the easy way
-  main_url: 'https://nihgwu.github.io/stickyard/'
-  url: 'https://nihgwu.github.io/stickyard/'
-  source_url: 'https://github.com/nihgwu/stickyard/tree/master/website'
+  main_url: "https://nihgwu.github.io/stickyard/"
+  url: "https://nihgwu.github.io/stickyard/"
+  source_url: "https://github.com/nihgwu/stickyard/tree/master/website"
   categories:
     - Web Dev
   built_by: Neo Nie
@@ -2000,19 +2062,19 @@
 - title: Agata Milik
   description: |
     Website of a Polish psychologist/psychotherapist based in Gdańsk, Poland.
-  main_url: 'https://agatamilik.pl'
-  url: 'https://agatamilik.pl'
+  main_url: "https://agatamilik.pl"
+  url: "https://agatamilik.pl"
   categories:
     - Landing
     - Marketing
     - Healthcare
   built_by: Piotr Fedorczyk
-  built_by_url: 'https://piotrf.pl'
+  built_by_url: "https://piotrf.pl"
   featured: false
 - title: WebPurple
-  main_url: 'https://www.webpurple.net/'
-  url: 'https://www.webpurple.net/'
-  source_url: 'https://github.com/WebPurple/site'
+  main_url: "https://www.webpurple.net/"
+  url: "https://www.webpurple.net/"
+  source_url: "https://github.com/WebPurple/site"
   description: >-
     Site of local (Russia, Ryazan) frontend community. Main purpose is to show
     info about meetups and keep blog.
@@ -2023,24 +2085,24 @@
     - Blog
     - Open Source
   built_by: Nikita Kirsanov
-  built_by_url: 'https://twitter.com/kitos_kirsanov'
+  built_by_url: "https://twitter.com/kitos_kirsanov"
   featured: false
 - title: Papertrail.io
   description: |
     Inspection Management for the 21st Century
-  main_url: 'https://www.papertrail.io/'
-  url: 'https://www.papertrail.io/'
+  main_url: "https://www.papertrail.io/"
+  url: "https://www.papertrail.io/"
   categories:
     - Marketing
     - Technology
     - Landing
   built_by: Papertrail.io
-  built_by_url: 'https://www.papertrail.io'
+  built_by_url: "https://www.papertrail.io"
   featured: false
 - title: Matt Ferderer
-  main_url: 'https://mattferderer.com'
-  url: 'https://mattferderer.com'
-  source_url: 'https://github.com/mattferderer/gatsbyblog'
+  main_url: "https://mattferderer.com"
+  url: "https://mattferderer.com"
+  source_url: "https://github.com/mattferderer/gatsbyblog"
   description: >
     {titleofthesite} is a blog built with Gatsby that discusses web related tech
     such as JavaScript, .NET, Blazor & security.
@@ -2049,12 +2111,12 @@
     - Web Dev
     - Personal
   built_by: Matt Ferderer
-  built_by_url: 'https://twitter.com/mattferderer'
+  built_by_url: "https://twitter.com/mattferderer"
   featured: false
 - title: Sahyadri Open Source Community
-  main_url: 'https://sosc.org.in'
-  url: 'https://sosc.org.in'
-  source_url: 'https://github.com/haxzie/sosc-website'
+  main_url: "https://sosc.org.in"
+  url: "https://sosc.org.in"
+  source_url: "https://github.com/haxzie/sosc-website"
   description: >
     Official website of Sahyadri Open Source Community for community blog, event
     details and members info.
@@ -2063,34 +2125,34 @@
     - Community
     - Open Source
   built_by: Musthaq Ahamad
-  built_by_url: 'https://github.com/haxzie'
+  built_by_url: "https://github.com/haxzie"
   featured: false
 - title: Tech Confessions
-  main_url: 'https://confessions.tech'
-  url: 'https://confessions.tech'
-  source_url: 'https://github.com/JonathanSpeek/tech-confessions'
+  main_url: "https://confessions.tech"
+  url: "https://confessions.tech"
+  source_url: "https://github.com/JonathanSpeek/tech-confessions"
   description: "A guilt-free place for us to confess our tech sins \U0001F64F\n"
   categories:
     - Community
     - Open Source
   built_by: Jonathan Speek
-  built_by_url: 'https://speek.design'
+  built_by_url: "https://speek.design"
   featured: false
 - title: Thibault Maekelbergh
-  main_url: 'https://thibmaek.com'
-  url: 'https://thibmaek.com'
-  source_url: 'https://github.com/thibmaek/thibmaek.github.io'
+  main_url: "https://thibmaek.com"
+  url: "https://thibmaek.com"
+  source_url: "https://github.com/thibmaek/thibmaek.github.io"
   description: |
     A nice blog about development, Raspberry Pi, plants and probably records.
   categories:
     - Blog
     - Open Source
   built_by: Thibault Maekelbergh
-  built_by_url: 'https://twitter.com/thibmaek'
+  built_by_url: "https://twitter.com/thibmaek"
   featured: false
 - title: LearnReact.design
-  main_url: 'https://learnreact.design'
-  url: 'https://learnreact.design'
+  main_url: "https://learnreact.design"
+  url: "https://learnreact.design"
   description: >
     React Essentials For Designers: A React course tailored for product
     designers, ux designers, ui designers.
@@ -2099,22 +2161,10 @@
     - Landing
     - Creative
   built_by: Linton Ye
-  built_by_url: 'https://twitter.com/lintonye'
-- title: DesignSystems.com
-  main_url: 'https://www.designsystems.com/'
-  url: 'https://www.designsystems.com/'
-  description: |
-    A resource for learning, creating and evangelizing design systems.
-  categories:
-    - Design
-    - Blog
-    - Technology
-  built_by: Corey Ward
-  built_by_url: 'http://www.coreyward.me/'
-  featured: false
+  built_by_url: "https://twitter.com/lintonye"
 - title: Devol’s Dance
-  main_url: 'https://www.devolsdance.com/'
-  url: 'https://www.devolsdance.com/'
+  main_url: "https://www.devolsdance.com/"
+  url: "https://www.devolsdance.com/"
   description: >
     Devol’s Dance is an invite-only, one-day event celebrating industrial
     robotics, AI, and automation.
@@ -2123,11 +2173,11 @@
     - Landing
     - Technology
   built_by: Corey Ward
-  built_by_url: 'http://www.coreyward.me/'
+  built_by_url: "http://www.coreyward.me/"
   featured: false
 - title: Mega House Creative
-  main_url: 'https://www.megahousecreative.com/'
-  url: 'https://www.megahousecreative.com/'
+  main_url: "https://www.megahousecreative.com/"
+  url: "https://www.megahousecreative.com/"
   description: >
     Mega House Creative is a digital agency that provides unique goal-oriented
     web marketing solutions.
@@ -2137,31 +2187,31 @@
   built_by: Daniel Robinson
   featured: false
 - title: Tobie Marier Robitaille - csc
-  main_url: 'https://tobiemarierrobitaille.com/'
-  url: 'https://tobiemarierrobitaille.com/en/'
+  main_url: "https://tobiemarierrobitaille.com/"
+  url: "https://tobiemarierrobitaille.com/en/"
   description: |
     Portfolio site for director of photography Tobie Marier Robitaille
   categories:
     - Portfolio
     - Gallery
   built_by: Mill3 Studio
-  built_by_url: 'https://mill3.studio/en/'
+  built_by_url: "https://mill3.studio/en/"
   featured: false
 - title: Bestvideogame.deals
-  main_url: 'https://bestvideogame.deals/'
-  url: 'https://bestvideogame.deals/'
+  main_url: "https://bestvideogame.deals/"
+  url: "https://bestvideogame.deals/"
   description: |
     Video game comparison website for the UK, build with GatsbyJS.
   categories:
     - eCommerce
     - Video Games
   built_by: Koen Kamphuis
-  built_by_url: 'https://koenkamphuis.com/'
+  built_by_url: "https://koenkamphuis.com/"
   featured: false
 - title: Mahipat's Portfolio
-  main_url: 'https://mojaave.com/'
-  url: 'https://mojaave.com'
-  source_url: 'https://github.com/mhjadav/mojaave'
+  main_url: "https://mojaave.com/"
+  url: "https://mojaave.com"
+  source_url: "https://github.com/mhjadav/mojaave"
   description: >
     mojaave.com is Mahipat's portfolio, I have developed it using Gatsby v2 and
     Bootstrap, To get in touch with people looking for full stack developer.
@@ -2171,11 +2221,11 @@
     - Web Dev
     - Personal
   built_by: Mahipat Jadav
-  built_by_url: 'https://mojaave.com/'
+  built_by_url: "https://mojaave.com/"
   featured: false
 - title: Cmsbased
-  main_url: 'https://www.cmsbased.net'
-  url: 'https://www.cmsbased.net'
+  main_url: "https://www.cmsbased.net"
+  url: "https://www.cmsbased.net"
   description: >
     Cmsbased is providing automation tools and design resources for Web Hosting
     and IT services industry.
@@ -2185,8 +2235,8 @@
     - Digital Products
   featured: false
 - title: Traffic Design Biennale 2018
-  main_url: 'https://trafficdesign.pl'
-  url: 'http://trafficdesign.pl/pl/ficzery/2018-biennale/'
+  main_url: "https://trafficdesign.pl"
+  url: "http://trafficdesign.pl/pl/ficzery/2018-biennale/"
   description: |
     Mini site for 2018 edition of Traffic Design’s Biennale
   categories:
@@ -2195,46 +2245,11 @@
     - Nonprofit
     - Gallery
   built_by: Piotr Fedorczyk
-  built_by_url: 'https://piotrf.pl'
-  featured: false
-- title: Timely
-  main_url: 'https://timelyapp.com/'
-  url: 'https://timelyapp.com/'
-  description: |
-    Fully automatic time tracking. For those who trade in time.
-  categories:
-    - Software
-    - Time Tracking
-    - Tool
-  built_by: Timm Stokke
-  built_by_url: 'https://timm.stokke.me'
-  featured: false
-- title: Stitch Fix
-  main_url: 'https://www.stitchfix.com/'
-  url: 'https://www.stitchfix.com/'
-  description: >
-    Stitch Fix is an online styling service that delivers a truly personalized
-    shopping experience.
-  categories:
-    - eCommerce
-    - Clothing
-    - Fashion
-  featured: false
-- title: Snap Kit
-  main_url: 'https://kit.snapchat.com/'
-  url: 'https://kit.snapchat.com/'
-  description: >
-    Snap Kit lets developers integrate some of Snapchat’s best features across
-    platforms.
-  categories:
-    - Technology
-    - Tool
-    - Software
-    - Documentation
+  built_by_url: "https://piotrf.pl"
   featured: false
 - title: Insights
-  main_url: 'https://justaskusers.com/'
-  url: 'https://justaskusers.com/'
+  main_url: "https://justaskusers.com/"
+  url: "https://justaskusers.com/"
   description: >
     Insights helps user experience (UX) researchers conduct their research and
     make sense of the findings.
@@ -2243,12 +2258,12 @@
     - Research
     - Design
   built_by: Just Ask Users
-  built_by_url: 'https://justaskusers.com/'
+  built_by_url: "https://justaskusers.com/"
   featured: false
 - title: Tensiq
-  main_url: 'https://tensiq.com'
-  url: 'https://tensiq.com'
-  source_url: 'https://github.com/Tensiq/tensiq-site'
+  main_url: "https://tensiq.com"
+  url: "https://tensiq.com"
+  source_url: "https://github.com/Tensiq/tensiq-site"
   description: >
     Tensiq is an e-Residency startup, that provides development in cutting-edge
     technology while delivering secure, resilient, performant solutions.
@@ -2259,25 +2274,12 @@
     - Agency
     - Open Source
   built_by: Jens
-  built_by_url: 'https://github.com/arrkiin'
-  featured: false
-- title: SendGrid
-  main_url: 'https://sendgrid.com/docs/'
-  url: 'https://sendgrid.com/docs/'
-  description: >
-    SendGrid delivers your transactional and marketing emails through the
-    world's largest cloud-based email delivery platform.
-  categories:
-    - API
-    - Technology
-    - Tool
-    - Software
-    - Documentation
+  built_by_url: "https://github.com/arrkiin"
   featured: false
 - title: Mintfort
-  main_url: 'https://mintfort.com/'
-  url: 'https://mintfort.com/'
-  source_url: 'https://github.com/MintFort/mintfort.com'
+  main_url: "https://mintfort.com/"
+  url: "https://mintfort.com/"
+  source_url: "https://github.com/MintFort/mintfort.com"
   description: >
     Mintfort, the first crypto-friendly bank account. Store and manage assets on
     the blockchain.
@@ -2287,11 +2289,11 @@
     - Bank
     - Software
   built_by: Axel Fuhrmann
-  built_by_url: 'https://axelfuhrmann.com/'
+  built_by_url: "https://axelfuhrmann.com/"
   featured: false
 - title: React Native Explorer
-  main_url: 'https://react-native-explorer.firebaseapp.com'
-  url: 'https://react-native-explorer.firebaseapp.com'
+  main_url: "https://react-native-explorer.firebaseapp.com"
+  url: "https://react-native-explorer.firebaseapp.com"
   description: |
     Explorer React Native packages and examples effortlessly.
   categories:
@@ -2300,16 +2302,16 @@
     - Tool
   featured: false
 - title: 500Tech
-  main_url: 'https://500tech.com/'
-  url: 'https://500tech.com/'
+  main_url: "https://500tech.com/"
+  url: "https://500tech.com/"
   featured: false
   categories:
     - Web Dev
     - Agency
     - Open Source
 - title: eworld
-  main_url: 'http://eworld.herokuapp.com/'
-  url: 'http://eworld.herokuapp.com/'
+  main_url: "http://eworld.herokuapp.com/"
+  url: "http://eworld.herokuapp.com/"
   featured: false
   categories:
     - eCommerce
@@ -2317,8 +2319,8 @@
 - title: It's a Date
   description: >
     It's a Date is a dating app that actually involves dating.
-  main_url: 'https://www.itsadate.app/'
-  url: 'https://www.itsadate.app/'
+  main_url: "https://www.itsadate.app/"
+  url: "https://www.itsadate.app/"
   featured: false
   categories:
     - App
@@ -2328,7 +2330,7 @@
     Asynchronous HBase client for NodeJs using REST.
   main_url: https://hbase.js.org/
   url: https://hbase.js.org/
-  source_url: 'https://github.com/adaltas/node-hbase'
+  source_url: "https://github.com/adaltas/node-hbase"
   categories:
     - Documentation
     - Open Source
@@ -2369,8 +2371,8 @@
   built_by_url: https://twitter.com/geddski
   featured: false
 - title: Rung
-  main_url: 'https://rung.com.br/'
-  url: 'https://rung.com.br/'
+  main_url: "https://rung.com.br/"
+  url: "https://rung.com.br/"
   description: >
     Rung alerts you about the exceptionalities of your personal and professional life.
   categories:
@@ -2385,8 +2387,8 @@
     - Bot
   featured: false
 - title: Mokkapps
-  main_url: 'https://www.mokkapps.de/projects'
-  url: 'https://www.mokkapps.de/'
+  main_url: "https://www.mokkapps.de/projects"
+  url: "https://www.mokkapps.de/"
   description: >
     Mokkapps is a shiny new portfolio website from the software developer Michael Hoffmann which was built with Gatsby v2
   categories:
@@ -2395,8 +2397,8 @@
     - Web Dev
   featured: false
 - title: Premier Octet
-  main_url: 'https://www.premieroctet.com/'
-  url: 'https://www.premieroctet.com/'
+  main_url: "https://www.premieroctet.com/"
+  url: "https://www.premieroctet.com/"
   description: >
     Premier Octet is a React-based agency
   categories:
@@ -2406,9 +2408,9 @@
     - React Native
   featured: false
 - title: Thorium
-  main_url: 'https://www.thoriumsim.com/'
-  url: 'https://www.thoriumsim.com/'
-  source_url: 'https://github.com/thorium-sim/thoriumsim.com'
+  main_url: "https://www.thoriumsim.com/"
+  url: "https://www.thoriumsim.com/"
+  source_url: "https://github.com/thorium-sim/thoriumsim.com"
   description: >
     Thorium - Open-source Starship Simulator Controls for Live Action Role Play
   built_by: Alex Anderson

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1761,7 +1761,6 @@
   url: "https://premium.telegraph.co.uk/"
   categories:
     - Newspaper
-    - Subscription
   featured: false
 - title: html2canvas
   description: |

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1774,7 +1774,7 @@
   main_url: "https://us.trintellix.com/"
   url: "https://us.trintellix.com/"
   categories:
-    - Health
+    - Health & Wellness
     - Help
   featured: false
 - title: The Telegraph Premium
@@ -2003,7 +2003,7 @@
     - Blog
     - Travel
     - Technology
-    - Wellness
+    - Health & Wellness
     - Fashion
   built_by: Kframe Interactive SA
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -145,7 +145,6 @@
   categories:
     - Data
     - JavaScript
-    - Statistics
     - Featurd
   built_by: StateOfJS
   built_by_url: "https://github.com/StateOfJS/StateOfJS/graphs/contributors"

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1761,7 +1761,7 @@
   url: "https://open.fda.gov/"
   categories:
     - API
-    - Datasets
+    - Data
     - Reports
   featured: false
 - title: Office of Institutional Research and Assessment
@@ -1995,7 +1995,6 @@
     - Landing
     - Portfolio
     - Technology
-    - Digital Products
     - Web Dev
   built_by: Novatics
   built_by_url: "https://github.com/Novatics"
@@ -2209,7 +2208,6 @@
   categories:
     - Technology
     - Design
-    - Digital Products
   featured: false
 - title: Traffic Design Biennale 2018
   main_url: "https://trafficdesign.pl"


### PR DESCRIPTION
Hello everyone! Just updated the featured sites and took out tags that didn't seem to provide value or could be consolidated with another tag. 

Also considering taking out:
- marketing
- technology
- web dev

The tags above are used so frequently, they almost have no meaning. Although they might be useful as a secondary filter, e.g. if someone checks both "web dev" AND "documentation", that gets them a narrow set of sites.