### PR TITLE
fix(docs): Environment Variables Examples

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -81,6 +81,8 @@ Now the variables are available on `process.env` as usual.
 
 ## Example
 
+Please note that you shouldn't commit `.env.*` files to your source control and rather use options given by your CD provider (e.g.  Netlify with its [build environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables)).
+
 ```shell:title=.env.development
 GATSBY_API_URL=https://dev.example.com/api
 API_KEY=927349872349798
@@ -104,7 +106,7 @@ render() {
 }
 ```
 
-`API_KEY` will be available to your site (Server-side) as `process.env.API_KEY`:
+`API_KEY` will be available to your site (Server-side) as `process.env.API_KEY`. If you commit your `.env.*` file containing `API_KEY` to source control it would also be available on the client-side. However we strongly advise against that! You should prefix your variable with `GATSBY_` (as shown above) instead and Gatsby automatically makes it available in the browser context.
 
 ```js
 // In any server-side code, e.g. gatsby-config.js

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -47,6 +47,10 @@ In addition to these Project Environment Variables defined in `.env.*` files, yo
 OS Env Vars. OS Env Vars which are prefixed with `GATSBY_` will become available in
 browser JavaScript.
 
+```shell:title=.env.*
+GATSBY_API_URL=https://dev.example.com/api
+```
+
 #### Server-side Node.js
 
 Gatsby runs several Node.js scripts at build time, notably `gatsby-config.js` and `gatsby-node.js`.
@@ -77,28 +81,42 @@ Now the variables are available on `process.env` as usual.
 
 ## Example
 
-```shell
-# Example .env.development file
-
-API_URL=https://dev.example.com/api
+```shell:title=.env.development
+GATSBY_API_URL=https://dev.example.com/api
+API_KEY=927349872349798
 ```
 
-```shell
-# Example .env.production file
-
-API_URL=https://example.com/api
+```shell:title=.env.production
+GATSBY_API_URL=https://example.com/api
+API_KEY=927349872349798
 ```
 
-These variables will be available to your site as `process.env.API_URL`:
+`GATSBY_API_URL` will be available to your site (Client-side and server-side) as `process.env.GATSBY_API_URL`:
 
 ```jsx
-// usage
+// In any front-end code
 render() {
   return (
     <div>
-      <img src={`${process.env.API_URL}/logo.png`} alt="Logo" />
+      <img src={`${process.env.GATSBY_API_URL}/logo.png`} alt="Logo" />
     </div>
   )
+}
+```
+
+`API_KEY` will be available to your site (Server-side) as `process.env.API_KEY`:
+
+```js
+// In any server-side code, e.g. gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-patronus`,
+      options: {
+        apiKey: process.env.API_KEY,
+      },
+    },
+  ],
 }
 ```
 
@@ -121,8 +139,7 @@ For instance. If you would like to add a `staging` environment with a custom Goo
 
 ### Example
 
-```shell
-# .env.staging
+```shell:title=.env.staging
 GA_TRACKING_ID="UA-1234567890"
 API_URL="http://foo.bar"
 ```

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -81,7 +81,7 @@ Now the variables are available on `process.env` as usual.
 
 ## Example
 
-Please note that you shouldn't commit `.env.*` files to your source control and rather use options given by your CD provider (e.g.  Netlify with its [build environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables)).
+Please note that you shouldn't commit `.env.*` files to your source control and rather use options given by your CD provider (e.g. Netlify with its [build environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables)).
 
 ```shell:title=.env.development
 GATSBY_API_URL=https://dev.example.com/api


### PR DESCRIPTION
I followed the guide yesterday and stumbled across the issue that the guide is for using env vars in the browser is wrong. After prefixing the vars both in the `.env.*` and frontend files it worked, e.g.:
https://github.com/LekoArts/gatsby-source-tmdb-example/blob/master/src/components/DetailedView.jsx#L264

I added a little example to the client-side part, moved the comments to code block titles and expanded the example while fixing it.