### PR TITLE
[v2] [cache-dir] [develop] Add a button for custom 404s in development

### DIFF
--- a/docs/docs/add-404-page.md
+++ b/docs/docs/add-404-page.md
@@ -12,5 +12,5 @@ site another way, you'll need to setup a custom rule to serve this file for 404
 errors.
 
 When developing, Gatsby adds a default 404 page that overrides your custom 404
-page. But you can still visit the exact url for your 404 page to verify it's
-working as expected.
+page. But you can still preview your 404 page by clicking "Preview custom 404
+page" to verify it's working as expected.

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -76,12 +76,28 @@ class RouteHandler extends React.Component {
       )
     } else {
       const dev404Page = pages.find(p => /^\/dev-404-page\/?$/.test(p.path))
-      return createElement(
-        syncRequires.components[dev404Page.componentChunkName],
-        {
-          pages,
-          ...this.props,
-        }
+      const custom404 = locationAndPageResources =>
+        loader.getPage(`/404.html`) ? (
+          <JSONStore
+            pages={pages}
+            {...this.props}
+            {...locationAndPageResources}
+          />
+        ) : null
+
+      return (
+        <EnsureResources location={location}>
+          {locationAndPageResources =>
+            createElement(
+              syncRequires.components[dev404Page.componentChunkName],
+              {
+                pages,
+                custom404: custom404(locationAndPageResources),
+                ...this.props,
+              }
+            )
+          }
+        </EnsureResources>
       )
     }
   }

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -1,12 +1,24 @@
-import React from "react"
+import React, { createElement } from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
 
 class Dev404Page extends React.Component {
   static propTypes = {
     pages: PropTypes.arrayOf(PropTypes.object),
+    custom404: PropTypes.element,
     location: PropTypes.object,
   }
+
+  constructor(props) {
+    super(props)
+    this.state = { showCustom404: false }
+    this.showCustom404 = this.showCustom404.bind(this)
+  }
+
+  showCustom404() {
+    this.setState({ showCustom404: true })
+  }
+
   render() {
     const { pathname } = this.props.location
     const pages = this.props.pages.filter(
@@ -20,13 +32,26 @@ class Dev404Page extends React.Component {
     } else {
       newFilePath = `src/pages${pathname}.js`
     }
-    return (
+
+    return this.state.showCustom404 ? (
+      this.props.custom404
+    ) : (
       <div>
         <h1>Gatsby.js development 404 page</h1>
         <p>
           {`There's not a page yet at `}
           <code>{pathname}</code>
         </p>
+        {this.props.custom404 ? (
+          <p>
+            <button onClick={this.showCustom404}>Preview custom 404 page</button>
+          </p>
+        ) : (
+          <p>
+            {`A custom 404 page wasn't detected - if you would like to add one, create a component in your site directory at `}
+            <code>src/pages/404.js</code>.
+          </p>
+        )}
         <p>
           Create a React.js component in your site directory at
           {` `}

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -1,4 +1,4 @@
-import React, { createElement } from "react"
+import React from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
 


### PR DESCRIPTION
- Pass the `JSONStore` to the dev 404 page if `404.html` exists (since the 404 page will be rendered here)
- Detect whether there's a custom 404 page and if so, add a button to display it - otherwise, instruct the user how to create one

Fixes #8234