### PR TITLE
fix(graphql-skip-limit): fix hasNextPage

### DIFF
--- a/packages/graphql-skip-limit/src/connection/__tests__/arrayconnection.js
+++ b/packages/graphql-skip-limit/src/connection/__tests__/arrayconnection.js
@@ -150,6 +150,27 @@ describe(`connectionFromArray()`, () => {
         },
       })
     })
+
+    it(`returns hasNextPage correctly`, () => {
+      const c = connectionFromArray(letters, { limit: 2, skip: 3 })
+      return expect(c).toEqual({
+        edges: [
+          {
+            next: `E`,
+            node: `D`,
+            previous: `C`,
+          },
+          {
+            next: undefined,
+            node: `E`,
+            previous: `D`,
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+        },
+      })
+    })
   })
 })
 

--- a/packages/graphql-skip-limit/src/connection/arrayconnection.js
+++ b/packages/graphql-skip-limit/src/connection/arrayconnection.js
@@ -52,9 +52,7 @@ export function connectionFromArray<T>(
     edges,
     pageInfo: {
       hasNextPage:
-        typeof limit === `number`
-          ? limit + startSlice - 1 < data.length
-          : false,
+        typeof limit === `number` ? limit + startSlice < data.length : false,
     },
   }
 }


### PR DESCRIPTION
If `skip` and `limit` values are set in a way to get the last _n_ elements, `hasNextPage` incorrectly returns `true`. 

This pull request adds a failing test and fixes that behaviour. 

Fixes #10497 