### PR TITLE
[gatsby-image] Restore placeholder image transition

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -213,6 +213,7 @@ class Image extends React.Component {
 
     const imagePlaceholderStyle = {
       opacity: this.state.imgLoaded ? 0 : 1,
+      transition: `opacity 0.5s`,
       transitionDelay: this.state.imgLoaded ? `0.5s` : `0.25s`,
       ...imgStyle,
       ...placeholderStyle,


### PR DESCRIPTION
In #7083 the css `transition` was moved [from Img](https://github.com/gatsbyjs/gatsby/blob/bcf3af57f3b6438424b712ce1785a6a423b937da/packages/gatsby-image/src/index.js#L117) to [imageStyle](https://github.com/gatsbyjs/gatsby/blob/5ffb1307c17bef802026d5992e1ad000ff654f11/packages/gatsby-image/src/index.js#L224), leaving [imagePlaceholderStyle with a transitionDelay](https://github.com/gatsbyjs/gatsby/blob/5ffb1307c17bef802026d5992e1ad000ff654f11/packages/gatsby-image/src/index.js#L217), but without an actual transition.
Although I don't follow everything that changed with that commit, I think that wasn't on purpose. @tbrannam can you confirm?