### PR TITLE
Trigger CI unit tests if *any* commit changes `packages/` or `.circleci/`

### DIFF
--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 GREP_PATTERN=$1
 
-FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $CIRCLE_SHA1 | grep -E "$GREP_PATTERN" | wc -l)"
+FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $CIRCLE_BRANCH origin/master | grep -E "$GREP_PATTERN" | wc -l)"
 
 if [ $FILES_COUNT -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."


### PR DESCRIPTION
Trigger CI unit tests if *any* commit changes `packages/` or `.circleci/`, currently unit tests are triggered only if the last commit changes those folders.

Fixes #9476.