### PR TITLE
fix: circle ci integration tests setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ jobs:
       - <<: *restore_node_modules
       - <<: *install_node_modules
       - <<: *persist_node_modules
+      - run: yarn bootstrap
       - run: yarn test:integration
 
   e2e_tests_gatsbygram:
@@ -163,8 +164,7 @@ workflows:
       - unit_tests_node10:
           requires:
             - bootstrap
-      - integration_tests:
-          <<: *integration_test_workflow
+      - integration_tests
       - e2e_tests_gatsbygram:
           <<: *integration_test_workflow
       - e2e_tests_path-prefix:


### PR DESCRIPTION
I wanted to move a test from the gatsby-plugin-catch-links unit tests to the integration tests because it is actually testing the processing of the plugin + gatsby-link together. But the integration tests failed for absolute import of gatsby-link. I found the setup is not callling `yarn bootstrap`. Is this right?