### PR TITLE
docs(gatsby-plugin-manifest): link to plugin-offline

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -11,7 +11,7 @@ manifest—https://developers.google.com/web/fundamentals/engage-and-retain/web-
 
 For more information see the w3 spec https://www.w3.org/TR/appmanifest/ or Mozilla Docs https://developer.mozilla.org/en-US/docs/Web/Manifest.
 
-If you're using this plugin together with `gatsby-plugin-offline` (recommended),
+If you're using this plugin together with [`gatsby-plugin-offline`](../gatsby-plugin-offline) (recommended),
 this plugin should be listed _before_ the offline plugin so that it can cache
 the created manifest.webmanifest.
 

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -11,7 +11,7 @@ manifest—https://developers.google.com/web/fundamentals/engage-and-retain/web-
 
 For more information see the w3 spec https://www.w3.org/TR/appmanifest/ or Mozilla Docs https://developer.mozilla.org/en-US/docs/Web/Manifest.
 
-If you're using this plugin together with [`gatsby-plugin-offline`](../gatsby-plugin-offline) (recommended),
+If you're using this plugin together with [`gatsby-plugin-offline`](https://www.gatsbyjs.org/packages/gatsby-plugin-offline) (recommended),
 this plugin should be listed _before_ the offline plugin so that it can cache
 the created manifest.webmanifest.
 


### PR DESCRIPTION
I thought it would be a nice addition for easier discoverability

Off topic question related to `gatsby-plugin-manifest` wouldn't it be good to add some kind of cache busting to the generated icons?

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
