### PR TITLE
Link tag typo

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -68,7 +68,7 @@ render () {
     <Link
       to="/another-page/"
       replace
-    />
+    >
       Go and prevent back to bring you back here
     </Link>
   )


### PR DESCRIPTION
Fixed a typo in docs where the start `<Link>` tag had a forward slash.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
