### PR TITLE
Docs: Fix GitHub capitalization

### DIFF
--- a/docs/blog/2017-05-31-introduction-to-gatsby/index.md
+++ b/docs/blog/2017-05-31-introduction-to-gatsby/index.md
@@ -34,7 +34,7 @@ You could of course hard code all your content, but it’s likely you’ll want 
 
 Gatsby’s data layer is powered by GraphQL, and the tutorial walks through how to build database queries with Gatsby’s GraphiQL tool. It’s very visual, showing you exactly what your database queries will return, which for someone like me (who finds anything database-related a little scary) is a blessing.
 
-I write my blog posts in markdown files, but you could configure Gatsby to work with Github Pages, or the CMS of your choice for a better editorial experience.
+I write my blog posts in markdown files, but you could configure Gatsby to work with GitHub Pages, or the CMS of your choice for a better editorial experience.
 
 ### Deployment
 

--- a/docs/blog/2017-12-07-taking-gatsby-for-a-spin/index.md
+++ b/docs/blog/2017-12-07-taking-gatsby-for-a-spin/index.md
@@ -35,7 +35,7 @@ Can you say React without webpack? I can hardly say `hello world` without webpac
 
 ### Community
 
-Even though Gatsby is pretty new, the developers using it seem really involved. There are quite a few [articles on the Gatsby blog](/blog/). People seem to be happy to answer your Gatsby questions on Twitter and on Github you can ask anything without being shot down. Everyone is encouraged to contribute in form of plugins and pull requests, which gives me confidence that we'll see a lot of additions and improvements in the future.
+Even though Gatsby is pretty new, the developers using it seem really involved. There are quite a few [articles on the Gatsby blog](/blog/). People seem to be happy to answer your Gatsby questions on Twitter and on GitHub you can ask anything without being shot down. Everyone is encouraged to contribute in form of plugins and pull requests, which gives me confidence that we'll see a lot of additions and improvements in the future.
 
 ## Some thoughts on Gatsby
 
@@ -85,7 +85,7 @@ Incremental builds aren't yet possible, so every update means a complete rebuild
 
 ### Gatsby Image plugin is cool
 
-Did you see the SVG traced image before the image was loaded? If not, you're probably on Safari and I still haven't implemented the `intersection observer` polyfill. But in other browsers, images you add with the [gatsby image](https://using-gatsby-image.gatsbyjs.org/) component will include a blur or traced svg placeholder effect by default. It also has `srcset` and `webp`. It can use some work though it adds a few wrappers around your images that are hard to reconfigure without using `!important`. Oh and be warned, it uses `object-fit` by default, which is unsupported by IE11 and older browsers. Of course, you don't have to use this plugin and every addition / change is discussable on Github.
+Did you see the SVG traced image before the image was loaded? If not, you're probably on Safari and I still haven't implemented the `intersection observer` polyfill. But in other browsers, images you add with the [gatsby image](https://using-gatsby-image.gatsbyjs.org/) component will include a blur or traced svg placeholder effect by default. It also has `srcset` and `webp`. It can use some work though it adds a few wrappers around your images that are hard to reconfigure without using `!important`. Oh and be warned, it uses `object-fit` by default, which is unsupported by IE11 and older browsers. Of course, you don't have to use this plugin and every addition / change is discussable on GitHub.
 
 ### Keep an eye on the output
 

--- a/docs/blog/2017-12-20-introducing-the-gatsby-ux-research-program/index.md
+++ b/docs/blog/2017-12-20-introducing-the-gatsby-ux-research-program/index.md
@@ -102,9 +102,9 @@ Some specific problems with searching for plugins that interviewees described to
 
 We’re working on the final prototypes for the plugin search tool and welcome contributions from the community. Here are ways you can contribute:
 
-- Follow the plugin search tool’s progress and contribute to it on the [Github issue](https://github.com/gatsbyjs/gatsby/issues/3003).
+- Follow the plugin search tool’s progress and contribute to it on the [GitHub issue](https://github.com/gatsbyjs/gatsby/issues/3003).
 - [Contact me here](https://twitter.com/shannonb_ux/status/938551014956732418) if you have feedback that differs from or provides deeper insight into any of the pain points this article mentions
 - Follow us on [Twitter](https://twitter.com/gatsbyjs)
-- Contribute to issues in the [Github repo](https://github.com/gatsbyjs/gatsby/issues)
+- Contribute to issues in the [GitHub repo](https://github.com/gatsbyjs/gatsby/issues)
 
 Again, many thanks to all the community members who have contributed to this research and to making Gatsby awesome. Stay tuned for updates on the plugin search tool and future Gatsby UX research projects!

--- a/docs/blog/2018-02-09-announcing-gatsby-manor-themes-for-gatsbyjs/index.md
+++ b/docs/blog/2018-02-09-announcing-gatsby-manor-themes-for-gatsbyjs/index.md
@@ -75,7 +75,7 @@ months later, Gatsby Manor was born.
 ## Final notes
 
 Gatsby Manor is in public alpha stage. There are plenty of
-[Github](https://github.com/gatsbymanor) contributions to go around. To get
+[GitHub](https://github.com/gatsbymanor) contributions to go around. To get
 started, try out a Gatsby Manor theme using our tutorial on [getting started](https://www.gatsbymanor.com/docs/quick-start/getting-started). Open an
 issue if you see an area of improvement. Follow and send us positive vibes on
 Twitter using [@TheGatsbyManor](https://twitter.com/TheGatsbyManor).

--- a/docs/blog/2018-02-28-documentation-project/index.md
+++ b/docs/blog/2018-02-28-documentation-project/index.md
@@ -41,7 +41,7 @@ So why fix what isn’t broken?
 
 Many people have contributed to the docs and tutorials already and have done an excellent job. With that being said, there is still room to grow.
 
-Here is a brief overview of issues that have come up again and again as I've interviewed people and observed them going through the tutorials and docs (see [Issue #4175](https://github.com/gatsbyjs/gatsby/issues/4175) on Github to follow this and contribute):
+Here is a brief overview of issues that have come up again and again as I've interviewed people and observed them going through the tutorials and docs (see [Issue #4175](https://github.com/gatsbyjs/gatsby/issues/4175) on GitHub to follow this and contribute):
 
 - Gatsby is beginner-friendly; however, _true_ beginners to programming need an intro to basic tools like the command line, code editors, and browser consoles.
 - Upon first visit to Gatsbyjs.org, most visitors click “Get Started.” This is the perfect solution for them if they prefer to jump into coding without reading much. If they prefer step-by-step instructions, it takes some looking around before they see the tutorial tab across the top.
@@ -51,7 +51,7 @@ Here is a brief overview of issues that have come up again and again as I've int
 
 ## Documentation project beginnings
 
-After outlining the issues above and attempting to solve them myself, I realized the pooled efforts of the community would be incredibly valuable in creating solutions to these issues. So, I created the Documentation Project in Github to plan and track documentation issues.
+After outlining the issues above and attempting to solve them myself, I realized the pooled efforts of the community would be incredibly valuable in creating solutions to these issues. So, I created the Documentation Project in GitHub to plan and track documentation issues.
 
 The [Documentation Project’s](https://github.com/gatsbyjs/gatsby/projects/3) goal is to make Gatsby documentation clear, organized, and useful. Issues in the project come from the community and/or interviews with community members. This project also provides a centralized way to plan, manage, and track our progress so that we maintain and enhance the docs and tutorials.
 

--- a/docs/blog/2018-03-07-why-we-created-the-plugin-library/index.md
+++ b/docs/blog/2018-03-07-why-we-created-the-plugin-library/index.md
@@ -77,7 +77,7 @@ The plugin ecosystem is a huge part of what makes Gatsby awesome because plugins
 
 Here are some ways you can help make the Gatsby plugin ecoystem great:
 
-- Share feedback on the plugin library on [Github Issue #4394](https://github.com/gatsbyjs/gatsby/issues/4394).
+- Share feedback on the plugin library on [GitHub Issue #4394](https://github.com/gatsbyjs/gatsby/issues/4394).
 - If you created a plugin and it's not showing up in the library, double check that the package has "gatsby-plugin" in its keywords.
 - Create plugins (or publish ones you've already built)! If you're interested, the [Plugin Authoring](/docs/plugin-authoring/) page can help.
 - [Contact me](https://twitter.com/shannonb_ux/status/938551014956732418) here if you have feedback that differs from or provides deeper insight into one of the pain points this article mentions.

--- a/docs/blog/2018-04-04-gatsby-contentful-starter-tutorial/index.md
+++ b/docs/blog/2018-04-04-gatsby-contentful-starter-tutorial/index.md
@@ -28,7 +28,7 @@ Here’s an overview of what’s involved:
 
 ###Getting started
 
-This guide assumes that you have [GatsbyJS installed](/docs/) and, optionally, a [Github account](https://github.com/join). You will also need a free Contentful account - [creating one](https://www.contentful.com/sign-up/) only takes a moment.
+This guide assumes that you have [GatsbyJS installed](/docs/) and, optionally, a [GitHub account](https://github.com/join). You will also need a free Contentful account - [creating one](https://www.contentful.com/sign-up/) only takes a moment.
 
 Start by using this with the Gatsby CLI:
 
@@ -36,7 +36,7 @@ Start by using this with the Gatsby CLI:
 gatsby new contentful-starter https://github.com/contentful-userland/gatsby-contentful-starter
 ```
 
-Alternatively, you can also clone a sample repo from Github:
+Alternatively, you can also clone a sample repo from GitHub:
 
 ```bash
 git clone git@github.com:contentful-userland/gatsby-contentful-starter.git

--- a/docs/blog/2018-04-11-trying-out-gatsby-at-work-and-co/index.md
+++ b/docs/blog/2018-04-11-trying-out-gatsby-at-work-and-co/index.md
@@ -101,7 +101,7 @@ We ran into one schematic limitation working with Gatsby that’s helpful to be 
 
 [GraphQL](https://github.com/graphql/graphql-js) requires all queried fields to be defined in a schema, and Gatsby generates this schema from your site’s existing data. This means, for example, that if you don’t have a `Carousel` content model on your site right now, but you have a GraphQL query checking for it, the site will fail to build.
 
-The are some really promising discussions on the topic on Github, including an [RFC to refactor Gatsby’s schema generation](https://github.com/gatsbyjs/gatsby/issues/4261), but in the meantime, most users are getting around this issue by creating placeholder content on Contentful (or whatever their data source is) to guarantee a fully built-up schema.
+The are some really promising discussions on the topic on GitHub, including an [RFC to refactor Gatsby’s schema generation](https://github.com/gatsbyjs/gatsby/issues/4261), but in the meantime, most users are getting around this issue by creating placeholder content on Contentful (or whatever their data source is) to guarantee a fully built-up schema.
 
 This got the job done in our case, and we augmented the approach by creating a `DummyContentIndex` model on Contentful linking to all placeholder content. (In retrospect, I wish I had picked the a more PC name, like ‘PlaceholderContentIndex` 😉.) Using this approach, we could inform our Contentful scripts to make sure placeholder content was copied to the production environment during deploys, so that new models would not break the build.
 
@@ -111,7 +111,7 @@ While we were getting familiar with our Gatsby/Contentful setup, we also needed 
 
 ![our Netlify setup](./netlify.png)
 
-Unlike a single page app, which would fetch data from Contentful on the fly, our static site must rebuild anytime an editor publishes new or updated content. At the same time, we need to rebuild whenever code is updated on Github. With Netlify (and Contentful’s webhooks), I was able to set all of this up in about five minutes.
+Unlike a single page app, which would fetch data from Contentful on the fly, our static site must rebuild anytime an editor publishes new or updated content. At the same time, we need to rebuild whenever code is updated on GitHub. With Netlify (and Contentful’s webhooks), I was able to set all of this up in about five minutes.
 
 Although our China setup was still a bit of a mystery, we moved forward with dev, QA, and staging environments on Netlify, and wound up using it for US production as well.
 
@@ -151,7 +151,7 @@ To enforce such validations, we set up a static validator page that runs a repor
 
 #### 3. Communicating site status
 
-That same validation page also served as a site status page, containing the time and Github hash of the last build. The build time was particularly important. Since builds happen quite frequently (whenever content is updated), it’s helpful for the team to be able to easily see the time of the last build for a given environment. (We also had Netlify integrated to Slack, but this contained notifications about every branch and was a bit noisy for a less tech-savvy audience.)
+That same validation page also served as a site status page, containing the time and GitHub hash of the last build. The build time was particularly important. Since builds happen quite frequently (whenever content is updated), it’s helpful for the team to be able to easily see the time of the last build for a given environment. (We also had Netlify integrated to Slack, but this contained notifications about every branch and was a bit noisy for a less tech-savvy audience.)
 
 Capturing this information was easy and only took a few additional lines in our `createPages` hook. Netlify exposes a lot of interesting [environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables) (including some I hope to play with more on a future project, like `WEBHOOK_TITLE`, which can help you deduce the origin of the current build). In order to display these variables on the front end, we needed to rename them to begin with `GATSBY_`:
 
@@ -285,11 +285,11 @@ Of course, this is something developers do all the time. They push their fork to
 
 Gatsby, however, uses a monorepo architecture, so pushing up a fork with a change to a specific package is not such a trivial manner; npm and yarn just don’t support it. (If you feel like being depressed, check out the npm thread about [supporting github paths to monorepo packages](https://github.com/npm/npm/issues/2974).)
 
-Our workaround was to create a new repo for the package in question and push the build directly to Github. Here’s how it would work if you were making an update to, say, `gatsby-source-contentful`:
+Our workaround was to create a new repo for the package in question and push the build directly to GitHub. Here’s how it would work if you were making an update to, say, `gatsby-source-contentful`:
 
 - Go to your local fork of Gatsby, on the branch with your changes, and run `yarn watch` to compile a built version of your modified package.
 - Copy that package to a new directory `cp -a packages/gatsby-source-contentful path-to-my-repo`
-- Push the contents of this directory to Github and link it in your `package.json` as usual.
+- Push the contents of this directory to GitHub and link it in your `package.json` as usual.
 
 ## Following up
 

--- a/docs/blog/2018-07-07-graphic-design-class/index.md
+++ b/docs/blog/2018-07-07-graphic-design-class/index.md
@@ -39,7 +39,7 @@ Patrick wanted me to find a better, more modern solution and that’s where I st
 
 The speed is lightning fast. We removed WordPress entirely from the equation and replaced it with the more user-friendly, less of a headache [Contentful](https://www.contentful.com/).
 
-He also liked the cost-effectiveness of Godaddy but when things broke, it was a huge time suck to repair. We swapped Godaddy with [Netlify](https://netlify.com) and used Netlify to automatically run production builds from our Github repo. We wired Contentful to Netlify using a hook and to GatsbyJS using API keys and now Iron Cove’s site was fast and super simple to update. A win-win all around.
+He also liked the cost-effectiveness of Godaddy but when things broke, it was a huge time suck to repair. We swapped Godaddy with [Netlify](https://netlify.com) and used Netlify to automatically run production builds from our GitHub repo. We wired Contentful to Netlify using a hook and to GatsbyJS using API keys and now Iron Cove’s site was fast and super simple to update. A win-win all around.
 
 Patrick loved Gatsby so much he created a new product line where he is actively looking to help companies build sites using GatsbyJS and all the other tools he used on his current site.
 
@@ -68,7 +68,7 @@ Here’s a list of what they love about Gatsby:
 * _Speed_: They never heard of static site generators or the JAMstack, but the speed immediately impressed them
 * _Built off previous knowledge:_ They were able to use the routing knowledge they gleaned from NextJS
 * _Uses simple commands:_ They work locally and type `$ gatsby develop`. A server opens up and they see and can edit their site in real time. Easy peasy. They want to build for production they use `$ gatsby build && gatsby serve`. Simple!
-* _Netlify:_ When I showed them Netlify and how they could quickly (and freely) push their site to Github and hook it up to Netlify so that it would automatically build it and make their site live! They were blown away.
+* _Netlify:_ When I showed them Netlify and how they could quickly (and freely) push their site to GitHub and hook it up to Netlify so that it would automatically build it and make their site live! They were blown away.
 * _Fast to build:_ They were able to create their final projects in 3 weeks
 
 ### Anything they didn’t like?
@@ -83,7 +83,7 @@ They suggest that a link be added to the home page of Gatsby pointing to it and 
 
 ### What do you like about teaching with Gatsby?
 
-It wasn’t just Gatsby but the whole collaborative team of Gatsby, Git, Github, and Netlify that broke through to every student this term. It was amazing to witness this as a teacher. I also tried to show them blogs and Markdown but that wasn’t super smooth and none of the students added that part to their final project.
+It wasn’t just Gatsby but the whole collaborative team of Gatsby, Git, GitHub, and Netlify that broke through to every student this term. It was amazing to witness this as a teacher. I also tried to show them blogs and Markdown but that wasn’t super smooth and none of the students added that part to their final project.
 
 In my next class with Gatsby, I plan on introducing Contentful and GraphCMS to show them CAAS sites.
 

--- a/docs/blog/2018-07-17-announcing-gatsby-preview/index.md
+++ b/docs/blog/2018-07-17-announcing-gatsby-preview/index.md
@@ -21,7 +21,7 @@ When a copywriter edits a headline in their CMS, they shouldn’t have to _imagi
 
 That’s why today, we’re excited to launch a hosted preview service for teams using Gatsby.
 
-With Gatsby Preview, once teams connect their Github repositories and CMS to our service, we’ll provide a live URL where content creators can see their changes _in context_. Curious how the new paragraph header would play with the graphic to the left or the footer below? Take a look _before_ you hit publish and your changes go live.
+With Gatsby Preview, once teams connect their GitHub repositories and CMS to our service, we’ll provide a live URL where content creators can see their changes _in context_. Curious how the new paragraph header would play with the graphic to the left or the footer below? Take a look _before_ you hit publish and your changes go live.
 
 While we continue development on this product, we’re releasing it today in an invite-only alpha. To [apply to use the service, fill out this form](https://www.gatsbyjs.com/preview/) and we’ll be in touch. There will be no charge for the service while it’s in alpha.
 

--- a/docs/blog/2018-2-16-how-to-build-a-website-with-react/index.md
+++ b/docs/blog/2018-2-16-how-to-build-a-website-with-react/index.md
@@ -52,4 +52,4 @@ GatsbyJS is a great way to build websites with React and actually solves some un
 - _Creating pages and routes:_ Gatsby also gives you an intuitive interface for creating pages and routes. So intuitive, in fact, that when I talked to a coworker, I said, “I remember creating pages and links to those pages from other pages, but I don’t remember creating any routes in Gatsby.” They responded, “Yeah, Gatsby took care of that for you.”
 - _Solving performance problems:_ Gatsby sites rarely have performance problems due to Gatsby’s way of loading static files.
 
-Gatsby combines the awesomeness of React with all the friendly helpfulness you’d hope for in a modern PWA framework. Happy coding, and let us know how it goes by joining us on [Twitter](https://twitter.com/gatsbyjs) and [Github](https://github.com/gatsbyjs/gatsby)!
+Gatsby combines the awesomeness of React with all the friendly helpfulness you’d hope for in a modern PWA framework. Happy coding, and let us know how it goes by joining us on [Twitter](https://twitter.com/gatsbyjs) and [GitHub](https://github.com/gatsbyjs/gatsby)!

--- a/docs/blog/2018-2-6-choosing-a-back-end/index.md
+++ b/docs/blog/2018-2-6-choosing-a-back-end/index.md
@@ -96,7 +96,7 @@ We’ll be hearing more about Netlify in another article - their original produc
 
 One big difference from the others here is that the content in NetlifyCMS is kept in your Git repo, meaning that code and content are versioned together. You won’t ever lose content if you still have the repo, and you can see the history at the press of a button - same as you can with your code.
 
-[Gatsby has a handy tutorial for NetlifyCMS](/docs/netlify-cms/) but they do stress that in order to save to Github etc, you will need your own server:
+[Gatsby has a handy tutorial for NetlifyCMS](/docs/netlify-cms/) but they do stress that in order to save to GitHub etc, you will need your own server:
 
 > To save your content in a Git repo, the repo will need to be hosted on a service like GitHub, and you’ll need a way to authenticate with that service so Netlify CMS can make changes through the service’s API. For most services, including GitHub, authentication will require a server.
 
@@ -138,6 +138,6 @@ Cloud-hosted or Git-hosted seem to be the best for this. I don’t need a server
 
 In terms of which CMS to go with, they all have great merits and I can see them all being useful for different projects. But for my needs - for smaller side projects and for personal sites - Contentful and Prismic seem like the ones to go for. They’re both cloud-based with minimal setup and work via an API so I can access them wherever I need to. Also their free tiers have great features, and scale easily so that if I have a ‘proper’ project, I can get a version that will suit any needs.
 
-Was this post useful? Do you use any of these CMSs, or a different one? Please let me know, I’d love to hear about how you get one with them. And look out for a future post about hosting. I mentioned that NetlifyCMS runs great with Netlify, but there are other options! I’ll be looking at Github Pages, Heroku and more!
+Was this post useful? Do you use any of these CMSs, or a different one? Please let me know, I’d love to hear about how you get one with them. And look out for a future post about hosting. I mentioned that NetlifyCMS runs great with Netlify, but there are other options! I’ll be looking at GitHub Pages, Heroku and more!
 
 You can find me on [Twitter](https://twitter.com/RossWhitehouse) and [Instagram](https://www.instagram.com/ross.dw/), and [check out my other posts](https://medium.com/@RossWhitehouse)!

--- a/docs/blog/2018-2-7-jam-out-your-blog/index.md
+++ b/docs/blog/2018-2-7-jam-out-your-blog/index.md
@@ -66,7 +66,7 @@ All I wanted to do was streamline my process and here I was adding another servi
 
 To spare you the details, I spent a few hours comparing my GraphQL queries to those used in the [Gatsby + Contentful example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful) to find errors in my code. I eventually gave up and I thought that there had to be an easier way to manage content online. Luckily there is. It's called Prose.
 
-## Managing Content Via Github: Enter Prose.io
+## Managing Content Via GitHub: Enter Prose.io
 
 Prose was originally created for editing markdown files on GitHub by the people at [Development Seed](https://developmentseed.org/).
 
@@ -74,12 +74,12 @@ Prose was originally created for editing markdown files on GitHub by the people 
 
 - Simple Content Authoring Environment
 - Designed for CMS-Free Websites
-- Web-based Interface for Managing Content Directly on Github
+- Web-based Interface for Managing Content Directly on GitHub
 - Advanced Support for Markdown Content - Including Syntax Highlighting & Formatting Toolbar
 
 Source: [Prose](http://prose.io/#about)
 
-So, a service that works on top of Github where I, or anyone with a Github account can quickly create and manage posts. Sick!
+So, a service that works on top of GitHub where I, or anyone with a GitHub account can quickly create and manage posts. Sick!
 
 #### Follow these steps:
 
@@ -96,7 +96,7 @@ _**Yes, there’s more.**_
 
 Because Prose was built for Jekyll, it recognizes any headmatter you add to your .md files. This will give developers the ability to build queries and replicate familiar features from other CMS platforms. Say hello to publish states, publish date, article author and more.
 
-I should also mention that Prose is an open source project that is available for download if you wish to self-host. Check out the [documentation on Github.](https://github.com/prose/prose)
+I should also mention that Prose is an open source project that is available for download if you wish to self-host. Check out the [documentation on GitHub.](https://github.com/prose/prose)
 
 ## Get Lean and Get on Netlify
 
@@ -122,7 +122,7 @@ Let’s summarize where we are and why [Netlify](https://www.netlify.com/) will 
 
 When it comes to continuous deployment and inexpensive hosting, using Netlify is, as Josh mentions “ a no brainer.”  Check out [Netlify’s features here](https://www.netlify.com/features/) for a more in-depth look.
 
-With streamlining in mind, a workflow doesn’t get any leaner than working within the confines of Github and Netlify. Think about the magic:
+With streamlining in mind, a workflow doesn’t get any leaner than working within the confines of GitHub and Netlify. Think about the magic:
 
 1.  Use Gatsby to create your website.
 2.  Set up a GitHub repository to track changes and version history.

--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -55,8 +55,8 @@ Guides cover the smallest possible topic, while tutorials can cover a series of 
 Topics should be chosen based on these priorities:
 
 1.  Stub articles (already exist on the site but just don't have content in them yet)
-2.  Articles requested in the In Progress epics in Github Zenhub
-3.  Articles requested in the Roadmap in Github Zenhub
+2.  Articles requested in the In Progress epics in GitHub Zenhub
+3.  Articles requested in the Roadmap in GitHub Zenhub
 4.  Articles that you or other community members would like to see
 
 ### Length of a guide
@@ -145,8 +145,8 @@ If it needs to extend beyond the fold, try to keep it to the length of a piece o
 Guide overview articles are essentially new parent categories that help organize all the guide articles. Here’s how to decide if you should create a new guide overview article:
 
 1.  Stub articles (already exist on the site but just don't have content in them yet)
-2.  Articles requested in the In Progress epics in Github Zenhub
-3.  Articles requested in the Roadmap in Github Zenhub
+2.  Articles requested in the In Progress epics in GitHub Zenhub
+3.  Articles requested in the Roadmap in GitHub Zenhub
 4.  Articles that you or other community members would like to see
 
 ## Guide overview template
@@ -209,8 +209,8 @@ Guides cover the smallest possible topic, while tutorials can cover a series of 
 Topics should be chosen based on these priorities:
 
 1.  Stub articles (already exist on the site but just don't have content in them yet)
-2.  Tutorials requested in the In Progress epics in Github Zenhub
-3.  Tutorials requested in the Roadmap in Github Zenhub
+2.  Tutorials requested in the In Progress epics in GitHub Zenhub
+3.  Tutorials requested in the Roadmap in GitHub Zenhub
 4.  Tutorials that you or other community members would like to see
 
 ## Length of a tutorial

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -111,7 +111,7 @@ gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 - Starting with `gatsby` says, ‘hey, we want to use the gatsby-cli tool!’
 - `new` is a gatsby command to create a new Gatsby project.
 - Here, `hello-world` is an arbitrary title — you could pick anything. The CLI tool will place the code for your new site in a new folder called “hello-world”.
-- Lastly, the Github URL specified points to a code repository that holds the starter code you want to use. If you aren't familiar yet with git and Github, you can [learn more here](https://try.github.io/).
+- Lastly, the GitHub URL specified points to a code repository that holds the starter code you want to use. If you aren't familiar yet with git and GitHub, you can [learn more here](https://try.github.io/).
 
 ```bash
 cd hello-world

--- a/packages/gatsby-source-wordpress/src/request-in-queue.js
+++ b/packages/gatsby-source-wordpress/src/request-in-queue.js
@@ -25,7 +25,7 @@ async function handleQueue(task, cb) {
  * @typedef {Options}
  * @type {Object}
  * @see For a detailed descriptions of the options,
- *      see {@link https://www.npmjs.com/package/better-queue#full-documentation|better-queue on Github}
+ *      see {@link https://www.npmjs.com/package/better-queue#full-documentation|better-queue on GitHub}
  */
 
 /**

--- a/translations/es/CONTRIBUTING_ES.md
+++ b/translations/es/CONTRIBUTING_ES.md
@@ -61,7 +61,7 @@ Los pasos habituales para contribuir son:
 Gatsby, como era de esperar, utiliza Gatsby en la documentación de su sitio web.
 
 Si desea agregar/modificar cualquier documentación de Gatsby,debe ir a la
-[carpeta docs en Github](https://github.com/gatsbyjs/gatsby/tree/master/docs) y utilizar el editor de archivos para editar y luego ver una vista previa de tus cambios. Github luego te permite
+[carpeta docs en GitHub](https://github.com/gatsbyjs/gatsby/tree/master/docs) y utilizar el editor de archivos para editar y luego ver una vista previa de tus cambios. GitHub luego te permite
 que hagas el cambio a un commit y subas a PR justo en la interfaz de usuario. Esta es la _manera más facil_
 en la que puedes colaborar con el proyecto!
 

--- a/translations/es/docs/tutorial/part-zero/index.md
+++ b/translations/es/docs/tutorial/part-zero/index.md
@@ -111,7 +111,7 @@ gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 - Comenzando con `gatsby` decimos, '¡oye, quiero usar la herramienta gatsby-cli!'
 - `new` es un comando de gatsby para crear un nuevo proyecto de Gatsby.
 - Aquí, `hello-world` es un título arbitrario: puedes elegir cualquier cosa. La herramienta CLI colocará el código de tu nuevo sitio en una nueva carpeta llamada "hello-world".
-- Por último, el URL de Github especificado apunta a un repositorio de código que contiene el código de inicio que deseas utilizar. Si aún no estás familiarizado con git y Github, puedes [obtener más información aquí](https://try.github.io/).
+- Por último, el URL de GitHub especificado apunta a un repositorio de código que contiene el código de inicio que deseas utilizar. Si aún no estás familiarizado con git y GitHub, puedes [obtener más información aquí](https://try.github.io/).
 
 ```bash
 cd hello-world


### PR DESCRIPTION
Correct GitHub capitalization: `Github` ➡️ `GitHub`