### PR TITLE
docs(gatsby-source-wordpress): document site metadata node in plugin readme

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -24,7 +24,7 @@ An example site for this plugin is available.
 This module currently pulls from WordPress the following entities:
 
 - [x] All entities are supported (posts, pages, tags, categories, media, types,
-      users, statuses, taxonomies, ...)
+      users, statuses, taxonomies, site metadata, ...)
 - [x] Any new entity should be pulled as long the IDs are correct.
 - [x] [ACF Entities (Advanced Custom Fields)](https://www.advancedcustomfields.com/)
 - [x] Custom post types (any type you could have declared using WordPress'


### PR DESCRIPTION
Added info about the availability of site metadata (as per [this comment](https://github.com/gatsbyjs/gatsby/pull/9329#issuecomment-432619339) of @pieh in #9329).

I don't know if this is enough info, but I think it's pretty basic functionality, so maybe a couple of mentions are indeed enough?