### PR TITLE
Update deploy documentation for Now

### DIFF
--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -285,19 +285,19 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 
 4.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
+Note: The following steps assume that you have `now` installed on your machine.
+
 If you don't wish to use a node server package, alternatively do:
 
-1.  Install the Now CLI
+1.  Run `gatsby build` at the root of your project.
 
-`npm install -g now`
+2.  Run `now` inside `public/`. This will upload your project to the cloud.
 
-2.  Run `gatsby build` at the root of your project
+To deploy a custom path, run `now` as:
 
-3.  Switch to the `public/` directory
-
-`cd public/`
-
-4.  Run `now` inside `public/`. This will upload your project to the cloud.
+```shell
+$ now /usr/src/project
+```
 
 ## Debugging tips
 

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -285,6 +285,20 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 
 4.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
+If you don't wish to use a node server package, alternatively do:
+
+1.  Install the Now CLI
+
+`npm install -g now`
+
+2.  Run `gatsby build` at the root of your project
+
+3.  Switch to the `public/` directory
+
+`cd public/`
+
+4.  Run `now` inside `public/`. This will upload your project to the cloud.
+
 ## Debugging tips
 
 ### Don't minify HTML

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -275,29 +275,9 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 
 `npm install -g now`
 
-2.  Install a node server package (such as `serve`, or `http-server`)
+2.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
-`npm install --save serve`
-
-3.  Add a `start` script to your `package.json` file, this is what Now will use to run your application:
-
-`"start": "serve public/"`
-
-4.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
-
-Note: The following steps assume that you have `now` installed on your machine.
-
-If you don't wish to use a node server package, alternatively do:
-
-1.  Run `gatsby build` at the root of your project.
-
-2.  Run `now` inside `public/`. This will upload your project to the cloud.
-
-To deploy a custom path, run `now` as:
-
-```shell
-$ now /usr/src/project
-```
+For alternate [Now](https://zeit.co/now) deployment options, check out [this](/docs/deploying-to-now) document.
 
 ## Debugging tips
 

--- a/docs/docs/deploy-gatsby.md
+++ b/docs/docs/deploy-gatsby.md
@@ -277,7 +277,7 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 
 2.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
-For alternate [Now](https://zeit.co/now) deployment options, check out [this](/docs/deploying-to-now) document.
+For alternate [Now](https://zeit.co/now) deployment options, check out [this document](/docs/deploying-to-now).
 
 ## Debugging tips
 

--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -24,16 +24,16 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 
 4.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
+Note: The following steps assume that you have `now` installed on your machine.
+
 If you don't wish to use a node server package, alternatively do:
 
-1.  Install the Now CLI
+1.  Run `gatsby build` at the root of your project.
 
-`npm install -g now`
+2.  Run `now` inside `public/`. This will upload your project to the cloud.
 
-2.  Run `gatsby build` at the root of your project
+To deploy a custom path, run `now` as:
 
-3.  Switch to the `public/` directory
-
-`cd public/`
-
-4.  Run `now` inside `public/`. This will upload your project to the cloud.
+```shell
+$ now /usr/src/project
+```

--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -23,3 +23,17 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 ```
 
 4.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
+
+If you don't wish to use a node server package, alternatively do:
+
+1.  Install the Now CLI
+
+`npm install -g now`
+
+2.  Run `gatsby build` at the root of your project
+
+3.  Switch to the `public/` directory
+
+`cd public/`
+
+4.  Run `now` inside `public/`. This will upload your project to the cloud.

--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -8,11 +8,17 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 
 `npm install -g now`
 
-2.  Install a node server package (such as `serve`, or `http-server`)
+2.  Run `gatsby build` at the root of your project.
+
+3.  Run `now` inside `public/`. This will upload your project to the cloud.
+
+For large project sizes, it is better to install a Node server package (such as `serve`, or `http-server`):
+
+1.  Install a Node server package
 
 `npm install --save serve`
 
-3.  Add a `start` script to your `package.json` file, this is what Now will use to run your application:
+2.  Add a `start` script to your `package.json` file. This is what Now will use to run your application:
 
 ```json:title=package.json
 {
@@ -22,15 +28,7 @@ In order to deploy your Gatsby project using [Now](https://zeit.co/now), you can
 }
 ```
 
-4.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
-
-Note: The following steps assume that you have `now` installed on your machine.
-
-If you don't wish to use a node server package, alternatively do:
-
-1.  Run `gatsby build` at the root of your project.
-
-2.  Run `now` inside `public/`. This will upload your project to the cloud.
+3.  Run `now` at the root of your Gatsby project, this will upload your project, run the `build` script, and then your `start` script.
 
 To deploy a custom path, run `now` as:
 


### PR DESCRIPTION
Update deploy documentation for `Now`. I realize there's repetition, and I sort of intentionally pushed it because I want feedback from people @ Gatsby and otherwise on how to structure it better.

<hr />

Fixes #8943.