### PR TITLE
fix(gatsby): add main field pointing to transpiled commonjs entry

### DIFF
--- a/packages/gatsby/.gitignore
+++ b/packages/gatsby/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 decls
 dist
+
+# built files
+cache-dir/commonjs/

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -160,7 +160,8 @@
     "website"
   ],
   "license": "MIT",
-  "main": "cache-dir/gatsby-browser-entry.js",
+  "main": "cache-dir/commonjs/gatsby-browser-entry-cjs.js",
+  "module": "cache-dir/gatsby-browser-entry.js",
   "peerDependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2"
@@ -173,9 +174,10 @@
     "graphql": "^0.13.2"
   },
   "scripts": {
-    "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles",
+    "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",
     "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
     "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
+    "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs",
     "build:src": "babel src --out-dir dist --source-maps --ignore **/gatsby-cli.js,**/raw_*,**/__tests__",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -177,7 +177,7 @@
     "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",
     "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
     "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
-    "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs",
+    "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore **/__tests__",
     "build:src": "babel src --out-dir dist --source-maps --ignore **/gatsby-cli.js,**/raw_*,**/__tests__",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -160,7 +160,7 @@
     "website"
   ],
   "license": "MIT",
-  "main": "cache-dir/commonjs/gatsby-browser-entry-cjs.js",
+  "main": "cache-dir/commonjs/gatsby-browser-entry.js",
   "module": "cache-dir/gatsby-browser-entry.js",
   "peerDependencies": {
     "react": "^16.4.2",


### PR DESCRIPTION
Fixes #8821

This PR adds a main field corresponding to the transpiled/commonjs equivalent of gatsby cache-dir. It does this by transpiling the whole folder, and adding `main` with the cjs entry point. `module` is added, which is still used by Webpack to resolve the es2015+ source with import/export/etc.

Largely, this is to increase ease of unit testing gatsby without a transpile step, and also matches semantically what the main field _should_ produce (commonjs) whereas `module` can point to the es entry point.

To test this, I created the [following repo](https://github.com/DSchau/gatsby-cjs-test) and validated that CJS main field is resolved appropriately. Additionally, I added some logging to ensure that the es build is still used for build/develop lifecycles.

cc @travi