### PR TITLE
fix(gatsby): add mjs config to webpack and resolve correctly

### DIFF
--- a/packages/gatsby/src/utils/__tests__/webpack-utils.js
+++ b/packages/gatsby/src/utils/__tests__/webpack-utils.js
@@ -1,0 +1,29 @@
+const utils = require(`../webpack-utils`)
+
+let config
+beforeAll(async () => {
+  config = await utils({
+    stage: `develop`,
+    program: {
+      browserslist: [],
+    },
+  })
+})
+
+describe(`webpack utils`, () => {
+  describe(`mjs`, () => {
+    it(`adds .mjs rule`, () => {
+      expect(config.rules.mjs).toEqual(expect.any(Function))
+    })
+
+    it(`returns correct rule`, () => {
+      const rule = config.rules.mjs()
+
+      expect(rule).toEqual({
+        include: /node_modules/,
+        test: /\.mjs$/,
+        type: `javascript/auto`,
+      })
+    })
+  })
+})

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -296,6 +296,25 @@ module.exports = async ({
     rules.js = js
   }
 
+  /**
+   * mjs loader:
+   * webpack 4 has issues automatically dealing with
+   * the .mjs extension, thus we need to explicitly
+   * add this rule to use the default webpack js loader
+   */
+  {
+    let mjs = (options = {}) => {
+      return {
+        test: /\.mjs?$/,
+        include: /node_modules/,
+        type: `javascript/auto`,
+        ...options,
+      }
+    }
+
+    rules.mjs = mjs
+  }
+
   {
     let eslint = schema => {
       return {

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -305,7 +305,7 @@ module.exports = async ({
   {
     let mjs = (options = {}) => {
       return {
-        test: /\.mjs?$/,
+        test: /\.mjs$/,
         include: /node_modules/,
         type: `javascript/auto`,
         ...options,

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -285,6 +285,7 @@ module.exports = async (
     // Common config for every env.
     // prettier-ignore
     let configRules = [
+      rules.mjs(),
       rules.js(),
       rules.yaml(),
       rules.fonts(),
@@ -359,10 +360,7 @@ module.exports = async (
       // modules. But also make it possible to install modules within the src
       // directory if you need to install a specific version of a module for a
       // part of your site.
-      modules: [
-        directoryPath(path.join(`node_modules`)),
-        `node_modules`,
-      ],
+      modules: [directoryPath(path.join(`node_modules`)), `node_modules`],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),
         // Using directories for module resolution is mandatory because


### PR DESCRIPTION
deals with issues:
 - Fixes #8655
 - other various `.mjs` issues after the switch to webpack 4

Add webpack rule to explicitly state that `.mjs` files are to be loaded in with the default webpack 4 js loader. Comments also left for future references.

@KyleAMathews 's pr (https://github.com/gatsbyjs/gatsby/pull/8327/files) was correct to add the extensions -- but `.mjs` needs to be before the `.js` extension. Looks like someone changed it in a PR afterwards. In any case, this is half of the solution. We need to explicitly state what loader webpack should use when resolving these files.
