### PR TITLE
tidy using-gatsby-source-graphql example

### DIFF
--- a/examples/using-gatsby-source-graphql/README.md
+++ b/examples/using-gatsby-source-graphql/README.md
@@ -2,7 +2,7 @@
 
 Simple gatsby site that displays blog with data inside GraphCMS.
 
-Built using [gatsby-source-graphql](https://www.gatsbyjs.org/plugins/gatsby-source-graphql).
+Built using [gatsby-source-graphql](https://www.gatsbyjs.org/packages/gatsby-source-graphql/).
 
 <!-- [See it here](https://using-gatsby-source-graphql.netlify.com/) -->
 

--- a/examples/using-gatsby-source-graphql/package.json
+++ b/examples/using-gatsby-source-graphql/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-starter-hello-world",
-  "description": "Gatsby hello world starter",
+  "name": "using-gatsby-source-graphql",
+  "description": "Gatsby example site using gatsby-source-graphql",
   "license": "MIT",
   "scripts": {
     "develop": "gatsby develop",
@@ -18,7 +18,7 @@
     "react-markdown": "^3.3.4"
   },
   "devDependencies": {
-    "babel-eslint": "8.2.1",
+    "babel-eslint": "^8.2.2",
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
     "eslint-config-prettier": "^2.9.0",

--- a/examples/using-gatsby-source-graphql/src/pages/index.js
+++ b/examples/using-gatsby-source-graphql/src/pages/index.js
@@ -7,7 +7,7 @@ export default ({ data }) => (
   <div>
     <h1>My Gatsby Blog</h1>
     <p>
-      <a href="https://www.gatsbyjs.org/plugins/gatsby-source-graphql">
+      <a href="https://www.gatsbyjs.org/packages/gatsby-source-graphql/">
         Using gatsby-source-graphql
       </a>
     </p>


### PR DESCRIPTION
Minor cleanup:

- repair links in readme and index pointing to plugins/ instead of packages/
- add fitting name and description in package.json in style of using-gatsby-image: https://github.com/gatsbyjs/gatsby/blob/44db2f70967fd4408a86590899038c9f16eb4e5d/examples/using-gatsby-image/package.json#L2-L4
- babel-eslint to ^8.2.2 to remedy various compile errors in yarn and this more informative npm error:
  ```bash
  npm WARN eslint-config-react-app@3.0.0-next.66cc7a90 requires a peer of babel-eslint@^8.2.2 but none is installed. You must install peer dependencies yourself.
  ```
  ...seems like we might could go higher: https://github.com/babel/babel-eslint/releases
  ...but this fixes the issues and allows me to build the example in yarn 1.12.3 and npm 6.4.1 on node 10.13.0.