### PR TITLE
fix(www): Starters.yaml housekeeping

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -791,7 +791,7 @@
   repo: https://github.com/cpinnix/verious-boilerplate
   description: n/a
   tags:
-    - no tag
+    - Styling:Other
   features:
     - Components only. Bring your own data, plugins, etc.
     - Bootstrap inspired grid system with Container, Row, Column components.
@@ -879,7 +879,6 @@
   tags:
     - Styling:CSS-in-JS
     - i18n
-    - react-intl
     - Formik
     - Yup
     - Netlify Form
@@ -1271,9 +1270,8 @@
     - Katex
     - Tensorflow
     - CSV
-    - Graph
+    - Charts
     - Linting
-    - Chart.js
   features:
     - Write easly your scientific blog with katex and publish your research
     - Machine learning ready with tensorflowjs


### PR DESCRIPTION
- `no tag` is a weird tag. I added the `Styling:Other` and would propose that all *unknown* styling solutions get grouped under that. So no singular tags for every library on that world
- Removed Graph and Charts.js and would call all Charting libraries `Charts`
- Removed `react-intl` as all other starters with different i18n libraries are grouped under `i18n`