### PR TITLE
Small updates to next.gatsbyjs.org

### DIFF
--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -48,7 +48,7 @@ const SegmentTitle = ({ children }) => (
     css={{
       display: `inline`,
       background: colors.accent,
-      color: `#fff`,
+      color: colors.gray.copy,
       borderRadius: presets.radius,
       margin: `0 auto`,
       position: `relative`,
@@ -163,7 +163,7 @@ const ItemDescription = ({ children }) => (
     css={{
       lineHeight: 1.2,
       display: `block`,
-      color: colors.lilac,
+      color: colors.gatsby,
       [presets.Hd]: {
         fontSize: scale(-1 / 5).fontSize,
       },

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -125,8 +125,8 @@ const Navigation = ({ pathname }) => {
             : {}),
         }}
       >
-        <Link to="/" css={styles.logoLink}>
-          <img src={logo} css={styles.logo} alt="" />
+        <Link to="/" css={styles.logoLink} aria-label="Go to homepage">
+          <img src={logo} css={styles.logo} alt="Gatsby logo" />
         </Link>
         <ul css={styles.navContainer}>
           <NavItem linkTo="/docs/">Docs</NavItem>

--- a/www/src/fonts/Webfonts/futurapt_book_macroman/stylesheet.css
+++ b/www/src/fonts/Webfonts/futurapt_book_macroman/stylesheet.css
@@ -5,7 +5,7 @@
  * Fully installable fonts can be purchased at http://www.fontspring.com
  *
  * The fonts included in this stylesheet are subject to the End User License you purchased
- * from Fontspring. The fonts are protected under domestic and international trademark and 
+ * from Fontspring. The fonts are protected under domestic and international trademark and
  * copyright law. You are prohibited from modifying, reverse engineering, duplicating, or
  * distributing this font software.
  *
@@ -24,6 +24,7 @@
 
 @font-face {
   font-family: "Futura PT";
+  font-display: swap;
   src: url("./ftn45-webfont.woff2") format("woff2"),
     url("./ftn45-webfont.woff") format("woff"),
     url("./ftn45-webfont.ttf") format("truetype");

--- a/www/src/fonts/Webfonts/futurapt_bookitalic_macroman/stylesheet.css
+++ b/www/src/fonts/Webfonts/futurapt_bookitalic_macroman/stylesheet.css
@@ -5,7 +5,7 @@
  * Fully installable fonts can be purchased at http://www.fontspring.com
  *
  * The fonts included in this stylesheet are subject to the End User License you purchased
- * from Fontspring. The fonts are protected under domestic and international trademark and 
+ * from Fontspring. The fonts are protected under domestic and international trademark and
  * copyright law. You are prohibited from modifying, reverse engineering, duplicating, or
  * distributing this font software.
  *
@@ -24,6 +24,7 @@
 
 @font-face {
   font-family: "Futura PT";
+  font-display: swap;
   src: url("ftn46-webfont.woff2") format("woff2"),
     url("ftn46-webfont.woff") format("woff"),
     url("ftn46-webfont.ttf") format("truetype");

--- a/www/src/fonts/Webfonts/futurapt_demi_macroman/stylesheet.css
+++ b/www/src/fonts/Webfonts/futurapt_demi_macroman/stylesheet.css
@@ -5,7 +5,7 @@
  * Fully installable fonts can be purchased at http://www.fontspring.com
  *
  * The fonts included in this stylesheet are subject to the End User License you purchased
- * from Fontspring. The fonts are protected under domestic and international trademark and 
+ * from Fontspring. The fonts are protected under domestic and international trademark and
  * copyright law. You are prohibited from modifying, reverse engineering, duplicating, or
  * distributing this font software.
  *
@@ -24,6 +24,7 @@
 
 @font-face {
   font-family: "Futura PT";
+  font-display: swap;
   src: url("ftn65-webfont.woff2") format("woff2"),
     url("ftn65-webfont.woff") format("woff"),
     url("ftn65-webfont.ttf") format("truetype");

--- a/www/src/fonts/Webfonts/futurapt_demiitalic_macroman/stylesheet.css
+++ b/www/src/fonts/Webfonts/futurapt_demiitalic_macroman/stylesheet.css
@@ -5,7 +5,7 @@
  * Fully installable fonts can be purchased at http://www.fontspring.com
  *
  * The fonts included in this stylesheet are subject to the End User License you purchased
- * from Fontspring. The fonts are protected under domestic and international trademark and 
+ * from Fontspring. The fonts are protected under domestic and international trademark and
  * copyright law. You are prohibited from modifying, reverse engineering, duplicating, or
  * distributing this font software.
  *
@@ -24,6 +24,7 @@
 
 @font-face {
   font-family: "Futura PT";
+  font-display: swap;
   src: url("ftn66-webfont.woff2") format("woff2"),
     url("ftn66-webfont.woff") format("woff"),
     url("ftn66-webfont.ttf") format("truetype");

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
+import Helmet from "react-helmet"
 import Layout from "../components/layout"
 import presets, { colors } from "../utils/presets"
 import { rhythm, options } from "../utils/typography"
@@ -23,6 +24,9 @@ class IndexRoute extends React.Component {
     const blogPosts = this.props.data.allMarkdownRemark
     return (
       <Layout location={this.props.location}>
+        <Helmet>
+          <meta name="Description" content="Blazing fast modern site generator for React. Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby." />
+        </Helmet>
         <div css={{ position: `relative` }}>
           <MastheadBg />
           <div


### PR DESCRIPTION
Resolves most of the items at #7378. Some design changes, needs review from @fk!

@fk I changed the diagram label text from white to gray, and darkened one line of text to fix the contrast warnings:

Before: 
<img width="533" alt="screen shot 2018-09-13 at 23 33 51" src="https://user-images.githubusercontent.com/381801/45519576-91e92100-b7ad-11e8-9990-5a2e91c37930.png">

After:
<img width="514" alt="screen shot 2018-09-13 at 23 33 34" src="https://user-images.githubusercontent.com/381801/45519575-91e92100-b7ad-11e8-973c-12f460506dab.png">

I've also added `font-display: swap` to the fonts.

There's one outstanding issue related to a console error from the offline plugin, but I'm going to investigate further and create a separate PR for that.