### PR TITLE
Run coverage at the end of jest and configure thresholds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,8 @@ const reGatsby = /gatsby$/
 const gatsbyDir = pkgs.find(p => reGatsby.exec(p))
 const gatsbyBuildDirs = [`dist`].map(dir => path.join(gatsbyDir, dir))
 const builtTestsDirs = pkgs.map(p => path.join(p, `__tests__`))
-const distTestDirs = pkgs.map(p => path.join(p, `dist`))
-const ignoreDirs = [].concat(gatsbyBuildDirs, builtTestsDirs, distTestDirs)
+const distDirs = pkgs.map(p => path.join(p, `dist`))
+const ignoreDirs = [].concat(gatsbyBuildDirs, builtTestsDirs, distDirs)
 const coverageDirs = pkgs.map(p => path.join(p, `src/**/*.js`))
 
 module.exports = {
@@ -28,7 +28,7 @@ module.exports = {
   moduleNameMapper: {
     "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,
   },
-  collectCoverage: true,
+  collectCoverage: false,
   coverageReporters: [`json-summary`, `text`, `html`],
   coverageThreshold: {
     global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ const gatsbyBuildDirs = [`dist`].map(dir => path.join(gatsbyDir, dir))
 const builtTestsDirs = pkgs.map(p => path.join(p, `__tests__`))
 const distTestDirs = pkgs.map(p => path.join(p, `dist`))
 const ignoreDirs = [].concat(gatsbyBuildDirs, builtTestsDirs, distTestDirs)
+const coverageDirs = pkgs.map(p => path.join(p, `src/**/*.js`))
 
 module.exports = {
   notify: true,
@@ -28,13 +29,14 @@ module.exports = {
     "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,
   },
   collectCoverage: true,
-  coverageReporters: [`json-summary`, `text`],
+  coverageReporters: [`json-summary`, `text`, `html`],
   coverageThreshold: {
     global: {
-      lines: 70,
-      statements: 70,
-      functions: 66,
-      branches: 57,
+      lines: 42,
+      statements: 43,
+      functions: 40,
+      branches: 42,
     },
   },
+  collectCoverageFrom: coverageDirs,
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,8 @@ const reGatsby = /gatsby$/
 const gatsbyDir = pkgs.find(p => reGatsby.exec(p))
 const gatsbyBuildDirs = [`dist`].map(dir => path.join(gatsbyDir, dir))
 const builtTestsDirs = pkgs.map(p => path.join(p, `__tests__`))
-
-const ignoreDirs = [].concat(gatsbyBuildDirs, builtTestsDirs)
+const distTestDirs = pkgs.map(p => path.join(p, `dist`))
+const ignoreDirs = [].concat(gatsbyBuildDirs, builtTestsDirs, distTestDirs)
 
 module.exports = {
   notify: true,
@@ -26,5 +26,15 @@ module.exports = {
   transform: { '^.+\\.js$': `<rootDir>/jest-transformer.js` },
   moduleNameMapper: {
     "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,
+  },
+  collectCoverage: true,
+  coverageReporters: [`json-summary`, `text`],
+  coverageThreshold: {
+    global: {
+      lines: 70,
+      statements: 70,
+      functions: 66,
+      branches: 57,
+    },
   },
 }

--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
     "publish-canary": "lerna publish --canary --yes",
     "publish-next": "lerna publish --npm-tag=next --bump=prerelease",
     "test": "npm-run-all -s lint jest",
+    "test:coverage": "jest --coverage",
     "test:update": "jest --updateSnapshot",
     "test:watch": "jest --watch",
     "test:integration": "jest --config=jest.integration.js",
-    "test_bkup": "npm-run-all -s lint test-node test-integration",
     "version": "prettier --write \"**/CHANGELOG.md\" --no-semi",
     "watch": "lerna run watch --no-sort --stream --concurrency 999"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "glob": "^7.1.1",
     "jest": "^23.5.0",
     "jest-cli": "^23.5.0",
+    "jest-coverage-ratchet": "^0.2.3",
     "lerna": "^3.3.0",
     "npm-run-all": "4.1.2",
     "plop": "^1.8.1",
@@ -79,5 +80,15 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "lines": 70.78,
+        "statements": 70.16,
+        "functions": 66.64,
+        "branches": 57.23
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "glob": "^7.1.1",
     "jest": "^23.5.0",
     "jest-cli": "^23.5.0",
-    "jest-coverage-ratchet": "^0.2.3",
     "lerna": "^3.3.0",
     "npm-run-all": "4.1.2",
     "plop": "^1.8.1",
@@ -80,15 +79,5 @@
   },
   "workspaces": [
     "packages/*"
-  ],
-  "jest": {
-    "coverageThreshold": {
-      "global": {
-        "lines": 70.78,
-        "statements": 70.16,
-        "functions": 66.64,
-        "branches": 57.23
-      }
-    }
-  }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4441,13 +4441,6 @@ concat-stream@~1.5.0:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-concurrify@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/concurrify/-/concurrify-1.1.1.tgz#e903b6500b2ce9af7ac51bd5f2161f8db33cfb41"
-  dependencies:
-    sanctuary-show "^1.0.0"
-    sanctuary-type-identifiers "^2.0.0"
-
 config-chain@^1.1.11:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -5492,10 +5485,6 @@ delegate@^3.1.2:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-
-denque@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-1.3.0.tgz#681092ef44a630246d3f6edb2a199230eae8e76b"
 
 depd@1.1.1:
   version "1.1.1"
@@ -7073,16 +7062,6 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-fluture@^6.1.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/fluture/-/fluture-6.3.0.tgz#206297d986500131ea5bf9605725354236728a91"
-  dependencies:
-    concurrify "^1.0.0"
-    denque "^1.1.1"
-    inspect-f "^1.2.0"
-    sanctuary-type-classes "^6.0.0"
-    sanctuary-type-identifiers "^2.0.0"
-
 follow-redirects@^1.0.0, follow-redirects@^1.2.5, follow-redirects@^1.3.0:
   version "1.5.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.8.tgz#1dbfe13e45ad969f813e86c00e5296f525c885a1"
@@ -7210,14 +7189,6 @@ fs-copy-file-sync@^1.1.1:
 fs-exists-cached@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
-
-fs-extra@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
-    universalify "^0.1.0"
 
 fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.3"
@@ -8652,10 +8623,6 @@ inquirer@^6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inspect-f@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/inspect-f/-/inspect-f-1.2.2.tgz#7572803dc59099850e51d5c94f3d7962df10e46d"
-
 internal-ip@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-3.0.1.tgz#df5c99876e1d2eb2ea2d74f520e3f669a00ece27"
@@ -9435,16 +9402,6 @@ jest-config@^23.5.0:
     micromatch "^2.3.11"
     pretty-format "^23.5.0"
 
-jest-coverage-ratchet@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/jest-coverage-ratchet/-/jest-coverage-ratchet-0.2.3.tgz#ddf0fb18a0c3d44994571e102841cf31bd16e7fb"
-  dependencies:
-    chalk "^1.1.3"
-    fluture "^6.1.0"
-    fs-extra "^3.0.1"
-    ramda "^0.23.0"
-    yargs "^8.0.1"
-
 jest-diff@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.5.0.tgz#250651a433dd0050290a07642946cc9baaf06fba"
@@ -9915,12 +9872,6 @@ json3@^3.3.2:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -13282,10 +13233,6 @@ quote-stream@^1.0.1, quote-stream@~1.0.2:
     minimist "^1.1.3"
     through2 "^2.0.0"
 
-ramda@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
-
 randomatic@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
@@ -14357,24 +14304,6 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-
-sanctuary-show@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-show/-/sanctuary-show-1.0.0.tgz#72deb4812f9decec850e03286807dca1c97a1d61"
-
-sanctuary-type-classes@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-6.1.0.tgz#6bd67044358c8440d561e6e2556ab88dd8cd8001"
-  dependencies:
-    sanctuary-type-identifiers "1.0.x"
-
-sanctuary-type-identifiers@1.0.x:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-1.0.0.tgz#e8f359f006cb5e624cfb8464603fc114608bde9f"
-
-sanctuary-type-identifiers@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-2.0.1.tgz#fc524cf6dd92cebfcbb0dd9509eff193159a20ed"
 
 sane@^2.0.0:
   version "2.5.2"
@@ -17507,7 +17436,7 @@ yargs@^4.8.1:
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
 
-yargs@^8.0.1, yargs@^8.0.2:
+yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4441,6 +4441,13 @@ concat-stream@~1.5.0:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
+concurrify@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/concurrify/-/concurrify-1.1.1.tgz#e903b6500b2ce9af7ac51bd5f2161f8db33cfb41"
+  dependencies:
+    sanctuary-show "^1.0.0"
+    sanctuary-type-identifiers "^2.0.0"
+
 config-chain@^1.1.11:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -5485,6 +5492,10 @@ delegate@^3.1.2:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
+denque@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.3.0.tgz#681092ef44a630246d3f6edb2a199230eae8e76b"
 
 depd@1.1.1:
   version "1.1.1"
@@ -7062,6 +7073,16 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+fluture@^6.1.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/fluture/-/fluture-6.3.0.tgz#206297d986500131ea5bf9605725354236728a91"
+  dependencies:
+    concurrify "^1.0.0"
+    denque "^1.1.1"
+    inspect-f "^1.2.0"
+    sanctuary-type-classes "^6.0.0"
+    sanctuary-type-identifiers "^2.0.0"
+
 follow-redirects@^1.0.0, follow-redirects@^1.2.5, follow-redirects@^1.3.0:
   version "1.5.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.8.tgz#1dbfe13e45ad969f813e86c00e5296f525c885a1"
@@ -7189,6 +7210,14 @@ fs-copy-file-sync@^1.1.1:
 fs-exists-cached@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
+
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.3"
@@ -8623,6 +8652,10 @@ inquirer@^6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+inspect-f@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/inspect-f/-/inspect-f-1.2.2.tgz#7572803dc59099850e51d5c94f3d7962df10e46d"
+
 internal-ip@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-3.0.1.tgz#df5c99876e1d2eb2ea2d74f520e3f669a00ece27"
@@ -9402,6 +9435,16 @@ jest-config@^23.5.0:
     micromatch "^2.3.11"
     pretty-format "^23.5.0"
 
+jest-coverage-ratchet@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/jest-coverage-ratchet/-/jest-coverage-ratchet-0.2.3.tgz#ddf0fb18a0c3d44994571e102841cf31bd16e7fb"
+  dependencies:
+    chalk "^1.1.3"
+    fluture "^6.1.0"
+    fs-extra "^3.0.1"
+    ramda "^0.23.0"
+    yargs "^8.0.1"
+
 jest-diff@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.5.0.tgz#250651a433dd0050290a07642946cc9baaf06fba"
@@ -9872,6 +9915,12 @@ json3@^3.3.2:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -13233,6 +13282,10 @@ quote-stream@^1.0.1, quote-stream@~1.0.2:
     minimist "^1.1.3"
     through2 "^2.0.0"
 
+ramda@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
+
 randomatic@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
@@ -14304,6 +14357,24 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+sanctuary-show@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-show/-/sanctuary-show-1.0.0.tgz#72deb4812f9decec850e03286807dca1c97a1d61"
+
+sanctuary-type-classes@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-6.1.0.tgz#6bd67044358c8440d561e6e2556ab88dd8cd8001"
+  dependencies:
+    sanctuary-type-identifiers "1.0.x"
+
+sanctuary-type-identifiers@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-1.0.0.tgz#e8f359f006cb5e624cfb8464603fc114608bde9f"
+
+sanctuary-type-identifiers@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-2.0.1.tgz#fc524cf6dd92cebfcbb0dd9509eff193159a20ed"
 
 sane@^2.0.0:
   version "2.5.2"
@@ -17436,7 +17507,7 @@ yargs@^4.8.1:
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
 
-yargs@^8.0.2:
+yargs@^8.0.1, yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:


### PR DESCRIPTION
So i enabled (again it seems) the coverage tests and added a threshold using jest-coverage-ratchet

Questions for improvement

1. should i add thresholds for each package not just a global feel?
2. there is a prepush hook to configure with jest-coverage-ratchet to automatically adjust the thresholds. i could look how to add that
3. if the answer for 2 is no then i am not sure i should add jest-coverage-ratchet in dependencies
