### PR TITLE
gatsby-plugin-layout is all-or-nothing

### DIFF
--- a/packages/gatsby-plugin-layout/README.md
+++ b/packages/gatsby-plugin-layout/README.md
@@ -9,7 +9,9 @@ This can be helpful for:
 - Custom error handling using componentDidCatch
 - Inject additional data into pages using React Context.
 
-This plugin reimplements the behavior of layout components in `gatsby@1`, which [was removed in version 2](https://github.com/gatsbyjs/rfcs/blob/master/text/0002-remove-special-layout-components.md).
+This plugin reimplements the behavior of layout components in `gatsby@1`, which [was removed in version 2](https://github.com/gatsbyjs/rfcs/blob/master/text/0002-remove-special-layout-components.md). 
+
+Note: This plugin is all-or-nothing. If you choose to use `gatsby-plugin-layout`, all of your page elements will be wrapped by `<Layout />`. Do not try to refactor some components to use the `<Layout />` component from `gatsby-plugin-layout` and some components to use `<Layout />` as described in `gatsby@2`. This will cause Gatsby to render multiple layouts.
 
 ## Install
 


### PR DESCRIPTION
Fixes #9330

This PR updates to README to clarify that `gatsby-plugin-layout` is all or nothing, meaning that if you choose to use `gatsby-plugin-layout` in your project, _all_ of your components will be wrapped in the `<Layout />` component, and you should not attempt to refactor any of your components to use the `<Layout />` component as described in `gatsby@2`.