### PR TITLE
Add custom sizes for fluid images

### DIFF
--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -74,7 +74,9 @@ size / screen resolution.
 
 If you want more control over which sizes are output you can use the `srcSetBreakpoints`
 parameter. For example, if you want images that are 200, 340, 520, and 890 wide you
-can add `srcSetBreakpoints: [ 200, 340, 520, 890 ]` as a parameter.
+can add `srcSetBreakpoints: [ 200, 340, 520, 890 ]` as a parameter. You will also get
+`maxWidth` as a breakpoint (which is 800 by default), so you will actually get
+`[ 200, 340, 520, 800, 890 ]` as breakpoints.
 
 On top of that, `fluid` returns everything else (namely aspectRatio and
 a base64 image to use as a placeholder) you need to implement the "blur up"

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -72,6 +72,10 @@ rendered markdown file is 800px, the sizes would then be: 200, 400, 800, 1200,
 1600, 2400 – enough to provide close to the optimal image size for every device
 size / screen resolution.
 
+If you want more control over which sizes are output you can use the `customSizes`
+parameter. For example, if you want images that are 200, 340, 520, and 890 wide you
+can add `customSizes: [ 200, 340, 520, 890 ]` as a parameter.
+
 On top of that, `fluid` returns everything else (namely aspectRatio and
 a base64 image to use as a placeholder) you need to implement the "blur up"
 technique popularized by Medium and Facebook (and also available as a Gatsby
@@ -83,6 +87,7 @@ plugin for Markdown content as gatsby-remark-images).
 - `maxHeight` (int)
 - `quality` (int, default: 50)
 - `sizeByPixelDensity` (bool, default: false)
+- `customSizes` (array of int, default: [])
 
 #### Returns
 

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -72,9 +72,9 @@ rendered markdown file is 800px, the sizes would then be: 200, 400, 800, 1200,
 1600, 2400 – enough to provide close to the optimal image size for every device
 size / screen resolution.
 
-If you want more control over which sizes are output you can use the `customSizes`
+If you want more control over which sizes are output you can use the `srcSetBreakpoints`
 parameter. For example, if you want images that are 200, 340, 520, and 890 wide you
-can add `customSizes: [ 200, 340, 520, 890 ]` as a parameter.
+can add `srcSetBreakpoints: [ 200, 340, 520, 890 ]` as a parameter.
 
 On top of that, `fluid` returns everything else (namely aspectRatio and
 a base64 image to use as a placeholder) you need to implement the "blur up"
@@ -87,7 +87,7 @@ plugin for Markdown content as gatsby-remark-images).
 - `maxHeight` (int)
 - `quality` (int, default: 50)
 - `sizeByPixelDensity` (bool, default: false)
-- `customSizes` (array of int, default: [])
+- `srcSetBreakpoints` (array of int, default: [])
 
 #### Returns
 

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -115,6 +115,16 @@ describe(`gatsby-plugin-sharp`, () => {
       expect(result.presentationWidth).toEqual(41)
     })
 
+    it(`should throw if maxWidth is negative`, async () => {
+      const args = { maxWidth: -20 }
+      const result = fluid({
+        file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args,
+      })
+
+      await expect(result).rejects.toThrow()
+    })
+
     it(`accepts srcSet breakpoints`, async () => {
       const srcSetBreakpoints = [
         50,

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -107,6 +107,39 @@ describe(`gatsby-plugin-sharp`, () => {
 
       expect(result.presentationWidth).toEqual(41)
     })
+
+    it(`accepts custom sizes`, async () => {
+      const customSizes = [
+        50,
+        70,
+        150,
+        250,
+        300, // this shouldn't be in the output as it's wider than the original
+      ]
+      const args = { customSizes }
+      const result = await fluid({
+        file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args,
+      })
+
+      // width of the image tested
+      const originalWidth = 281
+      const expected = customSizes
+        // filter out the widths that are larger than the source image width
+        // (in this case it's the last value of the array: 300)
+        .filter((size) => size < originalWidth)
+        .map((size) => `${size}w`)
+      // add the original size of `144-density.png`
+      expected.push(`${originalWidth}w`)
+
+      // RegEx to find all occurrences of 'Xw', where 'X' can be any int
+      const regEx = /[0-9]+w/g
+      const actual = result.srcSet.match(regEx)
+      // should contain all requested sizes as well as the original size
+      expect(actual).toEqual(expect.arrayContaining(expected))
+      // should contain no other sizes
+      expect(actual.length).toEqual(expected.length)
+    })
   })
 
   describe(`fixed`, () => {

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -140,6 +140,20 @@ describe(`gatsby-plugin-sharp`, () => {
       // should contain no other sizes
       expect(actual.length).toEqual(expected.length)
     })
+
+    it(`should throw on negative srcSet breakpoints`, async () => {
+      const srcSetBreakpoints = [
+        50,
+        -100,
+      ]
+      const args = { srcSetBreakpoints }
+      const result = fluid({
+        file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args,
+      })
+
+      await expect(result).rejects.toThrow()
+    })
   })
 
   describe(`fixed`, () => {

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -108,15 +108,15 @@ describe(`gatsby-plugin-sharp`, () => {
       expect(result.presentationWidth).toEqual(41)
     })
 
-    it(`accepts custom sizes`, async () => {
-      const customSizes = [
+    it(`accepts srcSet breakpoints`, async () => {
+      const srcSetBreakpoints = [
         50,
         70,
         150,
         250,
         300, // this shouldn't be in the output as it's wider than the original
       ]
-      const args = { customSizes }
+      const args = { srcSetBreakpoints }
       const result = await fluid({
         file: getFileObject(path.join(__dirname, `images/144-density.png`)),
         args,
@@ -124,7 +124,7 @@ describe(`gatsby-plugin-sharp`, () => {
 
       // width of the image tested
       const originalWidth = 281
-      const expected = customSizes
+      const expected = srcSetBreakpoints
         // filter out the widths that are larger than the source image width
         // (in this case it's the last value of the array: 300)
         .filter((size) => size < originalWidth)

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -172,6 +172,40 @@ describe(`gatsby-plugin-sharp`, () => {
 
       expect(result.srcSet).toEqual(expect.stringContaining(`${maxWidth}w`))
     })
+
+    it(`reject any breakpoints larger than the original width`, async () => {
+      const srcSetBreakpoints = [
+        50,
+        70,
+        150,
+        250,
+        300, // this shouldn't be in the output as it's wider than the original
+      ]
+      const maxWidth = 500 // this also shouldn't be in the output
+      const args = {
+        maxWidth,
+        srcSetBreakpoints,
+      }
+      const result = await fluid({
+        file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args,
+      })
+
+      // width of the image tested
+      const originalWidth = 281
+      const expected = srcSetBreakpoints
+        // filter out the widths that are larger than the source image width
+        .filter((size) => size < originalWidth)
+        .map((size) => `${size}w`)
+      // add the original size of `144-density.png`
+      expected.push(`${originalWidth}w`)
+
+      const actual = findAllBreakpoints(result.srcSet)
+      // should contain all requested sizes as well as the original size
+      expect(actual).toEqual(expect.arrayContaining(expected))
+      // should contain no other sizes
+      expect(actual.length).toEqual(expected.length)
+    })
   })
 
   describe(`fixed`, () => {

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -115,8 +115,8 @@ describe(`gatsby-plugin-sharp`, () => {
       expect(result.presentationWidth).toEqual(41)
     })
 
-    it(`should throw if maxWidth is negative`, async () => {
-      const args = { maxWidth: -20 }
+    it(`should throw if maxWidth is less than 1`, async () => {
+      const args = { maxWidth: 0 }
       const result = fluid({
         file: getFileObject(path.join(__dirname, `images/144-density.png`)),
         args,
@@ -150,10 +150,10 @@ describe(`gatsby-plugin-sharp`, () => {
       expect(actual).toEqual(expect.arrayContaining(expected))
     })
 
-    it(`should throw on negative srcSet breakpoints`, async () => {
+    it(`should throw on srcSet breakpoints less than 1`, async () => {
       const srcSetBreakpoints = [
         50,
-        -100,
+        0,
       ]
       const args = { srcSetBreakpoints }
       const result = fluid({

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -206,6 +206,39 @@ describe(`gatsby-plugin-sharp`, () => {
       // should contain no other sizes
       expect(actual.length).toEqual(expected.length)
     })
+
+    it(`prevents duplicate breakpoints`, async () => {
+      const srcSetBreakpoints = [
+        50,
+        50,
+        100,
+        100,
+        100,
+        250,
+        250,
+      ]
+      const maxWidth = 100
+      const args = {
+        maxWidth,
+        srcSetBreakpoints,
+      }
+      const result = await fluid({
+        file: getFileObject(path.join(__dirname, `images/144-density.png`)),
+        args,
+      })
+
+      const originalWidth = 281
+      const expected = [
+        `50w`,
+        `100w`,
+        `250w`,
+        `${originalWidth}w`,
+      ]
+
+      const actual = findAllBreakpoints(result.srcSet)
+      expect(actual).toEqual(expect.arrayContaining(expected))
+      expect(actual.length).toEqual(expected.length)
+    })
   })
 
   describe(`fixed`, () => {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -548,11 +548,13 @@ async function fluid({ file, args = {}, reporter }) {
   // device size / screen resolution while (hopefully) not requiring too much
   // image processing time (Sharp has optimizations thankfully for creating
   // multiple sizes of the same input file)
-  const fluidSizes = []
+  const fluidSizes = [
+    options[fixedDimension], // ensure maxWidth (or maxHeight) is added
+  ]
+  // use standard breakpoints if no custom breakpoints are specified
   if (!options.srcSetBreakpoints || !options.srcSetBreakpoints.length) {
     fluidSizes.push(options[fixedDimension] / 4)
     fluidSizes.push(options[fixedDimension] / 2)
-    fluidSizes.push(options[fixedDimension])
     fluidSizes.push(options[fixedDimension] * 1.5)
     fluidSizes.push(options[fixedDimension] * 2)
     fluidSizes.push(options[fixedDimension] * 3)

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -520,6 +520,10 @@ async function fluid({ file, args = {}, reporter }) {
   const fixedDimension =
     options.maxWidth === undefined ? `maxHeight` : `maxWidth`
 
+  if (options[fixedDimension] < 0) {
+    throw new Error(`${fixedDimension} has to be a positive int (>=0), now it's ${options[fixedDimension]}`)
+  }
+
   let presentationWidth, presentationHeight
   if (fixedDimension === `maxWidth`) {
     presentationWidth = Math.min(

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -563,6 +563,10 @@ async function fluid({ file, args = {}, reporter }) {
       if (breakpoint < 0) {
         throw new Error(`All ints in srcSetBreakpoints should be positive (>=0), found ${breakpoint}`)
       }
+      // ensure no duplicates are added
+      if (fluidSizes.includes(breakpoint)) {
+        return
+      }
       fluidSizes.push(breakpoint)
     })
   }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -548,16 +548,19 @@ async function fluid({ file, args = {}, reporter }) {
   // device size / screen resolution while (hopefully) not requiring too much
   // image processing time (Sharp has optimizations thankfully for creating
   // multiple sizes of the same input file)
-  const fluidSizes = !options.customSizes || !options.customSizes.length
-    ? [
-      options[fixedDimension] / 4,
-      options[fixedDimension] / 2,
-      options[fixedDimension],
-      options[fixedDimension] * 1.5,
-      options[fixedDimension] * 2,
-      options[fixedDimension] * 3,
-    ]
-    : options.customSizes
+  const fluidSizes = []
+  if (!options.srcSetBreakpoints || !options.srcSetBreakpoints.length) {
+    fluidSizes.push(options[fixedDimension] / 4)
+    fluidSizes.push(options[fixedDimension] / 2)
+    fluidSizes.push(options[fixedDimension])
+    fluidSizes.push(options[fixedDimension] * 1.5)
+    fluidSizes.push(options[fixedDimension] * 2)
+    fluidSizes.push(options[fixedDimension] * 3)
+  } else {
+    options.srcSetBreakpoints.forEach((breakpoint) => {
+      fluidSizes.push(breakpoint)
+    })
+  }
   const filteredSizes = fluidSizes.filter(
     size => size < (fixedDimension === `maxWidth` ? width : height)
   )

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -548,7 +548,7 @@ async function fluid({ file, args = {}, reporter }) {
   // device size / screen resolution while (hopefully) not requiring too much
   // image processing time (Sharp has optimizations thankfully for creating
   // multiple sizes of the same input file)
-  const fluidSizes = !options.requestedSizes.length
+  const fluidSizes = !options.requestedSizes || !options.requestedSizes.length
     ? [
       options[fixedDimension] / 4,
       options[fixedDimension] / 2,

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -520,8 +520,8 @@ async function fluid({ file, args = {}, reporter }) {
   const fixedDimension =
     options.maxWidth === undefined ? `maxHeight` : `maxWidth`
 
-  if (options[fixedDimension] < 0) {
-    throw new Error(`${fixedDimension} has to be a positive int (>=0), now it's ${options[fixedDimension]}`)
+  if (options[fixedDimension] < 1) {
+    throw new Error(`${fixedDimension} has to be a positive int larger than zero (> 0), now it's ${options[fixedDimension]}`)
   }
 
   let presentationWidth, presentationHeight
@@ -564,8 +564,8 @@ async function fluid({ file, args = {}, reporter }) {
     fluidSizes.push(options[fixedDimension] * 3)
   } else {
     options.srcSetBreakpoints.forEach((breakpoint) => {
-      if (breakpoint < 0) {
-        throw new Error(`All ints in srcSetBreakpoints should be positive (>=0), found ${breakpoint}`)
+      if (breakpoint < 1) {
+        throw new Error(`All ints in srcSetBreakpoints should be positive ints larger than (> 0), found ${breakpoint}`)
       }
       // ensure no duplicates are added
       if (fluidSizes.includes(breakpoint)) {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -540,15 +540,15 @@ async function fluid({ file, args = {}, reporter }) {
     options.sizes = `(max-width: ${presentationWidth}px) 100vw, ${presentationWidth}px`
   }
 
-  // Create sizes (in width) for the image if none are provided. If the max
-  // width of the container for the rendered markdown file is 800px, the sizes
-  // would then be: 200, 400, 800, 1200, 1600, 2400.
+  // Create sizes (in width) for the image if no custom sizes are provided. If
+  // the max width of the container for the rendered markdown file is 800px,
+  // the sizes would then be: 200, 400, 800, 1200, 1600, 2400.
   //
   // This is enough sizes to provide close to the optimal image size for every
   // device size / screen resolution while (hopefully) not requiring too much
   // image processing time (Sharp has optimizations thankfully for creating
   // multiple sizes of the same input file)
-  const fluidSizes = !options.requestedSizes || !options.requestedSizes.length
+  const fluidSizes = !options.customSizes || !options.customSizes.length
     ? [
       options[fixedDimension] / 4,
       options[fixedDimension] / 2,
@@ -557,7 +557,7 @@ async function fluid({ file, args = {}, reporter }) {
       options[fixedDimension] * 2,
       options[fixedDimension] * 3,
     ]
-    : options.requestedSizes.slice()
+    : options.customSizes.slice()
   const filteredSizes = fluidSizes.filter(
     size => size < (fixedDimension === `maxWidth` ? width : height)
   )

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -544,9 +544,9 @@ async function fluid({ file, args = {}, reporter }) {
     options.sizes = `(max-width: ${presentationWidth}px) 100vw, ${presentationWidth}px`
   }
 
-  // Create sizes (in width) for the image if no custom sizes are provided. If
-  // the max width of the container for the rendered markdown file is 800px,
-  // the sizes would then be: 200, 400, 800, 1200, 1600, 2400.
+  // Create sizes (in width) for the image if no custom breakpoints are
+  // provided. If the max width of the container for the rendered markdown file
+  // is 800px, the sizes would then be: 200, 400, 800, 1200, 1600, 2400.
   //
   // This is enough sizes to provide close to the optimal image size for every
   // device size / screen resolution while (hopefully) not requiring too much
@@ -565,7 +565,7 @@ async function fluid({ file, args = {}, reporter }) {
   } else {
     options.srcSetBreakpoints.forEach((breakpoint) => {
       if (breakpoint < 1) {
-        throw new Error(`All ints in srcSetBreakpoints should be positive ints larger than (> 0), found ${breakpoint}`)
+        throw new Error(`All ints in srcSetBreakpoints should be positive ints larger than zero (> 0), found ${breakpoint}`)
       }
       // ensure no duplicates are added
       if (fluidSizes.includes(breakpoint)) {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -548,13 +548,17 @@ async function fluid({ file, args = {}, reporter }) {
   // device size / screen resolution while (hopefully) not requiring too much
   // image processing time (Sharp has optimizations thankfully for creating
   // multiple sizes of the same input file)
-  const fluidSizes = []
-  fluidSizes.push(options[fixedDimension] / 4)
-  fluidSizes.push(options[fixedDimension] / 2)
-  fluidSizes.push(options[fixedDimension])
-  fluidSizes.push(options[fixedDimension] * 1.5)
-  fluidSizes.push(options[fixedDimension] * 2)
-  fluidSizes.push(options[fixedDimension] * 3)
+  let fluidSizes = []
+  if (!options.requestedSizes.length) {
+    fluidSizes.push(options[fixedDimension] / 4)
+    fluidSizes.push(options[fixedDimension] / 2)
+    fluidSizes.push(options[fixedDimension])
+    fluidSizes.push(options[fixedDimension] * 1.5)
+    fluidSizes.push(options[fixedDimension] * 2)
+    fluidSizes.push(options[fixedDimension] * 3)
+  } else {
+    fluidSizes = options.requestedSizes.slice()
+  }
   const filteredSizes = fluidSizes.filter(
     size => size < (fixedDimension === `maxWidth` ? width : height)
   )

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -558,6 +558,9 @@ async function fluid({ file, args = {}, reporter }) {
     fluidSizes.push(options[fixedDimension] * 3)
   } else {
     options.srcSetBreakpoints.forEach((breakpoint) => {
+      if (breakpoint < 0) {
+        throw new Error(`All ints in srcSetBreakpoints should be positive (>=0), found ${breakpoint}`)
+      }
       fluidSizes.push(breakpoint)
     })
   }

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -557,7 +557,7 @@ async function fluid({ file, args = {}, reporter }) {
       options[fixedDimension] * 2,
       options[fixedDimension] * 3,
     ]
-    : options.customSizes.slice()
+    : options.customSizes
   const filteredSizes = fluidSizes.filter(
     size => size < (fixedDimension === `maxWidth` ? width : height)
   )

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -540,25 +540,24 @@ async function fluid({ file, args = {}, reporter }) {
     options.sizes = `(max-width: ${presentationWidth}px) 100vw, ${presentationWidth}px`
   }
 
-  // Create sizes (in width) for the image. If the max width of the container
-  // for the rendered markdown file is 800px, the sizes would then be: 200,
-  // 400, 800, 1200, 1600, 2400.
+  // Create sizes (in width) for the image if none are provided. If the max
+  // width of the container for the rendered markdown file is 800px, the sizes
+  // would then be: 200, 400, 800, 1200, 1600, 2400.
   //
   // This is enough sizes to provide close to the optimal image size for every
   // device size / screen resolution while (hopefully) not requiring too much
   // image processing time (Sharp has optimizations thankfully for creating
   // multiple sizes of the same input file)
-  let fluidSizes = []
-  if (!options.requestedSizes.length) {
-    fluidSizes.push(options[fixedDimension] / 4)
-    fluidSizes.push(options[fixedDimension] / 2)
-    fluidSizes.push(options[fixedDimension])
-    fluidSizes.push(options[fixedDimension] * 1.5)
-    fluidSizes.push(options[fixedDimension] * 2)
-    fluidSizes.push(options[fixedDimension] * 3)
-  } else {
-    fluidSizes = options.requestedSizes.slice()
-  }
+  const fluidSizes = !options.requestedSizes.length
+    ? [
+      options[fixedDimension] / 4,
+      options[fixedDimension] / 2,
+      options[fixedDimension],
+      options[fixedDimension] * 1.5,
+      options[fixedDimension] * 2,
+      options[fixedDimension] * 3,
+    ]
+    : options.requestedSizes.slice()
   const filteredSizes = fluidSizes.filter(
     size => size < (fixedDimension === `maxWidth` ? width : height)
   )

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -264,7 +264,7 @@ const fluidNodeType = ({
         type: GraphQLString,
         defaultValue: ``,
       },
-      customSizes: {
+      srcSetBreakpoints: {
         type: GraphQLList(GraphQLInt),
         defaultValue: [],
         description: `A list of image widths to be generated. Example: [ 200, 340, 520, 890 ]`,

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -1,6 +1,7 @@
 const Promise = require(`bluebird`)
 const {
   GraphQLObjectType,
+  GraphQLList,
   GraphQLBoolean,
   GraphQLString,
   GraphQLInt,
@@ -262,6 +263,10 @@ const fluidNodeType = ({
       sizes: {
         type: GraphQLString,
         defaultValue: ``,
+      },
+      requestedSizes: {
+        type: GraphQLList(GraphQLInt),
+        defaultValue: [],
       },
     },
     resolve: (image, fieldArgs, context) => {

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -264,7 +264,7 @@ const fluidNodeType = ({
         type: GraphQLString,
         defaultValue: ``,
       },
-      requestedSizes: {
+      customSizes: {
         type: GraphQLList(GraphQLInt),
         defaultValue: [],
       },

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -267,6 +267,7 @@ const fluidNodeType = ({
       customSizes: {
         type: GraphQLList(GraphQLInt),
         defaultValue: [],
+        description: `A list of image widths to be generated. Example: [ 200, 340, 520, 890 ]`,
       },
     },
     resolve: (image, fieldArgs, context) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9690,6 +9690,15 @@ imageinfo@^1.0.4:
   resolved "https://registry.yarnpkg.com/imageinfo/-/imageinfo-1.0.4.tgz#1dd2456ecb96fc395f0aa1179c467dfb3d5d7a2a"
   integrity sha1-HdJFbsuW/DlfCqEXnEZ9+z1deio=
 
+imagemin-mozjpeg@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/imagemin-mozjpeg/-/imagemin-mozjpeg-7.0.0.tgz#d926477fc6ef5f3a768a4222f7b2d808d3eba568"
+  integrity sha1-2SZHf8bvXzp2ikIi97LYCNPrpWg=
+  dependencies:
+    execa "^0.8.0"
+    is-jpg "^1.0.0"
+    mozjpeg "^5.0.0"
+
 imagemin-pngquant@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/imagemin-pngquant/-/imagemin-pngquant-6.0.0.tgz#7c0c956338fa9a3a535deb63973c1c894519cc78"
@@ -10220,6 +10229,11 @@ is-ip@^2.0.0:
   integrity sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=
   dependencies:
     ip-regex "^2.0.0"
+
+is-jpg@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-jpg/-/is-jpg-1.0.1.tgz#296d57fdd99ce010434a7283e346ab9a1035e975"
+  integrity sha1-KW1X/dmc4BBDSnKD40armhA16XU=
 
 is-lower-case@^1.1.0:
   version "1.1.3"
@@ -12828,6 +12842,15 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+mozjpeg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mozjpeg/-/mozjpeg-5.0.0.tgz#b8671c4924568a363de003ff2fd397ab83f752c5"
+  integrity sha1-uGccSSRWijY94AP/L9OXq4P3UsU=
+  dependencies:
+    bin-build "^2.2.0"
+    bin-wrapper "^3.0.0"
+    logalot "^2.0.0"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR adds support for custom sizes when creating fluid images. The current implementation returns sizes in the following way:

```js
num / 4   // if num is 800 --> 200
num / 2   // if num is 800 --> 400
num       // if num is 800 --> 800
num * 1.5 // if num is 800 --> 1200
num * 2   // if num is 800 --> 1600
num * 3   // if num is 800 --> 2400
```

With this PR you have direct control of the sizes you get back by using a new parameter called `customSizes`. See the example for how it works.

## Example

### Query

(For this example `image.jpg` has a width of 1000)

```graphql
{
  fluid: file(relativePath: {eq: "image.jpg"}) {
    childImageSharp {
      fluid (customSizes: [ 50, 180, 400, 710, 900 ]) {
        src
        sizes
        srcSet
      }
    }
  }
}
```

### Output

```json
{
  "data": {
    "fluid": {
      "childImageSharp": {
        "fluid": {
          "src": "/static/image-f00db918cb54b413b814ed8e193478ad-97776.jpg",
          "sizes": "(max-width: 800px) 100vw, 800px",
          "srcSet": "/static/image-f00db918cb54b413b814ed8e193478ad-12166.jpg 50w,\n/static/image-f00db918cb54b413b814ed8e193478ad-3e6f0.jpg 180w,\n/static/image-f00db918cb54b413b814ed8e193478ad-7d9ea.jpg 400w,\n/static/image-f00db918cb54b413b814ed8e193478ad-97776.jpg 710w,\n/static/image-f00db918cb54b413b814ed8e193478ad-a0877.jpg 900w,\n/static/image-f00db918cb54b413b814ed8e193478ad-fd737.jpg 1000w"
        }
      }
    }
  }
}
```

Here's `srcSet` in a more readable format:

```
/static/image-f00db918cb54b413b814ed8e193478ad-12166.jpg 50w,
/static/image-f00db918cb54b413b814ed8e193478ad-3e6f0.jpg 180w,
/static/image-f00db918cb54b413b814ed8e193478ad-7d9ea.jpg 400w,
/static/image-f00db918cb54b413b814ed8e193478ad-97776.jpg 710w,
/static/image-f00db918cb54b413b814ed8e193478ad-a0877.jpg 900w,
/static/image-f00db918cb54b413b814ed8e193478ad-fd737.jpg 1000w
```

## Some questions

Should `maxWidth` automatically be inserted into the `customSizes` array so that we have a perfect fit? Right now the nearest width to `maxWidth` is selected for `src`. (In the example above the `710w` version is chosen for `src`.)

Is `customSizes` a good name for it?