### PR TITLE
fix: check for empty fields in InputFilter inference

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
@@ -11,7 +11,6 @@ const {
   GraphQLInputObjectType,
   Kind,
 } = require(`graphql`)
-const GraphQLJSON = require(`graphql-type-json`)
 
 const {
   inferInputObjectStructureFromFields,
@@ -268,6 +267,14 @@ describe(`GraphQL Input args from fields, test-only`, () => {
                 },
               })
             ),
+            baz: typeField(
+              new GraphQLObjectType({
+                name: `Jbo2`,
+                fields: {
+                  aa: typeField(OddType),
+                },
+              })
+            ),
           },
         }),
       },
@@ -294,6 +301,10 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     isStringInput(innerObjFields.foo.type)
     expect(innerObjFields.ba).toBeUndefined()
     isIntInput(innerObjFields.bar.type)
+
+    // innerObj.baz is object containing only unsupported types
+    // so it should not be defined
+    expect(innerObj.baz).toBeUndefined()
   })
 
   it(`includes the filters of list elements`, async () => {
@@ -364,32 +375,5 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     })
 
     expect(sort.sort()).toEqual([`bar`, `baz___ka`, `baz___ma`, `foo`])
-  })
-
-  it(`handles JSON fields`, async () => {
-    const fields = {
-      foo: { type: GraphQLJSON },
-    }
-
-    const { inferredFields } = inferInputObjectStructureFromFields({ fields })
-
-    expect(inferredFields).toEqual({})
-  })
-
-  it(`handles custom types with JSON fields`, async () => {
-    const TypeA = new GraphQLObjectType({
-      name: `TypeA`,
-      fields: {
-        bar: { type: GraphQLJSON },
-      },
-    })
-
-    const fields = {
-      foo: { type: TypeA },
-    }
-
-    const { inferredFields } = inferInputObjectStructureFromFields({ fields })
-
-    expect(inferredFields).toEqual({})
   })
 })

--- a/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-input-type-from-fields-test.js
@@ -11,6 +11,7 @@ const {
   GraphQLInputObjectType,
   Kind,
 } = require(`graphql`)
+const GraphQLJSON = require(`graphql-type-json`)
 
 const {
   inferInputObjectStructureFromFields,
@@ -363,5 +364,32 @@ describe(`GraphQL Input args from fields, test-only`, () => {
     })
 
     expect(sort.sort()).toEqual([`bar`, `baz___ka`, `baz___ma`, `foo`])
+  })
+
+  it(`handles JSON fields`, async () => {
+    const fields = {
+      foo: { type: GraphQLJSON },
+    }
+
+    const { inferredFields } = inferInputObjectStructureFromFields({ fields })
+
+    expect(inferredFields).toEqual({})
+  })
+
+  it(`handles custom types with JSON fields`, async () => {
+    const TypeA = new GraphQLObjectType({
+      name: `TypeA`,
+      fields: {
+        bar: { type: GraphQLJSON },
+      },
+    })
+
+    const fields = {
+      foo: { type: TypeA },
+    }
+
+    const { inferredFields } = inferInputObjectStructureFromFields({ fields })
+
+    expect(inferredFields).toEqual({})
   })
 })

--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -138,15 +138,19 @@ function convertToInputFilter(
       fields: fields,
     })
   } else if (type instanceof GraphQLInputObjectType) {
+    const fields = _.transform(type.getFields(), (out, fieldConfig, key) => {
+      const type = convertToInputFilter(
+        `${prefix}${_.upperFirst(key)}`,
+        fieldConfig.type
+      )
+      if (type) out[key] = { type }
+    })
+    if (Object.keys(fields).length === 0) {
+      return null
+    }
     return new GraphQLInputObjectType({
       name: createTypeName(`${prefix}{type.name}`),
-      fields: _.transform(type.getFields(), (out, fieldConfig, key) => {
-        const type = convertToInputFilter(
-          `${prefix}${_.upperFirst(key)}`,
-          fieldConfig.type
-        )
-        if (type) out[key] = { type }
-      }),
+      fields: fields,
     })
   } else if (type instanceof GraphQLList) {
     const innerType = type.ofType


### PR DESCRIPTION
Check for empty fields in InputFilter inference to prevent crash in InputObjectType validation. This simply does in `convertToInputFilter` what is already done in  `convertToInputType`.

See: #9022 