### PR TITLE
fix(www/sidebar): Missing file / Outdated links

### DIFF
--- a/docs/docs/create-a-starter.md
+++ b/docs/docs/create-a-starter.md
@@ -1,0 +1,8 @@
+---
+title: Create a Starter
+---
+
+This is a stub. Help our community expand it.
+
+Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+pull request gets accepted.

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -64,7 +64,7 @@
           link: /docs/working-with-images/
         - title: Using gatsby-image
           link: /docs/using-gatsby-image/
-    - title: Sourcing content and data*
+    - title: Sourcing content and data
       link: /docs/content-and-data/
       items:
         - title: Using Unstructured Data
@@ -136,7 +136,7 @@
           link: /docs/layout-components/
         - title: CSS Modules
           link: /docs/css-modules/
-        - title: Typography.js*
+        - title: Typography.js
           link: /docs/typography-js/
         - title: Using CSS-in-JS library Glamor
           link: /docs/glamor/
@@ -144,9 +144,9 @@
           link: /docs/styled-components/
         - title: Creating global styles
           link: /docs/creating-global-styles/
-        - title: Component CSS*
+        - title: Component CSS
           link: /docs/component-css/
-        - title: PostCSS*
+        - title: PostCSS
           link: /docs/post-css/
     - title: Testing
       link: /docs/testing/
@@ -206,7 +206,7 @@
           link: /docs/adding-pagination/
         - title: Creating a sitemap*
           link: /docs/creating-a-sitemap/
-        - title: Linking between pages*
+        - title: Linking between pages
           link: /docs/linking-between-pages/
         - title: Interactive pages*
           link: /docs/interactive-pages/
@@ -374,7 +374,7 @@
       link: /docs/pair-programming/
     - title: Gatsby Style Guide
       link: /docs/gatsby-style-guide/
-    - title: RFC process*
+    - title: RFC process
       link: /docs/rfc-process/
     - title: Docs templates
       link: /docs/templates/
@@ -388,9 +388,8 @@
       link: /docs/submit-to-creator-showcase/
     - title: Submit to Starter Library
       link: /docs/submit-to-starter-library/
-      items:
-        - title: Submit to Plugin Library
-          link: /docs/submit-to-plugin-library/
+    - title: Submit to Plugin Library
+      link: /docs/submit-to-plugin-library/
 - title: Glossary*
   link: /docs/glossary/
 - title: Commands (Gatsby CLI)


### PR DESCRIPTION
- The `create-a-starter.md` was missing
- Removed the asterik from `Sourcing content and data` as other categories don't have that either even when some stubs are in the category
- Removed asteriks from files that are no longer stubs
- The `Submit to Plugin Library` is no sub-item of `Starter Library`
