### PR TITLE
Compat fix for gatsby-cli v2 with gatsby v1

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -34,10 +34,12 @@ function buildLocalCommands(cli, isLocalSite) {
   function installedGatsbyVersion() {
     let majorVersion
     try {
-      let packagePath = require.resolve(
-        path.join(process.cwd(), `node_modules`, `gatsby`, `package.json`)
-      )
-      const packageInfo = JSON.parse(fs.readFileSync(packagePath))
+      const packageInfo = require(path.join(
+        process.cwd(),
+        `node_modules`,
+        `gatsby`,
+        `package.json`
+      ))
       majorVersion = parseInt(packageInfo.version.split(`.`)[0], 10)
     } catch (err) {
       /* ignore */

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -4,7 +4,6 @@ const yargs = require(`yargs`)
 const report = require(`./reporter`)
 const envinfo = require(`envinfo`)
 const existsSync = require(`fs-exists-cached`).sync
-const fs = require(`fs`)
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -4,8 +4,7 @@ const yargs = require(`yargs`)
 const report = require(`./reporter`)
 const envinfo = require(`envinfo`)
 const existsSync = require(`fs-exists-cached`).sync
-
-const DEFAULT_BROWSERS = [`>0.25%`, `not dead`]
+const fs = require(`fs`)
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(
@@ -18,12 +17,33 @@ function buildLocalCommands(cli, isLocalSite) {
   const defaultHost = `localhost`
   const directory = path.resolve(`.`)
 
+  // 'not dead' query not available in browserslist used in Gatsby v1
+  const DEFAULT_BROWSERS =
+    installedGatsbyVersion() === 1
+      ? [`> 1%`, `last 2 versions`, `IE >= 9`]
+      : [`>0.25%`, `not dead`]
+
   let siteInfo = { directory, browserslist: DEFAULT_BROWSERS }
   const useYarn = existsSync(path.join(directory, `yarn.lock`))
   if (isLocalSite) {
     const json = require(path.join(directory, `package.json`))
     siteInfo.sitePackageJson = json
     siteInfo.browserslist = json.browserslist || siteInfo.browserslist
+  }
+
+  function installedGatsbyVersion() {
+    let majorVersion
+    try {
+      let packagePath = require.resolve(
+        path.join(process.cwd(), `node_modules`, `gatsby`, `package.json`)
+      )
+      const packageInfo = JSON.parse(fs.readFileSync(packagePath))
+      majorVersion = parseInt(packageInfo.version.split(`.`)[0], 10)
+    } catch (err) {
+      /* ignore */
+    }
+
+    return majorVersion
   }
 
   function resolveLocalCommand(command) {


### PR DESCRIPTION
Gatsby v1 includes postcss-next which uses an older version of browserslist. This means the default browserslist query `["> 0.25%", "not dead"]` won't work in Gatsby v1. This causes an error when you have `gatsby-cli` v2 installed and you're working on a Gatsby v1 site.

Fixes #8575 
Refs #8560