### PR TITLE
Docs - Clarify how to pass state with Link

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -76,6 +76,26 @@ render () {
 ```
 
 Using `replace` also won't scroll the page after navigation.
+## Passing props to Link targets 
+
+Sometimes you'll want to pass "props/state" from the source page to the page being linked to. You can do this by passing a **state** prop to the Link component or call to navigate function. The target component will have a prop called *location* white a child called *state* which will have to contents you passed. 
+
+```jsx
+const NewsFeed = () => (
+  <div>
+    <Link to="photos/123" state={{ fromFeed: true }} />
+  </div>
+)
+
+const Photo = ({ location, photoId }) => {
+  if (location.state.fromFeed) {
+    return <FromFeedPhoto id={photoId} />
+  } else {
+    return <Photo id={photoId} />
+  }
+}
+```
+
 
 ## Programmatic navigation
 

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -76,9 +76,10 @@ render () {
 ```
 
 Using `replace` also won't scroll the page after navigation.
-## Passing props to Link targets 
 
-Sometimes you'll want to pass "props/state" from the source page to the page being linked to. You can do this by passing a **state** prop to the Link component or call the navigate function. The target component will have a prop called *location* with a child called *state* which will have the contents you passed. 
+## Passing props to Link targets
+
+Sometimes you'll want to pass data from the source page to the linked page. You can do this by passing a `state` prop to the `Link` component or on a call to the `navigate` function. The linked page will have a `location` prop containing a nested `state` object structure containing the passed data.
 
 ```jsx
 const NewsFeed = () => (

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -78,7 +78,7 @@ render () {
 Using `replace` also won't scroll the page after navigation.
 ## Passing props to Link targets 
 
-Sometimes you'll want to pass "props/state" from the source page to the page being linked to. You can do this by passing a **state** prop to the Link component or call to navigate function. The target component will have a prop called *location* white a child called *state* which will have to contents you passed. 
+Sometimes you'll want to pass "props/state" from the source page to the page being linked to. You can do this by passing a **state** prop to the Link component or call the navigate function. The target component will have a prop called *location* with a child called *state* which will have the contents you passed. 
 
 ```jsx
 const NewsFeed = () => (


### PR DESCRIPTION
I was puzzled with how to pass state/props using a Link component or the navigate function. 
Eventually I managed to grok it out of the v1->v2 migration guide,  and copied it over to link documentation.

