### PR TITLE
[v2] Update Redux to v4

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -102,7 +102,7 @@
     "react-dev-utils": "^4.2.1",
     "react-error-overlay": "^3.0.0",
     "react-hot-loader": "^4.1.0",
-    "redux": "^3.6.0",
+    "redux": "^4.0.0",
     "relay-compiler": "1.5.0",
     "request": "^2.85.0",
     "shallow-compare": "^1.2.2",


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

## Summary

Redux 4 has been released for a while. Shall we update the dependency?

I've already tested the change in my fork and nothing is breaking.

### Motivation

Redux 4 has updated its TypeScript bindings. Personally, I prefer the new version much.

Putting it aside, Redux 4 has es modules support and dropped its dependency on `lodash`. Hence, it can make the bundle smaller.

close #8265