### PR TITLE
[gatsby-plugin-google-analytics] Add option for enabling/disabling tracking

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -24,6 +24,8 @@ module.exports = {
         respectDNT: true,
         // Avoids sending pageview hits from custom paths
         exclude: ["/preview/**", "/do-not-track/me/too/"],
+        // Enable tracking
+        enabled: "auto",
         // Enables Google Optimize using your container Id
         optimizeId: "YOUR_GOOGLE_OPTIMIZE_TRACKING_ID",
         // Any additional create only fields (optional)
@@ -87,6 +89,10 @@ If you enable this optional option, Google Analytics will not be loaded at all f
 ## The "exclude" option
 
 If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array as glob expressions.
+
+## The "enabled" option
+
+By default, tracking is disabled in development mode and enabled in production. If you want to fully disable/enable tracking in both environments, set this to `true` or `false`. To track in production but not development, omit the option or set to `'auto'`.
 
 ## The "optimizeId" option
 

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,6 +1,20 @@
-exports.onRouteUpdate = function({ location }) {
-  // Don't track while developing.
-  if (process.env.NODE_ENV === `production` && typeof ga === `function`) {
+exports.onRouteUpdate = function({ location }, pluginOptions) {
+  let { enabled } = pluginOptions
+  let isEnabled
+  if (typeof enabled === `boolean`) {
+    isEnabled = enabled
+  } else if (enabled && enabled !== `auto`) {
+    // If user specifies any value that is truthy but NOT the string `auto` it's invalid
+    throw new Error(
+      `[gatsby-plugin-google-analytics] Valid options for 'enabled' flag: true, false, or 'auto'`
+    )
+  } else {
+    // Default value, if `enabled` option is not specified
+    isEnabled = process.env.NODE_ENV === `production`
+  }
+
+  // Don't track while developing, or follow the `enabled` option value
+  if (isEnabled && typeof ga === `function`) {
     if (
       location &&
       typeof window.excludeGAPaths !== `undefined` &&

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -18,7 +18,21 @@ exports.onRenderBody = (
   { setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {
-  if (process.env.NODE_ENV === `production`) {
+  let { enabled } = pluginOptions
+  let isEnabled
+  if (typeof enabled === `boolean`) {
+    isEnabled = enabled
+  } else if (enabled && enabled !== `auto`) {
+    // If user specifies any value that is truthy but NOT the string `auto` it's invalid
+    throw new Error(
+      `[gatsby-plugin-google-analytics] Valid options for 'enabled' flag: true, false, or 'auto'`
+    )
+  } else {
+    // Default value, if `enabled` option is not specified
+    isEnabled = process.env.NODE_ENV === `production`
+  }
+
+  if (isEnabled) {
     let excludeGAPaths = []
     if (typeof pluginOptions.exclude !== `undefined`) {
       const Minimatch = require(`minimatch`).Minimatch


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

Fixes #9796 

I tried pulling out the `isEnabled` logic into a separate file to include in `gatsby-ssr.js` and `gatsby-browser.js`, but I couldn't easily get the `require()` to compile properly for running in the browser. I opted to just repeat the logic. If anyone has any suggestions on how to get that compilation working I'm happy to throw it into the PR.