### PR TITLE
Sample code graphql package not imported

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -100,6 +100,7 @@ This is what a component using `gatsby-image` looks like:
 
 ```jsx
 import React from "react"
+import { graphql } from "gatsby"
 import Img from "gatsby-image"
 
 export default ({ data }) => (


### PR DESCRIPTION
graphql object is used for query but not imported from `gatsby` package.