### PR TITLE
Update Testing Components Installation Section

### DIFF
--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -33,7 +33,6 @@ Lastly you need to tell Jest where to find this file. Open your `jest.config.js`
 
 ```js:title=jest.config.js
 module.exports = {
-  ...
   'setupTestFrameworkScriptFile': '<rootDir>/setup-test-env.js'
 }
 ```

--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -38,13 +38,6 @@ module.exports = {
 }
 ```
 
-*If you don't have a `jest.config.js` file, you need to instead add this to your `package.json` like so:*
-```json:title=package.json
-"jest": {
-  "setupTestFrameworkScriptFile": "<rootDir>/setup-test-env.js"
-}
-```
-
 ## Usage
 
 Let's create a little example test using the newly added library. If you haven't done already read the [unit testing guide](/docs/unit-testing) — essentially you'll use `react-testing-library` instead of `react-test-renderer` now. There are a lot of options when it comes to selectors, this example chooses `getByTestId` here. It also utilizes `toHaveTextContent` from `jest-dom`:

--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -29,8 +29,16 @@ import "react-testing-library/cleanup-after-each"
 
 This file gets run automatically by Jest before every test and therefore you don't need to add the imports to every single test file.
 
-Lastly you need to tell Jest where to find this file. Open your `package.json` and add this entry to your `"jest"` section:
+Lastly you need to tell Jest where to find this file. Assuming you followed the [Unit testing](/docs/unit-testing), open your `jest.config.js` and add this entry to the bottom after 'setupFiles':
 
+```js:title=jest.config.js
+module.exports = {
+  ...
+  'setupTestFrameworkScriptFile': '<rootDir>/setup-test-env.js'
+}
+```
+
+*If you don't have a `jest.config.js` file, you need to instead add this to your `package.json` like so:*
 ```json:title=package.json
 "jest": {
   "setupTestFrameworkScriptFile": "<rootDir>/setup-test-env.js"

--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -29,7 +29,7 @@ import "react-testing-library/cleanup-after-each"
 
 This file gets run automatically by Jest before every test and therefore you don't need to add the imports to every single test file.
 
-Lastly you need to tell Jest where to find this file. Assuming you followed the [Unit testing](/docs/unit-testing), open your `jest.config.js` and add this entry to the bottom after 'setupFiles':
+Lastly you need to tell Jest where to find this file. Open your `jest.config.js` and add this entry to the bottom after 'setupFiles':
 
 ```js:title=jest.config.js
 module.exports = {

--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -33,7 +33,7 @@ Lastly you need to tell Jest where to find this file. Open your `jest.config.js`
 
 ```js:title=jest.config.js
 module.exports = {
-  'setupTestFrameworkScriptFile': '<rootDir>/setup-test-env.js'
+  setupTestFrameworkScriptFile: "<rootDir>/setup-test-env.js",
 }
 ```
 


### PR DESCRIPTION
This PR changes the prose related to setting up your `setup-test-env.js` file. Because it's assumed the user followed the unit-testing section, they should have a `jest.config.js` file. If they do, they need to add the `setupTestFrameworkScriptFile` to the jest config, rather than the `package.json` otherwise, their `setup-test-env.js` will **not** run correctly.

I've added the instructions for `jest.config.js` but also kept the original instructions related to adding it to the `package.json`

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
