### PR TITLE
feat: pass pathname to replaceRenderer and onPreRenderHTML SSR APIs

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -180,6 +180,8 @@ export default (pagePath, callback) => {
     setPreBodyComponents,
     setPostBodyComponents,
     setBodyProps,
+    pathname: pagePath,
+    pathPrefix: __PATH_PREFIX__,
   })
 
   // If no one stepped up, we'll handle it.
@@ -366,6 +368,8 @@ export default (pagePath, callback) => {
     replacePreBodyComponents,
     getPostBodyComponents,
     replacePostBodyComponents,
+    pathname: pagePath,
+    pathPrefix: __PATH_PREFIX__,
   })
 
   const html = `<!DOCTYPE html>${renderToStaticMarkup(


### PR DESCRIPTION
For some situations (e.g. implementing AMP pages), a user may need to conditionally remove or add elements in the head or body of a page. Normally, this could be done when the page or node is created. But, styles and scripts may be added later in the lifecycle. The `onRenderBody` SSR API provides a `pathname` argument that could be used but does not allow the removal of existing elements. Using `replaceHeadComponents` or `replaceBodyComponents` in `onPreRenderHTML` would seem to be ideal. But, this API doesn't expose the `pathname` argument.

The following example for combining inline style elements in the head of the document is not currently possible but would be if pathname were exposed.

```js
import React from 'react'
import Helmet from 'react-helmet'

export const onPreRenderHTML = (
  { getHeadComponents, replaceHeadComponents, pathname },
  pluginOptions
) => {
  const headComponents = getHeadComponents()
  const styles = headComponents.reduce((str, x) => {
    if (x.type === 'style') {
      str += x.props.dangerouslySetInnerHTML.__html
    }
    return str
  }, '')
  const regex = new RegExp(pluginOptions.pathRegex || '\/amp\/')
  if (regex.test(pathname)) {
    replaceHeadComponents([
      <Helmet>
        <style id="amp-custom">
          {styles}
        </style>
      </Helmet>,
      ...headComponents.filter(x => x.type !== 'style'),
    ])
  }
}
```
I'm not sure if this needs to be submitted as an RFC or not. It does slightly modify an API but it seems very minor.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
