### PR TITLE
Change theme spec to match plugin spec

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -81,7 +81,7 @@ module.exports = async (args: BootstrapArgs) => {
     const themesConfig = await Promise.mapSeries(
       config.__experimentalThemes,
       async plugin => {
-        const resolve = plugin.resolve || plugin
+        const themeName = plugin.resolve || plugin
         const themeConfig = plugin.options || {}
         const theme = await preferDefault(
           getConfigFile(themeName, `gatsby-config`)

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -80,7 +80,7 @@ module.exports = async (args: BootstrapArgs) => {
   if (config && config.__experimentalThemes) {
     const themesConfig = await Promise.mapSeries(
       config.__experimentalThemes,
-      async ([themeName, themeConfig]) => {
+      async ({ resolve: themeName, options: themeConfig }) => {
         const theme = await preferDefault(
           getConfigFile(themeName, `gatsby-config`)
         )

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -80,7 +80,9 @@ module.exports = async (args: BootstrapArgs) => {
   if (config && config.__experimentalThemes) {
     const themesConfig = await Promise.mapSeries(
       config.__experimentalThemes,
-      async ({ resolve: themeName, options: themeConfig }) => {
+      async plugin => {
+        const resolve = plugin.resolve || plugin
+        const themeConfig = plugin.options || {}
         const theme = await preferDefault(
           getConfigFile(themeName, `gatsby-config`)
         )


### PR DESCRIPTION
This changes `__experimentalThemes` from the following

```
__experimentalThemes: [['theme-name', optionsObject]]
```

to match the plugins spec

```
__experimentalThemes: [{
  resolve: 'theme-name',
  options: {}
}]
```

* This is to reduce the number of user-visible config styles.
* There will be a future change to be fully compatible with the [load plugins](https://github.com/gatsbyjs/gatsby/blob/390803c8f679e53d398d40b9535c1a8784380a48/packages/gatsby/src/bootstrap/load-plugins/load.js#L37-L85) functionality (defines a `themes/` directory for local themes and handles absolute paths, etc). This change is meant to match the plugins API spec superficially so that the blogpost #9517 doesn't have syntax incompatible with the future.

