### PR TITLE
Ensure that File type is created first

### DIFF
--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -229,7 +229,7 @@ module.exports = async ({ parentSpan }) => {
   }
 
   // Create node types and node fields for nodes that have a resolve function.
-  // Ensure that File nodes are created first, so FileType can be imported
+  // Ensure that File type is created first, so it can be imported
   // in setFieldsOnGraphQLNodeType.
   const { File: fileNodes, ...otherTypes } = types
 

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -229,7 +229,17 @@ module.exports = async ({ parentSpan }) => {
   }
 
   // Create node types and node fields for nodes that have a resolve function.
-  await Promise.all(_.map(types, createType))
+  // Ensure that File nodes are created first, so FileType can be imported
+  // in setFieldsOnGraphQLNodeType.
+  const { File: fileNodes, ...otherTypes } = types
+
+  if (fileNodes && fileNodes.length) {
+    await createType(fileNodes, `File`)
+  }
+
+  await Promise.all(
+    Object.entries(otherTypes).map(([name, nodes]) => createType(nodes, name))
+  )
 
   span.finish()
 


### PR DESCRIPTION
This ensures that the File type is created before others.

I'm not sure if this change is acceptable, the motivation is to be able to import with `const FileType = require('gatsby/dist/schema/types/type-file').getType()` in `setFieldsOnGraphQLNodeType`. Without this change this would always return `null` as [`setFileNodeRootType`](https://github.com/gatsbyjs/gatsby/blob/fed6d35f991abadca5e4ab335597d0c045d882da/packages/gatsby/src/schema/build-node-types.js#L227) had not been called yet.