### PR TITLE
Offline plugin fetch error

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-browser.js
@@ -31,7 +31,6 @@ exports.onServiceWorkerInstalled = ({ getResourceURLsForPathname }) => {
   for (const resource of resources) {
     const url = new URL(resource, window.location.origin)
     const isExternal = url.origin !== window.location.origin
-    console.log(isExternal, resource)
     fetch(
       resource,
       isExternal ? { mode: `no-cors` } : undefined

--- a/packages/gatsby-plugin-offline/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-browser.js
@@ -28,8 +28,12 @@ exports.onServiceWorkerInstalled = ({ getResourceURLsForPathname }) => {
     .call(nodes)
     .map(node => node.src || node.href || node.getAttribute(`data-href`))
 
+  const a = document.createElement(`a`)
+
   for (const resource of resources) {
-    fetch(resource)
+    a.href = resource
+    const isExternal = (a.host && a.host !== window.location.host)
+    fetch(resource, isExternal ? { mode: `no-cors` } : undefined)
   }
 
   // Loop over all resources and fetch the page component and JSON

--- a/packages/gatsby-plugin-offline/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-browser.js
@@ -28,12 +28,14 @@ exports.onServiceWorkerInstalled = ({ getResourceURLsForPathname }) => {
     .call(nodes)
     .map(node => node.src || node.href || node.getAttribute(`data-href`))
 
-  const a = document.createElement(`a`)
-
   for (const resource of resources) {
-    a.href = resource
-    const isExternal = (a.host && a.host !== window.location.host)
-    fetch(resource, isExternal ? { mode: `no-cors` } : undefined)
+    const url = new URL(resource, window.location.origin)
+    const isExternal = url.origin !== window.location.origin
+    console.log(isExternal, resource)
+    fetch(
+      resource,
+      isExternal ? { mode: `no-cors` } : undefined
+    )
   }
 
   // Loop over all resources and fetch the page component and JSON


### PR DESCRIPTION
Use `no-cors` mode when fetching external resources

This 'fixes' #8145, although I don't really understand what was causing that issue. So maybe this will need some extra testing.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->