### PR TITLE
[www][docs] Fix docs "Routing" section subitem indention

### DIFF
--- a/docs/docs/linking-and-prefetching-with-gatsby.md
+++ b/docs/docs/linking-and-prefetching-with-gatsby.md
@@ -1,0 +1,8 @@
+---
+title: Linking and prefetching with Gatsby
+---
+
+This is a stub. Help our community expand it.
+
+Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+pull request gets accepted.

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -194,13 +194,13 @@
         - title: Routing
           link: /docs/routing/
           items:
-            - title: "@reach/router and Gatsby"
+            - title: "@reach/router and Gatsby*"
               link: /docs/reach-router-and-gatsby/
-            - title: Linking and prefetching with Gatsby
+            - title: Linking and prefetching with Gatsby*
               link: /docs/linking-and-prefetching-with-gatsby/
             - title: Centralizing your site's navigation
               link: /docs/centralizing-your-sites-navigation/
-            - title: Rendering sidebar navigation dynamically
+            - title: Rendering sidebar navigation dynamically*
               link: /docs/rendering-sidebar-navigation-dynamically/
     - title: Performance
       link: /docs/performance/

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -194,14 +194,14 @@
         - title: Routing
           link: /docs/routing/
           items:
-          - title: "@reach/router and Gatsby"
-            link: /docs/reach-router-and-gatsby/
-          - title: Linking and prefetching with Gatsby
-            link: /docs/linking-and-prefetching-with-gatsby/
-          - title: Centralizing your site's navigation
-            link: /docs/centralizing-your-sites-navigation/
-          - title: Rendering sidebar navigation dynamically
-            link: /docs/rendering-sidebar-navigation-dynamically/
+            - title: "@reach/router and Gatsby"
+              link: /docs/reach-router-and-gatsby/
+            - title: Linking and prefetching with Gatsby
+              link: /docs/linking-and-prefetching-with-gatsby/
+            - title: Centralizing your site's navigation
+              link: /docs/centralizing-your-sites-navigation/
+            - title: Rendering sidebar navigation dynamically
+              link: /docs/rendering-sidebar-navigation-dynamically/
     - title: Performance
       link: /docs/performance/
       items:


### PR DESCRIPTION
Also

- add a stub article for "Linking and prefetching with Gatsby"
- mark the "Routing" subitems stubs