### PR TITLE
feat(www): add doc links to static hosts in diagram

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -49,6 +49,12 @@ module.exports = {
     `gatsby-transformer-documentationjs`,
     `gatsby-transformer-yaml`,
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/src/data/diagram`,
+      },
+    },
+    {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -1,6 +1,6 @@
-import React from "react"
+import React, { Fragment } from "react"
 import { keyframes } from "react-emotion"
-import { Link } from "gatsby"
+import { Link, StaticQuery, graphql } from "gatsby"
 
 import { rhythm, scale, options } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
@@ -323,30 +323,31 @@ const Diagram = () => (
       >
         <ItemTitle>Static Web Host</ItemTitle>
         <ItemDescription>
-          <ItemDescriptionLink to="/docs/deploying-to-s3-cloudfront">
-            Amazon S3
-          </ItemDescriptionLink>
-          ,{" "}
-          <ItemDescriptionLink to="/docs/hosting-on-netlify">
-            Netlify
-          </ItemDescriptionLink>
-          ,{" "}
-          <ItemDescriptionLink to="/docs/how-gatsby-works-with-github-pages/">
-            GitHub Pages
-          </ItemDescriptionLink>
-          ,{" "}
-          <ItemDescriptionLink to="/tutorial/part-one/#--deploying-a-gatsby-site">
-            Surge.sh
-          </ItemDescriptionLink>
-          ,{" "}
-          <ItemDescriptionLink to="/docs/deploying-to-aerobatic/">
-            Aerobatic
-          </ItemDescriptionLink>
-          ,{" "}
-          <ItemDescriptionLink to="/docs/deploying-to-now/">
-            Now.sh
-          </ItemDescriptionLink>
-          , & many more
+          <StaticQuery
+            query={graphql`
+              query StaticHostsQuery {
+                allStaticHostsYaml {
+                  edges {
+                    node {
+                      title
+                      url
+                    }
+                  }
+                }
+              }
+            `}
+            render={({ allStaticHostsYaml: { edges: staticHosts } }) =>
+              staticHosts.map(({ node: staticHost }) => (
+                <Fragment key={staticHost.url}>
+                  <ItemDescriptionLink to={staticHost.url}>
+                    {staticHost.title}
+                  </ItemDescriptionLink>
+                  {", "}
+                </Fragment>
+              ))
+            }
+          />
+          & many more
         </ItemDescription>
       </div>
     </Segment>

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { keyframes } from "react-emotion"
+import { Link } from "gatsby"
 
 import { rhythm, scale, options } from "../utils/typography"
 import presets, { colors } from "../utils/presets"
@@ -173,6 +174,12 @@ const ItemDescription = ({ children }) => (
   </small>
 )
 
+const ItemDescriptionLink = ({ to, children }) => (
+  <Link css={{ "&&": { fontWeight: "normal" } }} to={to}>
+    {children}
+  </Link>
+)
+
 const Gatsby = ({ children }) => (
   <div
     css={{
@@ -316,8 +323,30 @@ const Diagram = () => (
       >
         <ItemTitle>Static Web Host</ItemTitle>
         <ItemDescription>
-          Amazon S3, Netlify, GitHub Pages, Surge.sh, Aerobatic, Now.sh, & many
-          more
+          <ItemDescriptionLink to="/docs/deploying-to-s3-cloudfront">
+            Amazon S3
+          </ItemDescriptionLink>
+          ,{" "}
+          <ItemDescriptionLink to="/docs/hosting-on-netlify">
+            Netlify
+          </ItemDescriptionLink>
+          ,{" "}
+          <ItemDescriptionLink to="/docs/how-gatsby-works-with-github-pages/">
+            GitHub Pages
+          </ItemDescriptionLink>
+          ,{" "}
+          <ItemDescriptionLink to="/tutorial/part-one/#--deploying-a-gatsby-site">
+            Surge.sh
+          </ItemDescriptionLink>
+          ,{" "}
+          <ItemDescriptionLink to="/docs/deploying-to-aerobatic/">
+            Aerobatic
+          </ItemDescriptionLink>
+          ,{" "}
+          <ItemDescriptionLink to="/docs/deploying-to-now/">
+            Now.sh
+          </ItemDescriptionLink>
+          , & many more
         </ItemDescription>
       </div>
     </Segment>

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -230,128 +230,132 @@ const Gatsby = ({ children }) => (
 )
 
 const Diagram = () => (
-  <section
-    className="Diagram"
-    css={{
-      borderRadius: presets.radiusLg,
-      fontFamily: options.headerFontFamily.join(`,`),
-      padding: vP,
-      marginTop: rhythm(1),
-      textAlign: `center`,
-      borderTopLeftRadius: 0,
-      borderTopRightRadius: 0,
-      flex: `1 1 100%`,
-      borderTop: `1px solid ${colors.ui.light}`,
-      [presets.Tablet]: {
-        marginTop: 0,
-      },
-    }}
-  >
-    <h1 css={{ marginBottom: rhythm(1.5), ...scale(0.9) }}>How Gatsby works</h1>
-    <div css={{ maxWidth: rhythm(20), margin: `0 auto ${rhythm(2)}` }}>
-      <FuturaParagraph>
-        Gatsby lets you build blazing fast sites with <em>your data</em>,
-        whatever the source. Liberate your sites from legacy CMSs and fly into
-        the future.
-      </FuturaParagraph>
-    </div>
-
-    <Segment className="Source">
-      <SegmentTitle>Data Sources</SegmentTitle>
-      <SourceItems>
-        <SourceItem>
-          <ItemTitle>CMSs</ItemTitle>
-          <ItemDescription>Contentful, Drupal, WordPress, etc.</ItemDescription>
-        </SourceItem>
-        <SourceItem>
-          <ItemTitle>Markdown</ItemTitle>
-          <ItemDescription>Documentation, Posts, etc.</ItemDescription>
-        </SourceItem>
-        <SourceItem>
-          <ItemTitle>Data</ItemTitle>
-          <ItemDescription>
-            APIs, Databases, YAML, JSON, CSV, etc.
-          </ItemDescription>
-        </SourceItem>
-      </SourceItems>
-    </Segment>
-
-    <Segment className="Build">
-      <VerticalLine />
-      <SegmentTitle>Build</SegmentTitle>
-      <div
+  <StaticQuery
+    query={graphql`
+      query StaticHostsQuery {
+        allStaticHostsYaml {
+          edges {
+            node {
+              title
+              url
+            }
+          }
+        }
+      }
+    `}
+    render={({ allStaticHostsYaml: { edges: staticHosts } }) => (
+      <section
+        className="Diagram"
         css={{
-          ...box,
-          ...stripeBg,
-          paddingTop: 0,
-          paddingBottom: 0,
+          borderRadius: presets.radiusLg,
+          fontFamily: options.headerFontFamily.join(`,`),
+          padding: vP,
+          marginTop: rhythm(1),
+          textAlign: `center`,
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          flex: `1 1 100%`,
+          borderTop: `1px solid ${colors.ui.light}`,
+          [presets.Tablet]: {
+            marginTop: 0,
+          },
         }}
       >
-        <VerticalLine />
-        <Gatsby />
-        <VerticalLine />
-        <div
-          css={{
-            ...borderAndBoxShadow,
-            ...boxPadding,
-            paddingTop: rhythm(1 / 2),
-            paddingBottom: rhythm(1 / 2),
-            width: `auto`,
-            display: `inline-block`,
-          }}
-        >
-          <ItemDescription>
-            HTML &middot; CSS &middot;
-            {` `}
-            <TechWithIcon icon={ReactJSIcon} height="1.1em">
-              React
-            </TechWithIcon>
-          </ItemDescription>
+        <h1 css={{ marginBottom: rhythm(1.5), ...scale(0.9) }}>
+          How Gatsby works
+        </h1>
+        <div css={{ maxWidth: rhythm(20), margin: `0 auto ${rhythm(2)}` }}>
+          <FuturaParagraph>
+            Gatsby lets you build blazing fast sites with <em>your data</em>,
+            whatever the source. Liberate your sites from legacy CMSs and fly
+            into the future.
+          </FuturaParagraph>
         </div>
-        <VerticalLine />
-      </div>
-    </Segment>
 
-    <Segment className="Deploy">
-      <VerticalLine />
-      <SegmentTitle>Deploy</SegmentTitle>
-      <div
-        css={{
-          ...box,
-          paddingBottom: rhythm(1),
-        }}
-      >
-        <ItemTitle>Static Web Host</ItemTitle>
-        <ItemDescription>
-          <StaticQuery
-            query={graphql`
-              query StaticHostsQuery {
-                allStaticHostsYaml {
-                  edges {
-                    node {
-                      title
-                      url
-                    }
-                  }
-                }
-              }
-            `}
-            render={({ allStaticHostsYaml: { edges: staticHosts } }) =>
-              staticHosts.map(({ node: staticHost }) => (
+        <Segment className="Source">
+          <SegmentTitle>Data Sources</SegmentTitle>
+          <SourceItems>
+            <SourceItem>
+              <ItemTitle>CMSs</ItemTitle>
+              <ItemDescription>
+                Contentful, Drupal, WordPress, etc.
+              </ItemDescription>
+            </SourceItem>
+            <SourceItem>
+              <ItemTitle>Markdown</ItemTitle>
+              <ItemDescription>Documentation, Posts, etc.</ItemDescription>
+            </SourceItem>
+            <SourceItem>
+              <ItemTitle>Data</ItemTitle>
+              <ItemDescription>
+                APIs, Databases, YAML, JSON, CSV, etc.
+              </ItemDescription>
+            </SourceItem>
+          </SourceItems>
+        </Segment>
+
+        <Segment className="Build">
+          <VerticalLine />
+          <SegmentTitle>Build</SegmentTitle>
+          <div
+            css={{
+              ...box,
+              ...stripeBg,
+              paddingTop: 0,
+              paddingBottom: 0,
+            }}
+          >
+            <VerticalLine />
+            <Gatsby />
+            <VerticalLine />
+            <div
+              css={{
+                ...borderAndBoxShadow,
+                ...boxPadding,
+                paddingTop: rhythm(1 / 2),
+                paddingBottom: rhythm(1 / 2),
+                width: `auto`,
+                display: `inline-block`,
+              }}
+            >
+              <ItemDescription>
+                HTML &middot; CSS &middot;
+                {` `}
+                <TechWithIcon icon={ReactJSIcon} height="1.1em">
+                  React
+                </TechWithIcon>
+              </ItemDescription>
+            </div>
+            <VerticalLine />
+          </div>
+        </Segment>
+
+        <Segment className="Deploy">
+          <VerticalLine />
+          <SegmentTitle>Deploy</SegmentTitle>
+          <div
+            css={{
+              ...box,
+              paddingBottom: rhythm(1),
+            }}
+          >
+            <ItemTitle>Static Web Host</ItemTitle>
+            <ItemDescription>
+              {staticHosts.map(({ node: staticHost }, index) => (
                 <Fragment key={staticHost.url}>
+                  {index > 0 && ", "}
                   <ItemDescriptionLink to={staticHost.url}>
                     {staticHost.title}
                   </ItemDescriptionLink>
-                  {", "}
                 </Fragment>
-              ))
-            }
-          />
-          & many more
-        </ItemDescription>
-      </div>
-    </Segment>
-  </section>
+              ))}{" "}
+              & many more
+            </ItemDescription>
+          </div>
+        </Segment>
+      </section>
+    )}
+  />
 )
 
 export default Diagram

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -175,7 +175,7 @@ const ItemDescription = ({ children }) => (
 )
 
 const ItemDescriptionLink = ({ to, children }) => (
-  <Link css={{ "&&": { fontWeight: "normal" } }} to={to}>
+  <Link css={{ "&&": { fontWeight: `normal` } }} to={to}>
     {children}
   </Link>
 )
@@ -343,13 +343,13 @@ const Diagram = () => (
             <ItemDescription>
               {staticHosts.map(({ node: staticHost }, index) => (
                 <Fragment key={staticHost.url}>
-                  {index > 0 && ", "}
+                  {index > 0 && `, `}
                   <ItemDescriptionLink to={staticHost.url}>
                     {staticHost.title}
                   </ItemDescriptionLink>
                 </Fragment>
-              ))}{" "}
-              & many more
+              ))}
+              {` `}& many more
             </ItemDescription>
           </div>
         </Segment>

--- a/www/src/data/diagram/static-hosts.yml
+++ b/www/src/data/diagram/static-hosts.yml
@@ -5,7 +5,7 @@
 - title: GitHub Pages
   url: /docs/how-gatsby-works-with-github-pages/
 - title: Surge.sh
-  url: /tutorial/part-one/#--deploying-a-gatsby-site
+  url: /tutorial/part-one/#deploying-a-gatsby-site
 - title: Aerobatic
   url: /docs/deploying-to-aerobatic/
 - title: Now.sh

--- a/www/src/data/diagram/static-hosts.yml
+++ b/www/src/data/diagram/static-hosts.yml
@@ -1,0 +1,12 @@
+- title: Amazon S3
+  url: /docs/deploying-to-s3-cloudfront
+- title: Netlify
+  url: /docs/hosting-on-netlify
+- title: GitHub Pages
+  url: /docs/how-gatsby-works-with-github-pages/
+- title: Surge.sh
+  url: /tutorial/part-one/#--deploying-a-gatsby-site
+- title: Aerobatic
+  url: /docs/deploying-to-aerobatic/
+- title: Now.sh
+  url: /docs/deploying-to-now/


### PR DESCRIPTION
This PR links the static hosts in the home page's diagram to their associated doc page.

![image](https://user-images.githubusercontent.com/809093/47579496-fba63000-d900-11e8-8151-9e49dc215339.png)

Background: I was actually looking for documentation on how/where to deploy Gatsby and the first place I thought of was the home page (remembering the awesome diagram) but it wasn't linked, so I thought that would be a helpful tweak for others as well. 👌 

First PR to Gatsby! 🎉  Feedback and thoughts welcome.