### PR TITLE
Add getambassador.io to showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -3154,3 +3154,15 @@
   built_by: Gabe Ragland
   built_by_url: https://twitter.com/gabe_ragland
   featured: false
+- title: Ambassador
+  url: https://www.getambassador.io
+  main_url: https://www.getambassador.io
+  description: >
+    Open source, Kubernetes-native API Gateway for microservices built on Envoy.
+  categories:
+    - Open Source
+    - Documentation
+    - Technology
+  built_by: Datawire
+  built_by_url: https://www.datawire.io
+  featured: false


### PR DESCRIPTION
Adds the documentation site for the Ambassador API gateway to the Gatbsy Showcase.