### PR TITLE
[gatsby-transformer-sharp] Provide fragments without gatsby-image 

### DIFF
--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -6,24 +6,11 @@ exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
 exports.onPreExtractQueries = async ({ store, getNodes }) => {
   const program = store.getState().program
 
-  // Check if there are any ImageSharp nodes and if gatsby-image is installed. If so
-  // add fragments for ImageSharp and gatsby-image. The fragment will cause an error
-  // if there's not ImageSharp nodes and without gatsby-image, the fragment is useless.
+  // Check if there are any ImageSharp nodes. If so add fragments for ImageSharp.
+  // The fragment will cause an error if there are no ImageSharp nodes.
   const nodes = getNodes()
 
   if (!nodes.some(n => n.internal.type === `ImageSharp`)) {
-    return
-  }
-
-  let gatsbyImageDoesNotExist = true
-  try {
-    require.resolve(`gatsby-image`)
-    gatsbyImageDoesNotExist = false
-  } catch (e) {
-    // Ignore
-  }
-
-  if (gatsbyImageDoesNotExist) {
     return
   }
 

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -14,8 +14,7 @@ exports.onPreExtractQueries = async ({ store, getNodes }) => {
     return
   }
 
-  // We have both gatsby-image installed as well as ImageSharp nodes so let's
-  // add our fragments to .cache/fragments.
+  // We have ImageSharp nodes so let's add our fragments to .cache/fragments.
   await fs.copy(
     require.resolve(`gatsby-transformer-sharp/src/fragments.js`),
     `${program.directory}/.cache/fragments/image-sharp-fragments.js`


### PR DESCRIPTION
Currently, `gatsby-transformer-sharp` only copies fragments when `gatsby-image` is installed as well. This is unnecessarily restrictive - using the transformer without gatsby-image (e.g. just for image manipulation) seems like an entirely legitimate usecase and should be supported.