### PR TITLE
Adds error message with filename on Markdown error, fixes bug in panicOnBuild

### DIFF
--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -52,7 +52,8 @@ module.exports = Object.assign(reporter, {
 
   panicOnBuild(...args) {
     this.error(...args)
-    if (process.env.gatsby_executing_command !== `build`) {
+    console.log(process.env)
+    if (process.env.gatsby_executing_command === `build`) {
       process.exit(1)
     }
   },

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -52,7 +52,6 @@ module.exports = Object.assign(reporter, {
 
   panicOnBuild(...args) {
     this.error(...args)
-    console.log(process.env)
     if (process.env.gatsby_executing_command === `build`) {
       process.exit(1)
     }

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -3,7 +3,7 @@ const crypto = require(`crypto`)
 const _ = require(`lodash`)
 
 module.exports = async function onCreateNode(
-  { node, getNode, loadNodeContent, actions, createNodeId },
+  { node, getNode, loadNodeContent, actions, createNodeId, reporter },
   pluginOptions
 ) {
   const { createNode, createParentChildLink } = actions
@@ -17,49 +17,56 @@ module.exports = async function onCreateNode(
   }
 
   const content = await loadNodeContent(node)
-  let data = grayMatter(content, pluginOptions)
 
-  // Convert date objects to string. Otherwise there's type mismatches
-  // during inference as some dates are strings and others date objects.
-  if (data.data) {
-    data.data = _.mapValues(data.data, v => {
-      if (_.isDate(v)) {
-        return v.toJSON()
-      } else {
-        return v
-      }
-    })
+  try {
+    let data = grayMatter(content, pluginOptions)
+    // Convert date objects to string. Otherwise there's type mismatches
+    // during inference as some dates are strings and others date objects.
+    if (data.data) {
+      data.data = _.mapValues(data.data, v => {
+        if (_.isDate(v)) {
+          return v.toJSON()
+        } else {
+          return v
+        }
+      })
+    }
+
+    const markdownNode = {
+      id: createNodeId(`${node.id} >>> MarkdownRemark`),
+      children: [],
+      parent: node.id,
+      internal: {
+        content: data.content,
+        type: `MarkdownRemark`,
+      },
+    }
+
+    markdownNode.frontmatter = {
+      title: ``, // always include a title
+      ...data.data,
+      _PARENT: node.id,
+    }
+
+    markdownNode.excerpt = data.excerpt
+    markdownNode.rawMarkdownBody = data.content
+
+    // Add path to the markdown file path
+    if (node.internal.type === `File`) {
+      markdownNode.fileAbsolutePath = node.absolutePath
+    }
+
+    markdownNode.internal.contentDigest = crypto
+      .createHash(`md5`)
+      .update(JSON.stringify(markdownNode))
+      .digest(`hex`)
+
+    createNode(markdownNode)
+    createParentChildLink({ parent: node, child: markdownNode })
+  } catch (err) {
+    reporter.panicOnBuild(
+      `Error processing Markdown file ${node.absolutePath}:\n
+      ${err.message}`
+    )
   }
-
-  const markdownNode = {
-    id: createNodeId(`${node.id} >>> MarkdownRemark`),
-    children: [],
-    parent: node.id,
-    internal: {
-      content: data.content,
-      type: `MarkdownRemark`,
-    },
-  }
-
-  markdownNode.frontmatter = {
-    title: ``, // always include a title
-    ...data.data,
-    _PARENT: node.id,
-  }
-
-  markdownNode.excerpt = data.excerpt
-  markdownNode.rawMarkdownBody = data.content
-
-  // Add path to the markdown file path
-  if (node.internal.type === `File`) {
-    markdownNode.fileAbsolutePath = node.absolutePath
-  }
-
-  markdownNode.internal.contentDigest = crypto
-    .createHash(`md5`)
-    .update(JSON.stringify(markdownNode))
-    .digest(`hex`)
-
-  createNode(markdownNode)
-  createParentChildLink({ parent: node, child: markdownNode })
 }

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -65,7 +65,9 @@ module.exports = async function onCreateNode(
     createParentChildLink({ parent: node, child: markdownNode })
   } catch (err) {
     reporter.panicOnBuild(
-      `Error processing Markdown file ${node.absolutePath}:\n
+      `Error processing Markdown file${
+        node.absolutePath ? ` ${node.absolutePath}` : ``
+      }:\n
       ${err.message}`
     )
   }

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -65,8 +65,8 @@ module.exports = async function onCreateNode(
     createParentChildLink({ parent: node, child: markdownNode })
   } catch (err) {
     reporter.panicOnBuild(
-      `Error processing Markdown${
-        node.absolutePath ? ` file ${node.absolutePath}` : ``
+      `Error processing Markdown ${
+        node.absolutePath ? `file ${node.absolutePath}` : `in node ${node.id}`
       }:\n
       ${err.message}`
     )

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -65,8 +65,8 @@ module.exports = async function onCreateNode(
     createParentChildLink({ parent: node, child: markdownNode })
   } catch (err) {
     reporter.panicOnBuild(
-      `Error processing Markdown file${
-        node.absolutePath ? ` ${node.absolutePath}` : ``
+      `Error processing Markdown${
+        node.absolutePath ? ` file ${node.absolutePath}` : ``
       }:\n
       ${err.message}`
     )


### PR DESCRIPTION
As discussed in #8524, when Markdown isn't correctly processed an error is thrown which doesn't include the filename. This fixes it using a try/catch with the `reporter.panicOnBuild` function, which is also changed since it had unexpected behavior (it didn't terminate the build, but it did terminate on other commands such as `gatsby develop`).

---edit by @pieh:
closes #8524 