### PR TITLE
Use correct function in example code

### DIFF
--- a/docs/docs/add-offline-support-with-a-service-worker.md
+++ b/docs/docs/add-offline-support-with-a-service-worker.md
@@ -49,7 +49,7 @@ To display a custom message once your service worker finds an update, you can us
 
 ```javascript:title=gatsby-browser.js
 exports.onServiceWorkerUpdateFound = () => {
-  const answer = window.prompt(
+  const answer = window.confirm(
     `This application has been updated. ` +
       `Reload to display the latest version?`
   )


### PR DESCRIPTION
`window.prompt()` doesn't return a boolean value, `window.confirm()` does :)

See https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm