### PR TITLE
Don't expect `application/json` type nodes to be files

### DIFF
--- a/packages/gatsby-transformer-json/README.md
+++ b/packages/gatsby-transformer-json/README.md
@@ -7,7 +7,7 @@ arrays of objects and single objects.
 
 `npm install --save gatsby-transformer-json`
 
-You also need to have `gatsby-source-filesystem` installed and configured so it
+If you want to transform json files, you also need to have `gatsby-source-filesystem` installed and configured so it
 points to your files.
 
 ## How to use
@@ -182,15 +182,15 @@ or a function that receives the following arguments:
 [
   {
     "level": "info",
-    "message": "hurray",
+    "message": "hurray"
   },
   {
     "level": "info",
-    "message": "it works",
+    "message": "it works"
   },
   {
     "level": "warning",
-    "message": "look out",
+    "message": "look out"
   }
 ]
 ```
@@ -201,7 +201,7 @@ module.exports = {
     {
       resolve: `gatsby-transformer-json`,
       options: {
-        typeName: (({ node, object, isArray }) => object.level),
+        typeName: ({ node, object, isArray }) => object.level,
       },
     },
   ],

--- a/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -41,9 +41,58 @@ Array [
         "internal": Object {
           "contentDigest": "whatever",
           "mediaType": "application/json",
-          "name": "test",
+          "type": "File",
         },
         "name": "nodeName",
+        "parent": "SOURCE",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Process JSON nodes correctly correctly creates a node from JSON which is a single object and doesn't come from fs 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "foo",
+      "internal": Object {
+        "contentDigest": "8838e569ae02d98806532310fb2a577a",
+        "type": "NotFileJson",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Process JSON nodes correctly correctly creates a node from JSON which is a single object and doesn't come from fs 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "foo",
+        "internal": Object {
+          "contentDigest": "8838e569ae02d98806532310fb2a577a",
+          "type": "NotFileJson",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "{\\"id\\":\\"foo\\",\\"blue\\":true,\\"funny\\":\\"yup\\"}",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "application/json",
+          "type": "NotFile",
+        },
         "parent": "SOURCE",
       },
     },
@@ -100,11 +149,12 @@ Array [
       "parent": Object {
         "children": Array [],
         "content": "[{\\"id\\":\\"foo\\",\\"blue\\":true,\\"funny\\":\\"yup\\"},{\\"blue\\":false,\\"funny\\":\\"nope\\"}]",
+        "dir": "/tmp/foo/",
         "id": "whatever",
         "internal": Object {
           "contentDigest": "whatever",
           "mediaType": "application/json",
-          "name": "test",
+          "type": "File",
         },
         "name": "nodeName",
         "parent": "SOURCE",
@@ -127,13 +177,102 @@ Array [
       "parent": Object {
         "children": Array [],
         "content": "[{\\"id\\":\\"foo\\",\\"blue\\":true,\\"funny\\":\\"yup\\"},{\\"blue\\":false,\\"funny\\":\\"nope\\"}]",
+        "dir": "/tmp/foo/",
         "id": "whatever",
         "internal": Object {
           "contentDigest": "whatever",
           "mediaType": "application/json",
-          "name": "test",
+          "type": "File",
         },
         "name": "nodeName",
+        "parent": "SOURCE",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Process JSON nodes correctly correctly creates nodes from JSON which is an array of objects and doesn't come from fs 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "foo",
+      "internal": Object {
+        "contentDigest": "8838e569ae02d98806532310fb2a577a",
+        "type": "NotFileJson",
+      },
+      "parent": "whatever",
+    },
+  ],
+  Array [
+    Object {
+      "blue": false,
+      "children": Array [],
+      "funny": "nope",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "f624311d932d73dcd416d2a8bea2b67d",
+        "type": "NotFileJson",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Process JSON nodes correctly correctly creates nodes from JSON which is an array of objects and doesn't come from fs 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "foo",
+        "internal": Object {
+          "contentDigest": "8838e569ae02d98806532310fb2a577a",
+          "type": "NotFileJson",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "[{\\"id\\":\\"foo\\",\\"blue\\":true,\\"funny\\":\\"yup\\"},{\\"blue\\":false,\\"funny\\":\\"nope\\"}]",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "application/json",
+          "type": "NotFile",
+        },
+        "parent": "SOURCE",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "child": Object {
+        "blue": false,
+        "children": Array [],
+        "funny": "nope",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "f624311d932d73dcd416d2a8bea2b67d",
+          "type": "NotFileJson",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "[{\\"id\\":\\"foo\\",\\"blue\\":true,\\"funny\\":\\"yup\\"},{\\"blue\\":false,\\"funny\\":\\"nope\\"}]",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "application/json",
+          "type": "NotFile",
+        },
         "parent": "SOURCE",
       },
     },

--- a/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
@@ -2,41 +2,72 @@ const Promise = require(`bluebird`)
 
 const { onCreateNode } = require(`../gatsby-node`)
 
+// Make some fake functions its expecting.
+const loadNodeContent = node => Promise.resolve(node.content)
+
+const bootstrapTest = async (node, pluginOptions = {}) => {
+  const createNode = jest.fn()
+  const createParentChildLink = jest.fn()
+  const actions = { createNode, createParentChildLink }
+  const createNodeId = jest.fn()
+  createNodeId.mockReturnValue(`uuid-from-gatsby`)
+
+  return await onCreateNode(
+    {
+      node,
+      loadNodeContent,
+      actions,
+      createNodeId,
+    },
+    pluginOptions
+  ).then(() => {
+    return {
+      createNode,
+      createParentChildLink,
+    }
+  })
+}
+
 describe(`Process JSON nodes correctly`, () => {
-  const node = {
-    name: `nodeName`,
+  const baseNode = {
     id: `whatever`,
     parent: `SOURCE`,
     children: [],
     internal: {
       contentDigest: `whatever`,
       mediaType: `application/json`,
-      name: `test`,
     },
   }
 
-  // Make some fake functions its expecting.
-  const loadNodeContent = node => Promise.resolve(node.content)
+  const baseFileNode = {
+    ...baseNode,
+    name: `nodeName`,
+    dir: `/tmp/foo/`,
+    internal: {
+      ...baseNode.internal,
+      type: `File`,
+    },
+  }
+
+  const baseNonFileNode = {
+    ...baseNode,
+    internal: {
+      ...baseNode.internal,
+      type: `NotFile`,
+    },
+  }
 
   it(`correctly creates nodes from JSON which is an array of objects`, async () => {
     const data = [
       { id: `foo`, blue: true, funny: `yup` },
       { blue: false, funny: `nope` },
     ]
-    node.content = JSON.stringify(data)
+    const node = {
+      ...baseFileNode,
+      content: JSON.stringify(data),
+    }
 
-    const createNode = jest.fn()
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    }).then(() => {
+    return bootstrapTest(node).then(({ createNode, createParentChildLink }) => {
       expect(createNode.mock.calls).toMatchSnapshot()
       expect(createParentChildLink.mock.calls).toMatchSnapshot()
       expect(createNode).toHaveBeenCalledTimes(2)
@@ -46,21 +77,12 @@ describe(`Process JSON nodes correctly`, () => {
 
   it(`correctly creates a node from JSON which is a single object`, async () => {
     const data = { id: `foo`, blue: true, funny: `yup` }
-    node.content = JSON.stringify(data)
-    node.dir = `/tmp/foo/`
+    const node = {
+      ...baseFileNode,
+      content: JSON.stringify(data),
+    }
 
-    const createNode = jest.fn()
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-    }).then(() => {
+    return bootstrapTest(node).then(({ createNode, createParentChildLink }) => {
       expect(createNode.mock.calls).toMatchSnapshot()
       expect(createParentChildLink.mock.calls).toMatchSnapshot()
       expect(createNode).toHaveBeenCalledTimes(1)
@@ -79,46 +101,41 @@ describe(`Process JSON nodes correctly`, () => {
         expectedNodeTypes: [`fixed`, `fixed`],
       },
       {
-        typeName: (({ node, object }) => object.funny),
+        typeName: ({ node, object }) => object.funny,
         expectedNodeTypes: [`yup`, `nope`],
       },
-    ].forEach(async ({ typeName, expectedNodeTypes: [expectedOne, expectedTwo] }) => {
-      const data = [
-        { id: `foo`, blue: true, funny: `yup` },
-        { blue: false, funny: `nope` },
-      ]
-      node.content = JSON.stringify(data)
+    ].forEach(
+      async ({ typeName, expectedNodeTypes: [expectedOne, expectedTwo] }) => {
+        const data = [
+          { id: `foo`, blue: true, funny: `yup` },
+          { blue: false, funny: `nope` },
+        ]
 
-      const createNode = jest.fn()
-      const createParentChildLink = jest.fn()
-      const actions = { createNode, createParentChildLink }
-      const createNodeId = jest.fn()
-      createNodeId.mockReturnValue(`uuid-from-gatsby`)
+        const node = {
+          ...baseFileNode,
+          content: JSON.stringify(data),
+        }
 
-      await onCreateNode({
-        node,
-        loadNodeContent,
-        actions,
-        createNodeId,
-      }, {
-        typeName,
-      }).then(() => {
-        expect(createNode).toBeCalledWith(
-          expect.objectContaining({
-            internal: expect.objectContaining({
-              type: expectedOne,
-            }),
-          })
+        return bootstrapTest(node, { typeName }).then(
+          ({ createNode, createParentChildLink }) => {
+            expect(createNode).toBeCalledWith(
+              expect.objectContaining({
+                internal: expect.objectContaining({
+                  type: expectedOne,
+                }),
+              })
+            )
+            expect(createNode).toBeCalledWith(
+              expect.objectContaining({
+                internal: expect.objectContaining({
+                  type: expectedTwo,
+                }),
+              })
+            )
+          }
         )
-        expect(createNode).toBeCalledWith(
-          expect.objectContaining({
-            internal: expect.objectContaining({
-              type: expectedTwo,
-            }),
-          })
-        )
-      })
-    })
+      }
+    )
   })
 
   it(`correctly sets node type for single object`, async () => {
@@ -132,36 +149,61 @@ describe(`Process JSON nodes correctly`, () => {
         expectedNodeType: `fixed`,
       },
       {
-        typeName: (({ node, object }) => object.funny),
+        typeName: ({ node, object }) => object.funny,
         expectedNodeType: `yup`,
       },
     ].forEach(async ({ typeName, expectedNodeType }) => {
       const data = { id: `foo`, blue: true, funny: `yup` }
-      node.content = JSON.stringify(data)
-      node.dir = `/tmp/foo/`
 
-      const createNode = jest.fn()
-      const createParentChildLink = jest.fn()
-      const actions = { createNode, createParentChildLink }
-      const createNodeId = jest.fn()
-      createNodeId.mockReturnValue(`uuid-from-gatsby`)
+      const node = {
+        ...baseFileNode,
+        content: JSON.stringify(data),
+      }
 
-      await onCreateNode({
-        node,
-        loadNodeContent,
-        actions,
-        createNodeId,
-      }, {
-        typeName,
-      }).then(() => {
-        expect(createNode).toBeCalledWith(
-          expect.objectContaining({
-            internal: expect.objectContaining({
-              type: expectedNodeType,
-            }),
-          })
-        )
-      })
+      return bootstrapTest(node, { typeName }).then(
+        ({ createNode, createParentChildLink }) => {
+          expect(createNode).toBeCalledWith(
+            expect.objectContaining({
+              internal: expect.objectContaining({
+                type: expectedNodeType,
+              }),
+            })
+          )
+        }
+      )
+    })
+  })
+
+  it(`correctly creates nodes from JSON which is an array of objects and doesn't come from fs`, async () => {
+    const data = [
+      { id: `foo`, blue: true, funny: `yup` },
+      { blue: false, funny: `nope` },
+    ]
+    const node = {
+      ...baseNonFileNode,
+      content: JSON.stringify(data),
+    }
+
+    return bootstrapTest(node).then(({ createNode, createParentChildLink }) => {
+      expect(createNode.mock.calls).toMatchSnapshot()
+      expect(createParentChildLink.mock.calls).toMatchSnapshot()
+      expect(createNode).toHaveBeenCalledTimes(2)
+      expect(createParentChildLink).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it(`correctly creates a node from JSON which is a single object and doesn't come from fs`, async () => {
+    const data = { id: `foo`, blue: true, funny: `yup` }
+    const node = {
+      ...baseNonFileNode,
+      content: JSON.stringify(data),
+    }
+
+    return bootstrapTest(node).then(({ createNode, createParentChildLink }) => {
+      expect(createNode.mock.calls).toMatchSnapshot()
+      expect(createParentChildLink.mock.calls).toMatchSnapshot()
+      expect(createNode).toHaveBeenCalledTimes(1)
+      expect(createParentChildLink).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -10,6 +10,8 @@ async function onCreateNode({ node, actions, loadNodeContent, createNodeId }, pl
       return pluginOptions.typeName
     } else if (isArray) {
       return _.upperFirst(_.camelCase(`${node.name} Json`))
+    } else if (node.internal.type !== `File`) {
+      return `${node.internal.type} Json`
     } else {
       return _.upperFirst(_.camelCase(`${path.basename(node.dir)} Json`))
     }

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -2,16 +2,19 @@ const _ = require(`lodash`)
 const crypto = require(`crypto`)
 const path = require(`path`)
 
-async function onCreateNode({ node, actions, loadNodeContent, createNodeId }, pluginOptions) {
+async function onCreateNode(
+  { node, actions, loadNodeContent, createNodeId },
+  pluginOptions
+) {
   function getType({ node, object, isArray }) {
     if (pluginOptions && _.isFunction(pluginOptions.typeName)) {
       return pluginOptions.typeName({ node, object, isArray })
     } else if (pluginOptions && _.isString(pluginOptions.typeName)) {
       return pluginOptions.typeName
+    } else if (node.internal.type !== `File`) {
+      return _.upperFirst(_.camelCase(`${node.internal.type} Json`))
     } else if (isArray) {
       return _.upperFirst(_.camelCase(`${node.name} Json`))
-    } else if (node.internal.type !== `File`) {
-      return `${node.internal.type} Json`
     } else {
       return _.upperFirst(_.camelCase(`${path.basename(node.dir)} Json`))
     }


### PR DESCRIPTION
`gatsby-source-contentful` creates nodes with a JSON type so we can't expect all nodes to have a `node.dir` property to generate a GraphQL type from. 

Fixes #8538.