### PR TITLE
remove asterisk from 'Sourcing from the filesystem'

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -77,7 +77,7 @@
       items:
         - title: Using unstructured data
           link: /docs/using-unstructured-data/
-        - title: Sourcing from the filesystem*
+        - title: Sourcing from the filesystem
           link: /docs/sourcing-from-the-filesystem/
         - title: Sourcing from databases*
           link: /docs/sourcing-from-databases/


### PR DESCRIPTION
The article exists [here](https://www.gatsbyjs.org/docs/sourcing-from-the-filesystem/ )but it still shows up on the sidebar as grayed out.
