### PR TITLE
scripts: fix an issue with the build-examples script

### DIFF
--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -2,7 +2,7 @@
 
 status=""
 
-yarn bootstrap && cd examples
+yarn bootstrap && cd examples &&
 
 for example in *; do
   if [ -d "$example" ]; then

--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -2,8 +2,7 @@
 
 status=""
 
-yarn boostrap &&
-cd examples &&
+yarn bootstrap && cd examples
 
 for example in *; do
   if [ -d "$example" ]; then


### PR DESCRIPTION
Fixes an issue with `boostrap` vs. `bootstrap`

(Minor one!)