### PR TITLE
Fix broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
   <span> · </span>
   <a href="https://gatsbyjs.org/plugins/">Plugins</a>
   <span> · </span>
-  <a href="https://gatsbyjs.org/docs/gatsby-starters/">Starters</a>
+  <a href="https://gatsbyjs.org/starters/">Starters</a>
   <span> · </span>
   <a href="https://gatsbyjs.org/showcase/">Showcase</a>
   <span> · </span>


### PR DESCRIPTION
`/docs/gatsby-starters/` redirects to `/starters/`.
Fix to move to `/starters/` from the beginning.