### PR TITLE
fix(gatsby-plugin-netlify-cms): ensure login listener is added after logout

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
@@ -2,11 +2,20 @@
 import netlifyIdentityWidget from "netlify-identity-widget"
 
 window.netlifyIdentity = netlifyIdentityWidget
+
+const addLoginListener = () =>
+  netlifyIdentityWidget.on(`login`, () => {
+    document.location.href = `${__PATH_PREFIX__}/${CMS_PUBLIC_PATH}/`
+  })
+
 netlifyIdentityWidget.on(`init`, user => {
   if (!user) {
-    netlifyIdentityWidget.on(`login`, () => {
-      document.location.href = `${__PATH_PREFIX__}/${CMS_PUBLIC_PATH}/`
+    addLoginListener()
+  } else {
+    netlifyIdentityWidget.on(`logout`, () => {
+      addLoginListener()
     })
   }
 })
+
 netlifyIdentityWidget.init()


### PR DESCRIPTION
Use the Netlify-identity-widget's logout listener to add a listener to redirect after login.

Note: I tried removing the check for user, but it resulted in a redirect loop.

See discussion #8286

@erquhart 

Closes #8352

