### PR TITLE
fix(gatsby-plugin-create-client-paths): don't process pages that already use matchPath

### DIFF
--- a/packages/gatsby-plugin-create-client-paths/src/gatsby-node.js
+++ b/packages/gatsby-plugin-create-client-paths/src/gatsby-node.js
@@ -15,7 +15,7 @@ exports.onCreatePage = ({ page, store, actions }, { prefixes }) => {
   return new Promise(resolve => {
     // Don't set matchPath again if it's already been set.
     if (page.matchPath || page.path.match(/dev-404-page/)) {
-      resolve()
+      return resolve()
     }
 
     prefixes.some(prefix => {


### PR DESCRIPTION
if `page.matchPath || page.path.match(/dev-404-page/)`, we should `resolve` **AND** `return`

closes https://github.com/gatsbyjs/gatsby/issues/9221