### PR TITLE
Gatsby Plugin CLI

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -271,6 +271,34 @@ function buildLocalCommands(cli, isLocalSite) {
   })
 
   cli.command({
+    command: `plugin <action> <plugins..>`,
+    desc: `Manage Gatsby plugins.`,
+    builder: _ =>
+      _.option(`dry-run`, {
+        default: false,
+        type: `boolean`,
+        describe: `Don't actually write any changes to disk or run npm/yarn.`,
+      })
+        .option(`confirm`, {
+          alias: `Y`,
+          default: false,
+          type: `boolean`,
+          describe: `Do not prompt for install or config confirmation`,
+        })
+        .positional(`action`, {
+          type: `string`,
+          describe: `Action to be taken for provided plugin.`,
+          choices: [`add`, `remove`, `config`, `search`],
+        })
+        .positional(`plugin`, {
+          type: `string`,
+          describe: `Package(s) to add, remove, configure, or search.`,
+        }),
+
+    handler: getCommandHandler(`plugin`),
+  })
+
+  cli.command({
     command: `clean`,
     desc: `Wipe the local gatsby environment including built assets and cache`,
     handler: getCommandHandler(`clean`),

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -49,6 +49,7 @@
     "detect-port": "^1.2.1",
     "devcert-san": "^0.3.3",
     "dotenv": "^4.0.0",
+    "enquirer": "^2.3.0",
     "eslint": "^5.6.0",
     "eslint-config-react-app": "^3.0.0",
     "eslint-loader": "^2.1.0",

--- a/packages/gatsby/src/commands/plugin.js
+++ b/packages/gatsby/src/commands/plugin.js
@@ -1,0 +1,168 @@
+const enquirer = require(`enquirer`)
+const reporter = require(`gatsby-cli/lib/reporter`)
+const execa = require(`execa`)
+
+const spawn = cmd => {
+  const [file, ...args] = cmd.split(/\s+/)
+  return execa(file, args)
+}
+
+// Returns true if yarn exists, false otherwise
+const shouldUseYarn = () => {
+  try {
+    execa.sync(`yarnpkg`, `--version`, { stdio: `ignore` })
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+const makeList = array => {
+  let list = ``
+
+  switch (array.length) {
+    case 1:
+      return array[0]
+    case 2:
+      return `${array[0]} and ${array[1]}`
+    default:
+      array.forEach((item, index) => {
+        if (index < array.length - 1) {
+          list += `${item}, `
+        } else if (index < array.length) {
+          list += `${item}, and`
+        } else {
+          list += item
+        }
+      })
+
+      return list
+  }
+}
+
+const verbs = {
+  add: {
+    present: `add`,
+    alt: `install`,
+    past: `added`,
+    participle: `adding`,
+    preposition: `to`,
+  },
+  config: {
+    present: `config`,
+    past: `configured`,
+    participle: `configuring`,
+  },
+  remove: {
+    present: `remove`,
+    alt: `uninstall`,
+    past: `removed`,
+    participle: `removing`,
+    preposition: `from`,
+  },
+  search: {
+    present: `search`,
+    past: `searched`,
+    participle: `searching`,
+    preposition: `for`,
+  },
+}
+
+const addRemovePlugin = async (action, plugins, dryRun) => {
+  let questions = new Array()
+
+  if (dryRun) {
+    reporter.info(
+      `Dry Run: The workflow will be unchanged, but nothing will be done in the end.`
+    )
+  }
+
+  plugins.forEach((plugin, index, plugins) => {
+    if (!plugin.startsWith(`gatsby-`)) {
+      plugin = `gatsby-` + plugin
+      plugins[index] = plugin
+    }
+
+    questions.push({
+      type: `confirm`,
+      name: plugin,
+      message: `You are about to ${action.alt} ${plugin}. This will ${
+        action.present
+      } it ${
+        action.preposition
+      } 'package.json'.\n Are you sure you want to do this?`,
+    })
+  })
+
+  let answers = await enquirer.prompt(questions)
+
+  let confirmedPlugins = new Array()
+
+  plugins.forEach(plugin => {
+    if (answers[plugin]) confirmedPlugins.push(plugin)
+  })
+
+  let pluginString = makeList(confirmedPlugins)
+
+  if (confirmedPlugins.length > 0) {
+    let spinner = reporter.activity()
+
+    try {
+      spinner.tick(`${action.participle} plugin(s): ${confirmedPlugins}`)
+
+      if (dryRun) {
+        reporter.info(
+          `Dry Run: Usually I'd be installing stuff right now, but this is a dry run!`
+        )
+      } else {
+        await spawn(
+          `${shouldUseYarn() ? `yarn` : `npm`} ${
+            action.present
+          } ${pluginString}`
+        )
+      }
+      reporter.success(`Successfully ${action.past}: ${pluginString}`)
+
+      spinner.end()
+
+      if (action.present === `add`) {
+        confirmedPlugins.forEach(plugin => {
+          reporter.info(
+            `For more info on using ${plugin} see: https://www.gatsbyjs.org/packages/${plugin}/`
+          )
+        })
+      }
+    } catch (error) {
+      spinner.end()
+      reporter.error(
+        `Error ${action.participle} plugin(s): ${pluginString}`,
+        error.stdout
+      )
+    }
+  } else {
+    reporter.info(`No plugins to ${action.present}`)
+  }
+}
+
+module.exports = async program => {
+  let action = verbs[program.action]
+  let plugins = program.plugins
+  let dry = program.dryRun
+
+  switch (action.present) {
+    case `add`:
+    case `remove`:
+      await addRemovePlugin(action, plugins, dry)
+      break
+    case `config`:
+      reporter.info(
+        `The future is not yet...but with your PR it could be soon!`
+      )
+      break
+    case `search`:
+      reporter.info(
+        `The future is not yet...but with your PR it could be soon!`
+      )
+      break
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3320,6 +3320,11 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.0.5.tgz#cb9dc64993b64fd6945485f797fc3853137d9a7b"
   integrity sha512-VVjWpkfaphxUBFarydrQ3n26zX5nIK7hcbT3/ielrvwDDyBBjuh2vuSw1P9zkPq0cfqvdw7lkYHnu+OLSfIBsg==
 
+ansi-colors@^3.2.1:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
+  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -8139,6 +8144,13 @@ enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
     tapable "^1.0.0"
+
+enquirer@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.0.tgz#c362c9d84984ebe854def63caaf12983a16af552"
+  integrity sha512-RNGUbRVlfnjmpxV+Ed+7CGu0rg3MK7MmlW+DW0v7V2zdAUBC1s4BxCRiIAozbYB2UJ+q4D+8tW9UFb11kF72/g==
+  dependencies:
+    ansi-colors "^3.2.1"
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
See: https://github.com/gatsbyjs/rfcs/pull/13 for discussion of feature and implementation details.

UI Tasks: 
- [x] Add "add" Command to CLI
- [x] Add "remove" Command to CLI
- [x] Add "search" Command to CLI
- [x] Add "config" Command to CLI
- [x] Add Confirmation for add/remove actions before executing
- [x] On completion of add/remove log completion and plugin docs to console
- [ ] ~~On completion of config log new config to console and wait for confirmation before writing~~

Implementation Tasks:
- [x] "add <plugin..>" add to package.json and install from npm
- [x] "remove <plugin..>" remove from package.json and remove from node_modules
- [ ] ~~"search <query>" command~~
- [ ] ~~extend gatsby API with 'onConfigPlugin' to add config to gatsby-config.js **in progress:** @moonmeister see: https://github.com/gatsbyjs/gatsby/tree/config-api~~
- [ ] ~~"config <plugin..>" command~~
- [ ] ~~add hooks for "add" to config added plugins~~
- [ ] ~~"remove" remove config from gatsby-config~~
- [ ] ~~auto search into add/remove/config~~
- [x] make library for code shared with "new" CLI (yarn choice and spawn)

Testing Tasks:
- [ ] Test all the things

Docs/Community Tasks:
- [ ] Document CLI
- [ ] ~~Document API Changes~~
- [ ] ~~Update plugins in the Gatsby repo to be compatible~~
- [ ] ~~Tutorial for plugin creators to make their plugins compatible with the configuration work flow~~
- [ ] Blog post announcing this sweet sweet feature!

Happy to take PRs against this branch to complete tasks. Please comment if you're going to take a task so we know!


UPDATE [18-03-2019]: Crossed out things no longer being done on this PR. It's not that we don't like these ideas. We're just simplifying this PR. 

