### PR TITLE
feat(gatsby-source-wordpress): normalize baseUrl

### DIFF
--- a/packages/gatsby-source-wordpress/src/__tests__/normalize-base-url.js
+++ b/packages/gatsby-source-wordpress/src/__tests__/normalize-base-url.js
@@ -1,0 +1,12 @@
+const normalizeBaseUrl = require(`../normalize-base-url`)
+
+describe(`Normalize baseUrl`, () => {
+  it(`Removes trailing slashes`, () => {
+    expect(normalizeBaseUrl(`example.com/`)).toBe(`example.com`)
+  })
+
+  it(`Removes the protocol`, () => {
+    expect(normalizeBaseUrl(`http://example.com`)).toBe(`example.com`)
+    expect(normalizeBaseUrl(`https://example.com`)).toBe(`example.com`)
+  })
+})

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -1,5 +1,6 @@
 const fetch = require(`./fetch`)
 const normalize = require(`./normalize`)
+const normalizeBaseUrl = require(`./normalize-base-url`)
 
 const typePrefix = `wordpress__`
 const refactoredEntityTypes = {
@@ -41,8 +42,10 @@ exports.sourceNodes = async (
   }
 ) => {
   const { createNode, touchNode } = actions
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+
   _verbose = verboseOutput
-  _siteURL = `${protocol}://${baseUrl}`
+  _siteURL = `${protocol}://${normalizedBaseUrl}`
   _useACF = useACF
   _acfOptionPageIds = acfOptionPageIds
   _hostingWPCOM = hostingWPCOM

--- a/packages/gatsby-source-wordpress/src/normalize-base-url.js
+++ b/packages/gatsby-source-wordpress/src/normalize-base-url.js
@@ -1,0 +1,13 @@
+function normalizeBaseUrl(baseUrl) {
+  let normalized = baseUrl
+
+  // remove trailing slashes
+  normalized = normalized.replace(/\/+$/, ``)
+
+  // remove protocol
+  normalized = normalized.replace(/^https?:\/\//, ``)
+
+  return normalized
+}
+
+module.exports = normalizeBaseUrl


### PR DESCRIPTION
I'm not very good at reading documentation and didn't see, that `baseUrl` should not contain a trailing slash nor the protocol. The error, which is thrown because of that mistake is quite cryptic, so this PR adds a little of normalization to `baseUrl`:

- remove trailing slashes
- remove protocol

A different approach might be, to print a proper error, which tells me about the mistake.