### PR TITLE
fix(www) Fix query for plugin links always ?=undefined

### DIFF
--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -301,14 +301,14 @@ class Search extends Component {
 }
 
 // the result component is fed into the InfiniteHits component
-const Result = ({ hit, pathname, search }) => {
+const Result = ({ hit, pathname, query }) => {
   // Example:
   // pathname = `/plugins/gatsby-link/` || `/plugins/@comsoc/gatsby-mdast-copy-linked-files`
   //  hit.name = `gatsby-link` || `@comsoc/gatsby-mdast-copy-linked-files`
   const selected = pathname.includes(hit.name)
   return (
     <Link
-      to={`/packages/${hit.name}/?=${search}`}
+      to={`/packages/${hit.name}/?=${query}`}
       css={{
         "&&": {
           boxShadow: `none`,


### PR DESCRIPTION
Was just browsing the website and found that #10389 PR changed the prop passed to the Result component to query but did not update the Result component itself.

https://github.com/gatsbyjs/gatsby/pull/10389/files#diff-86b9922590ad1703ea1c4ae10baab77cR252
