### PR TITLE
fix broken link to submit-to-starter-library

### DIFF
--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -200,7 +200,7 @@ export default class FilteredStarterLibrary extends Component {
                   aria-label="Search starters"
                 />
                 <Button
-                  to="https://gatsbyjs.org/docs/submit-to-starter-showcase/"
+                  to="https://gatsbyjs.org/docs/submit-to-starter-library/"
                   tag="href"
                   target="_blank"
                   rel="noopener noreferrer"


### PR DESCRIPTION
Found a 404 on the production site today. When on the https://www.gatsbyjs.org/starters/ page. Clicking on the `Submit a Starter` button 404s because it takes you to https://www.gatsbyjs.org/docs/submit-to-starter-showcase/ instead of https://www.gatsbyjs.org/docs/submit-to-starter-library/

I fixed the link to point to the correct URL.