### PR TITLE
fix: upgrade guess-webpack version to avoid error

### DIFF
--- a/packages/gatsby-plugin-guess-js/package.json
+++ b/packages/gatsby-plugin-guess-js/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "guess-webpack": "~0.1.3"
+    "guess-webpack": "^0.1.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
This PR fixes the error gatsby-plugin-guess-js was throwing: `TypeError: ts.createNodeArray is not a function`

Bumping to 0.1.6 locally (with `resolutions` field in www/package.json)
appeared to fix the issue.

Note: this is discussed (and fixed!) in guess-js/guess#76

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
