### PR TITLE
fix(gatsby/static-entry): Reorder props to standardize html output of `link` tag

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -277,10 +277,10 @@ export default (pagePath, callback) => {
     }.json`
     headComponents.push(
       <link
+        as="fetch"
         rel="preload"
         key={dataPath}
         href={dataPath}
-        as="fetch"
         crossOrigin="use-credentials"
       />
     )


### PR DESCRIPTION
Small fix to standardize HTML output of links tag:

Old output:
```html
  <link as="script" rel="preload" href="/component---src-pages-index-js-85595290af6100ca0650.js" />
  <link as="script" rel="preload" href="/0-7bb9d4a3af0df63a9d3c.js" />
  <link as="script" rel="preload" href="/app-5c3be57b1efc86e080fb.js" />
  <link as="script" rel="preload" href="/webpack-runtime-10d3952afbcc39dd7949.js" />
  <link rel="preload" href="/static/d/844/path---index-6a9-DzMKpBz6FLTLDRu155HKN7wQ.json" as="fetch" crossOrigin="use-credentials" />
```

New output:
```html
  <link as="script" rel="preload" href="/component---src-pages-index-js-85595290af6100ca0650.js" />
  <link as="script" rel="preload" href="/0-7bb9d4a3af0df63a9d3c.js" />
  <link as="script" rel="preload" href="/app-5c3be57b1efc86e080fb.js" />
  <link as="script" rel="preload" href="/webpack-runtime-10d3952afbcc39dd7949.js" />
  <link as="fetch" rel="preload" href="/static/d/844/path---index-6a9-DzMKpBz6FLTLDRu155HKN7wQ.json" crossOrigin="use-credentials" />