### PR TITLE
fix(gatsby-plugin-offline): Remove slash from `/static` + move `sw-append` out of `src`

### DIFF
--- a/packages/gatsby-plugin-offline/.gitignore
+++ b/packages/gatsby-plugin-offline/.gitignore
@@ -1,3 +1,4 @@
 /*.js
 !index.js
+!sw-append.js
 yarn.lock

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -40,12 +40,12 @@ const options = {
   cacheId: `gatsby-plugin-offline`,
   // Don't cache-bust JS or CSS files, and anything in the static directory,
   // since these files have unique URLs and their contents will never change
-  dontCacheBustUrlsMatching: /(\.js$|\.css$|\/static\/)/,
+  dontCacheBustUrlsMatching: /(\.js$|\.css$|static\/)/,
   runtimeCaching: [
     {
       // Use cacheFirst since these don't need to be revalidated (same RegExp
       // and same reason as above)
-      urlPattern: /(\.js$|\.css$|\/static\/)/,
+      urlPattern: /(\.js$|\.css$|static\/)/,
       handler: `cacheFirst`,
     },
     {

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -2,7 +2,6 @@ const fs = require(`fs`)
 const workboxBuild = require(`workbox-build`)
 const path = require(`path`)
 const slash = require(`slash`)
-const crypto = require(`crypto`)
 const _ = require(`lodash`)
 
 const getResourcesFromHTML = require(`./get-resources-from-html`)
@@ -126,9 +125,8 @@ exports.onPostBuild = (args, pluginOptions) => {
       const swAppend = fs
         .readFileSync(`${__dirname}/sw-append.js`, `utf8`)
         .replace(/%pathPrefix%/g, pathPrefix)
-        .replace(/%revision%/g, crypto.randomBytes(16).toString(`hex`))
 
-      fs.appendFileSync(`public/sw.js`, `\n${swAppend}`)
+      fs.appendFileSync(`public/sw.js`, `\n` + swAppend)
       console.log(
         `Generated ${swDest}, which will precache ${count} files, totaling ${size} bytes.`
       )

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -2,6 +2,7 @@ const fs = require(`fs`)
 const workboxBuild = require(`workbox-build`)
 const path = require(`path`)
 const slash = require(`slash`)
+const crypto = require(`crypto`)
 const _ = require(`lodash`)
 
 const getResourcesFromHTML = require(`./get-resources-from-html`)
@@ -82,12 +83,12 @@ exports.onPostBuild = (args, pluginOptions) => {
     cacheId: `gatsby-plugin-offline`,
     // Don't cache-bust JS or CSS files, and anything in the static directory,
     // since these files have unique URLs and their contents will never change
-    dontCacheBustUrlsMatching: /(\.js$|\.css$|\/static\/)/,
+    dontCacheBustUrlsMatching: /(\.js$|\.css$|static\/)/,
     runtimeCaching: [
       {
         // Use cacheFirst since these don't need to be revalidated (same RegExp
         // and same reason as above)
-        urlPattern: /(\.js$|\.css$|\/static\/)/,
+        urlPattern: /(\.js$|\.css$|static\/)/,
         handler: `cacheFirst`,
       },
       {
@@ -125,8 +126,9 @@ exports.onPostBuild = (args, pluginOptions) => {
       const swAppend = fs
         .readFileSync(`${__dirname}/sw-append.js`, `utf8`)
         .replace(/%pathPrefix%/g, pathPrefix)
+        .replace(/%revision%/g, crypto.randomBytes(16).toString(`hex`))
 
-      fs.appendFileSync(`public/sw.js`, swAppend)
+      fs.appendFileSync(`public/sw.js`, `\n${swAppend}`)
       console.log(
         `Generated ${swDest}, which will precache ${count} files, totaling ${size} bytes.`
       )

--- a/packages/gatsby-plugin-offline/sw-append.js
+++ b/packages/gatsby-plugin-offline/sw-append.js
@@ -1,4 +1,5 @@
 /* global importScripts, workbox, idbKeyval */
+/* revision %revision% */
 
 importScripts(`idb-keyval-iife.min.js`)
 const WHITELIST_KEY = `custom-navigation-whitelist`

--- a/packages/gatsby-plugin-offline/sw-append.js
+++ b/packages/gatsby-plugin-offline/sw-append.js
@@ -1,5 +1,4 @@
 /* global importScripts, workbox, idbKeyval */
-/* revision %revision% */
 
 importScripts(`idb-keyval-iife.min.js`)
 const WHITELIST_KEY = `custom-navigation-whitelist`


### PR DESCRIPTION
This prevents static resources incorrectly being revisioned by Workbox and prevents Babel compiling `sw-append.js`.