### PR TITLE
fix(www): prevent netlify builds from timing out

### DIFF
--- a/scripts/publish-site.sh
+++ b/scripts/publish-site.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 yarn bootstrap
-npm install -g gatsby-dev-cli
+npm install -g gatsby-dev-cli@2.4.1 # hard code, until gatsby-dev-cli is fixed
 gatsby-dev --set-path-to-repo .
 
 echo "=== Installing the website dependencies"


### PR DESCRIPTION
Note: this is a temporary, bandaid fix. I'll work on fixing this for
realsies later today.

Note: it's possible that #8683 fixes this!

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
