### PR TITLE
chore: remove unused gatsby-image prop type declaration

### DIFF
--- a/integration-tests/gatsby-image/src/pages/index.js
+++ b/integration-tests/gatsby-image/src/pages/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Link } from 'gatsby'
-import PropTypes from 'prop-types'
 
 import Layout from '../components/layout'
 


### PR DESCRIPTION
This fixes a silly linting error merging #8095 introduced.