### PR TITLE
[gatsby-transformer-sharp] Expose sizes argument from gatsby-plugin-sharp

### DIFF
--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -257,6 +257,10 @@ const fluidNodeType = ({
         type: GraphQLInt,
         defaultValue: 0,
       },
+      sizes: {
+        type: GraphQLString,
+        defaultValue: ``,
+      },
     },
     resolve: (image, fieldArgs, context) => {
       const file = getNodeAndSavePathDependency(image.parent, context.path)


### PR DESCRIPTION
`gatsby-plugin-sharp` [accepts a `sizes` argument to `fluid()`](https://github.com/gatsbyjs/gatsby/blob/a9a1178c370c9962c50b841b68586189e254b98f/packages/gatsby-plugin-sharp/src/index.js#L506), which is not exposed as graphql arg by `gatsby-transformer-sharp`. This PR adds that.