### PR TITLE
feat(www): add docsearch:version meta tag (v1)

### DIFF
--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -130,6 +130,7 @@ class DefaultLayout extends React.Component {
           <meta name="twitter:site" content="@gatsbyjs" />
           <meta name="og:type" content="website" />
           <meta name="og:site_name" content="GatsbyJS" />
+          <meta name="docsearch:version" content="1.0" />
           <link
             rel="canonical"
             href={`https://gatsbyjs.org${this.props.location.pathname}`}


### PR DESCRIPTION
add meta tag so docsearch can index both v1 and v2 websites

see https://github.com/gatsbyjs/gatsby/issues/9159#issuecomment-430604230 