### PR TITLE
[www] Drop Space Mono in favor of monospace system stack

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -70,7 +70,6 @@
     "remove-markdown": "^0.3.0",
     "slash": "^1.0.0",
     "slugify": "^1.3.0",
-    "typeface-space-mono": "^0.0.54",
     "typeface-spectral": "^0.0.54",
     "typography": "^1.0.0-alpha.4",
     "typography-plugin-code": "^1.0.0-alpha.0",

--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -19,7 +19,6 @@ import "../fonts/Webfonts/futurapt_demiitalic_macroman/stylesheet.css"
 
 // Other fonts
 import "typeface-spectral"
-import "typeface-space-mono"
 
 let windowWidth
 

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -87,18 +87,19 @@ const _options = {
       hr: {
         backgroundColor: colors.ui.light,
       },
+      "tt, code, kbd, samp": {
+        // reset line-height: 1.4rem set by
+        // https://github.com/KyleAMathews/typography.js/blob/3c99e905414d19cda124a7baabeb7a99295fec79/packages/typography/src/utils/createStyles.js#L198
+        lineHeight: `inherit`,
+      },
       "tt, code, kbd": {
         background: colors.code.bg,
-        paddingTop: `0.1em`,
-        paddingBottom: `0.1em`,
+        paddingTop: `0.2em`,
+        paddingBottom: `0.2em`,
       },
       "tt, code, kbd, .gatsby-code-title": {
         fontFamily: options.monospaceFontFamily.join(`,`),
         fontSize: `80%`,
-        // Disable ligatures as they look funny w/ Space Mono as code.
-        fontVariant: `none`,
-        WebkitFontFeatureSettings: `"clig" 0, "calt" 0`,
-        fontFeatureSettings: `"clig" 0, "calt" 0`,
       },
       ".gatsby-highlight": {
         background: colors.code.bg,
@@ -121,8 +122,10 @@ const _options = {
       },
       ".gatsby-highlight pre code": {
         display: `block`,
-        fontSize: `92%`,
+        fontSize: `94%`,
         lineHeight: 1.5,
+        // reset code vertical padding declared earlier
+        padding: 0,
       },
       ".gatsby-highlight-code-line": {
         background: colors.code.border,

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -22,7 +22,6 @@ const _options = {
   headerFontFamily,
   bodyFontFamily: [`Spectral`, `Georgia`, `Times New Roman`, `Times`, `serif`],
   monospaceFontFamily: [
-    `Space Mono`,
     `SFMono-Regular`,
     `Menlo`,
     `Monaco`,
@@ -103,7 +102,6 @@ const _options = {
       },
       ".gatsby-highlight": {
         background: colors.code.bg,
-        boxShadow: `inset 0 0 0 1px ${colors.code.border}`,
         borderRadius: `${presets.radius}px`,
         padding: rhythm(options.blockMarginBottom),
         marginBottom: rhythm(options.blockMarginBottom),
@@ -123,8 +121,8 @@ const _options = {
       },
       ".gatsby-highlight pre code": {
         display: `block`,
-        fontSize: `95%`,
-        lineHeight: options.baseLineHeight,
+        fontSize: `92%`,
+        lineHeight: 1.5,
       },
       ".gatsby-highlight-code-line": {
         background: colors.code.border,
@@ -225,25 +223,20 @@ const _options = {
       },
       ".gatsby-code-title": {
         background: colors.code.bg,
-        border: `1px solid ${colors.code.border}`,
-        borderBottomWidth: 0,
+        borderBottom: `1px solid ${colors.code.border}`,
         color: colors.code.text,
         marginLeft: rhythm(-options.blockMarginBottom),
         marginRight: rhythm(-options.blockMarginBottom),
-        padding: `${rhythm(options.blockMarginBottom / 2)} ${rhythm(
+        padding: `${rhythm(options.blockMarginBottom)} ${rhythm(
           options.blockMarginBottom
-        )}`,
+        )} ${rhythm(options.blockMarginBottom / 2)}`,
+        fontSize: `74%`,
       },
       "@media (max-width:634px)": {
         ".gatsby-highlight, .gatsby-resp-image-link": {
           borderRadius: 0,
           borderLeft: 0,
           borderRight: 0,
-        },
-        ".gatsby-highlight": {
-          boxShadow: `inset 0 1px 0 0 ${colors.code.border}, inset 0 -1px 0 0 ${
-            colors.code.border
-          }`,
         },
       },
       video: {
@@ -287,9 +280,9 @@ const _options = {
           )}`,
         },
         ".gatsby-code-title": {
-          padding: `${rhythm(options.blockMarginBottom / 2)} ${rhythm(
+          padding: `${rhythm(options.blockMarginBottom)} ${rhythm(
             options.blockMarginBottom * 1.5
-          )}`,
+          )} ${rhythm(options.blockMarginBottom / 2)}`,
         },
       },
       [presets.VVHd]: {


### PR DESCRIPTION
Fixes #8563:

* Replaces "Space Mono" with the Bootstrap monospace "system stack":
  `font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;`
* Along the way:
  * Removes the border around `.gatsby-highlight` for slightly less visual noise.
  * Slightly decreases `.gatsby-code-title`'s font-size and improves its vertical whitespace.

Here's a GIF showing (3s each)
  * the current gatsbyjs.org with Space Mono and borders around `.gatsby-highlight`,
  * the changes from this PR:
     * Mac OS' SF Mono (for people who have it [installed](http://osxdaily.com/2018/01/07/use-sf-mono-font-mac/)),
    * and finally Mac OS' default for most people, Menlo:

![yo](https://user-images.githubusercontent.com/21834/46729739-7d058d80-cc86-11e8-8d0e-40057df2d75c.gif)