### PR TITLE
Allow newer `eslint-config-react-app` versions

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -48,7 +48,7 @@
     "domready": "^1.0.8",
     "dotenv": "^4.0.0",
     "eslint": "^4.19.1",
-    "eslint-config-react-app": "3.0.0-next.66cc7a90",
+    "eslint-config-react-app": "^3.0.0-next.66cc7a90",
     "eslint-loader": "^2.0.0",
     "eslint-plugin-flowtype": "^2.46.1",
     "eslint-plugin-graphql": "^2.0.0",


### PR DESCRIPTION
Since `eslint-config-react-app@3.0.0-next.66cc7a90` has `eslint^4.1.1` as a peer dependency, npm shows an unmet peer dependency warning if `eslint@5.0.0` or higher is installed.

I don't see a reason to stay on this specific version of the config, so I propose we allow newer versions of `eslint-config-react-app`, which in turn allow `eslint@5`.