### PR TITLE
fix(www): avoid querying for no-cache=1

### DIFF
--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -174,10 +174,6 @@ injectGlobal`
 
 // Search shows a list of "hits", and is a child of the PluginSearchBar component
 class Search extends Component {
-  constructor(props, context) {
-    super(props)
-  }
-
   render() {
     return (
       <div
@@ -253,7 +249,7 @@ class Search extends Component {
                 <Result
                   hit={result.hit}
                   pathname={this.props.pathname}
-                  search={this.props.searchState}
+                  query={this.props.query}
                 />
               )}
             />
@@ -415,7 +411,8 @@ class PluginSearchBar extends Component {
 
   urlToSearch = () => {
     if (this.props.location.search) {
-      return this.props.location.search.slice(2)
+      // ignore this automatically added query parameter
+      return this.props.location.search.replace(`no-cache=1`, ``).slice(2)
     }
     return ``
   }
@@ -426,7 +423,7 @@ class PluginSearchBar extends Component {
     })
   }
 
-  onSearchStateChange(searchState) {
+  onSearchStateChange = searchState => {
     this.updateHistory(searchState)
     this.setState({ searchState })
   }
@@ -439,11 +436,11 @@ class PluginSearchBar extends Component {
           appId="OFCNCOG2CU"
           indexName="npm-search"
           searchState={this.state.searchState}
-          onSearchStateChange={this.onSearchStateChange.bind(this)}
+          onSearchStateChange={this.onSearchStateChange}
         >
           <Search
             pathname={this.props.location.pathname}
-            searchState={this.state.searchState.query}
+            query={this.state.searchState.query}
           />
         </InstantSearch>
       </div>


### PR DESCRIPTION
overall this could also have been done by parsing & stringifying with qs, but this should work too.

I haven't been able to try this out yet (I didn't have the patience to wait for all the images to transform ahah), but I don't think this can break anything.

Changes done:

1. small refactors to make code a little shorter
2. replace `no-cache=1` from the query before searching. 

I noticed when seeing a lot of `o-cache=1` hits on Algolia analytics