### PR TITLE
Update css minification configuration

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -460,7 +460,18 @@ module.exports = async ({
       ...options,
     })
 
-  plugins.minifyCss = (options = {}) => new OptimizeCssAssetsPlugin(options)
+  plugins.minifyCss = (options = {}) =>
+    new OptimizeCssAssetsPlugin({
+      cssProcessorOptions: {
+        preset: [
+          `default`,
+          {
+            calc: false,
+          },
+        ],
+      },
+      ...options,
+    })
 
   /**
    * Extracts css requires into a single file;


### PR DESCRIPTION
This PR is for fixing issue https://github.com/gatsbyjs/gatsby/issues/9858

Problem
---
`optimize-css-assets-webpack-plugin` is using `cssnano` (and `postcss` to that extend) for optimised css minification. `postcss-calc` used with the default cssnano preset is quite greedy in reducing the `calc()` usage.

Discussion
---
Nowadays `calc()` support is quite good with most of the browsers, with partial support for IE9.
Gatsby support for IE9+ is on the edge for not allowing such `calc` transformations as part of the `optimize-css-assets-webpack-plugin` configuration.

Solution
---
There are 2 possible options for solving this issue:
1. Default disable `calc` optimisations from `postcss-calc`
2. Expose an api for passing options configuring `optimize-css-assets-webpack-plugin` usage.