### PR TITLE
fix `@emotion/core` issues in tutorial-part-4

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -96,21 +96,21 @@ Then install some other needed dependencies at the root of the project. You'll u
 "Kirkham", and you'll try out a CSS-in-JS library, ["Emotion"](https://emotion.sh/):
 
 ```shell
-npm install --save gatsby-plugin-typography typography react-typography typography-theme-kirkham gatsby-plugin-emotion emotion emotion-server @emotion/core
+npm install --save gatsby-plugin-typography typography react-typography typography-theme-kirkham gatsby-plugin-emotion emotion emotion-server
 ```
 
 Set up a site similar to what you ended with in [Part Three](/tutorial/part-three). This site will have a layout component and two page components:
 
 ```jsx:title=src/components/layout.js
 import React from "react"
-import { css } from "@emotion/core"
+import { css } from "emotion"
 import { Link } from "gatsby"
 
 import { rhythm } from "../utils/typography"
 
 export default ({ children }) => (
   <div
-    css={css`
+    className={css`
       margin: 0 auto;
       max-width: 700px;
       padding: ${rhythm(2)};
@@ -119,7 +119,7 @@ export default ({ children }) => (
   >
     <Link to={`/`}>
       <h3
-        css={css`
+        className={css`
           margin-bottom: ${rhythm(2)};
           display: inline-block;
           font-style: normal;
@@ -130,7 +130,7 @@ export default ({ children }) => (
     </Link>
     <Link
       to={`/about/`}
-      css={css`
+      className={css`
         float: right;
       `}
     >
@@ -292,7 +292,7 @@ Go ahead and add a `<StaticQuery />` to your `src/components/layout.js` file, an
 
 ```jsx{3,8-18,35,48-49}:title=src/components/layout.js
 import React from "react"
-import { css } from "@emotion/core"
+import { css } from "emotion"
 import { StaticQuery, Link, graphql } from "gatsby"
 
 import { rhythm } from "../utils/typography"
@@ -310,7 +310,7 @@ export default ({ children }) => (
     `}
     render={data => (
       <div
-        css={css`
+        className={css`
           margin: 0 auto;
           max-width: 700px;
           padding: ${rhythm(2)};
@@ -319,7 +319,7 @@ export default ({ children }) => (
       >
         <Link to={`/`}>
           <h3
-            css={css`
+            className={css`
               margin-bottom: ${rhythm(2)};
               display: inline-block;
               font-style: normal;
@@ -330,7 +330,7 @@ export default ({ children }) => (
         </Link>
         <Link
           to={`/about/`}
-          css={css`
+          className={css`
             float: right;
           `}
         >

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -331,7 +331,7 @@ links.
 
 ```jsx{3,22-28,44,63-65}:title=src/pages/index.js
 import React from "react"
-import { css } from "@emotion/core"
+import { css } from "emotion"
 import { Link, graphql } from "gatsby"
 import { rhythm } from "../utils/typography"
 import Layout from "../components/layout"
@@ -341,7 +341,7 @@ export default ({ data }) => {
     <Layout>
       <div>
         <h1
-          css={css`
+          className={css`
             display: inline-block;
             border-bottom: 1px solid;
           `}
@@ -353,19 +353,19 @@ export default ({ data }) => {
           <div key={node.id}>
             <Link
               to={node.fields.slug}
-              css={css`
+              className={css`
                 text-decoration: none;
                 color: inherit;
               `}
             >
               <h3
-                css={css`
+                className={css`
                   margin-bottom: ${rhythm(1 / 4)};
                 `}
               >
                 {node.frontmatter.title}{" "}
                 <span
-                  css={css`
+                  className={css`
                     color: #bbb;
                   `}
                 >

--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -107,7 +107,7 @@ the following to add a GraphQL query with some initial HTML and styling.
 ```jsx:title=src/pages/index.js
 import React from "react"
 import { graphql } from "gatsby"
-import { css } from "@emotion/core"
+import { css } from "emotion"
 import { rhythm } from "../utils/typography"
 import Layout from "../components/layout"
 
@@ -117,7 +117,7 @@ export default ({ data }) => {
     <Layout>
       <div>
         <h1
-          css={css`
+          className={css`
             display: inline-block;
             border-bottom: 1px solid;
           `}
@@ -128,13 +128,13 @@ export default ({ data }) => {
         {data.allMarkdownRemark.edges.map(({ node }) => (
           <div key={node.id}>
             <h3
-              css={css`
+              className={css`
                 margin-bottom: ${rhythm(1 / 4)};
               `}
             >
               {node.frontmatter.title}{" "}
               <span
-                css={css`
+                className={css`
                   color: #bbb;
                 `}
               >


### PR DESCRIPTION
After following the tutorial part 4, I think there are some issues with `@emotion/core` as details below:

## The problem:
When `import { css } from '@emotion/core'` and call it in `css` props like this
```
<div
    css={css`
      margin: 0 auto;
      max-width: 700px;
      padding: ${rhythm(2)};
      padding-top: ${rhythm(1.5)};
    `}
  >
```
The page result is broken. It is displayed like there is no css attached to the page at all.

## My proposed solution:
1. Use `import { css } from 'emotion'` instead of `@emotion/core`
2. Use `className` props instead of `css` props in jsx, so the code will be like this:
```
<div
    className={css`
      margin: 0 auto;
      max-width: 700px;
      padding: ${rhythm(2)};
      padding-top: ${rhythm(1.5)};
    `}
  >
```

## My `package.json`:
```
{
  "name": "gatsby-starter-hello-world",
  "description": "Gatsby hello world starter",
  "license": "MIT",
  "scripts": {
    "develop": "gatsby develop",
    "start": "npm run develop",
    "build": "gatsby build",
    "serve": "gatsby serve"
  },
  "dependencies": {
    "@emotion/core": "^10.0.4",
    "emotion": "^10.0.2",
    "emotion-server": "^10.0.2",
    "gatsby": "^2.0.33",
    "gatsby-plugin-emotion": "^2.0.7",
    "gatsby-plugin-typography": "^2.2.2",
    "gatsby-source-filesystem": "^2.0.10",
    "gatsby-transformer-remark": "^2.1.15",
    "react": "^16.5.1",
    "react-dom": "^16.5.1",
    "react-typography": "^0.16.13",
    "typography": "^0.16.17",
    "typography-theme-kirkham": "^0.16.3"
  }
}

```