### PR TITLE
docs(visual-testing-with-storybook): Typo fix

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -26,7 +26,7 @@ sb init
 
 > Note that if you're running a recent version of `npm` (5.2.0+) you can run the following single command instead: `npx -p @storybook/cli sb init`, which is the recommended method by Storybook. This doesn't install the CLI on your machine, thereby ensuring you're always running the latest version of the CLI.
 
-The `sb init` command boostraps the basic config necessary to run Storybook for a React project. However, since this is for a Gatsby project, you need to update the default Storybook configuration a bit so that you don't get errors when trying to use Gatsby specific components inside of the stories.
+The `sb init` command bootstraps the basic config necessary to run Storybook for a React project. However, since this is for a Gatsby project, you need to update the default Storybook configuration a bit so that you don't get errors when trying to use Gatsby specific components inside of the stories.
 
 To update your Storybook config open `.storybook/config.js` and add the following before the `configure` method at the bottom of the file.
 


### PR DESCRIPTION
`boostraps` => `bootstraps`