### PR TITLE
Add license internal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Gatsby is a modern framework for blazing fast websites.
 - [Learning Gatsby](#-learning-gatsby)
 - [Migration Guides](#-migration-guides)
 - [How to Contribute](#-how-to-contribute)
+- [License](#memo-license)
 - [Thanks to Our Contributors and Sponsors](#-thanks-to-our-contributors-and-sponsors)
 
 ## 🚀 Get Up and Running in 5 Minutes


### PR DESCRIPTION
Closes #10135 
Added license to `What's in this document section` linking it to corresponding section within the `README` file.