### PR TITLE
fix(netlify-cms): redirect after git gateway login

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
@@ -1,4 +1,12 @@
+/* global __PATH_PREFIX__ CMS_PUBLIC_PATH */
 import netlifyIdentityWidget from "netlify-identity-widget"
 
 window.netlifyIdentity = netlifyIdentityWidget
+netlifyIdentityWidget.on(`init`, user => {
+  if (!user) {
+    netlifyIdentityWidget.on(`login`, () => {
+      document.location.href = `${__PATH_PREFIX__}/${CMS_PUBLIC_PATH}/`
+    })
+  }
+})
 netlifyIdentityWidget.init()

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -34,7 +34,7 @@ function deepMap(obj, fn) {
 }
 
 exports.onCreateWebpackConfig = (
-  { store, stage, getConfig, plugins },
+  { store, stage, getConfig, plugins, pathPrefix },
   {
     modulePath,
     publicPath = `admin`,
@@ -126,6 +126,14 @@ exports.onCreateWebpackConfig = (
          * `HtmlWebpackPlugin` config.
          */
         new HtmlWebpackExcludeAssetsPlugin(),
+
+        /**
+         * Pass in needed Gatsby config values.
+         */
+        new webpack.DefinePlugin({
+          __PATH__PREFIX__: pathPrefix,
+          CMS_PUBLIC_PATH: JSON.stringify(publicPath),
+        }),
       ].filter(p => p),
 
       /**


### PR DESCRIPTION
Redirect/reload Netlify CMS after login. Tested in dev and production, works correctly both with Gatsby `pathPrefix` and custom `publicPath` in the plugin options.

Fixes #8085.