### PR TITLE
Make local plugin resolution resilient to package.json files without a name field

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -45,11 +45,11 @@ function resolvePlugin(pluginName) {
         const packageJSON = JSON.parse(
           fs.readFileSync(`${resolvedPath}/package.json`, `utf-8`)
         )
-
+        const name = packageJSON.name || pluginName
         return {
           resolve: resolvedPath,
-          name: packageJSON.name || pluginName,
-          id: createNodeId(packageJSON.name, `Plugin`),
+          name,
+          id: createNodeId(name, `Plugin`),
           version:
             packageJSON.version || createFileContentHash(resolvedPath, `**`),
         }


### PR DESCRIPTION
Fixes #9559