### PR TITLE
fix(gatsby-plugin-netlify): do not cache service worker file on Netlify

### DIFF
--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -26,6 +26,7 @@ export const SECURITY_HEADERS = {
 
 export const CACHING_HEADERS = {
   "/static/*": [`Cache-Control: public, max-age=31536000, immutable`],
+  "/sw.js": [`Cache-Control: no-cache`],
 }
 
 export const LINK_REGEX = /^(Link: <\/)(.+)(>;.+)/


### PR DESCRIPTION
Related to https://www.netlify.com/blog/2018/06/28/5-pro-tips-and-plugins-for-optimizing-your-gatsby---netlify-site/#4-get-your-service-workers-um-working

Recommandation is not to cache service worker file : https://github.com/w3c/ServiceWorker/issues/893

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
