### PR TITLE
[www] Pin gatsby-remark-prismjs@3.0.0-beta.6 (again)

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -34,7 +34,7 @@
     "gatsby-remark-copy-linked-files": "^2.0.5",
     "gatsby-remark-graphviz": "^1.0.0",
     "gatsby-remark-images": "^2.0.1",
-    "gatsby-remark-prismjs": "^3.0.0",
+    "gatsby-remark-prismjs": "3.0.0-beta.6",
     "gatsby-remark-responsive-iframe": "^2.0.5",
     "gatsby-remark-smartypants": "^2.0.5",
     "gatsby-source-filesystem": "^2.0.1",


### PR DESCRIPTION
Hotfix for #8058.
Pinned version from #8068 got lost in #8231.