### PR TITLE
fix: update peerDependency, plugins rely on extra arg being passed in API hooks

### DIFF
--- a/packages/gatsby-plugin-jss/package.json
+++ b/packages/gatsby-plugin-jss/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": ">2.0.0-alpha"
+    "gatsby": ">=2.0.32"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss",
   "scripts": {

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -24,7 +24,7 @@
   "main": "index.js",
   "peerDependencies": {
     "babel-plugin-styled-components": ">1.5.0",
-    "gatsby": ">2.0.0-alpha",
+    "gatsby": ">=2.0.32",
     "styled-components": ">= 2.0.0"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components",


### PR DESCRIPTION
Those plugins rely on changes introduced in https://github.com/gatsbyjs/gatsby/pull/9401 which was released in `gatsby@2.0.32`