### PR TITLE
feat(www): add docsearch:version meta tag

### DIFF
--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -151,6 +151,7 @@ class DefaultLayout extends React.Component {
           <meta name="twitter:site" content="@gatsbyjs" />
           <meta name="og:type" content="website" />
           <meta name="og:site_name" content="GatsbyJS" />
+          <meta name="docsearch:version" content="2.0" />
           <link
             rel="canonical"
             href={`https://gatsbyjs.org${this.props.location.pathname}`}


### PR DESCRIPTION
add meta tag so docsearch can index both v1 and v2 websites

see https://github.com/gatsbyjs/gatsby/issues/9159#issuecomment-430604230 