### PR TITLE
fix(gatsby): detect additional 404 page locations when performing canonical path redirects

### DIFF
--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -64,14 +64,24 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   }
 
   const { page, location: browserLoc } = window
-  // TODO: comment what this check does
   if (
+    // Make sure the window.page object is defined
     page &&
-    page.path !== `/404.html` &&
+
+    // The canonical path doesn't match the actual path (i.e. the address bar)
     __PATH_PREFIX__ + page.path !== browserLoc.pathname &&
-    !page.path.match(/^\/offline-plugin-app-shell-fallback\/?$/) &&
+
+    // ...and if matchPage is specified, it also doesn't match the actual path
     (!page.matchPath ||
-      !match(__PATH_PREFIX__ + page.matchPath, browserLoc.pathname))
+      !match(__PATH_PREFIX__ + page.matchPath, browserLoc.pathname)) &&
+
+    // Ignore 404 pages, since we want to keep the same URL
+    page.path !== `/404.html` &&
+    !page.path.match(/^\/404\/?$/) &&
+
+    // Also ignore the offline shell (since when using the offline plugin, all
+    // pages have this canonical path)
+    !page.path.match(/^\/offline-plugin-app-shell-fallback\/?$/)
   ) {
     navigate(
       __PATH_PREFIX__ + page.path + browserLoc.search + browserLoc.hash,


### PR DESCRIPTION
Fixes the problem reported by @lipis in #7943

I've also reordered and commented all the checks so it makes more sense to someone unfamiliar