### PR TITLE
fix: Address #8579 Don't display double alt text.

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -50,8 +50,8 @@ With Gatsby, we can make images way _way_ better.
 processing capabilities powered by GraphQL and Sharp. To produce perfect images,
 you need only:
 
-1.  Import `gatsby-image` and use it in place of the built-in `img`
-2.  Write a GraphQL query using one of the included GraphQL "fragments"
+1. Import `gatsby-image` and use it in place of the built-in `img`
+2. Write a GraphQL query using one of the included GraphQL "fragments"
     which specify the fields needed by `gatsby-image`.
 
 The GraphQL query creates multiple thumbnails with optimized JPEG and PNG
@@ -64,14 +64,14 @@ effect as well as lazy loading of images further down the screen.
 
 Depending on the gatsby starter you used, you may need to include [gatsby-transformer-sharp](/packages/gatsby-transformer-sharp/) and [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/) as well, and make sure they are installed and included in your gatsby-config.
 
-```
+```bash
 npm install --save gatsby-transformer-sharp
 npm install --save gatsby-plugin-sharp
 ```
 
 Then in your `gatsby-config.js`:
 
-```
+```js
 plugins: [
   `gatsby-transformer-sharp`,
   `gatsby-plugin-sharp`
@@ -134,8 +134,8 @@ For other explanations of how to get started with gatsby-image, see this blog po
 
 There are two types of responsive images supported by gatsby-image.
 
-1.  Images that have a _fixed_ width and height
-2.  Images that stretch across a _fluid_ container
+1. Images that have a _fixed_ width and height
+2. Images that stretch across a _fluid_ container
 
 In the first scenario, you want to vary the image's size for different screen
 resolutions -- in other words, create retina images.

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -204,12 +204,7 @@ class Image extends React.Component {
       Tag,
     } = convertProps(this.props)
 
-    let bgColor
-    if (typeof backgroundColor === `boolean`) {
-      bgColor = `lightgray`
-    } else {
-      bgColor = backgroundColor
-    }
+    const bgColor = typeof backgroundColor === `boolean` ? `lightgray` : backgroundColor
 
     const imagePlaceholderStyle = {
       opacity: this.state.imgLoaded ? 0 : 1,
@@ -250,7 +245,7 @@ class Image extends React.Component {
             {/* Show the blurry base64 image. */}
             {image.base64 && (
               <Img
-                alt={alt}
+                alt={!this.state.isVisible ? alt : ``}
                 title={title}
                 src={image.base64}
                 style={imagePlaceholderStyle}
@@ -260,7 +255,7 @@ class Image extends React.Component {
             {/* Show the traced SVG image. */}
             {image.tracedSVG && (
               <Img
-                alt={alt}
+                alt={!this.state.isVisible ? alt : ``}
                 title={title}
                 src={image.tracedSVG}
                 style={imagePlaceholderStyle}
@@ -347,7 +342,7 @@ class Image extends React.Component {
           {/* Show the blurry base64 image. */}
           {image.base64 && (
             <Img
-              alt={alt}
+              alt={!this.state.isVisible ? alt : ``}
               title={title}
               src={image.base64}
               style={imagePlaceholderStyle}
@@ -357,7 +352,7 @@ class Image extends React.Component {
           {/* Show the traced SVG image. */}
           {image.tracedSVG && (
             <Img
-              alt={alt}
+              alt={!this.state.isVisible ? alt : ``}
               title={title}
               src={image.tracedSVG}
               style={imagePlaceholderStyle}


### PR DESCRIPTION
# Overview
This addresses #8579, it attempts to prevent double images from appearing on screen readers. 
The main change is that when the real image `isVisible`, then the alt text for the placeholder images is set to empty string which will hide the placeholder element from screen readers. 

# Testing
I did not update any of the existing tests, if someone has an idea on how to update please let me know. 