### PR TITLE
chore(www): bump gatsby-remark-autolink-headers version

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -33,7 +33,7 @@
     "gatsby-plugin-subfont": "^1.0.1",
     "gatsby-plugin-twitter": "^2.0.5",
     "gatsby-plugin-typography": "^2.2.0",
-    "gatsby-remark-autolink-headers": "^2.0.5",
+    "gatsby-remark-autolink-headers": "^2.0.10",
     "gatsby-remark-code-titles": "^1.0.2",
     "gatsby-remark-copy-linked-files": "^2.0.5",
     "gatsby-remark-graphviz": "^1.0.0",


### PR DESCRIPTION
Fixes anchor link behavior for `www` as described in #9638, fixed via #9657