### PR TITLE
Fix: redirect to other domains

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -7,6 +7,7 @@ const { stripIndent } = require(`common-tags`)
 const report = require(`gatsby-cli/lib/reporter`)
 const path = require(`path`)
 const fs = require(`fs`)
+const url = require(`url`)
 const kebabHash = require(`kebab-hash`)
 const { hasNodeChanged, getNode } = require(`./index`)
 const { trackInlineObjectsInRootNode } = require(`../schema/node-tracking`)
@@ -1099,10 +1100,11 @@ actions.createRedirect = ({
     pathPrefix = store.getState().config.pathPrefix
   }
 
-  // Check if URL is an external link
-  // and if it is, don't add pathPrefix
-  const isExternalUrl = /^(https?:|\/\/)/.test(toPath)
-  const toPathPrefix = isExternalUrl ? `` : pathPrefix
+  // Parse urls to get their protocols
+  // url.parse will not cover protocol-relative urls so do a separate check for those
+  const parsed = url.parse(toPath)
+  const isRelativeProtocol = toPath.startsWith(`//`)
+  const toPathPrefix = parsed.protocol != null || isRelativeProtocol ? `` : pathPrefix
 
   return {
     type: `CREATE_REDIRECT`,

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1101,7 +1101,7 @@ actions.createRedirect = ({
 
   // Check if URL is an external link
   // and if it is, don't add pathPrefix
-  const isExternalUrl = /^https?:/.test(toPath)
+  const isExternalUrl = /^(https?:|\/\/)/.test(toPath)
   const toPathPrefix = isExternalUrl ? `` : pathPrefix
 
   return {

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1101,7 +1101,7 @@ actions.createRedirect = ({
 
   // Check if URL is an external link
   // and if it is, don't add pathPrefix
-  const isExternalUrl = toPath.startsWith(`https://` || `http://`)
+  const isExternalUrl = /^https?:/.test(toPath)
   const toPathPrefix = isExternalUrl ? `` : pathPrefix
 
   return {

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1099,13 +1099,18 @@ actions.createRedirect = ({
     pathPrefix = store.getState().config.pathPrefix
   }
 
+  // Check if URL is an external link
+  // and if it is, don't add pathPrefix
+  const isExternalUrl = toPath.startsWith(`https://` || `http://`)
+  const toPathPrefix = isExternalUrl ? `` : pathPrefix
+
   return {
     type: `CREATE_REDIRECT`,
     payload: {
       fromPath: `${pathPrefix}${fromPath}`,
       isPermanent,
       redirectInBrowser,
-      toPath: `${pathPrefix}${toPath}`,
+      toPath: `${toPathPrefix}${toPath}`,
       ...rest,
     },
   }

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -43,84 +43,31 @@ describe(`redirects`, () => {
     )
   })
 
-  it(`lets you redirect using any protocol`, () => {
-    const action = {
-      type: `CREATE_REDIRECT`,
-      payload: {
-        fromPath: `/page1`,
-        toPath: `https://example.com`,
-      },
-    }
-    const action2 = {
-      type: `CREATE_REDIRECT`,
-      payload: {
-        fromPath: `/page2`,
-        toPath: `http://example.com`,
-      },
-    }
-    const action3 = {
-      type: `CREATE_REDIRECT`,
-      payload: {
-        fromPath: `/page3`,
-        toPath: `//example.com`,
-      },
-    }
-    const action4 = {
-      type: `CREATE_REDIRECT`,
-      payload: {
-        fromPath: `/page4`,
-        toPath: `ftp://example.com`,
-      },
-    }
-    const action5 = {
-      type: `CREATE_REDIRECT`,
-      payload: {
-        fromPath: `/page5`,
-        toPath: `mailto:example@email.com`,
-      },
-    }
-    const action6 = {
-      type: `CREATE_REDIRECT`,
-      payload: {
-        fromPath: `/page6`,
-        toPath: `/page6/`,
-      },
-    }
+  const protocolArr = [
+    [`https`, `https://example.com`],
+    [`http`, `http://example.com`],
+    [`//`, `//example.com`],
+    [`ftp`, `ftp://example.com`],
+    [`mailto`, `mailto:example@email.com`],
+  ]
+  
+  protocolArr.forEach(([protocol, toPath], index) => {
+    it(`lets you redirect using ${protocol}`, () => {
+      const fromPath = `/page${index}`
+      const action = {
+        type: `CREATE_REDIRECT`,
+        payload: {
+          fromPath,
+          toPath,
+        },
+      }
 
-    let state = reducer(undefined, action)
-    state = reducer(state, action2)
-    state = reducer(state, action3)
-    state = reducer(state, action4)
-    state = reducer(state, action5)
-    state = reducer(state, action6)
-
-    expect(state).toEqual(
-      [
+      expect(reducer(undefined, action)).toEqual([
         {
-          fromPath: `/page1`,
-          toPath: `https://example.com`,
+          fromPath,
+          toPath,
         },
-        {
-          fromPath: `/page2`,
-          toPath: `http://example.com`,
-        },
-        {
-          fromPath: `/page3`,
-          toPath: `//example.com`,
-        },
-        {
-          fromPath: `/page4`,
-          toPath: `ftp://example.com`,
-        },
-        {
-          fromPath: `/page5`,
-          toPath: `mailto:example@email.com`,
-        },
-        {
-          fromPath: `/page6`,
-          toPath: `/page6/`,
-        },
-      ]
-    )
+      ])
+    })
   })
 })

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -1,0 +1,126 @@
+const reducer = require(`../redirects`)
+
+describe(`redirects`, () => {
+  it(`lets you redirect to an internal url`, () => {
+    const action = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page1`,
+        toPath: `/page1/`,
+      },
+    }
+
+    let state = reducer(undefined, action)
+
+    expect(state).toEqual(
+      [
+        {
+          fromPath: `/page1`,
+          toPath: `/page1/`,
+        },
+      ]
+    )
+  })
+
+  it(`lets you redirect to an external url`, () => {
+    const action = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page1`,
+        toPath: `https://example.com`,
+      },
+    }
+
+    let state = reducer(undefined, action)
+
+    expect(state).toEqual(
+      [
+        {
+          fromPath: `/page1`,
+          toPath: `https://example.com`,
+        },
+      ]
+    )
+  })
+
+  it(`lets you redirect using any protocol`, () => {
+    const action = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page1`,
+        toPath: `https://example.com`,
+      },
+    }
+    const action2 = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page2`,
+        toPath: `http://example.com`,
+      },
+    }
+    const action3 = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page3`,
+        toPath: `//example.com`,
+      },
+    }
+    const action4 = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page4`,
+        toPath: `ftp://example.com`,
+      },
+    }
+    const action5 = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page5`,
+        toPath: `mailto:example@email.com`,
+      },
+    }
+    const action6 = {
+      type: `CREATE_REDIRECT`,
+      payload: {
+        fromPath: `/page6`,
+        toPath: `/page6/`,
+      },
+    }
+
+    let state = reducer(undefined, action)
+    state = reducer(state, action2)
+    state = reducer(state, action3)
+    state = reducer(state, action4)
+    state = reducer(state, action5)
+    state = reducer(state, action6)
+
+    expect(state).toEqual(
+      [
+        {
+          fromPath: `/page1`,
+          toPath: `https://example.com`,
+        },
+        {
+          fromPath: `/page2`,
+          toPath: `http://example.com`,
+        },
+        {
+          fromPath: `/page3`,
+          toPath: `//example.com`,
+        },
+        {
+          fromPath: `/page4`,
+          toPath: `ftp://example.com`,
+        },
+        {
+          fromPath: `/page5`,
+          toPath: `mailto:example@email.com`,
+        },
+        {
+          fromPath: `/page6`,
+          toPath: `/page6/`,
+        },
+      ]
+    )
+  })
+})


### PR DESCRIPTION
**Related Issue**

Fixes #7911 (hopefully 😅).

Added a check for external URLs and if so, don't prepend `pathPrefix`.

Tested online with `gatsby-plugin-netlify` and seems to be working (these links should redirect to Facebook):

https://heuristic-cray-e46eaa.netlify.com/page2
[https://heuristic-cray-e46eaa.netlify.com/page2/](https://heuristic-cray-e46eaa.netlify.com/page2/)

One thing that I'm not sure how to resolve is that external redirects on `http://localhost:8000/` flash a 404 before pushing the redirect. Not sure if that's fixable?