### PR TITLE
refactor(gatsby): update internal-data-bridge plugin to use createContentDigest

### DIFF
--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -1,4 +1,3 @@
-const crypto = require(`crypto`)
 const moment = require(`moment`)
 const chokidar = require(`chokidar`)
 const systemPath = require(`path`)
@@ -42,7 +41,7 @@ function transformPackageJson(json) {
 
 const createPageId = path => `SitePage ${path}`
 
-exports.sourceNodes = ({ actions, store }) => {
+exports.sourceNodes = ({ createContentDigest, actions, store }) => {
   const { createNode } = actions
   const state = store.getState()
   const { program } = state
@@ -58,10 +57,7 @@ exports.sourceNodes = ({ actions, store }) => {
     children: [],
     internal: {
       type: `SitePage`,
-      contentDigest: crypto
-        .createHash(`md5`)
-        .update(JSON.stringify(page))
-        .digest(`hex`),
+      contentDigest: createContentDigest(page),
     },
   })
 
@@ -75,10 +71,7 @@ exports.sourceNodes = ({ actions, store }) => {
       parent: `SOURCE`,
       children: [],
       internal: {
-        contentDigest: crypto
-          .createHash(`md5`)
-          .update(JSON.stringify(plugin))
-          .digest(`hex`),
+        contentDigest: createContentDigest(plugin),
         type: `SitePlugin`,
       },
     })
@@ -108,10 +101,7 @@ exports.sourceNodes = ({ actions, store }) => {
       parent: `SOURCE`,
       children: [],
       internal: {
-        contentDigest: crypto
-          .createHash(`md5`)
-          .update(JSON.stringify(node))
-          .digest(`hex`),
+        contentDigest: createContentDigest(node),
         type: `Site`,
       },
     })
@@ -139,7 +129,7 @@ exports.sourceNodes = ({ actions, store }) => {
   })
 }
 
-exports.onCreatePage = ({ page, actions }) => {
+exports.onCreatePage = ({ createContentDigest, page, actions }) => {
   const { createNode } = actions
   // eslint-disable-next-line
   const { updatedAt, ...pageWithoutUpdated } = page
@@ -152,10 +142,7 @@ exports.onCreatePage = ({ page, actions }) => {
     children: [],
     internal: {
       type: `SitePage`,
-      contentDigest: crypto
-        .createHash(`md5`)
-        .update(JSON.stringify(pageWithoutUpdated))
-        .digest(`hex`),
+      contentDigest: createContentDigest(pageWithoutUpdated),
       description:
         page.pluginCreatorId === `Plugin default-site-plugin`
           ? `Your site's "gatsby-node.js"`


### PR DESCRIPTION
This updates gatsby's internal-data-bridge plugin to use createContentDigest, as requested by #8805.

First time gatsby contributor here! I was unsure as to how to add tests to this particular plugin, as I didn't see any for the other internal plugins either.