### PR TITLE
ci: only run integration tests on pull requests

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -3,7 +3,9 @@ INTEGRATION_TEST=$1
 SRC_PATH=$2
 GATSBY_PATH="${TRAVIS_BUILD_DIR:-../../}" # set to third arg if defined, otherwise use ../../
 
-if [[ "$INTEGRATION_TEST" = true ]]; then
+is_pull_request='^[0-9]+$'
+
+if [[ "$INTEGRATION_TEST" = true && "$TRAVIS_PULL_REQUEST" =~ $is_pull_request ]]; then
   npm install -g gatsby-dev-cli
 
   # bootstrapping all packages so we test _this_ PR's changes


### PR DESCRIPTION
Note: this may be a controversial change, but I think the integration
tests running on _every_ event (merge/pr/etc.) are key to the slow down,
and this will help improve that.

Longer term, I'd like to figure out #8269