### PR TITLE
Fix my name on v2 blog post

### DIFF
--- a/docs/blog/2018-09-14-gatsby-v2.md
+++ b/docs/blog/2018-09-14-gatsby-v2.md
@@ -214,7 +214,7 @@ Special thanks to:
 - [Shannon Soper](https://github.com/shannonbux)
 - [Flo Kissling](https://github.com/fk)
 - [Jason Stallings](https://github.com/octalmage)
-- [Porfirio Beiro](https://github.com/porfirioribeiro)
+- [Porfírio Ribeiro](https://github.com/porfirioribeiro)
 - [Yang Bo](https://github.com/youngboy)
 - [Liviu Costea](https://github.com/lcostea)
 - [Alexander Nanberg](https://github.com/alexandernanberg)


### PR DESCRIPTION
My name was misspelled on v2 launch blog post.
By the way thank's for the mention