### PR TITLE
Changed some 'we' and 'lets' as per style guide issue 4396

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -47,7 +47,7 @@ Once this starts, you can now view your site at `localhost:9000`.
 
 ### Run a Lighthouse audit
 
-Now run your first Lighthouse test.
+Now you're going to run your first Lighthouse test.
 
 1.  Open the site in Chrome (if you didn't already do so) and then open up the Chrome DevTools.
 

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -47,7 +47,7 @@ Once this starts, you can now view your site at `localhost:9000`.
 
 ### Run a Lighthouse audit
 
-Now let's run your first Lighthouse test.
+Now run your first Lighthouse test.
 
 1.  Open the site in Chrome (if you didn't already do so) and then open up the Chrome DevTools.
 

--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -37,7 +37,7 @@ Source plugins fetch data from their source. E.g. the filesystem source plugin
 knows how to fetch data from the file system. The WordPress plugin knows how to
 fetch data from the WordPress API.
 
-Let's add [`gatsby-source-filesystem`](/packages/gatsby-source-filesystem/) and
+Add [`gatsby-source-filesystem`](/packages/gatsby-source-filesystem/) and
 explore how it works.
 
 First install the plugin at the root of the project:
@@ -149,7 +149,7 @@ you will see something like:
 
 The shape of the data matches the shape of the GraphQL query.
 
-Let's add some code to your component to print out the File data.
+Add some code to your component to print out the File data.
 
 ```jsx{9-31}:title=src/pages/my-files.js
 import React from "react"

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -83,7 +83,7 @@ Gatsby uses GraphQL to enable components to declare the data they need.
 
 ## Create a new example site
 
-Let's create another new site for this part of the tutorial. You're going to build a Markdown blog called "Pandas Eating Lots". It's dedicated to showing off the best pictures and videos of pandas eating lots of food. Along the way you'll be dipping your toes into GraphQL and Gatsby's Markdown support.
+Create another new site for this part of the tutorial. You're going to build a Markdown blog called "Pandas Eating Lots". It's dedicated to showing off the best pictures and videos of pandas eating lots of food. Along the way you'll be dipping your toes into GraphQL and Gatsby's Markdown support.
 
 Open a new terminal window and run the following commands to create a new Gatsby site in a directory called `tutorial-part-four`, and navigate to the new directory:
 
@@ -99,7 +99,7 @@ Then install some other needed dependencies at the root of the project. You'll u
 npm install --save gatsby-plugin-typography typography react-typography typography-theme-kirkham gatsby-plugin-emotion emotion react-emotion emotion-server
 ```
 
-Let's set up a site similar to what you ended with in [Part Three](/tutorial/part-three). This site will have a layout component and two page components:
+Set up a site similar to what you ended with in [Part Three](/tutorial/part-three). This site will have a layout component and two page components:
 
 ```jsx:title=src/components/layout.js
 import React from "react"
@@ -205,7 +205,7 @@ Add the above files and then run `gatsby develop`, per usual, and you should see
 
 You have another small site with a layout and two pages.
 
-Now let's start querying 😋
+Now to start querying 😋
 
 ## Your first GraphQL query
 
@@ -213,7 +213,7 @@ When building sites, you'll probably want to reuse common bits of data -- like t
 
 But what if you want to change the site title in the future? You'd have to search for the title across all your components and edit each instance. This is both cumbersome and error-prone, especially for larger, more complex sites. Instead, you can store the title in one location and reference that location from other files; Change the title in a single place, and Gatsby will _pull_ your updated title into files that reference it.
 
-The place for these common bits of data is the `siteMetadata` object in the `gatsby-config.js` file. Let's add your site title to the `gatsby-config.js` file:
+The place for these common bits of data is the `siteMetadata` object in the `gatsby-config.js` file. Add your site title to the `gatsby-config.js` file:
 
 ```javascript{2-4}:title=gatsby-config.js
 module.exports = {
@@ -236,7 +236,7 @@ Restart the development server.
 
 ### Use a page query
 
-Now the site title is available to be queried; Let's add it to the `about.js` file using a [page query](/docs/page-query):
+Now the site title is available to be queried; Add it to the `about.js` file using a [page query](/docs/page-query):
 
 ```jsx{2,5,7,14-23}:title=src/pages/about.js
 import React from "react"
@@ -280,7 +280,7 @@ The basic GraphQL query that retrieves the `title` in our `layout.js` changes ab
 }
 ```
 
-> 💡 In [part five](/tutorial/part-five/#introducing-graphiql), we'll meet a tool that lets us interactively explore the data available through GraphQL, and help formulate queries like the one above.
+> 💡 In [part five](/tutorial/part-five/#introducing-graphiql), you'll meet a tool that lets us interactively explore the data available through GraphQL, and help formulate queries like the one above.
 
 Page queries live outside of the component definition -- by convention at the end of a page component file -- and are only available on page components.
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -205,7 +205,7 @@ Add the above files and then run `gatsby develop`, per usual, and you should see
 
 You have another small site with a layout and two pages.
 
-Now to start querying 😋
+Now you can start querying 😋
 
 ## Your first GraphQL query
 

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -314,7 +314,7 @@ When you click the new "Contact" link on the homepage, you should see...
 
 > 💡 Want to know more about 404 pages in Gatsby? Check out [the docs](/docs/add-404-page/).
 
-2.  Create a page component for our new " Contact" page at `src/pages/contact.js`, and have it link back to the homepage:
+2.  Now you'll have to create a page component for our new " Contact" page at `src/pages/contact.js`, and have it link back to the homepage:
 
 ```jsx:title=src/pages/contact.js
 import React from "react"

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -21,7 +21,7 @@ gatsby new [SITE_DIRECTORY_NAME] [URL_OF_STARTER_GITHUB_REPO]
 
 > 💡 See a list of the existing [**official and community starters**](/docs/gatsby-starters/)!
 
-If you omit a URL from the end, Gatsby will automatically generate a site for you based on the [**default starter**](https://github.com/gatsbyjs/gatsby-starter-default). For this section of the tutorial, we’ll stick with the “Hello World” site you already created in tutorial part zero.
+If you omit a URL from the end, Gatsby will automatically generate a site for you based on the [**default starter**](https://github.com/gatsbyjs/gatsby-starter-default). For this section of the tutorial, stick with the “Hello World” site you already created in tutorial part zero.
 
 ### ✋ Open up the code.
 
@@ -52,7 +52,7 @@ Open the file at `src/pages/index.js`. The code in this file creates a component
 
 > 💡 Gatsby uses **hot reloading** to speed up your development process. Essentially, when you’re running a Gatsby development server, the Gatsby site files are being “watched” in the background — any time you save a file, your changes will be immediately reflected in the browser. You don’t need to hard refresh the page, or restart the development server — your changes just appear.
 
-2.  Let’s make our changes a little more visible. Try replacing the code in `src/pages/index.js` with the code below, and save again. You’ll see changes to the text; The text color will be purple, and the font size will be larger.
+2.  Now you can make your changes a little more visible. Try replacing the code in `src/pages/index.js` with the code below, and save again. You’ll see changes to the text; The text color will be purple, and the font size will be larger.
 
 ```jsx:title=src/pages/index.js
 import React from "react"
@@ -115,11 +115,11 @@ import React from "react"
 export default () => React.createElement("div", null, "Hello world!")
 ```
 
-Now you can spot the use of the `'react'` import! But wait. We’re writing JSX, not pure HTML and JavaScript. How does the browser read that? The short answer: It doesn’t. Gatsby sites come with tooling already set up to convert your source code into something that browsers can interpret.
+Now you can spot the use of the `'react'` import! But wait. You’re writing JSX, not pure HTML and JavaScript. How does the browser read that? The short answer: It doesn’t. Gatsby sites come with tooling already set up to convert your source code into something that browsers can interpret.
 
 ## Building with components
 
-The homepage we were just making edits to was created by defining a page component. What exactly is a “component”?
+The homepage you were just making edits to was created by defining a page component. What exactly is a “component”?
 
 Broadly defined, a component is a building block for your site; It is a self-contained piece of code that describes a section of UI (user interface).
 
@@ -154,7 +154,7 @@ limited to the building blocks the browser provides e.g. `<button />`, you can e
 
 Any React component defined in `src/pages/*.js` will automatically become a page. Let’s see this in action.
 
-We already have a `src/pages/index.js` file that came with the “Hello World” starter. Let’s create an about page.
+You already have a `src/pages/index.js` file that came with the “Hello World” starter. Let’s create an about page.
 
 1.  Create a new file at `src/pages/about.js`, copy the following code into the new file, and save.
 
@@ -173,11 +173,11 @@ export default () => (
 
 ![New about page](05-about-page.png)
 
-Just by putting a React component in the `src/pages/about.js` file, we now have a page accessible at `/about`.
+Just by putting a React component in the `src/pages/about.js` file, you now have a page accessible at `/about`.
 
 ### ✋ Using sub-components
 
-Let’s say the homepage and the about page both got quite large, and we were rewriting a lot of things. We can use sub-components to break the UI into reusable pieces. Both of our pages have `<h1>` headers — let’s create a component that will describe a `Header`.
+Let’s say the homepage and the about page both got quite large, and you were rewriting a lot of things. You can use sub-components to break the UI into reusable pieces. Both of your pages have `<h1>` headers — create a component that will describe a `Header`.
 
 1.  Create a new directory at `src/components`, and a file within that directory called `header.js`.
 2.  Add the following code to the new `src/components/header.js` file.
@@ -204,7 +204,7 @@ export default () => (
 
 ![Adding Header component](06-header-component.png)
 
-In the browser, the “About Gatsby” header text should now be replaced with “This is a header.” But we don’t want the “About” page to say “This is a header.” We want it to say, “About Gatsby”.
+In the browser, the “About Gatsby” header text should now be replaced with “This is a header.” But you don’t want the “About” page to say “This is a header.” You want it to say, “About Gatsby”.
 
 4.  Head back to `src/components/header.js`, and make the following change:
 
@@ -234,31 +234,31 @@ You should now see your “About Gatsby” header text again!
 
 ### What are “props”?
 
-Earlier we defined React components as reusable pieces of code describing a UI. To make these reusable pieces dynamic, we need to be able to supply them with different data. We do that with input called “props". Props are (appropriately enough) properties supplied to React components.
+Earlier you defined React components as reusable pieces of code describing a UI. To make these reusable pieces dynamic, you need to be able to supply them with different data. You do that with input called “props". Props are (appropriately enough) properties supplied to React components.
 
-In `about.js` we passed a `headerText` prop with the value of `"About Gatsby"` to the imported `Header` sub-component:
+In `about.js` you passed a `headerText` prop with the value of `"About Gatsby"` to the imported `Header` sub-component:
 
 ```jsx
 <Header headerText="About Gatsby" />
 ```
 
-Over in `header.js`, the header component expects to receive the `headerText` prop (because we’ve written it to expect that) So we can access it like so:
+Over in `header.js`, the header component expects to receive the `headerText` prop (because you’ve written it to expect that) So you can access it like so:
 
 ```jsx
 <h1>{props.headerText}</h1>
 ```
 
-> 💡 In JSX, you can embed any JavaScript expression by wrapping it with `{}`. This is how we can access the `headerText` property (or “prop!”) from the “props” object.
+> 💡 In JSX, you can embed any JavaScript expression by wrapping it with `{}`. This is how you can access the `headerText` property (or “prop!”) from the “props” object.
 
-If we had passed another prop to our `<Header />` component, like so...
+If you had passed another prop to our `<Header />` component, like so...
 
 ```jsx
 <Header headerText="About Gatsby" arbitraryPhrase="is arbitrary" />
 ```
 
-...we would have been able to also access the `arbitraryPhrase` prop: `{props.arbitraryPhrase}`.
+...you would have been able to also access the `arbitraryPhrase` prop: `{props.arbitraryPhrase}`.
 
-6.  To emphasize how this makes our components reusable, let’s add an extra `<Header />` component to the about page. Add the following code to the `src/pages/about.js` file, and save.
+6.  To emphasize how this makes your components reusable, add an extra `<Header />` component to the about page. Add the following code to the `src/pages/about.js` file, and save.
 
 ```jsx{7}:title=src/pages/about.js
 import React from "react"
@@ -275,13 +275,13 @@ export default () => (
 
 ![Duplicate header to show reusability](08-duplicate-header.png)
 
-And there we have it; A second header — without rewriting any code — by passing different data using props.
+And there you have it; A second header — without rewriting any code — by passing different data using props.
 
 ### Using layout components
 
 Layout components are for sections of a site that you want to share across multiple pages. For example, Gatsby sites will commonly have a layout component with a shared header and footer. Other common things to add to layouts include a sidebar, and/or a navigation menu.
 
-We’ll explore layout components in [part three](/tutorial/part-three).
+You’ll explore layout components in [part three](/tutorial/part-three).
 
 ## Linking between pages
 
@@ -310,11 +310,11 @@ When you click the new "Contact" link on the homepage, you should see...
 
 ![Gatsby dev 404 page](09-dev-404.png)
 
-...the Gatsby development 404 page. Why? Because we're attempting to link to a page that doesn't exist yet.
+...the Gatsby development 404 page. Why? Because you're attempting to link to a page that doesn't exist yet.
 
 > 💡 Want to know more about 404 pages in Gatsby? Check out [the docs](/docs/add-404-page/).
 
-2.  Let's create a page component for our new " Contact" page at `src/pages/contact.js`, and have it link back to the homepage:
+2.  Create a page component for our new " Contact" page at `src/pages/contact.js`, and have it link back to the homepage:
 
 ```jsx:title=src/pages/contact.js
 import React from "react"
@@ -345,7 +345,7 @@ The Gatsby `<Link />` component is for linking between pages within your site. F
 
 Gatsby.js is a _modern site generator_, which means there are no servers to setup or complicated databases to deploy. Instead, the Gatsby `build` command produces a directory of static HTML and JavaScript files which you can deploy to a static site hosting service.
 
-Let's try using [Surge](http://surge.sh/) for deploying your first Gatsby
+Try using [Surge](http://surge.sh/) for deploying your first Gatsby
 website. Surge is one of many "static site hosts" which make it possible to
 deploy Gatsby sites.
 
@@ -387,7 +387,7 @@ case) and you'll see your newly published site! Great work!
 
 ## ➡️ What’s Next?
 
-In this section we:
+In this section you:
 
 - Learned about Gatsby starters, and how to use them to create new projects
 - Learned about JSX syntax
@@ -395,4 +395,4 @@ In this section we:
 - Learned about Gatsby page components and sub-components
 - Learned about React “props” and reusing React components
 
-Now, let’s move on to [**adding styles to our site**](/tutorial/part-two/)!
+Now, move on to [**adding styles to our site**](/tutorial/part-two/)!

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -37,7 +37,7 @@ you'll see used in many sites and plugins.
 We do our best to make Gatsby APIs simple to implement. To implement an API, you export a function
 with the name of the API from `gatsby-node.js`.
 
-So do that. In the root of your site, create a file named
+So here's where you'll do that. In the root of your site, create a file named
 `gatsby-node.js`. Then add the following.
 
 ```javascript:title=gatsby-node.js
@@ -84,7 +84,7 @@ files.
 
 ![markdown-relative-path](markdown-relative-path.png)
 
-Now create slugs. As the logic for creating slugs from file names can get
+Now you'll have to create slugs. As the logic for creating slugs from file names can get
 tricky, the `gatsby-source-filesystem` plugin ships with a function for creating
 slugs. Let's use that.
 
@@ -102,7 +102,7 @@ The function handles finding the parent `File` node along with creating the
 slug. Run the development server again and you should see logged to the terminal
 two slugs, one for each markdown file.
 
-Now add your new slugs directly onto the `MarkdownRemark` nodes. This is
+Now you can add your new slugs directly onto the `MarkdownRemark` nodes. This is
 powerful, as any data you add to nodes is available to query later with GraphQL.
 So it'll be easy to get the slug when it comes time to create the pages.
 
@@ -286,7 +286,7 @@ Visit one of them and you see:
 
 ![hello-world-blog-post](hello-world-blog-post.png)
 
-Which is a bit boring and not what you want. Now pull in data from your markdown post. Change
+Which is a bit boring and not what you want. Now you can pull in data from your markdown post. Change
 `src/templates/blog-post.js` to:
 
 ```jsx{5-6,9-12,15-26}:title=src/templates/blog-post.js

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -37,7 +37,7 @@ you'll see used in many sites and plugins.
 We do our best to make Gatsby APIs simple to implement. To implement an API, you export a function
 with the name of the API from `gatsby-node.js`.
 
-So let's do that. In the root of your site, create a file named
+So do that. In the root of your site, create a file named
 `gatsby-node.js`. Then add the following.
 
 ```javascript:title=gatsby-node.js
@@ -51,7 +51,7 @@ This `onCreateNode` function will be called by Gatsby whenever a new node is cre
 Stop and restart the development server. As you do, you'll see quite a few newly
 created nodes get logged to the terminal console.
 
-Let's use this API to add the slugs for your markdown pages to `MarkdownRemark`
+Use this API to add the slugs for your markdown pages to `MarkdownRemark`
 nodes.
 
 Change your function so it now only logs `MarkdownRemark` nodes.
@@ -84,7 +84,7 @@ files.
 
 ![markdown-relative-path](markdown-relative-path.png)
 
-Now let's create slugs. As the logic for creating slugs from file names can get
+Now create slugs. As the logic for creating slugs from file names can get
 tricky, the `gatsby-source-filesystem` plugin ships with a function for creating
 slugs. Let's use that.
 
@@ -102,7 +102,7 @@ The function handles finding the parent `File` node along with creating the
 slug. Run the development server again and you should see logged to the terminal
 two slugs, one for each markdown file.
 
-Now let's add your new slugs directly onto the `MarkdownRemark` nodes. This is
+Now add your new slugs directly onto the `MarkdownRemark` nodes. This is
 powerful, as any data you add to nodes is available to query later with GraphQL.
 So it'll be easy to get the slug when it comes time to create the pages.
 
@@ -286,7 +286,7 @@ Visit one of them and you see:
 
 ![hello-world-blog-post](hello-world-blog-post.png)
 
-Which is a bit boring and not what you want. Let's pull in data from your markdown post. Change
+Which is a bit boring and not what you want. Now pull in data from your markdown post. Change
 `src/templates/blog-post.js` to:
 
 ```jsx{5-6,9-12,15-26}:title=src/templates/blog-post.js
@@ -326,7 +326,7 @@ Sweet!
 
 The last step is to link to your new pages from the index page.
 
-Return to `src/pages/index.js` and let's query for your markdown slugs and create
+Return to `src/pages/index.js` and query for your markdown slugs and create
 links.
 
 ```jsx{3,22-28,44,63-65}:title=src/pages/index.js

--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -21,7 +21,7 @@ content from source plugins and _transform_ it into something more usable.
 For example, markdown files. Markdown is nice to write in but when you build a
 page with it, you need the markdown to be HTML.
 
-Let's add a markdown file to your site at
+Add a markdown file to your site at
 `src/pages/sweet-pandas-eating-sweets.md` (This will become your first markdown
 blog post) and learn how to _transform_ it to HTML using transformer plugins and
 GraphQL.
@@ -45,7 +45,7 @@ the table. This is a very powerful feature of Gatsby. Like the earlier
 `gatsby-source-filesystem` is always scanning for new files to be added and when
 they are, re-runs your queries.
 
-Let's add a transformer plugin that can transform markdown files:
+Add a transformer plugin that can transform markdown files:
 
 ```shell
 npm install --save gatsby-transformer-remark
@@ -96,7 +96,7 @@ data transformation you might need when building a Gatsby site.
 
 ## Create a list of your site's markdown files in `src/pages/index.js`
 
-Let's now create a list of your markdown files on the front page. Like many
+Now create a list of your markdown files on the front page. Like many
 blogs, you want to end up with a list of links on the front page pointing to each
 blog post. With GraphQL you can _query_ for the current list of markdown blog
 posts so you won't need to maintain the list manually.

--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -96,7 +96,7 @@ data transformation you might need when building a Gatsby site.
 
 ## Create a list of your site's markdown files in `src/pages/index.js`
 
-Now create a list of your markdown files on the front page. Like many
+Now you'll have to create a list of your markdown files on the front page. Like many
 blogs, you want to end up with a list of links on the front page pointing to each
 blog post. With GraphQL you can _query_ for the current list of markdown blog
 posts so you won't need to maintain the list manually.

--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -26,7 +26,7 @@ cd tutorial-part-three
 ```
 
 Once the site is finished installing, install `gatsby-plugin-typography`. For a reminder of how to do this, see Part Two of the tutorials. For
-the Typography.js theme, let's try the "Fairy Gates" typography theme this time:
+the Typography.js theme, try the "Fairy Gates" typography theme this time:
 
 ```shell
 npm install --save gatsby-plugin-typography react-typography typography typography-theme-fairy-gates
@@ -58,7 +58,7 @@ module.exports = {
 }
 ```
 
-Now, let's add a few different pages: a front page, an about page, and a contact
+Now, add a few different pages: a front page, an about page, and a contact
 page.
 
 ```jsx:title=src/pages/index.js
@@ -108,7 +108,7 @@ centered on the screen like in part two of the tutorial. And second, you should
 really have some sort of global navigation so it's easy for visitors to find and
 visit each of the sub-pages.
 
-Let's tackle these problems by creating your first layout component.
+Tackle these problems by creating your first layout component.
 
 ## Your first layout component
 
@@ -154,7 +154,7 @@ But try navigating to one of the other pages e.g. `/about/`. That page still
 isn't centered. Try now importing and adding the layout component to `about.js` and
 `contact.js`.
 
-Let's now add your site title to the layout component:
+Now add your site title to the layout component:
 
 ```jsx{5}:title=src/components/layout.js
 import React from "react"
@@ -172,7 +172,7 @@ If you go to any of your three pages you'll see the same title added e.g. the
 
 ![with-title](with-title.png)
 
-Let's add navigation links to each of your three pages:
+Add navigation links to each of your three pages:
 
 ```jsx{2-10,13-23}:title=src/components/layout.js
 import React from "react"

--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -108,7 +108,7 @@ centered on the screen like in part two of the tutorial. And second, you should
 really have some sort of global navigation so it's easy for visitors to find and
 visit each of the sub-pages.
 
-Tackle these problems by creating your first layout component.
+You'll tackle these problems by creating your first layout component.
 
 ## Your first layout component
 

--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -58,7 +58,7 @@ module.exports = {
 }
 ```
 
-Now, add a few different pages: a front page, an about page, and a contact
+Now, you can add a few different pages: a front page, an about page, and a contact
 page.
 
 ```jsx:title=src/pages/index.js

--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -78,7 +78,7 @@ plugins.
 
 ## Installing your first Gatsby plugin
 
-Let's start by creating a new site. At this point it probably makes sense to close the terminal windows you used to build tutorial-part-one so that you don't accidentally start building tutorial-part-two in the wrong place. If you don't close tutorial-part-one prior to building tutorial-part-two, you will see that tutorial-part-two appears at localhost:8001 instead of localhost:8000.
+Start by creating a new site. At this point it probably makes sense to close the terminal windows you used to build tutorial-part-one so that you don't accidentally start building tutorial-part-two in the wrong place. If you don't close tutorial-part-one prior to building tutorial-part-two, you will see that tutorial-part-two appears at localhost:8001 instead of localhost:8000.
 
 Just like in part one, open a new terminal window and run the following commands to create a new Gatsby site in a directory called `tutorial-part-two`. Then, change to this new directory:
 
@@ -101,7 +101,7 @@ This is the minimal setup for a Gatsby site.
 To install a plugin, there are two steps. First, you install the plugin's NPM
 package and second, you add the plugin to your site's `gatsby-config.js`.
 
-Typography.js has a Gatsby plugin, so let's install that along with some additional required packages by running:
+Typography.js has a Gatsby plugin, so install that along with some additional required packages by running:
 
 ```shell
 npm install --save gatsby-plugin-typography react-typography typography
@@ -245,7 +245,7 @@ _Note that if you use `gatsby-plugin-typography` with the default starter, you'l
 
 There are
 [many themes available](https://github.com/KyleAMathews/typography.js#published-typographyjs-themes)
-for Typography.js. Let's try a couple. In your terminal at the root of your
+for Typography.js. Try a couple. In your terminal at the root of your
 site, run:
 
 ```shell
@@ -317,9 +317,9 @@ React in general).
 
 Gatsby works out of the box with CSS Modules.
 
-Let's build a page using CSS Modules.
+Build a page using CSS Modules.
 
-First, let's create a new `Container` component. Create a new directory at
+First, create a new `Container` component. Create a new directory at
 `src/components` and then, in this new directory, create a file named
 `container.js` and paste the following:
 
@@ -363,10 +363,10 @@ If you visit `http://localhost:8000/about-css-modules/`, your page should now lo
 
 ![css-modules-1](css-modules-1.png)
 
-Let's create a list of people with names, avatars, and short latin
+Create a list of people with names, avatars, and short latin
 biographies.
 
-First, let's create the file for the CSS at
+First, create the file for the CSS at
 `src/pages/about-css-modules.module.css`. You'll notice that the file name ends
 with `.module.css` instead of `.css` like normal. This is how you tell Gatsby
 that this CSS file should be processed as CSS modules.
@@ -426,9 +426,9 @@ Modules generates. They're guaranteed to be unique across your site. And because
 you have to import them to use the classes, there's never any question about
 where some CSS is being used.
 
-Let's use your styles to create a `User` component.
+Use your styles to create a `User` component.
 
-Let's create the new component inline in the `about-css-modules.js` page
+Create the new component inline in the `about-css-modules.js` page
 component. The general rule of thumb is this: if you use a component in multiple
 places on a site, it should be in its own module file in the `components`
 directory. But, if it's used only in one file, create it inline.

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -94,7 +94,7 @@ If successfully installed, running `gatsby --version` should return a version nu
 
 ## Create a site
 
-Now let’s use the gatsby-cli tool to create your first Gatsby site. Using the tool, you can use “starters”, or partially built sites with some default configuration, to help you get moving faster on creating a certain type of site. The “Hello World” starter we’ll be using here is a starter with the bare essentials needed for a [Gatsby](/) site.
+Now you can use the gatsby-cli tool to create your first Gatsby site. Using the tool, you can use “starters”, or partially built sites with some default configuration, to help you get moving faster on creating a certain type of site. The “Hello World” starter you’ll be using here is a starter with the bare essentials needed for a [Gatsby](/) site.
 
 ### ✋ Create a Gatsby site
 
@@ -173,4 +173,4 @@ To summarize, in this section you:
 - Downloaded a code editor
 - Installed a code formatter called Prettier
 
-Now, let’s move on to [**getting to know Gatsby building blocks**](/tutorial/part-one/).
+Now, move on to [**getting to know Gatsby building blocks**](/tutorial/part-one/).


### PR DESCRIPTION
In response to https://github.com/gatsbyjs/gatsby/issues/4396  altered the tutorial markdown files changing some 'we's to 'you' (where they referred to the user, not the company) and some 'let's' to 'now' or removed entirely. Tried to maintain flow. Left some in to avoid instructions becoming too abrupt.