### PR TITLE
chore: force LF style line ending for snapshot and fixture files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js.snap text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.js.snap text eol=lf
+**/*.js.snap text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 **/*.js.snap text eol=lf
+packages/gatsby-codemods/src/transforms/__testfixtures__/*/*.output.js text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 **/*.js.snap text eol=lf
-packages/gatsby-codemods/src/transforms/__testfixtures__/*/*.output.js text eol=lf
-packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/*.* text eol=lf
+**/__testfixtures__/** text eol=lf
+**/__tests__/fixtures/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 **/*.js.snap text eol=lf
 packages/gatsby-codemods/src/transforms/__testfixtures__/*/*.output.js text eol=lf
+packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/*.* text eol=lf


### PR DESCRIPTION
Let's see if this will make Azure Pipelines happy