### PR TITLE
keep original name of remote files along with hash

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/utils.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/utils.js
@@ -1,14 +1,15 @@
-const { getRemoteFileExtension } = require(`../utils`)
+const { getRemoteFileExtension, getRemoteFileName } = require(`../utils`)
 
 describe(`create remote file node`, () => {
-  it(`can correctly retrieve files extensions`, () => {
+  it(`can correctly retrieve file name and extensions`, () => {
     [
-      [`https://scontent.xx.fbcdn.net/v/t51.2885-15/42078503_294439751160571_1602896118583132160_n.jpg?_nc_cat=101&oh=e30490a47409051c45dc3daacf616bc0&oe=5C5EA8EB`, `.jpg`],
-      [`https://facebook.com/hello,_world_asdf12341234.jpeg?test=true&other_thing=also-true`, `.jpeg`],
-      [`https://test.com/asdf.png`, `.png`],
-      [`./path/to/relative/file.tiff`, `.tiff`],
-      [`/absolutely/this/will/work.bmp`, `.bmp`],
-    ].forEach(([url, ext]) => {
+      [`https://scontent.xx.fbcdn.net/v/t51.2885-15/42078503_294439751160571_1602896118583132160_n.jpg?_nc_cat=101&oh=e30490a47409051c45dc3daacf616bc0&oe=5C5EA8EB`, `42078503_294439751160571_1602896118583132160_n`,`.jpg`],
+      [`https://facebook.com/hello,_world_asdf12341234.jpeg?test=true&other_thing=also-true`, `hello,_world_asdf12341234`, `.jpeg`],
+      [`https://test.com/asdf.png`, `asdf`, `.png`],
+      [`./path/to/relative/file.tiff`, `file`, `.tiff`],
+      [`/absolutely/this/will/work.bmp`, `work`, `.bmp`],
+    ].forEach(([url, name, ext]) => {
+      expect(getRemoteFileName(url)).toBe(name)
       expect(getRemoteFileExtension(url)).toBe(ext)
     })
   })

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -6,7 +6,7 @@ const { isWebUri } = require(`valid-url`)
 const Queue = require(`better-queue`)
 
 const { createFileNode } = require(`./create-file-node`)
-const { getRemoteFileExtension } = require(`./utils`)
+const { getRemoteFileExtension, getRemoteFileName } = require(`./utils`)
 const cacheId = url => `create-remote-file-node-${url}`
 
 /********************
@@ -196,10 +196,11 @@ async function processRemoteNode({
 
   // Create the temp and permanent file names for the url.
   const digest = createHash(url)
+  const name = getRemoteFileName(url)
   const ext = getRemoteFileExtension(url)
 
   const tmpFilename = createFilePath(programDir, `tmp-${digest}`, ext)
-  const filename = createFilePath(programDir, digest, ext)
+  const filename = createFilePath(programDir, `${digest}_${name}`, ext)
 
   // Fetch the file.
   try {

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -13,3 +13,16 @@ const Url = require(`url`)
 export function getRemoteFileExtension(url) {
   return path.parse(Url.parse(url).pathname).ext
 }
+
+/**
+ * getRemoteFileName
+ * --
+ * Parses remote url to retrieve remote file name
+ *
+ *
+ * @param  {String}          url
+ * @return {String}          filename
+ */
+export function getRemoteFileName(url) {
+  return path.parse(Url.parse(url).pathname).name
+}


### PR DESCRIPTION
This PR is to enhance `createRemoteFileNode` to retain the filename of the remote file. Additional details in #9539 and [https://github.com/angeloashmore/gatsby-source-prismic/issues/40](https://github.com/angeloashmore/gatsby-source-prismic/issues/40)
