### PR TITLE
[starter library] WIP Filter for v2 starters by default

### DIFF
--- a/www/src/views/starter-library/index.js
+++ b/www/src/views/starter-library/index.js
@@ -45,6 +45,6 @@ class StarterLibraryPage extends Component {
   }
 }
 
-export default RRSM({ s: ``, c: [], d: [], v: [], sort: `recent` })(
+export default RRSM({ s: ``, c: [], d: [], v: [`2`], sort: `recent` })(
   StarterLibraryPage
 )


### PR DESCRIPTION
## Untested

I can't get the Gatsby site to run locally. The thumbnail generation takes forever and I haven't figured out the GitHub personal token thing yet.

## Changes

I believe that this will fix #7900 by setting the Gatsby v2 filter automatically when the starter showcase loads.

## Potential issues

* This might intersect weirdly with urls like `/?s=lumen` (a search query).

I'm hoping this PR will casue netlify to create a build preview that I can test.