### PR TITLE
Update doc-links.yaml to remove stub

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -187,7 +187,7 @@
       items:
         - title: Client data fetching*
           link: /docs/client-data-fetching/
-        - title: Building a site with authentication*
+        - title: Building a site with authentication
           link: /docs/building-a-site-with-authentication/
         - title: Building an e-commerce site*
           link: /docs/building-an-e-commerce-site/


### PR DESCRIPTION
Building a site with authentication is no longer a stub, removing * from doc-links.yaml for this article.