### PR TITLE
docs(browser-apis): fix replaceHydrateFunction JSDoc comment

### DIFF
--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -179,7 +179,7 @@ exports.onPostPrefetchPathname = true
  */
 exports.disableCorePrefetching = true
 
-/*
+/**
  * Allow a plugin to replace the ReactDOM.render function call by a custom renderer.
  * This method takes no param and should return a function with same signature as ReactDOM.render()
  * Note it's very important to call the callback after rendering, otherwise Gatsby will not be able to call `onInitialClientRender`


### PR DESCRIPTION
`replaceHydrateFunction` is not currently showing up in the [Gatsby Browser APIs](https://www.gatsbyjs.org/docs/browser-apis/) section of the documentation site. The entries there are generated based on the JSDoc comments in `packages/gatsby/src/utils/api-browser-docs.js`, and the comment for `replaceHydrateFunction` was missing an asterisk, making it invalid JSDoc.