### PR TITLE
fix(gatsby-source-contenful): fix crash when trying to push reverse link into non array

### DIFF
--- a/packages/gatsby-source-contentful/process-api-data.js
+++ b/packages/gatsby-source-contentful/process-api-data.js
@@ -264,7 +264,7 @@ exports.createContentTypeNodes = function (_ref8) {
       if (foreignReferences) {
         foreignReferences.forEach(function (foreignReference) {
           var existingReference = entryItemFields[foreignReference.name];
-          if (existingReference) {
+          if (existingReference && Array.isArray(existingReference)) {
             entryItemFields[foreignReference.name].push(mId(foreignReference.id));
           } else {
             // If there is one foreign reference, there can be many.

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -311,7 +311,7 @@ exports.createContentTypeNodes = ({
       if (foreignReferences) {
         foreignReferences.forEach(foreignReference => {
           const existingReference = entryItemFields[foreignReference.name]
-          if (existingReference) {
+          if (existingReference && Array.isArray(existingReference)) {
             entryItemFields[foreignReference.name].push(
               mId(foreignReference.id)
             )


### PR DESCRIPTION
Add checks for array before calling push in normalize.  Avoids error `entryItemFields[foreignReference.name].push is not a function`.

See https://github.com/gatsbyjs/gatsby/issues/3064