### PR TITLE
fix(gatsby-source-drupal): handle links outputted as objects in REST responses

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/article-2.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/article-2.json
@@ -1,0 +1,32 @@
+{
+  "data": [
+    {
+      "type": "node--article",
+      "id": "article-3",
+      "attributes": {
+        "id": 23,
+        "uuid": "article-3",
+        "title": "Article #3",
+        "body":
+          "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
+      },
+      "relationships": {
+        "field_main_image": {
+          "data": {
+            "type": "file--file",
+            "id": "file-1"
+          }
+        },
+        "field_tags": {
+          "data": [
+            {
+              "type": "taxonomy_term--tags",
+              "id": "tag-1"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "links": {}
+}

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/article.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/article.json
@@ -49,34 +49,9 @@
           "data": null
         }
       }
-    },
-    {
-      "type": "node--article",
-      "id": "article-3",
-      "attributes": {
-        "id": 23,
-        "uuid": "article-3",
-        "title": "Article #3",
-        "body":
-          "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
-      },
-      "relationships": {
-        "field_main_image": {
-          "data": {
-            "type": "file--file",
-            "id": "file-1"
-          }
-        },
-        "field_tags": {
-          "data": [
-            {
-              "type": "taxonomy_term--tags",
-              "id": "tag-1"
-            }
-          ]
-        }
-      }
     }
   ],
-  "links": {}
+  "links": {
+    "next": "http://fixture/jsonapi/node/article-2"
+  }
 }

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
@@ -4,6 +4,8 @@
       "self": "http://fixture/jsonapi",
       "file--file": "http://fixture/jsonapi/file/file",
       "node--article": "http://fixture/jsonapi/node/article",
-      "taxonomy_term--tags": "http://fixture/jsonapi/taxonomy_term/tags"
+      "taxonomy_term--tags": {
+        "href": "http://fixture/jsonapi/taxonomy_term/tags"
+      }
   }
 }

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/tags-2.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/tags-2.json
@@ -2,12 +2,12 @@
   "data": [
     {
       "type": "taxonomy_term--tags",
-      "id": "tag-1",
+      "id": "tag-2",
       "attributes": {
-        "id": 11,
-        "uuid": "tag-1",
+        "id": 12,
+        "uuid": "tag-2",
         "langcode": "en",
-        "name": "Tag #1",
+        "name": "Tag #2",
         "description": null,
         "weight": 0,
         "changed": 1523031646,
@@ -20,9 +20,5 @@
       }
     }
   ],
-  "links": {
-    "next": {
-      "href": "http://fixture/jsonapi/taxonomy_term/tags-2"
-    }
-  }
+  "links": {}
 }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -47,8 +47,12 @@ exports.sourceNodes = async (
       if (!url) return
       if (!type) return
       const getNext = async (url, data = []) => {
+        if (typeof url === `object`) {
+          // url can be string or object containing href field
+          url = url.href
+        }
+
         let d
-        if (typeof url === 'object') url = url.href
         try {
           d = await axios.get(url)
         } catch (error) {

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -48,6 +48,7 @@ exports.sourceNodes = async (
       if (!type) return
       const getNext = async (url, data = []) => {
         let d
+        if (typeof url === 'object') url = url.href
         try {
           d = await axios.get(url)
         } catch (error) {


### PR DESCRIPTION
While updating my Drupal Commerce + GatsbyJS example I ran into an error with GatsbyJS v2 and JSONAPI 2.0-rc1. I'm not sure where the breakage might of been, or if this plugin is even working technically.

In the JSON API response, all links have a `href` property, making them objects. I remember this working before. I had to add this check to allow my site to be built.