### PR TITLE
[gatsby-cli] Don't crash on linux TTY

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -206,7 +206,8 @@ function buildLocalCommands(cli, isLocalSite) {
           },
           {
             console: true,
-            clipboard: args.clipboard,
+            // Clipboard is not accessible when on a linux tty
+            clipboard: (process.platform === `linux` && !process.env.DISPLAY) ? false : args.clipboard,
           }
         )
       } catch (err) {


### PR DESCRIPTION
Fixes #8140
`gatsby-cli info --clipboard` crashes on linux when run on a text console without access to X11. This adds a check to pass `clipboard: false` to `envinfo` in that case.