### PR TITLE
feat(gatsby-plugin-typescript): allow specifying babel preset options

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -32,10 +32,10 @@ module.exports = {
     {
       resolve: `gatsby-plugin-typescript`,
       options: {
-        isTSX: true,         // defaults to false
-        jsxPragma: `jsx`,    // defaults to "React"
+        isTSX: true, // defaults to false
+        jsxPragma: `jsx`, // defaults to "React"
         allExtensions: true, // defaults to false
-      }
+      },
     },
   ],
 }

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -21,6 +21,28 @@ module.exports = {
 }
 ```
 
+## Options
+
+When adding this plugin to your `gatsby-config.js`, you can pass in options to override the default [@babel/preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript#options) config.
+
+```javascript
+// gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-typescript`,
+      options: {
+        isTSX: true,         // defaults to false
+        jsxPragma: `jsx`,    // defaults to "React"
+        allExtensions: true, // defaults to false
+      }
+    },
+  ],
+}
+```
+
+For more detailed documentation on the available options, visit https://babeljs.io/docs/en/babel-preset-typescript#options.
+
 ## Caveats
 
 This plugin uses [`babel-plugin-transform-typescript`](https://babeljs.io/docs/en/babel-plugin-transform-typescript.html)

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -1,8 +1,9 @@
 const resolvableExtensions = () => [`.ts`, `.tsx`]
 
-function onCreateBabelConfig({ actions }, pluginOptions) {
+function onCreateBabelConfig({ actions }, options) {
   actions.setBabelPreset({
     name: `@babel/preset-typescript`,
+    options,
   })
 }
 


### PR DESCRIPTION
`@babel/preset-typescript` accepts [options](https://babeljs.io/docs/en/babel-preset-typescript#options) but there is currently no way to set those options with `gatsby-plugin-typescript`. This pull passes the plugin options to the babel preset.
