### PR TITLE
[www] run prettier on pre-commit

### DIFF
--- a/www/.prettierrc
+++ b/www/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "es5",
+  "semi": false
+}

--- a/www/package.json
+++ b/www/package.json
@@ -94,6 +94,14 @@
     "front-matter": "^2.3.0",
     "get-package-json-from-github": "^1.2.1",
     "github-api": "^3.0.0",
+    "husky": "^1.0.0-rc.14",
+    "prettier": "^1.14.2",
+    "pretty-quick": "^1.6.0",
     "webshot": "^0.18.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }


### PR DESCRIPTION
references #7964

Runs prettier on all supported file-types in the www/ directory on pre-commit through a husky git-hook.

Started branch to mess around on my own, originally wanted to integrate ESLint and Prettier on www, dropped ESLint because the rules from higher up already apply. Figured I'd also submit this PR since it isn't huge.
