### PR TITLE
fix(gatsby-plugin-sharp): use actions provided, don't assume Gatsby module location.

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,4 +1,4 @@
-const { setBoundActionCreators } = require('./index')
+const { setBoundActionCreators } = require(`./index`)
 
 exports.onPreInit = ({ actions }) => {
   setBoundActionCreators(actions)

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,3 +1,9 @@
+const { setBoundActionCreators } = require('./index')
+
+exports.onPreInit = ({ actions }) => {
+  setBoundActionCreators(actions)
+}
+
 // TODO
 // exports.formatJobMessage = jobs => {
 // return {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -30,7 +30,15 @@ const getImageSize = file => {
 }
 
 const duotone = require(`./duotone`)
-const { boundActionCreators } = require(`gatsby/dist/redux/actions`)
+
+// Bound action creators are set when passed to onPreInit in gatsby-node.
+// ** Do NOT just directly require the gatsby module **.
+// There is no guarantee that the module resolved is the module executing!
+// This can occur in mono repos depending on how dependencies have been hoisted.
+let boundActionCreators
+exports.setBoundActionCreators = actions => {
+  boundActionCreators = actions
+}
 
 // Promisify the sharp prototype (methods) to promisify the alternative (for
 // raw) callback-accepting toBuffer(...) method

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -31,11 +31,12 @@ const getImageSize = file => {
 
 const duotone = require(`./duotone`)
 
-// Bound action creators are set when passed to onPreInit in gatsby-node.
-// ** Do NOT just directly require the gatsby module **.
+// Bound action creators should be set when passed to onPreInit in gatsby-node.
+// ** It is NOT safe to just directly require the gatsby module **.
 // There is no guarantee that the module resolved is the module executing!
 // This can occur in mono repos depending on how dependencies have been hoisted.
-let boundActionCreators
+// The direct require has been left only to avoid breaking changes.
+let { boundActionCreators } = require(`gatsby/dist/redux/actions`)
 exports.setBoundActionCreators = actions => {
   boundActionCreators = actions
 }


### PR DESCRIPTION
The gatsby module resolve by require might not be the gatsby module that is executing. This can occur in mono-repo configurations.

This will prevent the Redux store from receiving the job actions and the bootstrap process will complete without waiting for all images to be processed. This can cause the build to finish without all images being generated.

Fixes #9984.