### PR TITLE
fix(gatsby-plugin-page-creator): ensure that __tests__ directory is actually ignored

### DIFF
--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -24,6 +24,7 @@
     "fs-exists-cached": "^1.0.0",
     "glob": "^7.1.1",
     "lodash": "^4.17.10",
+    "micromatch": "^3.1.10",
     "parse-filepath": "^1.0.1",
     "slash": "^1.0.0"
   },
@@ -35,6 +36,5 @@
   },
   "peerDependencies": {
     "gatsby": ">2.0.0-alpha"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -92,13 +92,14 @@ describe(`JavaScript page creator`, () => {
     const validFiles = [{ path: `page.js` }, { path: `page.jsx` }]
 
     const testFiles = validFiles.concat([
-      { path: `__tests__/something.test.js` },
-      { path: `__tests__/something.test.tsx` },
-      { path: `__tests__/something.js` },
-      { path: `foo.spec.js` },
-      { path: `foo.spec.tsx` },
-      { path: `bar.test.js` },
-      { path: `bar.test.tsx` },
+      { path: `src/pages/__tests__/something.test.js` },
+      { path: `src/pages/__tests__/something.test.tsx` },
+      { path: `src/pages/__tests__/something.js` },
+      { path: `src/pages/__tests__/nested-directory/something.js` },
+      { path: `src/pages/foo.spec.js` },
+      { path: `src/pages/foo.spec.tsx` },
+      { path: `src/pages/bar.test.js` },
+      { path: `src/pages/bar.test.tsx` },
     ])
 
     expect(testFiles.filter(file => validatePath(file.path))).toEqual(

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -1,3 +1,5 @@
+const path = require(`path`)
+
 const validatePath = require(`../validate-path`)
 const createPath = require(`../create-path`)
 
@@ -91,16 +93,21 @@ describe(`JavaScript page creator`, () => {
   it(`filters out test files`, () => {
     const validFiles = [{ path: `page.js` }, { path: `page.jsx` }]
 
-    const testFiles = validFiles.concat([
-      { path: `src/pages/__tests__/something.test.js` },
-      { path: `src/pages/__tests__/something.test.tsx` },
-      { path: `src/pages/__tests__/something.js` },
-      { path: `src/pages/__tests__/nested-directory/something.js` },
-      { path: `src/pages/foo.spec.js` },
-      { path: `src/pages/foo.spec.tsx` },
-      { path: `src/pages/bar.test.js` },
-      { path: `src/pages/bar.test.tsx` },
-    ])
+    const testFiles = validFiles
+      .concat([
+        { path: `src/pages/__tests__/something.test.js` },
+        { path: `src/pages/__tests__/something.test.tsx` },
+        { path: `src/pages/__tests__/something.js` },
+        { path: `src/pages/__tests__/nested-directory/something.js` },
+        { path: `src/pages/foo.spec.js` },
+        { path: `src/pages/foo.spec.tsx` },
+        { path: `src/pages/bar.test.js` },
+        { path: `src/pages/bar.test.tsx` },
+      ])
+      .map(file => {
+        file.path = path.join(...file.path.split("/"))
+        return file
+      })
 
     expect(testFiles.filter(file => validatePath(file.path))).toEqual(
       validFiles

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -105,7 +105,7 @@ describe(`JavaScript page creator`, () => {
         { path: `src/pages/bar.test.tsx` },
       ])
       .map(file => {
-        file.path = path.join(...file.path.split("/"))
+        file.path = path.join(...file.path.split(`/`))
         return file
       })
 

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -10,28 +10,26 @@ describe(`JavaScript page creator`, () => {
       { path: `somedir/dir2/test1.js` },
     ]
 
-    expect(validFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+    expect(validFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
   })
 
   it(`filters out files that start with underscores`, () => {
-    const validFiles = [
-      { path: `something/blah.js` },
-      { path: `test1.js` },
-    ]
+    const validFiles = [{ path: `something/blah.js` }, { path: `test1.js` }]
 
     const testFiles = validFiles.concat([
       { path: `something/_foo.js` },
       { path: `_blah.js` },
     ])
 
-    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+    expect(testFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
   })
 
   it(`filters out files that start with dot`, () => {
-    const validFiles = [
-      { path: `something/blah.js` },
-      { path: `test1.ts` },
-    ]
+    const validFiles = [{ path: `something/blah.js` }, { path: `test1.ts` }]
 
     const testFiles = validFiles.concat([
       { path: `.eslintrc` },
@@ -41,14 +39,13 @@ describe(`JavaScript page creator`, () => {
       { path: `something/.markdownlint.json` },
     ])
 
-    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+    expect(testFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
   })
 
   it(`filters out json and yaml files`, () => {
-    const validFiles = [
-      { path: `somefile.js` },
-      { path: `something/blah.js` },
-    ]
+    const validFiles = [{ path: `somefile.js` }, { path: `something/blah.js` }]
 
     const testFiles = validFiles.concat([
       { path: `something/otherConfig.yml` },
@@ -58,20 +55,21 @@ describe(`JavaScript page creator`, () => {
       { path: `dir1/dir2/file.json` },
     ])
 
-    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+    expect(testFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
   })
 
   it(`filters out files that start with template-*`, () => {
-    const validFiles = [
-      { path: `something/blah.js` },
-      { path: `file1.js` },
-    ]
+    const validFiles = [{ path: `something/blah.js` }, { path: `file1.js` }]
 
     const testFiles = validFiles.concat([
       { path: `template-cool-page-type.js` },
     ])
 
-    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+    expect(testFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
   })
 
   it(`filters out files that have TypeScript declaration extensions`, () => {
@@ -85,22 +83,27 @@ describe(`JavaScript page creator`, () => {
       { path: `something-else/other-declaration-file.d.tsx` },
     ])
 
-    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+    expect(testFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
   })
 
   it(`filters out test files`, () => {
-    const validFiles = [
-      { path: `page.js` },
-      { path: `page.jsx` },
-    ]
+    const validFiles = [{ path: `page.js` }, { path: `page.jsx` }]
 
     const testFiles = validFiles.concat([
       { path: `__tests__/something.test.js` },
+      { path: `__tests__/something.test.tsx` },
+      { path: `__tests__/something.js` },
       { path: `foo.spec.js` },
+      { path: `foo.spec.tsx` },
       { path: `bar.test.js` },
+      { path: `bar.test.tsx` },
     ])
 
-    expect(testFiles.filter(file => validatePath(file.path)).length).toEqual(validFiles.length)
+    expect(testFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
   })
 
   describe(`create-path`, () => {

--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -1,5 +1,3 @@
-const path = require(`path`)
-
 const validatePath = require(`../validate-path`)
 const createPath = require(`../create-path`)
 
@@ -93,21 +91,18 @@ describe(`JavaScript page creator`, () => {
   it(`filters out test files`, () => {
     const validFiles = [{ path: `page.js` }, { path: `page.jsx` }]
 
-    const testFiles = validFiles
-      .concat([
-        { path: `src/pages/__tests__/something.test.js` },
-        { path: `src/pages/__tests__/something.test.tsx` },
-        { path: `src/pages/__tests__/something.js` },
-        { path: `src/pages/__tests__/nested-directory/something.js` },
-        { path: `src/pages/foo.spec.js` },
-        { path: `src/pages/foo.spec.tsx` },
-        { path: `src/pages/bar.test.js` },
-        { path: `src/pages/bar.test.tsx` },
-      ])
-      .map(file => {
-        file.path = path.join(...file.path.split(`/`))
-        return file
-      })
+    const testFiles = validFiles.concat([
+      { path: `src/pages/__tests__/something.test.js` },
+      { path: `src/pages/__tests__/something.test.tsx` },
+      { path: `src/pages/__tests__/something.js` },
+      { path: `src/pages/__tests__/nested-directory/something.js` },
+      { path: `src/pages/foo.spec.js` },
+      { path: `src/pages/foo.spec.tsx` },
+      { path: `src/pages/bar.test.js` },
+      { path: `src/pages/bar.test.tsx` },
+      { path: `src\\pages\\bar.test.js` },
+      { path: `src\\pages\\__tests__\\nested-directory\\something.js` },
+    ])
 
     expect(testFiles.filter(file => validatePath(file.path))).toEqual(
       validFiles

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -3,9 +3,12 @@ const systemPath = require(`path`)
 const tsDeclarationExtTest = /\.d\.tsx?$/
 const jsonYamlExtTest = /\.(json|ya?ml)$/
 
-function isTestFile(path) {
-  const testFileTest = new RegExp(`(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$`)
-  return path.match(testFileTest)
+function isTestFile({ base, dir }) {
+  const testFileExpr = new RegExp(
+    `(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts)x?$`,
+    "i"
+  )
+  return testFileExpr.test(base) || dir === `__tests__`
 }
 
 module.exports = path => {
@@ -19,6 +22,6 @@ module.exports = path => {
     parsedPath.name.slice(0, 9) !== `template-` &&
     !tsDeclarationExtTest.test(parsedPath.base) &&
     !jsonYamlExtTest.test(parsedPath.base) &&
-    !isTestFile(parsedPath.base)
+    !isTestFile(parsedPath)
   )
 }

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -11,7 +11,7 @@ function isTestFile(filePath) {
     `**/?(*.)+(spec|test).(js|ts)?(x)`,
   ]
 
-  return mm.isMatch(filePath, testPatterns)
+  return testPatterns.some(pattern => mm.isMatch(filePath, pattern))
 }
 
 module.exports = path => {

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -1,14 +1,17 @@
 const systemPath = require(`path`)
+const mm = require(`micromatch`)
 
 const tsDeclarationExtTest = /\.d\.tsx?$/
 const jsonYamlExtTest = /\.(json|ya?ml)$/
 
-function isTestFile({ base, dir }) {
-  const testFileExpr = new RegExp(
-    `(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts)x?$`,
-    `i`
-  )
-  return testFileExpr.test(base) || dir === `__tests__`
+// https://github.com/facebook/jest/blob/v24.0.0-alpha.4/packages/jest-config/src/Defaults.js#L71
+function isTestFile(filePath) {
+  const testPatterns = [
+    `**/__tests__/**/*.(js|ts)?(x)`,
+    `**/?(*.)+(spec|test).(js|ts)?(x)`,
+  ]
+
+  return mm.isMatch(filePath, testPatterns)
 }
 
 module.exports = path => {
@@ -22,6 +25,6 @@ module.exports = path => {
     parsedPath.name.slice(0, 9) !== `template-` &&
     !tsDeclarationExtTest.test(parsedPath.base) &&
     !jsonYamlExtTest.test(parsedPath.base) &&
-    !isTestFile(parsedPath)
+    !isTestFile(path)
   )
 }

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -6,7 +6,7 @@ const jsonYamlExtTest = /\.(json|ya?ml)$/
 function isTestFile({ base, dir }) {
   const testFileExpr = new RegExp(
     `(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts)x?$`,
-    "i"
+    `i`
   )
   return testFileExpr.test(base) || dir === `__tests__`
 }

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -11,7 +11,7 @@ function isTestFile(filePath) {
     `**/?(*.)+(spec|test).(js|ts)?(x)`,
   ]
 
-  return testPatterns.some(pattern => mm.isMatch(filePath, pattern))
+  return mm.isMatch(filePath, testPatterns)
 }
 
 module.exports = path => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,17 +3504,6 @@ babel-preset-flow@^6.23.0:
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
-babel-preset-gatsby-package@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-gatsby-package/-/babel-preset-gatsby-package-0.1.2.tgz#418d52343bea31e1594ec69d106207fafa5ffaf7"
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/preset-env" "^7.0.0"
-    "@babel/preset-flow" "^7.0.0"
-    "@babel/preset-react" "^7.0.0"
-
 babel-preset-jest@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz#ec9fbd8bcd7dfd24b8b5320e0e688013235b7c39"


### PR DESCRIPTION
This (simple) PR fixes a bug I was noticing in #9629, specifically that
__tests__/*.js files _were_ being included in the bundle.

This is because the isTestFile function in gatsby-plugin-page-creator is
passed the file name, not the file name _with_ the folder (__tests__ in
this case).

So, this PR does the following:

- Adds a fallback check to check the base dir (which could be __tests__)
- (Also) ignores typescript files as part of this check, since this isn't readily apparent _how_ it would be configurable to ignore them currently

Note: I could've solved this by also passing the raw path (not system path parsed) but wanted to avoid any Windows idiosyncrasies _just in case_

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
