### PR TITLE
fix(gatsby-source-filesystem): allow empty password for basic auth in createRemoteFileNode

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -188,7 +188,7 @@ async function processRemoteNode({
 
   // Add htaccess authentication if passed in. This isn't particularly
   // extensible. We should define a proper API that we validate.
-  if (auth && auth.htaccess_pass && auth.htaccess_user) {
+  if (auth && (auth.htaccess_pass || auth.htaccess_user)) {
     headers.auth = `${auth.htaccess_user}:${auth.htaccess_pass}`
   }
 


### PR DESCRIPTION
This allows createRemoteFileNode authentication with either user or password. Currently auth params with falsy keys are ignored, but not all authentication schemes require both user and password (e.g. [Stripe API](https://stripe.com/docs/api/authentication?lang=curl)).