### PR TITLE
Remove react-emotion from tutorial

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -96,14 +96,14 @@ Then install some other needed dependencies at the root of the project. You'll u
 "Kirkham", and you'll try out a CSS-in-JS library, ["Emotion"](https://emotion.sh/):
 
 ```shell
-npm install --save gatsby-plugin-typography typography react-typography typography-theme-kirkham gatsby-plugin-emotion emotion react-emotion emotion-server
+npm install --save gatsby-plugin-typography typography react-typography typography-theme-kirkham gatsby-plugin-emotion emotion emotion-server
 ```
 
 Set up a site similar to what you ended with in [Part Three](/tutorial/part-three). This site will have a layout component and two page components:
 
 ```jsx:title=src/components/layout.js
 import React from "react"
-import { css } from "react-emotion"
+import { css } from "emotion"
 import { Link } from "gatsby"
 
 import { rhythm } from "../utils/typography"


### PR DESCRIPTION
Emotion removed react-emotion package. Not sure which version to put this in but part 4 of the tutorial will be fixed.

<!--
  Q. Which branch should I use for my pull request?
  A. Your best bet is to go for `master`. If you are unsure, ask in the PR, and a Gatsby mantainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
