### PR TITLE
wip: test circleci integration_test setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,8 @@ workflows:
       - unit_tests_node10:
           requires:
             - bootstrap
-      - integration_tests
+      - integration_tests:
+          <<: *integration_test_workflow
       - e2e_tests_gatsbygram:
           <<: *integration_test_workflow
       - e2e_tests_path-prefix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ jobs:
       - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*"
       - <<: *restore_node_modules
       - <<: *install_node_modules
-      - <<: *persist_node_modules
       - <<: *attach_to_bootstrap
       - run: yarn test:integration
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,8 @@ jobs:
       - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*"
       - <<: *restore_node_modules
       - <<: *install_node_modules
-      - <<: *attach_to_bootstrap
+      - <<: *persist_node_modules
+      - run: yarn bootstrap
       - run: yarn test:integration
 
   e2e_tests_gatsbygram:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ jobs:
       - <<: *restore_node_modules
       - <<: *install_node_modules
       - <<: *persist_node_modules
+      - <<: *attach_to_bootstrap
       - run: yarn test:integration
 
   e2e_tests_gatsbygram:
@@ -163,8 +164,7 @@ workflows:
       - unit_tests_node10:
           requires:
             - bootstrap
-      - integration_tests:
-          <<: *integration_test_workflow
+      - integration_tests
       - e2e_tests_gatsbygram:
           <<: *integration_test_workflow
       - e2e_tests_path-prefix:

--- a/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
+++ b/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
@@ -1,8 +1,6 @@
 import { navigate } from "gatsby-link"
 import catchLinks from "gatsby-plugin-catch-links/catch-links"
 
-// dummy change for ci to run this test
-
 const pathPrefix = `/anything`
 
 const getNavigate = () => {

--- a/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
+++ b/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
@@ -1,0 +1,101 @@
+import { navigate } from "gatsby-link"
+import catchLinks from "gatsby-plugin-catch-links/catch-links"
+
+const pathPrefix = `/anything`
+
+const getNavigate = () => {
+  global.___navigate = jest.fn()
+  return navigate
+}
+
+beforeAll(() => {
+  // Set the base URL we will be testing against to http://localhost:8000/pathPrefix
+  window.history.pushState({}, `APP Url`, `${pathPrefix}`)
+})
+
+afterAll(() => {
+  // Set history back to http://localhost:8000
+  window.history.back()
+})
+
+describe(`gatsby-plugin-catch-links works with gatsby-link if`, () => {
+  describe(`navigate href matches catched anchor href`, () => {
+
+    // We're going to manually set up the event listener here
+    let hrefHandler
+    let eventDestroyer
+
+    beforeAll(() => {
+      hrefHandler = jest.fn()
+      eventDestroyer = catchLinks(window, hrefHandler)
+    })
+
+    afterAll(() => {
+      global.__PATH_PREFIX__ = ``
+      eventDestroyer()
+    })
+
+    it(`with pathPrefix set`, done => {
+      global.__PATH_PREFIX__ = pathPrefix
+      const anchor = document.createElement(`a`)
+      anchor.setAttribute(
+        `href`,
+        `${window.location.href}/path`
+      )
+      document.body.appendChild(anchor)
+
+      // create the click event we'll be using for testing
+      const clickEvent = new MouseEvent(`click`, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      })
+
+      hrefHandler.mockImplementation((path) => {
+        getNavigate()(path)
+        expect(global.___navigate).toHaveBeenCalledWith(
+          `${pathPrefix}/path`,
+          undefined
+        )
+
+        anchor.remove()
+
+        done()
+      })
+
+      anchor.dispatchEvent(clickEvent)
+    })
+
+    test(`with pathPrefix unset`, done => {
+      global.__PATH_PREFIX__ = ``
+      const anchor = document.createElement(`a`)
+      anchor.setAttribute(
+        `href`,
+        `${window.location.href}/path`
+      )
+      document.body.appendChild(anchor)
+
+      // create the click event we'll be using for testing
+      const clickEvent = new MouseEvent(`click`, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      })
+
+      hrefHandler.mockImplementation((path) => {
+        getNavigate()(path)
+        expect(global.___navigate).toHaveBeenCalledWith(
+          `${pathPrefix}/path`,
+          undefined
+        )
+
+        anchor.remove()
+
+        done()
+      })
+
+      anchor.dispatchEvent(clickEvent)
+    })
+
+  })
+})

--- a/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
+++ b/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
@@ -1,6 +1,8 @@
 import { navigate } from "gatsby-link"
 import catchLinks from "gatsby-plugin-catch-links/catch-links"
 
+// again
+
 const pathPrefix = `/anything`
 
 const getNavigate = () => {

--- a/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
+++ b/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
@@ -1,8 +1,6 @@
 import { navigate } from "gatsby-link"
 import catchLinks from "gatsby-plugin-catch-links/catch-links"
 
-// again
-
 const pathPrefix = `/anything`
 
 const getNavigate = () => {

--- a/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
+++ b/integration-tests/gatsby-plugin-catch-links/__tests__/catch-links.js
@@ -1,6 +1,8 @@
 import { navigate } from "gatsby-link"
 import catchLinks from "gatsby-plugin-catch-links/catch-links"
 
+// dummy change for ci to run this test
+
 const pathPrefix = `/anything`
 
 const getNavigate = () => {

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -54,6 +54,7 @@ describe(`the click event`, () => {
   it(`checks if the destination/origin URLs have matching origins`, () => {})
   it(`checks if the destination/origin URLs have matching top level paths`, () => {})
   it(`checks if the destination URL wants to scroll the page with a hash anchor`, () => {})
+  it(`checks if pathPrefix is handled`, () => {})
   it(`routes the destination href through gatsby`, () => {})
 })
 
@@ -350,4 +351,50 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
 
     withSearch.dispatchEvent(clickEvent)
   })
+})
+
+describe(`pathPrefix is handled if`, () => {
+  // We're going to manually set up the event listener here
+  let hrefHandler
+  let eventDestroyer
+
+  beforeAll(() => {
+    global.__PATH_PREFIX__ = `/pathPrefix`
+    hrefHandler = jest.fn()
+    eventDestroyer = catchLinks.default(window, hrefHandler)
+  })
+
+  afterAll(() => {
+    global.__PATH_PREFIX__ = ``
+    eventDestroyer()
+  })
+
+  it(`href with /\${pathPrefix}/someSubPath is passed to hrefHandler as /someSubPath`, done => {
+    const withPathPrefix = document.createElement(`a`)
+    withPathPrefix.setAttribute(
+      `href`,
+      `${window.location.href}/someSubPath`
+    )
+    document.body.appendChild(withPathPrefix)
+
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    })
+
+    hrefHandler.mockImplementation(() => {
+      expect(hrefHandler).toHaveBeenCalledWith(
+        `/someSubPath`
+      )
+
+      withPathPrefix.remove()
+
+      done()
+    })
+
+    withPathPrefix.dispatchEvent(clickEvent)
+  })
+
 })

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -60,7 +60,7 @@ describe(`the click event`, () => {
   it(`checks if the destination/origin URLs have matching origins`, () => {})
   it(`checks if the destination/origin URLs have matching top level paths`, () => {})
   it(`checks if the destination URL wants to scroll the page with a hash anchor`, () => {})
-  it(`checks if pathPrefix is handled`, () => {})
+  it(`handles pathPrefix if necessary`, () => {})
   it(`routes the destination href through gatsby`, () => {})
 })
 
@@ -374,7 +374,7 @@ describe(`pathPrefix is handled if href with ${pathPrefix}/someSubPath triggeres
     eventDestroyer()
   })
 
-  it(`with pathPrefix='${pathPrefix}'`, done => {
+  test(`with pathPrefix='${pathPrefix}'`, done => {
     global.__PATH_PREFIX__ = pathPrefix
     const withPathPrefix = document.createElement(`a`)
     withPathPrefix.setAttribute(
@@ -405,7 +405,7 @@ describe(`pathPrefix is handled if href with ${pathPrefix}/someSubPath triggeres
     withPathPrefix.dispatchEvent(clickEvent)
   })
 
-  it(`with pathPrefix unset`, done => {
+  test(`with pathPrefix unset`, done => {
     global.__PATH_PREFIX__ = ``
     const withPathPrefix = document.createElement(`a`)
     withPathPrefix.setAttribute(

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -1,12 +1,6 @@
 const pathPrefix = `/pathPrefix`
 
-import { navigate } from "gatsby-link"
 import * as catchLinks from "../catch-links"
-
-const getNavigate = () => {
-  global.___navigate = jest.fn()
-  return navigate
-}
 
 beforeAll(() => {
   global.__PATH_PREFIX__ = ``
@@ -60,7 +54,7 @@ describe(`the click event`, () => {
   it(`checks if the destination/origin URLs have matching origins`, () => {})
   it(`checks if the destination/origin URLs have matching top level paths`, () => {})
   it(`checks if the destination URL wants to scroll the page with a hash anchor`, () => {})
-  it(`handles pathPrefix if necessary`, () => {})
+  it(`removes pathPrefix if necessary before passing to navigate`, () => {})
   it(`routes the destination href through gatsby`, () => {})
 })
 
@@ -359,7 +353,7 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
   })
 })
 
-describe(`pathPrefix is handled if href with ${pathPrefix}/someSubPath triggeres navigate to ${pathPrefix}/someSubPath`, () => {
+describe(`pathPrefix is handled if target href /pathPrefix/someSubPath`, () => {
   // We're going to manually set up the event listener here
   let hrefHandler
   let eventDestroyer
@@ -374,7 +368,8 @@ describe(`pathPrefix is handled if href with ${pathPrefix}/someSubPath triggeres
     eventDestroyer()
   })
 
-  test(`with pathPrefix='${pathPrefix}'`, done => {
+  // gatsby-link adds pathPrefix, so this module must pass without
+  it(`is passed to hrefHandler as /someSubPath when pathPrefix='${pathPrefix}'`, done => {
     global.__PATH_PREFIX__ = pathPrefix
     const withPathPrefix = document.createElement(`a`)
     withPathPrefix.setAttribute(
@@ -390,11 +385,9 @@ describe(`pathPrefix is handled if href with ${pathPrefix}/someSubPath triggeres
       view: window,
     })
 
-    hrefHandler.mockImplementation((path) => {
-      getNavigate()(path)
-      expect(global.___navigate).toHaveBeenCalledWith(
-        `${pathPrefix}/someSubPath`,
-        undefined
+    hrefHandler.mockImplementation(() => {
+      expect(hrefHandler).toHaveBeenCalledWith(
+        `/someSubPath`
       )
 
       withPathPrefix.remove()
@@ -405,7 +398,7 @@ describe(`pathPrefix is handled if href with ${pathPrefix}/someSubPath triggeres
     withPathPrefix.dispatchEvent(clickEvent)
   })
 
-  test(`with pathPrefix unset`, done => {
+  it(`is passed to hrefHandler as is when pathPrefix is unset`, done => {
     global.__PATH_PREFIX__ = ``
     const withPathPrefix = document.createElement(`a`)
     withPathPrefix.setAttribute(
@@ -421,11 +414,9 @@ describe(`pathPrefix is handled if href with ${pathPrefix}/someSubPath triggeres
       view: window,
     })
 
-    hrefHandler.mockImplementation((path) => {
-      getNavigate()(path)
-      expect(global.___navigate).toHaveBeenCalledWith(
-        `${pathPrefix}/someSubPath`,
-        undefined
+    hrefHandler.mockImplementation(() => {
+      expect(hrefHandler).toHaveBeenCalledWith(
+        `/someSubPath`
       )
 
       withPathPrefix.remove()

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -72,8 +72,7 @@ export const urlsAreOnSameOrigin = (origin, destination) =>
   /* a.host includes both hostname and port in the expected format host:port */
   origin.host === destination.host
 
-export const pathIsNotHandledByApp = destination => {
-  const pathStartRegEx = new RegExp(`^${escapeStringRegexp(withPrefix(`/`))}`)
+export const pathIsNotHandledByApp = (destination, pathStartRegEx) => {
   const pathFileExtensionRegEx = /^.*\.((?!htm)[a-z0-9]{1,5})$/i
 
   return (
@@ -132,16 +131,22 @@ export const routeThroughBrowserOrApp = hrefHandler => event => {
 
   if (urlsAreOnSameOrigin(origin, destination) === false) return true
 
-  if (pathIsNotHandledByApp(destination)) return true
+  // Regex to test pathname against pathPrefix
+  const pathStartRegEx = new RegExp(`^${escapeStringRegexp(withPrefix(`/`))}`)
+
+  if (pathIsNotHandledByApp(destination, pathStartRegEx)) return true
 
   if (hashShouldBeFollowed(origin, destination)) return true
 
   event.preventDefault()
 
+  // See issue #8907: destination.pathname already includes pathPrefix added
+  // by gatsby-transformer-remark but gatsby-link.navigate needs href without
+  const destinationPathname = slashedPathname(destination.pathname)
+    .replace(pathStartRegEx, `/`)
+
   hrefHandler(
-    `${slashedPathname(destination.pathname)}${destination.search}${
-      destination.hash
-    }`
+    `${destinationPathname}${destination.search}${destination.hash}`
   )
 
   return false

--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 GREP_PATTERN=$1
 
-MERGE_BASE="$(git merge-base master $CIRCLE_SHA1)"
-FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $MERGE_BASE $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
+FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
 
 if [ $FILES_COUNT -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."

--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 GREP_PATTERN=$1
 
-FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
+MERGE_BASE="$(git merge-base master $CIRCLE_SHA1)"
+FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $MERGE_BASE $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
 
 if [ $FILES_COUNT -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."


### PR DESCRIPTION
I don't know where by purpose or by accident: the circleci setup for integration-tests--not e2e but the regular-- is missing the `yarn bootstrap` step. Therefore any absolute `import { Link } from "gatsby-link` e.g. fails. This is just my (failing) test from 9e09c65ce5970f9d6b3857f5ffde01d9f2d36c56 with corrected (?) circle ci setup.