### PR TITLE
fix(static-query): Use @babel/traverse for traversing algorithm

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-remove-graphql-queries": "^2.5.2",
     "babel-preset-gatsby": "^0.1.6",
-    "babel-traverse": "6.26.0",
     "better-queue": "^3.8.6",
     "bluebird": "^3.5.0",
     "browserslist": "3.2.8",

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -1,6 +1,6 @@
 // @flow
 const fs = require(`fs`)
-const traverse = require(`babel-traverse`).default
+const traverse = require(`@babel/traverse`).default
 const get = require(`lodash/get`)
 const { codeFrameColumns } = require(`@babel/code-frame`)
 const { babelParseToAst } = require(`../utils/babel-parse-to-ast`)

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/__snapshots__/file-parser.js.snap
@@ -590,6 +590,118 @@ Map {
     ],
     "kind": "Document",
   },
+  "fragment-shorthand.js" => Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "hash": 1097489062,
+        "isStaticQuery": true,
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 74,
+          "start": 3,
+        },
+        "name": Object {
+          "kind": "Name",
+          "value": "fragmentShorthandJs1097489062",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 74,
+            "start": 9,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 70,
+                "start": 15,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 19,
+                  "start": 15,
+                },
+                "value": "site",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 70,
+                  "start": 20,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 64,
+                      "start": 28,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 40,
+                        "start": 28,
+                      },
+                      "value": "siteMetadata",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 64,
+                        "start": 41,
+                      },
+                      "selections": Array [
+                        Object {
+                          "alias": undefined,
+                          "arguments": Array [],
+                          "directives": Array [],
+                          "kind": "Field",
+                          "loc": Object {
+                            "end": 56,
+                            "start": 51,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 56,
+                              "start": 51,
+                            },
+                            "value": "title",
+                          },
+                          "selectionSet": undefined,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "text": "
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+",
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
   "query-in-separate-variable.js" => Object {
     "definitions": Array [
       Object {

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/file-parser.js
@@ -80,6 +80,27 @@ export const fragment3 = graphql\`
   }
 \`
 `,
+    "fragment-shorthand.js": `import React from "react"
+import { StaticQuery, graphql } from "gatsby"
+
+const query = graphql\`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+\`
+
+export default () => (
+  <>
+    <StaticQuery
+      query={query}
+      render={data => <div>{data.title}</div>}
+    />
+  </>
+)`,
     "query-in-separate-variable.js": `import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 

--- a/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/file-parser.js
@@ -4,7 +4,7 @@ const crypto = require(`crypto`)
 const _ = require(`lodash`)
 
 // Traverse is a es6 module...
-import traverse from "babel-traverse"
+import traverse from "@babel/traverse"
 const getGraphQLTag = require(`babel-plugin-remove-graphql-queries`)
   .getGraphQLTag
 const report = require(`gatsby-cli/lib/reporter`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3701,7 +3701,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-te
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@6.26.0, babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
@@ -9122,7 +9122,7 @@ graphql-type-json@^0.2.1:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.2.1.tgz#d2c177e2f1b17d87f81072cd05311c0754baa420"
   integrity sha1-0sF34vGxfYf4EHLNBTEcB1S6pCA=
 
-graphql@0.13.2, graphql@^0.13.0, graphql@^0.13.2:
+graphql@^0.13.0, graphql@^0.13.2:
   version "0.13.2"
   resolved "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   integrity sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==


### PR DESCRIPTION
Hello :wave: , this PR fixes https://github.com/gatsbyjs/gatsby/issues/10016.
## Summary
After digging deep into the rabbit hole of the traversal algorithm in `/packages/gatsby/src/internal-plugins/query-runners/file-parser.js`, I found out that the traversing algorithm wasn't taking into account the ast nodes of type JSXFragment. Internally, this is because considered in the babel-types version used by babel-traverse v6.26. Therefore, I am using now the more updated @babel/traverse which is a dependency this package already had.

## Test code
I created a simple `gatsby new gastsby-test` and created a index with the following code
```javascript
import React from 'react'
import { StaticQuery, graphql } from 'gatsby'

import Layout from '../components/layout'

const query = graphql`
  query {
    site {
      siteMetadata {
        title
      }
    }
  }
`;

const IndexPage = () => (
  <Layout>
      <>
        <h1>Hello world!</h1>
        <StaticQuery query={query} render={() => (<div>Hello world</div>)}/>
      </>
  </Layout>
)

export default IndexPage
```

Then, tested it out with before the changes (displaying loading forever) and after the changes (displays correct text). It works fine and tests are still passing :smile: 

Let me know if you have any comments
Cheers