### PR TITLE
[Docs] fix doc about how to install styled-components.

### DIFF
--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -23,7 +23,9 @@ gatsby new styled-components-tutorial https://github.com/gatsbyjs/gatsby-starter
 Second, we'll install the Gatsby plugin for Styled Components.
 
 ```sh
-npm install --save gatsby-plugin-styled-components styled-components babel-plugin-styled-components
+npm install --save gatsby-plugin-styled-components styled-components
+
+npm install --save-dev babel-plugin-styled-components
 ```
 
 And then add it to your site's `gatsby-config.js`:


### PR DESCRIPTION
In this PR, I fixed document.
In that doc,  `babel-plugin-styled-components` is installed in dependencies. 
But I think it might be better idea that babel-plugin is installed in dev-dependencies. 