### PR TITLE
[gatsby-remark-autolink-headers] Add options to disable icon, customize class

### DIFF
--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -53,7 +53,8 @@ Note: if you are using `gatsby-remark-prismjs`, make sure that it’s listed aft
 ## Options
 
 - `offsetY`: Signed integer. Vertical offset value in pixels (optional)
-- `icon`: SVG shape inside a template literal. Set your own svg icon (optional)
+- `icon`: SVG shape inside a template literal or boolean `false`. Set your own svg or disable icon (optional)
+- `className`: String. Set your own class for the anchor (optional)
 
 ```javascript
 // In your gatsby-config.js
@@ -69,6 +70,7 @@ module.exports = {
               offsetY: `100`,
               icon: `<svg aria-hidden="true" height="20" version="1.1" viewBox="0 0 16 16" width="20"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`,
             },
+            className: `heading-anchor`,
           },
         ],
       },

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -1,37 +1,42 @@
 import React from "react"
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
+  let className = `anchor`
+  if (pluginOptions.className) {
+    className = pluginOptions.className
+  }
+
   let offsetY = 0
   if (pluginOptions.offsetY) {
     offsetY = pluginOptions.offsetY
   }
 
   const styles = `
-    .anchor {
+    .${className} {
       float: left;
       padding-right: 4px;
       margin-left: -20px;
     }
-    h1 .anchor svg,
-    h2 .anchor svg,
-    h3 .anchor svg,
-    h4 .anchor svg,
-    h5 .anchor svg,
-    h6 .anchor svg {
+    h1 .${className} svg,
+    h2 .${className} svg,
+    h3 .${className} svg,
+    h4 .${className} svg,
+    h5 .${className} svg,
+    h6 .${className} svg {
       visibility: hidden;
     }
-    h1:hover .anchor svg,
-    h2:hover .anchor svg,
-    h3:hover .anchor svg,
-    h4:hover .anchor svg,
-    h5:hover .anchor svg,
-    h6:hover .anchor svg,
-    h1 .anchor:focus svg,
-    h2 .anchor:focus svg,
-    h3 .anchor:focus svg,
-    h4 .anchor:focus svg,
-    h5 .anchor:focus svg,
-    h6 .anchor:focus svg {
+    h1:hover .${className} svg,
+    h2:hover .${className} svg,
+    h3:hover .${className} svg,
+    h4:hover .${className} svg,
+    h5:hover .${className} svg,
+    h6:hover .${className} svg,
+    h1 .${className}:focus svg,
+    h2 .${className}:focus svg,
+    h3 .${className}:focus svg,
+    h4 .${className}:focus svg,
+    h5 .${className}:focus svg,
+    h6 .${className}:focus svg {
       visibility: visible;
     }
   `

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -16,37 +16,35 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     showIcon = pluginOptions.icon
   }
 
-  const styles = showIcon
-    ? `
-      .${className} {
-        float: left;
-        padding-right: 4px;
-        margin-left: -20px;
-      }
-      h1 .${className} svg,
-      h2 .${className} svg,
-      h3 .${className} svg,
-      h4 .${className} svg,
-      h5 .${className} svg,
-      h6 .${className} svg {
-        visibility: hidden;
-      }
-      h1:hover .${className} svg,
-      h2:hover .${className} svg,
-      h3:hover .${className} svg,
-      h4:hover .${className} svg,
-      h5:hover .${className} svg,
-      h6:hover .${className} svg,
-      h1 .${className}:focus svg,
-      h2 .${className}:focus svg,
-      h3 .${className}:focus svg,
-      h4 .${className}:focus svg,
-      h5 .${className}:focus svg,
-      h6 .${className}:focus svg {
-        visibility: visible;
-      }
-    `
-  : ``
+  const styles = `
+    .${className} {
+      float: left;
+      padding-right: 4px;
+      margin-left: -20px;
+    }
+    h1 .${className} svg,
+    h2 .${className} svg,
+    h3 .${className} svg,
+    h4 .${className} svg,
+    h5 .${className} svg,
+    h6 .${className} svg {
+      visibility: hidden;
+    }
+    h1:hover .${className} svg,
+    h2:hover .${className} svg,
+    h3:hover .${className} svg,
+    h4:hover .${className} svg,
+    h5:hover .${className} svg,
+    h6:hover .${className} svg,
+    h1 .${className}:focus svg,
+    h2 .${className}:focus svg,
+    h3 .${className}:focus svg,
+    h4 .${className}:focus svg,
+    h5 .${className}:focus svg,
+    h6 .${className}:focus svg {
+      visibility: visible;
+    }
+  `
 
   const script = `
     document.addEventListener("DOMContentLoaded", function(event) {
@@ -64,10 +62,14 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     })
   `
 
+  const style = showIcon
+    ?  <style key={`gatsby-remark-autolink-headers-style`} type="text/css">
+        {styles}
+      </style>
+    : undefined
+
   return setHeadComponents([
-    <style key={`gatsby-remark-autolink-headers-style`} type="text/css">
-      {styles}
-    </style>,
+    style,
     <script
       key={`gatsby-remark-autolink-headers-script`}
       dangerouslySetInnerHTML={{ __html: script }}

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -11,35 +11,42 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     offsetY = pluginOptions.offsetY
   }
 
-  const styles = `
-    .${className} {
-      float: left;
-      padding-right: 4px;
-      margin-left: -20px;
-    }
-    h1 .${className} svg,
-    h2 .${className} svg,
-    h3 .${className} svg,
-    h4 .${className} svg,
-    h5 .${className} svg,
-    h6 .${className} svg {
-      visibility: hidden;
-    }
-    h1:hover .${className} svg,
-    h2:hover .${className} svg,
-    h3:hover .${className} svg,
-    h4:hover .${className} svg,
-    h5:hover .${className} svg,
-    h6:hover .${className} svg,
-    h1 .${className}:focus svg,
-    h2 .${className}:focus svg,
-    h3 .${className}:focus svg,
-    h4 .${className}:focus svg,
-    h5 .${className}:focus svg,
-    h6 .${className}:focus svg {
-      visibility: visible;
-    }
-  `
+  let showIcon = true
+  if ("icon" in pluginOptions) {
+    showIcon = pluginOptions.icon
+  }
+
+  const styles = showIcon
+    ? `
+      .${className} {
+        float: left;
+        padding-right: 4px;
+        margin-left: -20px;
+      }
+      h1 .${className} svg,
+      h2 .${className} svg,
+      h3 .${className} svg,
+      h4 .${className} svg,
+      h5 .${className} svg,
+      h6 .${className} svg {
+        visibility: hidden;
+      }
+      h1:hover .${className} svg,
+      h2:hover .${className} svg,
+      h3:hover .${className} svg,
+      h4:hover .${className} svg,
+      h5:hover .${className} svg,
+      h6:hover .${className} svg,
+      h1 .${className}:focus svg,
+      h2 .${className}:focus svg,
+      h3 .${className}:focus svg,
+      h4 .${className}:focus svg,
+      h5 .${className}:focus svg,
+      h6 .${className}:focus svg {
+        visibility: visible;
+      }
+    `
+  : ``
 
   const script = `
     document.addEventListener("DOMContentLoaded", function(event) {

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -12,7 +12,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   }
 
   let showIcon = true
-  if ("icon" in pluginOptions) {
+  if (`icon` in pluginOptions) {
     showIcon = pluginOptions.icon
   }
 

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -25,24 +25,26 @@ module.exports = ({ markdownAST }, { icon = svgIcon, className = "anchor" }) => 
     patch(data.htmlAttributes, `id`, id)
     patch(data.hProperties, `id`, id)
 
-    node.children.unshift({
-      type: `link`,
-      url: `#${id}`,
-      title: null,
-      data: {
-        hProperties: {
-          "aria-hidden": true,
-          class: className,
-        },
-        hChildren: [
-          {
-            type: `raw`,
-            // The Octicon link icon is the default. But users can set their own icon via the "icon" option.
-            value: icon,
+    if (icon !== false) {
+      node.children.unshift({
+        type: `link`,
+        url: `#${id}`,
+        title: null,
+        data: {
+          hProperties: {
+            "aria-hidden": true,
+            class: className,
           },
-        ],
-      },
-    })
+          hChildren: [
+            {
+              type: `raw`,
+              // The Octicon link icon is the default. But users can set their own icon via the "icon" option.
+              value: icon,
+            },
+          ],
+        },
+      })
+    }
   })
 
   return markdownAST

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -12,7 +12,7 @@ function patch(context, key, value) {
 
 const svgIcon = `<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`
 
-module.exports = ({ markdownAST }, { icon = svgIcon, className = "anchor" }) => {
+module.exports = ({ markdownAST }, { icon = svgIcon, className = `anchor` }) => {
   slugs.reset()
 
   visit(markdownAST, `heading`, node => {

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -12,7 +12,7 @@ function patch(context, key, value) {
 
 const svgIcon = `<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`
 
-module.exports = ({ markdownAST }, { icon = svgIcon }) => {
+module.exports = ({ markdownAST }, { icon = svgIcon, className = "anchor" }) => {
   slugs.reset()
 
   visit(markdownAST, `heading`, node => {
@@ -32,7 +32,7 @@ module.exports = ({ markdownAST }, { icon = svgIcon }) => {
       data: {
         hProperties: {
           "aria-hidden": true,
-          class: `anchor`,
+          class: className,
         },
         hChildren: [
           {


### PR DESCRIPTION
Hi! 👋Would like to propose 2 options (one is new, the other is a revision).

Add options to:
1. Disable the icon
2. Customize anchor’s class

```
plugins: [
  {
    resolve: "gatsby-remark-autolink-headers",
    options: {
      className: "custom-class",
      icon: false,
    }
  }
]
```

I’m not familiar with writing tests—I could use a hand in updating them; otherwise, happy to try and figure it out, too.

Also, what is the process for properly running tests, updating snapshots, etc. for individual packages? When I run `npm run test` I get inundated with failed tests for all packages.