### PR TITLE
fix(gatsby-plugin-emotion): allow for React.Fragment shorthand syntax

### DIFF
--- a/packages/gatsby-plugin-emotion/src/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/gatsby-node.js
@@ -14,6 +14,7 @@ export const onCreateBabelConfig = ({ actions }, pluginOptions) => {
     name: `@babel/plugin-transform-react-jsx`,
     options: {
       pragma: pragmaName,
+      pragmaFrag: `React.Fragment`,
     },
   })
 


### PR DESCRIPTION
This change resolves the following error thrown by `@babel/plugin-transform-react-jsx` when using the React.Fragment shorthand syntax (`<> </>`) in conjunction with emotion v10 and `gatsby-plugin-emotion` v3:

```
Error: transform-react-jsx: pragma has been set but pragmafrag has not been set
```
