### PR TITLE
gatsby-link: add forwardRef

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -174,11 +174,11 @@ GatsbyLink.propTypes = {
 }
 
 // eslint-disable-next-line react/display-name
-const withLocation = Comp => props => (
+const withLocation = Comp => React.forwardRef((props, ref) => (
   <Location>
-    {({ location }) => <Comp location={location} {...props} />}
+    {({ location }) => <Comp location={location} innerRef={ref} {...props} />}
   </Location>
-)
+))
 
 export default withLocation(GatsbyLink)
 


### PR DESCRIPTION
This allows other components that manage focus (like a dropdown) to manage focus on a gatsby link