### PR TITLE
Adds link to new Gatsby Link documentation

### DIFF
--- a/packages/gatsby-link/README.md
+++ b/packages/gatsby-link/README.md
@@ -1,3 +1,5 @@
 # gatsby-link
 
 All components and utility functions from this package are now exported from [`gatsby`](/packages/gatsby) package. You should not import anything from this package directly.
+
+The [API reference](/docs/gatsby-link/) has more documentation.


### PR DESCRIPTION
I often navigate to the [old docs](https://www.gatsbyjs.org/packages/gatsby-link/) for Gatsby Link (as a plugin), whether it's via search engine or browser history. Adding a link to the new documentation for Gatsby Link as a core API element should be helpful for a lot of visitors.