### PR TITLE
Mark Commands page as "complete"

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -384,5 +384,5 @@
       link: /docs/submit-to-starter-library/
 - title: Glossary*
   link: /docs/glossary/
-- title: Commands (Gatsby CLI)*
+- title: Commands (Gatsby CLI)
   link: /docs/gatsby-cli/


### PR DESCRIPTION
Looks like this the [Commands](https://www.gatsbyjs.org/docs/gatsby-cli/) page has information in it but it is marked as a stub in the navigation bar.

I can't find where exactly adding a `*` to the title of the page marks it as a stub, but it seems to.