### PR TITLE
[WIP]: feat: enable PnP in gatsby-cli

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -25,6 +25,7 @@
     "opentracing": "^0.14.3",
     "pretty-error": "^2.1.1",
     "resolve-cwd": "^2.0.0",
+    "semver": "^5.6.0",
     "source-map": "^0.5.7",
     "stack-trace": "^0.0.10",
     "update-notifier": "^2.3.0",

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -301,7 +301,7 @@ module.exports = (argv, handlers) => {
         _.option(`use-pnp`, {
           default: false,
           type: `boolean`,
-          describe: `Use Yarn Plug n' Play to install dependencies`,
+          describe: `Use Yarn Plug'n'Play to install dependencies`,
         }),
       desc: `Create new Gatsby project.`,
       handler: handlerP(

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -297,11 +297,17 @@ module.exports = (argv, handlers) => {
   return cli
     .command({
       command: `new [rootPath] [starter]`,
+      builder: _ =>
+        _.option(`use-pnp`, {
+          default: false,
+          type: `boolean`,
+          describe: `Use Yarn Plug n' Play to install dependencies`,
+        }),
       desc: `Create new Gatsby project.`,
       handler: handlerP(
-        ({ rootPath, starter = `gatsbyjs/gatsby-starter-default` }) => {
+        ({ starter = `gatsbyjs/gatsby-starter-default`, ...options }) => {
           const initStarter = require(`./init-starter`)
-          return initStarter(starter, { rootPath })
+          return initStarter(starter, options)
         }
       ),
     })

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -58,10 +58,16 @@ const install = async (rootPath, { usePnp }: InitOptions) => {
   process.chdir(rootPath)
 
   try {
+    console.log(
+      [`yarnpkg`]
+        .concat(usePnp && shouldUseYarnPnp() ? `--enable-pnp` : [])
+        .join(` `)
+    )
     let cmd = shouldUseYarn()
       ? spawn(
-          `yarnpkg`,
-          ...[].concat(usePnp && shouldUseYarnPnp() ? `--enable-pnp` : [])
+          [`yarnpkg`]
+            .concat(usePnp && shouldUseYarnPnp() ? `--enable-pnp` : [])
+            .join(` `)
         )
       : spawn(`npm install`)
     await cmd

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -30,8 +30,21 @@ const shouldUseYarn = () => {
 
 const shouldUseYarnPnp = (yarnPnpVersion = `1.12.0`) => {
   try {
-    const version = execSync(`yarnpkg --version`).toString()
-    return semver.gte(version, yarnPnpVersion)
+    const version = execSync(`yarnpkg --version`)
+      .toString()
+      .trim()
+    const validVersion = semver.gte(version, yarnPnpVersion)
+
+    if (!validVersion) {
+      report.warn(
+        report.stripIndent`
+          You are using yarn ${version} which does not contain pnp support.
+          Please upgrade yarn to at least ${yarnPnpVersion}
+        `
+      )
+    }
+
+    return validVersion
   } catch (e) {
     return false
   }

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -58,11 +58,6 @@ const install = async (rootPath, { usePnp }: InitOptions) => {
   process.chdir(rootPath)
 
   try {
-    console.log(
-      [`yarnpkg`]
-        .concat(usePnp && shouldUseYarnPnp() ? `--enable-pnp` : [])
-        .join(` `)
-    )
     let cmd = shouldUseYarn()
       ? spawn(
           [`yarnpkg`]

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -93,6 +93,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "parse-filepath": "^1.0.1",
     "physical-cpu-count": "^2.0.0",
+    "pnp-webpack-plugin": "^1.2.0",
     "postcss-flexbugs-fixes": "^3.0.0",
     "postcss-loader": "^2.1.3",
     "raw-loader": "^0.5.1",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -57,6 +57,7 @@
     "file-loader": "^1.1.11",
     "flat": "^4.0.0",
     "friendly-errors-webpack-plugin": "^1.6.1",
+    "fs-exists-cached": "^1.0.0",
     "fs-extra": "^5.0.0",
     "gatsby-cli": "^2.4.5",
     "gatsby-link": "^2.0.6",

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -4,6 +4,7 @@ const fs = require(`fs-extra`)
 const path = require(`path`)
 const dotenv = require(`dotenv`)
 const FriendlyErrorsWebpackPlugin = require(`friendly-errors-webpack-plugin`)
+const PnpWebpackPlugin = require(`pnp-webpack-plugin`)
 const { store } = require(`../redux`)
 const { actions } = require(`../redux/actions`)
 const debug = require(`debug`)(`gatsby:webpack-config`)
@@ -359,6 +360,11 @@ module.exports = async (
       // directory if you need to install a specific version of a module for a
       // part of your site.
       modules: [directoryPath(path.join(`node_modules`)), `node_modules`],
+      // Yarn Plug'n'Play support
+      plugins: [PnpWebpackPlugin],
+      resolveLoader: {
+        plugins: [PnpWebpackPlugin.moduleLoader(module)],
+      },
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),
         // Using directories for module resolution is mandatory because

--- a/yarn.lock
+++ b/yarn.lock
@@ -14675,6 +14675,13 @@ pngquant-bin@^5.0.0:
     execa "^0.10.0"
     logalot "^2.0.0"
 
+pnp-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.2.0.tgz#a85338bc313b8a0469c1d8c5c5d016873be47cb2"
+  integrity sha512-cCaqL7SZCqeJoCEL5GhSGU9CFJOMcDIEAS83X+0m2q25vtt9IqrMJ5dObm8WyqnM4CHRaIn0VVkn7RXdZ0C6Kg==
+  dependencies:
+    ts-pnp "^1.0.0"
+
 portfinder@^1.0.9:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.17.tgz#a8a1691143e46c4735edefcf4fbcccedad26456a"
@@ -18675,6 +18682,11 @@ trough@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
+
+ts-pnp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.0.0.tgz#44a3a9e8c13fcb711bcda75d7b576c21af120c9d"
+  integrity sha512-qgwM7eBrxFvZSXLtSvjf3c2mXwJOOGD49VlE+KocUGX95DuMdLc/psZHBnPpZL5b2NU7VtQGHRCWF3cNfe5kxQ==
 
 tsickle@^0.27.2:
   version "0.27.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16894,6 +16894,11 @@ semver@^4.0.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
This enables flags in gatsby-cli (i.e. `gatsby new some-project` will enable PnP.

It's hard to test because as @m-allanson noted, gatsby-dev _requires_ a node_modules structure, but fairly certain this is working as intended.

I'll add a comment with metrics in a bit.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
