### PR TITLE
fix: get gatsby-dev-cli working with tilde/home shortcut

### DIFF
--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -4,6 +4,7 @@ const Configstore = require(`configstore`)
 const pkg = require(`../package.json`)
 const _ = require(`lodash`)
 const path = require(`path`)
+const os = require(`os`)
 const watch = require(`./watch`)
 
 const argv = require(`yargs`)
@@ -40,9 +41,12 @@ if (!havePackageJsonFile) {
   process.exit()
 }
 
-const pathToRepo = argv.setPathToRepo
+let pathToRepo = argv.setPathToRepo
+
 if (pathToRepo) {
-  console.log(`Saving path to your Gatsby repo`)
+  if (pathToRepo.includes(`~`)) {
+    pathToRepo = path.join(os.homedir(), pathToRepo.split(`~`).pop())
+  }
   conf.set(`gatsby-location`, path.resolve(pathToRepo))
   process.exit()
 }


### PR DESCRIPTION
In re: to #8269 this should be the ticket for getting gatsby-dev-cli working with `~`.

For example, given the command

```bash
gatsby-dev --set-path-to-repo ~/projects
```

This will correctly resolve the `~` to `${os.homedir()}/projects`. Should be pass-through behavior if the path doesn't contain a tilde, so this should be fairly low-risk. Tested locally 🤷‍♂️ 

Also see [this comment](https://github.com/gatsbyjs/gatsby/pull/8269#discussion_r218950122) for a bit more context