### PR TITLE
Fix typo of plugin authoring

### DIFF
--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -60,7 +60,7 @@ plugins
 
 **NOTE:** You still need to add the plugin to your `gatsby-config.js`. There is no auto-detection of local plugins.
 
-**NOTE:** For the plugin to be discovered, the plugin's root folder name is the value that needs to be referenced in order to load it (_not_ it's _name_ in it's package.json file). For example, in the above structure, the correct way to load the plugin is:
+**NOTE:** For the plugin to be discovered, the plugin's root folder name is the value that needs to be referenced in order to load it (_not_ its _name_ in its package.json file). For example, in the above structure, the correct way to load the plugin is:
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
Fix the typo of "it's" to "its".

This is my first pull request in gatsby repo, not sure if I'm doing this correctly.
Thanks!

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
