### PR TITLE
Docs: Add Matomo to list of analytics plugins

### DIFF
--- a/docs/docs/adding-analytics.md
+++ b/docs/docs/adding-analytics.md
@@ -62,3 +62,4 @@ Once this is configured you can deploy your site to test! If you navigate to the
 - [Amplitude Analytics](/packages/gatsby-plugin-amplitude-analytics)
 - [Fathom](/packages/gatsby-plugin-fathom/)
 - [Baidu](/packages/gatsby-plugin-baidu-analytics/)
+- [Matomo (formerly Piwik)](/packages/gatsby-plugin-matomo/)


### PR DESCRIPTION
Add [gatsby-plugin-matomo](https://www.gatsbyjs.org/packages/gatsby-plugin-matomo/) for tracking with [Matomo](https://matomo.org) (formerly Piwik) to list of analytics plugins in doc _Adding analytics_.