### PR TITLE
Fix/starter sidebar scroll

### DIFF
--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -17,7 +17,7 @@ class Collapsible extends Component {
   }
 
   render() {
-    const { heading, children } = this.props
+    const { heading, fixed, children } = this.props
     const { collapsed } = this.state
 
     return (
@@ -26,7 +26,9 @@ class Collapsible extends Component {
           borderBottom: collapsed ? 0 : `1px solid ${colors.ui.light}`,
           display: collapsed ? false : `flex`,
           flex: collapsed ? `0 0 auto` : `1 1 auto`,
-          minHeight: collapsed ? `initial` : `130px`,
+          minHeight: fixed ? `${fixed}px` : `initial`,
+          maxHeight: fixed ? `${fixed}px` : `initial`,
+          flexBasis: 0,
           // paddingBottom: collapsed ? 0 : rhythm(options.blockMarginBottom),
         }}
       >

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -96,6 +96,7 @@ export default class FilteredStarterLibrary extends Component {
               <ResetFilters onClick={resetFilters} />
             )}
             <LHSFilter
+              fixed={130}
               heading="Gatsby Version"
               data={Array.from(
                 count(

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -92,11 +92,13 @@ export default class FilteredStarterLibrary extends Component {
         <SidebarContainer>
           <SidebarHeader />
           <SidebarBody>
-            {(filters.size > 0 || urlState.s.length > 0) && ( // search is a filter too https://gatsbyjs.slack.com/archives/CB4V648ET/p1529224551000008
-              <ResetFilters onClick={resetFilters} />
-            )}
+            <div css={{ height: `3.5rem` }}>
+              {(filters.size > 0 || urlState.s.length > 0) && ( // search is a filter too https://gatsbyjs.slack.com/archives/CB4V648ET/p1529224551000008
+                <ResetFilters onClick={resetFilters} />
+              )}
+            </div>
             <LHSFilter
-              fixed={130}
+              fixed={150}
               heading="Gatsby Version"
               data={Array.from(
                 count(

--- a/www/src/views/starter-library/lhs-filter.js
+++ b/www/src/views/starter-library/lhs-filter.js
@@ -15,9 +15,10 @@ export default function LHSFilter({
   data,
   filters,
   setFilters,
+  fixed,
 }) {
   return (
-    <Collapsible heading={heading}>
+    <Collapsible heading={heading} fixed={fixed}>
       {data
         .sort(([a, anum], [b, bnum]) => {
           if (sortRecent) {
@@ -69,4 +70,8 @@ export default function LHSFilter({
         ))}
     </Collapsible>
   )
+}
+
+LHSFilter.defaultProps = {
+  fixed: false,
 }


### PR DESCRIPTION
Related to @LeKoArts [observation about the sidebar filters on starter library](https://github.com/gatsbyjs/gatsby/pull/8693#issue-219646021). (Had been bothering me too).

![starter_gif](https://user-images.githubusercontent.com/3461087/46391396-581b8400-c6a2-11e8-9232-34c365e277db.gif)

- Adds option to set a filter set as "fixed"
- Evenly distributes height to remaining filters
- Consistent space for "Reset Filters" button