### PR TITLE
fix(gatsby-source-drupal): use basic auth credentials to fetch remote files as well.

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -200,6 +200,7 @@ exports.sourceNodes = async (
             cache,
             createNode,
             createNodeId,
+            auth: { htaccess_user: basicAuth.username, htaccess_pass: basicAuth.password }
           })
         } catch (e) {
           // Ignore

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -194,13 +194,21 @@ exports.sourceNodes = async (
           }
           // Resolve w/ baseUrl if node.uri isn't absolute.
           const url = new URL(fileUrl, baseUrl)
+          // If we have basicAuth credentials, add them to the request.
+          const auth =
+            typeof basicAuth === `object`
+              ? {
+                  htaccess_user: basicAuth.username,
+                  htaccess_pass: basicAuth.password,
+                }
+              : {}
           fileNode = await createRemoteFileNode({
             url: url.href,
             store,
             cache,
             createNode,
             createNodeId,
-            auth: { htaccess_user: basicAuth.username, htaccess_pass: basicAuth.password }
+            auth,
           })
         } catch (e) {
           // Ignore


### PR DESCRIPTION
After the merging of #9848 , we can now interact with the jsonapi endpoints of a drupal site behind basic authentication.

This works, however Gatsby cannot retrieve remote files, because the calls executed in `createRemoteFileNode` do not currently take into consideration the basic auth credentials.

This pull request adds those credentials so that files are correctly fetched from the remote drupal site behind basic auth.