### PR TITLE
fix(gatsby-remark-images-contentful): add in missing colon for the fallback src

### DIFF
--- a/packages/gatsby-remark-images-contentful/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images-contentful/src/__tests__/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`it transforms HTML img tags 1`] = `
 
   <span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; ; max-width: 600px; margin-left: auto; margin-right: auto;\\">
     <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 100%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image;&apos;); background-size: cover; display: block;\\">
-      <img class=\\"gatsby-resp-image-image\\" style=\\"width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px white;\\" alt=\\"quwowooybuqbl6ntboz3\\" title=\\"\\" src=\\"https//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg\\" srcset=\\"srcSet\\" sizes=\\"128px,250px\\">
+      <img class=\\"gatsby-resp-image-image\\" style=\\"width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px white;\\" alt=\\"quwowooybuqbl6ntboz3\\" title=\\"\\" src=\\"https://images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg\\" srcset=\\"srcSet\\" sizes=\\"128px,250px\\">
     </span>
   </span>
   
@@ -37,7 +37,7 @@ exports[`it transforms images in markdown 1`] = `
         style=\\"width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px white;\\"
         alt=\\"image\\"
         title=\\"\\"
-        src=\\"https//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg\\"
+        src=\\"https://images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg\\"
         srcset=\\"srcSet\\"
         sizes=\\"128px,250px\\"
       />

--- a/packages/gatsby-remark-images-contentful/src/index.js
+++ b/packages/gatsby-remark-images-contentful/src/index.js
@@ -77,7 +77,7 @@ module.exports = async (
     // Calculate the paddingBottom %
     const ratio = `${(1 / responsiveSizesResult.aspectRatio) * 100}%`
 
-    const fallbackSrc = `https${node.url}`
+    const fallbackSrc = `https:${node.url}`
     const srcSet = responsiveSizesResult.srcSet
     const presentationWidth = responsiveSizesResult.presentationWidth
 


### PR DESCRIPTION
Hey there. I was looking to add in AMP support for my pages, and noticed my Contentful images weren't able to be fetched properly because the URLs were invalid:

```
https//images.ctfassets.net/sk06mmp11skx/6FZZJDW2VGcEMM2sCyKI6w/32a06680dc5ba66c69925befe2ca6ace/costs-estimate.JPG
```

I noticed it was missing a `:`, as were the plugin's tests!. This resolves it :)