### PR TITLE
Gatsby on Linux + WSL

### DIFF
--- a/docs/docs/gatsby-on-linux.md
+++ b/docs/docs/gatsby-on-linux.md
@@ -4,7 +4,9 @@ title: Gatsby on Linux
 
 # Linux
 
-TODO
+> This is a TODO. Help our community expand it.
+
+> Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your pull request gets accepted.
 
 ## Windows Subsystem Linux (WSL)
 
@@ -56,7 +58,7 @@ sudo apt install git
 sudo apt install libpng-dev
 ```
 
-Or to install all at the same time and approve (y) all installs:
+Or to install all at the same time and approve `(y)` all installs:
 
 ```sh
 sudo apt update && sudo apt -y upgrade && sudo apt install build-essential && sudo apt install git && sudo apt install libpng-dev

--- a/docs/docs/gatsby-on-windows.md
+++ b/docs/docs/gatsby-on-windows.md
@@ -86,3 +86,5 @@ Sharp uses a c library, libvips. If you are having issues while installing Sharp
 ## Windows Subsystem for Linux
 
 If the installation of dependencies or developing on Windows in general gives you headaches, Windows 10 provides a great alternative: [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about). It lets you run most command-line tools, utilities, and applications in a GNU/Linux environment directly on Windows, unmodified, without the overhead of a virtual machine. In the above scenario you would download e.g. Ubuntu, open the terminal, [install Node](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions), and run `sudo apt-get install build-essential` in the terminal — and the compilation works way more reliable. Please note that you have to delete any existing `node_modules` folder in your project and re-install the dependencies in your WSL environment.
+
+You can also visit [Gatsby on Linux](/docs/gatsby-on-linux/) to learn more.

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -15,6 +15,8 @@
           link: /docs/browser-support/
         - title: Gatsby on Windows
           link: /docs/gatsby-on-windows/
+        - title: Gatsby on Linux
+          link: /docs/gatsby-on-linux/
     - title: Deploying & hosting
       link: /docs/deploying-and-hosting/
       items:


### PR DESCRIPTION
Soo in March this year @spences10 opened this PR: https://github.com/gatsbyjs/gatsby/issues/4139
But it never got added to the sidebar 😛 

Therefore I added unknowingly this PR: https://github.com/gatsbyjs/gatsby/pull/8876

-----------

This PR exposes the Linux doc to the sidebar and puts a link to this doc on the windows doc.