### PR TITLE
Extend the docs on `sourceNodes`

### DIFF
--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -78,7 +78,12 @@ exports.createPages = true
 exports.createPagesStatefully = true
 
 /**
- * Extension point to tell plugins to source nodes.
+ * Extension point to tell plugins to source nodes. This API is called during
+ * the Gatsby bootstrap sequence. Source plugins use this hook to create nodes.
+ * This API is called exactly once per plugin (and once for your site's
+ * `gatsby-config.js` file). If you define this hook in `gatsby-config.js` it
+ * will be called exactly once after all of your source plugins have finished
+ * creating nodes.
  *
  * See also the documentation for [`createNode`](/docs/actions/#createNode).
  * @example


### PR DESCRIPTION
Expanding the docs to be a bit more verbose and explain in more depth what this API does. Based on a discussion with @pieh.