### PR TITLE
fix(gatsby): Prevent minifier from compressing output using ES6+ syntax

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -445,8 +445,16 @@ module.exports = async ({
       exclude: /\.min\.js/,
       sourceMap: true,
       terserOptions: {
-        ecma: 8,
         ie8: false,
+        parse: {
+          ecma: 8,
+        },
+        compress: {
+          ecma: 5,
+        },
+        output: {
+          ecma: 5,
+        },
         ...terserOptions,
       },
       ...options,


### PR DESCRIPTION
Fixes #8905 
Fixes #7003

The previous configuration allowed terser to take opportunities to compress the output code using ES6+ syntax. This PR configures terser to parse ES8 but prevents any ES6+ optimizations in the output.

from https://github.com/terser-js/terser#output-options
> The ecma option will only change the output in direct control of the beautifier. Non-compatible features in the abstract syntax tree will still be output as is. For example: an ecma setting of 5 will not convert ES6+ code to ES5.