### PR TITLE
Add missing htmlAttributes and bodyAttributes to develop-static-entry.js

### DIFF
--- a/packages/gatsby/cache-dir/develop-static-entry.js
+++ b/packages/gatsby/cache-dir/develop-static-entry.js
@@ -101,6 +101,8 @@ export default (pagePath, callback) => {
     headComponents: headComponents.concat([
       <script key={`io`} src="/socket.io/socket.io.js" />,
     ]),
+    htmlAttributes,
+    bodyAttributes,
     preBodyComponents,
     postBodyComponents: postBodyComponents.concat([
       <script key={`commons`} src="/commons.js" />,


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Fix for https://github.com/gatsbyjs/gatsby/issues/8569

Use https://github.com/taktran/gatsby-bug (and `gatsby-dev-cli`) to check it shows attributes in `html` and `body` tags
