### PR TITLE
Updates how-to-contribute docs

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -79,7 +79,7 @@ a pull request.
 
 - Clone the repo and navigate to `/www`
 - Run `yarn` to install all of the website's dependencies.
-- Run `gatsby develop` to preview the website in `http://localhost:8000`
+- Run `gatsby develop` to preview the website in `http://localhost:8000` or [try these settings](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot#placeholder-image) if it gets stuck processing.
 - Make any necessary documentation modifications or additions to the
   markdown files in `/docs`
 - Make sure to double check your grammar and capitalise correctly.


### PR DESCRIPTION
Recently I tried to run the instance of gatsby's website locally. 
By using `gatsby develop` in /www, unfortunately, it got stuck. Refer #9640 for more info.
Thanks to @DSchau he suggested trying `GATSBY_SCREENSHOT_PLACEHOLDER=true` to run the dev server. But for a new contributor, it's hard for him to figure this out. 

So I made some changes in the `how-to-contribute` docs. 
