### PR TITLE
Add more unittests for transformer remark

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -54,3 +54,64 @@ Object {
   },
 }
 `;
+
+exports[`Table of contents is generated correctly from schema correctly generates table of contents 1`] = `
+Object {
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+  "tableOfContents": "<ul>
+<li>
+<p><a href=\\"/my%20little%20pony/#first-title\\">first title</a></p>
+<ul>
+<li><a href=\\"/my%20little%20pony/#second-title\\">second title</a></li>
+</ul>
+</li>
+<li><a href=\\"/my%20little%20pony/#third-title\\">third title</a></li>
+</ul>",
+}
+`;
+
+exports[`Table of contents is generated correctly from schema returns null on non existing table of contents field 1`] = `
+Object {
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+  "tableOfContents": null,
+}
+`;
+
+exports[`Wordcount and timeToRead are generated correctly from schema correctly uses a default value for timeToRead 1`] = `
+Object {
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+  "timeToRead": 1,
+}
+`;
+
+exports[`Wordcount and timeToRead are generated correctly from schema correctly uses a default value for wordCount 1`] = `
+Object {
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+  "wordCount": Object {
+    "paragraphs": null,
+    "sentences": null,
+    "words": null,
+  },
+}
+`;
+
+exports[`Wordcount and timeToRead are generated correctly from schema correctly uses wordCount parameters 1`] = `
+Object {
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+  "wordCount": Object {
+    "paragraphs": 2,
+    "sentences": 19,
+    "words": 150,
+  },
+}
+`;

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -69,7 +69,7 @@ async function queryResult(nodes, fragment, { types = [] } = {}) {
   return result
 }
 
-describe(`Excerpt is generated correctly from schema`, () => {
+const bootstrapTest = (label, content, query, test, additionalParameters = {}) => {
   const node = {
     id: `whatever`,
     children: [],
@@ -78,37 +78,21 @@ describe(`Excerpt is generated correctly from schema`, () => {
       mediaType: `text/markdown`,
     },
   }
-
   // Make some fake functions its expecting.
   const loadNodeContent = node => Promise.resolve(node.content)
 
-  it(`correctly loads an excerpt`, async (done) => {
-    const content = `---
-title: "my little pony"
-date: "2017-09-18T23:19:51.246Z"
----
-Where oh where is my little pony?
-`
-
+  it(label, async (done) => {
     node.content = content
-
     const createNode = markdownNode => {
       queryResult(
         [markdownNode],
-        `
-                excerpt
-                frontmatter {
-                    title
-                }
-            `,
+        query,
         {
           types: [{ name: `MarkdownRemark` }],
         }
       ).then(result => {
         try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.excerpt).toMatch(`Where oh where is my little pony?`)
+          test(result.data.listNode[0])
           done()
         }
         catch(err) {
@@ -120,63 +104,57 @@ Where oh where is my little pony?
     const actions = { createNode, createParentChildLink }
     const createNodeId = jest.fn()
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
-
     await onCreateNode({
       node,
       loadNodeContent,
       actions,
       createNodeId,
+    },
+    { ...additionalParameters }
+    )
     })
-  })
+}
 
-  it(`correctly loads a default excerpt`, async (done) => {
-    const content = `---
+describe(`Excerpt is generated correctly from schema`, () => {
+
+  bootstrapTest(
+    `correctly loads an excerpt`,
+    `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
-`
-
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                excerpt
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.excerpt).toMatch(``)
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
+Where oh where is my little pony?`,
+    `excerpt
+    frontmatter {
+        title
     }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    `,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt).toMatch(`Where oh where is my little pony?`)
+    }
+  )
 
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    })
-  })
+  bootstrapTest(
+    `correctly loads a default excerpt`,
+    `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---`,
+    `excerpt
+    frontmatter {
+        title
+    }
+    `,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt).toMatch(``)
+    }
+  )
 
-  it(`correctly uses excerpt separator`, async (done) => {
-    const content = `---
+  bootstrapTest(
+    `correctly uses excerpt separator`,
+    `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
@@ -185,393 +163,148 @@ Where oh where is my little pony?
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
 
 In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
-
-`
-
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                excerpt
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.excerpt).toMatch(`Where oh where is my little pony?`)
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
+    `,
+    `excerpt
+    frontmatter {
+        title
     }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
+    `,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt).toMatch(`Where oh where is my little pony?`)
     },
     { excerpt_separator: `<!-- end -->` }
-    )
-  })
+  )
 
-  it(`correctly prunes length to default value`, async (done) => {
-    const content = `---
+  const content = `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
 Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
 In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
-
 `
 
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                excerpt
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.excerpt.length).toBe(139)
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
+  bootstrapTest(
+    `correctly prunes length to default value`,
+    content,
+    `excerpt
+    frontmatter {
+        title
     }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
-  })
-
-  it(`correctly prunes length to provided parameter`, async (done) => {
-    const content = `---
-title: "my little pony"
-date: "2017-09-18T23:19:51.246Z"
----
-Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
-In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
-
-`
-
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                excerpt(pruneLength: 50)
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.excerpt.length).toBe(46)
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
+    `,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt.length).toBe(139)
     }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+  )
 
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
-  })
-
-  it(`correctly prunes length to provided parameter with truncate`, async (done) => {
-    const content = `---
-title: "my little pony"
-date: "2017-09-18T23:19:51.246Z"
----
-Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
-In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
-
-`
-
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                excerpt(pruneLength: 50, truncate: true)
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.excerpt.length).toBe(50)
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
+  bootstrapTest(
+    `correctly prunes length to provided parameter`,
+    content,
+    `excerpt(pruneLength: 50)
+    frontmatter {
+        title
     }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    `,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt.length).toBe(46)
+    }
+  )
 
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
-  })
+  bootstrapTest(
+    `correctly prunes length to provided parameter with truncate`,
+    content,
+    `excerpt(pruneLength: 50, truncate: true)
+    frontmatter {
+        title
+    }
+    `,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt.length).toBe(50)
+    }
+  )
 })
 
 describe(`Wordcount and timeToRead are generated correctly from schema`, () => {
-  const node = {
-    id: `whatever`,
-    children: [],
-    internal: {
-      contentDigest: `whatever`,
-      mediaType: `text/markdown`,
-    },
-  }
-
-  // Make some fake functions its expecting.
-  const loadNodeContent = node => Promise.resolve(node.content)
-
-  it(`correctly uses wordCount parameters`, async (done) => {
-    const content = `---
+  bootstrapTest(
+    `correctly uses wordCount parameters`,
+    `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
 Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
 
 In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
-`
-
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                wordCount {
-                  words
-                  paragraphs
-                  sentences
-                }
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.wordCount).toEqual(
-            {
-            paragraphs: 2,
-            sentences: 19,
-            words: 150,
-            }
-          )
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
+`,
+    `wordCount {
+      words
+      paragraphs
+      sentences
     }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    frontmatter {
+        title
+    }`,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.wordCount).toEqual(
+        {
+        paragraphs: 2,
+        sentences: 19,
+        words: 150,
+        }
+      )
+    })
 
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
-  })
-
-  it(`correctly uses a default value for wordCount`, async (done) => {
-    const content = `---
+  const content = `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
 `
 
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                wordCount {
-                  words
-                  paragraphs
-                  sentences
-                }
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.wordCount).toEqual(
-            {
-            paragraphs: null,
-            sentences: null,
-            words: null,
-            }
-          )
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
+  bootstrapTest(
+    `correctly uses a default value for wordCount`,
+    content,
+    `wordCount {
+      words
+      paragraphs
+      sentences
     }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
-  })
-
-  it(`correctly uses a default value for timeToRead`, async (done) => {
-    const content = `---
-title: "my little pony"
-date: "2017-09-18T23:19:51.246Z"
----
-`
-
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                timeToRead
-                frontmatter {
-                    title
-                }
-            `,
+    frontmatter {
+        title
+    }`,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.wordCount).toEqual(
         {
-          types: [{ name: `MarkdownRemark` }],
+        paragraphs: null,
+        sentences: null,
+        words: null,
         }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(createdNode.timeToRead).toBe(1)
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
-    }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+      )
+    })
 
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
-  })
+  bootstrapTest(
+    `correctly uses a default value for timeToRead`,
+    content,
+    `timeToRead
+    frontmatter {
+        title
+    }`,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(node.timeToRead).toBe(1)
+    })
 })
 
 describe(`Table of contents is generated correctly from schema`, () => {
-  const node = {
-    id: `whatever`,
-    children: [],
-    internal: {
-      contentDigest: `whatever`,
-      mediaType: `text/markdown`,
-    },
-  }
+  // Used to verify that console.warn is called when field not found
+  jest.spyOn(global.console, `warn`)
 
-  // Make some fake functions its expecting.
-  const loadNodeContent = node => Promise.resolve(node.content)
-  it(`returns null on non existing table of contents field`, async (done) => {
-    const content = `---
+  bootstrapTest(
+    `returns null on non existing table of contents field`,
+    `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
@@ -582,52 +315,20 @@ some text
 ## second title
 
 some other text
-`
-    node.content = content
+`,
+    `tableOfContents
+    frontmatter {
+        title
+    }`,
+    (node) => {
+      expect(node).toMatchSnapshot()
+      expect(console.warn).toBeCalled()
+      expect(node.tableOfContents).toBe(null)
+    })
 
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                tableOfContents
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          expect(console.warn).toBeCalled()
-          expect(createdNode.tableOfContents).toBe(null)
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
-    }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-    // Used to verify that console.warn is called when field not found
-    jest.spyOn(global.console, `warn`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
-  })
-
-  it(`correctly generates table of contents`, async (done) => {
-    const content = `---
+  bootstrapTest(
+    `correctly generates table of contents`,
+    `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
@@ -642,44 +343,12 @@ some other text
 # third title
 
 final text
-`
-
-    node.content = content
-
-    const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        `
-                tableOfContents(pathToSlugField: "frontmatter.title")
-                frontmatter {
-                    title
-                }
-            `,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        }
-      ).then(result => {
-        try {
-          const createdNode = result.data.listNode[0]
-          expect(createdNode).toMatchSnapshot()
-          done()
-        }
-        catch(err) {
-          done.fail(err)
-        }
-      })
-    }
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    },
-    )
+`,
+    `tableOfContents(pathToSlugField: "frontmatter.title")
+    frontmatter {
+        title
+    }`,
+    (node) => {
+      expect(node).toMatchSnapshot()
+    })
   })
-})

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -379,3 +379,307 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     )
   })
 })
+
+describe(`Wordcount and timeToRead are generated correctly from schema`, () => {
+  const node = {
+    id: `whatever`,
+    children: [],
+    internal: {
+      contentDigest: `whatever`,
+      mediaType: `text/markdown`,
+    },
+  }
+
+  // Make some fake functions its expecting.
+  const loadNodeContent = node => Promise.resolve(node.content)
+
+  it(`correctly uses wordCount parameters`, async (done) => {
+    const content = `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
+
+In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
+`
+
+    node.content = content
+
+    const createNode = markdownNode => {
+      queryResult(
+        [markdownNode],
+        `
+                wordCount {
+                  words
+                  paragraphs
+                  sentences
+                }
+                frontmatter {
+                    title
+                }
+            `,
+        {
+          types: [{ name: `MarkdownRemark` }],
+        }
+      ).then(result => {
+        try {
+          const createdNode = result.data.listNode[0]
+          expect(createdNode).toMatchSnapshot()
+          expect(createdNode.wordCount).toEqual(
+            {
+            paragraphs: 2,
+            sentences: 19,
+            words: 150,
+            }
+          )
+          done()
+        }
+        catch(err) {
+          done.fail(err)
+        }
+      })
+    }
+    const createParentChildLink = jest.fn()
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+
+    await onCreateNode({
+      node,
+      loadNodeContent,
+      actions,
+      createNodeId,
+    },
+    )
+  })
+
+  it(`correctly uses a default value for wordCount`, async (done) => {
+    const content = `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+`
+
+    node.content = content
+
+    const createNode = markdownNode => {
+      queryResult(
+        [markdownNode],
+        `
+                wordCount {
+                  words
+                  paragraphs
+                  sentences
+                }
+                frontmatter {
+                    title
+                }
+            `,
+        {
+          types: [{ name: `MarkdownRemark` }],
+        }
+      ).then(result => {
+        try {
+          const createdNode = result.data.listNode[0]
+          expect(createdNode).toMatchSnapshot()
+          expect(createdNode.wordCount).toEqual(
+            {
+            paragraphs: null,
+            sentences: null,
+            words: null,
+            }
+          )
+          done()
+        }
+        catch(err) {
+          done.fail(err)
+        }
+      })
+    }
+    const createParentChildLink = jest.fn()
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+
+    await onCreateNode({
+      node,
+      loadNodeContent,
+      actions,
+      createNodeId,
+    },
+    )
+  })
+
+  it(`correctly uses a default value for timeToRead`, async (done) => {
+    const content = `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+`
+
+    node.content = content
+
+    const createNode = markdownNode => {
+      queryResult(
+        [markdownNode],
+        `
+                timeToRead
+                frontmatter {
+                    title
+                }
+            `,
+        {
+          types: [{ name: `MarkdownRemark` }],
+        }
+      ).then(result => {
+        try {
+          const createdNode = result.data.listNode[0]
+          expect(createdNode).toMatchSnapshot()
+          expect(createdNode.timeToRead).toBe(1)
+          done()
+        }
+        catch(err) {
+          done.fail(err)
+        }
+      })
+    }
+    const createParentChildLink = jest.fn()
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+
+    await onCreateNode({
+      node,
+      loadNodeContent,
+      actions,
+      createNodeId,
+    },
+    )
+  })
+})
+
+describe(`Table of contents is generated correctly from schema`, () => {
+  const node = {
+    id: `whatever`,
+    children: [],
+    internal: {
+      contentDigest: `whatever`,
+      mediaType: `text/markdown`,
+    },
+  }
+
+  // Make some fake functions its expecting.
+  const loadNodeContent = node => Promise.resolve(node.content)
+  it(`returns null on non existing table of contents field`, async (done) => {
+    const content = `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+# first title
+
+some text
+
+## second title
+
+some other text
+`
+    node.content = content
+
+    const createNode = markdownNode => {
+      queryResult(
+        [markdownNode],
+        `
+                tableOfContents
+                frontmatter {
+                    title
+                }
+            `,
+        {
+          types: [{ name: `MarkdownRemark` }],
+        }
+      ).then(result => {
+        try {
+          const createdNode = result.data.listNode[0]
+          expect(createdNode).toMatchSnapshot()
+          expect(console.warn).toBeCalled()
+          expect(createdNode.tableOfContents).toBe(null)
+          done()
+        }
+        catch(err) {
+          done.fail(err)
+        }
+      })
+    }
+    const createParentChildLink = jest.fn()
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    // Used to verify that console.warn is called when field not found
+    jest.spyOn(global.console, `warn`)
+
+    await onCreateNode({
+      node,
+      loadNodeContent,
+      actions,
+      createNodeId,
+    },
+    )
+  })
+
+  it(`correctly generates table of contents`, async (done) => {
+    const content = `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+# first title
+
+some text
+
+## second title
+
+some other text
+
+# third title
+
+final text
+`
+
+    node.content = content
+
+    const createNode = markdownNode => {
+      queryResult(
+        [markdownNode],
+        `
+                tableOfContents(pathToSlugField: "frontmatter.title")
+                frontmatter {
+                    title
+                }
+            `,
+        {
+          types: [{ name: `MarkdownRemark` }],
+        }
+      ).then(result => {
+        try {
+          const createdNode = result.data.listNode[0]
+          expect(createdNode).toMatchSnapshot()
+          done()
+        }
+        catch(err) {
+          done.fail(err)
+        }
+      })
+    }
+    const createParentChildLink = jest.fn()
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+
+    await onCreateNode({
+      node,
+      loadNodeContent,
+      actions,
+      createNodeId,
+    },
+    )
+  })
+})


### PR DESCRIPTION
Following the work with https://github.com/gatsbyjs/gatsby/pull/8075 and https://github.com/gatsbyjs/gatsby/pull/7759
i added some more tests to extend-node-type (mainly to test the table of contents as was asked in the #7759 PR)
