### PR TITLE
What files to add to the repo / add to the .gitignore???

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -50,3 +50,6 @@ After running `npm run deploy` you should see your website at `http://username.g
 If you use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add a `pathPrefix` as it will break navigation on your site. Path prefixing is only necessary when the site is _not_ at the root of the domain like with repository sites.
 
 **Note**: Don't forget to add your [CNAME](https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors) file to the `static` directory.
+
+## Files to check into git / Files to add to the .gitignore
+


### PR DESCRIPTION
This isn't a useful addition to this page, but it would be good to include what files need to be checked into the git repo, I'd imagine we can throw the node-modules and possibly others into the .gitignore. I've also noticed the the `/src` files and others don't get pushed to the github.io site. Is the idea that you would have another repo that would manage all of your commits while developing and then the push to github.io would just be the `/public` folder?? Sorry that this is more of a question than an addition, but I think this would be good to add here. Thanks!

If I set up the way it is stated in the docs, I wouldn't then be able to clone that `<reponame>.github.io` and build from there so, what is the best way to manage that?

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
