### PR TITLE
fix(gatsby-plugin-offline): don't precache the index page

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -53,7 +53,6 @@ exports.onPostBuild = (args, pluginOptions) => {
 
   const criticalFilePaths = _.uniq(
     _.concat(
-      getResourcesFromHTML(`${process.cwd()}/${rootDir}/index.html`),
       getResourcesFromHTML(`${process.cwd()}/${rootDir}/404.html`),
       getResourcesFromHTML(
         `${process.cwd()}/${rootDir}/offline-plugin-app-shell-fallback/index.html`
@@ -62,7 +61,6 @@ exports.onPostBuild = (args, pluginOptions) => {
   ).map(omitPrefix)
 
   const globPatterns = files.concat([
-    `index.html`,
     `offline-plugin-app-shell-fallback/index.html`,
     ...criticalFilePaths,
   ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,13 +2928,6 @@ babel-plugin-lodash@^3.2.11:
     lodash "^4.17.10"
     require-package-name "^2.0.1"
 
-babel-plugin-macros@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.0.tgz#6c5f9836e1f6c0a9743b3bab4af29f73e437e544"
-  integrity sha512-flIBfrqAdHWn+4l2cS/4jZEyl+m5EaBHVzTb0aOF+eu/zR7E41/MoCFHPhDNL8Wzq1nyelnXeT+vcL2byFLSZw==
-  dependencies:
-    cosmiconfig "^5.0.5"
-
 babel-plugin-macros@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz#21b1a2e82e2130403c5ff785cba6548e9b644b28"
@@ -11329,6 +11322,11 @@ json-stable-stringify@^1.0.0:
   integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
   dependencies:
     jsonify "~0.0.0"
+
+json-stream-stringify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/json-stream-stringify/-/json-stream-stringify-2.0.1.tgz#8bc0e65ff94567d9010e14c27c043a951cb14939"
+  integrity sha512-5XymtJXPmzRWZ1UdLQQQXbjHV/E7NAanSClikEqORbkZKOYLSYLNHqRuooyju9W90kJUzknFhX2xvWn4cHluHQ==
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Fixes #7997

Rationale: we don't need to precache the index page, because the offline plugin automatically caches resources it finds in the `<head>` of the page it was installed on. So it just means that resources are cached a little later.