### PR TITLE
Add option to keep metadata in files processed by `gatsby-plugin-sharp`

### DIFF
--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -22,7 +22,15 @@ images. By default it uses a quality setting of [50-75].
 
 ```javascript
 // In your gatsby-config.js
-plugins: [`gatsby-plugin-sharp`]
+plugins: [
+  {
+    resolve: `gatsby-plugin-sharp`,
+    options: {
+      useMozJpeg: process.env.GATSBY_JPEG_ENCODER === `MOZJPEG`,
+      stripMetadata: true,
+    },
+  },
+]
 ```
 
 ## Methods
@@ -242,11 +250,20 @@ You can opt-in to use [MozJPEG][16] for jpeg-encoding. MozJPEG provides even
 better image compression than the default encoder used in `gatsby-plugin-sharp`.
 However, when using MozJPEG the build time of your Gatsby project will increase
 significantly.
-To enable MozJPEG set the [environment variable](/docs/environment-variables/#environment-variables):
+To enable MozJPEG, you can set the `useMozJpeg` plugin option to `true` in
+`gatsby-config.js` or set
+the [environment variable](/docs/environment-variables/#environment-variables):
 
 ```shell
 GATSBY_JPEG_ENCODER=MOZJPEG
 ```
+
+### EXIF and ICC metadata
+
+By default, `gatsby-plugin-sharp` strips all EXIF, ICC and other metadata
+present in your source file. If you wish to preserve this metadata, you can
+set the `stripMetadata` plugin option to `false` in
+`gatsby-config.js`.
 
 [1]: https://alistapart.com/article/finessing-fecolormatrix
 [2]: http://blog.72lions.com/blog/2015/7/7/duotone-in-js

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -265,14 +265,14 @@ GATSBY_JPEG_ENCODER=MOZJPEG
 ### EXIF and ICC metadata
 
 By default, `gatsby-plugin-sharp` strips all EXIF, ICC and other metadata
-present in your source file. This is the recommended default for most
-situations as it leads to smaller file sizes.
+present in your source file. This is the recommended default as it leads to
+smaller file sizes.
 
 However, in situations where you wish to preserve EXIF metadata or ICC profiles
-(for example if you are building a photography portfolio and which to conserve
-the color profile of the photos you've exported from Adobe Lightroom or Phase
-One's Capture One), you can set the `stripMetadata` plugin option to `false` in
-`gatsby-config.js`.
+(example: you are building a photography portfolio and wish to conserve
+the color profile or the copyright information of the photos you've exported
+from Adobe Lightroom or Phase One's Capture One), you can set the `stripMetadata`
+plugin option to `false` in `gatsby-config.js`.
 
 It is important to note that if `stripMetadata` is set to `false`, **all**
 metadata information will be preserved from the source image, including but not

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -26,7 +26,7 @@ plugins: [
   {
     resolve: `gatsby-plugin-sharp`,
     options: {
-      useMozJpeg: process.env.GATSBY_JPEG_ENCODER === `MOZJPEG`,
+      useMozJpeg: false,
       stripMetadata: true,
     },
   },
@@ -250,9 +250,13 @@ You can opt-in to use [MozJPEG][16] for jpeg-encoding. MozJPEG provides even
 better image compression than the default encoder used in `gatsby-plugin-sharp`.
 However, when using MozJPEG the build time of your Gatsby project will increase
 significantly.
+
 To enable MozJPEG, you can set the `useMozJpeg` plugin option to `true` in
-`gatsby-config.js` or set
-the [environment variable](/docs/environment-variables/#environment-variables):
+`gatsby-config.js`.
+
+For backwards compatible reasons, if `useMozJpeg` is not defined in the plugin
+options, the [environment variable](/docs/environment-variables/#environment-variables)
+`GATSBY_JPEG_ENCODER` acts as a fallback if set to `MOZJPEG`:
 
 ```shell
 GATSBY_JPEG_ENCODER=MOZJPEG
@@ -261,9 +265,21 @@ GATSBY_JPEG_ENCODER=MOZJPEG
 ### EXIF and ICC metadata
 
 By default, `gatsby-plugin-sharp` strips all EXIF, ICC and other metadata
-present in your source file. If you wish to preserve this metadata, you can
-set the `stripMetadata` plugin option to `false` in
+present in your source file. This is the recommended default for most
+situations as it leads to smaller file sizes.
+
+However, in situations where you wish to preserve EXIF metadata or ICC profiles
+(for example if you are building a photography portfolio and which to conserve
+the color profile of the photos you've exported from Adobe Lightroom or Phase
+One's Capture One), you can set the `stripMetadata` plugin option to `false` in
 `gatsby-config.js`.
+
+It is important to note that if `stripMetadata` is set to `false`, **all**
+metadata information will be preserved from the source image, including but not
+limited to the latitude/longitude information of where the picture was taken
+(if present). If you wish to strip this information from the source file, you
+can either leave `stripMetadata` to its default of `true`, or manually
+pre-process your images with a tool such as [ExifTool][17].
 
 [1]: https://alistapart.com/article/finessing-fecolormatrix
 [2]: http://blog.72lions.com/blog/2015/7/7/duotone-in-js
@@ -281,3 +297,4 @@ set the `stripMetadata` plugin option to `false` in
 [14]: https://github.com/oliver-moran/jimp
 [15]: http://sharp.dimens.io/en/stable/api-operation/#flatten
 [16]: https://github.com/mozilla/mozjpeg
+[17]: https://www.sno.phy.queensu.ca/~phil/exiftool/

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,7 +1,8 @@
-const { setBoundActionCreators } = require(`./index`)
+const { setBoundActionCreators, setPluginOptions } = require(`./index`)
 
-exports.onPreInit = ({ actions }) => {
+exports.onPreInit = ({ actions }, pluginOptions) => {
   setBoundActionCreators(actions)
+  setPluginOptions(pluginOptions)
 }
 
 // TODO

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -141,7 +141,7 @@ const processFile = (file, jobs, cb, reporter) => {
     pipeline = sharp(file)
 
     // Keep Metadata
-    if (pluginOptions.stripMetadata === false) {
+    if (!pluginOptions.stripMetadata) {
       pipeline = pipeline.withMetadata()
     }
 

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -246,6 +246,7 @@ const processFile = (file, jobs, cb, reporter) => {
                     args.quality + 25,
                     100
                   )}`, // e.g. 40-65
+                  strip: !!pluginOptions.stripMetadata, // Must be a bool
                 }),
               ],
             })

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -42,19 +42,13 @@ exports.setBoundActionCreators = actions => {
 }
 
 /// Plugin options are loaded onPreInit in gatsby-node
-let pluginOptions = {
+const pluginDefaults = {
   useMozJpeg: process.env.GATSBY_JPEG_ENCODER === `MOZJPEG`,
   stripMetadata: true,
 }
-exports.setPluginOptions = options => {
-  // Typechecks
-  if (typeof options.useMozJpeg === `boolean`) {
-    pluginOptions.useMozJpeg = options.useMozJpeg
-  }
-
-  if (typeof options.stripMetadata === `boolean`) {
-    pluginOptions.stripMetadata = options.stripMetadata
-  }
+let pluginOptions = Object.assign({}, pluginDefaults)
+exports.setPluginOptions = opts => {
+  pluginOptions = Object.assign({}, pluginOptions, opts)
 }
 
 // Promisify the sharp prototype (methods) to promisify the alternative (for


### PR DESCRIPTION
## Work Done
- Added an option to keep metadata (ICC profile, EXIF information) from files processed by `gatsby-plugin-sharp`. The old behavior remains as default.
- `gatsby-plugin-sharp` was one of the only plugins who didn't support passing configuration thru `gatsby-config.js`. The only way to enable MozJpeg was via an environment variable. This also has been normalized while maintaining old behavior as default.

## Reasoning
I'm currently rebuilding my website with `gatsby`. While I was working on my portfolio section, I noticed that many of my pictures were rendering differently in Firefox vs Chrome due to the lack of ICC profile attached to the image (untagged images in most browsers render using the Monitor's RGB profile; Chrome seems to assume the pictures are using sRGB IEC61966-2.1). Also, I tend to like to keep my Copyright EXIF information on my images.

This PR (with no breaking changes to old behavior) allows us to specify if we want to strip metadata in the images or not. 