### PR TITLE
[WIP]: feat: add script and circleci job to sync examples to read-only repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,12 @@ jobs:
       - e2e-test:
           test_path: e2e-tests/production-runtime
 
+  sync_examples:
+    executor: node
+    steps:
+      - checkout
+      - run: ./scripts/sync-repos.sh "examples"
+
 workflows:
   version: 2
   build-test:
@@ -173,3 +179,7 @@ workflows:
           <<: *e2e-test-workflow
       - e2e_tests_runtime:
           <<: *e2e-test-workflow
+      - sync_examples:
+          filters:
+            branches:
+              only: master

--- a/scripts/sync-repos.sh
+++ b/scripts/sync-repos.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-FOLDER_PATTERN="${1:-examples}" # grab first argument, otherwise use examples folder
+BASE_FOLDER="${1:-examples}" # grab first argument, otherwise use examples folder
 
 CURRENT_COMMIT="$(git log --format="%H" -n 1)"
 CURRENT_COMMIT_MESSAGE="$(git log --format="%s" -n 1)"
 LAST_COMMIT="$(git log --format="%H" -n 2 | tail -1)"
 
-CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r $CURRENT_COMMIT $LAST_COMMIT | grep -E "$FOLDER_PATTERN/*")"
+CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r $CURRENT_COMMIT $LAST_COMMIT | grep -E "$BASE_FOLDER/*")"
 
 # TODO: figure out secure way to push to github
 for file in $CHANGED_FILES
 do
   FOLDER="$(echo $file | cut -d'/' -f2)"
-  cd examples/$FOLDER
+  cd $BASE_FOLDER/$FOLDER
 
   git init
   git remote add origin git@github.com:gatsbyjs/$FOLDER

--- a/scripts/sync-repos.sh
+++ b/scripts/sync-repos.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+FOLDER_PATTERN="${1:-examples}" # grab first argument, otherwise use examples folder
+
+CURRENT_COMMIT="$(git log --format="%H" -n 1)"
+CURRENT_COMMIT_MESSAGE="$(git log --format="%s" -n 1)"
+LAST_COMMIT="$(git log --format="%H" -n 2 | tail -1)"
+
+CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r $CURRENT_COMMIT $LAST_COMMIT | grep -E "$FOLDER_PATTERN/*")"
+
+# TODO: figure out secure way to push to github
+for file in $CHANGED_FILES
+do
+  FOLDER="$(echo $file | cut -d'/' -f2)"
+  cd examples/$FOLDER
+
+  git init
+  git remote add origin git@github.com:gatsbyjs/$FOLDER
+  git fetch origin/master
+  git add .
+  git commit -m "$CURRENT_COMMIT_MESSAGE"
+  git push origin master
+done


### PR DESCRIPTION
WIP WIP WIP WIP

This simple script will check the most recent commit's file changes
(i.e. on master push) vs. the previous state of the repo. It then
iterates over those files (if they match a given pattern, e.g.
examples/*) and will push to those repo clones. We can re-use this script later if we add starters/* to this monorepo.

This will give us some nice benefits, e.g. tracking on forks/stars/etc.
for our examples, starters, etc. while keeping the code in our monorepo,
but also providing a means for others to access those repos outside of
the monorepo

cc @amberleyromo @pieh @KyleAMathews

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
