### PR TITLE
fix(gatsby-plugin-google-gtag): use CommonJS instead of ES modules

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
@@ -1,4 +1,4 @@
-export const onRouteUpdate = function({ location }) {
+exports.onRouteUpdate = ({ location }) => {
   if (process.env.NODE_ENV !== `production` || typeof gtag !== `function`) {
     return null
   }

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { Minimatch } from "minimatch"
 
-export const onRenderBody = (
+exports.onRenderBody = (
   { setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {


### PR DESCRIPTION
Fixes #9218