### PR TITLE
Feature: placeholderClass prop for gatsby-image

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -276,6 +276,7 @@ prop. e.g. `<Img fluid={fluid} />`
 | `style`            | `object`            | Spread into the default styles of the wrapper element                                                                       |
 | `imgStyle`         | `object`            | Spread into the default styles of the actual `img` element                                                                  |
 | `placeholderStyle` | `object`            | Spread into the default styles of the placeholder `img` element                                                             |
+| `placeholderClass` | `string`            | A class that is passed to the placeholder `img` element                                                                     |
 | `backgroundColor`  | `string` / `bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
 | `onLoad`           | `func`              | A callback that is called when the full-size image has loaded.                                                              |
 | `onError`          | `func`              | A callback that is called when the image fails to load.                                                                     |

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -198,6 +198,7 @@ class Image extends React.Component {
       style = {},
       imgStyle = {},
       placeholderStyle = {},
+      placeholderClass,
       fluid,
       fixed,
       backgroundColor,
@@ -249,6 +250,7 @@ class Image extends React.Component {
                 title={title}
                 src={image.base64}
                 style={imagePlaceholderStyle}
+                className={placeholderClass}
               />
             )}
 
@@ -259,6 +261,7 @@ class Image extends React.Component {
                 title={title}
                 src={image.tracedSVG}
                 style={imagePlaceholderStyle}
+                className={placeholderClass}
               />
             )}
 
@@ -346,6 +349,7 @@ class Image extends React.Component {
               title={title}
               src={image.base64}
               style={imagePlaceholderStyle}
+              className={placeholderClass}
             />
           )}
 
@@ -356,6 +360,7 @@ class Image extends React.Component {
               title={title}
               src={image.tracedSVG}
               style={imagePlaceholderStyle}
+              className={placeholderClass}
             />
           )}
 
@@ -465,6 +470,7 @@ Image.propTypes = {
   style: PropTypes.object,
   imgStyle: PropTypes.object,
   placeholderStyle: PropTypes.object,
+  placeholderClass: PropTypes.string,
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onLoad: PropTypes.func,
   onError: PropTypes.func,


### PR DESCRIPTION
Adds the ability to provide a class prop to the placeholder element in gatsby-image as described in #8916.