### PR TITLE
[www] TBD: Move „Expand/collapse all“ button to the bottom of the sidebar

### DIFF
--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -195,14 +195,6 @@ class SidebarBody extends Component {
 
     return (
       <div className="docSearch-sidebar" css={{ height: `100%` }}>
-        {!itemList[0].disableExpandAll && (
-          <div css={{ ...styles.utils }}>
-            <ExpandAllButton
-              onClick={this._expandAll}
-              expandAll={this.state.expandAll}
-            />
-          </div>
-        )}
         <div
           onScroll={({ nativeEvent }) => {
             // get proper scroll position
@@ -242,6 +234,14 @@ class SidebarBody extends Component {
             ))}
           </ul>
         </div>
+        {!itemList[0].disableExpandAll && (
+          <div css={{ ...styles.utils }}>
+            <ExpandAllButton
+              onClick={this._expandAll}
+              expandAll={this.state.expandAll}
+            />
+          </div>
+        )}
       </div>
     )
   }
@@ -258,7 +258,7 @@ const styles = {
     background: colors.ui.whisper,
     paddingLeft: 40,
     paddingRight: 8,
-    borderBottom: `1px solid ${colors.ui.border}`,
+    borderTop: `1px solid ${colors.ui.border}`,
   },
   sidebarScrollContainer: {
     WebkitOverflowScrolling: `touch`,


### PR DESCRIPTION
Using the next.gatsbyjs.org documentation over the past weeks, I grew a little weary about the "Expand/collapse all" button that currently sits at the top of the sidebar navigation. I only used it sparingly, and most of the times felt it interfered "scanning" the sidebar content itself.

This PR moves the button to the bottom of the sidebar, where I feel it is still discoverable (enough):

![image](https://user-images.githubusercontent.com/21834/45576421-65014080-b877-11e8-8807-eb2013e670ec.png)

