### PR TITLE
fix(gatsby-source-wordpress): add undefined check to avoid taxonomy mapping error

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -264,8 +264,11 @@ exports.mapTagsCategoriesToTaxonomies = entities =>
     // Where should api_menus stuff link to?
     if (e.taxonomy && e.__type !== `wordpress__wp_api_menus_menus`) {
       // Replace taxonomy with a link to the taxonomy node.
-      e.taxonomy___NODE = entities.find(t => t.wordpress_id === e.taxonomy).id
-      delete e.taxonomy
+      const taxonomyNode = entities.find(t => t.wordpress_id === e.taxonomy)
+      if (taxonomyNode) {
+        e.taxonomy___NODE = taxonomyNode.id
+        delete e.taxonomy
+      }
     }
     return e
   })


### PR DESCRIPTION
hello! this is a fix for https://github.com/gatsbyjs/gatsby/issues/10138! that issue contains all the details of the issue, so i won't repeat them here! i've copied the error avoidance approach from the `exports.mapElementsToParent` function just below this block!