### PR TITLE
Fix type of dependency to dev

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -25,7 +25,7 @@ Gatsby ships with a default .babelrc setup that should work for most sites. If y
 to add custom Babel presets or plugins, you can create your own `.babelrc` at the root of your site, import [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby), and overwrite the `target` option.
 
 ```bash
-npm install --save babel-preset-gatsby
+npm install --save-dev babel-preset-gatsby
 ```
 
 ```json5:title=.babelrc


### PR DESCRIPTION
As it is documented on the preset READMe ([`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby)), it should be installed as a devDependency.

