### PR TITLE
Ignore all local env files, not just dev

### DIFF
--- a/www/.gitignore
+++ b/www/.gitignore
@@ -33,4 +33,4 @@ src/cache
 /package-lock.json
 
 # Env variables
-.env.development
+.env.*

--- a/www/.gitignore
+++ b/www/.gitignore
@@ -33,4 +33,4 @@ src/cache
 /package-lock.json
 
 # Env variables
-.env.*
+.env*


### PR DESCRIPTION
To test building locally, I added a  `.env.production` file with my GitHub token. It doesn't make sense to have that file in git. So I broadened the env file ignore from `.env.development` to `.env.*`.