### PR TITLE
Fix dev-404-page with gatsby-plugin-remove-trailing-slashes

### DIFF
--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -75,7 +75,7 @@ class RouteHandler extends React.Component {
         </EnsureResources>
       )
     } else {
-      const dev404Page = pages.find(p => /^\/dev-404-page\/$/.test(p.path))
+      const dev404Page = pages.find(p => /^\/dev-404-page\/?$/.test(p.path))
       return createElement(
         syncRequires.components[dev404Page.componentChunkName],
         {


### PR DESCRIPTION
Fixes #8439
When using `gatsby-plugin-remove-trailing-slashes`, the dev-404 page breaks. This adjusts the regex.