### PR TITLE
Fix broken link in the v2 release notes

### DIFF
--- a/docs/docs/v2-release-notes.md
+++ b/docs/docs/v2-release-notes.md
@@ -5,6 +5,6 @@ title: v2 release notes
 Check out the following useful links for Gatsby v2:
 
 - [v2 release announcement](/blog/2018-09-17-gatsby-v2/)
-- [Migrating from v1 to v2](/migrating-from-v1-to-v2/)
+- [Migrating from v1 to v2](/docs/migrating-from-v1-to-v2/)
 - [v2 documentation](/docs/)
 - [v2 changelog](https://github.com/gatsbyjs/gatsby/blob/master/CHANGELOG.md#200---2018-09-13)


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

The link on the [v2 release notes](https://www.gatsbyjs.org/docs/v2-release-notes/) links to the v1 ➡️ v2 migration guide, but is missing the `/docs` from the link, resulting in a 404. This fixes it by pointing it to the correct URL.