### PR TITLE
 Update URL in error message

### DIFF
--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -63,7 +63,7 @@ module.exports = async function build(program: BuildArgs) {
       report.stripIndent`
         Building static HTML for pages failed
 
-        See our docs page on debugging HTML builds for help https://goo.gl/yL9lND
+        See our docs page on debugging HTML builds for help https://gatsby.app/debug-html
       `,
       err
     )

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -59,7 +59,7 @@ async function startServer(program) {
         report.stripIndent`
           There was an error compiling the html.js component for the development server.
 
-          See our docs page on debugging HTML builds for help https://goo.gl/yL9lND
+          See our docs page on debugging HTML builds for help https://gatsby.app/debug-html
         `,
         err
       )


### PR DESCRIPTION
Replaced goo.gl short links with gatsby.app short links in Gatsby error messages.