### PR TITLE
fix(gatsby-dev-cli): infer correct prefix from package path

### DIFF
--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -6,6 +6,7 @@ jest.mock(`chokidar`, () => {
 jest.mock(`fs-extra`, () => {
   return {
     copy: jest.fn(),
+    existsSync: jest.fn(),
   }
 })
 const chokidar = require(`chokidar`)
@@ -16,6 +17,7 @@ const watch = require(`../watch`)
 let on
 beforeEach(() => {
   fs.copy.mockReset()
+  fs.existsSync.mockImplementation(() => true)
   chokidar.watch.mockImplementation(() => {
     const mock = {
       on: jest.fn().mockImplementation(() => mock),
@@ -85,6 +87,14 @@ describe(`watching`, () => {
         `.cache/register-service-worker.js`,
         expect.any(Function)
       )
+    })
+
+    it(`filters non-existant files/directories`, () => {
+      fs.existsSync.mockReset().mockImplementation(file => false)
+
+      watch(...args)
+
+      expect(chokidar.watch).toHaveBeenCalledWith([], expect.any(Object))
     })
   })
 

--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -30,7 +30,7 @@ describe(`watching`, () => {
   const callReadyCallback = (...args) =>
     on.mock.calls[1].slice(-1).pop()(...args)
 
-  const args = [process.cwd(), [`gatsby`], {}]
+  const args = [`.`, [`gatsby`], {}]
 
   it(`watches files`, () => {
     watch(...args)
@@ -86,7 +86,7 @@ describe(`watching`, () => {
   describe(`exiting`, () => {
     let realProcess
     beforeAll(() => {
-      realProcess = process
+      realProcess = global.process
 
       global.process = {
         ...realProcess,
@@ -95,7 +95,7 @@ describe(`watching`, () => {
     })
 
     afterAll(() => {
-      global.process = process = realProcess
+      global.process = realProcess
     })
 
     it(`does not exit if scanOnce is not defined`, () => {
@@ -106,7 +106,7 @@ describe(`watching`, () => {
     })
 
     it(`exits if scanOnce is defined`, async () => {
-      watch(process.cwd(), [`gatsby`], { scanOnce: true })
+      watch(`.`, [`gatsby`], { scanOnce: true })
 
       await callReadyCallback()
 

--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -10,6 +10,7 @@ jest.mock(`fs-extra`, () => {
 })
 const chokidar = require(`chokidar`)
 const fs = require(`fs-extra`)
+const path = require(`path`)
 const watch = require(`../watch`)
 
 let on
@@ -30,7 +31,7 @@ describe(`watching`, () => {
   const callReadyCallback = (...args) =>
     on.mock.calls[1].slice(-1).pop()(...args)
 
-  const args = [`.`, [`gatsby`], {}]
+  const args = [process.cwd(), [`gatsby`], {}]
 
   it(`watches files`, () => {
     watch(...args)
@@ -58,12 +59,15 @@ describe(`watching`, () => {
 
     it(`copies files on watch event`, () => {
       watch(...args)
-      callEventCallback(`add`, `../gatsby/packages/gatsby/dist/index.js`)
+      callEventCallback(
+        `add`,
+        path.join(process.cwd(), `packages/gatsby/dist/index.js`)
+      )
 
       expect(fs.copy).toHaveBeenCalledTimes(1)
       expect(fs.copy).toHaveBeenCalledWith(
         expect.stringContaining(`gatsby/packages`),
-        expect.stringContaining(`node_modules/gatsby`),
+        `node_modules/gatsby/dist/index.js`,
         expect.any(Function)
       )
     })
@@ -71,7 +75,10 @@ describe(`watching`, () => {
     it(`copies cache-dir files`, () => {
       watch(...args)
 
-      const filePath = `../gatsby/packages/gatsby/cache-dir/register-service-worker.js`
+      const filePath = path.join(
+        process.cwd(),
+        `packages/gatsby/cache-dir/register-service-worker.js`
+      )
       callEventCallback(`add`, filePath)
 
       expect(fs.copy).toHaveBeenCalledTimes(2)
@@ -106,7 +113,7 @@ describe(`watching`, () => {
     })
 
     it(`exits if scanOnce is defined`, async () => {
-      watch(`.`, [`gatsby`], { scanOnce: true })
+      watch(process.cwd(), [`gatsby`], { scanOnce: true })
 
       await callReadyCallback()
 

--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -96,6 +96,15 @@ describe(`watching`, () => {
 
       expect(chokidar.watch).toHaveBeenCalledWith([], expect.any(Object))
     })
+
+    it(`filters duplicate directories`, () => {
+      watch(process.cwd(), [`gatsby`, `gatsby`], {})
+
+      expect(chokidar.watch).toHaveBeenCalledWith(
+        [expect.stringContaining(`gatsby`)],
+        expect.any(Object)
+      )
+    })
   })
 
   describe(`exiting`, () => {

--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -58,15 +58,13 @@ describe(`watching`, () => {
     })
 
     it(`copies files on watch event`, () => {
+      const filePath = path.join(process.cwd(), `packages/gatsby/dist/index.js`)
       watch(...args)
-      callEventCallback(
-        `add`,
-        path.join(process.cwd(), `packages/gatsby/dist/index.js`)
-      )
+      callEventCallback(`add`, filePath)
 
       expect(fs.copy).toHaveBeenCalledTimes(1)
       expect(fs.copy).toHaveBeenCalledWith(
-        expect.stringContaining(`gatsby/packages`),
+        filePath,
         `node_modules/gatsby/dist/index.js`,
         expect.any(Function)
       )

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -26,6 +26,10 @@ const copyPath = (oldPath, newPath, quiet) =>
     })
   })
 
+/*
+ * non-existant packages break on('ready')
+ * See: https://github.com/paulmillr/chokidar/issues/449
+ */
 function watch(root, packages, { scanOnce, quiet }) {
   const ignored = [/[/\\]node_modules[/\\]/i, /\.git/i, /\.DS_Store/].concat(
     packages.map(p => new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`))

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -34,9 +34,11 @@ function watch(root, packages, { scanOnce, quiet }) {
   const ignored = [/[/\\]node_modules[/\\]/i, /\.git/i, /\.DS_Store/].concat(
     packages.map(p => new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`))
   )
-  const watchers = packages
-    .map(p => path.join(root, `/packages/`, p))
-    .filter(p => fs.existsSync(p))
+  const watchers = _.uniq(
+    packages
+      .map(p => path.join(root, `/packages/`, p))
+      .filter(p => fs.existsSync(p))
+  )
 
   let allCopies = []
 

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -27,23 +27,23 @@ const copyPath = (oldPath, newPath, quiet) =>
   })
 
 function watch(root, packages, { scanOnce, quiet }) {
-  const ignored = [
-    /[/\\]node_modules[/\\]/i,
-    /\.git/i,
-    /\.DS_Store/,
-  ].concat(
+  const ignored = [/[/\\]node_modules[/\\]/i, /\.git/i, /\.DS_Store/].concat(
     packages.map(p => new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`))
   )
   const watchers = packages.map(p => path.join(root, `/packages/`, p))
 
   let allCopies = []
 
-  chokidar.watch(watchers, {
-    ignored: [filePath => _.some(ignored, reg => reg.test(filePath))],
-  })
+  chokidar
+    .watch(watchers, {
+      ignored: [filePath => _.some(ignored, reg => reg.test(filePath))],
+    })
     .on(`all`, (event, filePath) => {
       if (event === `change` || event === `add`) {
-        const packageName = path.basename(path.dirname(filePath.split(`packages/`).pop()))
+        const [packageName] = filePath
+          .split(`packages/`)
+          .pop()
+          .split(`/`)
         const prefix = path.join(root, `/packages/`, packageName)
 
         // Copy it over local version.

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -39,7 +39,8 @@ function watch(root, packages, { scanOnce, quiet }) {
       ignored: [filePath => _.some(ignored, reg => reg.test(filePath))],
     })
     .on(`all`, (event, filePath) => {
-      if (event === `change` || event === `add`) {
+      const watchEvents = [`change`, `add`]
+      if (_.includes(watchEvents, event)) {
         const [packageName] = filePath
           .split(`packages/`)
           .pop()
@@ -71,14 +72,14 @@ function watch(root, packages, { scanOnce, quiet }) {
         allCopies = allCopies.concat(localCopies)
       }
     })
-    .on(`ready`, () => {
+    .on(`ready`, () =>
       // all files watched, quit once all files are copied if necessary
       Promise.all(allCopies).then(() => {
         if (scanOnce) {
           quit()
         }
       })
-    })
+    )
 }
 
 module.exports = watch

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -30,7 +30,9 @@ function watch(root, packages, { scanOnce, quiet }) {
   const ignored = [/[/\\]node_modules[/\\]/i, /\.git/i, /\.DS_Store/].concat(
     packages.map(p => new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`))
   )
-  const watchers = packages.map(p => path.join(root, `/packages/`, p))
+  const watchers = packages
+    .map(p => path.join(root, `/packages/`, p))
+    .filter(p => fs.existsSync(p))
 
   let allCopies = []
 

--- a/scripts/publish-site.sh
+++ b/scripts/publish-site.sh
@@ -12,7 +12,7 @@ cd "$1" || exit
 yarn
 
 echo "=== Copying built Gatsby to website."
-gatsby-dev --scan-once --quiet
+gatsby-dev --scan-once
 
 # copy file if target dir exists
 FRAGMENTSDIR="node_modules/gatsby-transformer-sharp/src"


### PR DESCRIPTION
This fixes a bug in gatsby-dev-cli where the cache-dir was copying to the wrong spot--and likely other files as well.

`path.basename(path.dirname(somePath))` infers the parent folder of the current file, not the `packages/${packageName}` that we actually want.

Additionally, this PR fixes an issue with non-existant files causing the `ready` event to never be triggered. That particular issue has been fixed, and seems to be related to paulmillr/chokidar#449
