### PR TITLE
FIx highlighted (newly added) lines in Source Plugin Tutorial

### DIFF
--- a/docs/docs/source-plugin-tutorial.md
+++ b/docs/docs/source-plugin-tutorial.md
@@ -206,7 +206,7 @@ Note that Gatsby is warning that your plugin doesn't do anything yet. Time to fi
 
 Update `gatsby-node.js` in your `plugins/gatsby-source-pixabay/` directory:
 
-```js{11-30}:title=gatsby-node.js
+```js{10-29}:title=gatsby-node.js
 const fetch = require("node-fetch")
 const queryString = require("query-string")
 


### PR DESCRIPTION
Perhaps the plugin used to highlight lines starts from 0 while lines start from 1?
I know it's nit-picking, but I've always wanted to contribute to this project :)

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
