### PR TITLE
Minor Readme Link Clean Up 

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ Already have a Gatsby site? These handy guides will help you add the improvement
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community! :muscle::purple_heart:
 
-Check out our [Contributing Guide**](https://gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repositories up and running on your local machine.
+Check out our [**Contributing Guide**](https://gatsbyjs.org/docs/how-to-contribute/) for ideas on contributing and setup steps for getting our repositories up and running on your local machine.
 
 
 ### Code of Conduct
 
-Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [Code of Conduct**](https://gatsbyjs.org/docs/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
+Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [**Code of Conduct**](https://gatsbyjs.org/docs/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
 
 
 ### A note on how this repository is organized


### PR DESCRIPTION
Hi, I was just reading over your documentation as I am working on learning Gatsby and I noticed a couple of things. I hope this is ok (this is my first time contributing to this project), but I found the project really cool and wanted to share a suggestion since you already have such good documentation. :)

Double links in the Contribution and Conduct sections were confusing. I am suggesting replacing them with a single link in each case (in the context of the sentence, but bolded).

This is particularly true for the contributing section as it previously had two links to the same place, but referred to them as two different things ("contributor onboarding docs" and "Contributing Guide").
Changing "contributor onboarding docs" to "Contributing Guide" is easier to understand and more efficient. As such, it seemed redundant to have two "Contributing Guide" links one after the other so the one in context was kept.
A similar situation was present in the conduct section as well in which two identically named links were right next to each other. The link in context was kept.

It might be noted there is a similar set-up in the "Learn Gatsby", but those links were in a more complex sentence structure and the simplified bottom links read more as a TLDR in a way the two changed here did not.