### PR TITLE
chore(gatsby-transformer-remark): update gitignore

### DIFF
--- a/packages/gatsby-transformer-remark/.gitignore
+++ b/packages/gatsby-transformer-remark/.gitignore
@@ -1,3 +1,2 @@
-/gatsby-node.js
-/extend-node-type.js
-/on-node-create.js
+/*.js
+!index.js


### PR DESCRIPTION
built hast-processing.js wasn't gitignored after https://github.com/gatsbyjs/gatsby/pull/9716