### PR TITLE
[www] API docs: render return values

### DIFF
--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -57,7 +57,6 @@ exports.resolvableExtensions = true
  *     )
  *   })
  * }
- * @returns {Array} array of extensions
  */
 
 exports.createPages = true
@@ -193,8 +192,9 @@ exports.onCreateBabelConfig = true
  * See also the documentation for [`setWebpackConfig`](/docs/actions/#setWebpackConfig).
  *
  * @param {object} $0
- * @param {'develop' | 'develop-html' | 'build-javascript' | 'build-html'} $0.stage The current build stage
- * @param {function(): object} $0.getConfig Returns the current webpack config
+ * @param {string} $0.stage The current build stage. One of 'develop', 'develop-html',
+ * 'build-javascript', or 'build-html'
+ * @param {function} $0.getConfig Returns the current webpack config
  * @param {object} $0.rules A set of preconfigured webpack config rules
  * @param {object} $0.loaders A set of preconfigured webpack config loaders
  * @param {object} $0.plugins A set of preconfigured webpack config plugins

--- a/www/src/components/function-list.js
+++ b/www/src/components/function-list.js
@@ -80,34 +80,42 @@ export default ({ functions }) => (
             {node.params.map(param => Param(param, 0))}
           </div>
         )}
-        {(node.returns && node.returns.length > 0) && (
-          <div>
-            <h4>Return value</h4>
-            {JSON.stringify(node.returns)}
-            {node.returns.map(ret => (
-              <div
-                key={`ret ${JSON.stringify(ret)}`}
-                css={{
-                  marginLeft: `1.05rem`,
-                  ...(scale(-1 / 5)),
-                  lineHeight: options.baseLineHeight,
-                }}
-              >
-                <h5 css={{ margin: 0 }} >
-                  <span css={{ color: `#73725f` }}>{`{${ret.type.name}}`}</span>
-                </h5>
-                {ret.description && (
-                  <div
-                    css={{ marginBottom: rhythm(-1 / 4) }}
-                    dangerouslySetInnerHTML={{
-                      __html: ret.description.childMarkdownRemark.html,
-                    }}
-                  />
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+        {node.returns &&
+          node.returns.length > 0 && (
+            <div>
+              <h4>Return value</h4>
+              {node.returns.map(ret => (
+                <div
+                  key={`ret ${JSON.stringify(ret)}`}
+                  css={{
+                    marginLeft: `1.05rem`,
+                    ...scale(-1 / 5),
+                    lineHeight: options.baseLineHeight,
+                  }}
+                >
+                  <h5 css={{ margin: 0 }}>
+                    <span css={{ color: `#73725f` }}>
+                      {`{${
+                        ret.type.type === "UnionType"
+                          ? ret.type.elements
+                              .map(el => String(el.name))
+                              .join("|")
+                          : ret.type.name
+                      }}`}
+                    </span>
+                  </h5>
+                  {ret.description && (
+                    <div
+                      css={{ marginBottom: rhythm(-1 / 4) }}
+                      dangerouslySetInnerHTML={{
+                        __html: ret.description.childMarkdownRemark.html,
+                      }}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
 
         {node.examples &&
           node.examples.length > 0 && (
@@ -147,6 +155,11 @@ export const pageQuery = graphql`
     returns {
       type {
         name
+        type
+        elements {
+          name
+          type
+        }
       }
       description {
         childMarkdownRemark {

--- a/www/src/components/function-list.js
+++ b/www/src/components/function-list.js
@@ -80,6 +80,34 @@ export default ({ functions }) => (
             {node.params.map(param => Param(param, 0))}
           </div>
         )}
+        {(node.returns && node.returns.length > 0) && (
+          <div>
+            <h4>Return value</h4>
+            {JSON.stringify(node.returns)}
+            {node.returns.map(ret => (
+              <div
+                key={`ret ${JSON.stringify(ret)}`}
+                css={{
+                  marginLeft: `1.05rem`,
+                  ...(scale(-1 / 5)),
+                  lineHeight: options.baseLineHeight,
+                }}
+              >
+                <h5 css={{ margin: 0 }} >
+                  <span css={{ color: `#73725f` }}>{`{${ret.type.name}}`}</span>
+                </h5>
+                {ret.description && (
+                  <div
+                    css={{ marginBottom: rhythm(-1 / 4) }}
+                    dangerouslySetInnerHTML={{
+                      __html: ret.description.childMarkdownRemark.html,
+                    }}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
 
         {node.examples &&
           node.examples.length > 0 && (
@@ -117,7 +145,14 @@ export const pageQuery = graphql`
       }
     }
     returns {
-      title
+      type {
+        name
+      }
+      description {
+        childMarkdownRemark {
+          html
+        }
+      }
     }
     examples {
       highlighted


### PR DESCRIPTION
The API docs currently do not render a function's return value defined with jsdoc `@returns`. This PR fixes this for the simple case where
* a function defines one return value with `@returns {type} description`
* or multiple return values with the syntax `@returns {(type|type|type)] description`.

What is *not* supported is defining multiple return values as separate `@returns` statements. This currently does not work because of a bug in `gatsby-transformer-documentationjs`: the description of each `@returns` statement (`DocumentationJSComponentDescription` nodes) has the same `id` and thus all return statements get the description text of the last `@returns` statement.
What's also not supported is more complex syntax like `@returns {Array<number>}`, but I think that's not used in the API docs.

Fixes #8203

Edit: Also fix two small errors in the docs.