### PR TITLE
[gatsby-plugin-catch-links] fix/workaround for IE

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -78,7 +78,19 @@ module.exports = function(root, cb) {
     // will navigate to an external link instead of doing a pushState resulting
     // in `https://example.com/myapp/https://example.com/not-my-app`
     var re = new RegExp(`^${a2.host}${withPrefix(`/`)}`)
+
+    // IE quirk:
+    // - anchor.pathname misses starting slash
+    // - anchor.origin is missing - same with window.location.origin
+    // workaround 1: ie a.pathname
     var a1pathname = (a1.pathname[0] !== `/` ? `/` : ``) + a1.pathname
+    // workaround 2: ie origin
+    var a1origin = a1.origin ||
+          (a1.protocol + `//` + a1.hostname + (a1.port ? `:` + a1.port : ``))
+    var windowLocationOrigin = window.location.origin ||
+          (window.location.protocol + `//` + window.location.hostname +
+          (window.location.port ? `:` + window.location.port : ``))
+
     if (!re.test(`${a1.host}${a1pathname}`)) return true
 
     // Adding a check for absolute internal links in a callback or here,
@@ -86,13 +98,10 @@ module.exports = function(root, cb) {
     // to avoid `https://example.com/myapp/https://example.com/myapp/here` navigation
 
     ev.preventDefault()
-
-    var anchoreUrl = new URL(anchor.href)
-
     if (
-      checkSameOriginWithoutProtocol(window.location.origin, anchoreUrl.origin)
+      checkSameOriginWithoutProtocol(windowLocationOrigin, a1origin)
     ) {
-      cb(`${anchoreUrl.pathname}${anchoreUrl.search}${anchoreUrl.hash}`)
+      cb(`${a1pathname}${a1.search}${a1.hash}`)
       return false
     }
 

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -78,7 +78,7 @@ module.exports = function(root, cb) {
     // will navigate to an external link instead of doing a pushState resulting
     // in `https://example.com/myapp/https://example.com/not-my-app`
     var re = new RegExp(`^${a2.host}${withPrefix(`/`)}`)
-    var a1pathname = (a1.pathname[0] !== '/' ? '/' : '') + a1.pathname
+    var a1pathname = (a1.pathname[0] !== `/` ? `/` : ``) + a1.pathname
     if (!re.test(`${a1.host}${a1pathname}`)) return true
 
     // Adding a check for absolute internal links in a callback or here,

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -79,7 +79,6 @@ module.exports = function(root, cb) {
     // in `https://example.com/myapp/https://example.com/not-my-app`
     var re = new RegExp(`^${a2.host}${withPrefix(`/`)}`)
     var a1pathname = (a1.pathname[0] !== '/' ? '/' : '') + a1.pathname
-    // Adding a check for absolute internal links in a callback or here,
     if (!re.test(`${a1.host}${a1pathname}`)) return true
 
     // Adding a check for absolute internal links in a callback or here,

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -78,7 +78,9 @@ module.exports = function(root, cb) {
     // will navigate to an external link instead of doing a pushState resulting
     // in `https://example.com/myapp/https://example.com/not-my-app`
     var re = new RegExp(`^${a2.host}${withPrefix(`/`)}`)
-    if (!re.test(`${a1.host}${a1.pathname}`)) return true
+    var a1pathname = (a1.pathname[0] !== '/' ? '/' : '') + a1.pathname
+    // Adding a check for absolute internal links in a callback or here,
+    if (!re.test(`${a1.host}${a1pathname}`)) return true
 
     // Adding a check for absolute internal links in a callback or here,
     // or always pass only `${a1.pathname}${a1.hash}`


### PR DESCRIPTION
Two regressions broke the catch-links plugin in Internet Explorer: 

* [PR 3996](https://github.com/gatsbyjs/gatsby/pull/3996) uses `a.pathname`. IE does not include the starting slash there (see [this stackoverflow topic](https://stackoverflow.com/questions/956233/javascript-pathname-ie-quirk)) so this check always fails.
* Second [PR 6866](https://github.com/gatsbyjs/gatsby/pull/6866) uses URL API which does not work in IE.

The PR here just adds a quirk for the `a.pathname` bug. But the second issue **must** be fixed too before merging. In this state IE will again get past the line 81 and will raise an error at `var anchoreUrl = new URL(anchor.href)`