### PR TITLE
[www] Fix appearance of first-level sidebar nav items that link to a page and contain subitems

### DIFF
--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -104,6 +104,16 @@ const SplitButton = ({
         item,
         location,
         onLinkClick,
+        customCSS:
+          level === 0
+            ? {
+                "&&": {
+                  ...styles.smallCaps,
+                  color: isExpanded ? colors.gatsby : false,
+                  fontWeight: isActive ? `bold` : `normal`,
+                },
+              }
+            : false,
       })}
     </span>
     {/* @todo this should cover 100% of the item's height */}
@@ -153,13 +163,7 @@ const SectionTitle = ({ children, isExpanded, isActive, disabled, level }) => (
       fontSize: `100%`,
       fontWeight: isActive ? `bold` : `normal`,
       margin: 0,
-      ...(level === 0 && {
-        color: colors.lilac,
-        fontFamily: options.headerFontFamily.join(`,`),
-        letterSpacing: `.075em`,
-        textTransform: `uppercase`,
-      }),
-
+      ...(level === 0 && { ...styles.smallCaps }),
       color: isExpanded ? colors.gatsby : false,
       "&:hover": {
         color: disabled ? false : colors.gatsby,
@@ -192,5 +196,10 @@ const styles = {
     position: `absolute`,
     right: 0,
     left: 40,
+  },
+  smallCaps: {
+    fontFamily: options.headerFontFamily.join(`,`),
+    letterSpacing: `.075em`,
+    textTransform: `uppercase`,
   },
 }

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -296,10 +296,8 @@ const styles = {
       fontSize: scale(-4 / 10).fontSize,
       paddingBottom: 20,
     },
-    "&&": {
-      "& a": {
-        fontFamily: options.systemFontFamily.join(`,`),
-      },
+    "& a": {
+      fontFamily: options.systemFontFamily.join(`,`),
     },
     "& li": {
       margin: 0,

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -255,7 +255,7 @@
       link: /docs/prpl-pattern/
     - title: Querying data with GraphQL
       link: /docs/querying-with-graphql/
-- title: BEHIND THE SCENES
+- title: Behind the Scenes
   link: /docs/behind-the-scenes/
   items:
     - title: How APIS/Plugins Are Run

--- a/www/src/utils/sidebar/create-link.js
+++ b/www/src/utils/sidebar/create-link.js
@@ -12,6 +12,7 @@ const createLink = ({
   isActive,
   isParentOfActiveItem,
   stepsUI,
+  customCSS,
 }) => {
   const isDraft = _isDraft(item.title)
   const title = _getTitle(item.title, isDraft)
@@ -40,6 +41,7 @@ const createLink = ({
           isDraft && styles.draft,
           isActive && styles.activeLink,
           isParentOfActiveItem && styles.parentOfActiveLink,
+          customCSS && customCSS,
         ]}
         onClick={onLinkClick}
         to={item.link}


### PR DESCRIPTION
This PR aligns the appearance of top-level items that link to a page _and_ contain subitems ("top-level split buttons") with the appearance of top-level items which do _not_ link to a page themselves but only serve as a "header" to group and allow to expand/collapse its subitems.

---

If you take a look at the "Behind the Scenes" link in the sidebar, you'll notice that it's not set in "Futura PT", and upon further inspection that its text is all uppercase, while e.g. "Conceptual Guides" is uppercased via CSS:

![image](https://user-images.githubusercontent.com/21834/45573234-3762ca00-b86c-11e8-9500-352c91fff69b.png)

👇 👇 👇 

![image](https://user-images.githubusercontent.com/21834/45573759-e8b62f80-b86d-11e8-8c47-25d9977852df.png)
