### PR TITLE
fix(ci): use correct cache path per circleci documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ aliases:
       name: Save node modules cache
       key: yarn-cypress-cache-{{ checksum "yarn.lock" }}
       paths:
-        - ~/.cache # yarn + cypress cache
+        - ~/.cache
 
   attach_to_bootstrap: &attach_to_bootstrap
     attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,28 +9,26 @@ executors:
 
 aliases:
   e2e-executor: &e2e-executor
-    executor:
-      name: node
-      image: 10-browsers
+    docker:
+      - image: cypress/base:10
 
-  restore_node_modules: &restore_node_modules
+  restore_cache: &restore_cache
     restore_cache:
       name: Restore node_modules cache
       keys:
-        - node-modules-{{ checksum "yarn.lock" }}
+        - yarn-cypress-cache-{{ checksum "yarn.lock" }}
 
   install_node_modules: &install_node_modules
     run:
       name: Install node modules
-      command: |
-        yarn
+      command: yarn
 
-  persist_node_modules: &persist_node_modules
+  persist_cache: &persist_cache
     save_cache:
       name: Save node modules cache
-      key: node-modules-{{ checksum "yarn.lock" }}
+      key: yarn-cypress-cache-{{ checksum "yarn.lock" }}
       paths:
-        - node_modules
+        - ~/.cache # yarn + cypress cache
 
   attach_to_bootstrap: &attach_to_bootstrap
     attach_workspace:
@@ -46,9 +44,9 @@ aliases:
     steps:
       - checkout
       - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*"
-      - <<: *restore_node_modules
+      - <<: *restore_cache
       - <<: *install_node_modules
-      - <<: *persist_node_modules
+      - <<: *persist_cache
       - <<: *attach_to_bootstrap
       - run: yarn jest -w 1
 
@@ -68,8 +66,9 @@ commands:
     steps:
       - checkout
       - run: ./scripts/assert-changed-files.sh "<< parameters.trigger_pattern >>|<< parameters.test_path >>/*"
-      - <<: *restore_node_modules
+      - <<: *restore_cache
       - <<: *install_node_modules
+      - <<: *persist_cache
       - <<: *attach_to_bootstrap
       - run: ./scripts/e2e-test.sh "<< parameters.test_path >>"
 
@@ -81,9 +80,9 @@ jobs:
     steps:
       - checkout
       - run: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*"
-      - <<: *restore_node_modules
+      - <<: *restore_cache
       - <<: *install_node_modules
-      - <<: *persist_node_modules
+      - <<: *persist_cache
       - run: yarn bootstrap
       - persist_to_workspace:
           root: packages
@@ -94,9 +93,9 @@ jobs:
     executor: node
     steps:
       - checkout
-      - <<: *restore_node_modules
+      - <<: *restore_cache
       - <<: *install_node_modules
-      - <<: *persist_node_modules
+      - <<: *persist_cache
       - run: yarn lint
 
   unit_tests_node6:
@@ -120,8 +119,9 @@ jobs:
     steps:
       - checkout
       - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*|.circleci/*"
-      - <<: *restore_node_modules
+      - <<: *restore_cache
       - <<: *install_node_modules
+      - <<: *persist_cache
       - <<: *attach_to_bootstrap
       - run: yarn test:integration
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ aliases:
   test_template: &test_template
     steps:
       - checkout
-      - run: ./scripts/assert-changed-files.sh "packages/*|integration-tests/*"
+      - run: ./scripts/assert-changed-files.sh "packages/*|.circleci/*"
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *persist_cache
@@ -79,7 +79,7 @@ jobs:
     executor: node
     steps:
       - checkout
-      - run: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*"
+      - run: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*|.circleci/*"
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *persist_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ aliases:
   install_node_modules: &install_node_modules
     run:
       name: Install node modules
-      command: yarn
+      command: yarn --frozen-lockfile
 
   persist_cache: &persist_cache
     save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 aliases:
   e2e-executor: &e2e-executor
     docker:
-      - image: cypress/base:10
+      - image: cypress/browsers:chrome69
 
   restore_cache: &restore_cache
     restore_cache:

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -3,13 +3,13 @@ SRC_PATH=$1
 CUSTOM_COMMAND="${2:-test}"
 GATSBY_PATH="${CIRCLE_WORKING_DIRECTORY:-../../}"
 
-sudo npm install -g gatsby-dev-cli &&
+npm install -g gatsby-dev-cli &&
 
 # setting up child integration test link to gatsby packages
 cd $SRC_PATH &&
 yarn &&
 gatsby-dev --set-path-to-repo $GATSBY_PATH &&
 gatsby-dev --scan-once --copy-all --quiet && # copies _all_ files in gatsby/packages
-sudo chmod +x ./node_modules/.bin/gatsby && # this is sometimes necessary to ensure executable
+chmod +x ./node_modules/.bin/gatsby && # this is sometimes necessary to ensure executable
 yarn $CUSTOM_COMMAND &&
 echo "e2e test run succeeded"


### PR DESCRIPTION
This PR does the following things:

- Switches to an official cypress docker image (using node 10)
    - This should be a little lighter weight and more specific to Cypress
- persists the ~/.cache folder, which will include cypress + yarn caches
    - This should speed up install and subsequent run times, if yarn.lock doesn't change

Thanks @lekoarts for the tip!
