### PR TITLE
fix(gatsby-plugin-offline): Serve the offline shell for short URLs + use no-cors for external resources

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -88,7 +88,7 @@ exports.onPostBuild = (args, pluginOptions) => {
     // URLs and not any files hosted on the site.
     //
     // Regex based on http://stackoverflow.com/a/18017805
-    navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
+    navigateFallbackWhitelist: [/^([^.?]*|[^?]*\.([^.?]{5,}|html))(\?.*)?$/],
     navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
     cacheId: `gatsby-plugin-offline`,
     // Don't cache-bust JS or CSS files, and anything in the static directory
@@ -101,7 +101,7 @@ exports.onPostBuild = (args, pluginOptions) => {
       },
       {
         // Use the Network First handler for external resources
-        urlPattern: /^https:/,
+        urlPattern: /^https?:/,
         handler: `networkFirst`,
       },
     ],


### PR DESCRIPTION
- Fixes the fallback whitelist regex so that short pages match (e.g. `/`), so that these are served offline correctly
- Uses `no-cors` mode when caching external resources, so that errors don't appear if the target doesn't allow CORS requests
- Allow insecure external resources to be cached for testing on `localhost`

Fixes #8145