### PR TITLE
Revert json-stream-stringify to serialize redux state

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -75,7 +75,7 @@
     "jest-worker": "^23.2.0",
     "joi": "12.x.x",
     "json-loader": "^0.5.7",
-    "json-stream-stringify": "^2.0.1",
+    "json-stringify-safe": "^5.0.1",
     "kebab-hash": "^0.1.2",
     "lodash": "^4.17.10",
     "md5": "^2.2.1",

--- a/packages/gatsby/src/redux/index.js
+++ b/packages/gatsby/src/redux/index.js
@@ -2,7 +2,7 @@ const Redux = require(`redux`)
 const _ = require(`lodash`)
 const fs = require(`fs`)
 const mitt = require(`mitt`)
-const stringify = require(`json-stream-stringify`)
+const stringify = require(`json-stringify-safe`)
 
 // Create event emitter for actions
 const emitter = mitt()
@@ -78,21 +78,12 @@ const saveState = state => {
   )
   pickedState.components = mapToObject(pickedState.components)
   pickedState.nodes = mapToObject(pickedState.nodes)
-
-  const writeStream = fs.createWriteStream(
-    `${process.cwd()}/.cache/redux-state.json`
+  const stringified = stringify(pickedState, null, 2)
+  fs.writeFile(
+    `${process.cwd()}/.cache/redux-state.json`,
+    stringified,
+    () => {}
   )
-
-  new stringify(pickedState, null, 2, true)
-    .pipe(writeStream)
-    .on(`finish`, () => {
-      writeStream.destroy()
-      writeStream.end()
-    })
-    .on(`error`, () => {
-      writeStream.destroy()
-      writeStream.end()
-    })
 }
 const saveStateDebounced = _.debounce(saveState, 1000)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,14 @@ babel-plugin-macros@^2.4.2:
     cosmiconfig "^5.0.5"
     resolve "^1.8.1"
 
+babel-plugin-macros@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz#21b1a2e82e2130403c5ff785cba6548e9b644b28"
+  integrity sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==
+  dependencies:
+    cosmiconfig "^5.0.5"
+    resolve "^1.8.1"
+
 babel-plugin-react-css-modules@^3.2.1:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-css-modules/-/babel-plugin-react-css-modules-3.4.2.tgz#4c1db8d4bc8b2973f6c689da7dbd56b0cb8f099c"
@@ -11501,11 +11509,6 @@ json-stable-stringify@^1.0.0:
   integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
   dependencies:
     jsonify "~0.0.0"
-
-json-stream-stringify@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/json-stream-stringify/-/json-stream-stringify-2.0.1.tgz#8bc0e65ff94567d9010e14c27c043a951cb14939"
-  integrity sha512-5XymtJXPmzRWZ1UdLQQQXbjHV/E7NAanSClikEqORbkZKOYLSYLNHqRuooyju9W90kJUzknFhX2xvWn4cHluHQ==
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"


### PR DESCRIPTION
current implementation of using `json-stream-stringify` is causing a lot of problems and I think this should be reverted - see https://github.com/gatsbyjs/gatsby/pull/9370#issuecomment-435950494 

shortly put - this does help with not getting OOM, but it essentially make `.cache/redux-state.json` to not work at all