### PR TITLE
[gatsby-source-contentful] Make gatsby-plugin-sharp an optional dependency

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -14,7 +14,6 @@
     "contentful": "^6.1.0",
     "deep-map": "^1.5.0",
     "fs-extra": "^4.0.2",
-    "gatsby-plugin-sharp": "^2.0.0-rc.7",
     "is-online": "^7.0.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.10",
@@ -24,6 +23,9 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "cross-env": "^5.1.4"
+  },
+  "optionalDependencies": {
+    "gatsby-plugin-sharp": "^2.0.0-rc.7"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#readme",
   "keywords": [


### PR DESCRIPTION
## Rationale

Hi 👋 

We're having issues installing `gatsby-plugin-sharp` when using `gatsby-source-contentful`. Since this plugin is [only needed in certain cases](https://github.com/gatsbyjs/gatsby/blob/df08d26a21119e7f0a456eb9b9fddf51e3ab2bd5/packages/gatsby-source-contentful/src/extend-node-type.js#L466), it could be made optional.

Note that I haven't tried it and I might have to add it in `devDependencies` for tests, let me know if you need that!