### PR TITLE
Use panicOnBuild instead of process.exit

### DIFF
--- a/packages/gatsby/src/bootstrap/get-config-file.js
+++ b/packages/gatsby/src/bootstrap/get-config-file.js
@@ -32,11 +32,10 @@ module.exports = async function getConfigFile(
       })
     )
     if (!testRequireError(configPath, err)) {
-      report.error(
+      report.panic(
         `We encountered an error while trying to load your site's ${configName}. Please fix the error and try again.`,
         err
       )
-      process.exit(1)
     } else if (nearMatch) {
       console.log(``)
       report.error(
@@ -44,15 +43,10 @@ module.exports = async function getConfigFile(
           nearMatch
         )}" to "${chalk.bold(configName)}"`
       )
-      console.log(``)
-      process.exit(1)
     } else if (existsSync(path.join(rootDir, `src`, configName))) {
-      console.log(``)
-      report.error(
+      report.panic(
         `Your ${configName} file is in the wrong place. You've placed it in the src/ directory. It must instead be at the root of your site next to your package.json file.`
       )
-      console.log(``)
-      process.exit(1)
     }
   }
 

--- a/packages/gatsby/src/bootstrap/get-config-file.js
+++ b/packages/gatsby/src/bootstrap/get-config-file.js
@@ -37,8 +37,7 @@ module.exports = async function getConfigFile(
         err
       )
     } else if (nearMatch) {
-      console.log(``)
-      report.error(
+      report.panic(
         `It looks like you were trying to add the config file? Please rename "${chalk.bold(
           nearMatch
         )}" to "${chalk.bold(configName)}"`

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/validate.js
@@ -81,7 +81,7 @@ describe(`collatePluginAPIs`, () => {
 
 describe(`handleBadExports`, () => {
   it(`Does nothing when there are no bad exports`, async () => {
-    const result = handleBadExports({
+    handleBadExports({
       apis: {
         node: [`these`, `can`, `be`],
         browser: [`anything`, `as there`],
@@ -93,30 +93,6 @@ describe(`handleBadExports`, () => {
         ssr: [],
       },
     })
-
-    expect(result).toEqual(false)
-  })
-
-  it(`Returns true and logs a message when bad exports are detected`, async () => {
-    const result = handleBadExports({
-      apis: {
-        node: [``],
-        browser: [``],
-        ssr: [`notFoo`, `bar`],
-      },
-      badExports: {
-        node: [],
-        browser: [],
-        ssr: [
-          {
-            exportName: `foo`,
-            pluginName: `default-site-plugin`,
-          },
-        ],
-      },
-    })
-    // TODO: snapshot console.log()'s from handleBadExports?
-    expect(result).toEqual(true)
   })
 })
 

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/validate.js
@@ -1,5 +1,12 @@
+jest.mock(`gatsby-cli/lib/reporter`, () => {
+  return {
+    panicOnBuild: jest.fn(),
+    warn: jest.fn(),
+  }
+})
 jest.mock(`../../resolve-module-exports`)
 
+const reporter = require(`gatsby-cli/lib/reporter`)
 const {
   collatePluginAPIs,
   handleBadExports,
@@ -93,6 +100,28 @@ describe(`handleBadExports`, () => {
         ssr: [],
       },
     })
+  })
+
+  it(`Calls reporter.panicOnBuild when bad exports are detected`, async () => {	
+    handleBadExports({
+      apis: {
+        node: [``],
+        browser: [``],
+        ssr: [`notFoo`, `bar`],
+      },
+      badExports: {
+        node: [],
+        browser: [],
+        ssr: [
+          {
+            exportName: `foo`,
+            pluginName: `default-site-plugin`,
+          },
+        ],
+      },
+    })
+
+    expect(reporter.panicOnBuild.mock.calls.length).toBe(1)
   })
 })
 

--- a/packages/gatsby/src/bootstrap/load-plugins/index.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.js
@@ -52,8 +52,7 @@ module.exports = async (config = {}) => {
   const badExports = x.badExports
 
   // Show errors for any non-Gatsby APIs exported from plugins
-  const isBad = handleBadExports({ apis, badExports })
-  if (isBad && process.env.NODE_ENV === `production`) process.exit(1) // TODO: change to panicOnBuild
+  handleBadExports({ apis, badExports })
 
   // Show errors when ReplaceRenderer has been implemented multiple times
   flattenedPlugins = handleMultipleReplaceRenderers({

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.js
@@ -89,15 +89,12 @@ const getBadExportsMessage = (badExports, exportType, apis) => {
 
 const handleBadExports = ({ apis, badExports }) => {
   // Output error messages for all bad exports
-  let isBad = false
   _.toPairs(badExports).forEach(badItem => {
     const [exportType, entries] = badItem
     if (entries.length > 0) {
-      isBad = true
-      console.log(getBadExportsMessage(entries, exportType, apis[exportType]))
+      reporter.panicOnBuild(getBadExportsMessage(entries, exportType, apis[exportType]))
     }
   })
-  return isBad
 }
 
 /**

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -55,15 +55,10 @@ module.exports = async (queryJob: QueryJob, component: Any) => {
     errorDetails.set(`Plugin`, queryJob.pluginCreatorId || `none`)
     errorDetails.set(`Query`, queryJob.query)
 
-    report.log(`
+    report.panicOnBuild(`
 The GraphQL query from ${queryJob.componentPath} failed.
 
 ${formatErrorDetails(errorDetails)}`)
-
-    // Perhaps this isn't the best way to see if we're building?
-    if (program._[0] === `build`) {
-      process.exit(1)
-    }
   }
 
   // Add the page context onto the results.

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -213,12 +213,9 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
   }
 
   if (noPageOrComponent) {
-    console.log(``)
-    console.log(
+    report.panic(
       `See the documentation for createPage https://www.gatsbyjs.org/docs/bound-action-creators/#createPage`
     )
-    console.log(``)
-    process.exit(1)
   }
 
   let jsonName
@@ -280,25 +277,16 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       )
 
       if (!notEmpty) {
-        console.log(``)
-        console.log(
+        report.panicOnBuild(
           `You have an empty file in the "src/pages" directory at "${relativePath}". Please remove it or make it a valid component`
         )
-        console.log(``)
-        // TODO actually do die during builds.
-        // process.exit(1)
       }
 
       if (!includesDefaultExport) {
-        console.log(``)
-        console.log(
+        report.panicOnBuild(
           `[${fileName}] The page component must export a React component for it to be valid`
         )
-        console.log(``)
       }
-
-      // TODO actually do die during builds.
-      // process.exit(1)
     }
 
     fileOkCache[internalPage.component] = true
@@ -494,13 +482,12 @@ actions.createNode = (
 
   // Tell user not to set the owner name themself.
   if (node.internal.owner) {
-    console.log(JSON.stringify(node, null, 4))
-    console.log(
+    report.error(JSON.stringify(node, null, 4))
+    report.panic(
       chalk.bold.red(
         `The node internal.owner field is set automatically by Gatsby and not by plugins`
       )
     )
-    process.exit(1)
   }
 
   // Add the plugin name to the internal object.


### PR DESCRIPTION
Observing the code I found out TODO item to use `reporter.panicOnBuild` instead of direct call to `process.exit`.

This PR actually implements this change.