### PR TITLE
feat(gatsby): Add type checks to createNodeId

### DIFF
--- a/packages/gatsby/src/utils/create-node-id.js
+++ b/packages/gatsby/src/utils/create-node-id.js
@@ -15,7 +15,7 @@ function createNodeId(id, namespace) {
   if (typeof id === `number`) {
     id = id.toString()
   } else if (typeof id !== `string`) {
-    report.panic(`Parameter passed to createNodeId must be a String or Number`)
+    report.panic(`Parameter passed to createNodeId must be a String or Number (got ${typeof id})`)
   }
 
   return uuidv5(id, uuidv5(namespace, seedConstant))

--- a/packages/gatsby/src/utils/create-node-id.js
+++ b/packages/gatsby/src/utils/create-node-id.js
@@ -15,7 +15,9 @@ function createNodeId(id, namespace) {
   if (typeof id === `number`) {
     id = id.toString()
   } else if (typeof id !== `string`) {
-    report.panic(`Parameter passed to createNodeId must be a String or Number (got ${typeof id})`)
+    report.panic(
+      `Parameter passed to createNodeId must be a String or Number (got ${typeof id})`
+    )
   }
 
   return uuidv5(id, uuidv5(namespace, seedConstant))

--- a/packages/gatsby/src/utils/create-node-id.js
+++ b/packages/gatsby/src/utils/create-node-id.js
@@ -1,4 +1,5 @@
 const uuidv5 = require(`uuid/v5`)
+const report = require(`gatsby-cli/lib/reporter`)
 
 const seedConstant = `638f7a53-c567-4eca-8fc1-b23efb1cfb2b`
 
@@ -11,6 +12,12 @@ const seedConstant = `638f7a53-c567-4eca-8fc1-b23efb1cfb2b`
  * @return {String} - UUID
  */
 function createNodeId(id, namespace) {
+  if (typeof id === `number`) {
+    id = id.toString()
+  } else if (typeof id !== `string`) {
+    report.panic(`Parameter passed to createNodeId must be a String or Number`)
+  }
+
   return uuidv5(id, uuidv5(namespace, seedConstant))
 }
 


### PR DESCRIPTION
Before the change it was possible to enter all sorts of parameters. Also Numbers threw a weird error. Both fixed now.