### PR TITLE
Don't pass `plugins: []` into `pluginOptions`

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -96,9 +96,7 @@ module.exports = (config = {}) => {
 
       return {
         ...info,
-        pluginOptions: {
-          plugins: [],
-        },
+        pluginOptions: {},
       }
     } else {
       // Plugins can have plugins.


### PR DESCRIPTION
fixes #8317 where babel does not allow unsupported fields.

I couldn't find why this is ever passed, it does not seem like any plugins are relying on the field.