### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -2,7 +2,7 @@
 title: Add a manifest file
 ---
 
-If you've run an [audit with Lighthouse](/docs/audit-with-lighthouse/), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
+If you've run an [audit with Lighthouse](/docs/docs/audit-with-lighthouse.md), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
 
 But first, what exactly _are_ PWAs?
 

--- a/docs/docs/add-offline-support-with-a-service-worker.md
+++ b/docs/docs/add-offline-support-with-a-service-worker.md
@@ -2,7 +2,7 @@
 title: Add Offline Support with a Service Worker
 ---
 
-If you've run an [audit with Lighthouse](/docs/audit-with-lighthouse/), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
+If you've run an [audit with Lighthouse](/docs/docs/audit-with-lighthouse.md), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
 
 1.  You can [add a manifest file](/docs/add-a-manifest-file/). Ensure that the manifest plugin is listed _before_ the offline plugin so that the offline plugin can cache the created `manifest.webmanifest`.
 2.  You can also add offline support, since another requirement for a website to qualify as a PWA is the use of a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). [Gatsby's offline plugin](/packages/gatsby-plugin-offline/) makes a Gatsby site work offline--and makes it more resistant to bad network conditions--by creating a service worker for your site.

--- a/docs/docs/add-offline-support.md
+++ b/docs/docs/add-offline-support.md
@@ -2,7 +2,7 @@
 title: Add offline support
 ---
 
-If you've run an [audit with Lighthouse](/docs/audit-with-lighthouse/), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
+If you've run an [audit with Lighthouse](/docs/docs/audit-with-lighthouse.md), you may have noticed a lackluster score in the "Progressive Web App" category. Let's address how you can improve that score.
 
 1.  You can [add a manifest file](/docs/add-a-manifest-file/).
 2.  You can also add offline support, since another requirement for a website to qualify as a PWA is the use of a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). A service worker runs in the background, deciding to serve network or cached content based on connectivity, allowing for a seamless, managed offline experience.

--- a/docs/docs/add-page-metadata.md
+++ b/docs/docs/add-page-metadata.md
@@ -2,7 +2,7 @@
 title: Adding page metadata
 ---
 
-If you've run an [audit with Lighthouse](/docs/audit-with-lighthouse/), you may have noticed a lackluster score in the "SEO" category. Let's address how you can improve that score.
+If you've run an [audit with Lighthouse](/docs/docs/audit-with-lighthouse.md), you may have noticed a lackluster score in the "SEO" category. Let's address how you can improve that score.
 
 Adding metadata to pages (such as a title or description) are key in helping search engines like Google understand your content, and decide when to surface it in search results.
 

--- a/docs/docs/adding-forms.md
+++ b/docs/docs/adding-forms.md
@@ -4,5 +4,5 @@ title: Adding forms
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/adding-images-fonts-files.md
+++ b/docs/docs/adding-images-fonts-files.md
@@ -128,7 +128,7 @@ add a file named `sun.jpg` to the static folder, it'll be copied to
 `public/sun.jpg`. To reference assets in the `static` folder, you'll need to
 [import a helper function from `gatsby` named `withPrefix`](/docs/gatsby-link/#prefixed-paths-helper).
 You will need to make sure
-[you set `pathPrefix` in your gatsby-config.js for this to work](/docs/path-prefix/).
+[you set `pathPrefix` in your gatsby-config.js for this to work](/docs/docs/path-prefix.md).
 
 ```js
 import { withPrefix } from 'gatsby'

--- a/docs/docs/adding-website-functionality.md
+++ b/docs/docs/adding-website-functionality.md
@@ -5,7 +5,7 @@ overview: true
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.
 
 [[guidelist]]

--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -15,7 +15,7 @@ We also automatically add polyfills as needed — no more shipping code which my
 breaks on older browsers!
 
 If you only target newer browsers, see the [Browser
-Support](/docs/browser-support/) docs page for how to instruct Gatsby on which
+Support](/docs/docs/browser-support.md) docs page for how to instruct Gatsby on which
 browsers you support and then Babel will start compiling for only these
 browsers.
 

--- a/docs/docs/basic-hardware-software-requirements.md
+++ b/docs/docs/basic-hardware-software-requirements.md
@@ -4,5 +4,5 @@ title: Basic Hardware and Software Requirements
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/build-caching.md
+++ b/docs/docs/build-caching.md
@@ -4,5 +4,5 @@ title: Build Caching
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/building-a-blog.md
+++ b/docs/docs/building-a-blog.md
@@ -4,5 +4,5 @@ title: Building a blog
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/building-a-portfolio.md
+++ b/docs/docs/building-a-portfolio.md
@@ -4,5 +4,5 @@ title: Building a portfolio
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/building-a-site-with-asynchronous-data.md
+++ b/docs/docs/building-a-site-with-asynchronous-data.md
@@ -4,5 +4,5 @@ title: Building a site with asynchronous data
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/building-an-e-commerce-site.md
+++ b/docs/docs/building-an-e-commerce-site.md
@@ -4,5 +4,5 @@ title: Building an e-commerce site
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/building-an-image-heavy-site.md
+++ b/docs/docs/building-an-image-heavy-site.md
@@ -4,5 +4,5 @@ title: Building an image heavy site
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/client-data-fetching.md
+++ b/docs/docs/client-data-fetching.md
@@ -4,5 +4,5 @@ title: Client data fetching
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/coming-from-react-to-gatsby.md
+++ b/docs/docs/coming-from-react-to-gatsby.md
@@ -4,4 +4,4 @@ title: "Coming from React to Gatsby: What You Need to Know"
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your pull request gets accepted.
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your pull request gets accepted.

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -20,7 +20,7 @@ The Gatsby community welcomes contributions. Please refer to the guides below on
 - [How to Contribute](/docs/how-to-contribute/)
 - [How to File an Issue](/docs/how-to-file-an-issue/)
 - [Make feature requests with an RFC](/blog/2018-04-06-introducing-gatsby-rfc-process/)
-- [Gatsby Style Guide](/docs/gatsby-style-guide/)
+- [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md)
 
 ## Gatsby news
 

--- a/docs/docs/create-a-starter.md
+++ b/docs/docs/create-a-starter.md
@@ -4,5 +4,5 @@ title: Create a Starter
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/creating-a-sitemap.md
+++ b/docs/docs/creating-a-sitemap.md
@@ -4,5 +4,5 @@ title: Creating a sitemap
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/data-storage-redux.md
+++ b/docs/docs/data-storage-redux.md
@@ -4,5 +4,5 @@ title: Data Storage (Redux)
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/deploying-to-gitlab-pages.md
+++ b/docs/docs/deploying-to-gitlab-pages.md
@@ -19,7 +19,7 @@ You can deploy sites on GitLab Pages with or without a custom domain. If you cho
 
 As the site will be hosted under yourname.gitlab.io/examplerepository/, you will need to configure Gatsby to use the Path Prefix plugin.
 
-In the `gatsby-config.js`, set the `pathPrefix` to be added to your site's link paths. The `pathPrefix` should be the project name in your repository. (ex. `https://gitlab.com/yourname/examplerepository/` - your `pathPrefix` should be `/examplerepository`). See [the docs page on path prefixing for more](/docs/path-prefix/).
+In the `gatsby-config.js`, set the `pathPrefix` to be added to your site's link paths. The `pathPrefix` should be the project name in your repository. (ex. `https://gitlab.com/yourname/examplerepository/` - your `pathPrefix` should be `/examplerepository`). See [the docs page on path prefixing for more](/docs/docs/path-prefix.md).
 
 ```js:title=gatsby-config.js
 module.exports = {

--- a/docs/docs/dropping-images-into-static-folders.md
+++ b/docs/docs/dropping-images-into-static-folders.md
@@ -4,5 +4,5 @@ title: Dropping Images into Static Folders
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -68,7 +68,7 @@ module.exports = {
 }
 ```
 
-See more about [Adding a Path Prefix](/docs/path-prefix/).
+See more about [Adding a Path Prefix](/docs/docs/path-prefix.md).
 
 ## Polyfill
 
@@ -82,7 +82,7 @@ module.exports = {
 }
 ```
 
-See more about [Browser Support](/docs/browser-support/#polyfills) in Gatsby.
+See more about [Browser Support](/docs/docs/browser-support.md/#polyfills) in Gatsby.
 
 ## Mapping node types
 
@@ -259,7 +259,7 @@ module.exports = {
 }
 ```
 
-See more about [Proxying API Requests in Develop](/docs/api-proxy/).
+See more about [Proxying API Requests in Develop](/docs/docs/api-proxy.md).
 
 ## Advanced proxying with `developMiddleware`
 

--- a/docs/docs/gatsby-core-philosophy.md
+++ b/docs/docs/gatsby-core-philosophy.md
@@ -4,5 +4,5 @@ title: Gatsby core philosophy
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -100,7 +100,7 @@ Note that `navigate` was previously named `navigateTo`. `navigateTo` is deprecat
 ## Prefixed paths helper
 
 It is common to host sites in a sub-directory of a site. Gatsby lets you [set
-the path prefix for your site](/docs/path-prefix/). After doing so, Gatsby's `<Link>` component will automatically handle constructing the correct URL in development and production.
+the path prefix for your site](/docs/docs/path-prefix.md). After doing so, Gatsby's `<Link>` component will automatically handle constructing the correct URL in development and production.
 
 For pathnames you construct manually, there's a helper function, `withPrefix` that prepends your path prefix in production (but doesn't during development where paths don't need prefixed).
 

--- a/docs/docs/gatsby-on-linux.md
+++ b/docs/docs/gatsby-on-linux.md
@@ -6,7 +6,7 @@ title: Gatsby on Linux
 
 > This is a TODO. Help our community expand it.
 
-> Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your pull request gets accepted.
+> Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your pull request gets accepted.
 
 ## Windows Subsystem Linux (WSL)
 

--- a/docs/docs/gatsby-source-filesystem-programmatic-import.md
+++ b/docs/docs/gatsby-source-filesystem-programmatic-import.md
@@ -4,5 +4,5 @@ title: gatsby-source-filesystem programmatic import
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -4,5 +4,5 @@ title: Glossary
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/how-to-add-a-list-of-markdown-blog-posts.md
+++ b/docs/docs/how-to-add-a-list-of-markdown-blog-posts.md
@@ -4,4 +4,4 @@ title: How to Add a List of Markdown Blog Posts
 
 This is a stub. Help our community expand it.
 
-The [Gatsby Style Guide](/docs/gatsby-style-guide/) will help ensure your pull request gets accepted.
+The [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) will help ensure your pull request gets accepted.

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -114,7 +114,7 @@ To add a new blog post to the gatsbyjs.org blog:
 - Add `title`, `date`, `author`, and `tags` ([view existing tags](https://www.gatsbyjs.org/blog/tags/) or add a new one) to the frontmatter of your `index.md`. If you are cross posting your post you can add `canonicalLink` for SEO benefits. You can check the other blog posts in `/docs/blog` for examples.
 - If your blog post contains images add them to your blog post folder and reference them in your post's `index.md`.
 - Ensure any links to gatsbyjs.org are relative links - `/docs/how-to-contribute` instead of `https://gatsbyjs.org/docs/how-to-contribute`
-- Follow the [Style Guide](https://www.gatsbyjs.org/docs/gatsby-style-guide/#word-choice) to make sure you're using the appropriate wording.
+- Follow the [Style Guide](https://www.gatsbyjs.org/docs/docs/gatsby-style-guide.md#word-choice) to make sure you're using the appropriate wording.
 - Double check your grammar and capitalise correctly
 - Commit and push to your fork
 - Create a pull request from your branch

--- a/docs/docs/how-to-pitch-gatsby.md
+++ b/docs/docs/how-to-pitch-gatsby.md
@@ -4,5 +4,5 @@ title: How to pitch Gatsby
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/how-to-run-a-gatsby-workshop.md
+++ b/docs/docs/how-to-run-a-gatsby-workshop.md
@@ -4,5 +4,5 @@ title: How to run a Gatsby workshop
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/importing-media-content.md
+++ b/docs/docs/importing-media-content.md
@@ -4,5 +4,5 @@ title: Importing media content
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/importing-single-files.md
+++ b/docs/docs/importing-single-files.md
@@ -4,5 +4,5 @@ title: Importing single files
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/interactive-pages.md
+++ b/docs/docs/interactive-pages.md
@@ -4,5 +4,5 @@ title: Interactive pages
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/life-and-times-of-a-gatsby-build.md
+++ b/docs/docs/life-and-times-of-a-gatsby-build.md
@@ -4,5 +4,5 @@ title: Life and times of a Gatsby build
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/linking-and-prefetching-with-gatsby.md
+++ b/docs/docs/linking-and-prefetching-with-gatsby.md
@@ -4,5 +4,5 @@ title: Linking and prefetching with Gatsby
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/optimize-prefetching-with-guessjs.md
+++ b/docs/docs/optimize-prefetching-with-guessjs.md
@@ -4,5 +4,5 @@ title: Optimize Prefetching with Guess.js
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -4,5 +4,5 @@ title: Overview of the Docs
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/preparing-for-deployment.md
+++ b/docs/docs/preparing-for-deployment.md
@@ -4,5 +4,5 @@ title: Preparing a Site for Deployment
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/reach-router-and-gatsby.md
+++ b/docs/docs/reach-router-and-gatsby.md
@@ -4,5 +4,5 @@ title: "@reach/router and Gatsby"
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/rendering-sidebar-navigation-dynamically.md
+++ b/docs/docs/rendering-sidebar-navigation-dynamically.md
@@ -4,5 +4,5 @@ title: Rendering sidebar navigation dynamically
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/routing.md
+++ b/docs/docs/routing.md
@@ -4,5 +4,5 @@ title: Routing
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/sourcing-content-and-data.md
+++ b/docs/docs/sourcing-content-and-data.md
@@ -4,7 +4,7 @@ title: Sourcing Content and Data
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.
 
 ### Notes on this document:

--- a/docs/docs/sourcing-from-databases.md
+++ b/docs/docs/sourcing-from-databases.md
@@ -4,5 +4,5 @@ title: Sourcing from Databases
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/sourcing-from-prose.md
+++ b/docs/docs/sourcing-from-prose.md
@@ -4,5 +4,5 @@ title: Sourcing from Prose
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/sourcing-from-saas-services.md
+++ b/docs/docs/sourcing-from-saas-services.md
@@ -4,5 +4,5 @@ title: Sourcing from SaaS Services
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/docs/docs/gatsby-style-guide.md) to ensure your
 pull request gets accepted.

--- a/docs/docs/static-folder.md
+++ b/docs/docs/static-folder.md
@@ -39,7 +39,7 @@ render() {
 ```
 
 And make sure you
-[set `pathPrefix` in your gatsby-config.js](/docs/path-prefix/):
+[set `pathPrefix` in your gatsby-config.js](/docs/docs/path-prefix.md):
 
 ```javascript:title=gatsby-config.js
 module.exports = {


### PR DESCRIPTION
I've tried to fix some of the broken links in documentation. I'm sure there are broken more links. But there are the ones I could find in the little time I had. :smile_cat: