### PR TITLE
Emphasize importance of promise return on source-plugin docs

### DIFF
--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -89,10 +89,7 @@ But at a high-level, these are the jobs of a source plugin:
 - "Link" nodes types you create as appropriate (see
   [_Node Link_](/docs/api-specification/) in the API specification concepts
   section.
-- Return either a promise or use the callback (3rd parameter) to report back to
-  Gatsby when you're done sourcing nodes. Otherwise either Gatsby will continue
-  on before you're done sourcing or hang while waiting for you to indicate
-  you're finished.
+- Return either a promise or use the callback (3rd parameter) to report back to Gatsby when sourceNodes is fully executed. If a promise or callback isn't returned, Gatsby will continue on in the build process, before nodes are finished being created. Your nodes might not end up in the generated schema at compilation, or the process will hang while waiting for an indication that it's finished.
 
 [`gatsby-node-helpers`](https://github.com/angeloashmore/gatsby-node-helpers),
 a community-made NPM package, can help when writing source plugins. This

--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -89,7 +89,7 @@ But at a high-level, these are the jobs of a source plugin:
 - "Link" nodes types you create as appropriate (see
   [_Node Link_](/docs/api-specification/) in the API specification concepts
   section.
-- Return either a promise or use the callback (3rd parameter) to report back to Gatsby when sourceNodes is fully executed. If a promise or callback isn't returned, Gatsby will continue on in the build process, before nodes are finished being created. Your nodes might not end up in the generated schema at compilation, or the process will hang while waiting for an indication that it's finished.
+- Return either a promise or use the callback (3rd parameter) to report back to Gatsby when `sourceNodes` is fully executed. If a promise or callback isn't returned, Gatsby will continue on in the build process, before nodes are finished being created. Your nodes might not end up in the generated schema at compilation, or the process will hang while waiting for an indication that it's finished.
 
 [`gatsby-node-helpers`](https://github.com/angeloashmore/gatsby-node-helpers),
 a community-made NPM package, can help when writing source plugins. This

--- a/docs/docs/source-plugin-tutorial.md
+++ b/docs/docs/source-plugin-tutorial.md
@@ -139,7 +139,7 @@ const fetch = require("node-fetch")
 const queryString = require("query-string")
 ```
 
-Then you implemented Gatsby's [`sourceNodes` API](/docs/node-apis/#sourceNodes) which Gatsby will run as part of its bootstrap process. When Gatsby calls `sourceNodes`, it'll pass in some helper functions (`actions`, `createNodeId` and `createContentDigest`) along with any config options that are provided in your project's `gatsby-config.js` file:
+Then you implemented Gatsby's [`sourceNodes` API](/docs/node-apis/#sourceNodes) which Gatsby will run as part of its bootstrap process. Gatsby expects sourceNodes to return either a promise or a callback (3rd parameter). This is important as it tells Gatsby to wait to move on to next stages until your nodes are sourced, ensuring your nodes are created before the schema is generated.
 
 ```js
 exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOptions) => {


### PR DESCRIPTION
Solves #9459 

Makes it more clear in the docs and tutorial for source-nodes that the sourceNodes function should return a promise so that gatsby's build process knows to hold at this stage, until nodes are finished being sourced/created, before moving on.

