### PR TITLE
fix(www): add proper sorting for featured starters in Homepage Ecosystem section

### DIFF
--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -319,7 +319,7 @@ export const pageQuery = graphql`
       filter: {
         fields: { starterShowcase: { slug: { in: $featuredStarters } } }
       }
-      sort: { fields: [fields___starterShowcase___slug] }
+      sort: { order: DESC, fields: [fields___starterShowcase___stars] }
     ) {
       edges {
         node {


### PR DESCRIPTION
Instead by `slug` we sort the starters by `stars` (DESC) - solving https://github.com/gatsbyjs/gatsby/pull/10085#discussion_r235792615