### PR TITLE
chore: use cjs instead of esm for consistency

### DIFF
--- a/packages/gatsby/src/utils/js-chunk-names.js
+++ b/packages/gatsby/src/utils/js-chunk-names.js
@@ -1,4 +1,4 @@
-import _ from "lodash"
+const { kebabCase } = require(`lodash`)
 const path = require(`path`)
 const kebabHash = require(`kebab-hash`)
 const { store } = require(`../redux`)
@@ -15,7 +15,7 @@ const generateComponentChunkName = componentPath => {
     directory = program.directory
   }
   const name = path.relative(directory, componentPath)
-  return `component---${_.kebabCase(name)}`
+  return `component---${kebabCase(name)}`
 }
 
 exports.generatePathChunkName = generatePathChunkName


### PR DESCRIPTION
Use cjs instead of esm for consistency in `packages/gatsby/src/utils/js-chunk-names.js`
<!--
  Q. Which branch should I use for my pull request?
  A. Your best bet is to go for `master`. If you are unsure, ask in the PR, and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
