### PR TITLE
Docs: Added missing sidebar link

### DIFF
--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -14,6 +14,8 @@
           link: /tutorial/part-zero/#install-nodejs
         - title: Familiarize with npm
           link: /tutorial/part-zero/#familiarize-with-npm
+        - title: Install Git
+          link: /tutorial/part-zero/#install-git
         - title: Install the Gatsby CLI
           link: /tutorial/part-zero/#install-the-gatsby-cli
         - title: Create a Gatsby site


### PR DESCRIPTION
Add missing sidebar link for the Install Git section in the tutorial. 

Related to PR #8215 