### PR TITLE
Add support for setting a force redirect status in Netlify _redirects file

### DIFF
--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -118,6 +118,8 @@ createRedirect({ fromPath: "/old-url", toPath: "/new-url", isPermanent: true })
 createRedirect({ fromPath: "/url", toPath: "/zn-CH/url", Language: "zn" })
 ```
 
+> NOTE: You can pass the `force` option to override existing content in the path. This is particularly useful for domain alias redirects. See the Netlify documentation on this option [here](https://www.netlify.com/docs/redirects/#structured-configuration).
+
 You can also create a `_redirects` file in the `static` folder for the same effect. Any programmatically created redirects will be appended to the file.
 
 ```sh

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -19,16 +19,21 @@ export default async function writeRedirectsFile(
       fromPath,
       isPermanent,
       redirectInBrowser, // eslint-disable-line no-unused-vars
+      force,
       toPath,
       ...rest
     } = redirect
+
+    let status = isPermanent ? `301` : `302`
+
+    if (force) status = status.concat(`!`)
 
     // The order of the first 3 parameters is significant.
     // The order for rest params (key-value pairs) is arbitrary.
     const pieces = [
       fromPath,
       toPath,
-      isPermanent ? 301 : 302, // Status
+      status,
     ]
 
     for (let key in rest) {


### PR DESCRIPTION
## Proposed Change

Builds upon: #2890

When adding multiple domains in Netlify it can be nice to redirect domain aliases to your primary domain. In order to do so you need to add the correct redirect information into a `_redirects` file in the root of your site folder. The `gatsby-netlify-plugin` provides a nice way to automatically generate this file for us using the `createRedirect` action, see the documentation for it [here](https://www.gatsbyjs.org/docs/actions/#createRedirect). However, it does not allow us to set a redirect status with the `force` option which is mentioned in the Netlify redirect documentation [here](https://www.netlify.com/docs/redirects/#structured-configuration). In order for domain aliases redirects and any other redirect that wants to override existing content in the path to work correctly we need to add the ability to set a forced redirect status in our `_redirects` file. A forced status is denoted with an exclamation mark at the end of the status number. This change adds support for `force: true` to be passed into `createRedirect` which will result in a redirect status code with an exclamation mark concatenated to it in the outputted `_redirects` file.

For example: 

```
createRedirect({ fromPath: "https://qhacks.ca/*", toPath: "https://qhacks.io/:splat", isPermanent: true, force: true });
```

Will output:

```
https://qhacks.ca/*  https://qhacks.io/:splat  301!
```

### How did you do this?

Accept the `force` option to `createRedirect` and use it to build a redirect status.

### Why are you choosing this approach?

Improves functionality of `gatsby-netlify-plugin`!

### Any open questions you want to ask code reviewers?

Nope! 😎 

### List of changes:

  - Update `createRedirect` redux action!
  - Accept new `force` argument to `createRedirect` and build a redirect status from it.