### PR TITLE
feat(examples): Update emotion

### DIFF
--- a/examples/using-emotion-prismjs/package.json
+++ b/examples/using-emotion-prismjs/package.json
@@ -7,8 +7,8 @@
     "build": "gatsby build"
   },
   "dependencies": {
-    "emotion": "^9.1.3",
-    "emotion-server": "^9.1.3",
+    "emotion": "^9.2.12",
+    "emotion-server": "^9.2.12",
     "gatsby": "^2.0.0",
     "gatsby-plugin-emotion": "^2.0.5",
     "gatsby-plugin-google-analytics": "^2.0.5",
@@ -23,7 +23,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
-    "react-emotion": "^9.1.3",
+    "react-emotion": "^9.2.12",
     "react-helmet": "^5.2.0",
     "react-typography": "^0.16.13",
     "typography": "^0.16.17",

--- a/examples/using-emotion-prismjs/src/components/layout.js
+++ b/examples/using-emotion-prismjs/src/components/layout.js
@@ -19,7 +19,7 @@ const link = css`
   color: inherit;
 `
 
-class Layout extends React.Component {
+class PureLayout extends React.Component {
   render() {
     const HeadingTag = this.props.isIndex ? `h1` : `h3`
     const { siteTitle, pageTitle } = this.props
@@ -35,7 +35,6 @@ class Layout extends React.Component {
           />
           <meta name="referrer" content="origin" />
         </Helmet>
-        ` `
         <div className={indexContainer}>
           <HeadingTag>
             <Link className={link} to={`/`}>
@@ -49,7 +48,7 @@ class Layout extends React.Component {
   }
 }
 
-Layout.propTypes = {
+PureLayout.propTypes = {
   siteTitle: PropTypes.string.isRequired,
   pageTitle: PropTypes.string,
   isIndex: PropTypes.bool,
@@ -66,11 +65,13 @@ const query = graphql`
   }
 `
 
-export default props => (
+const Layout = props => (
   <StaticQuery
     query={query}
     render={data => (
-      <Layout siteTitle={data.site.siteMetadata.title} {...props} />
+      <PureLayout siteTitle={data.site.siteMetadata.title} {...props} />
     )}
   />
 )
+
+export default Layout

--- a/examples/using-emotion-prismjs/src/pages/index.js
+++ b/examples/using-emotion-prismjs/src/pages/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
-import { css } from "emotion"
+import { css } from "react-emotion"
 import get from "lodash/get"
 import { rhythm, scale } from "../utils/typography"
 

--- a/examples/using-emotion-prismjs/src/prism-styles.js
+++ b/examples/using-emotion-prismjs/src/prism-styles.js
@@ -1,4 +1,4 @@
-import { injectGlobal } from "emotion"
+import { injectGlobal } from "react-emotion"
 
 const colors = {
   dark: `#282c34`,
@@ -22,19 +22,18 @@ const prismColors = {
   operator: `#fc929e`,
 }
 
-injectGlobal`.gatsby-highlight {
-  background: ${colors.dark};
-  color: ${colors.white};
-  border-radius: 1em;
-  overflow: auto;
-  tab-size: 1.5em;
-  padding: 1em;
-  margin: 1em 0;
-}`
-
 injectGlobal`
-.gatsby-highlight code[class*="language-"],
-.gatsby-highlight pre[class*="language-"]
+  .gatsby-highlight {
+    background: ${colors.dark};
+    color: ${colors.white};
+    border-radius: 1em;
+    overflow: auto;
+    tab-size: 1.5em;
+    padding: 1em;
+    margin: 1em 0;
+  }
+  .gatsby-highlight code[class*="language-"],
+  .gatsby-highlight pre[class*="language-"]
   {
     height: auto !important;
     margin: 1rem;
@@ -42,118 +41,93 @@ injectGlobal`
     line-height: 20px;
     white-space: pre-wrap;
     word-break: break-word;
-  }`
-
-injectGlobal`code {
+  }
+  code {
   font-size: 1em;
   font-family: 'Source Code Pro', monospace;
-}`
-
-injectGlobal`.gatsby-highlight + .gatsby-highlight {
-  margin-top: 1.250em;
-}`
-
-injectGlobal`.gatsby-highlight-code-line {
-  background-color: ${prismColors.lineHighlight};
-  display: block;
-  margin: -0.125rem calc(-1rem - 15px);
-  padding: 0.125rem calc(1rem + 15px);
-}`
-
-injectGlobal`.token.attr-name {
-  color: ${prismColors.keyword};
-}`
-
-injectGlobal`
-.token.comment,
-.token.block-comment,
-.token.prolog,
-.token.doctype,
-.token.cdata
+  }
+  .gatsby-highlight + .gatsby-highlight {
+    margin-top: 1.250em;
+  }
+  .gatsby-highlight-code-line {
+    background-color: ${prismColors.lineHighlight};
+    display: block;
+    margin: -0.125rem calc(-1rem - 15px);
+    padding: 0.125rem calc(1rem + 15px);
+  }
+  .token.attr-name {
+    color: ${prismColors.keyword};
+  }
+  .token.comment,
+  .token.block-comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata
   {
     color: ${prismColors.comment};
-  }`
-
-injectGlobal`
-.token.property,
-.token.number,
-.token.function-name,
-.token.constant,
-.token.symbol,
-.token.deleted
+  }
+  .token.property,
+  .token.number,
+  .token.function-name,
+  .token.constant,
+  .token.symbol,
+  .token.deleted
   {
     color: ${prismColors.primitive};
-  }`
-
-injectGlobal`.token.boolean {
-  color: ${prismColors.boolean};
-}`
-
-injectGlobal`span.token.tag {
-  color: ${prismColors.tag};
-}`
-
-injectGlobal`.token.string {
-  color: ${prismColors.string};
-}`
-
-injectGlobal`.token.punctuation {
-  color: ${prismColors.punctuation};
-}`
-
-injectGlobal`
-.token.selector,
-.token.char,
-.token.builtin,
-.token.inserted
+  }
+  .token.boolean {
+    color: ${prismColors.boolean};
+  }
+  span.token.tag {
+    color: ${prismColors.tag};
+  }
+  .token.string {
+    color: ${prismColors.string};
+  }
+  .token.punctuation {
+    color: ${prismColors.punctuation};
+  }
+  .token.selector,
+  .token.char,
+  .token.builtin,
+  .token.inserted
   {
     color: ${prismColors.char};
-  }`
-
-injectGlobal`.token.function {
-  color: ${prismColors.function};
-}`
-
-injectGlobal`
-.token.operator,
-.token.entity,
-.token.url,
-.token.variable
+  }
+  .token.function {
+    color: ${prismColors.function};
+  }
+  .token.operator,
+  .token.entity,
+  .token.url,
+  .token.variable
   {
     color: ${prismColors.variable};
-  }`
-
-injectGlobal`token.attr-value {
-  color: ${prismColors.string};
-}`
-
-injectGlobal`.token.keyword {
-  color: ${prismColors.keyword};
-}`
-
-injectGlobal`
-.token.atrule,
-.token.class-name
+  }
+  .token.attr-value {
+    color: ${prismColors.string};
+  }
+  .token.keyword {
+    color: ${prismColors.keyword};
+  }
+  .token.atrule,
+  .token.class-name
   {
     color: ${prismColors.className};
-  }`
-
-injectGlobal`.token.important {
-  font-weight: 400;
-}`
-
-injectGlobal`.token.bold {
-  font-weight: 700;
-}`
-
-injectGlobal`.token.italic {
-  font-style: italic;
-}`
-
-injectGlobal`.token.entity {
-  cursor: help;
-}`
-
-injectGlobal`.namespace {
-  opacity: 0.7;
-}`
+  }
+  .token.important {
+    font-weight: 400;
+  }
+  .token.bold {
+    font-weight: 700;
+  }
+  .token.italic {
+    font-style: italic;
+  }
+  .token.entity {
+    cursor: help;
+  }
+  .namespace {
+    opacity: 0.7;
+  }
+`

--- a/examples/using-emotion-prismjs/src/templates/blog-post.js
+++ b/examples/using-emotion-prismjs/src/templates/blog-post.js
@@ -1,5 +1,6 @@
 import React from "react"
-import { css } from "emotion"
+import PropTypes from "prop-types"
+import { css } from "react-emotion"
 import { graphql } from "gatsby"
 import { rhythm, scale } from "../utils/typography"
 
@@ -13,8 +14,8 @@ const postContainer = css`
 const postDate = css`
   ${scale(-1 / 5)};
   display: block;
-  marginbottom: ${rhythm(1)};
-  margintop: ${rhythm(-1)};
+  margin-bottom: ${rhythm(1)};
+  margin-top: ${rhythm(-1)};
 `
 
 class BlogPostTemplate extends React.Component {
@@ -35,6 +36,12 @@ class BlogPostTemplate extends React.Component {
 }
 
 export default BlogPostTemplate
+
+BlogPostTemplate.propTypes = {
+  data: PropTypes.shape({
+    markdownRemark: PropTypes.object.isRequired,
+  }).isRequired,
+}
 
 export const pageQuery = graphql`
   query($path: String!) {

--- a/examples/using-emotion/package.json
+++ b/examples/using-emotion/package.json
@@ -4,8 +4,8 @@
   "description": "Gatsby example site using using-emotion",
   "author": "Tegan Churchill <churchill.tegan@gmail.com>",
   "dependencies": {
-    "emotion": "^9.1.3",
-    "emotion-server": "^9.1.3",
+    "emotion": "^9.2.12",
+    "emotion-server": "^9.2.12",
     "gatsby": "^2.0.0",
     "gatsby-plugin-emotion": "^2.0.5",
     "gatsby-plugin-google-analytics": "^2.0.5",
@@ -13,7 +13,7 @@
     "gatsby-plugin-react-helmet": "^3.0.0",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
-    "react-emotion": "^9.1.3",
+    "react-emotion": "^9.2.12",
     "react-helmet": "^5.2.0"
   },
   "license": "MIT",

--- a/examples/using-emotion/src/pages/index.js
+++ b/examples/using-emotion/src/pages/index.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react"
 import Helmet from "react-helmet"
-import { injectGlobal } from "emotion"
-import styled, { css } from "react-emotion"
+import styled, { css, injectGlobal } from "react-emotion"
+// You can import everything from "react-emotion"
 
 // Emotion supports different styling options, all of which are supported by gatsby-plugin-emotion out of the box
 
@@ -11,9 +11,6 @@ injectGlobal`
     padding: 0;
     box-sizing: border-box;
   }
-`
-
-injectGlobal`
   html, body {
     font-family: -apple-system,
       BlinkMacSystemFont,
@@ -67,12 +64,9 @@ const IndexPage = () => (
       <meta name="description" content="Gatsby example site using Emotion" />
       <meta name="referrer" content="origin" />
     </Helmet>
-    ` `
     <Wrapper>
       <h1 className={title}>
-        Hello World, this is my first component styled with
-        {` `}
-        <a href="https://emotion.sh/">emotion</a>!
+        Hello World, this is my first component styled with <a href="https://emotion.sh/">emotion</a>!
       </h1>
       <p className={subtitle}>
         <a


### PR DESCRIPTION
- Update the dependencies
- Change all imports to `react-emotion`
- Fix eslint errors (e.g. PropTypes)
- Remove stray backticks
- Only use injectGlobal once (not like in the PrismJS styles which is very chaotic)

I couldn't find something online if [this](https://www.styled-components.com/docs/api#deprecated-injectglobal) also applies to emotion, but I think it's a good change nevertheless:

> We do not encourage the use of this. Try to use it once per app at most, if you must, contained in a single file. 