### PR TITLE
Update Kentico Cloud naming conventions

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1132,8 +1132,8 @@
     - Gatsby v2 support
     - Content item <-> content type relationships
     - Language variants relationships
-    - Modular content elements relationships
-    - Modular content relationships in rich text
+    - Linked items elements relationships
+    - Content items in Rich text elements relationships
     - Reverse link relationships
 - url: https://gatsby-starter-storybook.netlify.com/
   repo: https://github.com/markoradak/gatsby-starter-storybook


### PR DESCRIPTION
Adjusting feature list according to the [renaming of modular content elements to linked items](https://developer.kenticocloud.com/v1/reference#linked-content).

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
