### PR TITLE
feat(examples/using-ghost)

### DIFF
--- a/examples/using-ghost/.eslintignore
+++ b/examples/using-ghost/.eslintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/using-ghost/.gitignore
+++ b/examples/using-ghost/.gitignore
@@ -1,0 +1,10 @@
+# Build Path of Test Fixtures
+.gatsby-context.js
+.DS_Store
+public/
+build/
+.cache/
+.netlify
+
+# IDE specific
+.vscode/

--- a/examples/using-ghost/README.md
+++ b/examples/using-ghost/README.md
@@ -1,0 +1,9 @@
+# Using Ghost
+
+Example site that demonstrates how to build Gatsby sites that pull data from the
+[Ghost Public API](https://www.ghost.org/).
+
+IMPORTANT NOTE: To make this example work with your Ghost blog you will need to
+find your clientSecretId and add your domain to the client trusted domains.
+Instructions on how to do this can be found
+[on the Ghost website](https://api.ghost.org/docs/ajax-calls-from-an-external-website).

--- a/examples/using-ghost/gatsby-config.js
+++ b/examples/using-ghost/gatsby-config.js
@@ -1,0 +1,37 @@
+module.exports = {
+  siteMetadata: {
+    blogName: `Ghost + Gatsby Demo Blog`,
+  },
+  plugins: [
+    // https://github.com/TryGhost/gatsby-source-ghost/
+    /*
+     * Gatsby's data processing layer begins with “source”
+     * plugins. Here the site sources its data from Ghost.
+     */
+    {
+      resolve: `gatsby-source-ghost`,
+      options: {
+        /*
+        * See https://github.com/TryGhost/gatsby-source-ghost
+        * for the latest information on obtaining the API
+        * endpoint. You may need to add the domain that makes
+        * calls to the Ghost Public API into the 
+        * client_trusted_domains. To do this see
+        * https://api.ghost.org/docs/ajax-calls-from-an-external-website
+        */
+        apiUrl: `https://blog.ghost.org`,
+        clientId: `ghost-frontend`,
+        clientSecret: `ca4d193a0d90`,
+      },
+    },
+    `gatsby-transformer-sharp`,
+    `gatsby-plugin-sharp`,
+    `gatsby-plugin-glamor`,
+    {
+      resolve: `gatsby-plugin-typography`,
+      options: {
+        pathToConfigModule: `src/utils/typography.js`,
+      },
+    },
+  ],
+}

--- a/examples/using-ghost/gatsby-node.js
+++ b/examples/using-ghost/gatsby-node.js
@@ -1,0 +1,122 @@
+const _ = require(`lodash`)
+const path = require(`path`)
+const slash = require(`slash`)
+
+// Implement the Gatsby API “createPages”. This is
+// called after the Gatsby bootstrap is finished so you have
+// access to any information necessary to programmatically
+// create pages.
+// Will create pages for Ghost pages (route : /{slug})
+// Will create pages for Ghost posts (route : /{slug})
+// Will create pages for Ghost tags (route : /tag/{slug})
+// Will create pages for Ghost authors (route : /author/{slug})
+exports.createPages = async ({ graphql, actions }) => {
+  const { createPage } = actions
+
+  const {
+    data: { allGhostPost, allGhostPage },
+  } = await graphql(
+    `
+      {
+        allGhostPost {
+          edges {
+            node {
+              id
+              slug
+              page
+              tags {
+                id
+                slug
+                name
+              }
+              authors {
+                id
+                slug
+                name
+              }
+            }
+          }
+        }
+        allGhostPage {
+          edges {
+            node {
+              id
+              slug
+              page
+              authors {
+                id
+                slug
+                name
+              }
+            }
+          }
+        }
+      }
+    `
+  )
+
+  if (allGhostPage.errors || allGhostPost.errors) {
+    console.log(allGhostPage.errors || allGhostPost.errors)
+    throw new Error(allGhostPage.errors || allGhostPost.errors)
+  }
+
+  const createGhostPage = ({ id, slug, name, route, templatePath }) => {
+    createPage({
+      path: route,
+      component: slash(path.resolve(templatePath)),
+      context: {
+        id,
+        slug,
+        name,
+      },
+    })
+  }
+
+  const allEdges = allGhostPost.edges.concat(allGhostPage.edges)
+
+  _.each(allEdges, ({ node: { id, slug, name, tags, authors, page } }) => {
+    if (page) {
+      /* ==== PAGE ==== */
+      createGhostPage({
+        id,
+        slug,
+        name,
+        route: `/${slug}/`,
+        templatePath: `./src/templates/page.js`,
+      })
+      /* ==== END PAGE ====*/
+    } else {
+      /* ==== POST ==== */
+      createGhostPage({
+        id,
+        slug,
+        name,
+        route: `/${slug}/`,
+        templatePath: `./src/templates/post.js`,
+      })
+      /* ==== END POST ====*/
+    }
+    _.each(tags, ({ id, slug, name }) => {
+      /* ==== TAG ==== */
+      createGhostPage({
+        id,
+        slug,
+        name,
+        route: `/tag/${slug}/`,
+        templatePath: `./src/templates/tag.js`,
+      })
+      /* ==== END TAG ====*/
+    })
+    _.each(authors, ({ id, slug, name }) => {
+      /* ==== AUTHOR ==== */
+      createGhostPage({
+        id,
+        slug,
+        name,
+        route: `/author/${slug}/`,
+        templatePath: `./src/templates/author.js`,
+      })
+      /* ==== END AUTHOR ==== */
+    })
+  })
+}

--- a/examples/using-ghost/package.json
+++ b/examples/using-ghost/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "gatsby-example-using-ghost",
+  "private": true,
+  "description": "Gatsby example site using the Ghost source plugin",
+  "version": "1.0.0",
+  "author": "Daniel Sutton <daniel@littlewolfstudio.co.uk>",
+  "dependencies": {
+    "gatsby": "^2.0.0",
+    "gatsby-image": "^2.0.5",
+    "gatsby-plugin-glamor": "^2.0.5",
+    "gatsby-plugin-react-helmet": "^3.0.0",
+    "gatsby-plugin-sharp": "^2.0.5",
+    "gatsby-plugin-typography": "^2.2.0",
+    "gatsby-source-ghost": "^2.1.2",
+    "gatsby-transformer-sharp": "^2.1.1",
+    "glamor": "^2.20.40",
+    "lodash": "^4.17.10",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
+    "react-typography": "^0.16.13",
+    "typography": "^0.16.16",
+    "typography-theme-fairy-gates": "^0.15.11"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "dev": "gatsby develop",
+    "lint": "./node_modules/.bin/eslint --ext .js,.jsx --ignore-pattern public .",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "start": "gatsby serve",
+    "predeploy": "gatsby build --prefix-paths"
+  },
+  "devDependencies": {
+    "eslint": "^4.1.1"
+  }
+}

--- a/examples/using-ghost/src/layouts/index.js
+++ b/examples/using-ghost/src/layouts/index.js
@@ -1,0 +1,61 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Link } from "gatsby"
+import { rhythm, scale } from "../utils/typography"
+
+const containerStyle = {
+  maxWidth: 700,
+  margin: `0 auto`,
+  padding: rhythm(3 / 4),
+}
+
+class DefaultLayout extends React.Component {
+  render() {
+    return (
+      <div>
+        <div
+          css={{
+            background: `rgb(0, 0, 0, 0.9)`,
+            marginBottom: rhythm(1),
+            padding: `${rhythm(1)} 0px`,
+            "@media screen and (min-width: 500px)": {
+              padding: `${rhythm(2)} 0px`,
+            },
+          }}
+        >
+          <div css={containerStyle}>
+            <h1
+              css={{
+                margin: 0,
+                fontSize: scale(1.5).fontSize,
+                lineHeight: 1,
+                "@media screen and (min-width: 500px)": {
+                  fontSize: scale(1.9).fontSize,
+                  lineHeight: 1,
+                },
+              }}
+            >
+              <Link
+                css={{
+                  color: `rgb(255,255,255,0.9)`,
+                  textDecoration: `none`,
+                  backgroundImage: `none`,
+                }}
+                to="/"
+              >
+                Ghost & Gatsby
+              </Link>
+            </h1>
+          </div>
+        </div>
+        <div css={containerStyle}>{this.props.children}</div>
+      </div>
+    )
+  }
+}
+
+DefaultLayout.propTypes = {
+  location: PropTypes.object.isRequired,
+}
+
+export default DefaultLayout

--- a/examples/using-ghost/src/pages/index.js
+++ b/examples/using-ghost/src/pages/index.js
@@ -1,0 +1,103 @@
+import React, { Component } from "react"
+import { Link, graphql } from "gatsby"
+import Layout from "../layouts"
+import { rhythm } from "../utils/typography"
+
+class Home extends Component {
+  render() {
+    const data = this.props.data
+
+    return (
+      <Layout>
+        <div css={{ marginBottom: rhythm(1) }}>
+          <h1>Latest Posts</h1>
+          {data
+            ? data.allGhostPost.edges.map(({ node }) => (
+                <div css={{ marginBottom: rhythm(2) }} key={node.slug}>
+                  <Link to={node.slug} css={{ textDecoration: `none` }}>
+                    <h3 css={{ color: `rgba(28,160,134,1)` }}>{node.title}</h3>
+                  </Link>
+                  <div>{node.custom_excerpt}</div>
+                </div>
+              ))
+            : null}
+        </div>
+        <h1>Pages</h1>
+        {data
+          ? data.allGhostPage.edges.map(({ node }) => (
+              <div key={node.slug}>
+                <Link to={node.slug} css={{ textDecoration: `none` }}>
+                  {node.title}
+                </Link>
+              </div>
+            ))
+          : null}
+        <h1>Tags</h1>
+        {data
+          ? data.allGhostTag.edges.map(({ node }) => (
+              <div key={node.slug}>
+                <Link to={`tag/${node.slug}`} css={{ textDecoration: `none` }}>
+                  {node.name}
+                </Link>
+              </div>
+            ))
+          : null}
+        <h1>Author</h1>
+        {data
+          ? data.allGhostAuthor.edges.map(({ node }) => (
+              <div key={node.slug}>
+                <Link
+                  to={`author/${node.slug}`}
+                  css={{ textDecoration: `none` }}
+                >
+                  {node.name}
+                </Link>
+              </div>
+            ))
+          : null}
+      </Layout>
+    )
+  }
+}
+
+export default Home
+
+export const pageQuery = graphql`
+  {
+    allGhostPost(limit: 3) {
+      edges {
+        node {
+          title
+          html
+          slug
+          custom_excerpt
+        }
+      }
+    }
+    allGhostPage {
+      edges {
+        node {
+          title
+          html
+          slug
+        }
+      }
+    }
+    allGhostTag(limit: 5) {
+      edges {
+        node {
+          name
+          slug
+        }
+      }
+    }
+    allGhostAuthor(limit: 5) {
+      edges {
+        node {
+          name
+          slug
+        }
+      }
+    }
+  }
+`

--- a/examples/using-ghost/src/templates/author.js
+++ b/examples/using-ghost/src/templates/author.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react"
+import { graphql, Link } from "gatsby"
+import Layout from "../layouts"
+import { rhythm } from "../utils/typography"
+
+class AuthorTemplate extends Component {
+  render() {
+    const pageContext = this.props.pageContext
+    const currentPosts = this.props.data.allGhostPost
+
+    return (
+      <Layout>
+        <h1>{pageContext.name}</h1>
+        {currentPosts
+          ? currentPosts.edges.map(({ node }) => (
+              <div css={{ marginBottom: rhythm(2) }} key={node.slug}>
+                <Link to={node.slug} css={{ textDecoration: `none` }}>
+                  <h3 css={{ color: `rgba(28,160,134,1)` }}>{node.title}</h3>
+                </Link>
+                <div>{node.custom_excerpt}</div>
+              </div>
+            ))
+          : null}
+      </Layout>
+    )
+  }
+}
+
+export default AuthorTemplate
+
+export const pageQuery = graphql`
+  query($slug: String!) {
+    allGhostPost(
+      limit: 5
+      filter: { authors: { elemMatch: { slug: { eq: $slug } } } }
+    ) {
+      edges {
+        node {
+          slug
+          title
+          custom_excerpt
+        }
+      }
+    }
+  }
+`

--- a/examples/using-ghost/src/templates/page.js
+++ b/examples/using-ghost/src/templates/page.js
@@ -1,0 +1,27 @@
+import React, { Component } from "react"
+import { graphql } from "gatsby"
+import Layout from "../layouts"
+
+class PageTemplate extends Component {
+  render() {
+    const currentPage = this.props.data.ghostPage
+
+    return (
+      <Layout>
+        <h1>{currentPage.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: currentPage.html }} />
+      </Layout>
+    )
+  }
+}
+
+export default PageTemplate
+
+export const pageQuery = graphql`
+  query($id: String!) {
+    ghostPage(id: { eq: $id }) {
+      title
+      html
+    }
+  }
+`

--- a/examples/using-ghost/src/templates/post.js
+++ b/examples/using-ghost/src/templates/post.js
@@ -1,0 +1,29 @@
+import React, { Component } from "react"
+import { graphql } from "gatsby"
+import Layout from "../layouts"
+
+class PostTemplate extends Component {
+  render() {
+    const currentPost = this.props.data.ghostPost
+
+    return (
+      <Layout>
+        <h1>{currentPost.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: currentPost.html }} />
+      </Layout>
+    )
+  }
+}
+
+export default PostTemplate
+
+export const pageQuery = graphql`
+  query($id: String!) {
+    ghostPost(id: { eq: $id }) {
+      title
+      html
+      slug
+      custom_excerpt
+    }
+  }
+`

--- a/examples/using-ghost/src/templates/tag.js
+++ b/examples/using-ghost/src/templates/tag.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react"
+import { graphql, Link } from "gatsby"
+import Layout from "../layouts"
+import { rhythm } from "../utils/typography"
+
+class TagTemplate extends Component {
+  render() {
+    const pageContext = this.props.pageContext
+    const currentPosts = this.props.data.allGhostPost
+
+    return (
+      <Layout>
+        <h1>{pageContext.name}</h1>
+        {currentPosts
+          ? currentPosts.edges.map(({ node }) => (
+              <div css={{ marginBottom: rhythm(2) }} key={node.slug}>
+                <Link to={node.slug} css={{ textDecoration: `none` }}>
+                  <h3 css={{ color: `rgba(28,160,134,1)` }}>{node.title}</h3>
+                </Link>
+                <div>{node.custom_excerpt}</div>
+              </div>
+            ))
+          : null}
+      </Layout>
+    )
+  }
+}
+
+export default TagTemplate
+
+export const pageQuery = graphql`
+  query($slug: String!) {
+    allGhostPost(
+      limit: 5
+      filter: { tags: { elemMatch: { slug: { eq: $slug } } } }
+    ) {
+      edges {
+        node {
+          slug
+          title
+          custom_excerpt
+        }
+      }
+    }
+  }
+`

--- a/examples/using-ghost/src/utils/typography.js
+++ b/examples/using-ghost/src/utils/typography.js
@@ -1,0 +1,24 @@
+import Typography from "typography"
+import fairygates from "typography-theme-fairy-gates"
+
+fairygates.headerLineHeight = 1.1
+fairygates.overrideThemeStyles = () => {
+  return {
+    a: {
+      textShadow: `none`,
+    },
+    img: {
+      maxWidth: `100%`,
+      height: `auto`,
+    },
+    video: {
+      maxWidth: `100%`,
+      height: `auto`,
+    },
+  }
+}
+
+const typography = new Typography(fairygates)
+
+export const { rhythm, scale } = typography
+export default typography


### PR DESCRIPTION
* created minimal working example of using `gatsby-source-ghost`

Inspired by the `using-wordpress` example and the fact that Ghost can be used as a data source I decided to give it a whirl. Please don't be alarmed by the commited field `clientSecret` in `gatsby-config.js`, the client secrets are actually public in Ghost front ends and API security is managed by trusted domains.

The aim of this example was to demonstrate how to use the API to render typical Ghost blog pages, implementing queries such as "Get all posts for a given tag", etc.