### PR TITLE
docs(babel-preset-gatsby): Update README to reflect dependencies

### DIFF
--- a/packages/babel-preset-gatsby/README.md
+++ b/packages/babel-preset-gatsby/README.md
@@ -9,9 +9,9 @@ For more information on how to customize the Babel configuration of your Gatsby 
 - [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env)
 - [`@babel/preset-react`](https://babeljs.io/docs/en/babel-preset-react)
 - [`@babel/plugin-proposal-class-properties`](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties)
-- [`babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros)
-- [`@babel/plugin-proposal-optional-chaining`](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining)
+- [`@babel/plugin-syntax-dynamic-import`](https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import)
 - [`@babel/plugin-transform-runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime#docsNav)
+- [`babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros)
 
 ## Usage
 


### PR DESCRIPTION
Based on the dependencies brought in from this present, the following updates were added to the README:

- Removed reference to `@babel/plugin-proposal-optional-chaining`
- Added reference to `@babel/plugin-syntax-dynamic-import`
- Updated ordering to move babel-core plugins above community ones.

Resolves #10214