### PR TITLE
feat(gatsby-remark-graphviz): wrap svg in element so we can style it

### DIFF
--- a/packages/gatsby-remark-graphviz/README.md
+++ b/packages/gatsby-remark-graphviz/README.md
@@ -36,7 +36,7 @@ Then, add `dot` code blocks to your markdown. E.g
     }
     ```
 
-Which will be rendered using viz.js and the output html will replace the code block with the actual SVG.
+Which will be rendered using viz.js and the output html will replace the code block with the actual SVG wrapped in `<div class="gatsby-graphviz-container">`.
 
 ![rendered-graph](/packages/gatsby-remark-graphviz/rendered-graph.svg)
 

--- a/packages/gatsby-remark-graphviz/src/index.js
+++ b/packages/gatsby-remark-graphviz/src/index.js
@@ -28,7 +28,8 @@ module.exports = async ({ markdownAST }, pluginOptions = {}) => {
         // Mutate the current node. Converting from a code block to
         // HTML (with svg content)
         node.type = `html`
-        node.value = svgString
+        node.value =
+          `<div class="gatsby-graphviz-container"` + svgString`</div>`
       } catch (error) {
         console.log(
           `Error during viz.js execution. Leaving code block unchanged`

--- a/packages/gatsby-remark-graphviz/src/index.js
+++ b/packages/gatsby-remark-graphviz/src/index.js
@@ -28,8 +28,7 @@ module.exports = async ({ markdownAST }, pluginOptions = {}) => {
         // Mutate the current node. Converting from a code block to
         // HTML (with svg content)
         node.type = `html`
-        node.value =
-          `<div class="gatsby-graphviz-container"` + svgString + `</div>`
+        node.value = `<div class="gatsby-graphviz-container">${svgString}</div>`
       } catch (error) {
         console.log(
           `Error during viz.js execution. Leaving code block unchanged`

--- a/packages/gatsby-remark-graphviz/src/index.js
+++ b/packages/gatsby-remark-graphviz/src/index.js
@@ -29,7 +29,7 @@ module.exports = async ({ markdownAST }, pluginOptions = {}) => {
         // HTML (with svg content)
         node.type = `html`
         node.value =
-          `<div class="gatsby-graphviz-container"` + svgString`</div>`
+          `<div class="gatsby-graphviz-container"` + svgString + `</div>`
       } catch (error) {
         console.log(
           `Error during viz.js execution. Leaving code block unchanged`

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -348,6 +348,10 @@ const _options = {
       ".gatsby-resp-image-link + em a[href*='//']:after": {
         content: `" " url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20class='i-external'%20viewBox='0%200%2032%2032'%20width='14'%20height='14'%20fill='none'%20stroke='%23744C9E'%20stroke-linecap='round'%20stroke-linejoin='round'%20stroke-width='9.38%'%3E%3Cpath%20d='M14%209%20L3%209%203%2029%2023%2029%2023%2018%20M18%204%20L28%204%2028%2014%20M28%204%20L14%2018'/%3E%3C/svg%3E")`,
       },
+      ".gatsby-graphviz-container": {
+        maxWidth: `100%`,
+        height: `auto`,
+      },
     }
   },
 }


### PR DESCRIPTION
Added a wrapper for all `svg`'s generated by `gatsby-remark-graphviz` so they can be styled.
Added global styling for [www] that prevents graphs to be wider than viewport;

 Thank you to @pieh and @Yurickh for help. 

closes #9271 