### PR TITLE
fix(gatsby): fix false type conflict warning on plugin fields

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-node-types-test.js
+++ b/packages/gatsby/src/schema/__tests__/build-node-types-test.js
@@ -14,6 +14,9 @@ const createPageDependency = require(`../../redux/actions/add-page-dependency`)
 jest.mock(`../../redux/actions/add-page-dependency`)
 const nodeTypes = require(`../build-node-types`)
 
+const { typeConflictReporter } = require(`../type-conflict-reporter`)
+const addConflictSpy = jest.spyOn(typeConflictReporter, `addConflict`)
+
 describe(`build-node-types`, () => {
   let schema, store, types
 
@@ -26,6 +29,7 @@ describe(`build-node-types`, () => {
 
   beforeEach(async () => {
     createPageDependency.mockClear()
+    addConflictSpy.mockClear()
     const apiRunnerResponse = [
       {
         pluginField: {
@@ -58,6 +62,7 @@ describe(`build-node-types`, () => {
         hair: `brown`,
         children: [],
         parent: `p1`,
+        pluginField: `string`,
       },
       {
         id: `c2`,
@@ -65,6 +70,7 @@ describe(`build-node-types`, () => {
         hair: `blonde`,
         children: [],
         parent: `p1`,
+        pluginField: 5,
       },
     ].forEach(n => store.dispatch({ type: `CREATE_NODE`, payload: n }))
 
@@ -266,5 +272,9 @@ describe(`build-node-types`, () => {
       path: `foo`,
       nodeId: `c2`,
     })
+  })
+
+  it(`should not report conflicts on plugin fields`, () => {
+    expect(typeConflictReporter.addConflict).not.toBeCalled()
   })
 })

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -20,7 +20,10 @@ const { nodeInterface } = require(`./node-interface`)
 const { getNodes, getNode } = require(`../db/nodes`)
 const pageDependencyResolver = require(`./page-dependency-resolver`)
 const { setFileNodeRootType } = require(`./types/type-file`)
-const { clearTypeExampleValues } = require(`./data-tree-utils`)
+const {
+  getExampleValues,
+  clearTypeExampleValues,
+} = require(`./data-tree-utils`)
 const { run: runQuery } = require(`../db/nodes-query`)
 const lazyFields = require(`./lazy-fields`)
 
@@ -200,9 +203,16 @@ async function buildProcessedType({ nodes, typeName, processedTypes, span }) {
     processedTypes,
   })
 
+  const exampleValue = getExampleValues({
+    nodes,
+    typeName,
+    ignoreFields: Object.keys(mergedFieldsFromPlugins),
+  })
+
   const nodeInputFields = inferInputObjectStructureFromNodes({
     nodes,
     typeName,
+    exampleValue,
   })
 
   const filterFields = _.merge(


### PR DESCRIPTION
Fixing regression surfaced in https://github.com/gatsbyjs/gatsby/pull/10342

Unit tests didn't caught those regressions because integration changed, so adding more integration type test to catch this in the future