### PR TITLE
Adding VS Code Rocks to site showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -3416,3 +3416,17 @@
     - React Native
   built_by: DexLab
   built_by_url: "https://github.com/dexlab-io"
+- title: VS Code Rocks
+  main_url: "https://vscode.rocks"
+  url: "https://vscode.rocks"
+  source_url: "https://github.com/lannonbr/vscode-rocks"
+  featured: false
+  description: >
+    VS Code Rocks is a place for weekly news on the newest features and updates to Visual Studio Code as well as trending extensions and neat tricks to continually improve your VS Code skills.
+  categories:
+    - Open Source
+    - VS Code
+    - Blog
+    - Web Development
+  built_by: Benjamin Lannon
+  built_by_url: "https://github.com/lannonbr"


### PR DESCRIPTION
I added my blog [VS Code Rocks](https://vscode.rocks) to the site showcase