### PR TITLE
Used `path` to concat url in serializer

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -1,6 +1,7 @@
 import fs from "fs"
 import pify from "pify"
 import minimatch from "minimatch"
+import path from "path"
 
 const withoutTrailingSlash = path =>
   path === `/` ? path : path.replace(/\/$/, ``)
@@ -59,7 +60,7 @@ export const defaultOptions = {
   serialize: ({ site, allSitePage }) =>
     allSitePage.edges.map(edge => {
       return {
-        url: site.siteMetadata.siteUrl + edge.node.path,
+        url: path.join(site.siteMetadata.siteUrl, edge.node.path),
         changefreq: `daily`,
         priority: 0.7,
       }


### PR DESCRIPTION
In case of using a trailing slash as the `siteUrl`, the `serialize` method returns a URL that contains double slashes. Using `path.join()` to concat the `siteUrl` with the `path` of the current node will prevent this.
