### PR TITLE
fix(www/starters): Capitalize all tags

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -129,7 +129,7 @@
   repo: https://github.com/gatsbyjs/gatsby-starter-blog
   description: official blog
   tags:
-    - official
+    - Official
     - Blog
 - url: https://gatsby-starter-bloomer.netlify.com/
   repo: https://github.com/Cethy/gatsby-starter-bloomer
@@ -745,8 +745,8 @@
   repo: https://github.com/Ganevru/gatsby-starter-blog-grommet
   description: GatsbyJS v2 starter for creating a blog. Based on Grommet v2 UI.
   tags:
-    - blog
-    - markdown
+    - Blog
+    - Markdown
     - Styling:Grommet
   features:
     - Grommet v2 UI


### PR DESCRIPTION
Fixing the capitalization of the tags (again). I missed one "Official" in my first run.
Peril should check that only capitalized tags get inserted: https://github.com/gatsbyjs/peril-gatsbyjs/pull/41

Initially I wanted to fix two more issues:
![18-10-02_8y63e](https://user-images.githubusercontent.com/16143594/46341670-186c8200-c639-11e8-980d-8a979ea1eb83.gif)

- No scrolling for the Gatsby version
- When you select a category the container gets smaller (I find that pretty annoying)

But I can't get `www` to work locally as I see this error in my terminal:

```
GraphQL Error Unknown field `allDependencies` on type `starterShowcase_2`

  file: C:/Users/Lennart/Documents/GitHub/gatsby/www/src/pages/starters.js

   8 |             starterShowcase {
   9 |               slug
  10 |               stub
  11 |               description
  12 |               stars
  13 |               lastUpdated
  14 |               owner
  15 |               name
  16 |               githubFullName
  17 |               gatsbyMajorVersion
> 18 |               allDependencies
     |               ^
  19 |               gatsbyDependencies
  20 |               miscDependencies
  21 |             }
  22 |           }
  23 |           url
  24 |           repo
  25 |           description
  26 |           tags
  27 |           features
  28 |           internal {
```

And this in my browser console:
`Cannot read property 'allStartersYaml' of undefined` & Cross-Origin Error