### PR TITLE
docs: add pagination doc

### DIFF
--- a/docs/docs/adding-pagination.md
+++ b/docs/docs/adding-pagination.md
@@ -1,6 +1,5 @@
 ---
 title: Adding pagination
-draft: true
 ---
 
 A page displaying a list of content gets longer as the amount of content grows.
@@ -10,14 +9,12 @@ The goal is to create multiple pages (from a single [template](https://www.gatsb
 
 Each page will [query GraphQL](https://www.gatsbyjs.org/docs/querying-with-graphql/) for the items it wants to display.
 
-The information needed to query for those specific items will come from the [pageContext](https://www.gatsbyjs.org/docs/graphql-reference/#query-variables) that is added when [creating pages](https://www.gatsbyjs.org/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`
-
-> You can access the values stored in the `pageContext` from withing your GraphQL query
+The information needed to query for those specific items will come from the [`context`](https://www.gatsbyjs.org/docs/graphql-reference/#query-variables) that is added when [creating pages](https://www.gatsbyjs.org/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`
 
 ### Example
 
-```js
-// in src/templates/blog-list-template.js
+```js{22-27}
+// src/templates/blog-list-template.js
 
 import React from "react"
 import { graphql } from "gatsby"
@@ -59,8 +56,8 @@ export const blogListQuery = graphql`
 `
 ```
 
-```js
-// in gatsby-node.js
+```js{36-49}
+// gatsby-node.js
 
 const path = require("path")
 const { createFilePath } = require("gatsby-source-filesystem")
@@ -91,6 +88,8 @@ exports.createPages = ({ graphql, actions }) => {
         if (result.errors) {
           reject(result.errors)
         }
+
+        // ...
 
         // Create blog-list pages
         const posts = result.data.allMarkdownRemark.edges
@@ -125,18 +124,11 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 }
 ```
 
-The code above will create a dynamic amount of pages that is based off the total number of blogposts. Each page will list `postsPerPage`(6) posts, until there are less than `postsPerPage`(6) posts left.
+The code above will create an amount of pages that is based off the total number of posts. Each page will list `postsPerPage`(6) posts, until there are less than `postsPerPage`(6) posts left.
 The urls will be `/blog/1`, `/blog/2`, `/blog/3` etc.
 
 ### Other resources
 
-[A step by step blog-post](https://nickymeuleman.netlify.com/blog/gatsby-pagination/) that also places a link to the previous/next page and adds the traditional page-number-navigation at the bottom of the page
-If there are other resources you think readers would benefit from or next steps they might want to take after reading your article, add
-them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blogposts, outside tutorials, etc.).
+[A step by step tutorial](https://nickymeuleman.netlify.com/blog/gatsby-pagination/) that adds links to the previous/next page and the traditional page-navigation at the bottom of the page.
 
-- Link to a blogpost
-- Link to a YouTube tutorial
-- Link to an example site
-- Link to source code for a live site
-- Links to relevant plugins
-- Links to starters
+[gatsby-paginated-blog](https://github.com/NickyMeuleman/gatsby-paginated-blog) [(demo)](https://nickymeuleman.github.io/gatsby-paginated-blog/) is an extension of the official [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog) with pagination in place.

--- a/docs/docs/adding-pagination.md
+++ b/docs/docs/adding-pagination.md
@@ -5,11 +5,11 @@ title: Adding pagination
 A page displaying a list of content gets longer as the amount of content grows.
 Pagination is the technique of spreading that content across multiple pages.
 
-The goal is to create multiple pages (from a single [template](/docs/building-with-components/#page-template-components)) that show a limited number of items.
+The goal of pagination is to create multiple pages (from a single [template](/docs/building-with-components/#page-template-components)) that show a limited number of items.
 
 Each page will [query GraphQL](/docs/querying-with-graphql/) for those specific items.
 
-The information needed to query for those specific items (a [limit](/docs/graphql-reference/#limit) and [skip](/docs/graphql-reference/#skip) value) will come from the [`context`](/docs/graphql-reference/#query-variables) that is added when [creating pages](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`
+The information needed to query for those specific items (a [limit](/docs/graphql-reference/#limit) and [skip](/docs/graphql-reference/#skip) value) will come from the [`context`](/docs/graphql-reference/#query-variables) that is added when [creating pages](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`.
 
 ### Example
 
@@ -125,6 +125,6 @@ The urls will be `/blog/1`, `/blog/2`, `/blog/3` etc.
 
 ### Other resources
 
-[A step by step tutorial](https://nickymeuleman.netlify.com/blog/gatsby-pagination/) that adds links to the previous/next page and the traditional page-navigation at the bottom of the page.
+- Follow this [step-by-step tutorial](https://nickymeuleman.netlify.com/blog/gatsby-pagination/) to add links to the previous/next page and the traditional page-navigation at the bottom of the page
 
-[gatsby-paginated-blog](https://github.com/NickyMeuleman/gatsby-paginated-blog) [(demo)](https://nickymeuleman.github.io/gatsby-paginated-blog/) is an extension of the official [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog) with pagination in place.
+- See [gatsby-paginated-blog](https://github.com/NickyMeuleman/gatsby-paginated-blog) [(demo)](https://nickymeuleman.github.io/gatsby-paginated-blog/) for an extension of the official [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog) with pagination in place

--- a/docs/docs/adding-pagination.md
+++ b/docs/docs/adding-pagination.md
@@ -5,17 +5,15 @@ title: Adding pagination
 A page displaying a list of content gets longer as the amount of content grows.
 Pagination is the technique of spreading that content across multiple pages.
 
-The goal is to create multiple pages (from a single [template](https://www.gatsbyjs.org/docs/building-with-components/#page-template-components)) that show a limited number of items.
+The goal is to create multiple pages (from a single [template](/docs/building-with-components/#page-template-components)) that show a limited number of items.
 
-Each page will [query GraphQL](https://www.gatsbyjs.org/docs/querying-with-graphql/) for the items it wants to display.
+Each page will [query GraphQL](/docs/querying-with-graphql/) for those specific items.
 
-The information needed to query for those specific items will come from the [`context`](https://www.gatsbyjs.org/docs/graphql-reference/#query-variables) that is added when [creating pages](https://www.gatsbyjs.org/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`
+The information needed to query for those specific items (a [limit](/docs/graphql-reference/#limit) and [skip](/docs/graphql-reference/#skip) value) will come from the [`context`](/docs/graphql-reference/#query-variables) that is added when [creating pages](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`
 
 ### Example
 
-```js{22-27}
-// src/templates/blog-list-template.js
-
+```js{20-25}:title=src/templates/blog-list-template.js
 import React from "react"
 import { graphql } from "gatsby"
 import Layout from "../components/layout"
@@ -56,9 +54,7 @@ export const blogListQuery = graphql`
 `
 ```
 
-```js{36-49}
-// gatsby-node.js
-
+```js{34-47}:title=gatsby-node.js
 const path = require("path")
 const { createFilePath } = require("gatsby-source-filesystem")
 

--- a/docs/docs/adding-pagination.md
+++ b/docs/docs/adding-pagination.md
@@ -1,0 +1,142 @@
+---
+title: Adding pagination
+draft: true
+---
+
+A page displaying a list of content gets longer as the amount of content grows.
+Pagination is the technique of spreading that content across multiple pages.
+
+The goal is to create multiple pages (from a single [template](https://www.gatsbyjs.org/docs/building-with-components/#page-template-components)) that show a limited number of items.
+
+Each page will [query GraphQL](https://www.gatsbyjs.org/docs/querying-with-graphql/) for the items it wants to display.
+
+The information needed to query for those specific items will come from the [pageContext](https://www.gatsbyjs.org/docs/graphql-reference/#query-variables) that is added when [creating pages](https://www.gatsbyjs.org/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`
+
+> You can access the values stored in the `pageContext` from withing your GraphQL query
+
+### Example
+
+```js
+// in src/templates/blog-list-template.js
+
+import React from "react"
+import { graphql } from "gatsby"
+import Layout from "../components/layout"
+
+export default class BlogList extends React.Component {
+  render() {
+    const posts = this.props.data.allMarkdownRemark.edges
+    return (
+      <Layout>
+        {posts.map(({ node }) => {
+          const title = node.frontmatter.title || node.fields.slug
+          return <div key={node.fields.slug}>{title}</div>
+        })}
+      </Layout>
+    )
+  }
+}
+
+export const blogListQuery = graphql`
+  query blogListQuery($skip: Int!, $limit: Int!) {
+    allMarkdownRemark(
+      sort: { fields: [frontmatter___date], order: DESC }
+      limit: $limit
+      skip: $skip
+    ) {
+      edges {
+        node {
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+          }
+        }
+      }
+    }
+  }
+`
+```
+
+```js
+// in gatsby-node.js
+
+const path = require("path")
+const { createFilePath } = require("gatsby-source-filesystem")
+
+exports.createPages = ({ graphql, actions }) => {
+  const { createPage } = actions
+
+  return new Promise((resolve, reject) => {
+    resolve(
+      graphql(
+        `
+          {
+            allMarkdownRemark(
+              sort: { fields: [frontmatter___date], order: DESC }
+              limit: 1000
+            ) {
+              edges {
+                node {
+                  fields {
+                    slug
+                  }
+                }
+              }
+            }
+          }
+        `
+      ).then(result => {
+        if (result.errors) {
+          reject(result.errors)
+        }
+
+        // Create blog-list pages
+        const posts = result.data.allMarkdownRemark.edges
+        const postsPerPage = 6
+        const numPages = Math.ceil(posts.length / postsPerPage)
+
+        Array.from({ length: numPages }).forEach((_, i) => {
+          createPage({
+            path: `/blog/${i + 1}`,
+            component: path.resolve("./src/templates/blog-list-template.js"),
+            context: {
+              limit: postsPerPage,
+              skip: i * postsPerPage,
+            },
+          })
+        })
+      })
+    )
+  })
+}
+
+exports.onCreateNode = ({ node, actions, getNode }) => {
+  const { createNodeField } = actions
+  if (node.internal.type === `MarkdownRemark`) {
+    const value = createFilePath({ node, getNode })
+    createNodeField({
+      name: `slug`,
+      node,
+      value,
+    })
+  }
+}
+```
+
+The code above will create a dynamic amount of pages that is based off the total number of blogposts. Each page will list `postsPerPage`(6) posts, until there are less than `postsPerPage`(6) posts left.
+The urls will be `/blog/1`, `/blog/2`, `/blog/3` etc.
+
+### Other resources
+
+[A step by step blog-post](https://nickymeuleman.netlify.com/blog/gatsby-pagination/) that also places a link to the previous/next page and adds the traditional page-number-navigation at the bottom of the page
+If there are other resources you think readers would benefit from or next steps they might want to take after reading your article, add
+them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blogposts, outside tutorials, etc.).
+
+- Link to a blogpost
+- Link to a YouTube tutorial
+- Link to an example site
+- Link to source code for a live site
+- Links to relevant plugins
+- Links to starters

--- a/docs/docs/adding-pagination.md
+++ b/docs/docs/adding-pagination.md
@@ -9,7 +9,7 @@ The goal of pagination is to create multiple pages (from a single [template](/do
 
 Each page will [query GraphQL](/docs/querying-with-graphql/) for those specific items.
 
-The information needed to query for those specific items (a [limit](/docs/graphql-reference/#limit) and [skip](/docs/graphql-reference/#skip) value) will come from the [`context`](/docs/graphql-reference/#query-variables) that is added when [creating pages](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`.
+The information needed to query for those specific items (i.e. values for [`limit`](/docs/graphql-reference/#limit) and [`skip`](/docs/graphql-reference/#skip)) will come from the [`context`](/docs/graphql-reference/#query-variables) that is added when [creating pages](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs) in `gatsby-node`.
 
 ### Example
 
@@ -94,7 +94,7 @@ exports.createPages = ({ graphql, actions }) => {
 
         Array.from({ length: numPages }).forEach((_, i) => {
           createPage({
-            path: `/blog/${i + 1}`,
+            path: i === 0 ? `/blog` : `/blog/${i + 1}`,
             component: path.resolve("./src/templates/blog-list-template.js"),
             context: {
               limit: postsPerPage,
@@ -121,7 +121,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 ```
 
 The code above will create an amount of pages that is based off the total number of posts. Each page will list `postsPerPage`(6) posts, until there are less than `postsPerPage`(6) posts left.
-The urls will be `/blog/1`, `/blog/2`, `/blog/3` etc.
+The path for the first page is `/blog`, following pages will have a path of the form: `/blog/2`, `/blog/3`, etc.
 
 ### Other resources
 


### PR DESCRIPTION
Tried to keep the information above the fold as [the docs templates page](https://www.gatsbyjs.org/docs/templates/) suggests.
The example code makes it much longer.

Tried to write the guide article in a way that conveys the principles used as opposed to a step by step tutorial where everything is spelled out (the links at the bottom take care of that)

I also have no idea where to put this in the docs sidebar (apart from under guides)

Please give feedback, does it communicate what I was going for? I have been looking at this for longer than I'd like to admit, so even small mistakes go by unnoticed now.