### PR TITLE
fix(www): [v1] update url to point to v1.gatsbyjs.org

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `Gatsby`,
-    siteUrl: `https://www.gatsbyjs.org`,
+    siteUrl: `https://v1.gatsbyjs.org`,
     description: `Blazing-fast static site generator for React`,
   },
   mapping: {


### PR DESCRIPTION
ref: https://github.com/gatsbyjs/gatsby/issues/9159#issuecomment-432157499