### PR TITLE
Add hotreload of typography.js to tutorial

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -52,6 +52,12 @@ const typography = new Typography({
   ],
   bodyFontFamily: ["Georgia", "serif"],
 })
+
+// Hot reload typography in development.
+if (process.env.NODE_ENV !== 'production') {
+  typography.injectStyles();
+}
+
 ```
 
 ## Gatsby plugins
@@ -215,6 +221,10 @@ In your site, create a new directory at `src/utils`. In that directory, create a
 import Typography from "typography"
 
 const typography = new Typography({ baseFontSize: "18px" })
+// Hot reload typography in development.
+if (process.env.NODE_ENV !== 'production') {
+  typography.injectStyles();
+}
 
 export default typography
 ```
@@ -259,6 +269,10 @@ import Typography from "typography"
 import bootstrapTheme from "typography-theme-bootstrap"
 
 const typography = new Typography(bootstrapTheme)
+// Hot reload typography in development.
+if (process.env.NODE_ENV !== 'production') {
+  typography.injectStyles();
+}
 
 export default typography
 ```


### PR DESCRIPTION
Per #9095, the way the tutorial is set up, hot reloading of typography.js doesn't work without the extra lines I added (credit to @LeKoArts ). Newcomers like myself expect that it will hotreload because the tutorial implies it does, and also, I think, it's the "Gatsby  way"
  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/

closes #9095 