### PR TITLE
Fix(www): Containter component may have class: 'undefined'.

### DIFF
--- a/www/src/components/container.js
+++ b/www/src/components/container.js
@@ -5,7 +5,7 @@ import { rhythm, options } from "../utils/typography"
 
 const Container = ({
   children,
-  className,
+  className = "",
   hasSideBar = true,
   overrideCSS = {},
 }) => (


### PR DESCRIPTION
Set `className` default value to be an empty string, so `undefined` won't appear in HTML code if `className` isn't passed in props.