### PR TITLE
fix(www): fix newsletter form style on blog post pages

### DIFF
--- a/www/src/components/email-capture-form.js
+++ b/www/src/components/email-capture-form.js
@@ -13,7 +13,7 @@ const StyledForm = styled(`form`)`
   margin: 0;
 
   ${presets.Desktop} {
-    display: flex;
+    display: ${props => (props.isHomepage ? `flex` : `block`)};
   }
 `
 
@@ -166,7 +166,7 @@ class Form extends React.Component {
       : SingleLineInput
 
     return (
-      <StyledForm onSubmit={this.onSubmit}>
+      <StyledForm onSubmit={this.onSubmit} isHomepage={isHomepage}>
         {!isHomepage && (
           <Label isRequired htmlFor="email">
             Email


### PR DESCRIPTION
Revert unintentional braking changes to style of the Newsletter form on Blog post pages applied during implementation of the same form presented on redesigned Hompage Newsletter section. 

- broken style 

![screenshot from 2018-11-28 13-54-21](https://user-images.githubusercontent.com/32480082/49153447-0b58d000-f316-11e8-9e75-213f74830768.png)

- fixed style (with this PR), the form looks the same as before refactoring of `www/src/components/email-capture-form.js`

![screenshot from 2018-11-28 13-53-55](https://user-images.githubusercontent.com/32480082/49153446-0ac03980-f316-11e8-929b-40e800ced254.png)

