### PR TITLE
docs: add ttag starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1344,3 +1344,10 @@
     - Support for code syntax highlighting
     - Support for mathematical expressions
     - Support for images
+- url: https://gatsby-starter-ttag.netlify.com/
+  repo: https://github.com/jaredh159/gatsby-starter-ttag
+  description: Gatsby starter with the minimum required to demonstrate using ttag for precompiled internationalization of strings.
+  tags:
+    - i18n
+  features:
+    - Support for precompiled string internationalization using ttag and it's babel plugin


### PR DESCRIPTION
[ttag](https://ttag.js.org/) is a really slick internationalization library based on es6 template tags. This starter provides a basic setup for integration with ttag in order to support precompiled internationalization of strings within gatsby sites during development or build.