### PR TITLE
[www] Don't `redirectInBrowser` our redirects

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -59,6 +59,18 @@ exports.createPages = ({ graphql, actions }) => {
     isPermanent: true,
   })
 
+  createRedirect({
+    fromPath: `/docs/bound-action-creators/`,
+    toPath: `/docs/actions/`,
+    isPermanent: true,
+  })
+
+  createRedirect({
+    fromPath: `/docs/bound-action-creators`,
+    toPath: `/docs/actions`,
+    isPermanent: true,
+  })
+
   return new Promise((resolve, reject) => {
     const docsTemplate = path.resolve(`src/templates/template-docs-markdown.js`)
     const blogPostTemplate = path.resolve(`src/templates/template-blog-post.js`)
@@ -79,18 +91,6 @@ exports.createPages = ({ graphql, actions }) => {
     const creatorPageTemplate = path.resolve(
       `src/templates/template-creator-details.js`
     )
-
-    createRedirect({
-      fromPath: `/docs/bound-action-creators/`,
-      toPath: `/docs/actions/`,
-      isPermanent: true,
-    })
-
-    createRedirect({
-      fromPath: `/docs/bound-action-creators`,
-      toPath: `/docs/actions`,
-      isPermanent: true,
-    })
 
     // Query for markdown nodes to use in creating pages.
     graphql(

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -43,9 +43,8 @@ exports.createPages = ({ graphql, actions }) => {
 
   createRedirect({
     fromPath: `/docs/netlify-cms/`,
-    isPermanent: true,
-    redirectInBrowser: true,
     toPath: `/docs/sourcing-from-netlify-cms/`,
+    isPermanent: true,
   })
 
   createRedirect({
@@ -53,12 +52,11 @@ exports.createPages = ({ graphql, actions }) => {
     toPath: `/starters/`,
     isPermanent: true,
   })
-  
+
   createRedirect({
     fromPath: `/docs/adding-third-party-services/`,
-    isPermanent: true,
-    redirectInBrowser: true,
     toPath: `/docs/adding-website-functionality/`,
+    isPermanent: true,
   })
 
   return new Promise((resolve, reject) => {
@@ -84,20 +82,17 @@ exports.createPages = ({ graphql, actions }) => {
 
     createRedirect({
       fromPath: `/docs/bound-action-creators/`,
-      isPermanent: true,
-      redirectInBrowser: true,
       toPath: `/docs/actions/`,
+      isPermanent: true,
     })
 
     createRedirect({
       fromPath: `/docs/bound-action-creators`,
-      isPermanent: true,
-      redirectInBrowser: true,
       toPath: `/docs/actions`,
+      isPermanent: true,
     })
 
     // Query for markdown nodes to use in creating pages.
-
     graphql(
       `
         query {


### PR DESCRIPTION
Removes `redirectInBrowser: true` that we set for a couple of our redirects, and don't need because we are already redirecting on the server via `gatsby-plugin-netlify`. See review comments in #8528 for more info.

Also moves two `createRedirect`s out of the promise.
