### PR TITLE
Change exports to export const in api-browser-docs

### DIFF
--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -1,7 +1,7 @@
 /**
  * Called when the Gatsby browser runtime first starts.
  * @example
- * exports.onClientEntry = () => {
+ * export const onClientEntry = () => {
  *   console.log("We've started!")
  *   callAnalyticsAPI()
  * }
@@ -11,7 +11,7 @@ exports.onClientEntry = true
 /**
  * Called when the initial (but not subsequent) render of Gatsby App is done on the client.
  * @example
- * exports.onInitialClientRender = () => {
+ * export const onInitialClientRender = () => {
  *   console.log("ReactDOM.render has executed")
  * }
  */
@@ -23,7 +23,7 @@ exports.onInitialClientRender = true
  * @param {object} $0.location A location object
  * @param {object} $0.action The "action" that caused the route change
  * @example
- * exports.onPreRouteUpdate = ({ location }) => {
+ * exports const onPreRouteUpdate = ({ location }) => {
  *   console.log("Gatsby started to change location", location.pathname)
  * }
  */
@@ -35,7 +35,7 @@ exports.onPreRouteUpdate = true
  * @param {object} $0.location A location object
  * @param {object} $0.action The "action" that caused the route change
  * @example
- * exports.onRouteUpdateDelayed = () => {
+ * export const onRouteUpdateDelayed = () => {
  *   console.log("We can show loading indicator now")
  * }
  */
@@ -47,7 +47,7 @@ exports.onRouteUpdateDelayed = true
  * @param {object} $0.location A location object
  * @param {object} $0.action The "action" that caused the route change
  * @example
- * exports.onRouteUpdate = ({ location }) => {
+ * export const onRouteUpdate = ({ location }) => {
  *   console.log('new pathname', location.pathname)
  *
  *   // Track pageview with google analytics
@@ -77,7 +77,7 @@ exports.onRouteUpdate = true
  * scroll to, `false` to not update the scroll position, or `true` for the
  * default behavior.
  * @example
- * exports.shouldUpdateScroll = ({
+ * exports const shouldUpdateScroll = ({
  *   routerProps: { location },
  *   getSavedScrollPosition
  * }) => {
@@ -94,7 +94,7 @@ exports.shouldUpdateScroll = true
 /**
  * Allow a plugin to register a Service Worker. Should be a function that returns true.
  * @example
- * exports.registerServiceWorker = () => true
+ * export const registerServiceWorker = () => true
  */
 exports.registerServiceWorker = true
 
@@ -184,7 +184,7 @@ exports.disableCorePrefetching = true
  * This method takes no param and should return a function with same signature as ReactDOM.render()
  * Note it's very important to call the callback after rendering, otherwise Gatsby will not be able to call `onInitialClientRender`
  * @example
- * exports.replaceHydrateFunction = () => {
+ * export const replaceHydrateFunction = () => {
  *   return (element, container, callback) => {
  *     console.log("rendering!");
  *     ReactDOM.render(element, container, callback);


### PR DESCRIPTION
If you import something in gatsby-browser.js and use 'exports' syntax it will cause the following error:
https://github.com/gatsbyjs/gatsby/issues/4452
https://github.com/gatsbyjs/gatsby/issues/6958

It seems that just replacing the syntax with 'export const' fixes this. I don't know about the details, but at the moment the docs are broken. Just wanted to make this pull request because this fixed my issues. I haven't tested this very well. I have just done this in develop mode.

I hope you can take this forward.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
