### PR TITLE
Fix sub section links for /docs/gatsby-config

### DIFF
--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -10,9 +10,9 @@ _Note: There are many sample configs which may be helpful to reference in the di
 
 Options available to set within `gatsby-config.js` include:
 
-1.  [siteMetadata](#siteMetadata) (object)
+1.  [siteMetadata](#sitemetadata) (object)
 2.  [plugins](#plugins) (array)
-3.  [pathPrefix](#pathPrefix) (string)
+3.  [pathPrefix](#pathprefix) (string)
 4.  [polyfill](#polyfill) (boolean)
 5.  [mapping](#mapping-node-types) (object)
 6.  [proxy](#proxy) (object)


### PR DESCRIPTION
### Bug:

The links for configuration options on the [Gatsby Config](https://www.gatsbyjs.org/docs/gatsby-config) page don't scroll to the right section because they have incorrect id 

URL in link: https://www.gatsbyjs.org/docs/gatsby-config/#pathPrefix
Actual link: https://www.gatsbyjs.org/docs/gatsby-config/#pathprefix

Notice the lowercased part at the end. The actual links are generated by [gatsby-remark-autolink-headers](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-autolink-headers/src/index.js#L19).

### Fix

In this pull request, I've changed the url in links to be lowercase as well. (This is what the react docs do as well)

### Alternate Fix

The problem with this fix is that it's not consistent with the older version of the docs which use camelCased links. Example: https://www.gatsbyjs.org/docs/actions/#addThirdPartySchema

`gatsby-remark-autolink-headers` uses `github-slugger` to create the slugs for markdown headers - which supports camelCased slugs as well by passing an addition argument (test case: [github-slugger/index#13](https://github.com/Flet/github-slugger/blob/master/test/index.js#L13))

This will have to be opt-in option for `gatsby-remark-autolink-headers` so that applications already using it don't break.

Let me know what you think