### PR TITLE
[themes] Introduce Component Shadowing

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -75,6 +75,20 @@ Array [
   },
   Object {
     "browserAPIs": Array [],
+    "id": "6f4b2fa9-66b5-5205-a03f-140005a2cfe5",
+    "name": "webpack-theme-component-shadowing",
+    "nodeAPIs": Array [
+      "onCreateWebpackConfig",
+    ],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
     "id": "7374ebf2-d961-52ee-92a2-c25e7cb387a9",
     "name": "default-site-plugin",
     "nodeAPIs": Array [],
@@ -169,6 +183,20 @@ Array [
     "name": "query-runner",
     "nodeAPIs": Array [
       "onCreatePage",
+    ],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "6f4b2fa9-66b5-5205-a03f-140005a2cfe5",
+    "name": "webpack-theme-component-shadowing",
+    "nodeAPIs": Array [
+      "onCreateWebpackConfig",
     ],
     "pluginOptions": Object {
       "plugins": Array [],

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -158,6 +158,7 @@ module.exports = (config = {}) => {
     `../../internal-plugins/internal-data-bridge`,
     `../../internal-plugins/prod-404`,
     `../../internal-plugins/query-runner`,
+    `../../internal-plugins/webpack-theme-component-shadowing`,
   ]
   internalPlugins.forEach(relPath => {
     const absPath = path.join(__dirname, relPath)

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
@@ -1,0 +1,26 @@
+const GatsbyThemeComponentShadowingResolverPlugin = require(`.`)
+
+exports.onCreateWebpackConfig = ({
+  store,
+  stage,
+  getConfig,
+  rules,
+  loaders,
+  actions,
+}) => {
+  const { config, program } = store.getState()
+  const themes = config.__experimentalThemes.map(({ resolve }) => resolve)
+
+  if (themes) {
+    actions.setWebpackConfig({
+      resolve: {
+        plugins: [
+          new GatsbyThemeComponentShadowingResolverPlugin({
+            themes,
+            projectRoot: program.directory,
+          }),
+        ],
+      },
+    })
+  }
+}

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
@@ -1,22 +1,17 @@
 const GatsbyThemeComponentShadowingResolverPlugin = require(`.`)
 
-exports.onCreateWebpackConfig = ({
-  store,
-  stage,
-  getConfig,
-  rules,
-  loaders,
-  actions,
-}) => {
+exports.onCreateWebpackConfig = (
+  { store, stage, getConfig, rules, loaders, actions },
+  pluginOptions
+) => {
   const { config, program } = store.getState()
-  const themes = config.__experimentalThemes.map(({ resolve }) => resolve)
 
-  if (themes) {
+  if (config.__experimentalThemes) {
     actions.setWebpackConfig({
       resolve: {
         plugins: [
           new GatsbyThemeComponentShadowingResolverPlugin({
-            themes,
+            themes: config.__experimentalThemes.map(({ resolve }) => resolve),
             projectRoot: program.directory,
           }),
         ],

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -1,0 +1,74 @@
+const path = require(`path`)
+
+module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
+  cache = {}
+
+  constructor({ projectRoot, themes }) {
+    this.themes = themes
+    this.projectRoot = projectRoot
+  }
+
+  apply(resolver) {
+    resolver.plugin(`relative`, (request, callback) => {
+      // find out which theme's src/components dir we're requiring from
+      const matchingThemes = this.themes.filter(name =>
+        request.path.includes(path.join(name, `src`, `components`))
+      )
+      // 0 matching themes happens a lot fo rpaths we don't want to handle
+      // > 1 matching theme means we have a path like
+      //   `gatsby-theme-blog/src/components/gatsby-theme-something/src/components`
+      if (matchingThemes.length > 1) {
+        throw new Error(
+          `Gatsby can't differentiate between themes ${matchingThemes.join(
+            ` and `
+          )} for path ${request.path}`
+        )
+      }
+      if (matchingThemes.length !== 1) {
+        return callback()
+      }
+      // theme is the theme package from which we're requiring the relative component
+      const [theme] = matchingThemes
+      // get the location of the component relative to src/components
+      const [, component] = request.path.split(
+        path.join(theme, `src`, `components`)
+      )
+
+      const resolvedComponentPath = require.resolve(
+        this.resolveComponentPath({
+          theme,
+          component,
+          projectRoot: this.projectRoot,
+        })
+      )
+      // this callback ends the resolver fallthrough chain.
+      return callback(null, {
+        directory: request.directory,
+        path: resolvedComponentPath,
+        query: request.query,
+        request: ``,
+      })
+    })
+  }
+
+  // check the cache, the user's project, and finally the theme files
+  resolveComponentPath({ theme, component, projectRoot }) {
+    if (!this.cache[`${theme}-${component}`]) {
+      this.cache[`${theme}-${component}`] = [
+        path.join(projectRoot, `src`, `components`, theme),
+        path.join(path.dirname(require.resolve(theme)), `src`, `components`),
+      ]
+        .map(dir => path.join(dir, component))
+        .filter(possibleComponentPath => {
+          try {
+            require.resolve(possibleComponentPath)
+            return true
+          } catch (e) {
+            return false
+          }
+        })[0]
+    }
+
+    return this.cache[`${theme}-${component}`]
+  }
+}

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -59,14 +59,14 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
         path.join(path.dirname(require.resolve(theme)), `src`, `components`),
       ]
         .map(dir => path.join(dir, component))
-        .filter(possibleComponentPath => {
+        .find(possibleComponentPath => {
           try {
             require.resolve(possibleComponentPath)
             return true
           } catch (e) {
             return false
           }
-        })[0]
+        })
     }
 
     return this.cache[`${theme}-${component}`]

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/package.json
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "webpack-theme-component-shadowing",
+  "version": "1.0.0",
+  "description": "An internal Gatsby plugin which handles configuring webpack to ensure theme components fall back from the user's site to theme modules.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Chris Biscardi <chris@christopherbiscardi.com>",
+  "license": "MIT"
+}


### PR DESCRIPTION
# Intro

Following up on https://github.com/gatsbyjs/gatsby/pull/9517#discussion_r229001969, Component Shadowing is the ability for a user's site to override the component a theme uses to render data. The primary use case goes something like:

* As a user of gatsby-theme-blog, I want to adjust the styling and markup for the Blog Post content

with additional use cases such as:

* I want to replace the design tokens of a gatsby theme
  - Imagine styled-system tokens laid out on disk as files
* I want to change a GraphQL query to return more information
  - Would replace the `WhateverQuery` component of the theme

# User Visible API

From the user's point of view, shadowing a component involves the creation of a single file (the replacement component) in the right location. As seen [in this commit to the examples repo](https://github.com/ChristopherBiscardi/gatsby-theme-examples/pull/6/commits/f4de66a42396494b9541269ea11d38381333bc7b). This means that the theme's override-able components become part of its public API.

# Implementation

Component Shadowing is implemented as a webpack resolver plugin. The algorithm for shadowing is roughly:

* If there is a relative require webpack is trying to resolve (ex: `./src/components/Bio.js`
* check the user's site for a component at the path `src/components/${theme}/Bio.js`
* if file exists, resolve to the user's component
* otherwise, fall back to the theme's component at `${theme}/src/components/Bio.js`

That is, if the user has created a file in the right place, we use it. Otherwise we don't.

Component Shadowing is only enabled if a theme has been specified.

