### PR TITLE
Remove gatsby-link from plugins library

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",
   "keywords": [
-    "gatsby",
-    "gatsby-component"
+    "gatsby"
   ],
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
As it's built into the `gatsby` package now.

Once we do the final v2 release, algolia _should_ stop showing
gatsby-link as the v2 version of the package will be the `latest`
version then.


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is an update to Gatsby v2?
  A. Definitely use `master` branch :)

  Q. Which branch if my change is an update to documentation or gatsbyjs.org?
  A. Use `master` branch. A Gatsby maintainer will copy your changes over to the `v1` branch for you

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->