### PR TITLE
Add "pass context to pages" to doc

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -139,14 +139,14 @@ The automatically created pages can receive context and use that as variables in
 ```javascript:title=gatsby-node.js
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions
-  
+
   deletePage(page)
   // You can access the variable "house" in your page queries now
   createPage({
     ...page,
     context: {
-      house: Gryffindor
-    }
+      house: Gryffindor,
+    },
   })
 }
 ```

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -131,3 +131,22 @@ exports.onCreatePage = ({ page, actions }) => {
   })
 }
 ```
+
+### Pass context to pages
+
+The automatically created pages can receive context and use that as variables in their GraphQL queries. To override the default and pass your own context, open your site's `gatsby-node.js` and add similar to the following:
+
+```javascript:title=gatsby-node.js
+exports.onCreatePage = ({ page, actions }) => {
+  const { createPage, deletePage } = actions
+  
+  deletePage(page)
+  // You can access the variable "house" in your page queries now
+  createPage({
+    ...page,
+    context: {
+      house: Gryffindor
+    }
+  })
+}
+```


### PR DESCRIPTION
Didn't find this anywhere in the docs, think that's a good spot for it.

The Promise is not needed actually, but I left it in the upper example.