### PR TITLE
bump drupal plugin major version - gatsby v1 version of plugin already uses v2.x.x

### DIFF
--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-drupal",
   "description": "Gatsby source plugin for building websites using the Drupal CMS as a data source",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"


### PR DESCRIPTION
This one is weird - according to https://github.com/gatsbyjs/gatsby/commit/dc95450df6e853d04b0b8c7bd1b6e1a17aaae6b0 we should have `gatsby-source-drupal@2.2.0` in npm repository, but we don't - which is also a bit nice, because we need major version bump here as gatsby v1 version of plugin is already in `2.x.x` version range

```
dist-tags:
canary: 2.2.0-alpha.80a21f04  
next: 2.2.0-rc.6
latest: 2.0.44
```
`latest` here is gatsby v1 version of plugin