### PR TITLE
Use Gatsby V2 project structure

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -135,7 +135,7 @@ CSS along your PrismJS theme and the styles for `.gatsby-highlight-code-line`:
 
 If you want to add line numbering alongside your code, you need to
 import the corresponding CSS file from PrismJS, right after importing your
-colorscheme in `layout/index.js`:
+colorscheme in `src/components/layout.js`:
 
 ```javascript
 // layouts/index.js

--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -138,7 +138,7 @@ import the corresponding CSS file from PrismJS, right after importing your
 colorscheme in `src/components/layout.js`:
 
 ```javascript
-// layouts/index.js
+// src/components/layout.js
 require("prismjs/plugins/line-numbers/prism-line-numbers.css")
 ```
 


### PR DESCRIPTION
From the guide "Migrating from v1 to v2" (https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#2-move-layoutsindexjs-to-srccomponentslayoutjs-optional-but-recommended). The project structure has the layout file now on "src/components/layout.js" instead of "layouts/index.js"

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
