### PR TITLE
Added overview graph to behind the scenes

### DIFF
--- a/docs/docs/behind-the-scenes.md
+++ b/docs/docs/behind-the-scenes.md
@@ -10,4 +10,136 @@ These docs aren't supposed to be definitive, or tell you everything there is to 
 
 A few more things. These docs are mostly focused on `gatsby build`. Operations specific to `gatsby develop` are mostly ignored. Though this may change in the future. Also, they mostly focus on the happy path, rather than getting bogged down in details of error handling.
 
-Ready? Dive in by exploring how [APIs/Plugins](/docs/how-plugins-apis-are-run/) work.
+The graph below shows roughly how all the sub systems of Gatsby fit together and the input/output artifacts at different parts of the build. To find out how different parts work, click on the nodes in the graph, or use the menu on the left.
+
+```dot
+digraph graphname {
+
+  node [ style = filled, fillcolor = white ];
+
+  ## Legend
+
+  subgraph cluster_legend {
+    label = "Legend";
+    gatsby [ label = "Gatsby", width=1 ];
+    redux [ label = "redux namespace", shape = box, fillcolor = skyblue, width=1 ];
+    cache [ label = "site/.cache/", shape = cylinder, fillcolor = moccasin, width=1 ];
+    public [ label ="site/public/", shape = cylinder, fillcolor = palegreen, width=1 ];
+    siteData [ label = "site/external data", fillcolor = gray, width=1 ];
+
+    siteData -> gatsby [ style = invis ];
+    gatsby -> redux [ style = invis ] ;
+    redux -> cache [ style = invis ];
+    cache -> public [ style = invis ];
+  }
+
+  ## Source Nodes
+
+  dataSource [ label = "data sources. e.g file, contentful", shape = cylinder, fillcolor = gray ];
+  sourceNodes [ label = "source nodes" URL = "/docs/node-creation/" ];
+  nodes [ label = "nodes", shape = box, fillcolor = skyblue, URL = "/docs/node-creation/" ];
+  nodesTouched [ label = "touchedNodes", shape = box, fillcolor = skyblue, URL = "/docs/node-creation/#freshstale-nodes" ];
+  rootNodeMap [ label = "rootNodeMap", shape = box, fillcolor = skyblue, URL = "docs/node-tracking/" ];
+
+  dataSource -> sourceNodes;
+  sourceNodes -> nodes;
+  sourceNodes -> nodesTouched;
+  sourceNodes -> rootNodeMap;
+
+  ## Schema
+
+  pluginResolvers [ label = "plugin resolvers", fillcolor = gray, URL = "/docs/schema-input-gql/#inferring-input-filters-from-plugin-fields" ];
+  generateSchema [ label = "generate schema", URL = "/docs/schema-generation/" ];
+  schema [ label = "schema\l (inc resolvers)", shape = box, fillcolor = skyblue ];
+
+  nodes -> generateSchema;
+  nodes -> schema;
+  pluginResolvers -> generateSchema;
+  rootNodeMap -> generateSchema;
+  generateSchema -> schema;
+
+  ## Pages
+
+  componentFiles [ label = "React components\l (src/template.js)", shape = cylinder, fillcolor = gray ];
+  createPages [ label = "site.createPages", URL = "/docs/page-creation/" ];
+  pages [ label = "pages", shape = box, fillcolor = skyblue ];
+  components [ label = "components", shape = box, fillcolor = skyblue ];
+
+  schema -> createPages;
+  componentFiles -> createPages;
+  createPages -> pages;
+  createPages -> components;
+
+  ## Query
+
+  fragments [ label = "query fragments *.js", shape = cylinder, fillcolor = gray ];
+  runQueries [ label = "extract and run queries", URL = "/docs/query-behind-the-scenes/" ];
+  componentsWithQueries [ label = "components\l (with queries)", shape = box, fillcolor = skyblue ];
+  queryResults [ label = "JSON result\l /public/static/d/dataPath", shape = cylinder, fillcolor = palegreen, URL = "/docs/query-execution/#save-query-results-to-redux-and-disk" ];
+  dataPaths [ label = "jsonDataPaths", shape = box, fillcolor = skyblue ];
+
+  fragments -> runQueries;
+  schema -> runQueries;
+  pages -> runQueries;
+  components -> runQueries;
+  runQueries -> componentsWithQueries;
+  runQueries -> queryResults;
+  runQueries -> dataPaths;
+
+  ## Write Pages
+
+  writePages [ label = "writePages", URL = "/docs/write-pages/" ];
+  dataJson [ label = "data.json", shape = cylinder, fillcolor = moccasin ];
+  asyncRequires [ label = "async-requires.js", shape = cylinder, fillcolor = moccasin ];
+  syncRequires [ label = "sync-requires.js", shape = cylinder, fillcolor = moccasin ];
+  pagesJson [ label = "pages.json", shape = cylinder, fillcolor = moccasin ];
+
+  dataPaths -> writePages;
+  components -> writePages;
+  pages -> writePages;
+  writePages -> dataJson;
+  writePages -> asyncRequires;
+  writePages -> syncRequires;
+  writePages -> pagesJson;
+
+  ## App.js
+
+  appWebpack [ label = "configure webpack\l (`build-javascript`)", URL = "/docs/production-app/#webpack-config" ];
+  productionApp [ label = "production-app.js", shape = cylinder, fillcolor = moccasin, URL = "/docs/production-app/#production-appjs" ];
+  buildJavascript [ label = "build-javascript.js", URL = "/docs/production-app/" ];
+  componentChunks [ label = "component chunks\l component---src-blog-[hash].js", shape = cylinder, fillcolor = palegreen, URL = "/docs/how-code-splitting-works/" ];
+  appChunk [ label = "app-[hash].js", shape = cylinder, fillcolor = palegreen ];
+  webpackStats [ label = "webpack.stats.json", shape = cylinder, fillcolor = palegreen, URL = "/docs/how-code-splitting-works/#webpackstatsjson" ];
+  chunkMap [ label = "chunk-map.json", shape = cylinder, fillcolor = palegreen, URL = "/docs/how-code-splitting-works/#chunk-mapjson" ];
+
+  appWebpack -> buildJavascript;
+  asyncRequires -> productionApp;
+  dataJson -> productionApp;
+  productionApp -> buildJavascript;
+  buildJavascript -> componentChunks;
+  buildJavascript -> appChunk;
+  buildJavascript -> webpackStats;
+  buildJavascript -> chunkMap;
+
+  queryResults -> componentChunks;
+
+  ## Generate html
+
+  htmlWebpack [ label = "configure webpack\l (`build-html`)", URL = "/docs/html-generation/#webpack" ];
+  staticEntry [ label = "static-entry.js", shape = cylinder, fillcolor = moccasin, URL = "/docs/html-generation/#static-entryjs" ];
+  buildHtml [ label = "build-html.js", URL = "/docs/html-generation/" ];
+  pageRenderer [ label = "page-renderer.js", shape = cylinder, fillcolor = palegreen ];
+  htmlFiles [ label = "html files\l (index.html)", shape = cylinder, fillcolor = palegreen ];
+
+  htmlWebpack -> buildHtml;
+  syncRequires -> staticEntry;
+  dataJson -> staticEntry;
+  webpackStats -> staticEntry;
+  chunkMap -> staticEntry;
+  staticEntry -> buildHtml;
+  buildHtml -> pageRenderer;
+  pages -> buildHtml;
+  pageRenderer -> buildHtml;
+  buildHtml -> htmlFiles;
+}
+```

--- a/docs/docs/node-creation.md
+++ b/docs/docs/node-creation.md
@@ -8,7 +8,7 @@ A node is stored in redux under the `nodes` namespace, whose state is a map of t
 
 ## Sourcing Nodes
 
-Nodes are created in Gatsby by calling [createNode](/docs/actions/#createNode). This happens primarily in the [sourceNodes](/docs/node-apis/#sourceNodes) bootstrap phase. Nodes created during this phase are top level nodes. I.e, they have no parent. This is represented by source plugins setting the node's `parent` field to `___SOURCE___`. Nodes created via transform plugins (who implement [onCreateNode](/docs/node-apis/#onCreateNode)) will have source nodes as their parents, or other transformed nodes. For a rough overview of what happens when source nodes run, see the [traceID illustration](/docs/how-plugins-apis-are-run/#using-traceid-to-await-downstream-api-calls).
+The creation of nodes occurs primarily in the [sourceNodes](/docs/node-apis/#sourceNodes) bootstrap phase. Nodes created during this phase are top level nodes. I.e, they have no parent. This is represented by source plugins setting the node's `parent` field to `___SOURCE___`. Nodes created via transform plugins (who implement [onCreateNode](/docs/node-apis/#onCreateNode)) will have source nodes as their parents, or other transformed nodes. For a rough overview of what happens when source nodes run, see the [traceID illustration](/docs/how-plugins-apis-are-run/#using-traceid-to-await-downstream-api-calls).
 
 ## Parent/Child/Refs
 


### PR DESCRIPTION
Added an overview graph to the "behind the scenes" intro. Makes it easier to grok the whole build process. Looks like so:

<img width="787" alt="screen shot 2018-09-19 at 1 10 22 pm" src="https://user-images.githubusercontent.com/495730/45728895-6fbc2c80-bc0d-11e8-9a88-e7ddae18cad7.png">
