### PR TITLE
Fail hard only for .jsx?|tsx? if default export is missing

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -266,7 +266,9 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
     if (
       !fileContent.includes(`export default`) &&
       !fileContent.includes(`module.exports`) &&
-      !fileContent.includes(`exports.default`)
+      !fileContent.includes(`exports.default`) &&
+      // this check only applies to js and ts, not mdx
+      /\.(jsx?|tsx?)/.test(path.extname(fileName))
     ) {
       includesDefaultExport = false
     }


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby/pull/9031#issuecomment-431209901