### PR TITLE
slight semantic change for clarity

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -62,7 +62,7 @@ MY_ENV_VAR=foo gatsby develop
 
 In Windows it's a little more complex. [Check out this Stack Overflow article for some options](https://stackoverflow.com/questions/1420719/powershell-setting-an-environment-variable-for-a-single-command-only documents some options.)
 
-However, the Project Env Vars that you defined in the `.env.*` files will _NOT_ be immediately available
+Project Env Vars that you defined in the `.env.*` files will _NOT_ be immediately available
 in your Node.js scripts. To use those variables, use NPM package [dotenv](https://www.npmjs.com/package/dotenv) to
 examine the active `.env.*` file and attached those values,
 It's already a dependency of Gatsby, so you can require it in your `gatsby-config.js` or `gatsby-node.js` like this:

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -60,9 +60,9 @@ In Linux terminals this can be done with:
 MY_ENV_VAR=foo gatsby develop
 ```
 
-In Windows it's a little more complex. [Check out this Stack Overflow article for some options](https://stackoverflow.com/questions/1420719/powershell-setting-an-environment-variable-for-a-single-command-only documents some options.)
+In Windows it's a little more complex. [Check out this Stack Overflow article for some options](https://stackoverflow.com/questions/1420719/powershell-setting-an-environment-variable-for-a-single-command-only)
 
-Project Env Vars that you defined in the `.env.*` files will _NOT_ be immediately available
+Project environment variables that you defined in the `.env.*` files will _NOT_ be immediately available
 in your Node.js scripts. To use those variables, use NPM package [dotenv](https://www.npmjs.com/package/dotenv) to
 examine the active `.env.*` file and attached those values,
 It's already a dependency of Gatsby, so you can require it in your `gatsby-config.js` or `gatsby-node.js` like this:


### PR DESCRIPTION
Removed "However, the " from the Project Env Vars description, it seems to reference the prior paragraph and is even less clear on the formatted .org doc page.  While seemingly minor, as a newcomer I read it as an extension of the Windows related paragraph, and it caused some confusion.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
