### PR TITLE
ci: update config to exclude docs/blog test running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ aliases:
     filters:
       branches:
         ignore:
-          - /docs(\/)?.*/
-          - /blog(\/)?.*/
+          - /docs.+/
+          - /blog.+/
 
   test_template: &test_template
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,13 @@ aliases:
         ignore:
           - master
 
+  ignore_docs: &ignore_docs
+    filters:
+      branches:
+        ignore:
+          - /docs(\/)?.*/
+          - /blog(\/)?.*/
+
   test_template: &test_template
     steps:
       - checkout
@@ -52,6 +59,7 @@ aliases:
 
   e2e-test-workflow: &e2e-test-workflow
     <<: *ignore_master
+    <<: *ignore_docs
     requires:
       - bootstrap
 
@@ -156,15 +164,19 @@ workflows:
       - bootstrap
       - lint
       - unit_tests_node6:
+          <<: *ignore_docs
           requires:
             - bootstrap
       - unit_tests_node8:
+          <<: *ignore_docs
           requires:
             - bootstrap
       - unit_tests_node10:
+          <<: *ignore_docs
           requires:
             - bootstrap
-      - integration_tests
+      - integration_tests:
+          <<: *ignore_docs
       - e2e_tests_gatsbygram:
           <<: *e2e-test-workflow
       - e2e_tests_path-prefix:


### PR DESCRIPTION
This will also hide the status check. The general idea is that any PR
whose branch starts with docs/, docs, blog/, or blog (e.g.
docs-some-update, docs/some-update, etc.) will not run e2e tests. This
seems pretty safe, and it's effectively opt-in. Unfortunately, we can't
really enforce this standard, so it's more relying on the community to
open up correct branch names, but if nothing else, it's valuable for us
:shrug:

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
