### PR TITLE
add secondary fields to www query sorts

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -144,7 +144,7 @@ exports.createPages = ({ graphql, actions }) => {
     graphql(`
       query {
         allMarkdownRemark(
-          sort: { order: DESC, fields: [frontmatter___date] }
+          sort: { order: DESC, fields: [frontmatter___date, fields___slug] }
           limit: 10000
           filter: { fileAbsolutePath: { ne: null } }
         ) {

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -301,7 +301,7 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      sort: { order: DESC, fields: [frontmatter___date] }
+      sort: { order: DESC, fields: [frontmatter___date, fields___slug] }
       limit: 3
       filter: {
         frontmatter: { draft: { ne: true } }
@@ -319,6 +319,7 @@ export const pageQuery = graphql`
       filter: {
         fields: { starterShowcase: { slug: { in: $featuredStarters } } }
       }
+      sort: { fields: [fields___starterShowcase___slug] }
     ) {
       edges {
         node {

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -61,7 +61,7 @@ export const pageQuery = graphql`
   query($tag: String) {
     allMarkdownRemark(
       limit: 2000
-      sort: { fields: [frontmatter___date], order: DESC }
+      sort: { fields: [frontmatter___date, fields___slug], order: DESC }
       filter: {
         frontmatter: { tags: { in: [$tag] } }
         fileAbsolutePath: { regex: "/docs.blog/" }

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -112,7 +112,7 @@ export default BlogPostsIndex
 export const pageQuery = graphql`
   query blogListQuery($skip: Int!, $limit: Int!) {
     allMarkdownRemark(
-      sort: { order: DESC, fields: [frontmatter___date] }
+      sort: { order: DESC, fields: [frontmatter___date, fields___slug] }
       filter: {
         frontmatter: { draft: { ne: true } }
         fileAbsolutePath: { regex: "/docs.blog/" }

--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -105,7 +105,7 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      sort: { order: DESC, fields: [frontmatter___date] }
+      sort: { order: DESC, fields: [frontmatter___date, fields___slug] }
       filter: {
         fileAbsolutePath: { regex: "/blog/" }
         frontmatter: { draft: { ne: true } }


### PR DESCRIPTION
While working on loki (#9919), I've run into lots of fun edge cases to do with sorting. One is that some connection queries specify a sort order, but some returned fields have the same value for the sort field. The behavior here is undefined, but by default sift will order by the order they were added to Gatsby. While that's not a terrible default, it makes testing sift and loki compatibility hard, since loki has undefined ordering for this case.

So this PR adds a specific secondary sort key to various `www` queries, mainly for the purpose of testing sift/loki compatibility, but also because it makes sense.