### PR TITLE
[v2] fix: rewrite [gatsby-plugin-twitter] to prevent React errors

### DIFF
--- a/packages/gatsby-plugin-twitter/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/gatsby-browser.js
@@ -21,7 +21,7 @@ const injectTwitterScript = () => {
 }
 
 let renderTweets = false
-const allTweets = []
+const renderedTweets = []
 
 exports.onRouteUpdate = function() {
   renderTweets = true
@@ -48,7 +48,7 @@ exports.onRouteUpdate = function() {
           .then(renderedTweet => {
             if (renderTweets) {
               tweet.parentNode.insertBefore(renderedTweet, tweet)
-              allTweets.push(renderedTweet)
+              renderedTweets.push(renderedTweet)
             } else {
               renderedTweet.remove()
             }
@@ -61,7 +61,7 @@ exports.onRouteUpdate = function() {
 exports.onPreRouteUpdate = function() {
   // Remove rendered tweets before navigating away, to prevent
   // memory leaks with React (since it's unaware of them)
-  allTweets.forEach(renderedTweet => renderedTweet.remove())
+  renderedTweets.forEach(renderedTweet => renderedTweet.remove())
 
   // Make sure tweets rendered later are removed (e.g. if the user
   // navigates away quickly, before the Twitter script loads)

--- a/packages/gatsby-plugin-twitter/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/gatsby-browser.js
@@ -1,47 +1,69 @@
 const injectTwitterScript = () => {
-  function addJS(jsCode) {
-    var s = document.createElement(`script`)
+  // Copied from:
+  // https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
+  window.twttr = (function(d, s, id) {
+    var js,
+      fjs = d.getElementsByTagName(s)[0],
+      t = window.twttr || {}
+    if (d.getElementById(id)) return t
+    js = d.createElement(s)
+    js.id = id
+    js.src = `https://platform.twitter.com/widgets.js`
+    fjs.parentNode.insertBefore(js, fjs)
 
-    s.type = `text/javascript`
-    s.innerText = jsCode
-    document.getElementsByTagName(`head`)[0].appendChild(s)
-  }
-  addJS(`
-          window.twttr = (function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0],
-    t = window.twttr || {};
-  if (d.getElementById(id)) return t;
-  js = d.createElement(s);
-  js.id = id;
-  js.src = "https://platform.twitter.com/widgets.js";
-  fjs.parentNode.insertBefore(js, fjs);
+    t._e = []
+    t.ready = function(f) {
+      t._e.push(f)
+    }
 
-  t._e = [];
-  t.ready = function(f) {
-    t._e.push(f);
-  };
-
-  return t;
-}(document, "script", "twitter-wjs"));
-`)
+    return t
+  })(document, `script`, `twitter-wjs`)
 }
 
-let injectedTwitterScript = false
-exports.onRouteUpdate = function({ location }) {
-  // If there's an embedded tweet, lazy-load the twitter script (if it hasn't
-  // already been loaded), and then run the twitter load function.
-  if (document.querySelector(`.twitter-tweet`) !== null) {
-    if (!injectedTwitterScript) {
-      injectTwitterScript()
-      injectedTwitterScript = true
-    }
+let renderTweets = false
+const allTweets = []
 
-    if (
-      typeof twttr !== `undefined` &&
-      window.twttr.widgets &&
-      typeof window.twttr.widgets.load === `function`
-    ) {
-      window.twttr.widgets.load()
-    }
+exports.onRouteUpdate = function() {
+  renderTweets = true
+  const tweets = document.querySelectorAll(`.twitter-tweet`)
+
+  // If there's an embedded tweet, lazy-load the twitter script (if it hasn't
+  // already been loaded), and then render the tweets.
+  if (tweets.length > 0) {
+    if (!document.querySelector(`#twitter-wjs`)) injectTwitterScript()
+
+    // Prevent the Twitter script automatically rendering tweets, and hide them
+    tweets.forEach(tweet => {
+      tweet.className = `twitter-tweet-unrendered`
+      tweet.style.display = `none`
+    })
+
+    window.twttr.ready(() =>
+      tweets.forEach(tweet => {
+        const url = tweet.querySelector(`a[href*="/status/"]`).href
+        const id = url.match(/\/status\/([0-9]+)/)[1]
+
+        window.twttr.widgets
+          .createTweet(id, tweet.parentNode)
+          .then(renderedTweet => {
+            if (renderTweets) {
+              tweet.parentNode.insertBefore(renderedTweet, tweet)
+              allTweets.push(renderedTweet)
+            } else {
+              renderedTweet.remove()
+            }
+          })
+      })
+    )
   }
+}
+
+exports.onPreRouteUpdate = function() {
+  // Remove rendered tweets before navigating away, to prevent
+  // memory leaks with React (since it's unaware of them)
+  allTweets.forEach(renderedTweet => renderedTweet.remove())
+
+  // Make sure tweets rendered later are removed (e.g. if the user
+  // navigates away quickly, before the Twitter script loads)
+  renderTweets = false
 }


### PR DESCRIPTION
Changes:

- Run the bootstrap code directly rather than creating an unnecessary script
- Render tweets using `createTweet` rather than automatically, so that we have more control
- Keep unrendered tweets in the DOM, to prevent React throwing errors when trying to remove them later
- Before navigating away, remove rendered tweets and prevent further renders on the same page, to prevent memory leaks

Fixes #8181