### PR TITLE
Reduce sidebar rerenders

### DIFF
--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -13,7 +13,7 @@ const isItemActive = (activeItemParents, item) => {
   return false
 }
 
-class Item extends React.Component {
+class Item extends React.PureComponent {
   render() {
     const {
       activeItemLink,

--- a/www/src/components/sidebar/scrollbar-position-provider.js
+++ b/www/src/components/sidebar/scrollbar-position-provider.js
@@ -7,14 +7,20 @@ const PositionContext = React.createContext({
   onPositionChange: () => {},
 })
 
+let timerId
+
 export default class ScrollPositionProvider extends Component {
   state = { positions: positionStore }
 
   onPositionChange = (cacheName, position) => {
-    this.setState(() => {
-      positionStore[cacheName] = position
-      return { positions: { ...positionStore } }
-    })
+    clearTimeout(timerId)
+    // wait until position has stopped changing
+    timerId = setTimeout(() => {
+      this.setState(() => {
+        positionStore[cacheName] = position
+        return { positions: { ...positionStore } }
+      })
+    }, 100)
   }
 
   render() {


### PR DESCRIPTION
I noticed that the sidebar scrolling wasn't always smooth. It looks like calling setState in response to scroll events was causing the sidebar tree to be repeatedly re-rendered while scrolling.

This PR adds a workaround by waiting until scrolling has finished before calling setState. I also switched the Item component out to a PureComponent so they shouldn't be re-rendered so often.

Edit: there's probably room for further improvemnt here, but this seems to be 'enough' for now. The [new React profiler](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html) is really nice, and these two articles make for good reading:

https://hackernoon.com/react-at-60fps-4e36b8189a4c
https://speakerdeck.com/vjeux/react-rally-animated-react-performance-toolbox

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->