### PR TITLE
fix: check for for both unix and win32 path separators

### DIFF
--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -67,7 +67,7 @@ describe(`watching`, () => {
       expect(fs.copy).toHaveBeenCalledTimes(1)
       expect(fs.copy).toHaveBeenCalledWith(
         filePath,
-        `node_modules/gatsby/dist/index.js`,
+        path.join(`node_modules`, `gatsby`, `dist`, `index.js`),
         expect.any(Function)
       )
     })
@@ -84,7 +84,7 @@ describe(`watching`, () => {
       expect(fs.copy).toHaveBeenCalledTimes(2)
       expect(fs.copy).toHaveBeenLastCalledWith(
         filePath,
-        `.cache/register-service-worker.js`,
+        path.join(`.cache`, `register-service-worker.js`),
         expect.any(Function)
       )
     })

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -50,9 +50,9 @@ function watch(root, packages, { scanOnce, quiet }) {
       const watchEvents = [`change`, `add`]
       if (_.includes(watchEvents, event)) {
         const [packageName] = filePath
-          .split(`packages/`)
+          .split(/packages[/\\]/)
           .pop()
-          .split(`/`)
+          .split(/[/\\]/)
         const prefix = path.join(root, `/packages/`, packageName)
 
         // Copy it over local version.


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
