### PR TITLE
fix: update official starters demo links

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -134,7 +134,7 @@
     - Styling:None
   features:
     - Same as official gatsby-starter-blog but with all styling removed
-- url: http://gatsbyjs.github.io/gatsby-starter-blog/
+- url: https://gatsby-starter-blog-demo.netlify.com/
   repo: https://github.com/gatsbyjs/gatsby-starter-blog
   description: official blog
   tags:
@@ -255,7 +255,7 @@
     - i18n
   features:
     - localization (Multilanguage)
-- url: http://gatsbyjs.github.io/gatsby-starter-default/
+- url: https://gatsby-starter-default-demo.netlify.com/
   repo: https://github.com/gatsbyjs/gatsby-starter-default
   description: official default
   tags:
@@ -369,7 +369,7 @@
   features:
     - Barebones configuration for using the Grommet design system
     - Uses Sass (with CSS modules support)
-- url: https://aberrant-fifth.surge.sh/
+- url: https://gatsby-starter-hello-world-demo.netlify.com/
   repo: https://github.com/gatsbyjs/gatsby-starter-hello-world
   description: official hello world
   tags:


### PR DESCRIPTION
links to official starters demo sites are outdated (using gatsby v1), we updated starters.md file before release with new links, but didn't update starters.yml (starter showcase didn't work then yet)

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
