### PR TITLE
Fix order of extension resolving so .mjs is first

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -320,7 +320,7 @@ module.exports = async (args: BootstrapArgs) => {
   activity.end()
 
   // Collect resolvable extensions and attach to program.
-  const extensions = [`.js`, `.jsx`, `.mjs`, `.wasm`, `.json`]
+  const extensions = [`.mjs`, `.js`, `.jsx`, `.wasm`, `.json`]
   // Change to this being an action and plugins implement `onPreBootstrap`
   // for adding extensions.
   const apiResults = await apiRunnerNode(`resolvableExtensions`, {


### PR DESCRIPTION
@kkemple and I found this when testing the using-multiple-providers example site.

It fails (on loading `graphql`) without this PR.


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->