### PR TITLE
Update "How to Contribute" guide to reflect site styling

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -6,7 +6,7 @@ We want contributing to Gatsby to be fun, enjoyable, and educational for anyone 
 
 - Blogging, speaking about, or creating tutorials about one of Gatsby's many features. Mention [@gatsbyjs on Twitter](https://twitter.com/gatsbyjs) and/or email shannon [at] gatsbyjs [dot] com so we can give pointers and tips (if you want them 😄) and help you spread the word. Please add your blog posts and videos of talks to our [Awesome Gatsby](/docs/awesome-gatsby/) page.
 - [Submitting new feature ideas through an RFC](/blog/2018-04-06-introducing-gatsby-rfc-process/)
-- Submitting new documentation; titles in _italics_ on gatsbyjs.org are stubs and need contributions
+- Submitting new documentation; titles which are lighter in color on gatsbyjs.org are stubs and need contributions
 - Tweeting about things you [#buildwithgatsby](https://twitter.com/search?q=%23buildwithgatsby) (make sure to use the hashtag and/or @ mention us!)
 - Submitting documentation updates, enhancements, designs, or bugfixes
 - Submitting spelling or grammar fixes

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -6,7 +6,7 @@ We want contributing to Gatsby to be fun, enjoyable, and educational for anyone 
 
 - Blogging, speaking about, or creating tutorials about one of Gatsby's many features. Mention [@gatsbyjs on Twitter](https://twitter.com/gatsbyjs) and/or email shannon [at] gatsbyjs [dot] com so we can give pointers and tips (if you want them 😄) and help you spread the word. Please add your blog posts and videos of talks to our [Awesome Gatsby](/docs/awesome-gatsby/) page.
 - [Submitting new feature ideas through an RFC](/blog/2018-04-06-introducing-gatsby-rfc-process/)
-- Submitting new documentation; titles which are lighter in color on gatsbyjs.org are stubs and need contributions
+- Submitting new documentation; titles in the side navigation on [docs](/docs) which are lighter in color on gatsbyjs.org are stubs and need contributions
 - Tweeting about things you [#buildwithgatsby](https://twitter.com/search?q=%23buildwithgatsby) (make sure to use the hashtag and/or @ mention us!)
 - Submitting documentation updates, enhancements, designs, or bugfixes
 - Submitting spelling or grammar fixes


### PR DESCRIPTION
This is a tiny change. I may have misunderstood what the original docs meant however. It seems that the docs which are just stubs are not italicised, but instead the title is just a lighter color.

My understanding is that when the word title is used, it refers to the title of the article in the left navigation bar. If this is not the case, feel free to reject this.
