### PR TITLE
Allow sharp image processing for files without extension

### DIFF
--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -5,6 +5,7 @@ const supportedExtensions = {
   webp: true,
   tif: true,
   tiff: true,
+  '': true
 }
 
 module.exports = async function onCreateNode({ node, actions, createNodeId }) {

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -5,7 +5,7 @@ const supportedExtensions = {
   webp: true,
   tif: true,
   tiff: true,
-  '': true
+  '': true,
 }
 
 module.exports = async function onCreateNode({ node, actions, createNodeId }) {


### PR DESCRIPTION
s3 images can be saved without extension. this change allows those images to be processed.