### PR TITLE
Fix publish auth checks

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,16 +8,13 @@
       "bump": "patch",
       "conventionalCommits": true,
       "message": "chore(release): Publish",
-      "ignoreChanges": [
-        "CHANGELOG.md"
-      ]
+      "ignoreChanges": ["CHANGELOG.md"]
     }
   },
   "loglevel": "success",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "independent",
   "npmClient": "yarn",
+  "registry": "https://registry.npmjs.org/",
   "useWorkspaces": true
 }


### PR DESCRIPTION
Specify npm as the registry so that lerna's auth checks work. 


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->