### PR TITLE
Correct link to source plugins

### DIFF
--- a/docs/docs/headless-cms.md
+++ b/docs/docs/headless-cms.md
@@ -9,7 +9,7 @@ A core benefit of this “data from anywhere” approach is that it allows teams
 
 Many content management systems (CMS) now support a “headless” mode, which is perfect for Gatsby sites. A headless CMS allows content creators to manage their content through a familiar admin interface, but allows developers to access the content via API endpoints, allowing for a fully customized front-end experience.
 
-Through use of [source plugins](/plugins/?=source), Gatsby has support for dozens of headless CMS options, allowing your content team the comfort and familiarity of its preferred admin interface, and your development team the improved developer experience and performance gains of using Gatsby, GraphQL, and React to build the front-end.
+Through use of [source plugins](https://www.gatsbyjs.org/plugins/?=gatsby-source), Gatsby has support for dozens of headless CMS options, allowing your content team the comfort and familiarity of its preferred admin interface, and your development team the improved developer experience and performance gains of using Gatsby, GraphQL, and React to build the front-end.
 
 The guides in this section will walk through the process of setting up content sourcing from some of the most popular headless CMSes in use today.
 


### PR DESCRIPTION
The link to the source plugins led to the repository file system that was used for storing source plugins. Currently, source plugins have its own repositories so I defined the link to lead to the plugin library.
