### PR TITLE
add a reference to the plugins documentation page on the plugins library page

### DIFF
--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -65,6 +65,9 @@ class Plugins extends Component {
                 {` `}
                 <Link to="/docs/plugin-authoring/">Plugin Authoring</Link> page
                 in the docs!
+                To learn more, visit the
+                {` `}
+                <Link to="/docs/plugins">plugins</Link> doc page.
               </p>
             </div>
           </Container>


### PR DESCRIPTION
refs #7848 

Please let me know if you have any feedback.

![image](https://user-images.githubusercontent.com/11466782/45727054-9c2d6580-bb87-11e8-9984-350c3c65641e.png)
