### PR TITLE
fix: load plugin object style without options object

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -87,7 +87,7 @@ Array [
   },
   Object {
     "browserAPIs": Array [],
-    "id": "d5fb39bc-5b13-5925-86de-f0e18549d272",
+    "id": "cc2293db-7635-5675-bb5e-05c41ff28688",
     "name": "gatsby-plugin-page-creator",
     "nodeAPIs": Array [
       "createPagesStatefully",
@@ -179,6 +179,7 @@ Array [
   },
   Object {
     "browserAPIs": Array [],
+    "id": "c731052f-1e62-5905-9fb3-edc9057be8f1",
     "name": "TEST",
     "nodeAPIs": Array [],
     "pluginOptions": Object {
@@ -202,7 +203,7 @@ Array [
   },
   Object {
     "browserAPIs": Array [],
-    "id": "d5fb39bc-5b13-5925-86de-f0e18549d272",
+    "id": "cc2293db-7635-5675-bb5e-05c41ff28688",
     "name": "gatsby-plugin-page-creator",
     "nodeAPIs": Array [
       "createPagesStatefully",

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -102,9 +102,11 @@ module.exports = (config = {}) => {
         },
       }
     } else {
+      plugin.options = plugin.options || {}
+
       // Plugins can have plugins.
       const subplugins = []
-      if (plugin.options && plugin.options.plugins) {
+      if (plugin.options.plugins) {
         plugin.options.plugins.forEach(p => {
           subplugins.push(processPlugin(p))
         })
@@ -130,12 +132,7 @@ module.exports = (config = {}) => {
         // Make sure key is unique to plugin options. E.g there could
         // be multiple source-filesystem plugins, with different names
         // (docs, blogs).
-        id: createNodeId(
-          plugin.options
-            ? plugin.name + JSON.stringify(plugin.options)
-            : plugin.name,
-          `Plugin`
-        ),
+        id: createNodeId(plugin.name + JSON.stringify(plugin.options)),
         pluginOptions: _.merge({ plugins: [] }, plugin.options),
       }
     }

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -114,6 +114,12 @@ module.exports = (config = {}) => {
         plugin.options.plugins = subplugins
       }
 
+      // Make sure key is unique to plugin options. E.g there could
+      // be multiple source-filesystem plugins, with different names
+      // (docs, blogs).
+      // Get the ID here so this call is included in the unit test.
+      const id = createNodeId(plugin.name + JSON.stringify(plugin.options), `Plugin`)
+
       // Add some default values for tests as we don't actually
       // want to try to load anything during tests.
       if (plugin.resolve === `___TEST___`) {
@@ -129,10 +135,7 @@ module.exports = (config = {}) => {
 
       return {
         ...info,
-        // Make sure key is unique to plugin options. E.g there could
-        // be multiple source-filesystem plugins, with different names
-        // (docs, blogs).
-        id: createNodeId(plugin.name + JSON.stringify(plugin.options), `Plugin`),
+        id,
         pluginOptions: _.merge({ plugins: [] }, plugin.options),
       }
     }

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -132,7 +132,7 @@ module.exports = (config = {}) => {
         // Make sure key is unique to plugin options. E.g there could
         // be multiple source-filesystem plugins, with different names
         // (docs, blogs).
-        id: createNodeId(plugin.name + JSON.stringify(plugin.options)),
+        id: createNodeId(plugin.name + JSON.stringify(plugin.options), `Plugin`),
         pluginOptions: _.merge({ plugins: [] }, plugin.options),
       }
     }


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Fixes issue at the end of #9559, e.g.:
```javascript
module.exports = {
    plugins: [
        {
            resolve: 'gatsby-plugin-react-helmet'
        }
    ]
}
```
where the plugin is loaded using object syntax but no `options` object is defined.

This wasn't caught by the unit test because the issue was occurring after the early out when it's the `___TEST___` plugin.