### PR TITLE
fix(docs): Typo pathContext

### DIFF
--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -109,7 +109,7 @@ const Tags = ({ pageContext, data }) => {
 }
 
 Tags.propTypes = {
-  pathContext: PropTypes.shape({
+  pageContext: PropTypes.shape({
     tag: PropTypes.string.isRequired,
   }),
   data: PropTypes.shape({


### PR DESCRIPTION
 pathContext has been deprecated and changed to the correct term, pageContext.

it seems https://github.com/gatsbyjs/gatsby/pull/6381 missed this. ;)

<!--
  Q. Which branch should I use for my pull request?
  A. Your best bet is to go for `master`. If you are unsure, ask in the PR, and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
