### PR TITLE
[gatsby-plugin-google-gtag] Add resolveEnv option

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -5,7 +5,9 @@ exports.onRenderBody = (
   { setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {
-  if (process.env.NODE_ENV !== `production`) return null
+  const { pluginConfig: { resolveEnv = () => process.env.NODE_ENV }} = pluginOptions
+
+  if (resolveEnv() !== `production`) return null
 
   const firstTrackingId =
     pluginOptions.trackingIds && pluginOptions.trackingIds.length


### PR DESCRIPTION
Add new `resolveEnv` option function to change the default enviroment variable resolution taken from `process.env.NODE_ENV`.
This could be useful for Netlify branch or preview deploy for example.