### PR TITLE
Allow for activeClassName to be passed to Link

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -136,7 +136,9 @@ following may be a good starting point:
 ```jsx
 import { Link as GatsbyLink } from "gatsby"
 
-const Link = ({ children, to, ...other }) => {
+// Since DOM elements <a> cannot receive activeClassName,
+// destructure the prop here and pass it only to GatsbyLink
+const Link = ({ children, to, activeClassName, ...other }) => {
   // Tailor the following test to your environment.
   // This example assumes that any internal link (intended for Gatsby)
   // will start with exactly one slash, and that anything else is external.
@@ -145,7 +147,7 @@ const Link = ({ children, to, ...other }) => {
   // Use Gatsby Link for internal links, and <a> for others
   if (internal) {
     return (
-      <GatsbyLink to={to} {...other}>
+      <GatsbyLink to={to} activeClassName={activeClassName} {...other}>
         {children}
       </GatsbyLink>
     )
@@ -164,7 +166,7 @@ export default Link
 
 You can similarly check for file downloads:
 
-```
+```jsx
   const file = /\.[0-9a-z]+$/i.test(to)
 
   ...


### PR DESCRIPTION
Without destructuring `activeClassName`, the <a> element will receive the prop and react will throw an error along the lines of `React does not recognize the `activeClassName` prop on a DOM element.`.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
