### PR TITLE
add key to page props within PageRenderer render, not for all PageRenderer instances

### DIFF
--- a/packages/gatsby/cache-dir/json-store.js
+++ b/packages/gatsby/cache-dir/json-store.js
@@ -91,7 +91,6 @@ class JSONStore extends React.Component {
     return (
       <StaticQueryContext.Provider value={this.state.staticQueryData}>
         <PageRenderer
-          key={this.props.location.pathname}
           {...propsWithoutPages}
           {...data}
         />

--- a/packages/gatsby/cache-dir/page-renderer.js
+++ b/packages/gatsby/cache-dir/page-renderer.js
@@ -41,7 +41,6 @@ class PageRenderer extends React.Component {
     const props = {
       ...this.props,
       pathContext: this.props.pageContext,
-      key: this.props.location.pathname,
     }
 
     const [replacementElement] = apiRunner(`replaceComponentRenderer`, {
@@ -51,7 +50,10 @@ class PageRenderer extends React.Component {
 
     const pageElement =
       replacementElement ||
-      createElement(this.props.pageResources.component, props)
+      createElement(this.props.pageResources.component, {
+        ...props,
+        key: this.props.location.pathname,
+      })
 
     const wrappedPage = apiRunner(
       `wrapPageElement`,

--- a/packages/gatsby/cache-dir/page-renderer.js
+++ b/packages/gatsby/cache-dir/page-renderer.js
@@ -41,6 +41,7 @@ class PageRenderer extends React.Component {
     const props = {
       ...this.props,
       pathContext: this.props.pageContext,
+      key: this.props.location.pathname,
     }
 
     const [replacementElement] = apiRunner(`replaceComponentRenderer`, {

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -50,7 +50,6 @@ apiRunnerAsync(`onClientEntry`).then(() => {
           <EnsureResources location={location}>
             {({ pageResources, location }) => (
               <PageRenderer
-                key={location.pathname}
                 {...this.props}
                 location={location}
                 pageResources={pageResources}

--- a/packages/gatsby/cache-dir/public-page-renderer-prod.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-prod.js
@@ -7,7 +7,6 @@ import loader from "./loader"
 const ProdPageRenderer = ({ location }) => {
   const pageResources = loader.getResourcesForPathnameSync(location.pathname)
   return React.createElement(InternalPageRenderer, {
-    key: location.pathname,
     location,
     pageResources,
     ...pageResources.json,


### PR DESCRIPTION
re fix-issue #8181 
fix pull #8218 add key To PageRenderer
add key to page props within PageRenderer render, not for all PageRenderer instances

more info: #8218 

---edit by pieh:
fixes #8250 and #8262