### PR TITLE
fix(gatsby-plugin-filesystem): throw meaningful errors on bad inputs

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -1,0 +1,55 @@
+const createRemoteFileNode = require(`../create-remote-file-node`)
+
+describe(`create-remote-file-node`, () => {
+  const defaultArgs = {
+    url: ``,
+    store: {},
+    cache: {},
+    createNode: jest.fn(),
+    createNodeId: jest.fn(),
+  }
+
+  it(`throws on invalid inputs: createNode`, () => {
+    expect(() => {
+      createRemoteFileNode({
+        ...defaultArgs,
+        createNode: undefined,
+      })
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"createNode must be a function, was undefined"`
+    )
+  })
+
+  it(`throws on invalid inputs: createNodeId`, () => {
+    expect(() => {
+      createRemoteFileNode({
+        ...defaultArgs,
+        createNodeId: undefined,
+      })
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"createNodeId must be a function, was undefined"`
+    )
+  })
+
+  it(`throws on invalid inputs: cache`, () => {
+    expect(() => {
+      createRemoteFileNode({
+        ...defaultArgs,
+        cache: undefined,
+      })
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"cache must be the Gatsby cache, was undefined"`
+    )
+  })
+
+  it(`throws on invalid inputs: store`, () => {
+    expect(() => {
+      createRemoteFileNode({
+        ...defaultArgs,
+        store: undefined,
+      })
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"store must be the redux store, was undefined"`
+    )
+  })
+})

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -292,6 +292,24 @@ module.exports = ({
   createNodeId,
   ext = null,
 }) => {
+  // validation of the input
+  // without this it's notoriously easy to pass in the wrong `createNodeId`
+  // see gatsbyjs/gatsby#6643
+  if (typeof createNodeId !== `function`) {
+    throw new Error(
+      `createNodeId must be a function, was ${typeof createNodeId}`
+    )
+  }
+  if (typeof createNode !== `function`) {
+    throw new Error(`createNode must be a function, was ${typeof createNode}`)
+  }
+  if (typeof store !== `object`) {
+    throw new Error(`store must be the redux store, was ${typeof store}`)
+  }
+  if (typeof cache !== `object`) {
+    throw new Error(`cache must be the Gatsby cache, was ${typeof cache}`)
+  }
+
   // Check if we already requested node for this remote file
   // and return stored promise if we did.
   if (processingCache[url]) {


### PR DESCRIPTION
fixes #6643

I also fell for this error before, sinc the original errors are swallowed (and fairly unclear too, because of the indirection). Adding validation was suggested in linked issue, so I went for this, since I didn't see any already used object validation like "ow" in use here.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
