### PR TITLE
Fix broken link to Gatsby community starters

### DIFF
--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -83,7 +83,7 @@ class IndexRoute extends React.Component {
               Running <code>gatsby new</code> installs the default Gatsby
               starter. There are
               {` `}
-              <Link to="/docs/gatsby-starters/">
+              <Link to="/starters/">
                 many other official and community starters
               </Link>
               {` `}


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
Clicking the link below results in a not found page. Updated with the correct url
<img width="733" alt="screen shot 2018-11-22 at 09 53 12" src="https://user-images.githubusercontent.com/1019869/48906947-7ac55000-ee3c-11e8-8ae9-45e88b5d733b.png">

<img width="1514" alt="screen shot 2018-11-22 at 09 52 22" src="https://user-images.githubusercontent.com/1019869/48906903-59646400-ee3c-11e8-9cac-cef544a127dc.png">

