### PR TITLE
[gatsby-remark-autolink-headers] Fixed className position in README.md

### DIFF
--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -69,8 +69,8 @@ module.exports = {
             options: {
               offsetY: `100`,
               icon: `<svg aria-hidden="true" height="20" version="1.1" viewBox="0 0 16 16" width="20"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`,
+              className: `custom-class`,
             },
-            className: `custom-class`,
           },
         ],
       },


### PR DESCRIPTION
Hey!　I'm a fan of Gatsby.
In [RREADME.md](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-autolink-headers/README.md) of gatsby-remark-autolink-headers,
I moved the className attribute into options.

I couldn't set custom class when I followed the current README.
But when I moved className into options, it worked.