### PR TITLE
feat(starters): add starter-ghost-blog

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1307,3 +1307,21 @@
     - Google Analytics Integration
     - Uses Gatsby v2
     - SEO
+- url: http://starter-ghost-blog.surge.sh/
+  repo: https://github.com/little-wolf-studio/gatsby-starter-ghost-blog
+  description: Ghost Blog Starter Kit
+  tags:
+    - Ghost
+    - Blog
+    - Prettier
+    - Linting
+    - Headless CMS
+    - Styling:CSS-in-JS
+  features:
+    - Uses the Ghost CMS source
+    - Renders pages for posts, tags and authors
+    - Responsive Design
+    - Google Analytics Integration
+    - Uses Gatsby v2
+    - ESLint and Prettier
+    - Offline support

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1313,7 +1313,6 @@
   tags:
     - Ghost
     - Blog
-    - Prettier
     - Linting
     - Headless CMS
     - Styling:CSS-in-JS


### PR DESCRIPTION
a simple starter for how to use Gatsby and the Ghost CMS together
