### PR TITLE
early WIP, base structure of the gatsby-source-sql plugin

### DIFF
--- a/packages/gatsby-source-sql/gatsby-node.js
+++ b/packages/gatsby-source-sql/gatsby-node.js
@@ -1,0 +1,46 @@
+const mysql = require(`mysql`)
+
+exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOptions) => {
+  const { createNode } = actions
+
+  delete configOptions.plugins
+
+  let credentials = {
+    host: configOptions.credentials.host || `localhost`,
+    user: configOptions.credentials.user || `root`,
+    password: configOptions.credentials.password || ``,
+    database: configOptions.credentials.database || `local`,
+  }
+
+  const connection = mysql.createConnection({ ...credentials })
+  connection.connect()
+
+  let queries = configOptions.queries.map((query) => new Promise((resolve, reject) => connection.query(query, (err, results, fields) => {
+        if (err) reject(err)
+        resolve(results)
+      })))
+
+  connection.end()
+
+  const createNodeStructure = (query, index) => {
+    const nodeId = credentials.database
+    return Object.assign({}, query, {
+      ...query,
+      id: nodeId + index,
+      parent: nodeId,
+      children: [],
+      internal: {
+        type: `Queries`,
+        content: query,
+        contentDigest: createContentDigest(query),
+      },
+    })
+  }
+
+  return Promise.all(queries).then(result => {
+    result.forEach((value, index) => {
+      const nodeData = createNodeStructure(JSON.stringify(value), index)
+      createNode(nodeData)
+    })
+  })
+}

--- a/packages/gatsby-source-sql/package.json
+++ b/packages/gatsby-source-sql/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gatsby-source-sql",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "node-fetch": "^2.2.0",
+    "query-string": "^6.2.0"
+  }
+}


### PR DESCRIPTION
#8714 This should have status: WIP. Seeking for a helping hand.

Hello, so I've made some progress with the plugin. What can it do right now:
- Connect to mysql,
- Accept queries and execute them.
- Create nodes. (You can see them in GraphiQL under content field.)

The result of the query is always a string and looks like this (depending on the query ofc):
`"content": "[{\"name\":\"paul\"},{\"name\":\"alice\"},{\"name\":\"tom\"},{\"name\":\"junior\"}]"`
and I'm not quite sure if that's correct way of outputting it even though in mongodb plugin `mongodbCloudDocuments` internal content displays data the same way.

The second thing is that I cant really figure out a way on how to query the data from mysql using GraphQL, which by the way mongodb plugin can.

Could anyone direct me to the right path? 