### PR TITLE
[gatsby-image] Optional “slot” inside wrapper

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -79,8 +79,9 @@ plugins: [
 ```
 
 Also, make sure you have set up a source plugin, so your images are available in `graphql` queries. For example, if your images live in a project folder on the local filesystem, you would set up `gatsby-source-filesystem` in `gatsby-config.js` like so:
+
 ```js
-const path = require(`path`);
+const path = require(`path`)
 
 module.exports = {
   plugins: [
@@ -88,13 +89,13 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `images`,
-        path: path.join(__dirname, `src`, `images`)
-      }
+        path: path.join(__dirname, `src`, `images`),
+      },
     },
     `gatsby-plugin-sharp`,
-    `gatsby-transformer-sharp`
-  ]
-};
+    `gatsby-transformer-sharp`,
+  ],
+}
 ```
 
 ## How to use
@@ -264,21 +265,21 @@ prop. e.g. `<Img fluid={fluid} />`
 
 ## `gatsby-image` props
 
-| Name                    | Type                | Description                                                                                                                 |
-| ----------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `fixed`                 | `object`            | Data returned from the `fixed` query                                                                                        |
-| `fluid`                 | `object`            | Data returned from the `fluid` query                                                                                        |
-| `fadeIn`                | `bool`              | Defaults to fading in the image on load                                                                                     |
-| `title`                 | `string`            | Passed to the `img` element                                                                                                 |
-| `alt`                   | `string`            | Passed to the `img` element                                                                                                 |
-| `className`             | `string` / `object` | Passed to the wrapper element. Object is needed to support Glamor's css prop                                                |
-| `style`                 | `object`            | Spread into the default styles in the wrapper element                                                                       |
-| `imgStyle`              | `object`            | Spread into the default styles for the actual `img` element                                                                 |
-| `backgroundColor`       | `string` / `bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
-| `onLoad`                | `func`              | A callback that is called when the full-size image has loaded.                                                              |
-| `Tag`                   | `string`            | Which HTML tag to use for wrapping elements. Defaults to `div`.                                                             |
-| `critical`              | `bool`              | Opt-out of lazy-loading behavior. Defaults to `false`.                                                                      |
-| `innerChild`            | `node`              | Optional “Slot” prop that takes any React element to be rendered before the closing tag of the wrapper element.                                                                      |
+| Name              | Type                | Description                                                                                                                 |
+| ----------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `fixed`           | `object`            | Data returned from the `fixed` query                                                                                        |
+| `fluid`           | `object`            | Data returned from the `fluid` query                                                                                        |
+| `fadeIn`          | `bool`              | Defaults to fading in the image on load                                                                                     |
+| `title`           | `string`            | Passed to the `img` element                                                                                                 |
+| `alt`             | `string`            | Passed to the `img` element                                                                                                 |
+| `className`       | `string` / `object` | Passed to the wrapper element. Object is needed to support Glamor's css prop                                                |
+| `style`           | `object`            | Spread into the default styles in the wrapper element                                                                       |
+| `imgStyle`        | `object`            | Spread into the default styles for the actual `img` element                                                                 |
+| `backgroundColor` | `string` / `bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
+| `onLoad`          | `func`              | A callback that is called when the full-size image has loaded.                                                              |
+| `Tag`             | `string`            | Which HTML tag to use for wrapping elements. Defaults to `div`.                                                             |
+| `critical`        | `bool`              | Opt-out of lazy-loading behavior. Defaults to `false`.                                                                      |
+| `innerChild`      | `node`              | Optional “Slot” prop that takes any React element to be rendered before the closing tag of the wrapper element.             |
 
 ## Image processing arguments
 
@@ -292,18 +293,20 @@ The `innerChild` prop is an optional “slot” that accepts any valid React nod
 Example of where this can be useful: overlaying text on top of images.
 
 ```jsx
-  <Img
-    // your other props, such as fixed / fluid, etc.
-    innerChild={
-      <p style={{
+<Img
+  // your other props, such as fixed / fluid, etc.
+  innerChild={
+    <p
+      style={{
         position: `absolute`,
         bottom: 0,
         left: 0,
-      }}>
-        Hello, I’m a text overlaid on top of the image
-      </p>
-    }
-  />
+      }}
+    >
+      Hello, I’m a text overlaid on top of the image
+    </p>
+  }
+/>
 ```
 
 ## Some other stuff to be aware of

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -278,11 +278,33 @@ prop. e.g. `<Img fluid={fluid} />`
 | `onLoad`                | `func`              | A callback that is called when the full-size image has loaded.                                                              |
 | `Tag`                   | `string`            | Which HTML tag to use for wrapping elements. Defaults to `div`.                                                             |
 | `critical`              | `bool`              | Opt-out of lazy-loading behavior. Defaults to `false`.                                                                      |
+| `innerChild`            | `node`              | Optional “Slot” prop that takes any React element to be rendered before the closing tag of the wrapper element.                                                                      |
 
 ## Image processing arguments
 
 [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp) supports many additional arguments for transforming your images like
 `quality`, `sizeByPixelDensity`, `pngCompressionLevel`, `cropFocus`, `greyscale` and many more. See its documentation for more.
+
+## Inserting additional DOM element(s) inside the wrapper element
+
+The `innerChild` prop is an optional “slot” that accepts any valid React node. It will render the node before the wrapper element’s closing tag.
+
+Example of where this can be useful: overlaying text on top of images.
+
+```jsx
+  <Img
+    // your other props, such as fixed / fluid, etc.
+    innerChild={
+      <p style={{
+        position: `absolute`,
+        bottom: 0,
+        left: 0,
+      }}>
+        Hello, I’m a text overlaid on top of the image
+      </p>
+    }
+  />
+```
 
 ## Some other stuff to be aware of
 
@@ -291,7 +313,7 @@ prop. e.g. `<Img fluid={fluid} />`
 - By default, images don't load until JavaScript is loaded. Gatsby's automatic code
   splitting generally makes this fine but if images seem slow coming in on a
   page, check how much JavaScript is being loaded there.
-- Images marked as `critical` will start loading immediately as the DOM is 
+- Images marked as `critical` will start loading immediately as the DOM is
   parsed, but unless `fadeIn` is set to `false`, the transition from placeholder
   to final image will not occur until after the component is mounted.
 - Gatsby-Image now is backed by newer `<picture>` tag. This newer standard allows for

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -30,6 +30,11 @@ exports[`<Img /> should render fixed size images 1`] = `
     <noscript>
       &lt;picture&gt;&lt;source type='image/webp' srcSet="some srcSetWebp" /&gt;&lt;source srcSet="some srcSet" /&gt;&lt;img width="100" height="100" src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
     </noscript>
+    <div
+      style="position: absolute; left: 0px; bottom: 0px;"
+    >
+      Text Overlay
+    </div>
   </div>
 </div>
 `;
@@ -67,6 +72,11 @@ exports[`<Img /> should render fluid images 1`] = `
     <noscript>
       &lt;picture&gt;&lt;source type='image/webp' srcSet="some srcSetWebp" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;source srcSet="some srcSet" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;img src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:0.5s;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
     </noscript>
+    <div
+      style="position: absolute; left: 0px; bottom: 0px;"
+    >
+      Text Overlay
+    </div>
   </div>
 </div>
 `;

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -33,6 +33,17 @@ const setup = (fluid = false, onLoad = () => {}, onError = () => {}) => {
       {...!fluid && { fixed: fixedShapeMock }}
       onLoad={onLoad}
       onError={onError}
+      innerChild={
+        <div
+          style={{
+            position: `absolute`,
+            left: 0,
+            bottom: 0,
+          }}
+        >
+          Text Overlay
+        </div>
+      }
     />
   )
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -74,21 +74,26 @@ const noscriptImg = props => {
   // HTML validation issues caused by empty values like width="" and height=""
   const src = props.src ? `src="${props.src}" ` : `src="" ` // required attribute
   const sizes = props.sizes ? `sizes="${props.sizes}" ` : ``
-  const srcSetWebp = props.srcSetWebp ? `<source type='image/webp' srcSet="${props.srcSetWebp}" ${sizes}/>` : ``
-  const srcSet = props.srcSet ? `<source srcSet="${props.srcSet}" ${sizes}/>` : ``
+  const srcSetWebp = props.srcSetWebp
+    ? `<source type='image/webp' srcSet="${props.srcSetWebp}" ${sizes}/>`
+    : ``
+  const srcSet = props.srcSet
+    ? `<source srcSet="${props.srcSet}" ${sizes}/>`
+    : ``
   const title = props.title ? `title="${props.title}" ` : ``
   const alt = props.alt ? `alt="${props.alt}" ` : `alt="" ` // required attribute
   const width = props.width ? `width="${props.width}" ` : ``
   const height = props.height ? `height="${props.height}" ` : ``
   const opacity = props.opacity ? props.opacity : `1`
   const transitionDelay = props.transitionDelay ? props.transitionDelay : `0.5s`
-  return (`<picture>${srcSetWebp}${srcSet}<img ${width}${height}${src}${alt}${title}style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"/></picture>`)
+  return `<picture>${srcSetWebp}${srcSet}<img ${width}${height}${src}${alt}${title}style="position:absolute;top:0;left:0;transition:opacity 0.5s;transition-delay:${transitionDelay};opacity:${opacity};width:100%;height:100%;object-fit:cover;object-position:center"/></picture>`
 }
 
 const Img = React.forwardRef((props, ref) => {
   const { style, onLoad, onError, ...otherProps } = props
 
-  return <img
+  return (
+    <img
       {...otherProps}
       onLoad={onLoad}
       onError={onError}
@@ -104,6 +109,7 @@ const Img = React.forwardRef((props, ref) => {
         ...style,
       }}
     />
+  )
 })
 
 Img.propTypes = {
@@ -149,7 +155,7 @@ class Image extends React.Component {
       IOSupported = false
     }
 
-    const hasNoScript =  !(this.props.critical && !this.props.fadeIn)
+    const hasNoScript = !(this.props.critical && !this.props.fadeIn)
 
     this.state = {
       isVisible,
@@ -245,79 +251,78 @@ class Image extends React.Component {
             }}
           />
 
-            {/* Show the blurry base64 image. */}
-            {image.base64 && (
-              <Img
-                alt={alt}
-                title={title}
-                src={image.base64}
-                style={imagePlaceholderStyle}
-              />
-            )}
+          {/* Show the blurry base64 image. */}
+          {image.base64 && (
+            <Img
+              alt={alt}
+              title={title}
+              src={image.base64}
+              style={imagePlaceholderStyle}
+            />
+          )}
 
-            {/* Show the traced SVG image. */}
-            {image.tracedSVG && (
-              <Img
-                alt={alt}
-                title={title}
-                src={image.tracedSVG}
-                style={imagePlaceholderStyle}
-              />
-            )}
+          {/* Show the traced SVG image. */}
+          {image.tracedSVG && (
+            <Img
+              alt={alt}
+              title={title}
+              src={image.tracedSVG}
+              style={imagePlaceholderStyle}
+            />
+          )}
 
-            {/* Show a solid background color. */}
-            {bgColor && (
-              <Tag
-                title={title}
-                style={{
-                  backgroundColor: bgColor,
-                  position: `absolute`,
-                  top: 0,
-                  bottom: 0,
-                  opacity: !this.state.imgLoaded ? 1 : 0,
-                  transitionDelay: `0.35s`,
-                  right: 0,
-                  left: 0,
-                }}
-              />
-            )}
+          {/* Show a solid background color. */}
+          {bgColor && (
+            <Tag
+              title={title}
+              style={{
+                backgroundColor: bgColor,
+                position: `absolute`,
+                top: 0,
+                bottom: 0,
+                opacity: !this.state.imgLoaded ? 1 : 0,
+                transitionDelay: `0.35s`,
+                right: 0,
+                left: 0,
+              }}
+            />
+          )}
 
-            {/* Once the image is visible (or the browser doesn't support IntersectionObserver), start downloading the image */}
-            {this.state.isVisible && (
-              <picture>
-                {image.srcSetWebp && (<source
+          {/* Once the image is visible (or the browser doesn't support IntersectionObserver), start downloading the image */}
+          {this.state.isVisible && (
+            <picture>
+              {image.srcSetWebp && (
+                <source
                   type={`image/webp`}
                   srcSet={image.srcSetWebp}
                   sizes={image.sizes}
-                />)}
-
-                <source
-                  srcSet={image.srcSet}
-                  sizes={image.sizes}
                 />
+              )}
 
-                <Img
-                  alt={alt}
-                  title={title}
-                  src={image.src}
-                  style={imageStyle}
-                  ref={this.imageRef}
-                  onLoad={this.handleImageLoaded}
-                  onError={this.props.onError}
-                />
-              </picture>
-            )}
+              <source srcSet={image.srcSet} sizes={image.sizes} />
 
-            {/* Show the original image during server-side rendering if JavaScript is disabled */}
-            {this.state.hasNoScript && (
-              <noscript
-                dangerouslySetInnerHTML={{
-                  __html: noscriptImg({ alt, title, ...image }),
-                }}
+              <Img
+                alt={alt}
+                title={title}
+                src={image.src}
+                style={imageStyle}
+                ref={this.imageRef}
+                onLoad={this.handleImageLoaded}
+                onError={this.props.onError}
               />
-            )}
+            </picture>
+          )}
 
-            {this.props.innerChild}
+          {/* Show the original image during server-side rendering if JavaScript is disabled */}
+          {this.state.hasNoScript && (
+            <noscript
+              dangerouslySetInnerHTML={{
+                __html: noscriptImg({ alt, title, ...image }),
+              }}
+            />
+          )}
+
+          {this.props.innerChild}
         </Tag>
       )
     }
@@ -380,16 +385,15 @@ class Image extends React.Component {
           {/* Once the image is visible, start downloading the image */}
           {this.state.isVisible && (
             <picture>
-              {image.srcSetWebp && (<source
-                type={`image/webp`}
-                srcSet={image.srcSetWebp}
-                sizes={image.sizes}
-              />)}
+              {image.srcSetWebp && (
+                <source
+                  type={`image/webp`}
+                  srcSet={image.srcSetWebp}
+                  sizes={image.sizes}
+                />
+              )}
 
-              <source
-                srcSet={image.srcSet}
-                sizes={image.sizes}
-              />
+              <source srcSet={image.srcSet} sizes={image.sizes} />
 
               <Img
                 alt={alt}

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -316,6 +316,8 @@ class Image extends React.Component {
                 }}
               />
             )}
+
+            {this.props.innerChild}
         </Tag>
       )
     }
@@ -417,6 +419,8 @@ class Image extends React.Component {
               }}
             />
           )}
+
+          {this.props.innerChild}
         </Tag>
       )
     }
@@ -430,6 +434,7 @@ Image.defaultProps = {
   fadeIn: true,
   alt: ``,
   Tag: `div`,
+  innerChild: undefined,
 }
 
 const fixedObject = PropTypes.shape({
@@ -471,6 +476,7 @@ Image.propTypes = {
   onLoad: PropTypes.func,
   onError: PropTypes.func,
   Tag: PropTypes.string,
+  innerChild: PropTypes.node,
 }
 
 export default Image


### PR DESCRIPTION
Currently, the [recommended](https://css-tricks.com/text-blocks-over-image/) [method](https://www.w3schools.com/howto/howto_css_image_text.asp) to overlay text is difficult to implement in gatsby-image.

This PR adds a [“slot”](https://reactjs.org/docs/composition-vs-inheritance.html) that you can use to add any React node.

I’m not 100% sold on the name `innerChild` and am open to suggestions.