### PR TITLE
[docs] add templates to starter/site/creator instructions

### DIFF
--- a/docs/docs/site-showcase-submissions.md
+++ b/docs/docs/site-showcase-submissions.md
@@ -44,6 +44,22 @@ There are only three major steps :)
   featured: false
 ```
 
+Use the following template to ensure required fields are filled:
+
+```yaml:title=docs/sites.yml
+- title: (required)
+  url: (required)
+  main_url: (required)
+  source_url: (optional - https://github.com/{username}/{titleofthesite})
+  description: >
+    (optional)
+  categories:
+    - (required)
+  built_by: (optional)
+  built_by_url: (optional)
+  featured: false
+```
+
 ## Helpful information
 
 ### Categories

--- a/docs/docs/submit-to-creator-showcase.md
+++ b/docs/docs/submit-to-creator-showcase.md
@@ -26,6 +26,7 @@ There are only two major steps :)
 
 ```yaml:title=docs/community/creators.yml
 - name: Your Name
+
   # You can choose one of three `types`: agency, company, or individual
   type: agency
   description: >-
@@ -36,11 +37,29 @@ There are only two major steps :)
   website: "https://yourname.io/"
   github: "https://github.com/githubusername"
   image: images/image.jpg
+
   # Right now, you can only answer true to either `for_hire` or for `hiring`, but not for both.
   for_hire: true
   hiring: false
+
   # If you mark `portfolio: true`, any sites you have in the Site Showcase that say `built_by: [imagine your name here]` will be linked to your Creator Profile. So make sure that `name`in `creators.yml` is exactly the same as `built_by` in `sites.yml`.
   portfolio: true
+```
+
+Use the following template to ensure required fields are filled:
+
+```yaml:title=docs/community/creators.yml
+- name: (required)
+  type: (required - agency, company, or individual)
+  image: (required - images/{filename}.{ext})
+  description: >-
+    (optional)
+  location: (optional)
+  website: (optional)
+  github: (optional)
+  for_hire: (optional)
+  hiring: (optional)
+  portfolio: (optional)
 ```
 
 4. If you sent your websites to the Showcase before but have not filled out the "built_by" field, you should edit [`sites.yml`](https://github.com/gatsbyjs/gatsby/blob/master/docs/sites.yml) and add your name (and the built_by field if it is not there) there as well to make sure your portfolio pieces are linked to your page.

--- a/docs/docs/submit-to-starter-library.md
+++ b/docs/docs/submit-to-starter-library.md
@@ -16,15 +16,28 @@ To get your site added to the starter library, follow the two steps below.
 - url: Link to a demo of your starter
   repo: Link to GitHub repo
   description: Your starter description
+
   # These correspond to the category filters in the library
   # Make an effort to use the existing tags, and add more if needed!
   tags:
     - Redux
+
   # Add your site features
   # These will be included on your starter's detail page.
   features:
     - Blog post listing with previews (image + summary) for each blog post
-    - Categories and tags for blog posts with pagination
+```
+
+Use the following template to ensure required fields are filled:
+
+```yaml:title=docs/starters.yml
+- url: (required)
+  repo: (required - https://github.com/{username}/{titleofthesite})
+  description: (optional)
+  tags:
+    - (required)
+  features:
+    - (optional, but encouraged)
 ```
 
 Check out the [`starters.yml`](https://github.com/gatsbyjs/gatsby/blob/master/docs/starters.yml) file for examples.


### PR DESCRIPTION
add simplified, copiable templates on starter/site/creator instruction pages.