### PR TITLE
use gatsby v2 version of filesystem plugin in gatsby-image integration test

### DIFF
--- a/integration-tests/gatsby-image/package.json
+++ b/integration-tests/gatsby-image/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-offline": "next",
     "gatsby-plugin-react-helmet": "next",
     "gatsby-plugin-sharp": "^2.0.0-rc.7",
-    "gatsby-source-filesystem": "^1.5.39",
+    "gatsby-source-filesystem": "next",
     "gatsby-transformer-sharp": "^2.1.1-rc.3",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",


### PR DESCRIPTION
should fix "TypeError:mime.getType is not a function" ( https://travis-ci.org/gatsbyjs/gatsby/jobs/429644553 )