### PR TITLE
fix(gatsby-image): TypeScript - Mark more props as optional

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -16,10 +16,10 @@ interface FluidObject {
   src: string
   srcSet: string
   sizes: string
-  base64: string
-  tracedSVG: string
-  srcWebp: string
-  srcSetWebp: string
+  base64?: string
+  tracedSVG?: string
+  srcWebp?: string
+  srcSetWebp?: string
 }
 
 interface GatsbyImageProps {
@@ -34,7 +34,7 @@ interface GatsbyImageProps {
   critical?: boolean
   style?: object
   imgStyle?: object
-  placeholderStyle: object
+  placeholderStyle?: object
   backgroundColor?: string | boolean
   onLoad?: () => void
   onStartLoad?: (param: { wasCached: boolean }) => void


### PR DESCRIPTION

It seems like these should not be a mandatory. At the moment when building a TypeScript gatsby site, TypeScript forces the user to pass a value.