### PR TITLE
fix(prettier): ignore coverage directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,3 +26,6 @@ packages/gatsby/cache-dir/commonjs/**/*.js
 **/__tests__/fixtures/**
 
 infrastructure
+
+# coverage
+coverage


### PR DESCRIPTION
Right now if you run `yarn test:coverage` and then `yarn lint` prettier will complain about the generated files. This PR simply ignores the file in the `coverage` directory.