### PR TITLE
Feat(gatsby-source-drupal): Added rateLimit to prevent ECONNREFUSED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ node_modules/
 
 # IDE specific
 .idea/
+*.iml
 .vscode/
 *.sw*
 

--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -13,6 +13,9 @@ https://using-drupal.gatsbyjs.org/
 jsonapi used by your Drupal instance. The default value is `jsonapi`, which has
 been used since jsonapi version `8.x-1.0-alpha4`.
 
+`rateLimit` Option allows setting a request rate limit if Drupal sits on a 
+server with DDOS prevention enabled.
+
 ## Install
 
 `npm install --save gatsby-source-drupal`
@@ -27,6 +30,7 @@ plugins: [
     options: {
       baseUrl: `https://live-contentacms.pantheonsite.io/`,
       apiBase: `api`, // optional, defaults to `jsonapi`
+      rateLimit: 1000, // optional, ignored by default
     },
   },
 ]

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -23,7 +23,7 @@ jest.mock(`axios`, () => {
         },
         interceptors: {
           request: {
-            use: fn => fn,
+            use: fn => fn(),
           },
         },
       }

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -45,7 +45,7 @@ describe(`gatsby-source-drupal`, () => {
       },
     }
 
-    await sourceNodes(args, { baseUrl: `http://fixture`, rateLimit: 500, })
+    await sourceNodes(args, { baseUrl: `http://fixture`, rateLimit: 500 })
   })
 
   it(`Generates nodes`, () => {

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -9,6 +9,25 @@ jest.mock(`axios`, () => {
         return null
       }
     },
+    create: path => {
+      return {
+        get: path => {
+          const last = path.split(`/`).pop()
+          try {
+            return { data: require(`./fixtures/${last}.json`) }
+          }
+          catch (e) {
+            console.log(`Error`, e)
+            return null
+          }
+        },
+        interceptors: {
+          request: {
+            use: fn => fn,
+          },
+        },
+      }
+    },
   }
 })
 
@@ -26,7 +45,7 @@ describe(`gatsby-source-drupal`, () => {
       },
     }
 
-    await sourceNodes(args, { baseUrl: `http://fixture` })
+    await sourceNodes(args, { baseUrl: `http://fixture`, rateLimit: 500, })
   })
 
   it(`Generates nodes`, () => {

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -31,7 +31,7 @@ exports.sourceNodes = async (
   console.log(`Starting to fetch data from Drupal`)
 
   // Create axiosClient on baseUrl.
-  const axiosClient = axios.create({ baseURL: `${baseUrl}`, })
+  const axiosClient = axios.create({ baseURL: `${baseUrl}` })
 
   // Do we have a rate limit? Then apply.
   if (rateLimit) {


### PR DESCRIPTION
I ran into a similar Problem like the already closed issue #3998 for gatsby-source-wordpress
(hosting provider using a DDOS prevention module, in this case mod_qos for apache),
leading to "mod_qos(010): access denied, QS_LocRequestLimit*" errors on the
server and resulting in **ECONNREFUSED** or **socket closed** failures for 
`gatsby develop` & `gatsby build` as well as the often cited
`warning The gatsby-source-drupal plugin has generated no Gatsby nodes. Do you need it?`.

I therefore added an option `rateLimit` and replaced the calls to `axios.get()` with an 
`axios.create()` Client call and added a `rateLimiter` request interceptor.

The tests are running through, only the coverage fell from 90% line to 89% (I didn't know how
to handle the `setTimeout()` call).