### PR TITLE
Fix Create a Gatsby site link

### DIFF
--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -19,7 +19,7 @@
         - title: Install Gatsby CLI
           link: /tutorial/part-zero/#install-gatsby-cli
         - title: Create a Gatsby site
-          link: /tutorial/part-zero/#create-a-site
+          link: /tutorial/part-zero/#create-a-gatsby-site
         - title: Set up a code editor
           link: /tutorial/part-zero/#set-up-a-code-editor
     - title: 1. Get to know Gatsby building blocks


### PR DESCRIPTION
In the [Set Up Your Development Environment](https://www.gatsbyjs.org/tutorial/part-zero/) page, the link with label "Create a Gatsby site" (sidebar) refers to #create-a-site instead of #create-a-gatsby-site.

