### PR TITLE
[www] Various "Creators/Community"…stuffs-and-things

### DIFF
--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -5,6 +5,7 @@ import Img from "gatsby-image"
 import Layout from "../components/layout"
 import Container from "../components/container"
 import BlogPostPreviewItem from "../components/blog-post-preview-item"
+import Badge from "../views/community/badge"
 import typography, { rhythm, options } from "../utils/typography"
 
 class ContributorPageTemplate extends React.Component {

--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -5,7 +5,6 @@ import Img from "gatsby-image"
 import Layout from "../components/layout"
 import Container from "../components/container"
 import BlogPostPreviewItem from "../components/blog-post-preview-item"
-import Badge from "../views/community/badge"
 import typography, { rhythm, options } from "../utils/typography"
 
 class ContributorPageTemplate extends React.Component {

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -98,7 +98,6 @@ class CreatorTemplate extends Component {
             <div
               css={{
                 display: `flex`,
-                borderBottom: `2px solid black`,
                 alignItems: `center`,
               }}
             >

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -9,6 +9,57 @@ import Badge from "../views/community/badge"
 import presets, { colors } from "../utils/presets"
 import GithubIcon from "react-icons/lib/go/mark-github"
 
+const MetaTitle = ({ children }) => (
+  <p
+    css={{
+      margin: `0`,
+      textTransform: `uppercase`,
+      color: colors.gray.calm,
+      letterSpacing: `0.03em`,
+      ...scale(-1 / 3),
+      marginBottom: rhythm(options.blockMarginBottom / 4),
+      [presets.Mobile]: {
+        width: 150,
+      },
+      [presets.Desktop]: {
+        fontWeight: `600`,
+        letterSpacing: 0,
+        ...scale(0),
+        marginBottom: 0,
+        color: colors.gray.dark,
+        textTransform: `none`,
+      },
+    }}
+  >
+    {children}
+  </p>
+)
+
+const MetaSection = ({ children, background, last, first }) => (
+  <div
+    css={{
+      background: background ? background : colors.ui.whisper,
+      marginLeft: rhythm(-3 / 4),
+      marginRight: rhythm(-3 / 4),
+      padding: rhythm(3 / 4),
+      borderTop: first ? `1px solid ${colors.ui.light}` : null,
+      borderBottom: last ? null : `1px solid ${colors.ui.light}`,
+      [presets.Desktop]: {
+        background: `transparent`,
+        paddingLeft: 0,
+        paddingRight: 0,
+        marginLeft: 0,
+        marginRight: 0,
+      },
+      [presets.Phablet]: {
+        display: `flex`,
+      },
+    }}
+  >
+    {children}
+  </div>
+)
+
 class CreatorTemplate extends Component {
   constructor(props) {
     super(props)
@@ -65,7 +116,7 @@ class CreatorTemplate extends Component {
               width: `100%`,
               [presets.Desktop]: {
                 width: `auto`,
-                maxWidth: `720`,
+                maxWidth: 560,
               },
             }}
           >
@@ -82,7 +133,7 @@ class CreatorTemplate extends Component {
               width: `100%`,
               [presets.Desktop]: {
                 width: `auto`,
-                maxWidth: `720`,
+                maxWidth: 640,
               },
             }}
           >
@@ -93,11 +144,10 @@ class CreatorTemplate extends Component {
             >
               {creator.name}
             </h1>
-
             <div
               css={{
-                display: `flex`,
                 alignItems: `center`,
+                display: `flex`,
                 marginTop: rhythm(options.blockMarginBottom / 2),
               }}
             >
@@ -140,28 +190,13 @@ class CreatorTemplate extends Component {
             </div>
             <div
               css={{
-                borderBottom: `2px solid black`,
                 padding: `${rhythm()} 0`,
               }}
             >
               {creator.description}
             </div>
-            <div
-              css={{
-                borderBottom: `2px solid black`,
-                padding: `${rhythm(3 / 4)} 0`,
-                display: `flex`,
-              }}
-            >
-              <p
-                css={{
-                  margin: `0`,
-                  fontWeight: `600`,
-                  width: `150`,
-                }}
-              >
-                Get in touch
-              </p>
+            <MetaSection first>
+              <MetaTitle>Get in touch</MetaTitle>
               <a
                 href={creator.website}
                 target="_blank"
@@ -169,23 +204,9 @@ class CreatorTemplate extends Component {
               >
                 {creator.website}
               </a>
-            </div>
-            <div
-              css={{
-                borderBottom: `2px solid black`,
-                padding: `${rhythm(3 / 4)} 0`,
-                display: `flex`,
-              }}
-            >
-              <p
-                css={{
-                  margin: `0`,
-                  fontWeight: `600`,
-                  width: `150`,
-                }}
-              >
-                From
-              </p>
+            </MetaSection>
+            <MetaSection>
+              <MetaTitle>From</MetaTitle>
               <p
                 css={{
                   margin: `0`,
@@ -193,24 +214,10 @@ class CreatorTemplate extends Component {
               >
                 {creator.location}
               </p>
-            </div>
+            </MetaSection>
             {creator.portfolio === true && (
-              <div
-                css={{
-                  borderBottom: `2px solid black`,
-                  padding: `${rhythm(3 / 4)} 0`,
-                }}
-              >
-                <p
-                  css={{
-                    margin: `0`,
-                    marginBottom: rhythm(3 / 4),
-                    fontWeight: `600`,
-                    width: `150`,
-                  }}
-                >
-                  Worked On
-                </p>
+              <MetaSection background="transparent" last>
+                <MetaTitle>Worked On</MetaTitle>
                 <div
                   css={{
                     display: `flex`,
@@ -245,7 +252,7 @@ class CreatorTemplate extends Component {
                     </Link>
                   ))}
                 </div>
-              </div>
+              </MetaSection>
             )}
           </div>
         </main>
@@ -301,16 +308,3 @@ export const pageQuery = graphql`
     }
   }
 `
-
-const styles = {
-  badge: {
-    ...scale(-1 / 3),
-    padding: `${rhythm(1 / 4)} 1.6rem`,
-    marginBottom: `${rhythm(3 / 4)}`,
-    borderRadius: `20px`,
-    alignSelf: `flex-start`,
-    color: `white`,
-    background: colors.gatsby,
-    textTransform: `uppercase`,
-  },
-}

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -9,6 +9,8 @@ import Badge from "../views/community/badge"
 import presets, { colors } from "../utils/presets"
 import GithubIcon from "react-icons/lib/go/mark-github"
 
+const removeProtocol = input => input.replace(/^https?:\/\//, ``)
+
 const MetaTitle = ({ children }) => (
   <p
     css={{
@@ -202,7 +204,7 @@ class CreatorTemplate extends Component {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {creator.website}
+                {removeProtocol(creator.website)}
               </a>
             </MetaSection>
             <MetaSection>

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -82,6 +82,7 @@ class CreatorTemplate extends Component {
     })
     this.setState({ sites: sites })
   }
+
   render() {
     const { data, location } = this.props
     const creator = data.creatorsYaml
@@ -114,6 +115,7 @@ class CreatorTemplate extends Component {
           <div
             css={{
               margin: rhythm(3 / 4),
+              marginBottom: rhythm(options.blockMarginBottom / 4),
               flexGrow: `1`,
               width: `100%`,
               [presets.Desktop]: {
@@ -158,7 +160,7 @@ class CreatorTemplate extends Component {
                   css={{
                     alignSelf: `flex-start`,
                     ...scale(-1 / 3),
-                    marginRight: `.25rem`,
+                    marginRight: `.5rem`,
                   }}
                 >
                   <Badge
@@ -176,9 +178,11 @@ class CreatorTemplate extends Component {
                 <a
                   href={creator.github}
                   css={{
+                    "& svg": { display: `block` },
                     "&&": {
                       border: 0,
                       boxShadow: `none`,
+                      lineHeight: 1,
                       "&:hover": {
                         background: `none`,
                         color: colors.gatsby,

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -63,29 +63,17 @@ const MetaSection = ({ children, background, last, first }) => (
 )
 
 class CreatorTemplate extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { sites: [] }
-  }
+  render() {
+    const { data, location } = this.props
+    const creator = data.creatorsYaml
 
-  componentDidMount() {
-    this.generateThumbnails()
-  }
-
-  generateThumbnails = () => {
     let sites = []
-    let creator = this.props.data.creatorsYaml
-    this.props.data.allSitesYaml.edges.map(site => {
+    data.allSitesYaml.edges.map(site => {
       if (site.node.built_by === creator.name) {
         sites.push(site)
       }
     })
-    this.setState({ sites: sites })
-  }
 
-  render() {
-    const { data, location } = this.props
-    const creator = data.creatorsYaml
     return (
       <Layout location={location}>
         <Helmet>
@@ -230,7 +218,7 @@ class CreatorTemplate extends Component {
                     alignItems: `flex-start`,
                   }}
                 >
-                  {this.state.sites.map(site => (
+                  {sites.map(site => (
                     <Link
                       key={site.node.title}
                       css={{

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -48,9 +48,7 @@ class CreatorTemplate extends Component {
             alignItems: `center`,
             justifyContent: `center`,
             width: `100%`,
-            ...scale(-1 / 4),
             [presets.Tablet]: {
-              ...scale(),
               paddingBottom: rhythm(3 / 4),
             },
             [presets.Desktop]: {

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -11,6 +11,8 @@ import GithubIcon from "react-icons/lib/go/mark-github"
 
 const removeProtocol = input => input.replace(/^https?:\/\//, ``)
 
+const breakpoint2Columns = presets.Tablet
+
 const MetaTitle = ({ children }) => (
   <p
     css={{
@@ -23,7 +25,7 @@ const MetaTitle = ({ children }) => (
       [presets.Mobile]: {
         width: 150,
       },
-      [presets.Desktop]: {
+      [breakpoint2Columns]: {
         fontWeight: `600`,
         letterSpacing: 0,
         ...scale(0),
@@ -46,7 +48,7 @@ const MetaSection = ({ children, background, last, first }) => (
       padding: rhythm(3 / 4),
       borderTop: first ? `1px solid ${colors.ui.light}` : null,
       borderBottom: last ? null : `1px solid ${colors.ui.light}`,
-      [presets.Desktop]: {
+      [breakpoint2Columns]: {
         background: `transparent`,
         paddingLeft: 0,
         paddingRight: 0,
@@ -90,10 +92,8 @@ class CreatorTemplate extends Component {
             alignItems: `center`,
             justifyContent: `center`,
             width: `100%`,
-            [presets.Tablet]: {
+            [breakpoint2Columns]: {
               paddingBottom: rhythm(3 / 4),
-            },
-            [presets.Desktop]: {
               flexDirection: `row`,
               alignItems: `flex-start`,
             },
@@ -106,8 +106,11 @@ class CreatorTemplate extends Component {
               marginBottom: rhythm(options.blockMarginBottom / 4),
               flexGrow: `1`,
               width: `100%`,
-              [presets.Desktop]: {
+              [breakpoint2Columns]: {
                 width: `auto`,
+                maxWidth: 480,
+              },
+              [presets.Desktop]: {
                 maxWidth: 560,
               },
             }}

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -68,6 +68,8 @@ class CreatorTemplate extends Component {
   render() {
     const { data, location } = this.props
     const creator = data.creatorsYaml
+    const isAgencyOrCompany =
+      creator.type === `agency` || creator.type === `company`
 
     let sites = []
     data.allSitesYaml.edges.map(site => {
@@ -146,6 +148,17 @@ class CreatorTemplate extends Component {
                 marginTop: rhythm(options.blockMarginBottom / 2),
               }}
             >
+              {isAgencyOrCompany && (
+                <span
+                  css={{
+                    color: colors.gray.calm,
+                    marginRight: `.5rem`,
+                  }}
+                >
+                  {creator.type.charAt(0).toUpperCase() + creator.type.slice(1)}
+                </span>
+              )}
+
               {creator.for_hire || creator.hiring ? (
                 <div
                   css={{
@@ -279,6 +292,7 @@ export const pageQuery = graphql`
       for_hire
       hiring
       portfolio
+      type
       fields {
         slug
       }

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -212,45 +212,46 @@ class CreatorTemplate extends Component {
                 {creator.location}
               </p>
             </MetaSection>
-            {creator.portfolio === true && (
-              <MetaSection background="transparent" last>
-                <MetaTitle>Worked On</MetaTitle>
-                <div
-                  css={{
-                    display: `flex`,
-                    alignItems: `flex-start`,
-                  }}
-                >
-                  {sites.map(site => (
-                    <Link
-                      key={site.node.title}
-                      css={{
-                        "&&": {
-                          marginRight: rhythm(3 / 4),
-                          borderBottom: `none`,
-                          boxShadow: `none`,
-                          transition: `all ${presets.animation.speedDefault} ${
-                            presets.animation.curveDefault
-                          }`,
-                          "&:hover": {
-                            background: `none`,
+            {creator.portfolio === true &&
+              sites.length > 0 && (
+                <MetaSection background="transparent" last>
+                  <MetaTitle>Worked On</MetaTitle>
+                  <div
+                    css={{
+                      display: `flex`,
+                      alignItems: `flex-start`,
+                    }}
+                  >
+                    {sites.map(site => (
+                      <Link
+                        key={site.node.title}
+                        css={{
+                          "&&": {
+                            marginRight: rhythm(3 / 4),
+                            borderBottom: `none`,
+                            boxShadow: `none`,
+                            transition: `all ${
+                              presets.animation.speedDefault
+                            } ${presets.animation.curveDefault}`,
+                            "&:hover": {
+                              background: `none`,
+                            },
                           },
-                        },
-                      }}
-                      to={site.node.fields.slug}
-                    >
-                      <Img
-                        alt={`${site.node.title}`}
-                        fixed={
-                          site.node.childScreenshot.screenshotFile
-                            .childImageSharp.fixed
-                        }
-                      />
-                    </Link>
-                  ))}
-                </div>
-              </MetaSection>
-            )}
+                        }}
+                        to={site.node.fields.slug}
+                      >
+                        <Img
+                          alt={`${site.node.title}`}
+                          fixed={
+                            site.node.childScreenshot.screenshotFile
+                              .childImageSharp.fixed
+                          }
+                        />
+                      </Link>
+                    ))}
+                  </div>
+                </MetaSection>
+              )}
           </div>
         </main>
       </Layout>

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -111,8 +111,13 @@ class CreatorTemplate extends Component {
                 >
                   <Badge
                     forHire={creator.for_hire}
-                    title={creator.for_hire ? `Open for work` : `Hiring`}
-                  />
+                    customCSS={{
+                      background: colors.success,
+                      color: `#fff`,
+                    }}
+                  >
+                    {creator.for_hire ? `Open for work` : `Hiring`}
+                  </Badge>
                 </div>
               ) : null}
               {creator.github && (
@@ -133,7 +138,6 @@ class CreatorTemplate extends Component {
                 </a>
               )}
             </div>
-
             <div
               css={{
                 borderBottom: `2px solid black`,

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -5,6 +5,7 @@ import Helmet from "react-helmet"
 import typography, { rhythm, scale } from "../utils/typography"
 import Img from "gatsby-image"
 import CommunityHeader from "../views/community/community-header"
+import Badge from "../views/community/badge"
 import presets, { colors } from "../utils/presets"
 import GithubIcon from "react-icons/lib/go/mark-github"
 
@@ -89,9 +90,10 @@ class CreatorTemplate extends Component {
             }}
           >
             {creator.for_hire || creator.hiring ? (
-              <div css={[styles.badge]}>
-                {creator.for_hire ? `Open For Work` : `Hiring`}
-              </div>
+              <Badge
+                forHire={creator.for_hire}
+                title={creator.for_hire ? `Open for work` : `Hiring`}
+              />
             ) : null}
             <div
               css={{

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -136,7 +136,6 @@ class CreatorTemplate extends Component {
               <p
                 css={{
                   margin: `0`,
-                  textDecoration: `underline`,
                   fontWeight: `600`,
                   width: `150`,
                 }}
@@ -161,9 +160,7 @@ class CreatorTemplate extends Component {
               <p
                 css={{
                   margin: `0`,
-                  textDecoration: `underline`,
                   fontWeight: `600`,
-
                   width: `150`,
                 }}
               >
@@ -188,7 +185,6 @@ class CreatorTemplate extends Component {
                   css={{
                     margin: `0`,
                     marginBottom: rhythm(3 / 4),
-                    textDecoration: `underline`,
                     fontWeight: `600`,
                     width: `150`,
                   }}

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -104,7 +104,6 @@ class CreatorTemplate extends Component {
             >
               <h1
                 css={{
-                  textTransform: `uppercase`,
                   margin: `0`,
                 }}
               >

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -2,7 +2,7 @@ import React, { Component } from "react"
 import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
 import Helmet from "react-helmet"
-import typography, { rhythm, scale } from "../utils/typography"
+import typography, { rhythm, scale, options } from "../utils/typography"
 import Img from "gatsby-image"
 import CommunityHeader from "../views/community/community-header"
 import Badge from "../views/community/badge"
@@ -78,8 +78,6 @@ class CreatorTemplate extends Component {
           </div>
           <div
             css={{
-              display: `flex`,
-              flexDirection: `column`,
               margin: rhythm(3 / 4),
               flex: `1`,
               width: `100%`,
@@ -89,33 +87,54 @@ class CreatorTemplate extends Component {
               },
             }}
           >
-            {creator.for_hire || creator.hiring ? (
-              <Badge
-                forHire={creator.for_hire}
-                title={creator.for_hire ? `Open for work` : `Hiring`}
-              />
-            ) : null}
+            <h1
+              css={{
+                margin: `0`,
+              }}
+            >
+              {creator.name}
+            </h1>
+
             <div
               css={{
                 display: `flex`,
                 alignItems: `center`,
+                marginTop: rhythm(options.blockMarginBottom / 2),
               }}
             >
-              <h1
-                css={{
-                  margin: `0`,
-                }}
-              >
-                {creator.name}
-              </h1>
-              {creator.github && (
-                <GithubIcon
+              {creator.for_hire || creator.hiring ? (
+                <div
                   css={{
-                    marginLeft: `auto`,
+                    alignSelf: `flex-start`,
+                    ...scale(-1 / 3),
+                    marginRight: `.25rem`,
                   }}
-                />
+                >
+                  <Badge
+                    forHire={creator.for_hire}
+                    title={creator.for_hire ? `Open for work` : `Hiring`}
+                  />
+                </div>
+              ) : null}
+              {creator.github && (
+                <a
+                  href={creator.github}
+                  css={{
+                    "&&": {
+                      border: 0,
+                      boxShadow: `none`,
+                      "&:hover": {
+                        background: `none`,
+                        color: colors.gatsby,
+                      },
+                    },
+                  }}
+                >
+                  <GithubIcon />
+                </a>
               )}
             </div>
+
             <div
               css={{
                 borderBottom: `2px solid black`,

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -71,6 +71,7 @@ class CreatorTemplate extends Component {
           >
             <Img
               alt={`${creator.name}`}
+              css={{ borderRadius: presets.radius }}
               fluid={creator.image.childImageSharp.fluid}
             />
           </div>

--- a/www/src/views/community/badge.js
+++ b/www/src/views/community/badge.js
@@ -29,6 +29,6 @@ const styles = {
   },
   forHire: {
     background: `#effaef`,
-    color: colors.success,
+    color: `#2b7e2b`,
   },
 }

--- a/www/src/views/community/badge.js
+++ b/www/src/views/community/badge.js
@@ -1,0 +1,30 @@
+import React from "React"
+
+import { rhythm, scale } from "../../utils/typography"
+import { colors } from "../../utils/presets"
+
+const Badge = ({ forHire, title }) => (
+  <div css={[styles.badge, forHire ? styles.forHire : styles.hiring]}>
+    {title}
+  </div>
+)
+
+export default Badge
+
+const styles = {
+  badge: {
+    ...scale(-1 / 2),
+    lineHeight: 1.5,
+    padding: `0 ${rhythm(1 / 3)}`,
+    borderRadius: 20,
+    alignSelf: `flex-start`,
+  },
+  hiring: {
+    background: colors.ui.light,
+    color: colors.gatsby,
+  },
+  forHire: {
+    background: colors.success,
+    color: `white`,
+  },
+}

--- a/www/src/views/community/badge.js
+++ b/www/src/views/community/badge.js
@@ -3,15 +3,16 @@ import React from "react"
 import { rhythm } from "../../utils/typography"
 import { colors } from "../../utils/presets"
 
-const Badge = ({ forHire, title }) => (
+const Badge = ({ forHire, children, customCSS }) => (
   <div
     css={[
       styles.badge,
       forHire ? styles.forHire : styles.hiring,
-      { letterSpacing: forHire ? `0.025em` : null },
+      { letterSpacing: customCSS ? `0.025em` : null },
+      customCSS && forHire ? customCSS : {},
     ]}
   >
-    {title}
+    {children}
   </div>
 )
 

--- a/www/src/views/community/badge.js
+++ b/www/src/views/community/badge.js
@@ -1,10 +1,16 @@
-import React from "React"
+import React from "react"
 
-import { rhythm, scale } from "../../utils/typography"
+import { rhythm } from "../../utils/typography"
 import { colors } from "../../utils/presets"
 
 const Badge = ({ forHire, title }) => (
-  <div css={[styles.badge, forHire ? styles.forHire : styles.hiring]}>
+  <div
+    css={[
+      styles.badge,
+      forHire ? styles.forHire : styles.hiring,
+      { letterSpacing: forHire ? `0.025em` : null },
+    ]}
+  >
     {title}
   </div>
 )
@@ -13,18 +19,15 @@ export default Badge
 
 const styles = {
   badge: {
-    ...scale(-1 / 2),
-    lineHeight: 1.5,
-    padding: `0 ${rhythm(1 / 3)}`,
     borderRadius: 20,
-    alignSelf: `flex-start`,
+    padding: `0 ${rhythm(1 / 3)}`,
   },
   hiring: {
     background: colors.ui.light,
-    color: colors.gatsby,
+    color: colors.lilac,
   },
   forHire: {
-    background: colors.success,
-    color: `white`,
+    background: `#effaef`,
+    color: colors.success,
   },
 }

--- a/www/src/views/community/community-header.js
+++ b/www/src/views/community/community-header.js
@@ -136,23 +136,21 @@ export default CommunityHeader
 const styles = {
   header: {
     display: `flex`,
-    flexDirection: `column`,
+    // flexDirection: `column`,
+    flexDirection: `row`,
+    alignItems: `center`,
     borderBottom: `1px solid ${colors.ui.light}`,
     backgroundColor: `rgba(255,255,255,0.975)`,
     zIndex: `2`,
-    padding: `${rhythm(2 / 4)} ${rhythm(3 / 4)} 0 ${rhythm(3 / 4)}`,
+    // padding: `${rhythm(2 / 4)} ${rhythm(3 / 4)} 0 ${rhythm(3 / 4)}`,
+    padding: `0 ${rhythm(3 / 4)}`,
+    height: presets.headerHeight,
     fontFamily: typography.options.headerFontFamily.join(`,`),
-    [presets.Tablet]: {
-      padding: `0 ${rhythm(3 / 4)}`,
-      height: presets.headerHeight,
-      flexDirection: `row`,
-      alignItems: `center`,
-    },
   },
   creatorsLink: {
     "&&": {
-      ...scale(1 / 7),
-      display: `none`,
+      ...scale(1 / 3),
+      // display: `none`,
       color: colors.gatsby,
       boxShadow: `none`,
       borderBottom: `none`,
@@ -161,7 +159,7 @@ const styles = {
         backgroundColor: `initial`,
       },
       [presets.Desktop]: {
-        display: `inline`,
+        // display: `inline`,
       },
     },
   },

--- a/www/src/views/community/community-header.js
+++ b/www/src/views/community/community-header.js
@@ -49,7 +49,7 @@ class CommunityHeader extends Component {
         >
           Creators
         </Link>
-        <nav
+        {/* <nav
           role="navigation"
           css={{
             display: `flex`,
@@ -70,7 +70,7 @@ class CommunityHeader extends Component {
           <CommunityHeaderLink linkTo="/community/companies/">
             Companies
           </CommunityHeaderLink>
-        </nav>
+        </nav> */}
         <div
           className="community--filters"
           css={{
@@ -78,7 +78,7 @@ class CommunityHeader extends Component {
             flex: `2`,
           }}
         >
-          <label
+          {/* <label
             className="label"
             css={[styles.filter, forHire && styles.activeFilter]}
           >
@@ -109,7 +109,7 @@ class CommunityHeader extends Component {
               disabled={forHire}
             />
             Hiring
-          </label>
+          </label> */}
           <div
             css={{
               marginLeft: `auto`,

--- a/www/src/views/community/index.js
+++ b/www/src/views/community/index.js
@@ -3,6 +3,7 @@ import Helmet from "react-helmet"
 import typography, { rhythm, scale } from "../../utils/typography"
 import Layout from "../../components/layout"
 import CommunityHeader from "./community-header"
+import Badge from "./badge"
 import GithubIcon from "react-icons/lib/go/mark-github"
 import { navigate } from "gatsby"
 import presets, { colors } from "../../utils/presets"
@@ -161,14 +162,10 @@ class CommunityView extends Component {
                     )}
                   </div>
                   {item.node.for_hire || item.node.hiring ? (
-                    <div
-                      css={[
-                        styles.badge,
-                        item.node.for_hire ? styles.forHire : styles.hiring,
-                      ]}
-                    >
-                      {item.node.for_hire ? `For Hire` : `Hiring`}
-                    </div>
+                    <Badge
+                      forHire={item.node.for_hire}
+                      title={item.node.for_hire ? `For Hire` : `Hiring`}
+                    />
                   ) : null}
                 </div>
               ))
@@ -184,21 +181,6 @@ class CommunityView extends Component {
 export default CommunityView
 
 const styles = {
-  badge: {
-    ...scale(-1 / 2),
-    lineHeight: 1.5,
-    padding: `0 ${rhythm(1 / 3)}`,
-    borderRadius: 20,
-    alignSelf: `flex-start`,
-  },
-  hiring: {
-    background: colors.ui.light,
-    color: colors.gatsby,
-  },
-  forHire: {
-    background: colors.success,
-    color: `white`,
-  },
   showcaseItem: {
     display: `flex`,
     flexDirection: `column`,

--- a/www/src/views/community/index.js
+++ b/www/src/views/community/index.js
@@ -168,10 +168,9 @@ class CommunityView extends Component {
                         ...scale(-1 / 3),
                       }}
                     >
-                      <Badge
-                        forHire={item.node.for_hire}
-                        title={item.node.for_hire ? `For Hire` : `Hiring`}
-                      />
+                      <Badge forHire={item.node.for_hire}>
+                        {item.node.for_hire ? `For Hire` : `Hiring`}
+                      </Badge>
                     </div>
                   ) : null}
                 </div>

--- a/www/src/views/community/index.js
+++ b/www/src/views/community/index.js
@@ -162,10 +162,17 @@ class CommunityView extends Component {
                     )}
                   </div>
                   {item.node.for_hire || item.node.hiring ? (
-                    <Badge
-                      forHire={item.node.for_hire}
-                      title={item.node.for_hire ? `For Hire` : `Hiring`}
-                    />
+                    <div
+                      css={{
+                        alignSelf: `flex-start`,
+                        ...scale(-1 / 3),
+                      }}
+                    >
+                      <Badge
+                        forHire={item.node.for_hire}
+                        title={item.node.for_hire ? `For Hire` : `Hiring`}
+                      />
+                    </div>
                   ) : null}
                 </div>
               ))


### PR DESCRIPTION
An intermediate step PR… 👣 🐤 

* Hide filters (by commenting)
  * „All/People/Agencies/Companies“
  * „For hire“ and „Hiring“
* Don’t query a creator’s sites in `componentDidMount()` but in `render()`
* Move „For Hire/Hiring“ badge to component, touch styles — slightly calmer "For Hire" on the index page, though still not happy  
  ![image](https://user-images.githubusercontent.com/21834/45937513-051a4080-bfc1-11e8-85e6-26b46eacce69.png)
* Don’t go below 1rem for main copy on small devices
* Drawing inspiration from the mocks for the Site/Starter Showcase detail view meta design to style „Get in touch“, „From“, and „Worked on“ blocks for small screens  
   * doing so, add <MetaTitle>, <MetaSection> components 👣 🐤(WIP)
  ![image](https://user-images.githubusercontent.com/21834/45937464-8de4ac80-bfc0-11e8-98fa-346a20714bf3.png)
* Don’t uppercase creator name
  * stick to general gatsbyjs.org main headline style
  * more readable
  * allow brand- or name-specific upper/lowercase usage (e.g. „LekoArts“)
* Move detail page "For hire/Hiring" badge below creator name and GitHub icon next to it
* Don’t underline detail page „Get in touch/From/Worked On“ "meta" block titles
* Remove protocol from „Get in touch“ link text
![image](https://user-images.githubusercontent.com/21834/45937543-44489180-bfc1-11e8-8f25-1103bd9b09ea.png)
* Break layout into two columns earlier (`presets.Tablet` instead of `Desktop`)  
![image](https://user-images.githubusercontent.com/21834/45937609-f718ef80-bfc1-11e8-84bb-c7633ff0165b.png)
* Output Creator "type" if its either `company` or `agency` (on the detail page):  
![image](https://user-images.githubusercontent.com/21834/45937903-51677f80-bfc5-11e8-99f7-601fb708fd70.png)

Fixes #8485, touches on #8484
