### PR TITLE
Fix codeblock not rendering on markdown

### DIFF
--- a/docs/docs/local-https.md
+++ b/docs/docs/local-https.md
@@ -44,7 +44,9 @@ If you need to use a custom https setup, you can pass the `--https`, `--key-file
 - `--cert-file` [relative path to ssl certificate file]
 - `--key-file` [relative path to ssl key file]
 
-  $ gatsby develop --https --key-file ../relative/path/to/key.key --cert-file ../relative/path/to/cert.crt
+See the example command;
+
+    $ gatsby develop --https --key-file ../relative/path/to/key.key --cert-file ../relative/path/to/cert.crt
 
 in most cases, the `--https` passed by itself is easier and more convenient to get local https.
 

--- a/docs/docs/local-https.md
+++ b/docs/docs/local-https.md
@@ -44,9 +44,11 @@ If you need to use a custom https setup, you can pass the `--https`, `--key-file
 - `--cert-file` [relative path to ssl certificate file]
 - `--key-file` [relative path to ssl key file]
 
-See the example command;
+See the example command:
 
-    $ gatsby develop --https --key-file ../relative/path/to/key.key --cert-file ../relative/path/to/cert.crt
+```bash
+$ gatsby develop --https --key-file ../relative/path/to/key.key --cert-file ../relative/path/to/cert.crt
+```
 
 in most cases, the `--https` passed by itself is easier and more convenient to get local https.
 


### PR DESCRIPTION
On the live documents page and on github's markdown, the code block is not rendering probably because of the previous list items. 

I added a text between them to make it work.

![screenshot at nov 18 00-02-40](https://user-images.githubusercontent.com/5216601/48665777-ac00f180-eac5-11e8-8861-522b4b10ccbc.png)


<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
