### PR TITLE
gatsby-image: add missing GatsbyImageProps to TS defs

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -9,10 +9,13 @@ interface GatsbyImageProps {
   title?: string;
   alt?: string;
   className?: string | object;
+  critical?: boolean;
   style?: object;
   imgStyle?: object;
+  placeholderStyle?: object;
   backgroundColor?: string | boolean;
   onLoad?: (event: any) => void;
+  onError?: (event: any) => void;
   Tag?: string;
 }
 


### PR DESCRIPTION
See React prop-types in [index.js](https://github.com/gatsbyjs/gatsby/blob/76c50aa00653d988043333ceefec7abb34078fca/packages/gatsby-image/src/index.js#L457-L474)