### PR TITLE
fix(www): persist filters on showcase item click

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -136,7 +136,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
         <Layout
           location={parent.props.location}
           isModal={isModal}
-          modalBackgroundPath="/showcase"
+          modalBackgroundPath={parent.getExitLocation()}
           modalNext={() => parent.next(allSitesYaml)}
           modalPrevious={() => parent.previous(allSitesYaml)}
           modalNextLink={

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { navigate, graphql } from "gatsby"
+import qs from "qs"
 
 import ShowcaseDetails from "../components/showcase-details"
 
@@ -29,6 +30,7 @@ class ShowcaseTemplate extends React.Component {
     navigate(nextSite.fields.slug, {
       state: {
         isModal: location.state.isModal,
+        filters: location.state.filters,
       },
     })
   }
@@ -47,8 +49,27 @@ class ShowcaseTemplate extends React.Component {
     navigate(previousSite.fields.slug, {
       state: {
         isModal: location.state.isModal,
+        filters: location.state.filters,
       },
     })
+  }
+
+  /**
+   * @returns {string} - the URI that should be navigated to when the showcase details modal is closed
+   */
+  getExitLocation() {
+    if (
+      this.props.location.state &&
+      this.props.location.state.filters &&
+      Object.keys(this.props.location.state.filters).length
+    ) {
+      const queryString = qs.stringify({
+        filters: this.props.location.state.filters,
+      })
+      return `/showcase?${queryString}`
+    } else {
+      return `/showcase`
+    }
   }
 
   render() {

--- a/www/src/views/shared/thumbnail.js
+++ b/www/src/views/shared/thumbnail.js
@@ -5,7 +5,7 @@ import Img from "gatsby-image"
 import styles from "./styles"
 import presets from "../../utils/presets"
 
-const ThumbnailLink = ({ slug, image, title, children }) => {
+const ThumbnailLink = ({ slug, image, title, children, state }) => {
   let screenshot = false
 
   // site showcase
@@ -19,7 +19,7 @@ const ThumbnailLink = ({ slug, image, title, children }) => {
   return (
     <Link
       to={slug}
-      state={{ isModal: true }}
+      state={{ isModal: true, ...state }}
       css={{
         ...styles.withTitleHover,
         "&&": {

--- a/www/src/views/showcase/filtered-showcase.js
+++ b/www/src/views/showcase/filtered-showcase.js
@@ -148,7 +148,11 @@ class FilteredShowcase extends Component {
                   </div>
                 </ContentHeader>
 
-                <ShowcaseList items={items} count={this.state.sitesToShow} />
+                <ShowcaseList
+                  items={items}
+                  count={this.state.sitesToShow}
+                  filters={filters}
+                />
 
                 {this.state.sitesToShow < items.length && (
                   <Button

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -13,7 +13,7 @@ import GithubIcon from "react-icons/lib/go/mark-github"
 import LaunchSiteIcon from "react-icons/lib/md/launch"
 import FeaturedIcon from "../../assets/featured-sites-icons--white.svg"
 
-const ShowcaseList = ({ items, count }) => {
+const ShowcaseList = ({ items, count, filters }) => {
   if (count) items = items.slice(0, count)
 
   return (
@@ -32,6 +32,7 @@ const ShowcaseList = ({ items, count }) => {
                 slug={node.fields.slug}
                 image={node.childScreenshot}
                 title={node.title}
+                state={{ filters }}
               >
                 <strong className="title">{node.title}</strong>
               </ThumbnailLink>


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
This should close #8069. 

**To test:**
1. Apply filters on the showcase view
2. Click a site from the filtered list
3. Close the details modal

**Expected Result:**
Filters applied in step 1 should still be applied

**Previous behavior:**
Filters would get reset

Feel free to make suggestions for improvements 🙂 This is my first Gatsby PR.
