### PR TITLE
docs: Un-mark "Bable plugin macros" guide as stub

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -43,7 +43,7 @@
       items:
         - title: Babel.js
           link: /docs/babel/
-        - title: Babel plugin macros*
+        - title: Babel plugin macros
           link: /docs/babel-plugin-macros/
         - title: Custom webpack config
           link: /docs/add-custom-webpack-config/


### PR DESCRIPTION
Sorry, didn't realize this had to be updated manually...

Related to #9963 