### PR TITLE
Fixed typo in test name

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-test.js
@@ -551,7 +551,7 @@ describe(`GraphQL Input args`, () => {
     expect(result.data.allNode.edges[0].node.name).toEqual(`The Mad Wax`)
   })
 
-  it(`handles the in operator for array of objects`, async () => {
+  it(`handles the elemMatch operator for array of objects`, async () => {
     let result = await queryResult(
       nodes,
       `


### PR DESCRIPTION
When trying to filter an array of objects:

- In v1 `in` gets autocompleted, but doesn't work, and `elemMatch` is undefined. 
- In v2 `elemMatch` gets autocompleted and works 🎉 

I got a bit confused between which version I was on, and this lil typo got me even more confused 😅 

Thanks for Gatsby v2 ❤️ 

-----

refs https://github.com/gatsbyjs/gatsby/pull/6315

- In was changed to elemMatch for arrays of objects but this one reference was missed

