### PR TITLE
docs(gatsby-image): use shortcut for multi package npm installs

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -65,8 +65,7 @@ effect as well as lazy loading of images further down the screen.
 Depending on the gatsby starter you used, you may need to include [gatsby-transformer-sharp](/packages/gatsby-transformer-sharp/) and [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/) as well, and make sure they are installed and included in your gatsby-config.
 
 ```bash
-npm install --save gatsby-transformer-sharp
-npm install --save gatsby-plugin-sharp
+npm install --save gatsby-transformer-sharp gatsby-plugin-sharp
 ```
 
 Then in your `gatsby-config.js`:


### PR DESCRIPTION
This is a tiny critique but something that I believe is rather inconsistent throughout the Gatsby docs. When providing multi package install snippets, I think they should be combined for single line copy/paste and readability.

Would love to see what others think and I'll make some more edits like this elsewhere throughout the docs.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
