### PR TITLE
Fix consistency with "and" rather than ampersands and usage of serial…

### DIFF
--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -84,7 +84,7 @@ class IndexRoute extends React.Component {
                       Gatsby’s rich data plugin ecosystem lets you build sites
                       with the data you want — from one or many sources: Pull
                       data from headless CMSs, SaaS services, APIs, databases,
-                      your file system & more directly into your pages using
+                      your file system, and more directly into your pages using
                       {` `}
                       <TechWithIcon icon={GraphQLIcon}>GraphQL</TechWithIcon>.
                     </FuturaParagraph>


### PR DESCRIPTION
… commas

Everywhere in the home page uses serial commas and the word "and" instead of an ampersand. This commit normalizes the one usage of an ampersand lacking a serial comma.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
