### PR TITLE
[v2] [cache-dir] fix: rendering pages with missing data

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -346,6 +346,11 @@ const queue = {
           getResourceModule(page.componentChunkName),
           getResourceModule(page.jsonName),
         ]).then(([component, json]) => {
+          if (!(component && json)) {
+            resolve(null)
+            return
+          }
+
           const pageResources = {
             component,
             json,

--- a/packages/gatsby/cache-dir/page-renderer.js
+++ b/packages/gatsby/cache-dir/page-renderer.js
@@ -40,6 +40,7 @@ class PageRenderer extends React.Component {
   render() {
     const props = {
       ...this.props,
+      ...this.props.pageResources.json,
       pathContext: this.props.pageContext,
     }
 

--- a/packages/gatsby/cache-dir/page-renderer.js
+++ b/packages/gatsby/cache-dir/page-renderer.js
@@ -40,7 +40,6 @@ class PageRenderer extends React.Component {
   render() {
     const props = {
       ...this.props,
-      ...this.props.pageResources.json,
       pathContext: this.props.pageContext,
     }
 

--- a/packages/gatsby/cache-dir/public-page-renderer-prod.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-prod.js
@@ -9,6 +9,7 @@ const ProdPageRenderer = ({ location }) => {
   return React.createElement(InternalPageRenderer, {
     location,
     pageResources,
+    ...pageResources.json,
   })
 }
 

--- a/packages/gatsby/cache-dir/public-page-renderer-prod.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-prod.js
@@ -5,7 +5,7 @@ import InternalPageRenderer from "./page-renderer"
 import loader from "./loader"
 
 const ProdPageRenderer = ({ location }) => {
-  const pageResources = loader.getResourcesForPathname(location.pathname)
+  const pageResources = loader.getResourcesForPathnameSync(location.pathname)
   return React.createElement(InternalPageRenderer, {
     location,
     pageResources,


### PR DESCRIPTION
Changes:

- Change `getResourcesForPathname` to `getResourcesForPathnameSync` in `public-page-renderer-prod.js`
- In `public-page-renderer-prod.js`, pass the JSON data into the component props - like in `production-app.js`:
   ![image](https://user-images.githubusercontent.com/4248177/45595413-3a140b00-b9a3-11e8-99c9-42ad24bfd347.png)
  - Previously, some pages e.g. https://next.gatsbyjs.org/showcase/ (after clicking a site), would error due to missing `props.data`
- In `loader.js`, check if `component` or `json` don't exist and return null
  - This is usually when we're offline - before this change, a blank page would be displayed and a console error would appear, due to undefined `component`, but after, the native offline page is displayed.

Fixes #8193