### PR TITLE
fix(gatsby-remark-autolink-headers): use shouldUpdateScroll api and not onRouteUpdate

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -1,7 +1,7 @@
 let offsetY = 0
 
 const getTargetOffset = hash => {
-  const id = window.decodeURI(window.location.hash.replace(`#`, ``))
+  const id = window.decodeURI(hash.replace(`#`, ``))
   if (id !== ``) {
     const element = document.getElementById(id)
     if (element) {


### PR DESCRIPTION
right now autolink-headers scroll is battling with scrollbehaviour and which should handle scroll to `#elementId`. This allow `autolink-headers` plugin to hook into scrollbehaviour to override default behaviour.

Potential problems: `shouldUpdateScroll` is API that handles only one instance of this hook, so using it in autolink-headers plugin will discard results of this hook in user code (if it's used there)


closes #9638 
