### PR TITLE
Replace plugin stub descriptions with actual descriptions.

### DIFF
--- a/packages/gatsby-codemods/package.json
+++ b/packages/gatsby-codemods/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-codemods",
   "version": "1.0.4",
-  "description": "Stub description for gatsby-codemods",
+  "description": "A collection of codemod scripts for use with JSCodeshift that help migrate to newer versions of Gatsby.",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-canonical-urls",
-  "description": "Stub description for gatsby-plugin-canonical-urls",
+  "description": "Add canonical links to HTML pages Gatsby generates.",
   "version": "2.0.5",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {

--- a/packages/gatsby-plugin-flow/package.json
+++ b/packages/gatsby-plugin-flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-flow",
   "version": "1.0.1",
-  "description": "Stub description for gatsby-plugin-flow",
+  "description": "Provides drop-in support for Flow by adding @babel/preset-flow.",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",

--- a/packages/gatsby-plugin-layout/package.json
+++ b/packages/gatsby-plugin-layout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-layout",
   "version": "1.0.2",
-  "description": "Stub description for gatsby-plugin-layout",
+  "description": "Reimplements the behavior of layout components in gatsby@1, which was removed in version 2.",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",

--- a/packages/gatsby-plugin-remove-trailing-slashes/package.json
+++ b/packages/gatsby-plugin-remove-trailing-slashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-remove-trailing-slashes",
-  "description": "Stub description for gatsby-plugin-remove-trailing-slashes",
+  "description": "Removes trailing slashes from your project's paths. For example, yoursite.com/about/ becomes yoursite.com/about",
   "version": "2.0.1",
   "author": "scott.eckenthal@gmail.com",
   "bugs": {

--- a/packages/gatsby-plugin-twitter/README.md
+++ b/packages/gatsby-plugin-twitter/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-twitter
 
-Loads the Twitter JavaScript for embedding tweets. Let's you add tweets to
+Loads the Twitter JavaScript for embedding tweets. Lets you add tweets to
 markdown and in other places.
 
 Note: when copying the embed code, just copy the blockquote section and not the

--- a/packages/gatsby-plugin-twitter/package.json
+++ b/packages/gatsby-plugin-twitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-twitter",
-  "description": "Stub description for gatsby-plugin-twitter",
+  "description": "Loads the Twitter JavaScript for embedding tweets.",
   "version": "2.0.5",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Connects #5073 

Replaces all stubbed plugin descriptions with real ones so that the search page will show real descriptions:

![image](https://user-images.githubusercontent.com/4777393/46304561-9c106b00-c574-11e8-9e57-43a2fbee4c23.png)

I'm having trouble getting the local `www` folder/project running in development, so this PR still needs verification.