### PR TITLE
fix: throw error instead of string

### DIFF
--- a/packages/gatsby-source-wordpress/src/request-in-queue.js
+++ b/packages/gatsby-source-wordpress/src/request-in-queue.js
@@ -47,7 +47,7 @@ module.exports = function requestInQueue(tasks, opts = {}) {
     )
 
     q.on(`task_failed`, (id, err) => {
-      rej(`${id} failed with err: ${err}`)
+      rej(new Error(`${id} failed with err: ${err}`))
       q.destroy()
     })
 


### PR DESCRIPTION
Fixes #9283

## Description

This is a minor issue around error visibility.

Here's how Bluebird's warning about the issue shows up:

![image](https://user-images.githubusercontent.com/397632/47270777-d47ce680-d52d-11e8-9a1d-1812a9837d5a.png)

`Warning: a promise was rejected with a non-error: [object String]`

To fix this, `rej(string)` must be called with a `new Error(string)` instead.
