### PR TITLE
Update install command documentation for gatsby-dev-cli

### DIFF
--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -6,7 +6,7 @@ Gatsby packages to Gatsby sites that you're testing your changes on.
 
 ## Install
 
-`npm install -g gatsby-dev-cli@canary`
+`npm install -g gatsby-dev-cli`
 
 ## Configuration / First time setup
 


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
`npm install -g gatsby-dev-cli@canary` will install `v2.0.0-alpha.80a21f04`. I assume since you are now at `v2.4.4` you don't want people installing the `canary` version.