### PR TITLE
fix: adjust page order to make nested matchPaths work

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -36,9 +36,11 @@ const writePages = async () => {
   })
 
   pagesData = _(pagesData)
-    // Ensure pages keep the same sorting through builds
-    // and sort pages with matchPath to end so explicit routes
-    // will match before general.
+    // Ensure pages keep the same sorting through builds.
+    // Pages without matchPath come first, then pages with matchPath,
+    // where more specific patterns come before less specific patterns.
+    // This ensures explicit routes will match before general.
+    // Specificity is inferred from number of path segments.
     .sortBy(p => `${p.matchPath ? 9999 - p.matchPath.split(`/`).length : `0000`}${p.path}`)
     .value()
   const newHash = crypto

--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -39,7 +39,7 @@ const writePages = async () => {
     // Ensure pages keep the same sorting through builds
     // and sort pages with matchPath to end so explicit routes
     // will match before general.
-    .sortBy(p => `${p.matchPath ? 1 : 0}${p.path}`)
+    .sortBy(p => `${p.matchPath ? 9999 - p.matchPath.split(`/`).length : `0000`}${p.path}`)
     .value()
   const newHash = crypto
     .createHash(`md5`)


### PR DESCRIPTION
As per [#9705](https://github.com/gatsbyjs/gatsby/issues/9705), this changes the order of the pages in pages-writer.js in order to account for the matchPath specificity and therefore make "nested" matchPaths work.

The proposed fix `sortByNumeric` is the most performant solution I could come up with:
[Benchmarks](https://runkit.com/juliansthl/5be08b8f2513440012001807)

Thanks a lot to @pieh for all the help!

(this is my first PR, please let me know if I have to adjust anything)