### PR TITLE
[gatsby-transformer-javascript-frontmatter] Improve README and add peer dependency

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/README.md
+++ b/packages/gatsby-transformer-javascript-frontmatter/README.md
@@ -4,16 +4,25 @@ Parses JavaScript files to extract frontmatter from exports.
 
 ## Install
 
-`npm install --save gatsby-transformer-javascript-frontmatter`
+`npm install --save gatsby-source-filesystem gatsby-transformer-javascript-frontmatter`
 
 ## How to use
 
-To use this plugin you also need [gatsby-source-filesystem](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) installed.
+To use this plugin you also need [gatsby-source-filesystem](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) installed and configured.
 
 ```javascript
 // In your gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-transformer-javascript-frontmatter`],
+  plugins: [
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `pages`,
+        path: `${__dirname}/src/pages/`
+      }
+    },
+    'gatsby-transformer-javascript-frontmatter'
+  ]
 }
 ```
 

--- a/packages/gatsby-transformer-javascript-frontmatter/package.json
+++ b/packages/gatsby-transformer-javascript-frontmatter/package.json
@@ -21,7 +21,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": ">2.0.0-alpha"
+    "gatsby": ">2.0.0-alpha",
+    "gatsby-source-filesystem": "^2.0.3"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter",
   "scripts": {


### PR DESCRIPTION
Closes https://github.com/gatsbyjs/gatsby/issues/9077

- [x] Improve the README by including the filesystem plugin in the install step
- [x] Add the filesystem config to the plugin config example
- [x] Add `gatsby-source-filesystem` to `peerDependencies` in `gatsby-transformer-javascript-frontmatter` to warn developers if they’ve left it out
