### PR TITLE
fix(gatsby-remark-images-contentful)

### DIFF
--- a/packages/gatsby-remark-images-contentful/src/index.js
+++ b/packages/gatsby-remark-images-contentful/src/index.js
@@ -99,7 +99,7 @@ module.exports = async (
       style="padding-bottom: ${ratio}; position: relative; bottom: 0; left: 0; background-image: url('${
       responsiveSizesResult.base64
     }'); background-size: cover; display: block;"
-    >
+    ></span>
       <img
         class="gatsby-resp-image-image"
         style="width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px ${
@@ -111,7 +111,6 @@ module.exports = async (
         srcset="${srcSet}"
         sizes="${responsiveSizesResult.sizes}"
       />
-    </span>
   </span>
   `
     // Make linking to original image optional.


### PR DESCRIPTION
This is a minor fix to the breaking changes that happened in gatsby-remark-images@3.0.0

### BREAKING CHANGES

- **gatsby-remark-images:** html markup has been changed, high resolution image (img.gatsby-resp-image-image) is no longer nested inside span with low resolution placeholder (span.gatsby-resp-image-wrapper) - it's sibling of that span now. This might affect any custom styling that is applied to inline images

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
