### PR TITLE
fix(www): Correct wrong entries in sites + starters

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1557,7 +1557,6 @@
   categories:
     - Blog
     - Portfolio
-    - Salesforce
   built_by: Gourav Sood
   built_by_url: "https://www.gouravsood.com/"
 - title: Jonas Tebbe Portfolio
@@ -2651,7 +2650,7 @@
   categories:
     - Portfolio
     - Technology
-    - Web development
+    - Web Development
   built_by: Ema Suriano
   built_by_url: https://emasuriano.com/
   featured: false

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -155,7 +155,7 @@
   description: n/a
   tags:
     - Styling:Bootstrap
-    - NetlifyCMS
+    - Netlify CMS
   features:
     - Very similar to gatsby-starter-netlify-cms, slightly more configurable (eg set site-title in gatsby-config) with Bootstrap/Bootswatch instead of bulma
 - url: https://jaxx2104.github.io/gatsby-starter-bootstrap/
@@ -184,7 +184,7 @@
   tags:
     - Styling:Bulma
     - PWA
-    - NetlifyCMS
+    - Netlify CMS
     - Disqus
   features:
     - Complete Business Website Suite - Home Page, About Page, Pricing Page, Contact Page and Blog
@@ -293,7 +293,7 @@
   tags:
     - Styling:Semantic
     - Stripe
-    - Ecommerce:Moltin
+    - Moltin
   features:
     - Uses the Moltin eCommerce Api
     - React 16 (gatsby-plugin-react-next)
@@ -459,7 +459,7 @@
   tags:
     - Blog
     - Styling:Bulma
-    - NetlifyCMS
+    - Netlify CMS
   features:
     - A simple blog built with Netlify CMS
     - Basic directory organization
@@ -515,7 +515,7 @@
   description: A portfolio starter for Gatsby. The target audience are designers and photographers. The light themed website shows your work with large images & big typography. The Onepage is powered by the Headless CMS Prismic.io. and has programatically created pages for your projects. General settings and colors can be changed in a config & theme file.
   tags:
     - Portfolio
-    - Prismic.io
+    - Prismic
     - Styling:CSS-in-JS
     - Onepage
     - PWA
@@ -695,7 +695,7 @@
   description: n/a
   tags:
     - Styling:CSS-in-JS
-    - Typescript
+    - TypeScript
     - Markdown
   features:
     - TypeScript
@@ -707,14 +707,14 @@
   repo: https://github.com/haysclark/gatsby-starter-typescript
   description: n/a
   tags:
-    - Typescript
+    - TypeScript
   features:
     - TypeScript
 - url: https://fabien0102-gatsby-starter.netlify.com/
   repo: https://github.com/fabien0102/gatsby-starter
   description: n/a
   tags:
-    - Typescript
+    - TypeScript
     - Styling:Semantic
   features:
     - Semantic-ui for styling


### PR DESCRIPTION
Changes:

- The website wasn't associated with Salesforce or was from Salesforce
- Netlify CMS is written with a space between the two words
- I don't see why Moltin should be categorized like this
- TypeScript is written with a capital S
