### PR TITLE
feat(gatsby-plugin-manifest): add option to remove the "theme color" meta tag

### DIFF
--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -37,6 +37,10 @@ npm install --save gatsby-plugin-manifest
         start_url: "/",
         background_color: "#6b37bf",
         theme_color: "#6b37bf",
+        // Optional: If is set to false then the meta theme-color won't be added to the head of the document
+        // Set it to false if you want to programmatically change color schemes
+        // See: https://developers.google.com/web/fundamentals/web-app-manifest/#theme-color
+        theme_color_in_head: true,
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",

--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -37,10 +37,6 @@ npm install --save gatsby-plugin-manifest
         start_url: "/",
         background_color: "#6b37bf",
         theme_color: "#6b37bf",
-        // Optional: If is set to false then the meta theme-color won't be added to the head of the document
-        // Set it to false if you want to programmatically change color schemes
-        // See: https://developers.google.com/web/fundamentals/web-app-manifest/#theme-color
-        theme_color_in_head: true,
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -207,3 +207,29 @@ module.exports = {
   ],
 }
 ```
+
+## Removing `theme-color` meta tag
+
+By default `gatsby-plugin-manifest` inserts `<meta content={theme_color} name="theme-color" />` tag to html output. This can be problematic if you want to programatically control that tag - for example when implementing light/dark themes in your project. You can set `theme_color_in_head` plugin option to `false` to opt-out of this behaviour. 
+
+```javascript:title=gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-manifest`,
+      options: {
+        name: `GatsbyJS`,
+        short_name: `GatsbyJS`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#a2466c`,
+        display: `standalone`,
+        icon: `src/images/icon.png`, // This path is relative to the root of the site.
+        theme_color_in_head: false, // This will avoid adding theme-color meta tag.
+      },
+    },
+  ],
+}
+```
+
+

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -210,7 +210,7 @@ module.exports = {
 
 ## Removing `theme-color` meta tag
 
-By default `gatsby-plugin-manifest` inserts `<meta content={theme_color} name="theme-color" />` tag to html output. This can be problematic if you want to programatically control that tag - for example when implementing light/dark themes in your project. You can set `theme_color_in_head` plugin option to `false` to opt-out of this behaviour. 
+By default `gatsby-plugin-manifest` inserts `<meta content={theme_color} name="theme-color" />` tag to html output. This can be problematic if you want to programatically control that tag - for example when implementing light/dark themes in your project. You can set `theme_color_in_head` plugin option to `false` to opt-out of this behaviour.
 
 ```javascript:title=gatsby-config.js
 module.exports = {
@@ -231,5 +231,3 @@ module.exports = {
   ],
 }
 ```
-
-

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,11 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gatsby-plugin-manifest Add a "theme color" meta tag if "theme_color_in_head" is set to true 1`] = `
+Array [
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
+  />,
+]
+`;
+
 exports[`gatsby-plugin-manifest Adds "shortcut icon" and "manifest" links and "theme_color" meta tag to head 1`] = `
 Array [
   <link
     href="/icons/icon-48x48.png"
     rel="shortcut icon"
   />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Adds a "theme color" meta tag to head if "theme_color_in_head" is not provided 1`] = `
+Array [
   <link
     href="/manifest.webmanifest"
     rel="manifest"
@@ -97,6 +123,15 @@ Array [
     href="/favicons/android-chrome-512x512.png"
     rel="apple-touch-icon"
     sizes="512x512"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Does not add a "theme color" meta tag if "theme_color_in_head" is set to false 1`] = `
+Array [
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
   />,
 ]
 `;

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -71,6 +71,7 @@ describe(`Test plugin manifest options`, () => {
       icon: undefined,
       legacy: true,
       plugins: [],
+      theme_color_in_head: false,
     }
     await onPostBootstrap([], {
       ...manifestOptions,

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -14,6 +14,27 @@ describe(`gatsby-plugin-manifest`, () => {
     headComponents = []
   })
 
+  it(`Adds a "theme color" meta tag to head if "theme_color_in_head" is not provided`, () => {
+    onRenderBody(ssrArgs, { theme_color: `#000000` })
+    expect(headComponents).toMatchSnapshot()
+  })
+
+  it(`Does not add a "theme color" meta tag if "theme_color_in_head" is set to false`, () => {
+    onRenderBody(ssrArgs, {
+      theme_color: `#000000`,
+      theme_color_in_head: false,
+    })
+    expect(headComponents).toMatchSnapshot()
+  })
+
+  it(`Add a "theme color" meta tag if "theme_color_in_head" is set to true`, () => {
+    onRenderBody(ssrArgs, {
+      theme_color: `#000000`,
+      theme_color_in_head: true,
+    })
+    expect(headComponents).toMatchSnapshot()
+  })
+
   it(`Adds "shortcut icon" and "manifest" links and "theme_color" meta tag to head`, () => {
     onRenderBody(ssrArgs, { icon: true, theme_color: `#000000` })
     expect(headComponents).toMatchSnapshot()

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -23,8 +23,10 @@ exports.onPostBootstrap = (args, pluginOptions) =>
     const { icon, ...manifest } = pluginOptions
 
     // Delete options we won't pass to the manifest.webmanifest.
+
     delete manifest.plugins
     delete manifest.legacy
+    delete manifest.theme_color_in_head
 
     // If icons are not manually defined, use the default icon set.
     if (!manifest.icons) {

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -31,16 +31,23 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       href={withPrefix(`/manifest.webmanifest`)}
     />
   )
-
   // The user has an option to opt out of the theme_color meta tag being inserted into the head.
   if (pluginOptions.theme_color) {
-    headComponents.push(
-      <meta
-        key={`gatsby-plugin-manifest-meta`}
-        name="theme-color"
-        content={pluginOptions.theme_color}
-      />
+    let theme_color = !Object.keys(pluginOptions).includes(
+      `theme_color_in_head`
     )
+      ? pluginOptions.theme_color
+      : pluginOptions.theme_color && pluginOptions.theme_color_in_head
+
+    if (theme_color) {
+      headComponents.push(
+        <meta
+          key={`gatsby-plugin-manifest-meta`}
+          name="theme-color"
+          content={pluginOptions.theme_color}
+        />
+      )
+    }
   }
 
   if (pluginOptions.legacy) {

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -33,13 +33,13 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   )
   // The user has an option to opt out of the theme_color meta tag being inserted into the head.
   if (pluginOptions.theme_color) {
-    let theme_color = !Object.keys(pluginOptions).includes(
+    let insertMetaTag = Object.keys(pluginOptions).includes(
       `theme_color_in_head`
     )
-      ? pluginOptions.theme_color
-      : pluginOptions.theme_color && pluginOptions.theme_color_in_head
+      ? pluginOptions.theme_color_in_head
+      : true
 
-    if (theme_color) {
+    if (insertMetaTag) {
       headComponents.push(
         <meta
           key={`gatsby-plugin-manifest-meta`}


### PR DESCRIPTION
This fixes https://github.com/gatsbyjs/gatsby/issues/9977

Added an option to remove the "theme color" meta tag from the head.

* `theme_color_in_head` is optional, so if it's not set then the meta tag is added.
* if `theme_color_in_head` is set to false, then the meta tag is not added
* if `theme_color_in_head` is set to true, then the meta tag is added