### PR TITLE
chore: add npm tag to v1 publish script to not update latest dist tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:flow": "babel-node scripts/flow-check.js",
     "plop": "plop",
     "prebootstrap": "yarn",
-    "publish": "lerna publish",
+    "publish": "lerna publish --npm-tag=latest-v1",
     "publish-canary": "lerna publish --canary --yes",
     "publish-next": "lerna publish --npm-tag=next",
     "remotedev": "remotedev --hostname=localhost --port=19999",


### PR DESCRIPTION
not sure about `tag` convention for older major versions - this is borrowing from `bluebird` (thanks @davidbailey00 )
```
$ npm dist-tag ls bluebird
latest-2.x: 2.11.0
latest: 3.5.2
```