### PR TITLE
Update doc-links.yaml

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -94,10 +94,8 @@
               link: /docs/sourcing-from-wordpress/
             - title: Sourcing from Drupal
               link: /docs/sourcing-from-drupal/
-            - title: Sourcing from Contentful*
+            - title: Sourcing from Contentful
               link: /docs/sourcing-from-contentful/
-            - title: Sourcing from Prose*
-              link: /docs/sourcing-from-prose/
     - title: Querying your data with GraphQL
       link: /docs/graphql/
       items:


### PR DESCRIPTION
Removing Prose because it's not a major CMS. Contentful article is not a stub anymore.