### PR TITLE
Add TestingJavaScript.com to showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -3126,3 +3126,16 @@
   built_by: Wieden Kennedy
   built_by_url: https://www.wk.com/about/
   featured: false
+- title: Testing JavaScript
+  description: >
+    This course will teach you the fundamentals of testing your JavaScript applications using eslint, Flow, Jest, and Cypress.
+  url: https://testingjavascript.com/
+  main_url: https://testingjavascript.com/
+  categories:
+    - Learning
+    - Education
+    - Testing
+    - JavaScript
+  built_by: Kent C. Dodds
+  built_by_url: https://kentcdodds.com/
+  featured: false


### PR DESCRIPTION
From the latest [newsletter from Kent C. Dodds](https://buttondown.email/kentcdodds/archive/f4e72397-adb8-45e9-aefc-1f1f0239a478):

> **The number one question I get asked about TestingJavaScript.com**: I'm seeing an outdated version of the site! I don't see a "buy" button anywhere!!!
>
> The answer to this is simple and slightly embarrassing... Workbox (a library that Gatsby's offline plugin used) had a bug and your browser has it. We fixed the problem on the site, but there's no way for us to force your browser to update due to this bug. Try clearing the site data in your browser settings or use another browser.

Of interest here is the fact that it uses Gatsby, hence this pull request. :-)