### PR TITLE
WIP: feat(gatsby): add automatic trailing slash support to createRedirect API

### DIFF
--- a/packages/gatsby/src/redux/__tests__/create-redirect.js
+++ b/packages/gatsby/src/redux/__tests__/create-redirect.js
@@ -35,18 +35,15 @@ describe(`createRedirect`, () => {
     expect(action.type).toBe(`CREATE_REDIRECT`)
   })
 
-  it(`adds pathPrefix`, () => {
-    mockStore(`/blog`)
+  it(`handles root path`, () => {
+    mockStore()
 
     const action = createRedirect({
-      fromPath: `/other.html`,
-      toPath: `/sample.html`,
+      fromPath: `/index.html`,
+      toPath: `/`
     })
 
-    expect(action.payload).toEqual(expect.objectContaining({
-      fromPath: expect.stringMatching(/^\/blog/),
-      toPath: expect.stringMatching(/^\/blog/),
-    }))
+    expect(action.payload.toPath).toBe(`/`)
   })
 
   it(`removes trailing slashes`, () => {
@@ -85,5 +82,35 @@ describe(`createRedirect`, () => {
       fromPath: `/blog/`,
       toPath: `/docs/`,
     }))
+  })
+
+  describe(`pathPrefix`, () => {
+    it(`adds on non-root domain`, () => {
+      mockStore(`/blog`)
+  
+      const action = createRedirect({
+        fromPath: `/other.html`,
+        toPath: `/sample.html`,
+      })
+  
+      expect(action.payload).toEqual(expect.objectContaining({
+        fromPath: expect.stringMatching(/^\/blog/),
+        toPath: expect.stringMatching(/^\/blog/),
+      }))
+    })
+
+    it(`adds on root domain`, () => {
+      mockStore(`/blog`)
+
+      const action = createRedirect({
+        fromPath: `/index.html`,
+        toPath: `/`
+      })
+
+      expect(action.payload).toEqual(expect.objectContaining({
+        fromPath: expect.stringMatching(/^\/blog/),
+        toPath: `/blog`,
+      }))
+    })
   })
 })

--- a/packages/gatsby/src/redux/__tests__/create-redirect.js
+++ b/packages/gatsby/src/redux/__tests__/create-redirect.js
@@ -1,0 +1,8 @@
+const { actions: { createRedirect } } = require(`gatsby/src/redux/actions`);
+
+describe(`createRedirect`, () => {
+  it(`it can redirect`, () => {
+    console.log(createRedirect)
+    expect(false).toBe(true)
+  })
+});

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1099,7 +1099,13 @@ actions.createRedirect = ({
     pathPrefix = store.getState().config.pathPrefix
   }
 
-  const normalize = pathPart => `${pathPrefix}${pathPart.replace(/\/+$/, ``)}`
+  const normalize = pathPart => {
+    const normalized = `${pathPrefix}${pathPart.replace(/\/+$/, ``)}`
+    if (normalized !== ``) {
+      return normalized
+    }
+    return `/`
+  }
 
   return {
     type: `CREATE_REDIRECT`,

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1099,15 +1099,34 @@ actions.createRedirect = ({
     pathPrefix = store.getState().config.pathPrefix
   }
 
+  const normalize = pathPart => `${pathPrefix}${pathPart.replace(/\/$/, '')}`;
+  const isFile = pathPart => /\..+$/.test(pathPart);
+
+  const addSlashRedirect = (...parts) => parts.some(part => !isFile(part))
+
+  const payload =       {
+    fromPath: normalize(fromPath),
+    isPermanent,
+    redirectInBrowser,
+    toPath: normalize(toPath),
+    ...rest,
+  };
+
   return {
     type: `CREATE_REDIRECT`,
-    payload: {
-      fromPath: `${pathPrefix}${fromPath}`,
-      isPermanent,
-      redirectInBrowser,
-      toPath: `${pathPrefix}${toPath}`,
-      ...rest,
-    },
+    payload: [
+      payload
+    ].concat(addSlashRedirect(fromPath, toPath) ? [
+      {
+        ...payload,
+        ...(isFile(fromPath) ? {} : {
+          fromPath: `${payload.fromPath}/`
+        }),
+        ...(isFile(toPath) ? {} : {
+          toPath: `${payload.toPath}/`
+        })
+      }
+    ] : []),
   }
 }
 

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -37,6 +37,16 @@ describe(`redirects`, () => {
     expect(state).toHaveLength(1)
   })
 
+  it(`skips root domain`, () => {
+    const redirect = { fromPath: `/`, toPath: `/docs` }
+    let state = []
+
+    state = createRedirects(state, createAction(redirect))
+
+    expect(state).toHaveLength(1)
+    expect(state).toEqual([expect.objectContaining(redirect)])
+  })
+
   it(`adds file redirects, as is`, () => {
     let state = []
 
@@ -83,10 +93,9 @@ describe(`redirects`, () => {
 
     expect(state).toEqual([
       expect.objectContaining(redirect),
-      {
-        fromPath: `/blog/`,
-        toPath: `/docs/`,
-      },
+      expect.objectContaining({
+        fromPath: `/blog/`
+      }),
     ])
   })
 })

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -1,54 +1,92 @@
-const createRedirects = require(`../redirects`);
+const createRedirects = require(`../redirects`)
 
-const createAction = payload => ({
+const createAction = payload => {return {
   type: `CREATE_REDIRECT`,
-  payload
-})
+  payload,
+}}
 
 describe(`redirects`, () => {
   it(`passes through non-redirect action types`, () => {
     let state = []
 
-    createRedirects(state, {
+    state = createRedirects(state, {
       type: `__SAMPLE_DO_NOT_PASS_THROUGH__`,
-      payload: [ { test: true }]
-    });
+      payload: { test: true },
+    })
 
-    expect(state).toEqual([]);
+    expect(state).toEqual([])
   })
 
-  it(`merges one item array`, () => {
+  it(`does not mutate array`, () => {
+    const state = [{ test: true }]
+
+    const newState = createRedirects(state, createAction({
+      fromPath: `/blog`,
+      toPath: `/docs`,
+    }))
+
+    expect(state).not.toEqual(newState)
+  })
+
+  it(`skips redirect, if already added`, () => {
+    const redirect = { fromPath: `/blog/sample.html`, toPath: `/docs/other.html` }
+    let state = [redirect]
+
+    state = createRedirects(state, createAction(redirect))
+
+    expect(state).toHaveLength(1)
+  })
+
+  it(`adds file redirects, as is`, () => {
     let state = []
 
-    const redirect = { fromPath: `/blog/sample.html`, toPath: `/blog/other.html` }
+    const redirect = {
+      fromPath: `/blog/sample.html`,
+      toPath: `/blog/other.html`,
+    }
 
-    state = createRedirects(state, createAction([
-      redirect
-    ]));
+    state = createRedirects(state, createAction(redirect))
 
+    expect(state).toHaveLength(1)
+    expect(state).toEqual([expect.objectContaining(redirect)])
+  })
+
+  it(`adds slash to folder redirect`, () => {
+    let state = []
+
+    const redirect = {
+      fromPath: `/blog`,
+      toPath: `/blog/sample.html`,
+    }
+
+    state = createRedirects(state, createAction(redirect))
+
+    expect(state).toHaveLength(2)
     expect(state).toEqual([
-      redirect
+      expect.objectContaining(redirect),
+      expect.objectContaining({
+        ...redirect,
+        fromPath: `${redirect.fromPath}/`,
+      }),
     ])
   })
 
-  it(`merges two item array`, () => {
+  it(`adds slash to multiple folder redirects`, () => {
     let state = []
 
-    const redirects = [ { fromPath: `/blog`, toPath: `/blog/sample.html` }, { fromPath:`/blog`, toPath: `/blog/sample.html`}]
+    const redirect = {
+      fromPath: `/blog`,
+      toPath: `/docs`,
+    }
 
-    state = createRedirects(state, createAction(redirects))
+    state = createRedirects(state, createAction(redirect))
 
-    expect(state).toEqual(redirects)
-  })
-
-  it(`skips items that already exist in state`, () => {
-    const redirect = { fromPath: `/blog/other.html`, toPath: `/blog/sample.html` }
-    let state = [redirect]
-
-    const existingStateLength = state.length;
-
-    state = createRedirects(state, createAction([redirect]))
-
-    expect(state).toHaveLength(existingStateLength)
+    expect(state).toEqual([
+      expect.objectContaining(redirect),
+      {
+        fromPath: `/blog/`,
+        toPath: `/docs/`,
+      },
+    ])
   })
 })

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -1,0 +1,54 @@
+const createRedirects = require(`../redirects`);
+
+const createAction = payload => ({
+  type: `CREATE_REDIRECT`,
+  payload
+})
+
+describe(`redirects`, () => {
+  it(`passes through non-redirect action types`, () => {
+    let state = []
+
+    createRedirects(state, {
+      type: `__SAMPLE_DO_NOT_PASS_THROUGH__`,
+      payload: [ { test: true }]
+    });
+
+    expect(state).toEqual([]);
+  })
+
+  it(`merges one item array`, () => {
+    let state = []
+
+    const redirect = { fromPath: `/blog/sample.html`, toPath: `/blog/other.html` }
+
+    state = createRedirects(state, createAction([
+      redirect
+    ]));
+
+    expect(state).toEqual([
+      redirect
+    ])
+  })
+
+  it(`merges two item array`, () => {
+    let state = []
+
+    const redirects = [ { fromPath: `/blog`, toPath: `/blog/sample.html` }, { fromPath:`/blog`, toPath: `/blog/sample.html`}]
+
+    state = createRedirects(state, createAction(redirects))
+
+    expect(state).toEqual(redirects)
+  })
+
+  it(`skips items that already exist in state`, () => {
+    const redirect = { fromPath: `/blog/other.html`, toPath: `/blog/sample.html` }
+    let state = [redirect]
+
+    const existingStateLength = state.length;
+
+    state = createRedirects(state, createAction([redirect]))
+
+    expect(state).toHaveLength(existingStateLength)
+  })
+})

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -7,9 +7,7 @@ const createAction = payload => {return {
 
 describe(`redirects`, () => {
   it(`passes through non-redirect action types`, () => {
-    let state = []
-
-    state = createRedirects(state, {
+    const state = createRedirects([], {
       type: `__SAMPLE_DO_NOT_PASS_THROUGH__`,
       payload: { test: true },
     })
@@ -39,37 +37,32 @@ describe(`redirects`, () => {
 
   it(`skips root domain`, () => {
     const redirect = { fromPath: `/`, toPath: `/docs` }
-    let state = []
 
-    state = createRedirects(state, createAction(redirect))
+    const state = createRedirects([], createAction(redirect))
 
     expect(state).toHaveLength(1)
     expect(state).toEqual([expect.objectContaining(redirect)])
   })
 
   it(`adds file redirects, as is`, () => {
-    let state = []
-
     const redirect = {
       fromPath: `/blog/sample.html`,
       toPath: `/blog/other.html`,
     }
 
-    state = createRedirects(state, createAction(redirect))
+    const state = createRedirects([], createAction(redirect))
 
     expect(state).toHaveLength(1)
     expect(state).toEqual([expect.objectContaining(redirect)])
   })
 
   it(`adds slash to folder redirect`, () => {
-    let state = []
-
     const redirect = {
       fromPath: `/blog`,
       toPath: `/blog/sample.html`,
     }
 
-    state = createRedirects(state, createAction(redirect))
+    const state = createRedirects([], createAction(redirect))
 
     expect(state).toHaveLength(2)
     expect(state).toEqual([
@@ -82,14 +75,12 @@ describe(`redirects`, () => {
   })
 
   it(`adds slash to multiple folder redirects`, () => {
-    let state = []
-
     const redirect = {
       fromPath: `/blog`,
       toPath: `/docs`,
     }
 
-    state = createRedirects(state, createAction(redirect))
+    const state = createRedirects([], createAction(redirect))
 
     expect(state).toEqual([
       expect.objectContaining(redirect),
@@ -105,7 +96,7 @@ describe(`redirects`, () => {
         fromPath: `/page1/sample.html`,
         toPath: `/page1`,
       }
-      let state = createRedirects([], createAction(redirect))
+      const state = createRedirects([], createAction(redirect))
   
       expect(state).toEqual(
         [

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,19 +1,15 @@
 const _ = require(`lodash`)
 
 const createRedirectWithSlash = redirect => {
-  const { fromPath, toPath } = redirect
+  const { fromPath } = redirect
   const isFile = pathPart => /\..+$/.test(pathPart)
-  const addSlashRedirect = (...parts) => parts.map(part => part.split(`/`).pop()).some(part => !isFile(part))
 
-  if (addSlashRedirect(fromPath, toPath)) {
+  if (!isFile(fromPath) && fromPath !== `/`) {
     return {
       ...redirect,
       ...(isFile(fromPath) ? {} : {
         fromPath: `${fromPath}/`,
-      }),
-      ...(isFile(toPath) ? {} : {
-        toPath: `${toPath}/`,
-      }),
+      })
     }
   }
 

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,14 +1,35 @@
 const _ = require(`lodash`)
 
+const createRedirectWithSlash = redirect => {
+  const { fromPath, toPath } = redirect
+  const isFile = pathPart => /\..+$/.test(pathPart)
+  const addSlashRedirect = (...parts) => parts.map(part => part.split(`/`).pop()).some(part => !isFile(part))
+
+  if (addSlashRedirect(fromPath, toPath)) {
+    return {
+      ...redirect,
+      ...(isFile(fromPath) ? {} : {
+        fromPath: `${fromPath}/`,
+      }),
+      ...(isFile(toPath) ? {} : {
+        toPath: `${toPath}/`,
+      }),
+    }
+  }
+
+  return []
+}
+
 /*
  * Explicitly add redirect with and without trailing slash
  */
 module.exports = (state = [], action) => {
   switch (action.type) {
     case `CREATE_REDIRECT`: {
-      const filtered = action.payload.filter(redirect => !state.find(existing => _.isEqual(existing, redirect)))
+      const payload = [action.payload].concat(createRedirectWithSlash(action.payload))
+      const filtered = payload.filter(redirect => !state.find(existing => _.isEqual(existing, redirect)))
       if (filtered.length > 0) {
-        return [...state, ...action.payload]
+        return [...state, ...filtered]
       }
       return state
     }

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,11 +1,14 @@
 const _ = require(`lodash`)
 
+/*
+ * Explicitly add redirect with and without trailing slash
+ */
 module.exports = (state = [], action) => {
   switch (action.type) {
     case `CREATE_REDIRECT`: {
-      if (!state.some(redirect => _.isEqual(redirect, action.payload))) {
-        // Add redirect only if it wasn't yet added to prevent duplicates
-        return [...state, action.payload]
+      const filtered = action.payload.filter(redirect => !state.find(existing => _.isEqual(existing, redirect)))
+      if (filtered.length > 0) {
+        return [...state, ...action.payload]
       }
       return state
     }


### PR DESCRIPTION
This (simple) PR automatically adds, e.g. /blog -> /blog/something.html slash suffixing.

The general algorithm is pretty simple, basically if the URL appears to be a folder, a redirect both containing and not containing a slash is created.  This should address and remove confusion around e.g. reactjs/reactjs.org#1209

I don't believe there's a high risk here, but thoughts appreciated!

cc @jlengstorf