### PR TITLE
Fix writing out new page information (so new pages hot reload) during development

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -141,9 +141,9 @@ let oldPages
 const debouncedWritePages = _.debounce(
   () => {
     // Don't write pages again until bootstrap has finished.
-    if (bootstrapFinished && !_.isEqual(oldPages, store.getState().pages)) {
+    if (bootstrapFinished && oldPages !== store.getState().pages) {
       writePages()
-      oldPages = store.getState().pages
+      oldPages = new Map(store.getState().pages)
     }
   },
   500,


### PR DESCRIPTION
This was broken when we switched from storing pages in an object to a
Map as we used to create new objects whenver page data was updated so
comparing an old version of the pages to the new worked but stopped
working with Map as we started directly mutating.

We now make a shallow clone of the pages Map so we can compare old and
new versions.


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->