### PR TITLE
fix: ignore dot files in page creator plugin.

### DIFF
--- a/packages/gatsby-plugin-page-creator/README.md
+++ b/packages/gatsby-plugin-page-creator/README.md
@@ -3,6 +3,16 @@
 Gatsby plugin that automatically creates pages from React components in specified directories. Gatsby
 includes this plugin automatically in all sites for creating pages from components in `src/pages`.
 
+With this plugin, *any* file that lives in the `src/pages` folder (or subfolders) will be expected to export a React Component to generate a Page. The following files are automatically excluded:
+
+- `template-*`
+- `__tests__/*`
+- `*.test.jsx?`
+- `*.spec.jsx?`
+- `*.d.tsx?`
+- `_*`
+- `.*`
+
 ## Install
 
 `npm install --save gatsby-plugin-page-creator`

--- a/packages/gatsby-plugin-page-creator/README.md
+++ b/packages/gatsby-plugin-page-creator/README.md
@@ -10,6 +10,8 @@ With this plugin, *any* file that lives in the `src/pages` folder (or subfolders
 - `*.test.jsx?`
 - `*.spec.jsx?`
 - `*.d.tsx?`
+- `*.json`
+- `*.yaml`
 - `_*`
 - `.*`
 

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -1,7 +1,7 @@
 const validatePath = require(`../validate-path`)
 const createPath = require(`../create-path`)
 
-describe.only(`JavaScript page creator`, () => {
+describe(`JavaScript page creator`, () => {
   it(`filters out files that start with underscores`, () => {
     const files = [
       {
@@ -41,6 +41,34 @@ describe.only(`JavaScript page creator`, () => {
     ]
 
     expect(files.filter(file => validatePath(file.path)).length).toEqual(1)
+  })
+
+  it(`filters out json and yaml files`, () => {
+    const files = [
+      {
+        path: `something/blah.js`,
+      },
+      {
+        path: `something/otherConfig.yml`,
+      },
+      {
+        path: `config.yaml`,
+      },
+      {
+        path: `somefile.json`,
+      },
+      {
+        path: `somefile.js`,
+      },
+      {
+        path: `dir1/file.json`,
+      },
+      {
+        path: `dir1/dir2/file.json`,
+      },
+    ]
+
+    expect(files.filter(file => validatePath(file.path)).length).toEqual(2)
   })
 
   it(`filters out files that start with template-*`, () => {

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -64,7 +64,7 @@ describe(`JavaScript page creator`, () => {
   it(`filters out files that start with template-*`, () => {
     const validFiles = [
       { path: `something/blah.js` },
-      { path: `something/template-cool-page-type.js` },
+      { path: `file1.js` },
     ]
 
     const testFiles = validFiles.concat([

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -1,7 +1,7 @@
 const validatePath = require(`../validate-path`)
 const createPath = require(`../create-path`)
 
-describe(`JavaScript page creator`, () => {
+describe.only(`JavaScript page creator`, () => {
   it(`filters out files that start with underscores`, () => {
     const files = [
       {
@@ -12,6 +12,31 @@ describe(`JavaScript page creator`, () => {
       },
       {
         path: `_blah.js`,
+      },
+    ]
+
+    expect(files.filter(file => validatePath(file.path)).length).toEqual(1)
+  })
+
+  it(`filters out files that start with dot`, () => {
+    const files = [
+      {
+        path: `.eslintrc`,
+      },
+      {
+        path: `something/.eslintrc`,
+      },
+      {
+        path: `something/.eslintrc.js`,
+      },
+      {
+        path: `something/blah.js`,
+      },
+      {
+        path: `.markdownlint.json`,
+      },
+      {
+        path: `something/.markdownlint.json`,
       },
     ]
 

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -2,130 +2,105 @@ const validatePath = require(`../validate-path`)
 const createPath = require(`../create-path`)
 
 describe(`JavaScript page creator`, () => {
-  it(`filters out files that start with underscores`, () => {
-    const files = [
-      {
-        path: `something/blah.js`,
-      },
-      {
-        path: `something/_blah.js`,
-      },
-      {
-        path: `_blah.js`,
-      },
+  it(`includes the correct file types`, () => {
+    const validFiles = [
+      { path: `test1.js` },
+      { path: `somedir/test1.js` },
+      { path: `somedir/test2.ts` },
+      { path: `somedir/dir2/test1.js` },
     ]
 
-    expect(files.filter(file => validatePath(file.path)).length).toEqual(1)
+    expect(validFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+  })
+
+  it(`filters out files that start with underscores`, () => {
+    const validFiles = [
+      { path: `something/blah.js` },
+      { path: `test1.js` },
+    ]
+
+    const testFiles = validFiles.concat([
+      { path: `something/_foo.js` },
+      { path: `_blah.js` },
+    ])
+
+    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
   })
 
   it(`filters out files that start with dot`, () => {
-    const files = [
-      {
-        path: `.eslintrc`,
-      },
-      {
-        path: `something/.eslintrc`,
-      },
-      {
-        path: `something/.eslintrc.js`,
-      },
-      {
-        path: `something/blah.js`,
-      },
-      {
-        path: `.markdownlint.json`,
-      },
-      {
-        path: `something/.markdownlint.json`,
-      },
+    const validFiles = [
+      { path: `something/blah.js` },
+      { path: `test1.ts` },
     ]
 
-    expect(files.filter(file => validatePath(file.path)).length).toEqual(1)
+    const testFiles = validFiles.concat([
+      { path: `.eslintrc` },
+      { path: `something/.eslintrc` },
+      { path: `something/.eslintrc.js` },
+      { path: `.markdownlint.json` },
+      { path: `something/.markdownlint.json` },
+    ])
+
+    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
   })
 
   it(`filters out json and yaml files`, () => {
-    const files = [
-      {
-        path: `something/blah.js`,
-      },
-      {
-        path: `something/otherConfig.yml`,
-      },
-      {
-        path: `config.yaml`,
-      },
-      {
-        path: `somefile.json`,
-      },
-      {
-        path: `somefile.js`,
-      },
-      {
-        path: `dir1/file.json`,
-      },
-      {
-        path: `dir1/dir2/file.json`,
-      },
+    const validFiles = [
+      { path: `somefile.js` },
+      { path: `something/blah.js` },
     ]
 
-    expect(files.filter(file => validatePath(file.path)).length).toEqual(2)
+    const testFiles = validFiles.concat([
+      { path: `something/otherConfig.yml` },
+      { path: `config.yaml` },
+      { path: `somefile.json` },
+      { path: `dir1/file.json` },
+      { path: `dir1/dir2/file.json` },
+    ])
+
+    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
   })
 
   it(`filters out files that start with template-*`, () => {
-    const files = [
-      {
-        path: `something/blah.js`,
-      },
-      {
-        path: `something/template-cool-page-type.js`,
-      },
-      {
-        path: `template-cool-page-type.js`,
-      },
+    const validFiles = [
+      { path: `something/blah.js` },
+      { path: `something/template-cool-page-type.js` },
     ]
 
-    expect(files.filter(file => validatePath(file.path)).length).toEqual(1)
+    const testFiles = validFiles.concat([
+      { path: `template-cool-page-type.js` },
+    ])
+
+    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
   })
 
   it(`filters out files that have TypeScript declaration extensions`, () => {
-    const files = [
-      {
-        path: `something/foo.ts`,
-      },
-      {
-        path: `something/bar.tsx`,
-      },
-      {
-        path: `something/declaration-file.d.ts`,
-      },
-      {
-        path: `something-else/other-declaration-file.d.tsx`,
-      },
+    const validFiles = [
+      { path: `something/foo.ts` },
+      { path: `something/bar.tsx` },
     ]
 
-    expect(files.filter(file => validatePath(file.path)).length).toEqual(2)
+    const testFiles = validFiles.concat([
+      { path: `something/declaration-file.d.ts` },
+      { path: `something-else/other-declaration-file.d.tsx` },
+    ])
+
+    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
   })
 
   it(`filters out test files`, () => {
-    const files = [
-      {
-        path: `__tests__/something.test.js`,
-      },
-      {
-        path: `foo.spec.js`,
-      },
-      {
-        path: `bar.test.js`,
-      },
-      {
-        path: `page.js`,
-      },
-      {
-        path: `page.jsx`,
-      },
+    const validFiles = [
+      { path: `page.js` },
+      { path: `page.jsx` },
     ]
 
-    expect(files.filter(file => validatePath(file.path)).length).toEqual(2)
+    const testFiles = validFiles.concat([
+      { path: `__tests__/something.test.js` },
+      { path: `foo.spec.js` },
+      { path: `bar.test.js` },
+    ])
+
+    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
   })
 
   describe(`create-path`, () => {

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -1,6 +1,7 @@
 const systemPath = require(`path`)
 
 const tsDeclarationExtTest = /\.d\.tsx?$/
+const jsonYamlExtTest = /\.(json|ya?ml)$/
 
 function isTestFile(path) {
   const testFileTest = new RegExp(`(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$`)
@@ -17,6 +18,7 @@ module.exports = path => {
     parsedPath.name.slice(0, 1) !== `.` &&
     parsedPath.name.slice(0, 9) !== `template-` &&
     !tsDeclarationExtTest.test(parsedPath.base) &&
+    !jsonYamlExtTest.test(parsedPath.base) &&
     !isTestFile(parsedPath.base)
   )
 }

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -8,12 +8,13 @@ function isTestFile(path) {
 }
 
 module.exports = path => {
-  // Disallow paths starting with an underscore
+  // Disallow paths starting with an underscore (_) or dot (.)
   // and template-.
   // and .d.ts
   const parsedPath = systemPath.parse(path)
   return (
     parsedPath.name.slice(0, 1) !== `_` &&
+    parsedPath.name.slice(0, 1) !== `.` &&
     parsedPath.name.slice(0, 9) !== `template-` &&
     !tsDeclarationExtTest.test(parsedPath.base) &&
     !isTestFile(parsedPath.base)


### PR DESCRIPTION
Closes #8474 

Refactor the page creator plugin to ignore "dot" files. 