### PR TITLE
feat(gatsby-plugin-sass): Support Dart SASS

### DIFF
--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -8,15 +8,33 @@ Provides drop-in support for SASS/SCSS stylesheets
 
 ## How to use
 
-1.  Include the plugin in your `gatsby-config.js` file.
-2.  Write your stylesheets in SASS/SCSS and require or import them as normal.
+1. Include the plugin in your `gatsby-config.js` file.
+2. Write your stylesheets in SASS/SCSS and require or import them as normal.
 
 ```javascript
 // in gatsby-config.js
 plugins: [`gatsby-plugin-sass`]
 ```
 
-If you need to pass options to Sass use the plugins options, see [node-sass](https://github.com/sass/node-sass)
+By Default `node-sass` is used. To use `dart-sass`.
+
+```bash
+npm i -D sass
+```
+
+```javascript
+// in gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-sass`,
+    options: {
+      implementation: "dart-sass",
+    },
+  },
+]
+```
+
+If you need to pass options to Sass use the plugins options, see [node-sass](https://github.com/sass/node-sass)/[dart-sass](https://github.com/sass/dart-sass) docs
 for all available options.
 
 ```javascript
@@ -26,6 +44,7 @@ plugins: [
     resolve: `gatsby-plugin-sass`,
     options: {
       includePaths: ["absolute/path/a", "absolute/path/b"],
+      ...
     },
   },
 ]

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -26,8 +26,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": ">2.0.0-alpha",
-    "node-sass": "^4.9.0"
+    "gatsby": "^2.0.0"
   },
   "readme": "README.md",
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass",

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -2,11 +2,15 @@ import resolve from "./resolve"
 
 exports.onCreateWebpackConfig = (
   { actions, stage, rules, plugins, loaders },
-  { cssLoaderOptions = {}, postCssPlugins, ...sassOptions }
+  { cssLoaderOptions = {}, postCssPlugins, implementation, ...sassOptions }
 ) => {
   const { setWebpackConfig } = actions
   const PRODUCTION = stage !== `develop`
   const isSSR = stage.includes(`html`)
+
+  if (implementation && implementation === `dart-sass`) {
+    sassOptions.implementation = require(`sass`)
+  }
 
   const sassLoader = {
     loader: resolve(`sass-loader`),


### PR DESCRIPTION
Feature: Support Dart SASS.

Hi,

Gatsby uses `sass-loader` which supports both `node-sass` and `dart-sass`. This PR enables users to use sass of his choice.

**Motivation**

In the current implementation `gatsby-plugin-sass` sends options directly to `sass-loader` so the following usage should work 

```js
 options: {
   implementation: require("sass")
  }
``` 

but it throws some error, I am not sure of it yet. 

<details><summary><b>Error Message</b> </summary>

```bash
error Maximum call stack size exceeded


  RangeError: Maximum call stack size exceeded

  - lodash.js:11714 isLength
    [gatsby-hfc-website]/[lodash]/lodash.js:11714:22

  - lodash.js:11334 isArrayLike
    [gatsby-hfc-website]/[lodash]/lodash.js:11334:31

  - lodash.js:13308 keys
    [gatsby-hfc-website]/[lodash]/lodash.js:13308:14

  - lodash.js:4906
    [gatsby-hfc-website]/[lodash]/lodash.js:4906:21

  - lodash.js:2996 baseForOwn
    [gatsby-hfc-website]/[lodash]/lodash.js:2996:24

  - lodash.js:4880
    [gatsby-hfc-website]/[lodash]/lodash.js:4880:18

  - lodash.js:2846 baseEvery
    [gatsby-hfc-website]/[lodash]/lodash.js:2846:7

  - lodash.js:9133 Function.every
    [gatsby-hfc-website]/[lodash]/lodash.js:9133:14

  - data-tree-utils.js:32 isEmptyObjectOrArray
    [gatsby-hfc-website]/[gatsby]/dist/schema/data-tree-utils.js:32:14

  - data-tree-utils.js:36 _.every
    [gatsby-hfc-website]/[gatsby]/dist/schema/data-tree-utils.js:36:16

  - lodash.js:2847
    [gatsby-hfc-website]/[lodash]/lodash.js:2847:20

  - lodash.js:4911
    [gatsby-hfc-website]/[lodash]/lodash.js:4911:15

  - lodash.js:2996 baseForOwn
    [gatsby-hfc-website]/[lodash]/lodash.js:2996:24

  - lodash.js:4880
    [gatsby-hfc-website]/[lodash]/lodash.js:4880:18

  - lodash.js:2846 baseEvery
    [gatsby-hfc-website]/[lodash]/lodash.js:2846:7

  - lodash.js:9133 Function.every
    [gatsby-hfc-website]/[lodash]/lodash.js:9133:14


error UNHANDLED REJECTION


  RangeError: Maximum call stack size exceeded

  - lodash.js:11714 isLength
    [gatsby-hfc-website]/[lodash]/lodash.js:11714:22

  - lodash.js:11334 isArrayLike
    [gatsby-hfc-website]/[lodash]/lodash.js:11334:31

  - lodash.js:13308 keys
    [gatsby-hfc-website]/[lodash]/lodash.js:13308:14

  - lodash.js:4906
    [gatsby-hfc-website]/[lodash]/lodash.js:4906:21

  - lodash.js:2996 baseForOwn
    [gatsby-hfc-website]/[lodash]/lodash.js:2996:24

  - lodash.js:4880
    [gatsby-hfc-website]/[lodash]/lodash.js:4880:18

  - lodash.js:2846 baseEvery
    [gatsby-hfc-website]/[lodash]/lodash.js:2846:7

  - lodash.js:9133 Function.every
    [gatsby-hfc-website]/[lodash]/lodash.js:9133:14

  - data-tree-utils.js:32 isEmptyObjectOrArray
    [gatsby-hfc-website]/[gatsby]/dist/schema/data-tree-utils.js:32:14

  - data-tree-utils.js:36 _.every
    [gatsby-hfc-website]/[gatsby]/dist/schema/data-tree-utils.js:36:16

  - lodash.js:2847
    [gatsby-hfc-website]/[lodash]/lodash.js:2847:20

  - lodash.js:4911
    [gatsby-hfc-website]/[lodash]/lodash.js:4911:15

  - lodash.js:2996 baseForOwn
    [gatsby-hfc-website]/[lodash]/lodash.js:2996:24

  - lodash.js:4880
    [gatsby-hfc-website]/[lodash]/lodash.js:4880:18

  - lodash.js:2846 baseEvery
    [gatsby-hfc-website]/[lodash]/lodash.js:2846:7

  - lodash.js:9133 Function.every
    [gatsby-hfc-website]/[lodash]/lodash.js:9133:14
```
</details>

<br />
But the following works,

```js
const sass = require('sass')

options: {
   implementation: {
     info: sass.info,
     render: sass.render
    }
}
``` 

Hence the PR to simplify the process.

_NOTE: `node-sass` is removed from peerDependencies to let user to use sass of their choice_ 
