### PR TITLE
test: fix failing path prefix test by updating gatsby/cli version

### DIFF
--- a/integration-tests/path-prefix/package.json
+++ b/integration-tests/path-prefix/package.json
@@ -5,7 +5,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "cypress": "^3.1.0",
-    "gatsby": "next",
+    "gatsby": "^2.0.6",
     "gatsby-plugin-manifest": "next",
     "gatsby-plugin-offline": "next",
     "gatsby-plugin-react-helmet": "next",

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -9,6 +9,7 @@ sudo npm install -g gatsby-dev-cli &&
 cd $SRC_PATH &&
 yarn &&
 gatsby-dev --set-path-to-repo $GATSBY_PATH &&
-gatsby-dev --scan-once --copy-all && # copies _all_ files in gatsby/packages
+gatsby-dev --scan-once --copy-all --quiet && # copies _all_ files in gatsby/packages
+sudo chmod +x ./node_modules/.bin/gatsby && # this is sometimes necessary to ensure executable
 yarn $CUSTOM_COMMAND &&
 echo "Integration test run succeeded"

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SRC_PATH=$1
 CUSTOM_COMMAND="${2:-test}"
-GATSBY_PATH="/home/circleci/project"
+GATSBY_PATH="${CIRCLE_WORKING_DIRECTORY:-../../}"
 
 sudo npm install -g gatsby-dev-cli &&
 


### PR DESCRIPTION
This updates the internal gatsby version in one of the tests (path
prefix) so that the `gatsby serve` command now has the option
`--prefix-paths` which is required for the test to pass. To the best of
my knowledge, the --copy-all behavior of gatsby-dev-cli isn't meaningful
here, because it doesn't copy over the .bin executables, so the local
package.json versions are still used for some things.

Also note, for the chmod change, check out [this test run](https://circleci.com/gh/gatsbyjs/gatsby/1410). I've seen that happen locally after running gatsby-dev-cli, and that's the fix that's worked for me!

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
