### PR TITLE
docs: add missing eslint-plugin-node plugin to eslint docs

### DIFF
--- a/docs/docs/eslint.md
+++ b/docs/docs/eslint.md
@@ -16,7 +16,7 @@ npm rm prettier
 
 # Install ESLint and its packages
 npm install --save-dev eslint babel-eslint \
-  eslint-config-standard \
+  eslint-config-standard eslint-plugin-node \
   eslint-plugin-standard eslint-plugin-react \
   eslint-plugin-import eslint-plugin-promise \
 ```


### PR DESCRIPTION
The eslint-plugin-node is required for the recommended eslintrc configuration, but it's not listed in the installation instructions. Without this change, running eslint results in the error `Failed to load plugin node: Cannot find module 'eslint-plugin-node'`.