### PR TITLE
[gatsby-remark-copy-linked-files] add support for video elements with `src` attribute

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -170,6 +170,18 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalled()
   })
 
+  it(`can copy HTML videos from video elements with the src attribute`, async () => {
+    const path = `videos/sample-video.mp4`
+
+    const markdownAST = remark.parse(
+      `<video controls="controls" autoplay="true" src="${path}">\n<p>Your browser does not support the video element.</p>\n</video>`
+    )
+
+    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).toHaveBeenCalled()
+  })
+
   it(`can copy HTML videos when some siblings are in ignore extensions`, async () => {
     const path = `videos/sample-video.mp4`
     const path1 = `images/sample-image.jpg`

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -234,7 +234,7 @@ module.exports = (
 
     // Handle video tags.
     const videoRefs = []
-    $(`video source`).each(function() {
+    $(`video source, video`).map(function() {
       try {
         if (isRelativeUrl($(this).attr(`src`))) {
           videoRefs.push($(this))


### PR DESCRIPTION
This adds support for video elements that only have a `src` attribute.

```html
<video src="myvideo.mp4"></video>
```