### PR TITLE
fix: check for INVALID_VALUE to avoid throwing exceptions on bad data

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -264,7 +264,7 @@ export function inferInputObjectStructureFromNodes({
     let key = k
     // Remove fields for traversing through nodes as we want to control
     // setting traversing up not try to automatically infer them.
-    if (isRoot && EXCLUDE_KEYS[key]) return
+    if (typeof value === `symbol` || (isRoot && EXCLUDE_KEYS[key])) return
 
     if (_.includes(key, `___NODE`)) {
       // TODO: Union the objects in array

--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -17,6 +17,7 @@ const {
   getExampleValues,
   extractFieldNames,
   isEmptyObjectOrArray,
+  INVALID_VALUE,
 } = require(`./data-tree-utils`)
 
 const { findLinkedNode } = require(`./infer-graphql-type`)
@@ -264,7 +265,7 @@ export function inferInputObjectStructureFromNodes({
     let key = k
     // Remove fields for traversing through nodes as we want to control
     // setting traversing up not try to automatically infer them.
-    if (typeof value === `symbol` || (isRoot && EXCLUDE_KEYS[key])) return
+    if (value === INVALID_VALUE || (isRoot && EXCLUDE_KEYS[key])) return
 
     if (_.includes(key, `___NODE`)) {
       // TODO: Union the objects in array

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -16,7 +16,11 @@ const { store, getNode, getNodes } = require(`../redux`)
 const { createPageDependency } = require(`../redux/actions/add-page-dependency`)
 const createTypeName = require(`./create-type-name`)
 const createKey = require(`./create-key`)
-const { getExampleValues, isEmptyObjectOrArray } = require(`./data-tree-utils`)
+const {
+  getExampleValues,
+  isEmptyObjectOrArray,
+  INVALID_VALUE,
+} = require(`./data-tree-utils`)
 const DateType = require(`./types/type-date`)
 const FileType = require(`./types/type-file`)
 const is32BitInteger = require(`../utils/is-32-bit-integer`)
@@ -341,7 +345,7 @@ function _inferObjectStructureFromNodes(
   _.each(resolvedExample, (value, key) => {
     // Remove fields common to the top-level of all nodes.  We add these
     // elsewhere so don't need to infer their type.
-    if (typeof value === `symbol` || (isRoot && EXCLUDE_KEYS[key])) return
+    if (value === INVALID_VALUE || (isRoot && EXCLUDE_KEYS[key])) return
 
     // Several checks to see if a field is pointing to custom type
     // before we try automatic inference.

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -341,7 +341,7 @@ function _inferObjectStructureFromNodes(
   _.each(resolvedExample, (value, key) => {
     // Remove fields common to the top-level of all nodes.  We add these
     // elsewhere so don't need to infer their type.
-    if (isRoot && EXCLUDE_KEYS[key]) return
+    if (typeof value === `symbol` || (isRoot && EXCLUDE_KEYS[key])) return
 
     // Several checks to see if a field is pointing to custom type
     // before we try automatic inference.


### PR DESCRIPTION
Avoids throwing error `TypeError: Cannot read property 'internal' of null` for bad data containing symbols.

See https://github.com/gatsbyjs/gatsby/issues/8345

