### PR TITLE
chore: consistent badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     <img src="https://travis-ci.org/gatsbyjs/gatsby.svg?branch=master" alt="Current TravisCI build status." />
   </a>
   <a href="https://www.npmjs.org/package/gatsby">
-    <img src="https://img.shields.io/npm/v/gatsby.svg?style=flat-square" alt="Current npm package version." />
+    <img src="https://img.shields.io/npm/v/gatsby.svg" alt="Current npm package version." />
   </a>
   <a href="https://npmcharts.com/compare/gatsby?minimal=true">
     <img src="https://img.shields.io/npm/dm/gatsby.svg" alt="Downloads per month on npm." />


### PR DESCRIPTION
The npm badge was the only one using flat style, so I changed it.
I can also make all badges flat if prefered.