### PR TITLE
a11y improvements - Part 2

### DIFF
--- a/www/src/components/docsearch-content.js
+++ b/www/src/components/docsearch-content.js
@@ -1,5 +1,7 @@
 import React from "react"
 
 export default ({ children }) => (
-  <main className={`docSearch-content`}>{children}</main>
+  <main id={`MainContent`} className={`docSearch-content`}>
+    {children}
+  </main>
 )

--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -157,6 +157,9 @@ class DefaultLayout extends React.Component {
           />
           <html lang="en" />
         </Helmet>
+        <a href="#MainContent" css={styles.skipLink}>
+          Skip to main content
+        </a>
         <Banner background={isHomepage ? `#402060` : false}>
           These are the docs for v2.
           {` `}
@@ -206,6 +209,20 @@ class DefaultLayout extends React.Component {
       </div>
     )
   }
+}
+
+const styles = {
+  skipLink: {
+    flex: `none`,
+    position: `absolute !important`,
+    top: `0`,
+    clip: `rect(1px, 1px, 1px, 1px) !important`,
+    overflow: `hidden !important`,
+    height: `1px !important`,
+    width: `1px !important`,
+    padding: `0 !important`,
+    border: `0 !important`,
+  },
 }
 
 export default DefaultLayout

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -57,9 +57,7 @@ const Navigation = ({ pathname }) => {
   )
 
   return (
-    <nav
-      className="navigation"
-      aria-label="Primary Navigation"
+    <header
       css={{
         backgroundColor: isHomepage ? `transparent` : `rgba(255,255,255,0.975)`,
         position: isHomepage ? `absolute` : `relative`,
@@ -125,26 +123,41 @@ const Navigation = ({ pathname }) => {
             : {}),
         }}
       >
-        <Link to="/" css={styles.logoLink} aria-label="Go to homepage">
-          <img src={logo} css={styles.logo} alt="Gatsby logo" />
+        <Link
+          to="/"
+          css={styles.logoLink}
+          aria-label="Gatsby, Back to homepage"
+        >
+          <img
+            src={logo}
+            css={styles.logo}
+            alt="Gatsby Logo"
+            aria-hidden="true"
+          />
         </Link>
-        <ul css={styles.navContainer}>
-          <NavItem linkTo="/docs/">Docs</NavItem>
-          <NavItem linkTo="/tutorial/">Tutorial</NavItem>
-          <NavItem linkTo="/plugins/">Plugins</NavItem>
-          <NavItem linkTo="/features/">Features</NavItem>
-          <NavItem linkTo="/blog/">Blog</NavItem>
-          <NavItem linkTo="/showcase/">Showcase</NavItem>
-          {/* <li css={styles.li}>
-              <Link
-                to="/community/"
-                css={styles.navItem}
-                state={{ filter: `` }}
-              >
-                Community
-              </Link>
-            </li> */}
-        </ul>
+        <nav
+          className="navigation"
+          aria-label="Primary Navigation"
+          css={styles.navContainer}
+        >
+          <ul css={styles.ulContainer}>
+            <NavItem linkTo="/docs/">Docs</NavItem>
+            <NavItem linkTo="/tutorial/">Tutorial</NavItem>
+            <NavItem linkTo="/plugins/">Plugins</NavItem>
+            <NavItem linkTo="/features/">Features</NavItem>
+            <NavItem linkTo="/blog/">Blog</NavItem>
+            <NavItem linkTo="/showcase/">Showcase</NavItem>
+            {/* <li css={styles.li}>
+                <Link
+                  to="/community/"
+                  css={styles.navItem}
+                  state={{ filter: `` }}
+                >
+                  Community
+                </Link>
+              </li> */}
+          </ul>
+        </nav>
         <div css={styles.searchAndSocialContainer}>
           <SearchForm
             key="SearchForm"
@@ -187,7 +200,7 @@ const Navigation = ({ pathname }) => {
           </SocialNavItem>
         </div>
       </div>
-    </nav>
+    </header>
   )
 }
 
@@ -199,6 +212,13 @@ const styles = {
     marginRight: navItemHorizontalSpacing,
   },
   navContainer: {
+    display: `none`,
+    [presets.Tablet]: {
+      alignSelf: `flex-end`,
+      display: `flex`,
+    },
+  },
+  ulContainer: {
     display: `none`,
     [presets.Tablet]: {
       alignSelf: `flex-end`,

--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -18,6 +18,7 @@ class PageWithPluginSearchBar extends Component {
           <PluginSearchBar location={this.props.location} />
         </section>
         <main
+          id={`MainContent`}
           css={{
             ...styles.content,
             // mobile: hide README on gatsbyjs.org/plugins index page

--- a/www/src/pages/features.js
+++ b/www/src/pages/features.js
@@ -112,7 +112,7 @@ const LegendTable = () => {
 }
 
 const FeaturesHeader = () => (
-  <div>
+  <section>
     <h1 id="introduction" style={{ marginTop: 0 }}>
       Features
     </h1>
@@ -158,7 +158,7 @@ const FeaturesHeader = () => (
       Legend
     </h6>
     <LegendTable />
-  </div>
+  </section>
 )
 
 const getFeaturesData = function(data) {
@@ -212,12 +212,14 @@ class FeaturesPage extends Component {
         enableScrollSync={true}
       >
         <Container>
-          <FeaturesHeader />
-          <EvaluationTable
-            sections={sections}
-            sectionHeaders={sectionHeaders}
-          />
-          <FeaturesFooter />
+          <main id={`MainContent`}>
+            <FeaturesHeader />
+            <EvaluationTable
+              sections={sections}
+              sectionHeaders={sectionHeaders}
+            />
+            <FeaturesFooter />
+          </main>
         </Container>
       </Layout>
     )

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -54,6 +54,7 @@ class IndexRoute extends React.Component {
               }}
             >
               <main
+                id={`MainContent`}
                 css={{
                   display: `flex`,
                   flexDirection: `row`,

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -18,7 +18,8 @@ class BlogPostsIndex extends React.Component {
 
     return (
       <Layout location={this.props.location}>
-        <div
+        <main
+          id={`MainContent`}
           css={{
             [presets.Tablet]: {
               background: colors.ui.whisper,
@@ -100,7 +101,7 @@ class BlogPostsIndex extends React.Component {
             <Pagination context={this.props.pageContext} />
             <EmailCaptureForm signupMessage="Enjoying our blog? Receive the next post in your inbox!" />
           </Container>
-        </div>
+        </main>
       </Layout>
     )
   }

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -67,174 +67,181 @@ class BlogPostTemplate extends React.Component {
     return (
       <Layout location={this.props.location}>
         <Container className="post" css={{ paddingBottom: `0` }}>
-          {/* Add long list of social meta tags */}
-          <Helmet>
-            <title>{post.frontmatter.title}</title>
-            <link
-              rel="author"
-              href={`https://gatsbyjs.org${
-                post.frontmatter.author.fields.slug
-              }`}
-            />
-            <meta
-              name="description"
-              content={
-                post.frontmatter.excerpt
-                  ? post.frontmatter.excerpt
-                  : post.excerpt
-              }
-            />
+          <main id={`MainContent`}>
+            {/* Add long list of social meta tags */}
+            <Helmet>
+              <title>{post.frontmatter.title}</title>
+              <link
+                rel="author"
+                href={`https://gatsbyjs.org${
+                  post.frontmatter.author.fields.slug
+                }`}
+              />
+              <meta
+                name="description"
+                content={
+                  post.frontmatter.excerpt
+                    ? post.frontmatter.excerpt
+                    : post.excerpt
+                }
+              />
 
-            <meta name="og:description" content={post.excerpt} />
-            <meta name="twitter:description" content={post.excerpt} />
-            <meta name="og:title" content={post.frontmatter.title} />
-            {post.frontmatter.image && (
-              <meta
-                name="og:image"
-                content={`https://gatsbyjs.org${
-                  post.frontmatter.image.childImageSharp.resize.src
-                }`}
-              />
-            )}
-            {post.frontmatter.image && (
-              <meta
-                name="twitter:image"
-                content={`https://gatsbyjs.org${
-                  post.frontmatter.image.childImageSharp.resize.src
-                }`}
-              />
-            )}
-            <meta name="og:type" content="article" />
-            <meta name="article:author" content={post.frontmatter.author.id} />
-            <meta
-              name="twitter:creator"
-              content={post.frontmatter.author.twitter}
-            />
-            <meta name="author" content={post.frontmatter.author.id} />
-            <meta name="twitter:label1" content="Reading time" />
-            <meta
-              name="twitter:data1"
-              content={`${post.timeToRead} min read`}
-            />
-            <meta
-              name="article:published_time"
-              content={post.frontmatter.rawDate}
-            />
-            {canonicalLink}
-          </Helmet>
-          <header
-            css={{
-              display: `flex`,
-              marginTop: rhythm(-1 / 4),
-              marginBottom: rhythm(1),
-              [presets.Tablet]: {
-                marginTop: rhythm(1 / 2),
-                marginBottom: rhythm(2),
-              },
-            }}
-          >
-            <div
-              css={{
-                flex: `0 0 auto`,
-              }}
-            >
-              <Link to={post.frontmatter.author.fields.slug}>
-                <Img
-                  fixed={post.frontmatter.author.avatar.childImageSharp.fixed}
-                  css={{
-                    height: rhythm(2.3),
-                    width: rhythm(2.3),
-                    margin: 0,
-                    borderRadius: `100%`,
-                    display: `inline-block`,
-                    verticalAlign: `middle`,
-                  }}
+              <meta name="og:description" content={post.excerpt} />
+              <meta name="twitter:description" content={post.excerpt} />
+              <meta name="og:title" content={post.frontmatter.title} />
+              {post.frontmatter.image && (
+                <meta
+                  name="og:image"
+                  content={`https://gatsbyjs.org${
+                    post.frontmatter.image.childImageSharp.resize.src
+                  }`}
                 />
-              </Link>
-            </div>
-            <div
+              )}
+              {post.frontmatter.image && (
+                <meta
+                  name="twitter:image"
+                  content={`https://gatsbyjs.org${
+                    post.frontmatter.image.childImageSharp.resize.src
+                  }`}
+                />
+              )}
+              <meta name="og:type" content="article" />
+              <meta
+                name="article:author"
+                content={post.frontmatter.author.id}
+              />
+              <meta
+                name="twitter:creator"
+                content={post.frontmatter.author.twitter}
+              />
+              <meta name="author" content={post.frontmatter.author.id} />
+              <meta name="twitter:label1" content="Reading time" />
+              <meta
+                name="twitter:data1"
+                content={`${post.timeToRead} min read`}
+              />
+              <meta
+                name="article:published_time"
+                content={post.frontmatter.rawDate}
+              />
+              {canonicalLink}
+            </Helmet>
+            <section
               css={{
-                flex: `1 1 auto`,
-                marginLeft: rhythm(1 / 2),
+                display: `flex`,
+                marginTop: rhythm(-1 / 4),
+                marginBottom: rhythm(1),
+                [presets.Tablet]: {
+                  marginTop: rhythm(1 / 2),
+                  marginBottom: rhythm(2),
+                },
               }}
             >
-              <Link to={post.frontmatter.author.fields.slug}>
-                <h4
-                  css={{
-                    ...scale(0),
-                    fontWeight: 400,
-                    margin: 0,
-                    color: `${colors.gatsby}`,
-                  }}
-                >
-                  <span
-                    css={{
-                      borderBottom: `1px solid ${colors.ui.bright}`,
-                      boxShadow: `inset 0 -2px 0 0 ${colors.ui.bright}`,
-                      transition: `all ${presets.animation.speedFast} ${
-                        presets.animation.curveDefault
-                      }`,
-                      "&:hover": {
-                        background: colors.ui.bright,
-                      },
-                    }}
-                  >
-                    {post.frontmatter.author.id}
-                  </span>
-                </h4>
-              </Link>
-              <BioLine>{post.frontmatter.author.bio}</BioLine>
-              <BioLine>
-                {post.timeToRead} min read · {post.frontmatter.date}
-                {post.frontmatter.canonicalLink && (
-                  <span>
-                    {` `}
-                    (originally published at
-                    {` `}
-                    <a href={post.frontmatter.canonicalLink}>
-                      {post.frontmatter.publishedAt}
-                    </a>
-                    )
-                  </span>
-                )}
-              </BioLine>
-            </div>
-          </header>
-          <h1
-            css={{
-              marginTop: 0,
-              [presets.Desktop]: {
-                marginBottom: rhythm(5 / 4),
-              },
-            }}
-          >
-            {this.props.data.markdownRemark.frontmatter.title}
-          </h1>
-          {post.frontmatter.image &&
-            !(post.frontmatter.showImageInArticle === false) && (
               <div
                 css={{
-                  marginBottom: rhythm(1),
+                  flex: `0 0 auto`,
                 }}
               >
-                <Img fluid={post.frontmatter.image.childImageSharp.fluid} />
-                {post.frontmatter.imageAuthor &&
-                  post.frontmatter.imageAuthorLink && (
-                    <em>
-                      Image by
-                      {` `}
-                      <a href={post.frontmatter.imageAuthorLink}>
-                        {post.frontmatter.imageAuthor}
-                      </a>
-                    </em>
-                  )}
+                <Link to={post.frontmatter.author.fields.slug}>
+                  <Img
+                    fixed={post.frontmatter.author.avatar.childImageSharp.fixed}
+                    css={{
+                      height: rhythm(2.3),
+                      width: rhythm(2.3),
+                      margin: 0,
+                      borderRadius: `100%`,
+                      display: `inline-block`,
+                      verticalAlign: `middle`,
+                    }}
+                  />
+                </Link>
               </div>
-            )}
-          <div className="post-body">
-            {renderAst(this.props.data.markdownRemark.htmlAst)}
-          </div>
-          <TagsSection tags={this.props.data.markdownRemark.frontmatter.tags} />
-          <EmailCaptureForm />
+              <div
+                css={{
+                  flex: `1 1 auto`,
+                  marginLeft: rhythm(1 / 2),
+                }}
+              >
+                <Link to={post.frontmatter.author.fields.slug}>
+                  <h4
+                    css={{
+                      ...scale(0),
+                      fontWeight: 400,
+                      margin: 0,
+                      color: `${colors.gatsby}`,
+                    }}
+                  >
+                    <span
+                      css={{
+                        borderBottom: `1px solid ${colors.ui.bright}`,
+                        boxShadow: `inset 0 -2px 0 0 ${colors.ui.bright}`,
+                        transition: `all ${presets.animation.speedFast} ${
+                          presets.animation.curveDefault
+                        }`,
+                        "&:hover": {
+                          background: colors.ui.bright,
+                        },
+                      }}
+                    >
+                      {post.frontmatter.author.id}
+                    </span>
+                  </h4>
+                </Link>
+                <BioLine>{post.frontmatter.author.bio}</BioLine>
+                <BioLine>
+                  {post.timeToRead} min read · {post.frontmatter.date}
+                  {post.frontmatter.canonicalLink && (
+                    <span>
+                      {` `}
+                      (originally published at
+                      {` `}
+                      <a href={post.frontmatter.canonicalLink}>
+                        {post.frontmatter.publishedAt}
+                      </a>
+                      )
+                    </span>
+                  )}
+                </BioLine>
+              </div>
+            </section>
+            <h1
+              css={{
+                marginTop: 0,
+                [presets.Desktop]: {
+                  marginBottom: rhythm(5 / 4),
+                },
+              }}
+            >
+              {this.props.data.markdownRemark.frontmatter.title}
+            </h1>
+            {post.frontmatter.image &&
+              !(post.frontmatter.showImageInArticle === false) && (
+                <div
+                  css={{
+                    marginBottom: rhythm(1),
+                  }}
+                >
+                  <Img fluid={post.frontmatter.image.childImageSharp.fluid} />
+                  {post.frontmatter.imageAuthor &&
+                    post.frontmatter.imageAuthorLink && (
+                      <em>
+                        Image by
+                        {` `}
+                        <a href={post.frontmatter.imageAuthorLink}>
+                          {post.frontmatter.imageAuthor}
+                        </a>
+                      </em>
+                    )}
+                </div>
+              )}
+            <section className="post-body">
+              {renderAst(this.props.data.markdownRemark.htmlAst)}
+            </section>
+            <TagsSection
+              tags={this.props.data.markdownRemark.frontmatter.tags}
+            />
+            <EmailCaptureForm />
+          </main>
         </Container>
         <div
           css={{

--- a/www/src/views/community/index.js
+++ b/www/src/views/community/index.js
@@ -107,7 +107,7 @@ class CommunityView extends Component {
           submissionText={submissionText}
         />
         <main
-          role="main"
+          id={`MainContent`}
           css={{
             padding: rhythm(3 / 4),
             paddingBottom: `10vh`,

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -17,7 +17,7 @@ const ShowcaseList = ({ items, count }) => {
   if (count) items = items.slice(0, count)
 
   return (
-    <div css={{ ...styles.showcaseList }}>
+    <main id={`MainContent`} css={{ ...styles.showcaseList }}>
       {items.map(
         ({ node }) =>
           node.fields &&
@@ -94,7 +94,7 @@ const ShowcaseList = ({ items, count }) => {
           )
       )}
       {items.length && <EmptyGridItems styles={styles.showcaseItem} />}
-    </div>
+    </main>
   )
 }
 


### PR DESCRIPTION
## Changes

- Added `MainContent` as `id` to `<main>` tag
- Added invisible link to this MainContent at the begin of the page
- Header tag + nav for navigation
- Added main tag to features site & blog site & blog template & showcase

## Reasonings

- The invisible link at the begin allows users with screenreaders to skip the Header (+ Navigation).
- The `<nav>` inside a `<header>` is the more common way

## Comments

I tried my best to change given tags but in some cases only components like `Container` wrapped the relevant content and without something like `styled-components` I've got no idea how to smoothly change that tag for the given instance. Or I manually wrapped it with a `<main>` tag