### PR TITLE
[www] a11y improvements

### DIFF
--- a/www/src/components/docsearch-content.js
+++ b/www/src/components/docsearch-content.js
@@ -1,5 +1,5 @@
 import React from "react"
 
 export default ({ children }) => (
-  <div className={`docSearch-content`}>{children}</div>
+  <main className={`docSearch-content`}>{children}</main>
 )

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -57,9 +57,9 @@ const Navigation = ({ pathname }) => {
   )
 
   return (
-    <div
-      role="navigation"
+    <nav
       className="navigation"
+      aria-label="Primary Navigation"
       css={{
         backgroundColor: isHomepage ? `transparent` : `rgba(255,255,255,0.975)`,
         position: isHomepage ? `absolute` : `relative`,
@@ -187,7 +187,7 @@ const Navigation = ({ pathname }) => {
           </SocialNavItem>
         </div>
       </div>
-    </div>
+    </nav>
   )
 }
 

--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -8,7 +8,7 @@ class PageWithPluginSearchBar extends Component {
   render() {
     return (
       <Fragment>
-        <div
+        <section
           css={{
             ...styles.sidebar,
             // mobile: hide PluginSearchBar when on gatsbyjs.org/packages/foo, aka package README page
@@ -16,8 +16,8 @@ class PageWithPluginSearchBar extends Component {
           }}
         >
           <PluginSearchBar location={this.props.location} />
-        </div>
-        <div
+        </section>
+        <main
           css={{
             ...styles.content,
             // mobile: hide README on gatsbyjs.org/plugins index page
@@ -25,7 +25,7 @@ class PageWithPluginSearchBar extends Component {
           }}
         >
           {this.props.children}
-        </div>
+        </main>
       </Fragment>
     )
   }

--- a/www/src/components/search-icon.js
+++ b/www/src/components/search-icon.js
@@ -6,6 +6,8 @@ const SearchIcon = ({ overrideCSS }) => (
     viewBox="0 0 40 40"
     xmlns="http://www.w3.org/2000/svg"
     fill="currentColor"
+    focusable="false"
+    aria-hidden="true"
     css={{ ...overrideCSS }}
   >
     {/* Based on the 'search' icon in https://github.com/ionic-team/ionicons */}

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -194,16 +194,21 @@ class SidebarBody extends Component {
     const { openSectionHash, activeItemLink, activeItemParents } = this.state
 
     return (
-      <div className="docSearch-sidebar" css={{ height: `100%` }}>
+      <section
+        aria-label="Secondary Navigation"
+        id="SecondaryNavigation"
+        className="docSearch-sidebar"
+        css={{ height: `100%` }}
+      >
         {!itemList[0].disableExpandAll && (
-          <div css={{ ...styles.utils }}>
+          <header css={{ ...styles.utils }}>
             <ExpandAllButton
               onClick={this._expandAll}
               expandAll={this.state.expandAll}
             />
-          </div>
+          </header>
         )}
-        <div
+        <nav
           onScroll={({ nativeEvent }) => {
             // get proper scroll position
             const position = nativeEvent.target.scrollTop
@@ -241,8 +246,8 @@ class SidebarBody extends Component {
               />
             ))}
           </ul>
-        </div>
-      </div>
+        </nav>
+      </section>
     )
   }
 }

--- a/www/src/components/sidebar/sticky-responsive-sidebar.js
+++ b/www/src/components/sidebar/sticky-responsive-sidebar.js
@@ -69,6 +69,9 @@ class StickyResponsiveSidebar extends Component {
           css={{ ...styles.sidebarToggleButton }}
           onClick={this._openSidebar}
           role="button"
+          aria-label="Show Secondary Navigation"
+          aria-controls="SecondaryNavigation"
+          aria-expanded={open ? "true" : "false"}
           tabIndex={0}
         >
           <div css={{ ...styles.sidebarToggleButtonInner }}>

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -53,7 +53,7 @@ class IndexRoute extends React.Component {
                 },
               }}
             >
-              <div
+              <main
                 css={{
                   display: `flex`,
                   flexDirection: `row`,
@@ -207,7 +207,7 @@ class IndexRoute extends React.Component {
                     </Container>
                   </div>
                 </Cards>
-              </div>
+              </main>
             </div>
           </div>
         </div>

--- a/www/src/views/community/index.js
+++ b/www/src/views/community/index.js
@@ -143,7 +143,7 @@ class CommunityView extends Component {
                     <div
                       css={{
                         margin: `0 0 ${rhythm(1 / 8)}`,
-                        color: colors.gray.bright,
+                        color: colors.gray.calm,
                         ...scale(-1 / 3),
                       }}
                     >

--- a/www/src/views/showcase/showcase-item-categories.js
+++ b/www/src/views/showcase/showcase-item-categories.js
@@ -30,7 +30,7 @@ const ShowcaseItemCategories = ({ categories, onClickHandler, showcase }) => {
       <LinkComponent
         css={{
           "&&": {
-            color: colors.gray.bright,
+            color: colors.gray.calm,
             fontWeight: `normal`,
             borderBottom: `none`,
             boxShadow: `none`,


### PR DESCRIPTION
## Changes

- Changed some generic div tags to HTML semantic tags, e.g. added the `<main>` tag to index page or doc template
- Give the nav div the `<nav>` tag
- Changed the plugin/doc sidebar to `<section>`
- Hide the svg search icon
- Give the navigation and sidebar an `aria-label`
- Give the sidebar section a `<header>` and `<nav>`
- Add `aria-expanded` to the mobile menu button and link it to the sidebar with `aria-controls`
- Change the links in the community / starter showcase to a darker grey

## Notes

I did these changes in all conscience but please tell me if something should be done in another way. I did this as a pastime so I guess there are still things to fix.

I didn't want to mess up the components too much so I did the changes in the "easy" ones (as a element nearly every time has multiple div wrappers).
 
### Reasonings

- The `<aside>` should have a connection to the content of the site so that's why I didn't use that one for the sidebar.
- The `<main>` tag should wrap a "unique" thing of the site so that's why I didn't wrap the sidebar
- The search icon is unnecessary for screen readers
- Screen readers now know what's the primary and secondary navigation
- A `<section>` can have a `<header>` and `<nav>`

### Further improvements

Initially I wanted to change the current `<div role="navigation">` to a `<header>` and then only wrap the `ul` links in a `<nav>`. But that would be a follow-up PR if that is okay?

Is it necessary to put the tags on the outer wrappers? Some of the changed tags are wrapped by multiple divs. Don't know really...