### PR TITLE
[gatsby-link] - adding onMouseLeave prop

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -94,6 +94,7 @@ class GatsbyLink extends React.Component {
       getProps = this.defaultGetProps,
       onClick,
       onMouseEnter,
+      onMouseLeave,
       /* eslint-disable no-unused-vars */
       activeClassName: $activeClassName,
       activeStyle: $activeStyle,
@@ -117,6 +118,9 @@ class GatsbyLink extends React.Component {
           // eslint-disable-line
           onMouseEnter && onMouseEnter(e)
           ___loader.hovering(parsePath(to).pathname)
+        }}
+        onMouseLeave={e => {
+          onMouseLeave && onMouseLeave(e)
         }}
         onClick={e => {
           // eslint-disable-line


### PR DESCRIPTION
Adding a `onMouseLeave` prop to gatsby-link component to be able to handle on/off hover states. 

Reference issue #10477 