### PR TITLE
[www] Replace `typography-breakpoint-constants` with `utils/presets` constants

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -70,7 +70,6 @@
     "typeface-space-mono": "^0.0.54",
     "typeface-spectral": "^0.0.54",
     "typography": "^1.0.0-alpha.4",
-    "typography-breakpoint-constants": "^1.0.0-alpha.0",
     "typography-plugin-code": "^1.0.0-alpha.0",
     "zipkin": "^0.14.0",
     "zipkin-javascript-opentracing": "^1.6.0",

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -1,12 +1,6 @@
 import Typography from "typography"
 import CodePlugin from "typography-plugin-code"
 import presets, { colors } from "./presets"
-import {
-  MOBILE_MEDIA_QUERY,
-  TABLET_MEDIA_QUERY,
-  MIN_DEFAULT_MEDIA_QUERY,
-  MIN_LARGER_DISPLAY_MEDIA_QUERY,
-} from "typography-breakpoint-constants"
 
 const headerFontFamily = [
   `Futura PT`,
@@ -51,8 +45,8 @@ const _options = {
     `Arial`,
     `sans-serif`,
   ],
-  baseFontSize: `18px`,
   baseLineHeight: 1.4,
+  baseFontSize: `16px`,
   headerLineHeight: 1.075,
   headerColor: colors.gray.dark,
   bodyColor: colors.gray.copy,
@@ -264,18 +258,17 @@ const _options = {
         height: `348px`,
         border: `none`,
       },
-      [MOBILE_MEDIA_QUERY]: {
-        // Make baseFontSize on mobile 16px.
-        html: {
-          fontSize: `${(16 / 16) * 100}%`,
-        },
-      },
-      [TABLET_MEDIA_QUERY]: {
+      [presets.Mobile]: {
         html: {
           fontSize: `${(17 / 16) * 100}%`,
         },
       },
-      [MIN_DEFAULT_MEDIA_QUERY]: {
+      [presets.Tablet]: {
+        html: {
+          fontSize: `${(18 / 16) * 100}%`,
+        },
+      },
+      [presets.Desktop]: {
         ".gatsby-highlight, .post .gatsby-resp-iframe-wrapper, .post .gatsby-resp-image-link, .gatsby-code-title": {
           marginLeft: rhythm(-options.blockMarginBottom * 1.5),
           marginRight: rhythm(-options.blockMarginBottom * 1.5),
@@ -299,7 +292,7 @@ const _options = {
           )}`,
         },
       },
-      [MIN_LARGER_DISPLAY_MEDIA_QUERY]: {
+      [presets.VVHd]: {
         html: {
           fontSize: `${(21 / 16) * 100}%`,
         },


### PR DESCRIPTION
Fixes #7944, and hopefully resolves the confusion around #4851 by now starting out with a `baseFontSize` of 16 instead of 18px. Slightly changes typography/UI breakpoints:

- MOBILE_MEDIA_QUERY = `@media only screen and (max-width:480px)`  
  -> presets.Mobile = `@media (min-width: 400px)` — we switch to 17px rem 80px earlier
- TABLET_MEDIA_QUERY = `@media only screen and (max-width:768px)`  
  -> presets.Tablet = `@media (min-width: 750px)` — we switch to 18px rem 18px earlier
- MIN_DEFAULT_MEDIA_QUERY = `@media (min-width:980px)`  
  -> presets.Desktop = `@media (min-width: 1000px)` — we pull code blocks and iframes into the gutter 20px later
- MIN_LARGER_DISPLAY_MEDIA_QUERY = `@media (min-width:1600px)`  
  -> presets.VVHd = `@media (min-width: 1650px)` — we switch to 21px rem 50px later

I’m still happy with how typography and UI behave across breakpoints with those changes in place (essentially the same). Consolidating breakpoints should make getting a grip of what is going on a little easier for everyone.

That said, I'm planning on revisiting those breakpoint names and values in a bit…;-)