### PR TITLE
[gatsby-plugin-google-gtag] Disable default pageview tracking

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -6,6 +6,8 @@ exports.onRenderBody = (
   pluginOptions
 ) => {
   if (process.env.NODE_ENV !== `production`) return null
+  
+  pluginOptions.gtagConfig["send_page_view"] = false
 
   const firstTrackingId =
     pluginOptions.trackingIds && pluginOptions.trackingIds.length
@@ -49,9 +51,7 @@ exports.onRenderBody = (
         ${pluginOptions.trackingIds
           .map(
             trackingId =>
-              `gtag('config', '${trackingId}', ${JSON.stringify(
-                pluginOptions.gtagConfig || {}
-              )});`
+              `gtag('config', '${trackingId}', ${JSON.stringify(pluginOptions.gtagConfig)});`
           )
           .join(``)}
       }

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -6,9 +6,9 @@ exports.onRenderBody = (
   pluginOptions
 ) => {
   if (process.env.NODE_ENV !== `production`) return null
-  
+
   const gtagConfig = pluginOptions.gtagConfig || {}
-  
+
   // Prevent duplicate or excluded pageview events being emitted on initial load of page by the `config` command
   // https://developers.google.com/analytics/devguides/collection/gtagjs/#disable_pageview_tracking
 

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -7,7 +7,12 @@ exports.onRenderBody = (
 ) => {
   if (process.env.NODE_ENV !== `production`) return null
   
-  pluginOptions.gtagConfig["send_page_view"] = false
+  const gtagConfig = pluginOptions.gtagConfig || {}
+  
+  // Prevent duplicate or excluded pageview events being emitted on initial load of page by the `config` command
+  // https://developers.google.com/analytics/devguides/collection/gtagjs/#disable_pageview_tracking
+
+  gtagConfig.send_page_view = false
 
   const firstTrackingId =
     pluginOptions.trackingIds && pluginOptions.trackingIds.length
@@ -33,8 +38,8 @@ exports.onRenderBody = (
           : ``
       }
       ${
-        typeof pluginOptions.gtagConfig.anonymize_ip !== `undefined` &&
-        pluginOptions.gtagConfig.anonymize_ip === true
+        typeof gtagConfig.anonymize_ip !== `undefined` &&
+        gtagConfig.anonymize_ip === true
           ? `function gaOptout(){document.cookie=disableStr+'=true; expires=Thu, 31 Dec 2099 23:59:59 UTC;path=/',window[disableStr]=!0}var gaProperty='${firstTrackingId}',disableStr='ga-disable-'+gaProperty;document.cookie.indexOf(disableStr+'=true')>-1&&(window[disableStr]=!0);`
           : ``
       }
@@ -51,7 +56,7 @@ exports.onRenderBody = (
         ${pluginOptions.trackingIds
           .map(
             trackingId =>
-              `gtag('config', '${trackingId}', ${JSON.stringify(pluginOptions.gtagConfig)});`
+              `gtag('config', '${trackingId}', ${JSON.stringify(gtagConfig)});`
           )
           .join(``)}
       }


### PR DESCRIPTION
The default behavior of the `config` snippet is to send a pageview automatically; this is in contrast with the `exclude` option and the plugin tracks, on page load, even the excluded pages.

This PR solve also the double pageview hits on page load too: the first is made by the default behavior and the second one by the `onRouteUpdate` event.