### PR TITLE
Add Jest to v2 migration docs

### DIFF
--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -34,6 +34,7 @@ This is a reference for upgrading your site from Gatsby v1 to Gatsby v2. While t
   - [Use Query in place of RootQueryType](#use-query-in-place-of-rootquerytype)
   - [Typography.js Plugin Config](#typographyjs-plugin-config-changes)
   - [Update CSS Modules class names that use dashes](#update-css-modules-class-names-that-use-dashes)
+  - [Update Jest configuration](#update-jest-configuration)
 
 - [Resolving Deprecations](#resolving-deprecations)
 
@@ -679,6 +680,10 @@ export default ({ children }) => (
 ```
 
 TODO: add a code snippet that uses [`onCreateWebpackConfig`](/docs/node-apis/#onCreateWebpackConfig) to revert to Gatsby's v1 behaviour.
+
+### Update Jest configuration
+
+If you were using Jest with Gatsby V1, you will need to make some updates to your configuration when upgrading to Gatsby V2. You can view the complete details of setting up your test environment on the [Unit Testing](/docs/unit-testing/) page of the docs.
 
 ### gatsby-image's `outerWrapperClassName` was removed
 


### PR DESCRIPTION
It would be helpful to include the required Jest updates in the migration guide. We were in the middle of upgrading based on following this guide, and we did not find the Unit Testing docs page until several hours into a search on why our tests were breaking.