### PR TITLE
Set maxWidth of fluid image to avoid them stretching to match div width

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -253,14 +253,17 @@ class Image extends React.Component {
     if (fluid) {
       const image = fluid
 
+      const divStyle = {
+        position: `relative`,
+        overflow: `hidden`,
+        maxWidth: image.presentationWidth,
+        ...style,
+      }
+
       return (
         <Tag
           className={`${className ? className : ``} gatsby-image-wrapper`}
-          style={{
-            position: `relative`,
-            overflow: `hidden`,
-            ...style,
-          }}
+          style={divStyle}
           ref={this.handleRef}
           key={`fluid-${JSON.stringify(image.srcSet)}`}
         >


### PR DESCRIPTION
So gatsby-image when on fluid mode sets maxWidth to be 100% for the div. This is a bit problematic since images smaller than the div will be stretched. Here's an example https://gatsby-remark-rehype-images.netlify.com/custom-component/ (further down there is an image).

The problem here though is that this change modifies default behaviour people might have relied upon. Images no longer taking maxWidth are left aligned which might mess with people designs. 
Maybe its best to document this as a breaking change. Open for suggestions.

FTR here's how the presentationWidth is calculated on plugin-sharp

```
let presentationWidth, presentationHeight
  if (fixedDimension === `maxWidth`) {
    presentationWidth = Math.min(
      options.maxWidth,
      Math.round(width / pixelRatio)
    )
    presentationHeight = Math.round(presentationWidth * (height / width))
  } else {
    presentationHeight = Math.min(
      options.maxHeight,
      Math.round(height / pixelRatio)
    )
    presentationWidth = Math.round(presentationHeight * (width / height))
  }
```

This happens more or less in the same way for `fixed` images. Here's the styles applied to the div

```
const divStyle = {
        position: `relative`,
        overflow: `hidden`,
        display: `inline-block`,
        width: image.width,
        height: image.height,
        ...style,
      }
```