### PR TITLE
feat(gatsby-source-contentful): adds CENTER option to ImageCropFocusType

### DIFF
--- a/packages/gatsby-source-contentful/src/schemes.js
+++ b/packages/gatsby-source-contentful/src/schemes.js
@@ -52,6 +52,7 @@ const ImageCropFocusType = new GraphQLEnumType({
     RIGHT: { value: `right` },
     LEFT: { value: `left` },
     FACES: { value: `faces` },
+    CENTER: { value: `center` },
   },
 })
 


### PR DESCRIPTION
Adds missing CENTER option to ImageCropFocusType for gatsby-source-contentful plugin.

Currently you get an error if you do something like

`resize(width:1024, height:400, cropFocus:CENTER)`

in a graphql query inside a component.

This will remove that error and pass the correct param to Contentful