### PR TITLE
Change chevron direction of sidebar opener

### DIFF
--- a/www/src/components/sidebar/sticky-responsive-sidebar.js
+++ b/www/src/components/sidebar/sticky-responsive-sidebar.js
@@ -32,7 +32,7 @@ class StickyResponsiveSidebar extends Component {
     } = this.props
     const SidebarComponent = enableScrollSync ? ScrollSyncSidebar : Sidebar
 
-    const iconOffset = open ? 8 : -4
+    const iconOffset = open ? 5 : -5
     const menuOpacity = open ? 1 : 0
     const menuOffset = open ? 0 : rhythm(10)
 
@@ -78,14 +78,14 @@ class StickyResponsiveSidebar extends Component {
             <ChevronSvg
               size={15}
               cssProps={{
-                transform: `translate(2px, ${iconOffset}px) rotate(180deg)`,
+                transform: `translate(${iconOffset}px, 5px) rotate(90deg)`,
                 transition: `transform 0.2s ease`,
               }}
             />
             <ChevronSvg
               size={15}
               cssProps={{
-                transform: `translate(2px, ${0 - iconOffset}px)`,
+                transform: `translate(${5 - iconOffset}px, -5px) rotate(270deg)`,
                 transition: `transform 0.2s ease`,
               }}
             />


### PR DESCRIPTION
Since the sidebar is opening from the left side, having the chevron animate from side-to-side will be consistent.

Current:
![image](https://user-images.githubusercontent.com/19631364/46276219-eaab0e80-c54e-11e8-8c15-bb2e1e285d87.png)


After this PR is merged:
![image](https://user-images.githubusercontent.com/19631364/46276271-0a423700-c54f-11e8-80f0-10ee247d58fb.png)
