### PR TITLE
docs(examples.usingremark): Typo fix

### DIFF
--- a/examples/using-remark/src/pages/2017-11-14---excerpts/index.md
+++ b/examples/using-remark/src/pages/2017-11-14---excerpts/index.md
@@ -22,7 +22,7 @@ tags:
 }
 ```
 
-You can also manually mark in your markdown where to stop excerpting—similar to Jekyl. `gatsby-transformer-remark` uses [gray-matter](https://github.com/jonschlinkert/gray-matter) to parse markdown frontmatter, so you can specify an `excerpt_separator`, as well as any of the other options mentioned [here](https://github.com/jonschlinkert/gray-matter#options), in the `gatsby-config.js` file.
+You can also manually mark in your markdown where to stop excerpting—similar to Jekyll. `gatsby-transformer-remark` uses [gray-matter](https://github.com/jonschlinkert/gray-matter) to parse markdown frontmatter, so you can specify an `excerpt_separator`, as well as any of the other options mentioned [here](https://github.com/jonschlinkert/gray-matter#options), in the `gatsby-config.js` file.
 
 ```json
 {


### PR DESCRIPTION
`Jekyl` => `Jekyll`