### PR TITLE
remove asterisk to note active doc

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -202,7 +202,7 @@
       items:
         - title: Adding search
           link: /docs/adding-search/
-        - title: Adding analytics*
+        - title: Adding analytics
           link: /docs/adding-analytics/
         - title: Adding forms*
           link: /docs/adding-forms/


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

It seems like the asterisk in the `.yaml` file is noting which docs should be gray to indicate that they are not complete. The `Adding analytics` document seems complete, so I removed the asterisk.
