### PR TITLE
chore(www): bump version of gatsby-remark-prismjs

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -36,7 +36,7 @@
     "gatsby-remark-copy-linked-files": "^2.0.5",
     "gatsby-remark-graphviz": "^1.0.0",
     "gatsby-remark-images": "^2.0.1",
-    "gatsby-remark-prismjs": "3.0.0-beta.6",
+    "gatsby-remark-prismjs": "^3.0.2",
     "gatsby-remark-responsive-iframe": "^2.0.5",
     "gatsby-remark-smartypants": "^2.0.5",
     "gatsby-source-filesystem": "^2.0.1",


### PR DESCRIPTION
This lets us move off the pinned version. Didn't check it out a ton, but it worked well on reactjs/reactjs.org, so I don't foresee any regression on our end!