### PR TITLE
test: Separate the test for windows and others in gatsby-plugin-feed

### DIFF
--- a/packages/gatsby-plugin-feed/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-feed/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -66,11 +66,94 @@ exports[`Test plugin feed custom query runs 2`] = `
 }
 `;
 
+exports[`Test plugin feed custom query runs in Windows 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "public\\\\rss_new.xml",
+      "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><rss xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\" version=\\"2.0\\"><channel><title><![CDATA[a sample title]]></title><description><![CDATA[a description]]></description><link>http://github.com/dylang/node-rss</link><generator>RSS for Node</generator><lastBuildDate>Mon, 01 Jan 2018 00:00:00 GMT</lastBuildDate><item><title><![CDATA[No title]]></title><description><![CDATA[post description]]></description><link>http://dummy.url/a-custom-path</link><guid isPermaLink=\\"true\\">http://dummy.url/a-custom-path</guid></item><item><title><![CDATA[No title]]></title><description><![CDATA[post description]]></description><link>http://dummy.url/another-custom-path</link><guid isPermaLink=\\"true\\">http://dummy.url/another-custom-path</guid></item></channel></rss>",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Test plugin feed custom query runs in Windows 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "
+    {
+      site {
+        siteMetadata {
+          title
+          description
+          siteUrl
+          site_url: siteUrl
+        }
+      }
+    }
+  ",
+    ],
+    Array [
+      "
+          {
+            allMarkdownRemark(
+              limit: 1000,
+            ) {
+              edges {
+                node {
+                  frontmatter {
+                    path
+                  }
+                  excerpt
+                }
+              }
+            }
+          }
+        ",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`Test plugin feed default settings work properly 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
       "public/rss.xml",
+      "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><rss xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\" version=\\"2.0\\"><channel><title><![CDATA[a sample title]]></title><description><![CDATA[a description]]></description><link>http://github.com/dylang/node-rss</link><generator>RSS for Node</generator><lastBuildDate>Mon, 01 Jan 2018 00:00:00 GMT</lastBuildDate><item><title><![CDATA[No title]]></title><description><![CDATA[post description]]></description><link>http://dummy.url/a-slug</link><guid isPermaLink=\\"false\\">http://dummy.url/a-slug</guid><content:encoded></content:encoded></item></channel></rss>",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`Test plugin feed default settings work properly in Windows 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "public\\\\rss.xml",
       "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><rss xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\" version=\\"2.0\\"><channel><title><![CDATA[a sample title]]></title><description><![CDATA[a description]]></description><link>http://github.com/dylang/node-rss</link><generator>RSS for Node</generator><lastBuildDate>Mon, 01 Jan 2018 00:00:00 GMT</lastBuildDate><item><title><![CDATA[No title]]></title><description><![CDATA[post description]]></description><link>http://dummy.url/a-slug</link><guid isPermaLink=\\"false\\">http://dummy.url/a-slug</guid><content:encoded></content:encoded></item></channel></rss>",
     ],
   ],

--- a/packages/gatsby-plugin-feed/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/__tests__/gatsby-node.js
@@ -8,8 +8,8 @@ global.Date = jest.fn(() => DATE_TO_USE)
 global.Date.UTC = _Date.UTC
 global.Date.now = _Date.now
 
-const whenWindows = { it: process.platform === "win32" ? it : it.skip }
-const whenOthers = { it: process.platform === "win32" ? it.skip : it }
+const whenWindows = { it: process.platform === `win32` ? it : it.skip }
+const whenOthers = { it: process.platform === `win32` ? it.skip : it }
 
 describe(`Test plugin feed`, async () => {
   fs.existsSync = jest.fn()

--- a/packages/gatsby-plugin-feed/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/__tests__/gatsby-node.js
@@ -8,12 +8,14 @@ global.Date = jest.fn(() => DATE_TO_USE)
 global.Date.UTC = _Date.UTC
 global.Date.now = _Date.now
 
+const whenWindows = { it: process.platform === "win32" ? it : it.skip }
+const whenOthers = { it: process.platform === "win32" ? it.skip : it }
 
 describe(`Test plugin feed`, async () => {
   fs.existsSync = jest.fn()
   fs.existsSync.mockReturnValue(true)
 
-  it(`default settings work properly`, async () => {
+  const defaultSettingsWorkProperly = async () => {
     internals.writeFile = jest.fn()
     internals.writeFile.mockResolvedValue(true)
     const graphql = jest.fn()
@@ -38,9 +40,9 @@ describe(`Test plugin feed`, async () => {
     } })
     await onPostBuild({ graphql }, {})
     expect(internals.writeFile).toMatchSnapshot()
-  })
+  }
 
-  it(`custom query runs`, async () => {
+  const customQueryRuns = async () => {
     internals.writeFile = jest.fn()
     internals.writeFile.mockResolvedValue(true)
     const graphql = jest.fn()
@@ -106,5 +108,11 @@ describe(`Test plugin feed`, async () => {
     await onPostBuild({ graphql }, options)
     expect(internals.writeFile).toMatchSnapshot()
     expect(graphql).toMatchSnapshot()
-  })
+  }
+
+  whenWindows.it(`custom query runs in Windows`, customQueryRuns)
+  whenOthers.it(`custom query runs`, customQueryRuns)
+
+  whenWindows.it(`default settings work properly in Windows`, defaultSettingsWorkProperly)
+  whenOthers.it(`default settings work properly`, defaultSettingsWorkProperly)
 })


### PR DESCRIPTION
Windows uses a different type of directory separator and it breaks the test cause of jest mock.

Maybe the test should not use jest mock in this case but I can see the reason why it is used in here. The test will separate via `it.skip()` which jest provided as a temporary workaround.