### PR TITLE
Added fullpage option for puppeteer API call

### DIFF
--- a/packages/gatsby-transformer-screenshot/lambda/index.js
+++ b/packages/gatsby-transformer-screenshot/lambda/index.js
@@ -26,9 +26,11 @@ exports.handler = async (event, context, callback) => {
   const width = request.width || 1024
   const height = request.height || 768
 
+  const fullPage = request.fullPage || false
+
   const browser = await setup.getBrowser()
   exports
-    .run(browser, url, width, height)
+    .run(browser, url, width, height, fullPage)
     .then(result => {
       callback(null, proxyResponse(result))
     })
@@ -37,13 +39,13 @@ exports.handler = async (event, context, callback) => {
     })
 }
 
-exports.run = async (browser, url, width, height) => {
+exports.run = async (browser, url, width, height, fullPage) => {
   console.log(`Invoked: ${url} (${width}x${height})`)
 
   if (!process.env.S3_BUCKET) {
     throw new Error(
       `Provide the S3 bucket to use by adding an S3_BUCKET` +
-        ` environment variable to this Lambda's configuration`
+      ` environment variable to this Lambda's configuration`
     )
   }
 
@@ -62,7 +64,7 @@ exports.run = async (browser, url, width, height) => {
 
   const screenshotUrl = `https://s3-${region}.amazonaws.com/${
     process.env.S3_BUCKET
-  }/${key}`
+    }/${key}`
 
   const metadata = await s3HeadObject(key)
 
@@ -88,7 +90,7 @@ exports.run = async (browser, url, width, height) => {
   // wait for full-size images to fade in
   await page.waitFor(1000)
 
-  const screenshot = await page.screenshot()
+  const screenshot = await page.screenshot({ fullPage })
   const up = await s3PutObject(key, screenshot)
 
   await page.close()


### PR DESCRIPTION
Puppeteer's API already supports the `fullPage` API to take a screenshot of an entire page. This pull request proxies the parameter via the `gatsby-transformer-screenshot` to puppeteer.
Issue reference: #10483 
