### PR TITLE
Update hyperlink to the gatsby-link package

### DIFF
--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -14,7 +14,7 @@ In addition links to various resources (JavaScript, images, CSS) need the same
 prefix added (this is accomplished by setting the `publicPath` in webpack).
 
 Luckily, for most sites, this work can be offloaded to Gatsby. Using
-[Gatsby's Link component](/packages/gatsby/) for internal links ensures those links
+[Gatsby's Link component](/packages/gatsby-link/) for internal links ensures those links
 will be prefixed correctly. Gatsby ensures that paths created internally and by
 webpack are also correctly prefixed.
 


### PR DESCRIPTION
The copy was implying the link is to the Gatsby-Link package but was actually redirecting to the general packages page.

