### PR TITLE
Update 'How Gatsby works doc': CNAME file should be copied in public folder

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -49,4 +49,4 @@ After running `npm run deploy` you should see your website at `http://username.g
 
 If you use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add a `pathPrefix` as it will break navigation on your site. Path prefixing is only necessary when the site is _not_ at the root of the domain like with repository sites.
 
-**Note**: Don't forget to add your [CNAME](https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors) file to the `static` directory.
+**Note**: Don't forget to add your [CNAME](https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors) file to the `public` directory.


### PR DESCRIPTION
Though the `build` process is working perfectly, it seems to me that, as suggested, the`CNAME` should be in the `public` folder in order to get into the right place for GitHub to recognize.

(I'm really new to this project so if I'm wrong, I would be glad to receive feedback if this PR is wrong 🙏)