### PR TITLE
fix: pretty print syntax error in gatsby api files

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/__snapshots__/resolve-module-exports.js.snap
+++ b/packages/gatsby/src/bootstrap/__tests__/__snapshots__/resolve-module-exports.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Resolve module exports Show meaningful error message for invalid JavaScript 1`] = `
+Array [
+  "Syntax error in \\"/bad/file\\":
+Unexpected token (1:13)
+> 1 | const exports.blah = () = }}}
+    |             ^",
+]
+`;

--- a/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
@@ -5,6 +5,7 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
   }
 })
 
+const reporter = require(`gatsby-cli/lib/reporter`)
 const resolveModuleExports = require(`../resolve-module-exports`)
 let resolver
 
@@ -111,7 +112,7 @@ describe(`Resolve module exports`, () => {
   beforeEach(() => {
     resolver = jest.fn(arg => arg)
     require(`fs`).__setMockFiles(MOCK_FILE_INFO)
-    require(`gatsby-cli/lib/reporter`).panic.mockClear()
+    reporter.panic.mockClear()
   })
 
   it(`Returns empty array for file paths that don't exist`, () => {
@@ -127,7 +128,7 @@ describe(`Resolve module exports`, () => {
   it(`Show meaningful error message for invalid JavaScript`, () => {
     resolveModuleExports(`/bad/file`, resolver)
     expect(
-      require(`gatsby-cli/lib/reporter`).panic.mock.calls.map(c =>
+      reporter.panic.mock.calls.map(c =>
         // Remove console colors + trim whitespace
         // eslint-disable-next-line
         c[0].replace(/\x1B[[(?);]{0,2}(;?\d)*./g, ``).trim()


### PR DESCRIPTION
Display more useful warning message when there is syntax error in gatsby-x api files. Right now babel parser exceptions are not handled - this add handling at least for syntax errors (not sure about other types that can be expected there, so I just rethrow them)

It changes output from:
```bash
success open and validate gatsby-config — 0.010 s
error Unexpected token, expected ";" (8:4)


  SyntaxError: Unexpected token, expected ";" (8:4)

  - index.js:3939 _class.raise
    [gatsby-i8147]/[@babel]/parser/lib/index.js:3939:15

  - index.js:5248 _class.unexpected
    [gatsby-i8147]/[@babel]/parser/lib/index.js:5248:16

  - index.js:5232 _class.semicolon
    [gatsby-i8147]/[@babel]/parser/lib/index.js:5232:40
[...]
```
to
```bash
success open and validate gatsby-config — 0.010 s
error Syntax error in "/Users/misiek/issues/gatsby-i8147/gatsby-node.js":
Unexpected token, expected ";" (8:4)
  6 |
  7 | // You can delete this file if you're not using it
> 8 | foo bar baz
    |    ^
```

closes #8147