### PR TITLE
feat(www): add 'lead' animation to the Ecosystem horizontal scrollers

### DIFF
--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -88,7 +88,6 @@ class EcosystemBoard extends Component {
       icons: { plugins: PluginsIcon, starters: StartersIcon },
       starters,
       plugins,
-      background,
     } = this.props
 
     return (

--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -53,7 +53,7 @@ class EcosystemBoard extends Component {
       if (entry.intersectionRatio > 0) {
         setTimeout(
           () => this.turnOnLeadScroll({ target, duration: 1000, distance: 20 }),
-          500
+          250
         )
         this.observer.unobserve(target)
       }

--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Component } from "react"
 import PropTypes from "prop-types"
 import styled from "react-emotion"
 
@@ -20,46 +20,115 @@ const EcosystemBoardRoot = styled(`div`)`
   }
 `
 
-const EcosystemBoard = ({
-  icons: { plugins: PluginsIcon, starters: StartersIcon },
-  starters,
-  plugins,
-}) => (
-  <EcosystemBoardRoot>
-    <EcosystemSection
-      title="Plugins"
-      description="Plugins are packages that extend Gatsby sites. They can source content, transform data, and more!"
-      subTitle="Featured Plugins"
-      icon={PluginsIcon}
-      links={[
-        { label: `Browse Plugins`, to: `/plugins/` },
-        {
-          label: `Plugin Authoring`,
-          to: `/docs/plugin-authoring/`,
-          secondary: true,
-        },
-        { label: `Plugin Docs`, to: `/docs/plugins/`, secondary: true },
-      ]}
-      featuredItems={plugins}
-    />
-    <EcosystemSection
-      title="Starters"
-      description="Starters are Gatsby sites that are preconfigured for different use cases to give you a head start for your project."
-      subTitle="Featured Starters"
-      icon={StartersIcon}
-      links={[
-        { label: `Browse Starters`, to: `/starters/` },
-        { label: `Starter Docs`, to: `/docs/starters/`, secondary: true },
-      ]}
-      featuredItems={starters}
-    />
-    <EcosystemSection
-      title="External Resources"
-      description="A curated list of interesting Gatsby community projects and learning resources like podcasts and tutorials."
-      links={[{ label: `Browse Resources`, to: `/docs/awesome-gatsby/` }]}
-    />
-  </EcosystemBoardRoot>
-)
+class EcosystemBoard extends Component {
+  observer
+  observerTargets = []
+
+  componentDidMount() {
+    if (typeof window.IntersectionObserver !== "undefined") {
+      this.setupObserver()
+    }
+  }
+
+  componentWillUnmount() {
+    if (typeof window.IntersectionObserver !== "undefined") {
+      this.observerTargets.forEach(target => this.observer.unobserve(target))
+    }
+  }
+
+  setupObserver = () => {
+    const options = { rootMargin: "0px", threshold: [1] }
+    this.observer = new IntersectionObserver(this.handleIntersect, options)
+    this.observerTargets = Array.from(
+      document.querySelectorAll(".featuredItems")
+    )
+
+    this.observerTargets.forEach(target => this.observer.observe(target))
+  }
+
+  handleIntersect = (entries, observer) => {
+    entries.forEach(entry => {
+      const target = entry.target
+
+      if (entry.intersectionRatio > 0) {
+        this.turnOnLeadScroll({ target, duration: 1000, distance: 20 })
+        this.observer.unobserve(target)
+      }
+    })
+  }
+
+  turnOnLeadScroll = ({ target, duration, distance }) => {
+    let startTime = null
+
+    function animation(currentTime) {
+      if (startTime === null) {
+        startTime = currentTime
+      }
+
+      const timeElapsed = currentTime - startTime
+      const getDistanceToScroll = ease(timeElapsed, 0, distance, duration)
+
+      target.scroll({ top: 0, left: getDistanceToScroll })
+
+      if (timeElapsed < duration) {
+        requestAnimationFrame(animation)
+      }
+    }
+
+    function ease(t, b, c, d) {
+      t /= d
+      return -c * t * (t - 2) + b
+    }
+
+    requestAnimationFrame(animation)
+  }
+
+  render() {
+    const {
+      icons: { plugins: PluginsIcon, starters: StartersIcon },
+      starters,
+      plugins,
+      background,
+    } = this.props
+
+    return (
+      <EcosystemBoardRoot>
+        <EcosystemSection
+          title="Plugins"
+          description="With 429 plugins, lorem ipsum sunt we need some proper copy here pulling in data from your favorite source is only a few mouseclicks away."
+          subTitle="Featured Plugins"
+          icon={PluginsIcon}
+          links={[
+            { label: "Browse Plugins", to: "/plugins/" },
+            {
+              label: "Plugin Authoring",
+              to: "/docs/plugin-authoring/",
+              secondary: true,
+            },
+            { label: "Plugin Docs", to: "/docs/plugins/", secondary: true },
+          ]}
+          featuredItems={plugins}
+        />
+        <EcosystemSection
+          title="Starters"
+          description="Starters are boilerplate Gatsby sites maintained by the community which give you a headstart for your Gatsby project."
+          subTitle="Featured Starters"
+          icon={StartersIcon}
+          links={[
+            { label: "Browse Starters", to: "/starters/" },
+            { label: "Starter Docs", to: "/docs/starters/", secondary: true },
+          ]}
+          featuredItems={starters}
+        />
+        <EcosystemSection
+          title="External Resources"
+          description="More awesome Gatsby content, created by the community."
+          links={[{ label: "Browse Resources", to: "/docs/awesome-gatsby/" }]}
+        />
+      </EcosystemBoardRoot>
+    )
+  }
+}
 
 EcosystemBoard.propTypes = {
   icons: PropTypes.object,

--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -25,22 +25,22 @@ class EcosystemBoard extends Component {
   observerTargets = []
 
   componentDidMount() {
-    if (typeof window.IntersectionObserver !== "undefined") {
+    if (typeof window.IntersectionObserver !== `undefined`) {
       this.setupObserver()
     }
   }
 
   componentWillUnmount() {
-    if (typeof window.IntersectionObserver !== "undefined") {
+    if (typeof window.IntersectionObserver !== `undefined`) {
       this.observerTargets.forEach(target => this.observer.unobserve(target))
     }
   }
 
   setupObserver = () => {
-    const options = { rootMargin: "0px", threshold: [1] }
+    const options = { rootMargin: `0px`, threshold: [1] }
     this.observer = new IntersectionObserver(this.handleIntersect, options)
     this.observerTargets = Array.from(
-      document.querySelectorAll(".featuredItems")
+      document.querySelectorAll(`.featuredItems`)
     )
 
     this.observerTargets.forEach(target => this.observer.observe(target))
@@ -99,13 +99,13 @@ class EcosystemBoard extends Component {
           subTitle="Featured Plugins"
           icon={PluginsIcon}
           links={[
-            { label: "Browse Plugins", to: "/plugins/" },
+            { label: `Browse Plugins`, to: `/plugins/` },
             {
-              label: "Plugin Authoring",
-              to: "/docs/plugin-authoring/",
+              label: `Plugin Authoring`,
+              to: `/docs/plugin-authoring/`,
               secondary: true,
             },
-            { label: "Plugin Docs", to: "/docs/plugins/", secondary: true },
+            { label: `Plugin Docs`, to: `/docs/plugins/`, secondary: true },
           ]}
           featuredItems={plugins}
         />
@@ -115,15 +115,15 @@ class EcosystemBoard extends Component {
           subTitle="Featured Starters"
           icon={StartersIcon}
           links={[
-            { label: "Browse Starters", to: "/starters/" },
-            { label: "Starter Docs", to: "/docs/starters/", secondary: true },
+            { label: `Browse Starters`, to: `/starters/` },
+            { label: `Starter Docs`, to: `/docs/starters/`, secondary: true },
           ]}
           featuredItems={starters}
         />
         <EcosystemSection
           title="External Resources"
           description="More awesome Gatsby content, created by the community."
-          links={[{ label: "Browse Resources", to: "/docs/awesome-gatsby/" }]}
+          links={[{ label: `Browse Resources`, to: `/docs/awesome-gatsby/` }]}
         />
       </EcosystemBoardRoot>
     )

--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -79,8 +79,7 @@ class EcosystemBoard extends Component {
     }
 
     function ease(t, b, c, d) {
-      t /= d
-      return -c * t * (t - 2) + b
+      return -c * (t /= d) * (t - 2) + b
     }
 
     requestAnimationFrame(animation)

--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -51,7 +51,10 @@ class EcosystemBoard extends Component {
       const target = entry.target
 
       if (entry.intersectionRatio > 0) {
-        this.turnOnLeadScroll({ target, duration: 1000, distance: 20 })
+        setTimeout(
+          () => this.turnOnLeadScroll({ target, duration: 1000, distance: 20 }),
+          500
+        )
         this.observer.unobserve(target)
       }
     })

--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -96,7 +96,7 @@ class EcosystemBoard extends Component {
       <EcosystemBoardRoot>
         <EcosystemSection
           title="Plugins"
-          description="With 429 plugins, lorem ipsum sunt we need some proper copy here pulling in data from your favorite source is only a few mouseclicks away."
+          description="Plugins are packages that extend Gatsby sites. They can source content, transform data, and more!"
           subTitle="Featured Plugins"
           icon={PluginsIcon}
           links={[
@@ -112,7 +112,7 @@ class EcosystemBoard extends Component {
         />
         <EcosystemSection
           title="Starters"
-          description="Starters are boilerplate Gatsby sites maintained by the community which give you a headstart for your Gatsby project."
+          description="Starters are Gatsby sites that are preconfigured for different use cases to give you a head start for your project."
           subTitle="Featured Starters"
           icon={StartersIcon}
           links={[
@@ -123,7 +123,7 @@ class EcosystemBoard extends Component {
         />
         <EcosystemSection
           title="External Resources"
-          description="More awesome Gatsby content, created by the community."
+          description="A curated list of interesting Gatsby community projects and learning resources like podcasts and tutorials."
           links={[{ label: `Browse Resources`, to: `/docs/awesome-gatsby/` }]}
         />
       </EcosystemBoardRoot>

--- a/www/src/components/ecosystem/ecosystem-featured-items.js
+++ b/www/src/components/ecosystem/ecosystem-featured-items.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import styled, { keyframes } from "react-emotion"
+import styled from "react-emotion"
 
 import EcosystemFeaturedItem from "./ecosystem-featured-item"
 

--- a/www/src/components/ecosystem/ecosystem-featured-items.js
+++ b/www/src/components/ecosystem/ecosystem-featured-items.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import styled from "react-emotion"
+import styled, { keyframes } from "react-emotion"
 
 import EcosystemFeaturedItem from "./ecosystem-featured-item"
 
@@ -11,6 +11,7 @@ import { scrollbarStyles } from "../../utils/styles"
 const EcosystemFeaturedItemsRoot = styled(`div`)`
   overflow-x: scroll;
   margin: ${rhythm(0.1)} -${rhythm(options.blockMarginBottom)};
+  -webkit-overflow-scrolling: touch;
 
   ${presets.Tablet} {
     border-top: 1px solid ${colors.gray.superLight};
@@ -33,25 +34,31 @@ const List = styled(`ul`)`
     flex-direction: column;
     padding: 0;
     width: 100%;
+
+    .leadAnimation & {
+      animation: none;
+    }
   }
 `
 
-const EcosystemFeaturedItems = ({ items }) => (
-  <EcosystemFeaturedItemsRoot>
-    <List numberOfItems={items.length}>
-      {items.map(item => {
-        const { slug } = item
-        return (
-          <EcosystemFeaturedItem
-            key={slug}
-            item={item}
-            numberOfItems={items.length}
-          />
-        )
-      })}
-    </List>
-  </EcosystemFeaturedItemsRoot>
-)
+const EcosystemFeaturedItems = ({ items }) => {
+  return (
+    <EcosystemFeaturedItemsRoot className="featuredItems">
+      <List numberOfItems={items.length}>
+        {items.map(item => {
+          const { slug } = item
+          return (
+            <EcosystemFeaturedItem
+              key={slug}
+              item={item}
+              numberOfItems={items.length}
+            />
+          )
+        })}
+      </List>
+    </EcosystemFeaturedItemsRoot>
+  )
+}
 
 EcosystemFeaturedItems.propTypes = {
   items: PropTypes.array,

--- a/www/src/components/ecosystem/ecosystem-featured-items.js
+++ b/www/src/components/ecosystem/ecosystem-featured-items.js
@@ -34,10 +34,6 @@ const List = styled(`ul`)`
     flex-direction: column;
     padding: 0;
     width: 100%;
-
-    .leadAnimation & {
-      animation: none;
-    }
   }
 `
 

--- a/www/src/components/ecosystem/ecosystem-featured-items.js
+++ b/www/src/components/ecosystem/ecosystem-featured-items.js
@@ -41,24 +41,22 @@ const List = styled(`ul`)`
   }
 `
 
-const EcosystemFeaturedItems = ({ items }) => {
-  return (
-    <EcosystemFeaturedItemsRoot className="featuredItems">
-      <List numberOfItems={items.length}>
-        {items.map(item => {
-          const { slug } = item
-          return (
-            <EcosystemFeaturedItem
-              key={slug}
-              item={item}
-              numberOfItems={items.length}
-            />
-          )
-        })}
-      </List>
-    </EcosystemFeaturedItemsRoot>
-  )
-}
+const EcosystemFeaturedItems = ({ items }) => (
+  <EcosystemFeaturedItemsRoot className="featuredItems">
+    <List numberOfItems={items.length}>
+      {items.map(item => {
+        const { slug } = item
+        return (
+          <EcosystemFeaturedItem
+            key={slug}
+            item={item}
+            numberOfItems={items.length}
+          />
+        )
+      })}
+    </List>
+  </EcosystemFeaturedItemsRoot>
+)
 
 EcosystemFeaturedItems.propTypes = {
   items: PropTypes.array,


### PR DESCRIPTION
* ~install `intersection-observer` polyfill~
* refactor `ecosystem-board.js` to `class` component to manage IntersectionObserver
* setup `IntersectionObserver` to observe horizontal scrollers
* add style class with initial 'lead' animation

Video preview at Slack