### PR TITLE
fix(gatsby-plugin-emotion): promote @babel/core to a real dependency

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/plugin-transform-react-jsx": "^7.1.6",
     "@babel/runtime": "^7.0.0",
     "babel-plugin-emotion": "^10.0.0",
@@ -14,7 +15,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
-    "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.3",
     "cross-env": "^5.1.4"
   },


### PR DESCRIPTION
This gets rid of the following warnings when using `gatsby-plugin-emotion` v3:

```
warning "gatsby-plugin-emotion > @babel/plugin-transform-react-jsx > @babel/plugin-syntax-jsx@7.0.0" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "gatsby-plugin-emotion > @babel/plugin-transform-react-jsx@7.1.6" has unmet peer dependency "@babel/core@^7.0.0-0".
```

`@babel/core` is already present due to many other packages depending on it (including Gatsby itself), but some users may not be aware of this and the warnings may cause them unnecessary concern.