### PR TITLE
Docs - Add clarification to custom domains on github pages

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -49,4 +49,4 @@ After running `npm run deploy` you should see your website at `http://username.g
 
 If you use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add a `pathPrefix` as it will break navigation on your site. Path prefixing is only necessary when the site is _not_ at the root of the domain like with repository sites.
 
-**Note**: Don't forget to add your [CNAME](https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors) file to the `static` directory.
+**Note**: Don't forget to add your [CNAME](https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors) file to the `public` directory.

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -50,3 +50,14 @@ After running `npm run deploy` you should see your website at `http://username.g
 If you use a [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/), don't add a `pathPrefix` as it will break navigation on your site. Path prefixing is only necessary when the site is _not_ at the root of the domain like with repository sites.
 
 **Note**: Don't forget to add your [CNAME](https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors) file to the `public` directory.
+
+Assuming your `CNAME` file is in `src/`, you can copy this to your site on every deploy like this:
+
+```json:title=package.json
+    {
+        "scripts": {
+            ...
+            "deploy": "gatsby build && cp src/CNAME public/ && gh-pages -d public -b master",
+        }
+    }
+```


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Your best bet is to go for `master`. If you are unsure, ask in the PR, and a Gatsby mantainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->

## Changes
- Changed the folder in which the `CNAME` file should be copied to. Github wants it in the root of the folder you deploy
- Added an example deploy script that copies `CNAME` from `src/` on every deploy
