### PR TITLE
fix(source-contentful): fix argument arity

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -193,13 +193,7 @@ function prepareTextNode(node, key, text, createNode, createNodeId) {
   return textNode
 }
 
-function prepareStructuredTextNode(
-  node,
-  key,
-  content,
-  createNode,
-  createNodeId
-) {
+function prepareStructuredTextNode(node, key, content, createNodeId) {
   const str = JSON.stringify(content)
   const structuredTextNode = {
     ...content,


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

This PR fixes an issue with `gatsby-source-contentful` where the internal `prepareStructuredTextNode()` was trying to call an undefined function.

You can see here that the function defines 5 expected arguments:

https://github.com/gatsbyjs/gatsby/blob/19f3d5a70cc857229e1360ecef486dbbba0093fc/packages/gatsby-source-contentful/src/normalize.js#L196-L221

The 4th argument is `createNode` (which is unused). And the only usage I could find of this function receives 4 arguments (with `createNodeId` being the last argument):

https://github.com/gatsbyjs/gatsby/blob/19f3d5a70cc857229e1360ecef486dbbba0093fc/packages/gatsby-source-contentful/src/normalize.js#L415-L420
