### PR TITLE
fix(package.json): update homepage to point at the package

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -149,7 +149,7 @@
     "graphql.js",
     "index.d.ts"
   ],
-  "homepage": "https://github.com/gatsbyjs/gatsby#readme",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages#readme",
   "keywords": [
     "blog",
     "generator",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -149,7 +149,7 @@
     "graphql.js",
     "index.d.ts"
   ],
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages#readme",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby#readme",
   "keywords": [
     "blog",
     "generator",


### PR DESCRIPTION
i followed a greenkeeper link, looking for details in the changelog, and was taken to the project root rather than the specific package that was updated in my project. this change seems to align to how the other packages are configured and would result in following links related to the npm package landing at the expected details.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
