### PR TITLE
Prevent error when no gatsby-config.js

### DIFF
--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -10,10 +10,11 @@ module.exports = async program => {
   let { prefixPaths, port, open } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 
-  let { pathPrefix } = await preferDefault(
+  const config = await preferDefault(
     getConfigFile(program.directory, `gatsby-config`)
   )
 
+  let pathPrefix = config && config.pathPrefix
   pathPrefix = prefixPaths && pathPrefix ? pathPrefix : `/`
 
   const app = express()


### PR DESCRIPTION
This PR avoids a `ReferenceError: pathPrefix is not defined` error when running `gatsby serve` on a site with no gatsby-config.js

It's rare but not impossible for a site to have no config file - see https://github.com/gatsbyjs/gatsby-starter-hello-world. 
