### PR TITLE
fix: querying nodes by id and operator different than eq

### DIFF
--- a/packages/gatsby/src/schema/__tests__/run-sift.js
+++ b/packages/gatsby/src/schema/__tests__/run-sift.js
@@ -1,4 +1,4 @@
-const runSfit = require(`../run-sift`)
+const runSift = require(`../run-sift`)
 const {
   GraphQLObjectType,
   GraphQLNonNull,
@@ -61,7 +61,7 @@ describe(`run-sift`, () => {
         },
       }
 
-      const resultSingular = await runSfit({
+      const resultSingular = await runSift({
         type,
         nodes,
         typeName,
@@ -69,7 +69,7 @@ describe(`run-sift`, () => {
         connection: false,
       })
 
-      const resultConnection = await runSfit({
+      const resultConnection = await runSift({
         type,
         nodes,
         typeName,
@@ -89,7 +89,7 @@ describe(`run-sift`, () => {
         },
       }
 
-      const resultSingular = await runSfit({
+      const resultSingular = await runSift({
         type,
         nodes,
         typeName,
@@ -97,7 +97,7 @@ describe(`run-sift`, () => {
         connection: false,
       })
 
-      const resultConnection = await runSfit({
+      const resultConnection = await runSift({
         type,
         nodes,
         typeName,

--- a/packages/gatsby/src/schema/__tests__/run-sift.js
+++ b/packages/gatsby/src/schema/__tests__/run-sift.js
@@ -1,0 +1,115 @@
+const runSfit = require(`../run-sift`)
+const {
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLID,
+  GraphQLString,
+} = require(`graphql`)
+const { connectionFromArray } = require(`graphql-skip-limit`)
+
+jest.mock(`../node-tracking`, () => {
+  return {
+    trackInlineObjectsInRootNode: () => jest.fn(),
+  }
+})
+
+jest.mock(`../../redux/actions/add-page-dependency`, () => {
+  return {
+    createPageDependency: jest.fn(),
+  }
+})
+
+const mockNodes = [
+  {
+    id: `id_1`,
+    string: `foo`,
+  },
+  {
+    id: `id_2`,
+    string: `bar`,
+  },
+  {
+    id: `id_3`,
+    string: `baz`,
+  },
+]
+
+jest.mock(`../../redux`, () => {
+  return {
+    getNode: id => mockNodes.find(node => node.id === id),
+  }
+})
+
+describe(`run-sift`, () => {
+  const typeName = `test`
+  const type = new GraphQLObjectType({
+    name: typeName,
+    fields: () => {
+      return {
+        id: new GraphQLNonNull(GraphQLID),
+        string: GraphQLString,
+      }
+    },
+  })
+  const nodes = mockNodes
+
+  describe(`filters by just id correctly`, () => {
+    it(`eq operator`, async () => {
+      const args = {
+        filter: {
+          id: { eq: `id_2` },
+        },
+      }
+
+      const resultSingular = await runSfit({
+        type,
+        nodes,
+        typeName,
+        args,
+        connection: false,
+      })
+
+      const resultConnection = await runSfit({
+        type,
+        nodes,
+        typeName,
+        args,
+        connection: true,
+      })
+      delete resultConnection.totalCount
+
+      expect(resultSingular).toEqual(nodes[1])
+      expect(resultConnection).toEqual(connectionFromArray([nodes[1]], args))
+    })
+
+    it(`non-eq operator`, async () => {
+      const args = {
+        filter: {
+          id: { ne: `id_2` },
+        },
+      }
+
+      const resultSingular = await runSfit({
+        type,
+        nodes,
+        typeName,
+        args,
+        connection: false,
+      })
+
+      const resultConnection = await runSfit({
+        type,
+        nodes,
+        typeName,
+        args,
+        connection: true,
+      })
+      delete resultConnection.totalCount
+
+      expect(resultSingular).toEqual(nodes[0])
+      expect(resultConnection).toEqual(
+        connectionFromArray([nodes[0], nodes[2]], args)
+      )
+    })
+  })
+})

--- a/packages/gatsby/src/schema/run-sift.js
+++ b/packages/gatsby/src/schema/run-sift.js
@@ -143,11 +143,14 @@ module.exports = ({
     })
   }
 
-  // If the the query only has a filter for an "id", then we'll just grab
-  // that ID and return it.
+  // If the the query for single node only has a filter for an "id"
+  // using "eq" operator, then we'll just grab that ID and return it.
   if (
+    !connection &&
     Object.keys(fieldsToSift).length === 1 &&
-    Object.keys(fieldsToSift)[0] === `id`
+    Object.keys(fieldsToSift)[0] === `id` &&
+    Object.keys(siftArgs[0].id).length === 1 &&
+    Object.keys(siftArgs[0].id)[0] === `$eq`
   ) {
     const nodePromise = resolveRecursive(
       getNode(siftArgs[0].id[`$eq`]),


### PR DESCRIPTION
We have special case for querying by id, but it only really makes sense (and works) for `eq` operator and for non-connection queries - this adds more restrictions to that special case and some basic tests

closes #8322