### PR TITLE
Add pooling opt

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -204,6 +204,11 @@ async function startServer(program) {
     }
   })
 
+  // use chokidar usePoling option
+  if (process.env.GATSBY_USEPOLLING) {
+    process.env.CHOKIDAR_USEPOLLING = `true`
+  }
+
   // Register watcher that rebuilds index.html every time html.js changes.
   const watchGlobs = [`src/html.js`, `plugins/**/gatsby-ssr.js`].map(path =>
     slash(directoryPath(path))


### PR DESCRIPTION
HMR does not works when I run `gatsby develop` on Docker for Windows.

```
OS: Windows 10
Docker: Docker version 18.06.1-ce, build e68fc7a
```

This solution is
- setting ``process.env.CHOKIDAR_USEPOLLING=`true` `` and `process.env.GATSBY_WEBPACK_PUBLICPATH=/`
- running `gatsby develop -H 0.0.0.0`

and I think `GATSBY_USEPOLLING` is easier to understand than `CHOKIDAR_USEPOLLING`.