### PR TITLE
[transformer-remark] Docs: plugin options

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -10,8 +10,33 @@ Parses Markdown files using [Remark](http://remark.js.org/).
 
 ```javascript
 // In your gatsby-config.js
-plugins: [`gatsby-transformer-remark`]
+plugins: [
+  {
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      // CommonMark mode (default: true)
+      commonmark: true,
+      // Footnotes mode (default: true)
+      footnotes: true,
+      // Pedantic mode (default: true)
+      pedantic: true,
+      // GitHub Flavored Markdown mode (default: true) 
+      gfm: true,
+      // Plugins configs
+      plugins: [],
+    },
+  },
+],
 ```
+
+The following parts of `options` are passed down to Remark as options:
+
+- `options.commonmark`
+- `options.footnotes`
+- `options.pedantic`
+- `options.gfm`
+
+The details of the Remark options above could be found in [`remark-parse`'s documentation](https://github.com/remarkjs/remark/tree/master/packages/remark-parse#processoruseparse-options)
 
 A full explanation of how to use markdown in Gatsby can be found here:
 [Creating a Blog with Gatsby](https://www.gatsbyjs.org/blog/2017-07-19-creating-a-blog-with-gatsby/)


### PR DESCRIPTION
Include documentations about `transformer-remark`'s options:

- `options.commonmark`
- `options.footnotes`
- `options.pedantic`
- `options.gfm`