### PR TITLE
fix(gatsby-plugin-netlify-cms): remove uglifyjs-webpack-plugin reference

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -4,7 +4,6 @@ import webpack from "webpack"
 import HtmlWebpackPlugin from "html-webpack-plugin"
 import HtmlWebpackExcludeAssetsPlugin from "html-webpack-exclude-assets-plugin"
 import MiniCssExtractPlugin from "mini-css-extract-plugin"
-import UglifyJsPlugin from "uglifyjs-webpack-plugin"
 import FriendlyErrorsPlugin from "friendly-errors-webpack-plugin"
 
 /**
@@ -83,7 +82,7 @@ exports.onCreateWebpackConfig = (
          */
         ...gatsbyConfig.plugins.filter(
           plugin =>
-            ![UglifyJsPlugin, MiniCssExtractPlugin, FriendlyErrorsPlugin].find(
+            ![MiniCssExtractPlugin, FriendlyErrorsPlugin].find(
               Plugin => plugin instanceof Plugin
             )
         ),


### PR DESCRIPTION
In webpack [4.26.0](https://github.com/webpack/webpack/releases/tag/v4.26.0) they changed the default minimizer to `terser`. This causes the following error on "fresh" sites when building: `Error: Cannot find module 'uglifyjs-webpack-plugin'`.

Since gatsby has no references to `uglifyjs-webpack-plugin` I _think_ it should be safe to just remove it.
