### PR TITLE
Added option to support 'defval' option

### DIFF
--- a/packages/gatsby-transformer-excel/src/gatsby-node.js
+++ b/packages/gatsby-transformer-excel/src/gatsby-node.js
@@ -30,7 +30,11 @@ async function onCreateNode(
   if (!_.has(xlsxOptions, `raw`) && _.has(xlsxOptions, `rawOutput`)) {
     xlsxOptions.raw = xlsxOptions.rawOutput
   }
-  delete xlsxOptions.rawOutput
+  if (!_.has(xlsxOptions, `defval`) && _.has(xlsxOptions, `defaultValue`)) {
+    xlsxOptions.defval = xlsxOptions.defaultValue;
+  }
+  delete xlsxOptions.rawOutput;
+  delete xlsxOptions.defaultValue;
   delete xlsxOptions.plugins
 
   // Parse


### PR DESCRIPTION
The default behaviour is to make them null or undefined and cells are skipped. Often when parsing Excel spreadsheets it may be practical to include blank cells for a record. This added option allows you to specify what the default value is, such as an empty string (i.e. '').

This applies to master for Gatsby v2.
