### PR TITLE
fix(plugin-netlify-cms): fix uglify webpack plugin check

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -4,7 +4,6 @@ import webpack from "webpack"
 import HtmlWebpackPlugin from "html-webpack-plugin"
 import HtmlWebpackExcludeAssetsPlugin from "html-webpack-exclude-assets-plugin"
 import MiniCssExtractPlugin from "mini-css-extract-plugin"
-import UglifyJsPlugin from "uglifyjs-webpack-plugin"
 import FriendlyErrorsPlugin from "friendly-errors-webpack-plugin"
 
 /**
@@ -83,8 +82,9 @@ exports.onCreateWebpackConfig = (
          */
         ...gatsbyConfig.plugins.filter(
           plugin =>
-            ![UglifyJsPlugin, MiniCssExtractPlugin, FriendlyErrorsPlugin].find(
-              Plugin => plugin instanceof Plugin
+            ![`MiniCssExtractPlugin`].find(
+              pluginName =>
+                plugin.constructor && plugin.constructor.name === pluginName
             )
         ),
 


### PR DESCRIPTION
Closes #10067.
Replaces #10149.

Webpack started using terser instead of uglify, which broke our plugin's check for the uglify webpack plugin (to exclude it from our pipeline). But it seems that excluding terser isn't even necessary, can't find any bugs in dev or prod builds.

The remaining plugin that needs to be avoided will be handled by name rather than instance.

cc/ @pieh 