### PR TITLE
Change all instances of next.gatsbyjs.org to gatsbyjs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://next.gatsbyjs.org">
+  <a href="https://gatsbyjs.org">
     <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
   </a>
 </p>
@@ -27,23 +27,23 @@
   <a href="https://npmcharts.com/compare/gatsby?minimal=true">
     <img src="https://img.shields.io/npm/dm/gatsby.svg" alt="Downloads per month on npm." />
   </a>
-  <a href="https://next.gatsbyjs.org/docs/how-to-submit-a-pr/">
+  <a href="https://gatsbyjs.org/docs/how-to-submit-a-pr/">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
   </a>
 </p>
 
 <h3 align="center">
-  <a href="https://next.gatsbyjs.org/docs/">Quickstart</a>
+  <a href="https://gatsbyjs.org/docs/">Quickstart</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/tutorial/">Tutorial</a>
+  <a href="https://gatsbyjs.org/tutorial/">Tutorial</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/plugins/">Plugins</a>
+  <a href="https://gatsbyjs.org/plugins/">Plugins</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/docs/gatsby-starters/">Starters</a>
+  <a href="https://gatsbyjs.org/docs/gatsby-starters/">Starters</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/showcase/">Showcase</a>
+  <a href="https://gatsbyjs.org/showcase/">Showcase</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
+  <a href="https://gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
   <span> · </span>
   Support: <a href="https://spectrum.chat/gatsby-js">Spectrum</a>
   <span> & </span>
@@ -72,7 +72,7 @@ Gatsby is a modern framework for blazing fast websites.
   site on a CDN for a fraction of the cost of a server-rendered site. Many Gatsby sites can be
   hosted entirely free on services like GitHub Pages and Netlify.
 
-[**Learn how to use Gatsby for your next project.**](https://next.gatsbyjs.org/docs/)
+[**Learn how to use Gatsby for your next project.**](https://gatsbyjs.org/docs/)
 
 ## What’s In This Document
 
@@ -111,40 +111,40 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
     Your site is now running at `http://localhost:8000`. Open the `my-blazing-fast-site` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
 
-At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://next.gatsbyjs.org/plugins/) and [the official tutorial](https://next.gatsbyjs.org/tutorial/).
+At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://gatsbyjs.org/plugins/) and [the official tutorial](https://gatsbyjs.org/tutorial/).
 
 ## 🎓 Learning Gatsby
 
-Full documentation for Gatsby lives [on the website](https://next.gatsbyjs.org/).
+Full documentation for Gatsby lives [on the website](https://gatsbyjs.org/).
 
-- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://next.gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
+- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
 
-- **To dive straight into code samples head [to our documentation](https://next.gatsbyjs.org/docs/).** In particular, check out the “Guides”, API reference, and “Advanced Tutorials” sections in the sidebar.
+- **To dive straight into code samples head [to our documentation](https://gatsbyjs.org/docs/).** In particular, check out the “Guides”, API reference, and “Advanced Tutorials” sections in the sidebar.
 
-We welcome suggestions for improving our docs. See the [“how to contribute”](https://next.gatsbyjs.org/docs/how-to-contribute/) documentation for more details.
+We welcome suggestions for improving our docs. See the [“how to contribute”](https://gatsbyjs.org/docs/how-to-contribute/) documentation for more details.
 
-**Start Learning Gatsby: [Follow the Tutorial](https://next.gatsbyjs.org/tutorial/) · [Read the Docs](https://next.gatsbyjs.org/docs/)**
+**Start Learning Gatsby: [Follow the Tutorial](https://gatsbyjs.org/tutorial/) · [Read the Docs](https://gatsbyjs.org/docs/)**
 
 ## 💼 Migration Guides
 
 Already have a Gatsby site? These handy guides will help you add the improvements of Gatsby v2 to your site without starting from scratch!
 
-- [Migrate a Gatsby site from v1 to v2](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/)
-- Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://next.gatsbyjs.org/docs/migrating-from-v0-to-v1/)
+- [Migrate a Gatsby site from v1 to v2](https://gatsbyjs.org/docs/migrating-from-v1-to-v2/)
+- Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://gatsbyjs.org/docs/migrating-from-v0-to-v1/)
 
 ## 🤝 How to Contribute
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community! :muscle::purple_heart:
 
-Check out our [contributor onboarding docs](https://next.gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repos up and running on your local machine.
+Check out our [contributor onboarding docs](https://gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repos up and running on your local machine.
 
-[**Read the Contributing Guide**](https://next.gatsbyjs.org/docs/how-to-contribute/)
+[**Read the Contributing Guide**](https://gatsbyjs.org/docs/how-to-contribute/)
 
 ### Code of Conduct
 
-Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [Code of Conduct](https://next.gatsbyjs.org/docs/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
+Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [Code of Conduct](https://gatsbyjs.org/docs/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
 
-[**Read the Code of Conduct**](https://next.gatsbyjs.org/docs/code-of-conduct/)
+[**Read the Code of Conduct**](https://gatsbyjs.org/docs/code-of-conduct/)
 
 ### A note on how this repository is organized
 

--- a/examples/using-redirects/src/pages/index.js
+++ b/examples/using-redirects/src/pages/index.js
@@ -45,7 +45,7 @@ const IndexPage = () => (
         {` `}
         link uses
         {` `}
-        <a href="https://next.gatsbyjs.org/docs/gatsby-link/">
+        <a href="https://gatsbyjs.org/docs/gatsby-link/">
           <code>Link</code>
         </a>
         {` `}

--- a/packages/gatsby-codemods/README.md
+++ b/packages/gatsby-codemods/README.md
@@ -41,7 +41,7 @@ Structure of a jscodeshift call:
 
 Add a `graphql` import to modules that use the `graphql` tag function without an import. This was supported in Gatsby v1 and deprecated for Gatsby v2.
 
-See the [Gatsby v2 migration guide for details on when to use this](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#import-graphql-from-gatsby).
+See the [Gatsby v2 migration guide for details on when to use this](https://gatsbyjs.org/docs/migrating-from-v1-to-v2/#import-graphql-from-gatsby).
 
 ```sh
 jscodeshift -t node_modules/gatsby-codemods/dist/transforms/global-graphql-calls.js <path>
@@ -72,7 +72,7 @@ export const query = graphql`
 
 Import `Link` from `gatsby` instead of `gatsby-link` and remove the `gatsby-link` import.
 
-See the [Gatsby v2 migration guide for details on when to use this](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#import-link-from-gatsby).
+See the [Gatsby v2 migration guide for details on when to use this](https://gatsbyjs.org/docs/migrating-from-v1-to-v2/#import-link-from-gatsby).
 
 ```sh
 jscodeshift -t node_modules/gatsby-codemods/dist/transforms/import-link.js <path>
@@ -93,7 +93,7 @@ export default props => (
 
 Change the deprecated `navigateTo` method from `gatsby-link` to `navigate` from the `gatsby` module.
 
-See the [Gatsby v2 migration guide for details on when to use this](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#change-navigateto-to-navigate).
+See the [Gatsby v2 migration guide for details on when to use this](https://gatsbyjs.org/docs/migrating-from-v1-to-v2/#change-navigateto-to-navigate).
 
 ```sh
 jscodeshift -t node_modules/gatsby-codemods/dist/transforms/navigate-calls.js <path>
@@ -120,7 +120,7 @@ Rename `boundActionCreators` to `actions`. `boundActionCreators` has been deprec
 
 Note: Run this codemod only against files that use `boundActionCreators` instead of running it against a whole directory.
 
-See the [Gatsby v2 migration guide for details on when to use this](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions).
+See the [Gatsby v2 migration guide for details on when to use this](https://gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions).
 
 ```sh
 jscodeshift -t node_modules/gatsby-codemods/dist/transforms/rename-bound-action-creators.js <path-to-file>

--- a/packages/gatsby-plugin-catch-links/README.md
+++ b/packages/gatsby-plugin-catch-links/README.md
@@ -7,7 +7,7 @@ For instance, in a markdown file with relative links (transformed
 to `a` tags by
 [`gatsby-transformer-remark`](/packages/gatsby-transformer-remark/)), this
 plugin replaces the default link behaviour
-with that of [`gatsby-link`'s `navigate`](https://next.gatsbyjs.org/docs/gatsby-link/#programmatic-navigation), preserving the
+with that of [`gatsby-link`'s `navigate`](https://gatsbyjs.org/docs/gatsby-link/#programmatic-navigation), preserving the
 SPA-like page change without reload.
 
 Check out the [_Using Remark_ example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark) to see this plugin in action.

--- a/packages/gatsby-plugin-layout/README.md
+++ b/packages/gatsby-plugin-layout/README.md
@@ -73,7 +73,7 @@ In version 2, the layout component is no longer special, and it's included in ev
 </Root>
 ```
 
-This can make it complicated to support transitions or state without using the [`wrapPageElement` browser API](https://next.gatsbyjs.org/docs/browser-apis/#wrapPageElement) (and the [SSR equivalent](https://next.gatsbyjs.org/docs/ssr-apis/#wrapPageElement)). This plugin implements those APIs for you, which reimplements the behavior of Gatsby V1.
+This can make it complicated to support transitions or state without using the [`wrapPageElement` browser API](https://gatsbyjs.org/docs/browser-apis/#wrapPageElement) (and the [SSR equivalent](https://gatsbyjs.org/docs/ssr-apis/#wrapPageElement)). This plugin implements those APIs for you, which reimplements the behavior of Gatsby V1.
 
 ## Troubleshooting
 

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://next.gatsbyjs.org">
+  <a href="https://gatsbyjs.org">
     <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
   </a>
 </p>
@@ -27,23 +27,23 @@
   <a href="https://npmcharts.com/compare/gatsby?minimal=true">
     <img src="https://img.shields.io/npm/dm/gatsby.svg" alt="Downloads per month on npm." />
   </a>
-  <a href="https://next.gatsbyjs.org/docs/how-to-submit-a-pr/">
+  <a href="https://gatsbyjs.org/docs/how-to-submit-a-pr/">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
   </a>
 </p>
 
 <h3 align="center">
-  <a href="https://next.gatsbyjs.org/docs/">Quickstart</a>
+  <a href="https://gatsbyjs.org/docs/">Quickstart</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/tutorial/">Tutorial</a>
+  <a href="https://gatsbyjs.org/tutorial/">Tutorial</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/plugins/">Plugins</a>
+  <a href="https://gatsbyjs.org/plugins/">Plugins</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/docs/gatsby-starters/">Starters</a>
+  <a href="https://gatsbyjs.org/docs/gatsby-starters/">Starters</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/showcase/">Showcase</a>
+  <a href="https://gatsbyjs.org/showcase/">Showcase</a>
   <span> · </span>
-  <a href="https://next.gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
+  <a href="https://gatsbyjs.org/docs/how-to-contribute/">Contribute</a>
   <span> · </span>
   Support: <a href="https://spectrum.chat/gatsby-js">Spectrum</a>
   <span> & </span>
@@ -72,7 +72,7 @@ Gatsby is a modern framework for blazing fast websites.
   site on a CDN for a fraction of the cost of a server-rendered site. Many Gatsby sites can be
   hosted entirely free on services like GitHub Pages and Netlify.
 
-[**Learn how to use Gatsby for your next project.**](https://next.gatsbyjs.org/docs/)
+[**Learn how to use Gatsby for your next project.**](https://gatsbyjs.org/docs/)
 
 ## What’s In This Document
 
@@ -111,40 +111,40 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
     Your site is now running at `http://localhost:8000`. Open the `my-blazing-fast-site` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
 
-At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://next.gatsbyjs.org/plugins/) and [the official tutorial](https://next.gatsbyjs.org/tutorial/).
+At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://gatsbyjs.org/plugins/) and [the official tutorial](https://gatsbyjs.org/tutorial/).
 
 ## 🎓 Learning Gatsby
 
-Full documentation for Gatsby lives [on the website](https://next.gatsbyjs.org/).
+Full documentation for Gatsby lives [on the website](https://gatsbyjs.org/).
 
-- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://next.gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
+- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
 
-- **To dive straight into code samples head [to our documentation](https://next.gatsbyjs.org/docs/).** In particular, check out the “Guides”, API reference, and “Advanced Tutorials” sections in the sidebar.
+- **To dive straight into code samples head [to our documentation](https://gatsbyjs.org/docs/).** In particular, check out the “Guides”, API reference, and “Advanced Tutorials” sections in the sidebar.
 
-We welcome suggestions for improving our docs. See the [“how to contribute”](https://next.gatsbyjs.org/docs/how-to-contribute/) documentation for more details.
+We welcome suggestions for improving our docs. See the [“how to contribute”](https://gatsbyjs.org/docs/how-to-contribute/) documentation for more details.
 
-**Start Learning Gatsby: [Follow the Tutorial](https://next.gatsbyjs.org/tutorial/) · [Read the Docs](https://next.gatsbyjs.org/docs/)**
+**Start Learning Gatsby: [Follow the Tutorial](https://gatsbyjs.org/tutorial/) · [Read the Docs](https://gatsbyjs.org/docs/)**
 
 ## 💼 Migration Guides
 
 Already have a Gatsby site? These handy guides will help you add the improvements of Gatsby v2 to your site without starting from scratch!
 
-- [Migrate a Gatsby site from v1 to v2](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/)
-- Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://next.gatsbyjs.org/docs/migrating-from-v0-to-v1/)
+- [Migrate a Gatsby site from v1 to v2](https://gatsbyjs.org/docs/migrating-from-v1-to-v2/)
+- Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://gatsbyjs.org/docs/migrating-from-v0-to-v1/)
 
 ## 🤝 How to Contribute
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community! :muscle::purple_heart:
 
-Check out our [contributor onboarding docs](https://next.gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repos up and running on your local machine.
+Check out our [contributor onboarding docs](https://gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repos up and running on your local machine.
 
-[**Read the Contributing Guide**](https://next.gatsbyjs.org/docs/how-to-contribute/)
+[**Read the Contributing Guide**](https://gatsbyjs.org/docs/how-to-contribute/)
 
 ### Code of Conduct
 
-Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [Code of Conduct](https://next.gatsbyjs.org/docs/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
+Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [Code of Conduct](https://gatsbyjs.org/docs/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
 
-[**Read the Code of Conduct**](https://next.gatsbyjs.org/docs/code-of-conduct/)
+[**Read the Code of Conduct**](https://gatsbyjs.org/docs/code-of-conduct/)
 
 ### A note on how this repository is organized
 

--- a/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js
@@ -155,7 +155,7 @@ const updateStateAndRunQueries = isFirstRun => {
         query (or other fragment) of the top-level page that renders this component, or
         use a <StaticQuery> in this component. For more info on fragments and
         composition, see http://graphql.org/learn/queries/#fragments and for more
-        information on <StaticQuery>, see https://next.gatsbyjs.org/docs/static-query
+        information on <StaticQuery>, see https://gatsbyjs.org/docs/static-query
       `)
     }
     runQueuedQueries()

--- a/www/src/views/showcase/featured-sites.js
+++ b/www/src/views/showcase/featured-sites.js
@@ -137,7 +137,7 @@ class FeaturedSites extends Component {
               Want to get featured?
             </div>
             <Button
-              to="https://next.gatsbyjs.org/docs/site-showcase-submissions/"
+              to="https://gatsbyjs.org/docs/site-showcase-submissions/"
               tag="href"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
In response to #8398, replaced all instances of next.gatsbyjs.org with gatsbyjs.org. The changes included markdown files, let me know if that's not what you want!