### PR TITLE
fix(hot-reload): page updates when querying by id

### DIFF
--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -156,14 +156,13 @@ module.exports = ({
     )
 
     nodePromise.then(node => {
-        if(node) {
-          createPageDependency({
-            path,
-            nodeId: node.id,
-          })
-        }
+      if (node) {
+        createPageDependency({
+          path,
+          nodeId: node.id,
+        })
       }
-    )
+    })
 
     return nodePromise
   }

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -155,11 +155,14 @@ module.exports = ({
       type.getFields()
     )
 
-    nodePromise.then(node =>
-      createPageDependency({
-        path,
-        nodeId: node.id,
-      })
+    nodePromise.then(node => {
+        if(node) {
+          createPageDependency({
+            path,
+            nodeId: node.id,
+          })
+        }
+      }
     )
 
     return nodePromise

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -149,20 +149,20 @@ module.exports = ({
     Object.keys(fieldsToSift).length === 1 &&
     Object.keys(fieldsToSift)[0] === `id`
   ) {
-    const node = resolveRecursive(
+    const nodePromise = resolveRecursive(
       getNode(siftArgs[0].id[`$eq`]),
       fieldsToSift,
       type.getFields()
     )
 
-    if (node) {
+    nodePromise.then(node =>
       createPageDependency({
         path,
         nodeId: node.id,
       })
-    }
+    )
 
-    return node
+    return nodePromise
   }
 
   const nodesPromise = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9690,6 +9690,15 @@ imageinfo@^1.0.4:
   resolved "https://registry.yarnpkg.com/imageinfo/-/imageinfo-1.0.4.tgz#1dd2456ecb96fc395f0aa1179c467dfb3d5d7a2a"
   integrity sha1-HdJFbsuW/DlfCqEXnEZ9+z1deio=
 
+imagemin-mozjpeg@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/imagemin-mozjpeg/-/imagemin-mozjpeg-7.0.0.tgz#d926477fc6ef5f3a768a4222f7b2d808d3eba568"
+  integrity sha1-2SZHf8bvXzp2ikIi97LYCNPrpWg=
+  dependencies:
+    execa "^0.8.0"
+    is-jpg "^1.0.0"
+    mozjpeg "^5.0.0"
+
 imagemin-pngquant@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/imagemin-pngquant/-/imagemin-pngquant-6.0.0.tgz#7c0c956338fa9a3a535deb63973c1c894519cc78"
@@ -10220,6 +10229,11 @@ is-ip@^2.0.0:
   integrity sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=
   dependencies:
     ip-regex "^2.0.0"
+
+is-jpg@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-jpg/-/is-jpg-1.0.1.tgz#296d57fdd99ce010434a7283e346ab9a1035e975"
+  integrity sha1-KW1X/dmc4BBDSnKD40armhA16XU=
 
 is-lower-case@^1.1.0:
   version "1.1.3"
@@ -12828,6 +12842,15 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+mozjpeg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mozjpeg/-/mozjpeg-5.0.0.tgz#b8671c4924568a363de003ff2fd397ab83f752c5"
+  integrity sha1-uGccSSRWijY94AP/L9OXq4P3UsU=
+  dependencies:
+    bin-build "^2.2.0"
+    bin-wrapper "^3.0.0"
+    logalot "^2.0.0"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Since `resolveRecursive` returns a Promise, `createPageDependency` was being called with an undefined `nodeId`.  This meant it was possible, if a page was only queried by id, that it would never be reported as being dirty and would not update during development.

Fixes: #8795