### PR TITLE
feat(prefetch): add support for effective-connection-type & saveData

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/prefetching.js
+++ b/e2e-tests/production-runtime/cypress/integration/prefetching.js
@@ -1,0 +1,27 @@
+describe(`Prefetching`, () => {
+  if (Cypress.env(`CONNECTION_TYPE`) === `slow`) {
+    it(`should not prefetch if on slow connection`, () => {
+      cy.visit(`/`).waitForAPI(`onRouteUpdate`)
+
+      cy.window().then(win => {
+        const isPrefetching = win.___loader.enqueue(`/page-2`)
+        expect(isPrefetching).to.equal(false)
+      })
+
+      cy.get(`link[rel="prefetch"]`).should(`not.exist`)
+      cy.lifecycleCallCount(`onPrefetchPathname`).should(`equal`, 0)
+    })
+  } else {
+    it(`should prefetch`, () => {
+      cy.visit(`/`).waitForAPI(`onRouteUpdate`)
+
+      cy.window().then(win => {
+        const isPrefetching = win.___loader.enqueue(`/page-2`)
+        expect(isPrefetching).to.equal(true)
+      })
+
+      cy.get(`link[rel="prefetch"]`).should(`exist`)
+      cy.lifecycleCallCount(`onPrefetchPathname`).should(`not.equal`, 0)
+    })
+  }
+})

--- a/e2e-tests/production-runtime/cypress/plugins/index.js
+++ b/e2e-tests/production-runtime/cypress/plugins/index.js
@@ -14,4 +14,17 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+
+  if (process.env.CYPRESS_CONNECTION_TYPE) {
+    on(`before:browser:launch`, (browser = {}, args) => {
+      if (
+        browser.name === `chrome` &&
+        process.env.CYPRESS_CONNECTION_TYPE === `slow`
+      ) {
+        args.push(`--force-effective-connection-type=2G`)
+      }
+
+      return args
+    })
+  }
 }

--- a/e2e-tests/production-runtime/gatsby-browser.js
+++ b/e2e-tests/production-runtime/gatsby-browser.js
@@ -18,3 +18,7 @@ exports.onPreRouteUpdate = ({ location }) => {
 exports.onRouteUpdate = ({ location }) => {
   addLogEntry(`onRouteUpdate`, location)
 }
+
+exports.onPrefetchPathname = ({ pathname }) => {
+  addLogEntry(`onPrefetchPathname`, pathname)
+}

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -26,7 +26,9 @@
     "start-server-and-test": "start-server-and-test serve http://localhost:9000 cy:run",
     "serve": "gatsby serve",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --browser chrome"
+    "cy:run": "npm run cy:run:normal && npm run cy:run:slow",
+    "cy:run:normal": "cypress run --browser chrome",
+    "cy:run:slow": "CYPRESS_CONNECTION_TYPE=slow cypress run --browser chrome --config testFiles=prefetching.js"
   },
   "devDependencies": {
     "prettier": "^1.14.3",

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -195,15 +195,12 @@ const queue = {
 
     // Skip prefetching if we know user is on slow or constrained connection
     if (`connection` in navigator) {
-      window.___log = `connection type "${navigator.connection.effectiveType}"`
       if ((navigator.connection.effectiveType || ``).includes(`2g`)) {
         return false
       }
       if (navigator.connection.saveData) {
         return false
       }
-    } else {
-      window.___log = `no connection in navigator`
     }
 
     // Tell plugins with custom prefetching logic that they should start

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -193,6 +193,19 @@ const queue = {
     if (!apiRunner)
       console.error(`Run setApiRunnerForLoader() before enqueing paths`)
 
+    // Skip prefetching if we know user is on slow or constrained connection
+    if (`connection` in navigator) {
+      window.___log = `connection type "${navigator.connection.effectiveType}"`
+      if ((navigator.connection.effectiveType || ``).includes(`2g`)) {
+        return false
+      }
+      if (navigator.connection.saveData) {
+        return false
+      }
+    } else {
+      window.___log = `no connection in navigator`
+    }
+
     // Tell plugins with custom prefetching logic that they should start
     // prefetching this path.
     onPrefetchPathname(path)

--- a/packages/gatsby/cache-dir/prefetch.js
+++ b/packages/gatsby/cache-dir/prefetch.js
@@ -65,6 +65,17 @@ const prefetch = function(url) {
       return
     }
 
+    if (`connection` in navigator) {
+      if ((navigator.connection.effectiveType || ``).includes(`2g`)) {
+        resolve()
+        return
+      }
+      if (navigator.connection.saveData) {
+        resolve()
+        return
+      }
+    }
+
     supportedPrefetchStrategy(url)
       .then(() => {
         resolve()

--- a/packages/gatsby/cache-dir/prefetch.js
+++ b/packages/gatsby/cache-dir/prefetch.js
@@ -65,17 +65,6 @@ const prefetch = function(url) {
       return
     }
 
-    if (`connection` in navigator) {
-      if ((navigator.connection.effectiveType || ``).includes(`2g`)) {
-        resolve()
-        return
-      }
-      if (navigator.connection.saveData) {
-        resolve()
-        return
-      }
-    }
-
     supportedPrefetchStrategy(url)
       .then(() => {
         resolve()


### PR DESCRIPTION
Sending a PR for this after chatting with @KyleAMathews :)

This change introduces support for network and data-savings related checks to the Gatsby prefetcher. 

* If a browser supports [navigator.connection.effectiveType](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType), we will not prefetch if the user is on a connection that is effectively `slow-2g` or `2g`. As users on these connections already have constrained bandwidth, limiting this feature to `3g`, `4g` and better seems reasonable.

* If a browser supports the [saveData](https://github.com/WICG/netinfo/issues/42) client-hint (e.g. Chromium based browsers) and the user has indicated they prefer to save data (e.g. are on a constrained data plan), we also don't prefetch in those cases. Data Saving is primarily turned on in NBU regions and I don't anticipate this change having any negative effect for users with the feature off.

These changes are ones I've already made to a prefetcher we're using in an upcoming project called `quicklink` and think they'd benefit Gatsby users too :)