### PR TITLE
Lighthouse doc

### DIFF
--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -1,0 +1,48 @@
+---
+title: Add a manifest file
+---
+
+If you've run an [audit with Lighthouse](/audit-with-lighthouse/), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
+
+But first, what exactly _are_ PWAs?
+
+They are regular websites that take advantage of modern browser functionality to augment the web experience with app-like features and benefits. Check out [Google's overview](https://developers.google.com/web/progressive-web-apps/) of what defines a PWA experience and the [Progressive web apps (PWAs) doc](/progressive-web-app/) to learn how a Gatsby site is a progressive web app.
+
+Inclusion of a web app manifest is one of the three generally accepted [baseline requirements for a PWA](https://alistapart.com/article/yes-that-web-project-should-be-a-pwa#section1).
+
+Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest/):
+
+> The web app manifest is a simple JSON file that tells the browser about your web application and how it should behave when 'installed' on the users mobile device or desktop.
+
+[Gatsby's manifest plugin](/packages/gatsby-plugin-manifest/) configures Gatsby to create a `manifest.webmanifest` file on every site build.
+
+### Using `gatsby-plugin-manifest`
+
+1.  Install the plugin:
+
+```bash
+npm install --save gatsby-plugin-manifest
+```
+
+2.  Add the plugin to the `plugins` array in your `gatsby-config.js` file.
+
+```javascript
+{
+  plugins: [
+    {
+      resolve: `gatsby-plugin-manifest`,
+      options: {
+        name: "GatsbyJS",
+        short_name: "GatsbyJS",
+        start_url: "/",
+        background_color: "#6b37bf",
+        theme_color: "#6b37bf",
+        display: "minimal-ui",
+        icon: "src/images/icon.png", // This path is relative to the root of the site.
+      },
+    },
+  ]
+}
+```
+
+That's all you need to get started with adding a web manifest to a Gatsby site. The example given reflects a base configuration -- Check out the [plugin reference](/packages/gatsby-plugin-manifest/?=gatsby-plugin-manifest#automatic-mode) for more options.

--- a/docs/docs/add-offline-support.md
+++ b/docs/docs/add-offline-support.md
@@ -1,0 +1,38 @@
+---
+title: Add offline support
+---
+
+If you've run an [audit with Lighthouse](/audit-with-lighthouse/), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
+
+1.  You can [add a manifest file](/add-a-manifest-file/).
+2.  You can also add offline support, since another requirement for a website to qualify as a PWA is the use of a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). A service worker runs in the background, deciding to serve network or cached content based on connectivity, allowing for a seamless, managed offline experience.
+
+[Gatsby's offline plugin](/packages/gatsby-plugin-offline/) makes a Gatsby site work offline--and makes it more resistant to bad network conditions--by creating a service worker for your site.
+
+### Using `gatsby-plugin-offline`
+
+1.  Install the plugin:
+
+```bash
+npm install --save gatsby-plugin-offline
+```
+
+2.  Add the plugin to the `plugins` array in your `gatsby-config.js` file.
+
+```javascript
+{
+    plugins: [
+        {
+            resolve: `gatsby-plugin-manifest`,
+            options: {
+                ...
+            }
+        },
+        'gatsby-plugin-offline'
+    ]
+}
+```
+
+That's all you need to get started with service workers with Gatsby.
+
+> 💡 If you are also [adding a manifest file](add-a-manifest-file), the manifest plugin should be listed _before_ the offline plugin so that the offline plugin can cache the created `manifest.webmanifest`.

--- a/docs/docs/add-page-metadata.md
+++ b/docs/docs/add-page-metadata.md
@@ -1,0 +1,51 @@
+--- 
+title: Add page metadata
+---
+
+If you've run an [audit with Lighthouse](/audit-with-lighthouse/), you may have noticed a lackluster score in the "SEO" category. Let's address how you can improve that score.
+
+Adding metadata to pages (such as a title or description) are key in helping search engines like Google understand your content, and decide when to surface it in search results.
+
+[React Helmet](https://github.com/nfl/react-helmet) is a package that provides a React component interface for you to manage your [document head](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head).
+
+Gatsby's [react helmet plugin](/packages/gatsby-plugin-react-helmet/) provides drop-in support for server rendering data added with React Helmet. Using the plugin, attributes you add to React Helmet will be added to the static HTML pages that Gatsby builds.
+
+### Using `React Helmet` and `gatsby-plugin-react-helmet`
+
+1.  Install both packages:
+
+```bash
+npm install --save gatsby-plugin-react-helmet react-helmet
+```
+
+2.  Add the plugin to the `plugins` array in your `gatsby-config.js` file.
+
+```javascript
+{
+  plugins: [`gatsby-plugin-react-helmet`]
+}
+```
+
+3.  Use `React Helmet` in your pages:
+
+```jsx{8-12}
+import React from "react"
+import { Helmet } from "react-helmet"
+
+class Application extends React.Component {
+  render() {
+    return (
+      <div className="application">
+        <Helmet>
+          <meta charSet="utf-8" />
+          <title>My Title</title>
+          <link rel="canonical" href="http://mysite.com/example" />
+        </Helmet>
+        ...
+      </div>
+    )
+  }
+}
+```
+
+> 💡 The above example is from the [React Helmet docs](https://github.com/nfl/react-helmet#example). Check those out for more!

--- a/docs/docs/audit-with-lighthouse.md
+++ b/docs/docs/audit-with-lighthouse.md
@@ -1,0 +1,51 @@
+---
+title: Audit with Lighthouse
+---
+
+Quoting from the [Lighthouse website](https://developers.google.com/web/tools/lighthouse/):
+
+> Lighthouse is an open-source, automated tool for improving the quality of web pages. You can run it against any web page, public or requiring authentication. It has audits for performance, accessibility, progressive web apps (PWAs), and more.
+
+Lighthouse is included in Chrome DevTools. Running its audit -- and then addressing the errors it finds and implementing the improvements it suggests -- is a great way to prepare your site to go live. It helps give you confidence that your site is as fast and accessible as possible.
+
+If you haven't yet, you need to create a production build of your Gatsby site. The Gatsby development server is optimized for making development fast, but the site that it generates, while closely resembling a production version of the site, isn't as optimized.
+
+### Create a production build
+
+1.  Stop the development server (if it's still running) and run:
+
+```bash
+gatsby build
+```
+
+> 💡 This does a production build of your site and outputs the built static files into the `public` directory.
+
+2.  View the production site locally. Run:
+
+```bash
+gatsby serve
+```
+
+Once this starts, you can now view your site at `localhost:9000`.
+
+### Run a Lighthouse audit
+
+Now let's run your first Lighthouse test.
+
+1.  Open the site in Chrome (if you didn't already do so) and then open up the Chrome DevTools.
+
+2.  Click on the "Audits" tab where you'll see a screen that looks like:
+
+![Lighthouse audit start](./lighthouse-audit.png)
+
+3.  Click "Perform an audit..." (All available audit types should be selected by default). Then click "Run audit". (It'll then take a minute or so to run the audit). Once the audit is complete, you should see results that look like this:
+
+![Lighthouse audit results](./lighthouse-audit-results.png)
+
+As you can see, Gatsby's performance is excellent out of the box but we're missing some things for PWA, Accessibility, Best Practices, and SEO that will improve your scores (and in the process make your site much more friendly to visitors and search engines). To improve your scores further, see the links under "Next steps" below.
+
+Next steps:
+
+- [Add a manifest file](/add-a-manifest-file/)
+- [Add offline support](/add-offline-support/)
+- [Add page metadata](/add-page-metadata/)

--- a/docs/docs/lighthouse-audit.md
+++ b/docs/docs/lighthouse-audit.md
@@ -1,8 +1,0 @@
----
-title: Lighthouse audit
----
-
-This is a stub. Help our community expand it.
-
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
-pull request gets accepted.


### PR DESCRIPTION
Wondering if it'd be worth creating a doc about webpagetest.org too?

Need feedback on the division of these docs--does it make sense to have them all separate? I was thinking it does because people might search for them separately.

Another titling option would be to use the names of each plugin, since three of these docs have you use a gatsby plugin.
