### PR TITLE
fix(gatsby): skip functions when inferring schema

### DIFF
--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -29,7 +29,7 @@ const isEmptyObjectOrArray = (obj: any): boolean => {
       if (!isDefined(value)) {
         return true
       } else if (_.isObject(value)) {
-        return isEmptyObjectOrArray(value)
+        return isEmptyObjectOrArray(_.flatten(value))
       } else {
         return false
       }

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -21,6 +21,8 @@ const isEmptyObjectOrArray = (obj: any): boolean => {
     return true
   } else if (_.isDate(obj)) {
     return false
+  } else if (typeof obj === `function`) {
+    return true
     // Simple "is object empty" check.
   } else if (_.isObject(obj) && _.isEmpty(obj)) {
     return true
@@ -29,7 +31,7 @@ const isEmptyObjectOrArray = (obj: any): boolean => {
       if (!isDefined(value)) {
         return true
       } else if (_.isObject(value)) {
-        return isEmptyObjectOrArray(_.flatten(value))
+        return isEmptyObjectOrArray(value)
       } else {
         return false
       }


### PR DESCRIPTION
Hi,

This is a fix for issue as discussed here https://github.com/gatsbyjs/gatsby/pull/10159#issuecomment-442045709.

prevent loop if the object is of type function