### PR TITLE
Share union type instances

### DIFF
--- a/docs/docs/create-transformer-plugin.md
+++ b/docs/docs/create-transformer-plugin.md
@@ -7,7 +7,7 @@ Transformer plugins are responsible for "transforming" data provided by
 
 ## Transformer plugin example
 
-The [`gatsby-transform-remark`](/packages/gatsby-transform-remark/) plugin
+The [`gatsby-transformer-remark`](/packages/gatsby-transformer-remark/) plugin
 "transforms" markdown nodes (fetched for example from the filesystem source plugin) into html and provides additional node details such as for example the `timeToRead` the `tableOfContents` and the `excerpt`.
 
 ## What do transformer plugins do?
@@ -31,7 +31,7 @@ Your `gatsby-node.js` should look something like:
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
 ```
 
-Information on the purpose of this function can be found in the [API reference](docs/node-apis/#setFieldsOnGraphQLNodeType).
+Information on the purpose of this function can be found in the [API reference](/docs/node-apis/#setFieldsOnGraphQLNodeType).
 
 ## Using the cache
 

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -8,7 +8,7 @@ const path = require(`path`)
 const normalizePath = require(`normalize-path`)
 const { clearTypeExampleValues } = require(`../data-tree-utils`)
 const { typeConflictReporter } = require(`../type-conflict-reporter`)
-const { inferObjectStructureFromNodes } = require(`../infer-graphql-type`)
+const { inferObjectStructureFromNodes, clearUnionTypes } = require(`../infer-graphql-type`)
 
 function queryResult(nodes, fragment, { types = [], ignoreFields } = {}) {
   const schema = new GraphQLSchema({
@@ -764,6 +764,14 @@ describe(`GraphQL type inferance`, () => {
         types: types.concat([{ name: `Toy` }]),
       })
       expect(fields.test.type).not.toEqual(fields2.test.type)
+    })
+
+    it(`Creates a new type after schema updates clear union types`, () => {
+      const nodes = [{ test___NODE: [`pet_1`, `child_1`] } ]
+      const fields = inferObjectStructureFromNodes({ nodes, types })
+      clearUnionTypes()
+      const updatedFields = inferObjectStructureFromNodes({ nodes, types })
+      expect(fields.test.type).not.toEqual(updatedFields.test.type)
     })
   })
 

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -698,80 +698,86 @@ describe(`GraphQL type inferance`, () => {
       )
     })
 
-    it(`Creates union types when an array field is linking to multiple node types`, async () => {
-      let result = await queryResult(
-        [{ linked___NODE: [`child_1`, `pet_1`] }],
-        `
-          linked {
-            __typename
-            ... on Child {
-              hair
+    describe(`Creation of union types when array field is linking to multiple types`, () => {
+      beforeEach(() => {
+        clearUnionTypes()
+      })
+
+      it(`Creates union types`, async () => {
+        let result = await queryResult(
+          [{ linked___NODE: [`child_1`, `pet_1`] }],
+          `
+            linked {
+              __typename
+              ... on Child {
+                hair
+              }
+              ... on Pet {
+                species
+              }
             }
-            ... on Pet {
-              species
-            }
-          }
-        `,
-        { types }
-      )
-      expect(result.errors).not.toBeDefined()
-      expect(result.data.listNode[0].linked[0].hair).toEqual(`brown`)
-      expect(result.data.listNode[0].linked[0].__typename).toEqual(`Child`)
-      expect(result.data.listNode[0].linked[1].species).toEqual(`dog`)
-      expect(result.data.listNode[0].linked[1].__typename).toEqual(`Pet`)
-      store.dispatch({
-        type: `CREATE_NODE`,
-        payload: { id: `baz`, internal: { type: `Bar` } },
+          `,
+          { types }
+        )
+        expect(result.errors).not.toBeDefined()
+        expect(result.data.listNode[0].linked[0].hair).toEqual(`brown`)
+        expect(result.data.listNode[0].linked[0].__typename).toEqual(`Child`)
+        expect(result.data.listNode[0].linked[1].species).toEqual(`dog`)
+        expect(result.data.listNode[0].linked[1].__typename).toEqual(`Pet`)
+        store.dispatch({
+          type: `CREATE_NODE`,
+          payload: { id: `baz`, internal: { type: `Bar` } },
+        })
       })
-    })
 
-    it(`Uses same union type for same child node types and key`, () => {
-      const fields = inferObjectStructureFromNodes({
-        nodes: [{ test___NODE: [`pet_1`, `child_1`] } ],
-        types,
+      it(`Uses same union type for same child node types and key`, () => {
+        const fields = inferObjectStructureFromNodes({
+          nodes: [{ test___NODE: [`pet_1`, `child_1`] } ],
+          types,
+        })
+        const fields2 = inferObjectStructureFromNodes({
+          nodes: [{ test___NODE: [`pet_1`, `child_2`] }],
+          types,
+        })
+        expect(fields.test.type).toEqual(fields2.test.type)
       })
-      const fields2 = inferObjectStructureFromNodes({
-        nodes: [{ test___NODE: [`pet_1`, `child_2`] }],
-        types,
-      })
-      expect(fields.test.type).toEqual(fields2.test.type)
-    })
 
 
-    it(`Uses a different type for the same child node types but a different key`, () => {
-      const fields = inferObjectStructureFromNodes({
-        nodes: [{ test___NODE: [`pet_1`, `child_1`] }],
-        types,
+      it(`Uses a different type for the same child node types but a different key`, () => {
+        const fields = inferObjectStructureFromNodes({
+          nodes: [{ test___NODE: [`pet_1`, `child_1`] }],
+          types,
+        })
+        const fields2 = inferObjectStructureFromNodes({
+          nodes: [{ differentKey___NODE: [`pet_1`, `child_2`] }],
+          types,
+        })
+        expect(fields.test.type).not.toEqual(fields2.differentKey.type)
       })
-      const fields2 = inferObjectStructureFromNodes({
-        nodes: [{ differentKey___NODE: [`pet_1`, `child_2`] }],
-        types,
-      })
-      expect(fields.test.type).not.toEqual(fields2.differentKey.type)
-    })
 
-    it(`Uses a different type for the different child node types but the same key`, () => {
-      store.dispatch({
-        type: `CREATE_NODE`,
-        payload: { id: `toy_1`, internal: { type: `Toy` } },
+      it(`Uses a different type for the different child node types but the same key`, () => {
+        store.dispatch({
+          type: `CREATE_NODE`,
+          payload: { id: `toy_1`, internal: { type: `Toy` } },
+        })
+        const fields = inferObjectStructureFromNodes({
+          nodes: [{ test___NODE: [`pet_1`, `child_1`] } ],
+          types,
+        })
+        const fields2 = inferObjectStructureFromNodes({
+          nodes: [{ test___NODE: [`pet_1`, `child_1`, `toy_1`] }],
+          types: types.concat([{ name: `Toy` }]),
+        })
+        expect(fields.test.type).not.toEqual(fields2.test.type)
       })
-      const fields = inferObjectStructureFromNodes({
-        nodes: [{ test___NODE: [`pet_1`, `child_1`] } ],
-        types,
-      })
-      const fields2 = inferObjectStructureFromNodes({
-        nodes: [{ test___NODE: [`pet_1`, `child_1`, `toy_1`] }],
-        types: types.concat([{ name: `Toy` }]),
-      })
-      expect(fields.test.type).not.toEqual(fields2.test.type)
-    })
 
-    it(`Creates a new type after schema updates clear union types`, () => {
-      const nodes = [{ test___NODE: [`pet_1`, `child_1`] } ]
-      const fields = inferObjectStructureFromNodes({ nodes, types })
-      clearUnionTypes()
-      const updatedFields = inferObjectStructureFromNodes({ nodes, types })
-      expect(fields.test.type).not.toEqual(updatedFields.test.type)
+      it(`Creates a new type after schema updates clear union types`, () => {
+        const nodes = [{ test___NODE: [`pet_1`, `child_1`] } ]
+        const fields = inferObjectStructureFromNodes({ nodes, types })
+        clearUnionTypes()
+        const updatedFields = inferObjectStructureFromNodes({ nodes, types })
+        expect(fields.test.type).not.toEqual(updatedFields.test.type)
+      })
     })
   })
 

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -9,6 +9,7 @@ const normalizePath = require(`normalize-path`)
 const { clearTypeExampleValues } = require(`../data-tree-utils`)
 const { typeConflictReporter } = require(`../type-conflict-reporter`)
 const { inferObjectStructureFromNodes, clearUnionTypes } = require(`../infer-graphql-type`)
+const { clearTypeNames } = require(`../create-type-name`)
 
 function queryResult(nodes, fragment, { types = [], ignoreFields } = {}) {
   const schema = new GraphQLSchema({
@@ -700,6 +701,7 @@ describe(`GraphQL type inferance`, () => {
 
     describe(`Creation of union types when array field is linking to multiple types`, () => {
       beforeEach(() => {
+        clearTypeNames()
         clearUnionTypes()
       })
 
@@ -777,6 +779,14 @@ describe(`GraphQL type inferance`, () => {
         clearUnionTypes()
         const updatedFields = inferObjectStructureFromNodes({ nodes, types })
         expect(fields.test.type).not.toEqual(updatedFields.test.type)
+      })
+
+      it(`Uses a reliable naming convention for union types`, () => {
+        const nodes = [{ test___NODE: [`pet_1`, `child_1`] } ]
+        const fields = inferObjectStructureFromNodes({ nodes, types })
+        clearUnionTypes()
+        const updatedFields = inferObjectStructureFromNodes({ nodes, types })
+        expect(updatedFields.test.type.ofType.name).toEqual('unionTestNode_2')
       })
     })
   })

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -736,6 +736,19 @@ describe(`GraphQL type inferance`, () => {
       })
       expect(fields.test.type).toEqual(fields2.test.type)
     })
+
+
+    it(`Uses a different type for the same child node types but a different key`, () => {
+      const fields = inferObjectStructureFromNodes({
+        nodes: [{ test___NODE: [`pet_1`, `child_1`] }],
+        types,
+      })
+      const fields2 = inferObjectStructureFromNodes({
+        nodes: [{ differentKey___NODE: [`pet_1`, `child_2`] }],
+        types,
+      })
+      expect(fields.test.type).not.toEqual(fields2.differentKey.type)
+    })
   })
 
   it(`Infers graphql type from array of nodes`, () =>

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -749,6 +749,22 @@ describe(`GraphQL type inferance`, () => {
       })
       expect(fields.test.type).not.toEqual(fields2.differentKey.type)
     })
+
+    it(`Uses a different type for the different child node types but the same key`, () => {
+      store.dispatch({
+        type: `CREATE_NODE`,
+        payload: { id: `toy_1`, internal: { type: `Toy` } },
+      })
+      const fields = inferObjectStructureFromNodes({
+        nodes: [{ test___NODE: [`pet_1`, `child_1`] } ],
+        types,
+      })
+      const fields2 = inferObjectStructureFromNodes({
+        nodes: [{ test___NODE: [`pet_1`, `child_1`, `toy_1`] }],
+        types: types.concat([{ name: `Toy` }]),
+      })
+      expect(fields.test.type).not.toEqual(fields2.test.type)
+    })
   })
 
   it(`Infers graphql type from array of nodes`, () =>

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -725,22 +725,13 @@ describe(`GraphQL type inferance`, () => {
       })
     })
 
-    it(`Uses same union type for same key`, () => {
+    it(`Uses same union type for same child node types and key`, () => {
       const fields = inferObjectStructureFromNodes({
-        nodes: [
-          {
-            test___NODE: [`pet_1`, `child_1`],
-          },
-        ],
+        nodes: [{ test___NODE: [`pet_1`, `child_1`] } ],
         types,
       })
-
       const fields2 = inferObjectStructureFromNodes({
-        nodes: [
-          {
-            test___NODE: [`pet_1`, `child_1`],
-          },
-        ],
+        nodes: [{ test___NODE: [`pet_1`, `child_2`] }],
         types,
       })
       expect(fields.test.type).toEqual(fields2.test.type)

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -745,7 +745,7 @@ describe(`GraphQL type inferance`, () => {
       })
 
 
-      it(`Uses a different type for the same child node types but a different key`, () => {
+      it(`Uses a different type for the same child node types with a different key`, () => {
         const fields = inferObjectStructureFromNodes({
           nodes: [{ test___NODE: [`pet_1`, `child_1`] }],
           types,
@@ -757,7 +757,7 @@ describe(`GraphQL type inferance`, () => {
         expect(fields.test.type).not.toEqual(fields2.differentKey.type)
       })
 
-      it(`Uses a different type for the different child node types but the same key`, () => {
+      it(`Uses a different type for different child node types with the same key`, () => {
         store.dispatch({
           type: `CREATE_NODE`,
           payload: { id: `toy_1`, internal: { type: `Toy` } },
@@ -781,7 +781,7 @@ describe(`GraphQL type inferance`, () => {
         expect(fields.test.type).not.toEqual(updatedFields.test.type)
       })
 
-      it(`Uses a reliable naming convention for union types`, () => {
+      it(`Uses a reliable naming convention`, () => {
         const nodes = [{ test___NODE: [`pet_1`, `child_1`] } ]
         inferObjectStructureFromNodes({ nodes, types })
         clearUnionTypes()

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -783,10 +783,10 @@ describe(`GraphQL type inferance`, () => {
 
       it(`Uses a reliable naming convention for union types`, () => {
         const nodes = [{ test___NODE: [`pet_1`, `child_1`] } ]
-        const fields = inferObjectStructureFromNodes({ nodes, types })
+        inferObjectStructureFromNodes({ nodes, types })
         clearUnionTypes()
         const updatedFields = inferObjectStructureFromNodes({ nodes, types })
-        expect(updatedFields.test.type.ofType.name).toEqual('unionTestNode_2')
+        expect(updatedFields.test.type.ofType.name).toEqual(`unionTestNode_2`)
       })
     })
   })

--- a/packages/gatsby/src/schema/create-type-name.js
+++ b/packages/gatsby/src/schema/create-type-name.js
@@ -1,14 +1,18 @@
 const _ = require(`lodash`)
 
-const seenNames = {}
+const seenNames = new Map()
 
 module.exports = function createTypeName(name) {
   const cameledName = _.camelCase(name)
-  if (seenNames[cameledName]) {
-    seenNames[cameledName] += 1
-    return `${cameledName}_${seenNames[cameledName]}`
+  if (seenNames.has(cameledName)) {
+    seenNames.set(cameledName, seenNames.get(cameledName) + 1)
+    return `${cameledName}_${seenNames.get(cameledName)}`
   } else {
-    seenNames[cameledName] = 1
+    seenNames.set(cameledName, 1)
     return cameledName
   }
+}
+
+module.exports.clearTypeNames = () => {
+  seenNames.clear()
 }

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -7,7 +7,7 @@ const buildNodeTypes = require(`./build-node-types`)
 const buildNodeConnections = require(`./build-node-connections`)
 const { store } = require(`../redux`)
 const invariant = require(`invariant`)
-const { clearUnionTypes } = require('./infer-graphql-type')
+const { clearUnionTypes } = require(`./infer-graphql-type`)
 
 module.exports = async ({ parentSpan }) => {
   clearUnionTypes()

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -7,8 +7,10 @@ const buildNodeTypes = require(`./build-node-types`)
 const buildNodeConnections = require(`./build-node-connections`)
 const { store } = require(`../redux`)
 const invariant = require(`invariant`)
+const { clearUnionTypes } = require('./infer-graphql-type')
 
 module.exports = async ({ parentSpan }) => {
+  clearUnionTypes()
   const typesGQL = await buildNodeTypes({ parentSpan })
   const connections = buildNodeConnections(_.values(typesGQL))
 

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -24,7 +24,7 @@ const {
 const DateType = require(`./types/type-date`)
 const FileType = require(`./types/type-file`)
 const is32BitInteger = require(`../utils/is-32-bit-integer`)
-const unionTypes = {}
+const unionTypes = new Map()
 
 import type { GraphQLOutputType } from "graphql"
 import type {
@@ -257,17 +257,15 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
     let type
     // If there's more than one type, we'll create a union type.
     if (fields.length > 1) {
-      const typeName = `Union_${key}`
+      const typeName = `Union_${key}_${fields.map(f => f.name).sort().join(`__`)}`
 
-      if (unionTypes[typeName]) {
-        type = unionTypes[typeName].find(type =>
-          _.isEqual(type.getTypes(), fields.map(f => f.nodeObjectType))
-        )
+      if (unionTypes.has(typeName)) {
+        type = unionTypes.get(typeName)
       }
 
       if (!type) {
         type = new GraphQLUnionType({
-          name: createTypeName(typeName),
+          name: createTypeName(`Union_${key}`),
           description: `Union interface for the field "${key}" for types [${fields
             .map(f => f.name)
             .sort()
@@ -276,7 +274,7 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
           resolveType: data =>
             fields.find(f => f.name == data.internal.type).nodeObjectType,
         })
-        ;(unionTypes[typeName] = unionTypes[typeName] || []).push(type)
+        unionTypes.set(typeName, type)
       }
     } else {
       type = fields[0].nodeObjectType
@@ -427,4 +425,8 @@ function _inferObjectStructureFromNodes(
 
 export function inferObjectStructureFromNodes(options: inferTypeOptions) {
   return _inferObjectStructureFromNodes(options, null)
+}
+
+export function clearUnionTypes() {
+  unionTypes.clear()
 }

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -257,12 +257,7 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
     // If there's more than one type, we'll create a union type.
     if (fields.length > 1) {
       type = new GraphQLUnionType({
-        name: createTypeName(
-          `Union_${key}_${fields
-            .map(f => f.name)
-            .sort()
-            .join(`__`)}`
-        ),
+        name: createTypeName(`Union_${key}`),
         description: `Union interface for the field "${key}" for types [${fields
           .map(f => f.name)
           .sort()


### PR DESCRIPTION
Hello, Gatsby team 👋

I hope to get some feedback on this PR. Let's dive in. Currently, [union types are named as follows](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L260-L265):

1. Using the names of all the fields they contain;
2. Incremented automatically when the same key occurs (`createTypeName`).

This causes union types to not be very reliable for usage in GraphQL queries (and not pretty, such as `unionContentPostNodeWordPressAcfImageWordPressAcfText_2` for a WordPress flexible content field).

This issue is mentioned in https://github.com/gatsbyjs/gatsby/pull/4074#issuecomment-366299727 and is the root of the cause of this problem: https://github.com/gatsbyjs/gatsby/issues/8615. This PR takes a first shot at naming union types more consistently.

- **Naïvety**: Might this approach be overlooking some use-case in which you would _not_ want to share union type instances when the same child-node types are used? I'm not too familiar with the use-cases for all source plugins.
- **Shared across all keys**: In this PR, union type instances are shared across all fields that contain the same child-node types, disregarding the key of the field. We could also choose to only share these instances for the exact same field key, to name union types more consistently for some specific use-cases. Any ideas on this?
- **`createTypeName` and updated schema**: Because `createTypeName` is used (that stores all seen names in memory), the field name still gets incremented. This ensures a unique union type, when the same key is used for different child-node types. However, because [schema is updated](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/bootstrap/index.js#L377) during bootstrap (for the `SitePage` node), all fields using `createTypeName` end on `_2`. While this never changes, this makes it _seem_ less reliable for developers trying to use the field. Maybe this is out of scope, but would there be a way to fix this issue? If you have any pointers on where to start, that would be great.
- **Test**: I could also use some pointers on how to write a test for this use-case. Looking at [the current tests](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js), I'm not sure on how to check the type of a union type field or even query several node types (only `listNode` is queried).

Thanks!