### PR TITLE
Move the 'Visit site' and 'share' buttons above the showcase screenshot

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -435,8 +435,8 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                 <div
                   css={{
                     position: `absolute`,
-                    right: gutter,
-                    top: gutter,
+                    right: rhythm(3 / 4),
+                    top: rhythm(-15 / 8),
                     left: `auto`,
                     zIndex: 1,
                     display: `flex`,


### PR DESCRIPTION
This PR moves the the "Visit site" and "share" buttons so that they don't obscure the screenshot.

**Before**:
<img width="229" alt="screen shot 2018-10-23 at 12 00 59 pm" src="https://user-images.githubusercontent.com/190387/47378393-02952e80-d6c6-11e8-8723-a3cf251a94ba.png">
<img width="711" alt="screen shot 2018-10-23 at 12 01 17 pm" src="https://user-images.githubusercontent.com/190387/47378394-02952e80-d6c6-11e8-8df6-3827783b50be.png">

**After**:
<img width="230" alt="screen shot 2018-10-23 at 11 59 04 am" src="https://user-images.githubusercontent.com/190387/47378416-0c1e9680-d6c6-11e8-8735-7bb43083624b.png">
<img width="705" alt="screen shot 2018-10-23 at 11 59 32 am" src="https://user-images.githubusercontent.com/190387/47378417-0cb72d00-d6c6-11e8-870d-15c74f90e586.png">
