### PR TITLE
WIP: Feature: render data

### DIFF
--- a/packages/gatsby/cache-dir/api-runner-ssr.js
+++ b/packages/gatsby/cache-dir/api-runner-ssr.js
@@ -40,3 +40,13 @@ module.exports = (api, args, defaultReturn, argTransform) => {
     return [defaultReturn]
   }
 }
+
+module.exports.apiRunnerAsync = (api, args, defaultReturn) =>
+  // eslint-disable-next-line no-undef
+  plugins.reduce(
+    (previous, next) =>
+      next.plugin[api]
+        ? previous.then(() => next.plugin[api](args, next.options))
+        : previous,
+    Promise.resolve()
+  )

--- a/packages/gatsby/cache-dir/develop-static-entry.js
+++ b/packages/gatsby/cache-dir/develop-static-entry.js
@@ -111,5 +111,5 @@ export default (pagePath, callback) => {
   htmlStr = renderToStaticMarkup(htmlElement)
   htmlStr = `<!DOCTYPE html>${htmlStr}`
 
-  callback(null, htmlStr)
+  return { html: htmlStr }
 }

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -6,6 +6,7 @@ const { ServerLocation, Router, isRedirect } = require(`@reach/router`)
 const { get, merge, isObject, flatten, uniqBy } = require(`lodash`)
 
 const apiRunner = require(`./api-runner-ssr`)
+const { apiRunnerAsync } = apiRunner
 const syncRequires = require(`./sync-requires`)
 const { dataPaths, pages } = require(`./data.json`)
 const { version: gatsbyVersion } = require(`gatsby/package.json`)
@@ -49,7 +50,7 @@ const getPage = path => pagesObjectMap.get(path)
 
 const createElement = React.createElement
 
-export default (pagePath, callback) => {
+export default async (pagePath, callback) => {
   let bodyHtml = ``
   let headComponents = [
     <meta name="generator" content={`Gatsby ${gatsbyVersion}`} />,
@@ -171,7 +172,7 @@ export default (pagePath, callback) => {
   ).pop()
 
   // Let the site or plugin render the page component.
-  apiRunner(`replaceRenderer`, {
+  await apiRunnerAsync(`replaceRenderer`, {
     bodyComponent,
     replaceBodyHTMLString,
     setHeadComponents,

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -60,6 +60,12 @@ export default async (pagePath, callback) => {
   let preBodyComponents = []
   let postBodyComponents = []
   let bodyProps = {}
+  let renderData = {}
+
+  const getRenderData = () => renderData
+  const setRenderData = _data => {
+    renderData = _data
+  }
 
   const replaceBodyHTMLString = body => {
     bodyHtml = body
@@ -369,6 +375,8 @@ export default async (pagePath, callback) => {
     replacePreBodyComponents,
     getPostBodyComponents,
     replacePostBodyComponents,
+    setRenderData,
+    getRenderData,
     pathname: pagePath,
     pathPrefix: __PATH_PREFIX__,
   })
@@ -386,5 +394,5 @@ export default async (pagePath, callback) => {
     />
   )}`
 
-  callback(null, html)
+  return { html, renderData }
 }

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -501,7 +501,7 @@ module.exports = async (args: BootstrapArgs) => {
       parentSpan: bootstrapSpan,
     })
     activity.start()
-    await apiRunnerNode(`onPostBootstrap`, { parentSpan: activity.span })
+    await apiRunnerNode(`onPostBootstrap`, { store, parentSpan: activity.span })
     activity.end()
 
     bootstrapSpan.finish()

--- a/packages/gatsby/src/utils/html-renderer-queue.js
+++ b/packages/gatsby/src/utils/html-renderer-queue.js
@@ -3,6 +3,9 @@ const convertHrtime = require(`convert-hrtime`)
 const Worker = require(`jest-worker`).default
 const numWorkers = require(`physical-cpu-count`) || 1
 const { chunk } = require(`lodash`)
+const { store } = require(`../redux`)
+const fs = require(`fs-extra`)
+const path = require(`path`)
 
 const workerPool = new Worker(require.resolve(`./worker`), {
   numWorkers,
@@ -10,6 +13,17 @@ const workerPool = new Worker(require.resolve(`./worker`), {
     silent: false,
   },
 })
+
+// copied from https://github.com/markdalgleish/static-site-generator-webpack-plugin/blob/master/index.js#L161
+const generatePathToOutput = outputPath => {
+  let outputFileName = outputPath.replace(/^(\/|\\)/, ``) // Remove leading slashes for webpack-dev-server
+
+  if (!/\.(html?)$/i.test(outputFileName)) {
+    outputFileName = path.join(outputFileName, `index.html`)
+  }
+
+  return path.join(process.cwd(), `public`, outputFileName)
+}
 
 module.exports = (htmlComponentRendererPath, pages, activity) =>
   new Promise((resolve, reject) => {
@@ -34,6 +48,31 @@ module.exports = (htmlComponentRendererPath, pages, activity) =>
               htmlComponentRendererPath,
               paths: pageSegment,
               envVars,
+            })
+            .then(async results => {
+              await Promise.all(
+                results.map(async ({ path: outputPath, html, renderData }) => {
+                  await fs.outputFile(generatePathToOutput(outputPath), html)
+
+                  const { program, pages, jsonDataPaths } = store.getState()
+                  const page = pages.get(outputPath)
+                  const jsonDataPath = jsonDataPaths[page.jsonName]
+
+                  const resultPath = path.join(
+                    program.directory,
+                    `public`,
+                    `static`,
+                    `d`,
+                    `${jsonDataPath}.json`
+                  )
+                  const jsonData = await fs.readJson(resultPath)
+                  const newJsonData = {
+                    ...jsonData,
+                    render: renderData || {},
+                  }
+                  await fs.writeJson(resultPath, newJsonData)
+                })
+              )
             })
             .then(() => {
               finished += pageSegment.length

--- a/packages/gatsby/src/utils/worker.js
+++ b/packages/gatsby/src/utils/worker.js
@@ -21,10 +21,10 @@ export function renderHTML({ htmlComponentRendererPath, paths, envVars }) {
   return Promise.map(
     paths,
     path =>
-      new Promise((resolve, reject) => {
+      new Promise(async (resolve, reject) => {
         const htmlComponentRenderer = require(htmlComponentRendererPath)
         try {
-          htmlComponentRenderer.default(path, (throwAway, htmlString) => {
+          await htmlComponentRenderer.default(path, (throwAway, htmlString) => {
             resolve(fs.outputFile(generatePathToOutput(path), htmlString))
           })
         } catch (e) {

--- a/packages/gatsby/src/utils/worker.js
+++ b/packages/gatsby/src/utils/worker.js
@@ -1,35 +1,15 @@
-const fs = require(`fs-extra`)
-const path = require(`path`)
 const Promise = require(`bluebird`)
-
-// copied from https://github.com/markdalgleish/static-site-generator-webpack-plugin/blob/master/index.js#L161
-const generatePathToOutput = outputPath => {
-  let outputFileName = outputPath.replace(/^(\/|\\)/, ``) // Remove leading slashes for webpack-dev-server
-
-  if (!/\.(html?)$/i.test(outputFileName)) {
-    outputFileName = path.join(outputFileName, `index.html`)
-  }
-
-  return path.join(process.cwd(), `public`, outputFileName)
-}
 
 export function renderHTML({ htmlComponentRendererPath, paths, envVars }) {
   // This is being executed in child process, so we need to set some vars
   // for modules that aren't bundled by webpack.
   envVars.forEach(([key, value]) => (process.env[key] = value))
 
-  return Promise.map(
-    paths,
-    path =>
-      new Promise(async (resolve, reject) => {
-        const htmlComponentRenderer = require(htmlComponentRendererPath)
-        try {
-          await htmlComponentRenderer.default(path, (throwAway, htmlString) => {
-            resolve(fs.outputFile(generatePathToOutput(path), htmlString))
-          })
-        } catch (e) {
-          reject(e)
-        }
-      })
-  )
+  return Promise.map(paths, async path => {
+    const htmlComponentRenderer = require(htmlComponentRendererPath)
+    return {
+      path,
+      ...(await htmlComponentRenderer.default(path)),
+    }
+  })
 }


### PR DESCRIPTION
Hi,

First, the title of this PR does probably not fit well. Naming things is hard...
Note: I am pretty new in the Gatsby codebase. Please don't hesitate to highlight me if I am going wrong!

### What's inside:

- **render static: allow `replaceRenderer` to be async**

It allow plugins to be `async` in to the `replaceRenderer` SSR hook.
Ex:
```js
export const replaceRenderer = async ({ bodyComponent }) => {
  await getDataFromTree(bodyComponent)
}
```

- **implement "render data"**

New concept: add the possibility to the `onPreRenderHTML` SSR hook to emit additional data that will be written in the page json data file.
It will be useful if some data are emitted by the rendering itself.

### What's the purpose ?

One thing that blocks me regularly in Gatsby is that the GraphQL queries are extremely statics.
Indeed, we can only write queries in page components which only accepts `pageContext` in variables. Or we can use `StaticQuery` but no variables are available.

So I tried to use another GraphQL client to query the same schema, but anywhere in the codebase.
This has been accomplished in this experimental repo:

**https://github.com/LoicMahieu/gatsby-plugin-query-demo**

I don't have time for now to explain whole things about that but I will write more about it this monday. (But at this time, my wife is waiting for me to go on weekend, it is better not to make here wait!)
I wanted to post this PR, I would be very happy to receive comments about this.

Thanks!
