### PR TITLE
Fixed link to `withPrefix` function in adding-images-fonts-files.md

### DIFF
--- a/docs/docs/adding-images-fonts-files.md
+++ b/docs/docs/adding-images-fonts-files.md
@@ -128,7 +128,7 @@ If you put a file into the `static` folder, it will **not** be processed by
 Webpack. Instead it will be copied into the public folder untouched. E.g. if you
 add a file named `sun.jpg` to the static folder, it'll be copied to
 `public/sun.jpg`. To reference assets in the `static` folder, you'll need to
-[import a helper function from `gatsby` named `withPrefix`](/packages/gatsby/#prefixed-paths-helper).
+[import a helper function from `gatsby` named `withPrefix`](/docs/gatsby-link/#prefixed-paths-helper).
 You will need to make sure
 [you set `pathPrefix` in your gatsby-config.js for this to work](/docs/path-prefix/).
 


### PR DESCRIPTION
Previous link (www.gatsbyjs.org/packages/gatsby/#prefixed-paths-helper) was redirecting to the main docs page. Updated so that it'll point to the actual content (https://www.gatsbyjs.org/docs/gatsby-link/#prefixed-paths-helper)