### PR TITLE
Fix diff highlighting in StaticQuery example

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -290,7 +290,7 @@ Page queries live outside of the component definition -- by convention at the en
 
 Go ahead and add a `<StaticQuery />` to your `src/components/layout.js` file, and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
 
-```jsx{3,8-18,35,48}:title=src/components/layout.js
+```jsx{3,8-18,35,48-49}:title=src/components/layout.js
 import React from "react"
 import { css } from "react-emotion"
 import { StaticQuery, Link, graphql } from "gatsby"


### PR DESCRIPTION
`/>` on line 49 of the StaticQuery example should be highlighted, as it's the closing brace for the newly added `<StaticQuery>` component tag.