### PR TITLE
fix: scripts/assert-changed-files.sh only looks in latest commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ aliases:
   test_template: &test_template
     steps:
       - checkout
-      - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*"
+      - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*|.circleci/*"
       - <<: *restore_node_modules
       - <<: *install_node_modules
       - <<: *persist_node_modules
@@ -64,7 +64,7 @@ commands:
     parameters:
       ignore_pattern:
         type: string
-        default: packages/*|integration-tests/*
+        default: packages/*|integration-tests/*|.circleci/*
       test_path:
         type: string
     steps:
@@ -82,7 +82,7 @@ jobs:
     <<: *node10
     steps:
       - checkout
-      - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*"
+      - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*|.circleci/*"
       - <<: *restore_node_modules
       - <<: *install_node_modules
       - <<: *persist_node_modules
@@ -117,7 +117,7 @@ jobs:
     <<: *node10
     steps:
       - checkout
-      - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*"
+      - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*|.circleci/*"
       - <<: *restore_node_modules
       - <<: *install_node_modules
       - <<: *persist_node_modules

--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 GREP_PATTERN=$1
 
-MERGE_BASE="$(git merge-base master $CIRCLE_SHA1)"
-FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $MERGE_BASE $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
+FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
 
 if [ $FILES_COUNT -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."

--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 GREP_PATTERN=$1
 
-FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
+MERGE_BASE="$(git merge-base master $CIRCLE_SHA1)"
+FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $MERGE_BASE $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
 
 if [ $FILES_COUNT -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."


### PR DESCRIPTION
More a question than a PR: The ci only looks for files changed in the last commit. If a branch has several commits but the integration tests are not on the last commit, they aren't tested.

This PR would change the script to list all files changed in the branch instead only from last commit.