### PR TITLE
feat(gatsby): provide a mechanism for plugins to use a named cache instance

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -62,7 +62,7 @@ const withPathPrefix = (url, pathPrefix) =>
 const ASTPromiseMap = new Map()
 
 module.exports = (
-  { type, store, pathPrefix, getNode, getNodesByType, cache, reporter },
+  { type, pathPrefix, getNode, getNodesByType, cache, reporter, ...rest },
   pluginOptions
 ) => {
   if (type.name !== `MarkdownRemark`) {
@@ -133,6 +133,7 @@ module.exports = (
                     getNode,
                     reporter,
                     cache,
+                    ...rest,
                   },
                   plugin.pluginOptions
                 )
@@ -201,6 +202,7 @@ module.exports = (
                       pathPrefix,
                       reporter,
                       cache,
+                      ...rest,
                     },
                     plugin.pluginOptions
                   )

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -3,7 +3,7 @@ const crypto = require(`crypto`)
 const _ = require(`lodash`)
 
 module.exports = async function onCreateNode(
-  { node, getNode, loadNodeContent, actions, createNodeId, reporter },
+  { node, loadNodeContent, actions, createNodeId, reporter },
   pluginOptions
 ) {
   const { createNode, createParentChildLink } = actions

--- a/packages/gatsby/src/utils/__tests__/get-cache.js
+++ b/packages/gatsby/src/utils/__tests__/get-cache.js
@@ -1,0 +1,21 @@
+const getCache = require(`../get-cache`)
+
+const CACHE_KEY = `__test__`
+
+test(`it returns a new cache instance`, () => {
+  const cache = getCache(CACHE_KEY)
+
+  expect(cache.get).toEqual(expect.any(Function))
+  expect(cache.set).toEqual(expect.any(Function))
+})
+
+test(`it retrieves already created cache instance`, async () => {
+  const key = `some-value`
+  const value = [`a`, `b`, `c`]
+  const cache = getCache(CACHE_KEY)
+  await cache.set(key, value)
+
+  const other = getCache(CACHE_KEY)
+
+  expect(await other.get(key)).toEqual(value)
+})

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -4,12 +4,10 @@ const _ = require(`lodash`)
 
 const tracer = require(`opentracing`).globalTracer()
 const reporter = require(`gatsby-cli/lib/reporter`)
-const Cache = require(`./cache`)
+const getCache = require(`./get-cache`)
 const apiList = require(`./api-node-docs`)
 const createNodeId = require(`./create-node-id`)
 const createContentDigest = require(`./create-content-digest`)
-
-let caches = new Map()
 
 // Bind action creators per plugin so we can auto-add
 // metadata to actions they create.
@@ -94,11 +92,7 @@ const runAPI = (plugin, api, args) => {
 
     const tracing = initAPICallTracing(pluginSpan)
 
-    let cache = caches.get(plugin.name)
-    if (!cache) {
-      cache = new Cache({ name: plugin.name }).init()
-      caches.set(plugin.name, cache)
-    }
+    const cache = getCache(plugin.name)
 
     const apiCallArgs = [
       {
@@ -109,6 +103,7 @@ const runAPI = (plugin, api, args) => {
         loadNodeContent,
         store,
         emitter,
+        getCache,
         getNodes,
         getNode,
         getNodesByType,

--- a/packages/gatsby/src/utils/get-cache.js
+++ b/packages/gatsby/src/utils/get-cache.js
@@ -1,0 +1,12 @@
+const Cache = require(`./cache`)
+
+let caches = new Map()
+
+module.exports = function getCache(name) {
+  let cache = caches.get(name)
+  if (!cache) {
+    cache = new Cache({ name }).init()
+    caches.set(name, cache)
+  }
+  return cache
+}


### PR DESCRIPTION
Fixes #8788

This PR provides a mechanism for any plugin to call a `getCache` helper, which takes a single argument (name) and returns or creates a new cache instance for that named instance.

This is particularly applicable to cases where a plugin has sub-plugins (e.g. gatsby-transformer-remark). In this scenario, we have a cache mismatch, essentially the cache provided by Gatsby is named to the plugins name, whereas the cache provided by gatsby-transformer-remark is named `gatsby-transformer-remark`

This PR fixes this imbalance. Few questions/comments:

- I think it might make sense to override the cache passed, e.g. `cache: getCache(plugin.name)` for sub plugins. We can still inject getCache so if the parent cache is needed (rarely?) this will still function, as expected
- I'll need to bump the peer dependency of gatsby-transformer-remark to the next version of gatsby at merge time