### PR TITLE
feat(gatsby-source-wordpress): improve error logging for wordpress API requests

### DIFF
--- a/packages/gatsby-source-wordpress/src/http-exception-handler.js
+++ b/packages/gatsby-source-wordpress/src/http-exception-handler.js
@@ -7,6 +7,7 @@ const colorized = require(`./output-color`)
  */
 function httpExceptionHandler(e) {
   const { response, code } = e
+  console.log(colorized.out(`Path: ${response.request.path}`, colorized.color.Font.FgRed))
   if (!response) {
     console.log(
       colorized.out(
@@ -20,7 +21,6 @@ function httpExceptionHandler(e) {
     status,
     statusText,
     data: { message },
-    request: { path },
   } = response
   console.log(
     colorized.out(
@@ -35,7 +35,6 @@ function httpExceptionHandler(e) {
         colorized.color.Font.FgRed
       )
     )
-    console.log(colorized.out(`Path: ${path}`, colorized.color.Font.FgRed))
   }
 }
 

--- a/packages/gatsby-source-wordpress/src/http-exception-handler.js
+++ b/packages/gatsby-source-wordpress/src/http-exception-handler.js
@@ -20,6 +20,7 @@ function httpExceptionHandler(e) {
     status,
     statusText,
     data: { message },
+    request: { path },
   } = response
   console.log(
     colorized.out(
@@ -30,10 +31,11 @@ function httpExceptionHandler(e) {
   if (message) {
     console.log(
       colorized.out(
-        `Inner exception message : "${message}"`,
+        `Inner exception message: "${message}"`,
         colorized.color.Font.FgRed
       )
     )
+    console.log(colorized.out(`Path: ${path}`, colorized.color.Font.FgRed))
   }
 }
 


### PR DESCRIPTION
closes #8928