### PR TITLE
fix(gatsby-source-contentful): use safe stringification for Rich Text fields

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -194,7 +194,7 @@ function prepareTextNode(node, key, text, createNodeId) {
 }
 
 function prepareStructuredTextNode(node, key, content, createNodeId) {
-  const str = JSON.stringify(content)
+  const str = stringify(content)
   const structuredTextNode = {
     ...content,
     id: createNodeId(`${node.id}${key}RichTextNode`),


### PR DESCRIPTION
The "Beta" Rich Text field for contentful breaks when trying to load data into GraphQL that has circular references.

Using a safe stringify method prevents it falling over and instead just prevents the referenced circular data from being available.