### PR TITLE
docs: add note about using client-side environment variables 

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -93,7 +93,8 @@ GATSBY_API_URL=https://example.com/api
 API_KEY=927349872349798
 ```
 
-`GATSBY_API_URL` will be available to your site (Client-side and server-side) as `process.env.GATSBY_API_URL`:
+Note that, since Gatsby uses the [Webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/) to make the environment variables available at run time, they cannot be destructured from `process.env`, instead they have to be fully referenced.
+`GATSBY_API_URL` will be available to your site (Client-side and server-side) as `process.env.GATSBY_API_URL`.:
 
 ```jsx
 // In any front-end code

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -93,7 +93,7 @@ GATSBY_API_URL=https://example.com/api
 API_KEY=927349872349798
 ```
 
-Note that, since Gatsby uses the [Webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/) to make the environment variables available at run time, they cannot be destructured from `process.env`, instead they have to be fully referenced.
+Note: since Gatsby uses the [Webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/) to make the environment variables available at runtime, they cannot be destructured from `process.env`; instead, they have to be fully referenced.
 `GATSBY_API_URL` will be available to your site (Client-side and server-side) as `process.env.GATSBY_API_URL`.:
 
 ```jsx


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Your best bet is to go for `master`. If you are unsure, ask in the PR, and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
I recently spent some time scratching my head why my environment variables where no longer available after I updated gatsby.

I couldn't find anything in the documentation of why they were undefined, but after some digging I came across #10030 , and it all made sense. 

Just thought I'd add an extra note of why object destructing of `process.env` doesn't work, I hope what I'm saying is correct. All feedback's appreciated :)