### PR TITLE
feat(gatsby-plugin-less): add support for overriding the default options of `css-loader`

### DIFF
--- a/packages/gatsby-plugin-less/README.md
+++ b/packages/gatsby-plugin-less/README.md
@@ -38,8 +38,10 @@ If you need to override the default options passed into [`css-loader`](https://g
 plugins: [
   {
     resolve: `gatsby-plugin-less`,
-    cssLoaderOptions: {
-      camelCase: false,
+    options: {
+      cssLoaderOptions: {
+        camelCase: false,
+      },
     },
   },
 ]

--- a/packages/gatsby-plugin-less/README.md
+++ b/packages/gatsby-plugin-less/README.md
@@ -31,6 +31,20 @@ plugins: [
 ]
 ```
 
+If you need to override the default options passed into [`css-loader`](https://github.com/webpack-contrib/css-loader)
+
+```javascript
+// in gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-less`,
+    cssLoaderOptions: {
+      camelCase: false,
+    },
+  },
+]
+```
+
 ### With CSS Modules
 
 Using CSS modules requires no additional configuration. Simply prepend `.module` to the extension. For example: `App.less` -> `App.module.less`.

--- a/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -183,6 +183,50 @@ exports[`gatsby-plugin-less Stage: build-html / PostCss plugins 1`] = `
 }
 `;
 
+exports[`gatsby-plugin-less Stage: build-html / css-loader options 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "null",
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -385,6 +429,59 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                     "miniCssExtract",
                     "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-less Stage: build-javascript / css-loader options 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"camelCase\\":false,\\"importLoaders\\":2})",
+                    "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
@@ -635,6 +732,59 @@ exports[`gatsby-plugin-less Stage: develop / PostCss plugins 1`] = `
 }
 `;
 
+exports[`gatsby-plugin-less Stage: develop / css-loader options 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"camelCase\\":false,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -788,6 +938,50 @@ exports[`gatsby-plugin-less Stage: develop-html / PostCss plugins 1`] = `
                   "use": Array [
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "null",
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-less Stage: develop-html / css-loader options 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {

--- a/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -12,7 +12,6 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #1 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -21,7 +20,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #1 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                         "strictMath": true,
                       },
                     },
@@ -30,19 +29,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #1 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
-                        },
-                        "sourceMap": true,
-                        "strictMath": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],
@@ -73,7 +60,6 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -82,7 +68,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -90,18 +76,7 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
-                        },
-                        "sourceMap": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],
@@ -132,13 +107,12 @@ exports[`gatsby-plugin-less Stage: build-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -146,15 +120,7 @@ exports[`gatsby-plugin-less Stage: build-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],
@@ -185,13 +151,12 @@ exports[`gatsby-plugin-less Stage: build-html / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -199,15 +164,7 @@ exports[`gatsby-plugin-less Stage: build-html / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({\\"plugins\\":[\\"test1\\"]})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],
@@ -247,7 +204,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                         "strictMath": true,
                       },
                     },
@@ -265,7 +222,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                         "strictMath": true,
                       },
                     },
@@ -308,7 +265,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -325,7 +282,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -364,7 +321,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -378,7 +335,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -417,7 +374,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -431,7 +388,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -690,7 +647,6 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -699,7 +655,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                         "strictMath": true,
                       },
                     },
@@ -708,19 +664,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
-                        },
-                        "sourceMap": true,
-                        "strictMath": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],
@@ -751,7 +695,6 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -760,7 +703,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                         "modifyVars": Object {
                           "text-color": "#fff",
                         },
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -768,18 +711,7 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
-                        },
-                        "sourceMap": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],
@@ -810,13 +742,12 @@ exports[`gatsby-plugin-less Stage: develop-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -824,15 +755,7 @@ exports[`gatsby-plugin-less Stage: develop-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],
@@ -863,13 +786,12 @@ exports[`gatsby-plugin-less Stage: develop-html / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "sourceMap": true,
+                        "sourceMap": false,
                       },
                     },
                   ],
@@ -877,15 +799,7 @@ exports[`gatsby-plugin-less Stage: develop-html / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.less\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css({\\"importLoaders\\":2})",
-                    "postcss({\\"plugins\\":[\\"test1\\"]})",
-                    Object {
-                      "loader": "/resolved/path/less-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
+                    "null",
                   ],
                 },
               ],

--- a/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
@@ -35,6 +35,11 @@ describe(`gatsby-plugin-less`, () => {
       "PostCss plugins": {
         postCssPlugins: [`test1`],
       },
+      "css-loader options": {
+        cssLoaderOptions: {
+          camelCase: false,
+        },
+      },
     },
   }
 

--- a/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
@@ -10,6 +10,7 @@ describe(`gatsby-plugin-less`, () => {
     miniCssExtract: () => `miniCssExtract`,
     css: args => `css(${JSON.stringify(args)})`,
     postcss: args => `postcss(${JSON.stringify(args)})`,
+    null: () => `null`,
   }
 
   const { onCreateWebpackConfig } = require(`../gatsby-node`)
@@ -41,7 +42,7 @@ describe(`gatsby-plugin-less`, () => {
     for (let label in tests.options) {
       const options = tests.options[label]
       it(`Stage: ${stage} / ${label}`, () => {
-        onCreateWebpackConfig({ actions, loaders, stage: `develop` }, options)
+        onCreateWebpackConfig({ actions, loaders, stage }, options)
         expect(actions.setWebpackConfig).toMatchSnapshot()
       })
     }

--- a/packages/gatsby-plugin-less/src/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/gatsby-node.js
@@ -2,7 +2,7 @@ import resolve from "./resolve"
 
 exports.onCreateWebpackConfig = (
   { actions, stage, rules, plugins, loaders },
-  { postCssPlugins, ...lessOptions }
+  { cssLoaderOptions = {}, postCssPlugins, ...lessOptions }
 ) => {
   const { setWebpackConfig } = actions
   const PRODUCTION = stage !== `develop`
@@ -22,7 +22,7 @@ exports.onCreateWebpackConfig = (
       ? [loaders.null()]
       : [
           loaders.miniCssExtract(),
-          loaders.css({ importLoaders: 2 }),
+          loaders.css({ ...cssLoaderOptions, importLoaders: 2 }),
           loaders.postcss({ plugins: postCssPlugins }),
           lessLoader,
         ],
@@ -31,7 +31,7 @@ exports.onCreateWebpackConfig = (
     test: /\.module\.less$/,
     use: [
       !isSSR && loaders.miniCssExtract(),
-      loaders.css({ modules: true, importLoaders: 2 }),
+      loaders.css({ ...cssLoaderOptions, modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       lessLoader,
     ].filter(Boolean),


### PR DESCRIPTION
Yay! 💖

<hr />
Closes #9142.
