### PR TITLE
More work to prevent queries from running when there's in-progress node processing

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -47,8 +47,6 @@ const createFSMachine = () =>
     },
   })
 
-let currentState
-
 exports.sourceNodes = (
   { actions, getNode, createNodeId, hasNodeChanged, reporter, emitter },
   pluginOptions
@@ -75,7 +73,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
   }
 
   const fsMachine = createFSMachine()
-  currentState = fsMachine.initialState
+  let currentState = fsMachine.initialState
 
   // Once bootstrap is finished, we only let one File node update go through
   // the system at a time.

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -114,9 +114,6 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
       `BOOTSTRAP_FINISHED`
     )
   })
-  emitter.on(`API_RUNNING_QUEUE_EMPTY`, () => {
-    console.log(`API_RUNNING_QUEUE_EMPTY`)
-  })
   emitter.on(`TOUCH_NODE`, () => {
     // If we create a node which is the same as the previous version, createNode
     // returns TOUCH_NODE and then nothing else happens so we listen to that

--- a/packages/gatsby/src/internal-plugins/query-runner/query-queue.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-queue.js
@@ -61,8 +61,22 @@ const queue = new Queue((plObj, callback) => {
     )
 }, queueOptions)
 
+// Pause running queries when new nodes are added (processing starts).
+emitter.on(`CREATE_NODE`, () => {
+  queue.pause()
+})
+
+// Resume running queries as soon as the api queue is empty.
+emitter.on(`API_RUNNING_QUEUE_EMPTY`, () => {
+  queue.resume()
+})
+
 queue.on(`drain`, () => {
   emitter.emit(`QUERY_QUEUE_DRAINED`)
+})
+
+queue.on(`task_queued`, () => {
+  emitter.emit(`QUERY_ENQUEUED`)
 })
 
 module.exports = queue


### PR DESCRIPTION
@gaearon reported that reactjs.org was still seeing problems with broken queries
when saving a markdown file multiple times in quick succession.

~I investigated and confirmed and found two improvements to our query running
system that prevent this. With these fixes, I'm not able to trigger the bug anymore
with VSCode set to autosave every 100ms.~

~This PR has two fixes:~

- ~Changing a file can trigger pages to be recreated which often trigger
  TOUCH_NODE which would change the state back to idle. This wasn't accurrate
  as queries haven't yet been run so I added a new state to source-filesystem's
  state machine to track that a query has been queued so we actually wait to emit
  new nodes until queries have run.~
- ~Pause query running when new nodes are created and resume once the processing
  is finished. A file node could get created which would dirty a page with a
  markdown query and the query sometimes runs before the markdown file node had
  been recreated which results in an empty query result. Pausing and resuming
  queue running fixes that.~

After more investigation, it occurred to me that all that was necessary was to pause query running when node processing was happening which is easy to detect. That removed the need for special code in gatsby-source-filesystem & means we'll solve this same problem for any other plugin which might encounter it in the future.


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->