### PR TITLE
[Starter Library] make the ResetFilters div conditional

### DIFF
--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -92,11 +92,11 @@ export default class FilteredStarterLibrary extends Component {
         <SidebarContainer>
           <SidebarHeader />
           <SidebarBody>
-            <div css={{ height: `3.5rem` }}>
-              {(filters.size > 0 || urlState.s.length > 0) && ( // search is a filter too https://gatsbyjs.slack.com/archives/CB4V648ET/p1529224551000008
+            {(filters.size > 0 || urlState.s.length > 0) && ( // search is a filter too https://gatsbyjs.slack.com/archives/CB4V648ET/p1529224551000008
+              <div css={{ height: `3.5rem` }}>          
                 <ResetFilters onClick={resetFilters} />
-              )}
-            </div>
+              </div>
+            )}
             <LHSFilter
               fixed={150}
               heading="Gatsby Version"


### PR DESCRIPTION
currently there is a div space there with a 3.5rem height even if no filters are selected. this looks ugly on first load:

![image](https://user-images.githubusercontent.com/6764957/46634826-3a29a580-cb20-11e8-88b0-b6b89e152fc2.png)

so my pr tries to fix that at the cost of a jump in the filters when filters are selected. i think that's ok to make the first load look better.