### PR TITLE
chore(www): bump offline plugin version

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -26,7 +26,7 @@
     "gatsby-plugin-netlify": "^2.0.0",
     "gatsby-plugin-netlify-cache": "^0.1.0",
     "gatsby-plugin-nprogress": "^2.0.5",
-    "gatsby-plugin-offline": "^2.0.16",
+    "gatsby-plugin-offline": "^2.0.19",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.5",
     "gatsby-plugin-sitemap": "^2.0.1",


### PR DESCRIPTION
fixes #10151

Issue in `gatsby-plugin-offline` was fixed in #10329, but gatsbyjs.org didn't upgrade.