### PR TITLE
test: fix failing e2e tests for gatsby-image

### DIFF
--- a/integration-tests/gatsby-image/cypress/integration/fixed.js
+++ b/integration-tests/gatsby-image/cypress/integration/fixed.js
@@ -7,7 +7,7 @@ describe(`fixed`, () => {
 
   it(`does not render a spacer div`, () => {
     cy.getTestElement(fixedTestId)
-      .find(`.gatsby-image-outer-wrapper > .gatsby-image-wrapper > div`)
+      .find(`.gatsby-image-wrapper > div`)
       .should(`not.exist`)
   })
 

--- a/integration-tests/gatsby-image/cypress/integration/fluid.js
+++ b/integration-tests/gatsby-image/cypress/integration/fluid.js
@@ -7,7 +7,7 @@ describe(`fluid`, () => {
 
   it(`renders a spacer div`, () => {
     cy.getTestElement(fluidTestId)
-      .find(`.gatsby-image-outer-wrapper > .gatsby-image-wrapper > div`)
+      .find(`.gatsby-image-wrapper > div`)
       .should(`have.attr`, `style`)
       .and(`match`, /width:100%;padding-bottom/)
   })

--- a/integration-tests/gatsby-image/cypress/integration/image.js
+++ b/integration-tests/gatsby-image/cypress/integration/image.js
@@ -6,33 +6,17 @@ describe(`Production gatsby-image`, () => {
   })
 
   describe(`wrapping elements`, () => {
-    describe(`outer`, () => {
+    describe(`outer div`, () => {
       it(`exists`, () => {
         cy.getTestElement(fluidTestId)
-          .find(`.gatsby-image-outer-wrapper`)
+          .find(`.gatsby-image-wrapper`)
           .its(`length`)
           .should(`eq`, 1)
       })
 
       it(`contains position relative`, () => {
         cy.getTestElement(fluidTestId)
-          .find(`.gatsby-image-outer-wrapper`)
-          .should(`have.attr`, `style`)
-          .and(`contains`, `position:relative`)
-      })
-    })
-
-    describe(`inner`, () => {
-      it(`exists`, () => {
-        cy.getTestElement(fluidTestId)
-          .find(`.gatsby-image-outer-wrapper > .gatsby-image-wrapper`)
-          .its(`length`)
-          .should(`eq`, 1)
-      })
-
-      it(`contains position relative`, () => {
-        cy.getTestElement(fluidTestId)
-          .find(`.gatsby-image-outer-wrapper`)
+          .find(`.gatsby-image-wrapper`)
           .should(`have.attr`, `style`)
           .and(`contains`, `position:relative`)
       })

--- a/integration-tests/gatsby-image/package.json
+++ b/integration-tests/gatsby-image/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "cypress": "^3.1.0",
     "gatsby": "next",
-    "gatsby-image": "^2.0.0-rc.2",
+    "gatsby-image": "^2.0.5",
     "gatsby-plugin-manifest": "next",
     "gatsby-plugin-offline": "next",
     "gatsby-plugin-react-helmet": "next",


### PR DESCRIPTION
This PR fixes the failing tests introduced in merging #7826, which removed the element we were using as a selector in some tests.