### PR TITLE
fix(www): add arrow icon to' View all Posts' button

### DIFF
--- a/www/src/components/homepage/homepage-blog.js
+++ b/www/src/components/homepage/homepage-blog.js
@@ -1,6 +1,8 @@
 import React from "react"
 import PropTypes from "prop-types"
 
+import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
+
 import HomepageSection from "./homepage-section"
 import HomepageBlogPosts from "./homepage-blog-posts"
 
@@ -15,6 +17,7 @@ const HomepageBlog = ({ posts }) => (
       {
         label: `View all posts`,
         to: `/blog/`,
+        icon: ArrowForwardIcon,
       },
     ]}
   >


### PR DESCRIPTION
Add an arrow forward icon to the primary button of the Homepage Blog section for consistent look of sections.

![screenshot from 2018-171-28 18-16-29](https://user-images.githubusercontent.com/32480082/49169314-cf376680-f339-11e8-949a-da4faeb33591.png)
