### PR TITLE
Use full package name for url-loader (Gatsby 1.x)

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -429,7 +429,7 @@ module.exports = async (
     // assets smaller than specified size as data URLs to avoid requests.
     config.loader(`url-loader`, {
       test: /\.(svg|jpg|jpeg|png|gif|mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
-      loader: `url`,
+      loader: `url-loader`,
       query: {
         limit: 10000,
         name: `static/[name].[hash:8].[ext]`,


### PR DESCRIPTION
Version: `gatsby@1.9.277`

webpack 1 auto-infers the `-loader` suffix… so you could type `loader: "url"` and it’d pull in the `url-loader` package. The problem we hit is that there is also a `url` package, and webpack sees that first, and used that instead of `url-loader`. `url` is not a webpack loader. Completely different package.

As a result, running `gatsby develop` results in the following error every time an image is imported.

```log
 error

Loader [path/to/our/project]/node_modules/url/url.js?{"limit":10000,"name":"static/[name].[hash:8].[ext]"} didn't return a function
```

Webpack 2 stopped doing the `-loader` suffix inference to prevent this exact error. The bug is outlined further here: https://stackoverflow.com/questions/29883534/webpack-node-modules-css-index-js-didnt-return-a-function

Simply adding the `-loader` to loader references in the webpack config resolves the issue. 

We're unable to upgrade to Gatsby 2 at this time, and this bug is blocking development - would love to have this patch in quickly! (Ideally, you'd update references to all loaders to include the `-loader` suffix, but I didn't want to change more than what was immediately affecting us).
