### PR TITLE
[v1][gatsby-plugin-catch-links] workaround for ie a.pathname bug

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -9,6 +9,11 @@ export const userIsForcingNavigation = event => (
   event.shiftKey
 )
 
+// IE does not include starting slash in anchor.pathname
+export const slashedPathname = pathname => (
+  pathname[0] === `/` ? pathname : `/${pathname}`
+)
+
 export const navigationWasHandledElsewhere = event => (
   event.defaultPrevented
 )
@@ -102,7 +107,7 @@ export const pathIsNotHandledByApp = destination => {
      * will navigate to an external link instead of doing a pushState resulting
      * in `https://example.com/myapp/https://example.com/not-my-app`
      */
-    pathStartRegEx.test(`${destination.pathname}`) === false ||
+    pathStartRegEx.test(slashedPathname(destination.pathname)) === false ||
 
     /**
      * Don't catch links pointed at what look like file extensions (other than
@@ -157,7 +162,7 @@ export const routeThroughBrowserOrApp = hrefHandler => event => {
 
   event.preventDefault()
 
-  hrefHandler(`${destination.pathname}${destination.search}${destination.hash}`)
+  hrefHandler(`${slashedPathname(destination.pathname)}${destination.search}${destination.hash}`)
 
   return false
 }

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -9,7 +9,7 @@ export const userIsForcingNavigation = event => (
   event.shiftKey
 )
 
-// IE does not include starting slash in anchor.pathname
+// IE does not include leading slash in anchor.pathname
 export const slashedPathname = pathname => (
   pathname[0] === `/` ? pathname : `/${pathname}`
 )


### PR DESCRIPTION
Plugin was broken in IE before PR #7779 and still is. See PR #8494 for details. This is the same fix I suggested in PR #8646 v2 port of this