### PR TITLE
temporarily don't lint markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lint": "npm-run-all --continue-on-error -p lint:code lint:other",
     "lint:code": "eslint --ignore-path .gitignore --ignore-path .prettierignore --ext .js,.jsx .",
     "lint:flow": "babel-node scripts/flow-check.js",
-    "lint:other": "npm run prettier -- --list-different",
+    "lint:other": "prettier \"**/*.{css,scss,yaml,yml}\" --list-different",
     "plop": "plop",
     "prebootstrap": "yarn",
     "prettier": "prettier \"**/*.{md,css,scss,yaml,yml}\"",


### PR DESCRIPTION
Ref: https://github.com/gatsbyjs/gatsby/issues/10284

This is not ideal, but linting markdown files proved to be pain point for PRs made in GitHub UI. As mentioned in the issue, ideally we could trigger some kind of bot to run formatting on any PR on demand (and then we could revert change proposed in this PR)