### PR TITLE
[RFC] Add standard frontmatter transforms to netlify cms plugin

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -77,7 +77,7 @@ exports.onCreateNode = (
       createNodeField({
         node,
         name: `slug`,
-        value: slug || ``,
+        value: slug,
       })
 
       // Used to determine a page layout.


### PR DESCRIPTION
When trying to work with the Netlify CMS plugin, I ran into an issue with images like #8195. I found it odd that I had to manually transform the image paths to relative paths to make them compatible with	the gatsby-transformer-sharp plugin. 

I think it's safe to assume that anyone working with the Netlify CMS will want to process their images for resizing and such, otherwise you would be missing a big part of what makes Gatsby perform great.

In this PR I have pulled the code for transforming images and some other standard tasks like creating a slug into the plugin code.

I have added two config options for the plugin:

* `contentFolder`: This would be the root folder where all of your Netlify content lives, which defaults to "content".
* `imageFields`: A list of frontmatter fields that hold paths to images. These fields will be transformed to relative paths.

Now that I think of it, `imageFields` should maybe be renamed to `assetFields` or `mediaFields` since I assume that you'd want to same transformation if you use other types of assets in the CMS.

Of course the docs would need to be updated also, but first I'm curious to get some feedback and verify if this is all a good idea to begin with.

With these changes you can start using the CMS without writing additional client code in `gatsby-node.js`, which is I think how a plugin should work ideally. 