### PR TITLE
Fixed invalid gatsby-source-drupal version in package.json

### DIFF
--- a/examples/image-processing/package.json
+++ b/examples/image-processing/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-sharp": "^2.0.5",
     "gatsby-plugin-typography": "^2.2.0",
-    "gatsby-source-drupal": "^2.2.0",
+    "gatsby-source-drupal": "^2.0.44",
     "gatsby-source-filesystem": "^2.0.1",
     "gatsby-transformer-sharp": "^2.1.1",
     "react": "^16.4.0",

--- a/examples/image-processing/package.json
+++ b/examples/image-processing/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-sharp": "^2.0.5",
     "gatsby-plugin-typography": "^2.2.0",
-    "gatsby-source-drupal": "^2.0.44",
+    "gatsby-source-drupal": "^3.0.0",
     "gatsby-source-filesystem": "^2.0.1",
     "gatsby-transformer-sharp": "^2.1.1",
     "react": "^16.4.0",


### PR DESCRIPTION
`gatsby-source-drupal` doesn't have version `^2.2.0` yet. This causes yarn/npm install error

Updated it with the latest version `2.0.44`