### PR TITLE
Implement two fallbacks for getting extension when creating remote file

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -178,7 +178,7 @@ createRemoteFileNode({
 
   // OPTIONAL
   // Sets the file extension
-  ext = '.jpg',
+  ext: '.jpg',
 })
 ```
 

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -229,6 +229,17 @@ The file node can then be queried using GraphQL. See an example of this in the [
 
 #### Retrieving the remote file extension
 
-The helper tries first to retrieve the file extension by parsing the url and the path provided. If it fails to find an extension then it tries to guess it using file-type.
+The helper tries first to retrieve the file extension by parsing the url and the path provided (e.g. if the url is https://example.com/image.jpg, the extension will be inferred as `.jpg`). If the url does not contain an extension, we use the [`file-type`](https://www.npmjs.com/package/file-type) package to infer the file type. Finally, the extension _can_ be explicitly passed, like so:
 
-You may use the optional parameter to force the use of a specific extension. This could come in handy if the url-parser and file-type are not able to guess the extension (i.e md is not supported by file-type).
+```javascript
+createRemoteFileNode({
+  // The source url of the remote file
+  url: `https://example.com/a-file-without-an-extension`,
+  store,
+  cache,
+  createNode,
+  createNodeId,
+  // if necessary!
+  ext: '.jpg',
+})
+```

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -175,6 +175,10 @@ createRemoteFileNode({
   // OPTIONAL
   // Adds htaccess authentication to the download request if passed in.
   auth: { htaccess_user: `USER`, htaccess_pass: `PASSWORD` },
+
+  // OPTIONAL
+  // Sets the file extension
+  ext = '.jpg',
 })
 ```
 
@@ -222,3 +226,9 @@ exports.downloadMediaFiles = ({
 ```
 
 The file node can then be queried using GraphQL. See an example of this in the [gatsby-source-wordpress README](/packages/gatsby-source-wordpress/#image-processing) where downloaded images are queried using [gatsby-transformer-sharp](/packages/gatsby-transformer-sharp/) to use in the component [gatsby-image](/packages/gatsby-image/).
+
+#### Retrieving the remote file extension
+
+The helper tries first to retrieve the file extension by parsing the url and the path provided. If it fails to find an extension then it tries to guess it using file-type.
+
+You may use the optional parameter to force the use of a specific extension. This could come in handy if the url-parser and file-type are not able to guess the extension (i.e md is not supported by file-type).

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -11,7 +11,7 @@
     "better-queue": "^3.8.7",
     "bluebird": "^3.5.0",
     "chokidar": "^1.7.0",
-    "file-type": "^10.1.0",
+    "file-type": "^10.2.0",
     "fs-extra": "^5.0.0",
     "got": "^7.1.0",
     "md5-file": "^3.1.1",

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -11,11 +11,13 @@
     "better-queue": "^3.8.7",
     "bluebird": "^3.5.0",
     "chokidar": "^1.7.0",
+    "file-type": "^10.1.0",
     "fs-extra": "^5.0.0",
     "got": "^7.1.0",
     "md5-file": "^3.1.1",
     "mime": "^2.2.0",
     "pretty-bytes": "^4.0.2",
+    "read-chunk": "^3.0.0",
     "slash": "^1.0.0",
     "valid-url": "^1.0.9",
     "xstate": "^3.1.0"

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -4,6 +4,8 @@ const crypto = require(`crypto`)
 const path = require(`path`)
 const { isWebUri } = require(`valid-url`)
 const Queue = require(`better-queue`)
+const readChunk = require(`read-chunk`)
+const fileType = require(`file-type`)
 
 const { createFileNode } = require(`./create-file-node`)
 const { getRemoteFileExtension } = require(`./utils`)
@@ -128,10 +130,9 @@ async function pushToQueue(task, cb) {
  * @param  {String}   url
  * @param  {Headers}  headers
  * @param  {String}   tmpFilename
- * @param  {String}   filename
  * @return {Promise<Object>}  Resolves with the [http Result Object]{@link https://nodejs.org/api/http.html#http_class_http_serverresponse}
  */
-const requestRemoteNode = (url, headers, tmpFilename, filename) =>
+const requestRemoteNode = (url, headers, tmpFilename) =>
   new Promise((resolve, reject) => {
     const responseStream = got.stream(url, {
       ...headers,
@@ -174,6 +175,7 @@ async function processRemoteNode({
   createNode,
   auth = {},
   createNodeId,
+  ext,
 }) {
   // Ensure our cache directory exists.
   const programDir = store.getState().program.directory
@@ -196,10 +198,11 @@ async function processRemoteNode({
 
   // Create the temp and permanent file names for the url.
   const digest = createHash(url)
-  const ext = getRemoteFileExtension(url)
+  if (!ext){
+    ext = getRemoteFileExtension(url)
+  }
 
   const tmpFilename = createFilePath(programDir, `tmp-${digest}`, ext)
-  const filename = createFilePath(programDir, digest, ext)
 
   // Fetch the file.
   try {
@@ -207,11 +210,19 @@ async function processRemoteNode({
       url,
       headers,
       tmpFilename,
-      filename
     )
     // Save the response headers for future requests.
-    cache.set(cacheId(url), response.headers)
+    await cache.set(cacheId(url), response.headers)
 
+    // If the user did not provide an extension and we couldn't get one from remote file, try and guess one
+    if (ext === ``) {
+      const buffer = readChunk.sync(tmpFilename, 0, 4100)
+      const filetype = fileType(buffer)
+      if (filetype) {
+        ext = `.${filetype.ext}`
+      }
+    }
+    const filename = createFilePath(programDir, digest, ext)
     // If the status code is 200, move the piped temp file to the real name.
     if (response.statusCode === 200) {
       await fs.move(tmpFilename, filename, { overwrite: true })
@@ -283,6 +294,7 @@ module.exports = ({
   createNode,
   auth = {},
   createNodeId,
+  ext = null,
 }) => {
   // Check if we already requested node for this remote file
   // and return stored promise if we did.
@@ -303,5 +315,6 @@ module.exports = ({
     createNode,
     createNodeId,
     auth,
+    ext,
   }))
 }

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -216,7 +216,7 @@ async function processRemoteNode({
 
     // If the user did not provide an extension and we couldn't get one from remote file, try and guess one
     if (ext === ``) {
-      const buffer = readChunk.sync(tmpFilename, 0, 4100)
+      const buffer = readChunk.sync(tmpFilename, 0, fileType.minimumBytes)
       const filetype = fileType(buffer)
       if (filetype) {
         ext = `.${filetype.ext}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -7866,6 +7866,11 @@ file-type@5.2.0, file-type@^5.2.0:
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
   integrity sha1-LdvqfHP/42No365J3DOMBYwritY=
 
+file-type@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.2.0.tgz#91177ceb904963e2be53add360b213c2dc273f64"
+  integrity sha512-eqX81S1PWdLDPW39yyB214TVVOsUQjSmPcyUjeVH6ksH+94Y2YA/ItiIwa53rJiSofJZLK6lGsuCE3rwt0vp4w==
+
 file-type@^3.1.0, file-type@^3.8.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
@@ -14309,6 +14314,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pify@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -15428,6 +15438,14 @@ read-chunk@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-1.0.1.tgz#5f68cab307e663f19993527d9b589cace4661194"
   integrity sha1-X2jKswfmY/GZk1J9m1icrORmEZQ=
+
+read-chunk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-3.0.0.tgz#086cd198406104355626afacd2d21084afc367ec"
+  integrity sha512-8lBUVPjj9TC5bKLBacB+rpexM03+LWiYbv6ma3BeWmUYXGxqA1WNNgIZHq/iIsCrbFMzPhFbkOqdsyOFRnuoXg==
+  dependencies:
+    pify "^4.0.0"
+    with-open-file "^0.1.3"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -19578,6 +19596,15 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
   integrity sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=
+
+with-open-file@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/with-open-file/-/with-open-file-0.1.4.tgz#797e32055cbe55c58727ad026482fb0776474b2c"
+  integrity sha512-BswUwq/x/BYtNFMr4Uw9V+P2uroc9/tcDpZ2RdDHehzwCKJFF1PSIjJmBNfpUE3UQyJmVINRLOW49WTXQMEnvg==
+  dependencies:
+    p-finally "^1.0.0"
+    p-try "^2.0.0"
+    pify "^3.0.0"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
I was working on a dropbox source plugin (#6883) and encountered two issues. Sometimes APIs provide temporary download files which in case of dropbox look like https://dl.dropboxusercontent.com/apitl/1/AAD2_49EPcISoEH8iSevIIxSHWAKbTkggAYuCFa87DzSyDm5MAa0qQPy0DCbIgOBcnMDwoHVF5uUKrxWr20ErtUr4kAkwG1ZA9aArmpoj_G01ce-wf8aT1YLkwbYq6Cm0yApE0fzFcewG3CpVdr3yPmKbOareDzmaB6POuPbnAjDeUkHfc3Cv7jjHGm_Wgfl-LlN62-2bM1qfiftRPm9yW0--gjDbfdUECHDRzqQvWB1PD8ShRNn5b9e04vOVW6nTjUqrlsRDOQ6NfJOulW9R2B2bt2JsmOobqQ_eIFVVrDId8eZsWwyHCqK17dQLY5_ZiO9a0ag4lIavN9JCkw9TVdx

So parsing the url and the path can not get extension which is normal. So fallbacks are:

1) download the file and try and guess the extension
2) let the user provide the extension

The 2 was needed because for example file-type can not detect markdown files.

Maybe i can factor out the guessing part in utils and try and try and provide some unittests, but i am not sure which file i could use for testing purposes since in the repo there are only .js and .md files which are not detectable. (Add a small picture in tests?)
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
