### PR TITLE
fix links in centralizing-your-sites-navigation.md

### DIFF
--- a/docs/docs/centralizing-your-sites-navigation.md
+++ b/docs/docs/centralizing-your-sites-navigation.md
@@ -259,5 +259,5 @@ If you have made it this far, good job! You can now add new site links to your w
 
 Be sure to check out more documentation for further in-depth examples and guides on achieving tasks using Gatsby.
 
-- [Authentication in Gatsby](/docs/authentication/)
-- [E-commerce in Gatsby](/docs/e-commerce/)
+- [Authentication in Gatsby](/docs/authentication-tutorial/)
+- [E-commerce in Gatsby](/docs/ecommerce-tutorial/)


### PR DESCRIPTION
These links was broken on document site.

https://www.gatsbyjs.org/docs/centralizing-your-sites-navigation/