### PR TITLE
docs: contribute doc

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -43,7 +43,7 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
 }
 ```
 
-- [Install]((https://yarnpkg.com/en/docs/install))/confirm your installation of Yarn (>= 1.0.2).
+- [Install](https://yarnpkg.com/en/docs/install)/confirm your installation of Yarn (>= 1.0.2).
 - Fork the [official repository](https://github.com/gatsbyjs/gatsby).
 - Clone your fork: `git clone --depth=1 https://github.com/<your-username>/gatsby.git`
 - Setup up repo and install dependencies: `yarn run bootstrap`

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -35,24 +35,15 @@ Gatsby uses a "monorepo" pattern to manage its many dependencies and relies on
 
 #### Using Yarn
 
-Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/). While NPM is used to develop Gatsby sites with the CLI, contributing to the Gatsby repo requires Yarn for the following reason: we use Yarn's [workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) feature that comes really handy for monorepos. It allows us to install dependencies from multiple package.json files in sub-folders, enabling a faster and lighter installation process.
+Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/). While NPM is used to develop Gatsby sites with the CLI, contributing to the Gatsby repo requires Yarn for the following reason: we use Yarn's [workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) feature that comes really handy for monorepos. It allows us to install dependencies from multiple `package.json` files in sub-folders, enabling a faster and lighter installation process.
 
-```
-// package.json
+```json:title=package.json
 {
   "workspaces": ["workspace-a", "workspace-b"]
 }
 ```
 
-You can install the latest version of Gatsby by following these steps:
-
-- Clone the repo, navigate to its directory.
-- Ensure you have the latest version of Yarn installed (>= 1.0.2)
-  https://yarnpkg.com/en/docs/install. 
-- Install dependencies using `yarn run bootstrap` in the root of the repo.
-
-There are two ways to contribute. This is the most usual way:
-
+- [Install]((https://yarnpkg.com/en/docs/install))/confirm your installation of Yarn (>= 1.0.2).
 - Fork the [official repository](https://github.com/gatsbyjs/gatsby).
 - Clone your fork: `git clone --depth=1 https://github.com/<your-username>/gatsby.git`
 - Setup up repo and install dependencies: `yarn run bootstrap`

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -43,10 +43,11 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
 }
 ```
 
-- [Install](https://yarnpkg.com/en/docs/install)/confirm your installation of Yarn (>= 1.0.2).
+- [Install](https://yarnpkg.com/en/docs/install) the Yarn package manager.
+- Ensure you have the latest version of Yarn installed (>= 1.0.2). `yarn --version`
 - Fork the [official repository](https://github.com/gatsbyjs/gatsby).
 - Clone your fork: `git clone --depth=1 https://github.com/<your-username>/gatsby.git`
-- Setup up repo and install dependencies: `yarn run bootstrap`
+- Set up repo and install dependencies: `yarn run bootstrap`
 - Make sure tests are passing for you: `yarn test`
 - Create a topic branch: `git checkout -b topics/new-feature-name`
 - Run `yarn run watch` from the root of the repo to watch for changes to packages' source code and compile these changes on-the-fly as you work. Note that the watch command can be resource intensive. To limit it to the packages you're working on, add a scope flag, like `yarn run watch -- --scope={gatsby,gatsby-cli}`. To watch just one package, run `yarn run watch -- --scope=gatsby`.


### PR DESCRIPTION
small stylistic change to follow #5608,
also merged contribute instructions to avoid confusion.
Going trough these steps recently, that part confused me. Now encourage people to first fork the Gatsby repo before cloning it. (saves the hassle of having to change the git origin)