### PR TITLE
Referenced Spectrum and Discord in both Spanish and English contributing guides

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -13,7 +13,7 @@ We want contributing to Gatsby to be fun, enjoyable, and educational for anyone 
 - Adding unit or functional tests
 - Triaging [GitHub issues](https://github.com/gatsbyjs/gatsby/issues) -- especially determining whether an issue still persists or is reproducible
 - [Reporting bugs or issues](/docs/how-to-file-an-issue/)
-- Searching for Gatsby on Discord or Spectrum and helping someone else who needs help
+- Searching for Gatsby on [Discord](https://discordapp.com/invite/jUFVxtB) or [Spectrum](https://spectrum.chat/gatsby-js) and helping someone else who needs help
 - Teaching others how to contribute to Gatsby's repo!
 
 As our way of saying “thank you” to our contributors, **_all contributors_ are eligible for [free Gatsby swag](/docs/contributor-swag/)** — whether you’re contributing code, docs, a talk, an article, or something else that helps the Gatsby community. [Learn how to claim free swag for contributors.](/docs/contributor-swag/)
@@ -53,7 +53,7 @@ There are two ways to contribute. This is the most usual way:
 - For each of your Gatsby test sites, run the `gatsby-dev` command inside the test site's directory to copy
   the built files from your cloned copy of Gatsby. It'll watch for your changes
   to Gatsby packages and copy them into the site. For more detailed instructions
-  see the [gatsby-dev-cli README](/packages/gatsby-dev-cli/) and check out the [gatsby-dev-cli demo video](https://www.youtube.com/watch?v=D0SwX1MSuas).  
+  see the [gatsby-dev-cli README](/packages/gatsby-dev-cli/) and check out the [gatsby-dev-cli demo video](https://www.youtube.com/watch?v=D0SwX1MSuas).
   Note: if you plan to modify packages that are exported from `gatsby` directly, you need to either add those manually to your test sites so that they are listed in `package.json` (e.g. `yarn add gatsby-link`), or specify them explicitly with `gatsby-dev --packages gatsby-link`).
 - Add tests and code for your changes.
 - Once you're done, make sure all tests still pass: `yarn test`.

--- a/translations/es/CONTRIBUTING_ES.md
+++ b/translations/es/CONTRIBUTING_ES.md
@@ -14,7 +14,7 @@ Queremos contribuir con Gatsby para que sea divertido, agradable y educativo par
 - Agregar unidades o pruebas funcionales
 - Ayudar con [problemas de GitHub](https://github.com/gatsbyjs/gatsby/issues) -- especialmente determinando si un problema persiste o es reproducible
 - [Reportar errores o problemas encontrados](/docs/how-to-file-an-issue/)
-- Buscar a Gatsby en Discord o Spectrum y ayudar a alguien más que lo necesite
+- Buscar a Gatsby en [Discord](https://discordapp.com/invite/jUFVxtB) o [Spectrum](https://spectrum.chat/gatsby-js) y ayudar a alguien más que lo necesite
 - ¡Enseñar a otros cómo contribuir al repositorio de Gatsby!
 
 Si estás preocupado o no sabes por dónde empezar, siempre puedes comunicarte con Shannon Soper (@shannonb_ux) en Twitter o simplemente presentar el problema en github y una persona encargada del mantenimiento podrá ayudarlo a orientarse.


### PR DESCRIPTION
We mentioned Spectrum and Discord in the `contributing` docs, but we didn't link to any of the sites.

This PR adds the links to the contributing guides.

Thanks! 👍 