### PR TITLE
Add Hasura GraphQL engine example under third party

### DIFF
--- a/docs/docs/third-party-graphql.md
+++ b/docs/docs/third-party-graphql.md
@@ -98,3 +98,4 @@ exports.createPages = async ({ actions, graphql }) => {
 - [graphql-source-graphql docs](/packages/gatsby-source-graphql)
 - [Example with Github API](https://github.com/freiksenet/gatsby-github-displayer)
 - [Example with GraphCMS](https://github.com/freiksenet/gatsby-graphcms)
+- [Example with Hasura](https://github.com/hasura/graphql-engine/tree/master/community/boilerplates/gatsby-postgres-graphql)


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Added [Hasura](https://github.com/hasura/graphql-engine) usage example in docs/docs/third-party-graphql.md.