### PR TITLE
fix: link to creator showcase on submit page

### DIFF
--- a/docs/docs/submit-to-creator-showcase.md
+++ b/docs/docs/submit-to-creator-showcase.md
@@ -2,7 +2,7 @@
 title: Submit to Creator Showcase
 ---
 
-Want to be a part of the [Creator Showcase](link TBA)? Follow these instructions.
+Want to be a part of the [Creator Showcase](/showcase)? Follow these instructions.
 
 ## Steps
 


### PR DESCRIPTION
Fixes broken link on the [Submit to Creator Showcase](https://www.gatsbyjs.org/docs/submit-to-creator-showcase/) page, just below the title.

Closes #9761 
