### PR TITLE
fix typos in service worker docs and improve readability

### DIFF
--- a/docs/docs/add-a-service-worker.md
+++ b/docs/docs/add-a-service-worker.md
@@ -4,13 +4,11 @@ title: Add a Service Worker
 
 ### What is a service worker
 
-A service worker is a script that your browser runs in the background, separate from a web page, opening the door to features that don't need a web page or user interaction.They increase your site availability in spotty connections, and are essential to making a nice user experience.
-
-It supports features like push notifications and background sync.
+A service worker is a script that your browser runs in the background, separate from a web page, opening the door to features that don't need a web page or user interaction (such as push notifications or background sync). They increase your site availability in spotty connections and are essential to making a nice user experience.
 
 ### Using service workers in Gatsby with `gatsby-plugin-offline`
 
-Gatsby provides awesome plugin interface to create and load a service worker into your site [gatsby-plugin-offline](https://www.npmjs.com/package/gatsby-plugin-offline).
+Gatsby provides an awesome plugin interface to create and load a service worker into your site: [gatsby-plugin-offline](https://www.npmjs.com/package/gatsby-plugin-offline).
 
 We recommend using this plugin together with the [manifest plugin](https://www.npmjs.com/package/gatsby-plugin-manifest). (Don’t forget to list the offline plugin after the manifest plugin so that the manifest file can be included in the service worker).
 


### PR DESCRIPTION
This PR fixes a few minor typos in the service worker docs and improves the readability of the opening description.