### PR TITLE
Fix: link to showcase

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -423,5 +423,5 @@ Now that you've built a Gatsby site, where do you go next?
 - Share your Gatsby site on Twitter and see what other people have created by searching for #gatsbytutorial! Make sure to mention @gatsbyjs in your Tweet, and include the hashtag #gatsbytutorial :)
 - You could take a look at some [example sites](https://github.com/gatsbyjs/gatsby/tree/master/examples#gatsby-example-websites)
 - Explore more [plugins](/docs/plugins/)
-- See what [other people are building with Gatsby](https://www.gatsbyjs.org/showcase/)
+- See what [other people are building with Gatsby](/showcase/)
 - Check out the documentation on [Gatsby's APIs](/docs/api-specification/), [nodes](/docs/node-interface/) or [GraphQL](/docs/graphql-reference/)

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -423,5 +423,5 @@ Now that you've built a Gatsby site, where do you go next?
 - Share your Gatsby site on Twitter and see what other people have created by searching for #gatsbytutorial! Make sure to mention @gatsbyjs in your Tweet, and include the hashtag #gatsbytutorial :)
 - You could take a look at some [example sites](https://github.com/gatsbyjs/gatsby/tree/master/examples#gatsby-example-websites)
 - Explore more [plugins](/docs/plugins/)
-- See what [other people are building with Gatsby](https://github.com/gatsbyjs/gatsby/#showcase)
+- See what [other people are building with Gatsby](https://www.gatsbyjs.org/showcase/)
 - Check out the documentation on [Gatsby's APIs](/docs/api-specification/), [nodes](/docs/node-interface/) or [GraphQL](/docs/graphql-reference/)


### PR DESCRIPTION
This URL https://github.com/gatsbyjs/gatsby/#showcase only goes to the github page of the repository and there is no corresponding tag to scroll to. However we can find on the same page a "Showcase" link which goes to the showcase on the official Gatsby website.
I believe this was the original intention behind the link.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
