### PR TITLE
feat(gatsby): use cheap-module-source-map devtool webpack config in develop mode for easier debugging

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -263,7 +263,7 @@ module.exports = async (
   function getDevtool() {
     switch (stage) {
       case `develop`:
-        return `eval`
+        return `cheap-module-source-map`
       // use a normal `source-map` for the html phases since
       // it gives better line and column numbers
       case `develop-html`:


### PR DESCRIPTION
Closes #6278

Sourcemaps are not currently working on gatsby v2. This fixes that on 1 string.