### PR TITLE
feat(www): add start script to package.json

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -91,6 +91,7 @@
     "build": "gatsby build",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
     "develop": "gatsby develop",
+    "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Error: no test specified\" && exit 1",
     "scrapeStarters": "cd src/data/StarterShowcase && node scraper.js",


### PR DESCRIPTION
## Description
Most programmers tend to use npm start or yarn start to start any project, so I just added a start script to run the develop script already specified in package.json

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
