### PR TITLE
fix: use correct path argument

### DIFF
--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -39,7 +39,7 @@ function watch(root, packages, { scanOnce, quiet }) {
   let allCopies = []
 
   chokidar.watch(watchers, {
-    ignored: [(filePath, stats) => _.some(ignored, reg => reg.test(filePath))],
+    ignored: [filePath => _.some(ignored, reg => reg.test(filePath))],
   })
     .on(`all`, (event, filePath) => {
       if (event === `change` || event === `add`) {
@@ -65,7 +65,7 @@ function watch(root, packages, { scanOnce, quiet }) {
             `.cache/`,
             path.relative(path.join(prefix, `cache-dir`), filePath)
           )
-          localCopies.push(copyPath(path, newCachePath, quiet))
+          localCopies.push(copyPath(filePath, newCachePath, quiet))
         }
 
         allCopies = allCopies.concat(localCopies)


### PR DESCRIPTION
This fixes an issue that manifested itself in CI.

```
(node:10110) UnhandledPromiseRejectionWarning: TypeError: Path must be a string. Received { resolve: [Function: resolve],
  normalize: [Function: normalize],
```

`path` (previously) referred to what is now filePath, but this wasn't refactored correctly. This is why you don't rename variables 🙃 (my fault!)