### PR TITLE
fix(ci): actually only run tests on non-docs changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,12 @@ aliases:
       - run: yarn jest -w 1
 
   e2e-test-workflow: &e2e-test-workflow
-    <<: *ignore_master
-    <<: *ignore_docs
+    filters:
+      branches:
+        ignore:
+          - master
+          - /docs.+/
+          - /blog.+/
     requires:
       - bootstrap
 


### PR DESCRIPTION
Previously, this was mostly working (see
https://github.com/gatsbyjs/gatsby/pull/9889 where the unit tests are
not run, but the e2e tests are run), but as is evident, the e2e tests
are still run.

This is because the "merging" of template inclusions doesn't work quite
like we'd expect, so need to iron that out. This should iron it out!

<!--
  Q. Which branch should I use for my pull request?
  A. Your best bet is to go for `master`. If you are unsure, ask in the PR, and a Gatsby mantainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
