### PR TITLE
Add some options to render function

### DIFF
--- a/packages/gatsby-remark-katex/src/index.js
+++ b/packages/gatsby-remark-katex/src/index.js
@@ -7,6 +7,9 @@ module.exports = ({ markdownAST }) => {
     node.type = `html`
     node.value = katex.renderToString(node.value, {
       displayMode: false,
+      throwOnError: false,
+      errorColor: "#cc0000",
+      strict: "warn",
     })
   })
 
@@ -14,6 +17,9 @@ module.exports = ({ markdownAST }) => {
     node.type = `html`
     node.value = katex.renderToString(node.value, {
       displayMode: true,
+      throwOnError: false,
+      errorColor: "#cc0000",
+      strict: "warn",
     })
   })
 }


### PR DESCRIPTION
I set `throwOnError` to `false` and `strict` to `warn`. Gatsby can ignore katex math formula syntax error when `develop` or `build`