### PR TITLE
Use title syntax on markdown code blocks

### DIFF
--- a/docs/docs/querying-with-graphql.md
+++ b/docs/docs/querying-with-graphql.md
@@ -214,9 +214,7 @@ If you wish to define your own fragments for use in your application, you can us
 
 For example if I put a fragment in a helper component, I can use that fragment in any other query:
 
-```jsx
-// src/components/PostItem.js
-
+```jsx:title=src/components/PostItem.js
 export const markdownFrontmatterFragment = graphql`
   fragment MarkdownFrontmatter on MarkdownRemark {
     frontmatter {
@@ -240,9 +238,7 @@ query($path: String!) {
 
 It’s good practice for your helper components to define and export a fragment for the data they need. For example, on your index page might map over all of your posts to show them in a list.
 
-```jsx
-// src/pages/index.jsx
-
+```jsx:title=src/pages/index.jsx
 import React from "react"
 import { graphql } from "gatsby"
 
@@ -282,9 +278,7 @@ export const query = graphql`
 
 If the index component becomes too large, you might want to refactor it into smaller components.
 
-```jsx
-// src/components/IndexPost.jsx
-
+```jsx:title=src/components/IndexPost.jsx
 import React from "react"
 import { graphql } from "gatsby"
 
@@ -308,9 +302,7 @@ export const query = graphql`
 
 Now, we can use the component together with the exported fragment in our index page.
 
-```jsx{26}
-// src/pages/index.jsx
-
+```jsx:title=src/pages/index.jsx
 import React from "react"
 import IndexPost from "../components/IndexPost"
 import { graphql } from "gatsby"


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
In PR #8902, @LeKoArts pointed out that we should use JSX "title" syntax when giving a filename to a Markdown code block. I was basing my (incorrect) code off this page, which wasn't using the "title" syntax. 

This PR fixes the syntax of that page.
