### PR TITLE
Documentation fix: Execute trailing slash stripping function, rather than assign it.

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -114,6 +114,8 @@ _Note: There's also a plugin that will remove all trailing slashes from pages au
 [gatsby-plugin-remove-trailing-slashes](/packages/gatsby-plugin-remove-trailing-slashes/)_.
 
 ```javascript:title=gatsby-node.js
+// Replacing '/' would result in empty string which is invalid
+const replacePath = _path => (_path === `/` ? _path : _path.replace(/\/$/, ``))
 // Implement the Gatsby API “onCreatePage”. This is
 // called after every page is created.
 exports.onCreatePage = ({ page, actions }) => {
@@ -121,7 +123,7 @@ exports.onCreatePage = ({ page, actions }) => {
   return new Promise(resolve => {
     const oldPage = Object.assign({}, page)
     // Remove trailing slash unless page is /
-    page.path = (_path => (_path === `/` ? _path : _path.replace(/\/$/, ``)))(page.path)
+    page.path = replacePath(page.path)
     if (page.path !== oldPage.path) {
       // Replace new page with old page
       deletePage(oldPage)

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -121,7 +121,7 @@ exports.onCreatePage = ({ page, actions }) => {
   return new Promise(resolve => {
     const oldPage = Object.assign({}, page)
     // Remove trailing slash unless page is /
-    page.path = _path => (_path === `/` ? _path : _path.replace(/\/$/, ``))
+    page.path = (_path => (_path === `/` ? _path : _path.replace(/\/$/, ``)))(page.path)
     if (page.path !== oldPage.path) {
       // Replace new page with old page
       deletePage(oldPage)

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -115,7 +115,7 @@ _Note: There's also a plugin that will remove all trailing slashes from pages au
 
 ```javascript:title=gatsby-node.js
 // Replacing '/' would result in empty string which is invalid
-const replacePath = _path => (_path === `/` ? _path : _path.replace(/\/$/, ``))
+const replacePath = path => (path === `/` ? path : path.replace(/\/$/, ``))
 // Implement the Gatsby API “onCreatePage”. This is
 // called after every page is created.
 exports.onCreatePage = ({ page, actions }) => {


### PR DESCRIPTION
The trailing slash stripping plugin [executes the function](https://github.com/gatsbyjs/gatsby/blob/f9714a5646523bc728586e3692190507ad68e6c1/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js#L9) rather than just assigning it, so I'd imagine that's what the example code should be doing too.