### PR TITLE
fix: Improve spacing of dependency grid in starter detail page

### DIFF
--- a/www/src/views/starter/details.js
+++ b/www/src/views/starter/details.js
@@ -80,11 +80,10 @@ const Details = ({
       <div
         css={{
           display: `grid`,
-          gridAutoRows: `50px`,
           marginBottom: rhythm(options.blockMarginBottom * 5),
           [presets.Desktop]: {
             gridTemplateColumns: `repeat(3, 1fr)`,
-            gridColumnGap: 20,
+            gridGap: 20,
           },
         }}
       >
@@ -100,7 +99,6 @@ const Details = ({
                   key={dep}
                   css={{
                     ...sharedStyles.truncate,
-                    marginBottom: `1rem`,
                   }}
                 >
                   <a href={`https://npm.im/${dep}`}>


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

The spacing in the dependency grid looked off to me, so I improved it a bit.

Before: 
<img width="1064" alt="screenshot 2018-11-26 at 13 58 19" src="https://user-images.githubusercontent.com/541628/49015578-cbfa7a00-f183-11e8-9ee0-2452f8c1c83d.png">

After: 
<img width="1079" alt="screenshot 2018-11-26 at 13 58 07" src="https://user-images.githubusercontent.com/541628/49015584-d157c480-f183-11e8-86de-b7c20bee71f8.png">
