### PR TITLE
feat(www): Re-Organize tags on starters.yml

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -52,6 +52,7 @@
   tags:
     - Blog
     - Contentful
+    - Headless CMS
   features:
     - Based on the Gatsby Starter Blog
     - Includes Contentful Delivery API for production build
@@ -181,6 +182,7 @@
   description: n/a
   tags:
     - Styling:Bulma
+    - Storybook
   features:
     - Storybook for developing components in isolation
     - Bulma and Sass support for styling
@@ -234,6 +236,7 @@
   tags:
     - i18n
     - Contentful
+    - Headless CMS
   features:
     - Localization (Multilanguage)
     - Dynamic content from Contentful CMS
@@ -243,6 +246,7 @@
   description: n/a
   tags:
     - DatoCMS
+    - Headless CMS
   features:
     - Simple portfolio to quick start a site with DatoCMS
     - Contents and media from DatoCMS
@@ -354,6 +358,7 @@
   description: A starter template to build amazing static websites with Gatsby, Contentful and Netlify
   tags:
     - Contentful
+    - Headless CMS
     - Blog
     - Netlify Form
     - Styling:CSS-in-JS
@@ -532,6 +537,7 @@
   tags:
     - Portfolio
     - Prismic
+    - Headless CMS
     - Styling:CSS-in-JS
     - Onepage
     - PWA
@@ -597,6 +603,7 @@
   tags:
     - PWA
     - GraphCMS
+    - Headless CMS
     - Apollo Client
     - Styling:Material
     - Netlify Identity
@@ -795,6 +802,7 @@
   description: Contentful and TypeScript starter based on default starter.
   tags:
     - Contentful
+    - Headless CMS
     - TypeScript
     - Styling:CSS-in-JS
   features:
@@ -850,7 +858,6 @@
   description: Gatsby v2 Starter with i18n using react-intl and more cool features.
   tags:
     - Styling:CSS-in-JS
-    - Recompose
     - i18n
     - react-intl
     - Formik
@@ -868,6 +875,7 @@
   tags:
     - Styling:CSS-in-JS
     - Contentful
+    - Headless CMS
     - Portfolio
   features:
     - Gatsby v2
@@ -895,6 +903,7 @@
   description: A simple starter to display Contentful data in Gatsby, ready to deploy on Netlify. Comes with a detailed article detailing the process.
   tags:
     - Contentful
+    - Headless CMS
     - Markdown
     - Styling:CSS-in-JS
   features:
@@ -909,6 +918,7 @@
   description: Blog that utilizes the power of the Cosmic JS headless CMS for easy content management
   tags:
     - Cosmic JS
+    - Headless CMS
     - Blog
   features:
     - Uses the Cosmic JS Gatsby source plugin
@@ -917,6 +927,7 @@
   description: Simple Gatsby starter connected to the Cosmic JS headless CMS for easy content management
   tags:
     - Cosmic JS
+    - Headless CMS
   features:
     - Uses the Cosmic JS Gatsby source plugin
 - url: https://www.gatsby-typescript-template.com/
@@ -924,9 +935,7 @@
   description: This is a standard starter with Typescript, TSLint, Prettier, Lint-Staged(Husky) and Sass
   tags:
     - TypeScript
-    - TSLint
-    - Prettier
-    - Lint-Staged
+    - Linting
     - Styling:SCSS
   features:
     - Category and Tag for post
@@ -961,7 +970,6 @@
     - Styling:CSS-in-JS
     - Linting
     - Markdown
-    - Prettier
     - SEO
   features:
     - Page Transitions
@@ -982,6 +990,7 @@
   description: A typography-heavy & light-themed Gatsby Starter which uses the Headless CMS Prismic.
   tags:
     - Prismic
+    - Headless CMS
     - Styling:CSS-in-JS
     - SEO
     - Blog
@@ -1044,7 +1053,7 @@
   tags:
     - Portfolio
     - SEO
-    - Styling:Styled Components
+    - Styling:CSS-in-JS
   features:
     - Features a custom, accessible lightbox with gatsby-image
     - Styled with styled-components using CSS Grid
@@ -1075,7 +1084,7 @@
   description: Blog Template X Contentful, Twitter and Facebook style
   tags:
     - Blog
-    - Tags
+    - Styling:SCSS
   features:
     - GatsbyJS v2, faster than faster
     - Not just Contentful content source, you can use any database


### PR DESCRIPTION
- Added "Headless CMS" to entries appropriately
- Removed minor tags that create extra noise (Recompose, Prettier, Lint-Staged, TSLint, Tags) and removed them or put them into "Linting". Especially considering that almost all starters have ESLint and Prettier. "Linting" would mean for me that this starter is especially focused on that or has something fancy
- Removed invalid Styling tag