### PR TITLE
Fixing bug caused by #8917

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -73,7 +73,7 @@ module.exports = async (args: BootstrapArgs) => {
   )
 
   // theme gatsby configs can be functions or objects
-  if (config.__experimentalThemes) {
+  if (config && config.__experimentalThemes) {
     const themesConfig = await Promise.mapSeries(
       config.__experimentalThemes,
       async ([themeName, themeConfig]) => {


### PR DESCRIPTION
This is fixing a bug brought on in #8917.  It's not checking if the config object is undefined before trying to access a subkey on it.  This is breaking the hello-world starter that's used throughout the tutorial.