### PR TITLE
del babel-plugin-macros.md doc stub

### DIFF
--- a/docs/docs/babel-plugin-macros.md
+++ b/docs/docs/babel-plugin-macros.md
@@ -1,8 +1,0 @@
----
-title: Babel Plugin Macros
----
-
-This is a stub. Help our community expand it.
-
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
-pull request gets accepted.


### PR DESCRIPTION
dependency removed, so no need for this