### PR TITLE
fix: handle node api-api error gracefully

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -234,10 +234,10 @@ module.exports = async (api, args = {}, pluginSource) =>
     Promise.mapSeries(noSourcePluginPlugins, plugin => {
       let pluginName = plugin.name === `default-site-plugin` ? 
           `gatsby-node.js` : `Plugin ${plugin.name}`
-
-      return Promise.resolve(
-        runAPI(plugin, api, { ...args, parentSpan: apiSpan })
-      ).catch(err => { 
+      
+      return new Promise((resolve) => {
+        resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }))
+      }).catch(err => { 
         reporter.panicOnBuild(`${pluginName} returned an error`, err)
         return null
       })

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -162,8 +162,7 @@ module.exports = async (api, args = {}, pluginSource) =>
 
     // Check that the API is documented.
     if (!apiList[api]) {
-      reporter.error(`api: "${api}" is not a valid Gatsby api`)
-      process.exit()
+      reporter.panic(`api: "${api}" is not a valid Gatsby api`)
     }
 
     const { store } = require(`../redux`)
@@ -243,13 +242,8 @@ module.exports = async (api, args = {}, pluginSource) =>
       )
     })
       .catch(err => {
-        if (err) {
-          if (process.env.NODE_ENV === `production`) {
-            return reporter.panic(`${pluginName} returned an error`, err)
-          }
-          return reporter.error(`${pluginName} returned an error`, err)
-        }
-        return null
+        reporter.panicOnBuild(`${pluginName} returned an error`, err)
+        return []
       })
       .then(results => {
         // Remove runner instance

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -229,22 +229,19 @@ module.exports = async (api, args = {}, pluginSource) =>
       apisRunningByTraceId.set(apiRunInstance.traceId, 1)
     }
 
-    let pluginName = null
+   
 
     Promise.mapSeries(noSourcePluginPlugins, plugin => {
-      if (plugin.name === `default-site-plugin`) {
-        pluginName = `gatsby-node.js`
-      } else {
-        pluginName = `Plugin ${plugin.name}`
-      }
+      let pluginName = plugin.name === `default-site-plugin` ? 
+          `gatsby-node.js` : `Plugin ${plugin.name}`
+
       return Promise.resolve(
         runAPI(plugin, api, { ...args, parentSpan: apiSpan })
-      )
-    })
-      .catch(err => {
+      ).catch(err => { 
         reporter.panicOnBuild(`${pluginName} returned an error`, err)
-        return []
+        return null
       })
+    })
       .then(results => {
         // Remove runner instance
         apisRunningById.delete(apiRunInstance.id)


### PR DESCRIPTION
I keep getting weird errors and it was because my gatsby-node.js had issues, but the build was continuing assuming there was a `result`