### PR TITLE
chore(gatsby): Remove react-hot-loader/patch entry

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -144,7 +144,6 @@ module.exports = async (
       case `develop`:
         return {
           commons: [
-            require.resolve(`react-hot-loader/patch`),
             `${require.resolve(
               `webpack-hot-middleware/client`
             )}?path=${getHmrPath()}`,


### PR DESCRIPTION
The patch entry should no longer be necessary (after v4 I think), so I should be safe to remove it.

https://github.com/gaearon/react-hot-loader#no-patch-required
