### PR TITLE
docs: new starter features is required

### DIFF
--- a/docs/docs/submit-to-starter-library.md
+++ b/docs/docs/submit-to-starter-library.md
@@ -37,7 +37,7 @@ Use the following template to ensure required fields are filled:
   tags:
     - (required)
   features:
-    - (optional, but encouraged)
+    - (required)
 ```
 
 Check out the [`starters.yml`](https://github.com/gatsbyjs/gatsby/blob/master/docs/starters.yml) file for examples.


### PR DESCRIPTION
Tried to submit a new starter using the template provided in the docs, and got this error:

![2018-12-07_12-44-57](https://user-images.githubusercontent.com/7050938/49663934-40ec7000-fa1e-11e8-8c89-36c1f891f985.png)

So, it appears that `features` is in fact required. Updating the template accordingly.