### PR TITLE
Make contributing instructions consistent

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -53,7 +53,7 @@ There are two ways to contribute. This is the most usual way:
 - For each of your Gatsby test sites, run the `gatsby-dev` command inside the test site's directory to copy
   the built files from your cloned copy of Gatsby. It'll watch for your changes
   to Gatsby packages and copy them into the site. For more detailed instructions
-  see the [gatsby-dev-cli README](/packages/gatsby-dev-cli/) and check out the [gatsby-dev-cli demo video](https://www.youtube.com/watch?v=D0SwX1MSuas).  
+  see the [gatsby-dev-cli README](/packages/gatsby-dev-cli/) and check out the [gatsby-dev-cli demo video](https://www.youtube.com/watch?v=D0SwX1MSuas).
   Note: if you plan to modify packages that are exported from `gatsby` directly, you need to either add those manually to your test sites so that they are listed in `package.json` (e.g. `yarn add gatsby-link`), or specify them explicitly with `gatsby-dev --packages gatsby-link`).
 - Add tests and code for your changes.
 - Once you're done, make sure all tests still pass: `yarn test`.
@@ -76,12 +76,24 @@ a pull request.
 
 - Clone the repo and navigate to `/www`
 - Run `yarn` to install all of the website's dependencies.
-- Run `gatsby develop` to preview the website in `http://localhost:8000`
+- Run `yarn develop` to preview the website in `http://localhost:8000`
 - The Markdown files for the documentation live in `/docs` folder. Make
   additions or modifications here.
 - Make sure to double check your grammar and capitalise correctly.
 - Commit and push to your fork.
 - Create a pull request from your branch.
+
+To develop on the starter showcase, you'll need to supply a GitHub personal access token.
+
+1. Create a personal access token in your GitHub [Developer settings](https://github.com/settings/tokens).
+2. In the new token's settings, grant that token the "public_repo" scope.
+3. Create a file in the root of `www` called `.env.development`, and add the token to that file like so:
+
+```
+GITHUB_API_TOKEN=YOUR_TOKEN_HERE
+```
+
+The `.env.development` file is ignored by git. Your token should never be committed.
 
 ### Contributing to the blog
 

--- a/www/README.md
+++ b/www/README.md
@@ -2,10 +2,12 @@
 
 The main Gatsby site at gatsbyjs.org
 
-Run locally with
+Run locally with:
 
 - `yarn install`
 - `yarn run develop`
+
+See the full contributing instructions at https://www.gatsbyjs.org/docs/how-to-contribute/.
 
 ## Working with the starter showcase
 


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Connects #8676 

Changes instructions from `gatsby develop` to `yarn develop` to ensure contributors are using the local version of gatsby.

Adds instructions for contributing to the starter showcase into the main contributing instructions since a contributor might not know to also look in www/readme.md for separate instructions.