### PR TITLE
starters - Fix url for gatsby-starter-morning-dew

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -812,7 +812,7 @@
     - Based on default starter
     - Bulma Css
     - Sass based Styling
-- url: https://www.maxpou.fr/gatsby-starter-morning-dew/
+- url: https://maxpou.github.io/gatsby-starter-morning-dew/
   repo: https://github.com/maxpou/gatsby-starter-morning-dew
   description: Gatsby v2 blog starter
   tags:


### PR DESCRIPTION
Hey,

I changed the URL for the gatsby-starter-morning-dew's demo.
Unfortunately, the previous one is gone :(

New URL: https://maxpou.github.io/gatsby-starter-morning-dew/

Cheers
Max