### PR TITLE
fix(docs): ecosystem section in docs sidebar

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -1,12 +1,11 @@
 - title: Documentation
-  link: /docs/
   items:
+    - title: Introduction
+      link: /docs/
     - title: Quick Start
       link: /docs/quick-start
     - title: Recipes
       link: /docs/recipes/
-    - title: Awesome Gatsby Resources
-      link: /docs/awesome-gatsby/
 - title: Guides
   items:
     - title: Preparing your environment
@@ -259,6 +258,15 @@
           link: /docs/seo/
         - title: Optimize Prefetching with Guess.js*
           link: /docs/optimize-prefetching-with-guessjs/
+- title: Ecosystem
+  link: /ecosystem/
+  items:
+    - title: Plugin Library
+      link: /plugins
+    - title: Starter Library
+      link: /starters/
+    - title: Awesome Gatsby Resources
+      link: /docs/awesome-gatsby/
 - title: API Reference
   items:
     - title: Gatsby Link

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -50,6 +50,10 @@ class IndexRoute extends React.Component {
                   and more.
                 </li>
                 <li>
+                  <strong>Ecosystem</strong>: Check out libraries for Gatsby
+                  starters and plugins, as well as external community resources.
+                </li>
+                <li>
                   <strong>API Reference</strong>: Learn more about Gatsby APIs
                   and configuration.
                 </li>


### PR DESCRIPTION
![screen shot 2018-12-07 at 10 34 35 am](https://user-images.githubusercontent.com/3461087/49660457-4345ce80-fa0c-11e8-8715-d0fb7e516d78.png)

- better consistency with tutorial sidebar (intro landing page under "introduction")
- added ecosystem section which links out to starter library, plugin library, and awesome gatsby (external) resources.