### PR TITLE
fix(gatsby-plugin-layout): log uncaught errors in old browsers

### DIFF
--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -11,7 +11,9 @@ try {
         `Please create layout component in that location or specify path to layout component in gatsby-config.js`
     )
   } else {
-    console.error(e);
+    // Logging the error for debugging older browsers as there is no way
+    // to wrap the thrown error in a try/catch.
+    console.error(e)
     throw e
   }
 }

--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -11,6 +11,7 @@ try {
         `Please create layout component in that location or specify path to layout component in gatsby-config.js`
     )
   } else {
+    console.error(e);
     throw e
   }
 }


### PR DESCRIPTION
IE11 doesn't show the actual error, just `Error: Uncaugt error thrown` without any stack traces.

There is no way to implement try/catch around this as this module is the first entry point.

Adding an Error Boundary on the Layout component does not work.