### PR TITLE
Add support for a Google Optimize Id option within the google-analytics plugin

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -24,6 +24,8 @@ module.exports = {
         respectDNT: true,
         // Avoids sending pageview hits from custom paths
         exclude: ["/preview/**", "/do-not-track/me/too/"],
+        // Enables Google Optimize using your container Id
+        optimizeId: "YOUR_GOOGLE_OPTIMIZE_TRACKING_ID",
         // Any additional create only fields (optional)
         sampleRate: 5,
         siteSpeedSampleRate: 10,
@@ -85,6 +87,10 @@ If you enable this optional option, Google Analytics will not be loaded at all f
 ## The "exclude" option
 
 If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array as glob expressions.
+
+## The "optimizeId" option
+
+If you need to use Google Optimize for A/B testing, you can add this optional Optimize container id to allow Google Optimize to load the correct test parameters for your site.
 
 ## Create Only Fields
 

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -82,6 +82,11 @@ exports.onRenderBody = (
         pluginOptions.anonymize === true
           ? `ga('set', 'anonymizeIp', true);`
           : ``
+      }
+      ${
+        typeof pluginOptions.optimizeId !== `undefined`
+          ? `ga('require', '${pluginOptions.optimizeId}');`
+          : ``
       }}
       `,
         }}


### PR DESCRIPTION
This PR references Issue #8099 and adds support for an optimizeID option in the `gatsby-plugin-google-analytics` package to make it possible to run Google Optimize A/B tests.

All tests passed when running `yarn test`

Feedback welcome 🎉 