### PR TITLE
Blog starter kit with i18n support

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1049,6 +1049,18 @@
     - Features a custom, accessible lightbox with gatsby-image
     - Styled with styled-components using CSS Grid
     - React Helmet for SEO
+- url: https://stoic-swirles-4bd808.netlify.com/
+  repo: https://github.com/cardiv/gatsby-starter-antd
+  description: Gatsby's default starter configured for use with the Antd component library, modular imports and less.
+  tags:
+    - Antd
+    - Styling:Less
+  features:
+    - Fork of Gatsby's default starter
+    - React Helmet, Manifest and offline support retained
+    - Antd component library pre-installed
+    - Uses gatsby-plugin-antd for modular imports
+    - Customize the theme of Antd with `modifyVars`
 - url: http://jackbravo.github.io/gatsby-starter-i18n-blog/
   repo: https://github.com/jackbravo/gatsby-starter-i18n-blog
   description: Same as official gatsby-starter-blog but with i18n support

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1049,15 +1049,12 @@
     - Features a custom, accessible lightbox with gatsby-image
     - Styled with styled-components using CSS Grid
     - React Helmet for SEO
-- url: https://stoic-swirles-4bd808.netlify.com/
-  repo: https://github.com/cardiv/gatsby-starter-antd
-  description: Gatsby's default starter configured for use with the Antd component library, modular imports and less.
+- url: http://jackbravo.github.io/gatsby-starter-i18n-blog/
+  repo: https://github.com/jackbravo/gatsby-starter-i18n-blog
+  description: Same as official gatsby-starter-blog but with i18n support
   tags:
-    - Antd
-    - Styling:Less
+    - i18n
+    - Blog
   features:
-    - Fork of Gatsby's default starter
-    - React Helmet, Manifest and offline support retained
-    - Antd component library pre-installed
-    - Uses gatsby-plugin-antd for modular imports
-    - Customize the theme of Antd with `modifyVars`
+    - Translates site name and bio using .md files
+    - No extra libraries needed


### PR DESCRIPTION
This is the same official blog-starter-kit but with with i18n support. It doesn't use any external libraries like rect-intl, instead it relies on getting translations for things like the bio or site title from .md files. The philosophy is that the source-content (the CMS or in this case .md files) is the one that provides translations.

The example site is here:
https://jackbravo.github.io/gatsby-starter-i18n-blog/
And the repo here: https://github.com/jackbravo/gatsby-starter-i18n-blog