### PR TITLE
Store sync token for contentful preview

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -58,6 +58,9 @@ exports.sourceNodes = async (
     return
   }
 
+  const createSyncToken = () =>
+    `${options.spaceId}-${options.environment}-${options.host}`
+
   options.host = options.host || `cdn.contentful.com`
   options.environment = options.environment || `master` // default is always master
   // Get sync token if it exists.
@@ -66,11 +69,11 @@ exports.sourceNodes = async (
     store.getState().status.plugins &&
     store.getState().status.plugins[`gatsby-source-contentful`] &&
     store.getState().status.plugins[`gatsby-source-contentful`][
-      `${options.spaceId}-${options.environment}`
+      createSyncToken()
     ]
   ) {
     syncToken = store.getState().status.plugins[`gatsby-source-contentful`][
-      `${options.spaceId}-${options.environment}`
+      createSyncToken()
     ]
   }
 
@@ -131,7 +134,7 @@ exports.sourceNodes = async (
 
   // Store our sync state for the next sync.
   const newState = {}
-  newState[`${options.spaceId}-${options.environment}`] = nextSyncToken
+  newState[createSyncToken()] = nextSyncToken
   setPluginStatus(newState)
 
   // Create map of resolvable ids so we can check links against them while creating

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -130,13 +130,9 @@ exports.sourceNodes = async (
   const nextSyncToken = currentSyncData.nextSyncToken
 
   // Store our sync state for the next sync.
-  // TODO: we do not store the token if we are using preview, since only initial sync is possible there
-  // This might change though
-  if (options.host !== `preview.contentful.com`) {
-    const newState = {}
-    newState[`${options.spaceId}-${options.environment}`] = nextSyncToken
-    setPluginStatus(newState)
-  }
+  const newState = {}
+  newState[`${options.spaceId}-${options.environment}`] = nextSyncToken
+  setPluginStatus(newState)
 
   // Create map of resolvable ids so we can check links against them while creating
   // links.

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -425,8 +425,13 @@ module.exports = async (program: any) => {
       printInstructions(program.sitePackageJson.name, urls, program.useYarn)
       printDeprecationWarnings()
       if (program.open) {
-        require(`opn`)(urls.localUrlForBrowser)
-          .catch(err => console.log(`${chalk.yellow(`warn`)} Browser not opened because no browser was found`))
+        require(`opn`)(urls.localUrlForBrowser).catch(err =>
+          console.log(
+            `${chalk.yellow(
+              `warn`
+            )} Browser not opened because no browser was found`
+          )
+        )
       }
     }
 


### PR DESCRIPTION
@Khaledgarbaya using a sync token with preview.contentful.com is working now
at least in my local testing.

This speeds up syncs for Gatsby Preview quite a bit e.g. ~3 seconds to ~700ms.

I'm sure Contentful will appreciate the lowered load on their servers as well :-D

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->