### PR TITLE
Update gatsby-plugin-netlify to allow caching JS files via HTTP headers

### DIFF
--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -27,6 +27,7 @@ export const SECURITY_HEADERS = {
 export const CACHING_HEADERS = {
   "/static/*": [`Cache-Control: public, max-age=31536000, immutable`],
   "/*\.js": [`Cache-Control: public, max-age=31536000, immutable`],
+  "/workbox*/*\.js": [`Cache-Control: public, max-age=31536000, immutable`],
 }
 
 export const LINK_REGEX = /^(Link: <\/)(.+)(>;.+)/

--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -26,6 +26,7 @@ export const SECURITY_HEADERS = {
 
 export const CACHING_HEADERS = {
   "/static/*": [`Cache-Control: public, max-age=31536000, immutable`],
+  "/src/*": [`Cache-Control: public, max-age=0, no-cache`],
 }
 
 export const LINK_REGEX = /^(Link: <\/)(.+)(>;.+)/

--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -26,7 +26,7 @@ export const SECURITY_HEADERS = {
 
 export const CACHING_HEADERS = {
   "/static/*": [`Cache-Control: public, max-age=31536000, immutable`],
-  "/src/*": [`Cache-Control: public, max-age=0, no-cache`],
+  "/*\.js": [`Cache-Control: public, max-age=31536000, immutable`],
 }
 
 export const LINK_REGEX = /^(Link: <\/)(.+)(>;.+)/


### PR DESCRIPTION
This PR closes #9151 

Adds a line to apply recommended caching behavior on all /src/ files in a gatsby project served on netlify, increasing cached content and therefore performance. This also makes the plugin consistent with the documentation.
