### PR TITLE
chore: clear cache-dir/commonjs directory before building new one

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -174,7 +174,7 @@
     "graphql": "^0.13.2"
   },
   "scripts": {
-    "build": "rimraf dist && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",
+    "build": "rimraf dist && rimraf cache-dir/commonjs && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",
     "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
     "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
     "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore **/__tests__",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -174,12 +174,13 @@
     "graphql": "^0.13.2"
   },
   "scripts": {
-    "build": "rimraf dist && rimraf cache-dir/commonjs && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",
+    "build": "npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",
     "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
     "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
     "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore **/__tests__",
     "build:src": "babel src --out-dir dist --source-maps --ignore **/gatsby-cli.js,**/raw_*,**/__tests__",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
+    "prebuild": "rimraf dist && rimraf cache-dir/commonjs",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "test-coverage": "node_modules/.bin/nyc --reporter=lcov --reporter=text npm test",
     "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch"


### PR DESCRIPTION
This will fix nested `commonjs` dirs in published `gatsby` package 

![image](https://user-images.githubusercontent.com/419821/47388284-12d2fb00-d712-11e8-8a55-c6db491b15de.png)
