### PR TITLE
add type tabs to code snippets

### DIFF
--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -120,6 +120,82 @@ const _options = {
         minWidth: `100%`,
         overflow: `initial`,
       },
+      ".gatsby-highlight pre[class*='language-']::before": {
+        position: `absolute`,
+        top: `0px`,
+        right: `20px`,
+        padding: `3px 10px`,
+        fontSize: `12px`,
+        textAlign: `right`,
+        color: `#444`,
+        fontWeight: `700`,
+        letterSpacing: `0.8px`,
+        textTransform: `uppercase`,
+        borderRadius: `0 0 5px 5px`,
+        background: `#ddd`,
+      },
+      ".gatsby-highlight pre[class='language-javascript']::before": {
+        content: `'js'`,
+        background: `#f7df1e`,
+      },
+      ".gatsby-highlight pre[class='language-js']::before": {
+        content: `'js'`,
+        background: `#f7df1e`,
+      },
+      ".gatsby-highlight pre[class='language-jsx']::before": {
+        content: `'jsx'`,
+        background: `#61dafb`,
+      },
+      ".gatsby-highlight pre[class='language-graphql']::before": {
+        content: `'GraphQL'`,
+        background: `#E10098`,
+        color: `#fff`,
+        fontWeight: `400`,
+      },
+      ".gatsby-highlight pre[class='language-html']::before": {
+        content: `'html'`,
+        background: `#005A9C`,
+        color: `#fff`,
+        fontWeight: `400`,
+      },
+      ".gatsby-highlight pre[class='language-css']::before": {
+        content: `'css'`,
+        background: `#ff9800`,
+        color: `#fff`,
+        fontWeight: `400`,
+      },
+      ".gatsby-highlight pre[class='language-shell']::before": {
+        content: `'shell'`,
+      },
+      ".gatsby-highlight pre[class='language-sh']::before": {
+        content: `'sh'`,
+      },
+      ".gatsby-highlight pre[class='language-bash']::before": {
+        content: `'bash'`,
+      },
+      ".gatsby-highlight pre[class='language-yaml']::before": {
+        content: `'yaml'`,
+        background: `#ffa8df`,
+      },
+      ".gatsby-highlight pre[class='language-markdown']::before": {
+        content: `'md'`,
+      },
+      ".gatsby-highlight pre[class='language-json']::before, .gatsby-highlight pre[class='language-json5']::before": {
+        content: `'json'`,
+        background: `linen`,
+      },
+      ".gatsby-highlight pre[class='language-diff']::before": {
+        content: `'diff'`,
+        background: `#e6ffed`,
+      },
+      ".gatsby-highlight pre[class='language-text']::before": {
+        content: `'text'`,
+        background: `#fff`,
+      },
+      ".gatsby-highlight pre[class='language-flow']::before": {
+        content: `'flow'`,
+        background: `#E8BD36`,
+      },
       ".gatsby-highlight pre code": {
         display: `block`,
         fontSize: `94%`,


### PR DESCRIPTION
Add type tabs to `www` code snippets.

Better way to do this? Couldn't use `attr()` in typographyjs -- this seemed most straightforward. I've searched through `www` and tried to account for all types we currently use.

![screen shot 2018-12-17 at 11 35 58 am](https://user-images.githubusercontent.com/3461087/50105184-a2b49300-01f1-11e9-9a22-6ec82d79a5e6.png)

![screen shot 2018-12-17 at 11 36 25 am](https://user-images.githubusercontent.com/3461087/50105191-a6481a00-01f1-11e9-91a3-4d2cf4f8e38b.png)

![screen shot 2018-12-17 at 11 37 38 am](https://user-images.githubusercontent.com/3461087/50105233-c4ae1580-01f1-11e9-88b5-9d62b502d211.png)

![screen shot 2018-12-17 at 11 37 55 am](https://user-images.githubusercontent.com/3461087/50105235-c8419c80-01f1-11e9-9df0-53f0a26342e1.png)

![screen shot 2018-12-17 at 11 38 11 am](https://user-images.githubusercontent.com/3461087/50105241-caa3f680-01f1-11e9-8380-cc0545dd898c.png)

![screen shot 2018-12-17 at 11 38 22 am](https://user-images.githubusercontent.com/3461087/50105246-cd9ee700-01f1-11e9-9473-efc669c3c5ea.png)

![screen shot 2018-12-17 at 11 38 55 am](https://user-images.githubusercontent.com/3461087/50105249-d0014100-01f1-11e9-88d8-5940aab2488d.png)

![screen shot 2018-12-17 at 11 39 51 am](https://user-images.githubusercontent.com/3461087/50105277-dee7f380-01f1-11e9-9d6d-55ae8403f1cd.png)

![screen shot 2018-12-17 at 11 40 12 am](https://user-images.githubusercontent.com/3461087/50105280-e14a4d80-01f1-11e9-9a53-9ab609ae774a.png)

![screen shot 2018-12-17 at 11 40 37 am](https://user-images.githubusercontent.com/3461087/50105286-e3aca780-01f1-11e9-938b-c84888378607.png)

![screen shot 2018-12-17 at 11 41 10 am](https://user-images.githubusercontent.com/3461087/50105291-e6a79800-01f1-11e9-976f-fa89321e9e88.png)


