### PR TITLE
feat(gatsby-source-wordpress): add newline to error log message

### DIFF
--- a/packages/gatsby-source-wordpress/src/http-exception-handler.js
+++ b/packages/gatsby-source-wordpress/src/http-exception-handler.js
@@ -7,7 +7,12 @@ const colorized = require(`./output-color`)
  */
 function httpExceptionHandler(e) {
   const { response, code } = e
-  console.log(colorized.out(`Path: ${response.request.path}`, colorized.color.Font.FgRed))
+  console.log(
+    colorized.out(
+      `\nPath: ${response.request.path}`,
+      colorized.color.Font.FgRed
+    )
+  )
   if (!response) {
     console.log(
       colorized.out(


### PR DESCRIPTION
I noticed I was missing this newline in my last PR. I'd suggest we add it, otherwise the log ends up looking weird.

Follow-up to PR #8967 

<img width="580" alt="screen shot 2018-10-09 at 4 15 03 pm" src="https://user-images.githubusercontent.com/1874682/46825646-02517680-cd49-11e8-9ff8-09b6f9fdaaf2.png">
