### PR TITLE
Docs/Tutorial: Consistency in code snippet titles and syntax

### DIFF
--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -20,7 +20,7 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 
 1.  Install the plugin:
 
-```bash
+```shell
 npm install --save gatsby-plugin-manifest
 ```
 

--- a/docs/docs/add-page-metadata.md
+++ b/docs/docs/add-page-metadata.md
@@ -14,7 +14,7 @@ Gatsby's [react helmet plugin](/packages/gatsby-plugin-react-helmet/) provides d
 
 1. Install both packages:
 
-```bash
+```shell
 npm install --save gatsby-plugin-react-helmet react-helmet
 ```
 

--- a/docs/docs/add-page-metadata.md
+++ b/docs/docs/add-page-metadata.md
@@ -12,13 +12,13 @@ Gatsby's [react helmet plugin](/packages/gatsby-plugin-react-helmet/) provides d
 
 ### Using `React Helmet` and `gatsby-plugin-react-helmet`
 
-1.  Install both packages:
+1. Install both packages:
 
 ```bash
 npm install --save gatsby-plugin-react-helmet react-helmet
 ```
 
-2.  Add the plugin to the `plugins` array in your `gatsby-config.js` file.
+2. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 
 ```javascript:title=gatsby-config.js
 {
@@ -26,7 +26,7 @@ npm install --save gatsby-plugin-react-helmet react-helmet
 }
 ```
 
-3.  Use `React Helmet` in your pages:
+3. Use `React Helmet` in your pages:
 
 ```jsx
 import React from "react"
@@ -50,3 +50,5 @@ class Application extends React.Component {
 ```
 
 > 💡 The above example is from the [React Helmet docs](https://github.com/nfl/react-helmet#example). Check those out for more!
+
+You may also be interested in checking out the doc on [adding an SEO component](/docs/add-seo-component/).

--- a/docs/docs/adding-a-list-of-markdown-blog-posts.md
+++ b/docs/docs/adding-a-list-of-markdown-blog-posts.md
@@ -22,7 +22,7 @@ Has anyone heard about GatsbyJS yet?
 
 The first step will be to create the page which will display your posts, in `src/pages/`. You can for example use `index.js`.
 
-```jsx
+```jsx:title=src/pages/index.js
 import React from "react"
 import PostLink from "../components/post-link"
 
@@ -45,7 +45,7 @@ export default IndexPage
 
 Second, you need to provide the data to your component with a GraphQL query. Let's add it, so that `index.js` looks like this:
 
-```jsx
+```jsx:title=src/pages/index.js
 import React from "react"
 import { graphql } from "gatsby"
 import PostLink from "../components/post-link"
@@ -87,7 +87,7 @@ export const pageQuery = graphql`
 
 The only thing left to do is to add the `PostLink` component. Create a new file `post-link.js` in `src/components/` and add the following:
 
-```jsx
+```jsx:title=src/components/post-link.js
 import React from "react"
 import { Link } from "gatsby"
 

--- a/docs/docs/adding-analytics.md
+++ b/docs/docs/adding-analytics.md
@@ -32,7 +32,7 @@ Now, it's time to configure Gatsby to send page views to your Google Analytics a
 
 We are going to use `gatsby-plugin-google-analytics`. For other analytics options (including Google Analytics gtag.js and Google Tag Manager), check [other Gatsby analytics plugins](#other-gatsby-analytics-plugins).
 
-```bash
+```shell
 npm install --save gatsby-plugin-google-analytics
 ```
 

--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -44,7 +44,7 @@ If `gatsby develop` is running, restart it so Gatsby can pick up the new fields.
 
 Now, these fields are available in the data layer. To use field data, query it using `graphql`. All fields are available to query inside `frontmatter`
 
-Try running in Graph<em>i</em>QL (`localhost:8000/___graphql`) the following query
+Try running the following query in Graph<em>i</em>QL (`localhost:8000/___graphql`):
 
 ```graphql
 {

--- a/docs/docs/audit-with-lighthouse.md
+++ b/docs/docs/audit-with-lighthouse.md
@@ -14,7 +14,7 @@ If you haven't yet, you need to create a production build of your Gatsby site. T
 
 1.  Stop the development server (if it's still running) and run:
 
-```bash
+```shell
 gatsby build
 ```
 
@@ -22,7 +22,7 @@ gatsby build
 
 2.  View the production site locally. Run:
 
-```bash
+```shell
 gatsby serve
 ```
 

--- a/docs/docs/babel-plugin-macros.md
+++ b/docs/docs/babel-plugin-macros.md
@@ -24,7 +24,7 @@ they are named by their function, followed by `.macro`.
 For example, [`preval.macro`](https://www.npmjs.com/package/preval.macro) is a
 macro that pre-evaluates JavaScript code. You can install it by running:
 
-```bash
+```shell
 npm install --save-dev preval.macro
 ```
 

--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -24,7 +24,7 @@ browsers.
 Gatsby ships with a default .babelrc setup that should work for most sites. If you'd like
 to add custom Babel presets or plugins, you can create your own `.babelrc` at the root of your site, import [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby), and overwrite the `target` option.
 
-```bash
+```shell
 npm install --save-dev babel-preset-gatsby
 ```
 

--- a/docs/docs/building-with-components.md
+++ b/docs/docs/building-with-components.md
@@ -24,7 +24,7 @@ Everything in Gatsby is built using components.
 
 A basic directory structure of a project might look like this:
 
-```sh
+```
 .
 ├── gatsby-config.js
 ├── package.json

--- a/docs/docs/centralizing-your-sites-navigation.md
+++ b/docs/docs/centralizing-your-sites-navigation.md
@@ -48,7 +48,7 @@ Navigate to `http://localhost:8000/___graphql` in your browser to view the Graph
 
 Examining the available types in GraphQL you will notice that you can query `site`. This GraphQL type further returns the `siteMetadata` which needs to be accessed to create the dynamic navigation. At this point, it is useful if you know a little GraphQL in order to extract the menu links. If you are unfamiliar with GraphQL, there is some excellent documentation available at GraphQL's official website found [here](https://graphql.org/learn/) that you can use to brush up on your skills! The query below will return the menu links.
 
-```js
+```graphql
 query SiteQuery {
   site {
     siteMetadata {
@@ -64,7 +64,7 @@ query SiteQuery {
 
 When executing this query within the GraphiQL editor you see output that looks similar to the following:
 
-```js
+```json
 {
   "data": {
     "site": {

--- a/docs/docs/creating-global-styles.md
+++ b/docs/docs/creating-global-styles.md
@@ -46,7 +46,7 @@ div {
 
 In `src/components/layout.js`, include the stylesheet and export a layout component:
 
-```js:title=src/components/layout.js
+```jsx:title=src/components/layout.js
 import React from "react"
 import "./layout.css"
 

--- a/docs/docs/custom-html.md
+++ b/docs/docs/custom-html.md
@@ -33,7 +33,7 @@ If you see this error: `Uncaught Error: _registerComponent(...): Target containe
 "target container". Inside your `<body>` you must have a div with an id of
 `___gatsby` like:
 
-```jsx
+```jsx:title=src/html.js
 <div
   key={`body`}
   id="___gatsby"
@@ -45,7 +45,7 @@ If you see this error: `Uncaught Error: _registerComponent(...): Target containe
 
 You can add custom JavaScript to your HTML document by using React's [dangerouslySetInnerHTML](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml) attribute.
 
-```jsx
+```jsx:title=src/html.js
 <script
   dangerouslySetInnerHTML={{
     __html: `

--- a/docs/docs/deploying-to-gitlab-pages.md
+++ b/docs/docs/deploying-to-gitlab-pages.md
@@ -6,7 +6,7 @@ GitLab Pages are very similar to GitHub Pages. GitLab Pages also supports custom
 
 Create a new GitLab repository, [create a new Gatsby site](/docs/) if you haven't already, and add the GitLab remote.
 
-```bash
+```shell
 git init
 git remote add origin git@gitlab.com:examplerepository
 git add .

--- a/docs/docs/deploying-to-netlify.md
+++ b/docs/docs/deploying-to-netlify.md
@@ -17,19 +17,19 @@ continuous deployment from public or private repos and more.
 
 First, we'll want to create a new Gatsby project. If you don't already have Gatsby installed, install it:
 
-```sh
+```shell
 npm install --global gatsby-cli
 ```
 
 Next, we'll create a new Gatsby site:
 
-```sh
+```shell
 gatsby new my-gatsby-site
 ```
 
 Finally, change into the new site directory:
 
-```sh
+```shell
 cd my-gatsby-site
 ```
 

--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -69,7 +69,7 @@ The final step is to add a script to the `package.json` which will build our app
 
 You can deploy your application by running the following in the root of the project directory, where the `now.json` is:
 
-```bash
+```shell
 now
 ```
 

--- a/docs/docs/deploying-to-s3-cloudfront.md
+++ b/docs/docs/deploying-to-s3-cloudfront.md
@@ -12,19 +12,19 @@ Using the **Hosting** feature, you can deploy your application to AWS as well as
 
 First, we'll want to create a new Gatsby project. If you don't already have Gatsby installed, install it:
 
-```sh
+```shell
 npm install --global gatsby-cli
 ```
 
 Next, we'll create a new Gatsby site:
 
-```sh
+```shell
 gatsby new my-gatsby-site
 ```
 
 Finally, change into the new site directory:
 
-```sh
+```shell
 cd my-gatsby-site
 ```
 
@@ -34,13 +34,13 @@ Now that we have our Gatsby site up & running, let's add hosting & make the site
 
 First, we'll install the AWS Amplify CLI:
 
-```sh
+```shell
 npm i -g @aws-amplify/cli
 ```
 
 With the AWS Amplify CLI installed, we now need to configure it with an IAM User:
 
-```sh
+```shell
 amplify configure
 ```
 
@@ -48,7 +48,7 @@ amplify configure
 
 Now, we can create a new Amplify project in the root of our Gatsby project:
 
-```sh
+```shell
 amplify init
 ```
 
@@ -66,13 +66,13 @@ Now, the Amplify project has been created. You will see that you have a new ampl
 
 Next, we can type amplify into our command line & see all of the options that we have:
 
-```sh
+```shell
 amplify
 ```
 
 At the bottom, we can see the available categories available to us. Hosting is the category we would like to enable, so let's do so now:
 
-```sh
+```shell
 amplify add hosting
 ```
 
@@ -83,7 +83,7 @@ Here, we'll be prompted for the following:
 
 This will set up our local project with everything we need, now we can publish the app to AWS. To do so, we'll run the following command:
 
-```sh
+```shell
 amplify publish
 ```
 
@@ -101,7 +101,7 @@ What just happened? A few things:
 
 We should have also be given the URL that the site is hosted on. At any time that we would like to get the url for our site, we can run:
 
-```sh
+```shell
 amplify status
 ```
 
@@ -109,7 +109,7 @@ This command should give us all of the info about our app including the url of o
 
 If we ever want to configure the hosting setup, including adding Cloudfront, we can run:
 
-```sh
+```shell
 amplify configure hosting
 ```
 

--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -6,7 +6,7 @@ title: "End-to-end testing"
 
 In order to run Gatsby's development server and Cypress at the same time you'll use the little helper [start-server-and-test](https://github.com/bahmutov/start-server-and-test). If you're already using [react-testing-library](/docs/testing-react-components) for [unit testing](/docs/unit-testing) you might want to install [cypress-testing-library](https://github.com/kentcdodds/cypress-testing-library), too. This way you can use the exact same methods you used with `react-testing-library` in your Cypress tests. Install the following packages to your `devDependencies`:
 
-```sh
+```shell
 npm install --save-dev cypress start-server-and-test
 ```
 

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -47,7 +47,7 @@ In addition to these Project Environment Variables defined in `.env.*` files, yo
 OS Env Vars. OS Env Vars which are prefixed with `GATSBY_` will become available in
 browser JavaScript.
 
-```shell:title=.env.*
+```text:title=.env.*
 GATSBY_API_URL=https://dev.example.com/api
 ```
 
@@ -60,7 +60,7 @@ calling Gatsby on the command line.
 
 In Linux terminals this can be done with:
 
-```
+```shell
 MY_ENV_VAR=foo gatsby develop
 ```
 
@@ -83,12 +83,12 @@ Now the variables are available on `process.env` as usual.
 
 Please note that you shouldn't commit `.env.*` files to your source control and rather use options given by your CD provider (e.g. Netlify with its [build environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables)).
 
-```shell:title=.env.development
+```text:title=.env.development
 GATSBY_API_URL=https://dev.example.com/api
 API_KEY=927349872349798
 ```
 
-```shell:title=.env.production
+```text:title=.env.production
 GATSBY_API_URL=https://example.com/api
 API_KEY=927349872349798
 ```
@@ -141,7 +141,7 @@ For instance. If you would like to add a `staging` environment with a custom Goo
 
 ### Example
 
-```shell:title=.env.staging
+```text:title=.env.staging
 GA_TRACKING_ID="UA-1234567890"
 API_URL="http://foo.bar"
 ```
@@ -183,6 +183,6 @@ Note that `ACTIVE_ENV` could be called anything - it's not used or known about b
 
 Local testing of the `staging` environment can be done with:
 
-```
+```shell
 ACTIVE_ENV=staging gatsby develop
 ```

--- a/docs/docs/eslint.md
+++ b/docs/docs/eslint.md
@@ -10,7 +10,7 @@ Gatsby ships with Prettier, which is a simple, opinionated code _formatter_. [ES
 
 Here we will explore an ESLint configuration that acts like Prettier by adhering to [Standard.js](https://standardjs.com) rules. ESLint might seem intimidating at first, however it is aimed at providing a number of configurable options to make your code format fit your style. Run the following commands to remove Prettier and install ESLint.
 
-```bash
+```shell
 # Remove the Prettier package
 npm rm prettier
 
@@ -23,7 +23,7 @@ npm install --save-dev eslint babel-eslint \
 
 Now that we have our packages installed, remove `.prettierrc` from the root of your new Gatsby project and create a new file named `.eslintrc.js` using the commands below.
 
-```bash
+```shell
 # Remove the Prettier config file
 rm .prettierrc
 

--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -22,7 +22,7 @@ Options available to set within `gatsby-config.js` include:
 
 When you want to reuse common pieces of data across the site (for example, your site title), you can store that data in `siteMetadata`:
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   siteMetadata: {
     title: `Gatsby`,
@@ -40,7 +40,7 @@ See a fuller description and sample usage in [Gatsby.js Tutorial Part Four](/tut
 
 Plugins are Node.js packages that implement Gatsby APIs. The config file accepts an array of plugins. Some plugins may need only to be listed by name, while others may take options (see the docs for individual plugins).
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [
     `gatsby-plugin-react-helmet`,
@@ -61,7 +61,7 @@ See more about [Plugins](/docs/plugins/) for more on utilizing plugins, and to s
 
 It's common for sites to be hosted somewhere other than the root of their domain. Say we have a Gatsby site at `example.com/blog/`. In this case, we would need a prefix (`/blog`) added to all paths on the site.
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   // Note: it must *not* have a trailing slash.
   pathPrefix: `/blog`,
@@ -76,7 +76,7 @@ Gatsby uses the ES6 Promise API. Because some browsers don't support this, Gatsb
 
 If you'd like to provide your own Promise polyfill, you can set `polyfill` to false.
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   polyfill: false,
 }
@@ -99,9 +99,7 @@ author: Kyle Mathews
 A treatise on the efficacy of bezoar for treating agricultural pesticide poisoning.
 ```
 
-author.yaml
-
-```yaml
+```yaml:title=author.yaml
 - id: Kyle Mathews
   bio: Founder @ GatsbyJS. Likes tech, reading/writing, founding things. Blogs at bricolage.io.
   twitter: "@kylemathews"
@@ -143,8 +141,7 @@ query($slug: String!) {
 Mapping can also be used to map an array of ids to any other collection of data. For example, if you have two JSON files
 `experience.json` and `tech.json` as follows:
 
-```json
-// experience.json
+```json:title=experience.json
 [
   {
     "id": "companyA",
@@ -166,8 +163,7 @@ Mapping can also be used to map an array of ids to any other collection of data.
 ]
 ```
 
-```json
-// tech.json
+```json:title=tech.json
 [
   {
     "id": "REACT",
@@ -186,7 +182,7 @@ Mapping can also be used to map an array of ids to any other collection of data.
 
 And then add the following rule to your `gatsby-config.js`:
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [...],
   mapping: {
@@ -235,7 +231,7 @@ Founder @ GatsbyJS. Likes tech, reading/writing, founding things. Blogs at brico
 
 And then add the following rule to your `gatsby-config.js`:
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [...],
   mapping: {
@@ -250,7 +246,7 @@ Similarly to YAML and JSON files, mapping between Markdown files can also be use
 
 Setting the proxy config option will tell the develop server to proxy any unknown requests to your specified server. For example:
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   proxy: {
     prefix: "/api",

--- a/docs/docs/gatsby-on-linux.md
+++ b/docs/docs/gatsby-on-linux.md
@@ -12,7 +12,7 @@ title: Gatsby on Linux
 
 As of October 17th 2017, Windows 10 ships with WSL and Linux distributions are available via the [Windows Store], there are several different distributions to use which can be configured via `wslconfig` if you have more than one distribution installed.
 
-```sh
+```shell
 # set default distribution to Ubuntu
 wslconfig /setdefault ubuntu
 ```
@@ -21,7 +21,7 @@ wslconfig /setdefault ubuntu
 
 If you have a fresh install of Ubuntu then update and upgrade:
 
-```sh
+```shell
 sudo apt update
 sudo apt -y upgrade
 ```
@@ -32,7 +32,7 @@ sudo apt -y upgrade
 
 To compile and install native addons from npm you may also need to install build tools for `node-gyp`:
 
-```sh
+```shell
 sudo apt install -y build-essential
 ```
 
@@ -40,7 +40,7 @@ sudo apt install -y build-essential
 
 Following the install instructions on nodejs.org leaves a slightly broken install (i.e. permission errors when trying to `npm install`). Instead try installing node versions using [n] which you can install with [n-install]:
 
-```sh
+```shell
 curl -L https://git.io/n-install | bash
 ```
 
@@ -50,7 +50,7 @@ There are other alternatives for managing your node versions such as [nvm] but t
 
 Debian setup is nearly identical to Ubuntu except for the additional installs of `git` and `libpng-dev`.
 
-```sh
+```shell
 sudo apt update
 sudo apt -y upgrade
 sudo apt install build-essential
@@ -60,7 +60,7 @@ sudo apt install libpng-dev
 
 Or to install all at the same time and approve `(y)` all installs:
 
-```sh
+```shell
 sudo apt update && sudo apt -y upgrade && sudo apt install build-essential && sudo apt install git && sudo apt install libpng-dev
 ```
 

--- a/docs/docs/glamor.md
+++ b/docs/docs/glamor.md
@@ -25,7 +25,7 @@ npm install --save gatsby-plugin-glamor glamor
 
 And then add it to your site's `gatsby-config.js`:
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [`gatsby-plugin-glamor`],
 }
@@ -35,7 +35,7 @@ Then in your terminal run `gatsby develop` to start the Gatsby development serve
 
 Now let's create a sample Glamor page at `src/pages/index.js`
 
-```jsx
+```jsx:title=src/pages/index.js
 import React from "react"
 
 const Container = ({ children }) => <div>{children}</div>
@@ -50,7 +50,7 @@ export default () => (
 
 Let's add css styles to `Container` and add a inline `User` component using Glamor's `css` prop.
 
-```jsx
+```jsx:title=src/pages/index.js
 import React from "react"
 
 const Container = ({ children }) => (

--- a/docs/docs/hosting-on-netlify.md
+++ b/docs/docs/hosting-on-netlify.md
@@ -24,14 +24,14 @@ There are two ways, we can host our site.
 
 In Gatsby development mode, we constantly change content, add images, so Gatsby won't consume our time to optimize the source code as we are currently developing our site. For production usage, we want our site to load as fast as possible. Gatsby also informs us about it with below message.
 
-```sh
+```shell
 Note that the development build is not optimized.
 To create a production build, use Gatsby build
 ```
 
 For the production build, we will need to run `gatsby build` command and Gatsby will generate our production site under `public` folder, it will contain css, js, images and html files.
 
-```sh
+```shell
 gatsby build
 ```
 

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -69,6 +69,7 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
 Gatsby, unsurprisingly, uses Gatsby for its documentation website. Thank you in advance and cheers for contributing to Gatsby documentation! It's people like you that make this community great!
 
 #### Top priorities
+
 Check the Github repo for issues labeled with ["documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or ["documentation" and "status: help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22status%3A+help+wanted%22) to see all documentation issues that are ready for community help. Once you start a PR to address one of these issues, you can remove the "help wanted" label.
 
 #### Modifying markdown files in Gatsby documentation
@@ -82,7 +83,7 @@ Check the Github repo for issues labeled with ["documentation" and "good first i
 
 If you wrote a new document that was previously a stub, update `www/src/data/sidebars/doc-links.yaml` accordingly by removing the asterisk behind the document's title:
 
-```diff
+```diff:title=www/src/data/sidebars/doc-links.yaml
   ...
 - - title: Example Document*
 + - title: Example Document
@@ -105,7 +106,7 @@ To develop on the starter library, you'll need to supply a GitHub personal acces
 2. In the new token's settings, grant that token the "public_repo" scope.
 3. Create a file in the root of `www` called `.env.development`, and add the token to that file like so:
 
-```
+```text:title=.env.development
 GITHUB_API_TOKEN=YOUR_TOKEN_HERE
 ```
 

--- a/docs/docs/image-tutorial.md
+++ b/docs/docs/image-tutorial.md
@@ -133,7 +133,7 @@ Open localhost:8000 and localhost:8000/\_\_\_graphql.
 
 Here’s an example of creating specific widths and heights for images:
 
-```jsx
+```graphql
 {
   allWordpressPost {
     edges {
@@ -142,8 +142,8 @@ Here’s an example of creating specific widths and heights for images:
           photo {
             localFile {
               childImageSharp {
-                  # Try editing the "width" and "height" values.
-                  resolutions(width: 200, height: 200) {
+                # Try editing the "width" and "height" values.
+                resolutions(width: 200, height: 200) {
                   # In the GraphQL explorer, use field names
                   # like "src". In your site's code, remove them
                   # and use the fragments provided by Gatsby.
@@ -165,7 +165,7 @@ Here’s an example of creating specific widths and heights for images:
 
 Here’s an example query for generating different sizes of an image:
 
-```jsx
+```graphql
 {
   allWordpressPost {
     edges {

--- a/docs/docs/local-https.md
+++ b/docs/docs/local-https.md
@@ -46,7 +46,7 @@ If you need to use a custom https setup, you can pass the `--https`, `--key-file
 
 See the example command:
 
-```bash
+```shell
 $ gatsby develop --https --key-file ../relative/path/to/key.key --cert-file ../relative/path/to/cert.crt
 ```
 

--- a/docs/docs/migrating-from-v0-to-v1.md
+++ b/docs/docs/migrating-from-v0-to-v1.md
@@ -13,7 +13,7 @@ Everything related to webpack, loaders, Babel, React should work nearly
 identically under v1 of Gatsby compared to v0 so this part of the migration is
 super easy.
 
-```bash
+```shell
 mkdir src
 git mv pages src
 git mv components src

--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -90,7 +90,7 @@ You need update your `package.json` to use the latest version of Gatsby.
 
 Or run
 
-```bash
+```shell
 npm i gatsby@latest
 ```
 
@@ -98,13 +98,13 @@ npm i gatsby@latest
 
 Update your `package.json` to use the latest versions of Gatsby related packages. Any package name that starts with `gatsby-` should be upgraded. Note, this only applies to plugins managed in the gatsbyjs/gatsby repo. If you're using community plugins, they might not be upgraded yet. Check their repo for the status. Many plugins won't actually need upgrading so they very well might keep working. You can run
 
-```bash
+```shell
 npm outdated
 ```
 
 And compare "Wanted" and "Latest" versions and update `package.json` file manually or run
 
-```bash
+```shell
 npm i gatsby-plugin-google-analytics@latest gatsby-plugin-netlify@latest gatsby-plugin-sass@latest
 ```
 
@@ -114,7 +114,7 @@ npm i gatsby-plugin-google-analytics@latest gatsby-plugin-netlify@latest gatsby-
 
 In v1, the `react` and `react-dom` packages were included as part of the `gatsby` package. They are now `peerDependencies` so you are required to install them into your project.
 
-```bash
+```shell
 npm i react react-dom
 ```
 
@@ -122,7 +122,7 @@ npm i react react-dom
 
 Some plugins had dependencies that were also made `peerDependencies`. For example, if you use [`gatsby-plugin-typography`](https://www.gatsbyjs.org/packages/gatsby-plugin-typography/), you now need to install:
 
-```bash
+```shell
 npm i typography react-typography
 ```
 
@@ -160,7 +160,7 @@ export default ({ children }) => (
 
 #### 2. Move `layouts/index.js` to `src/components/layout.js` (optional, but recommended)
 
-```bash
+```shell
 git mv src/layouts/index.js src/components/layout.js
 ```
 

--- a/docs/docs/page-query.md
+++ b/docs/docs/page-query.md
@@ -25,7 +25,7 @@ module.exports = {
 
 A simple index page (`src/pages/index.js`) can be marked up like so:
 
-```js:title=src/pages/index.js
+```jsx:title=src/pages/index.js
 import React from "react"
 
 const HomePage = () => {

--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -39,7 +39,7 @@ module.exports = {
 
 Then pass `--prefix-paths` cmd option to Gatsby.
 
-```sh
+```shell
 gatsby build --prefix-paths
 ```
 

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -62,7 +62,7 @@ plugins
 
 **NOTE:** For the plugin to be discovered, the plugin's root folder name is the value that needs to be referenced in order to load it (_not_ its _name_ in its package.json file). For example, in the above structure, the correct way to load the plugin is:
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: ["my-own-plugin"],
 }

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -84,7 +84,7 @@ Note that plugin options will be stringified by Gatsby, so they cannot be functi
 
 Gatsby can also load plugins from the your local website plugins folder which is a folder named `plugins` in the website's root directory.
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [`gatsby-local-plugin`],
 }
@@ -92,7 +92,7 @@ module.exports = {
 
 If you want to reference a plugin that is not in the plugins folder then you could use something like the following:
 
-```javascript
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [
     // Shortcut for adding plugins without options.

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -33,7 +33,7 @@ For example, `gatsby-transformer-json` is a package which adds support for JSON 
 
 To install it, in the root of your site you run:
 
-```bash
+```shell
 npm install --save gatsby-transformer-json
 ```
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -6,7 +6,7 @@ This quick start is intended for intermediate to advanced developers. For a gent
 
 ## Install Gatsby's command line tool
 
-```bash
+```shell
 npm install --global gatsby-cli
 ```
 
@@ -14,19 +14,19 @@ npm install --global gatsby-cli
 
 ### Create a new site.
 
-```bash
+```shell
 gatsby new gatsby-site
 ```
 
 ### Change directories into site folder.
 
-```bash
+```shell
 cd gatsby-site
 ```
 
 ### Start development server.
 
-```bash
+```shell
 gatsby develop
 ```
 
@@ -36,7 +36,7 @@ Try editing the JavaScript pages in `src/pages`. Saved changes will live reload 
 
 ### Create a production build.
 
-```bash
+```shell
 gatsby build
 ```
 
@@ -44,7 +44,7 @@ Gatsby will perform an optimized production build for your site, generating stat
 
 ### Serve the production build locally.
 
-```bash
+```shell
 gatsby serve
 ```
 

--- a/docs/docs/source-plugin-tutorial.md
+++ b/docs/docs/source-plugin-tutorial.md
@@ -75,7 +75,7 @@ The bare essentials of a plugin are a directory named after your plugin, which c
 
 Start by creating the directory and changing into it:
 
-```
+```shell
 mkdir gatsby-source-pixabay
 cd gatsby-source-pixabay
 ```
@@ -102,7 +102,7 @@ npm install node-fetch query-string --save
 
 Open your `package.json` file and you'll see `node-fetch` and `query-string` have been added to a `dependencies` section at the end:
 
-```js:title=package.json
+```json:title=package.json
   "dependencies": {
     "node-fetch": "^2.2.0",
     "query-string": "^6.1.0"
@@ -137,20 +137,20 @@ exports.sourceNodes = (
 
 What did you do by adding this code? You started by importing the dependencies that you added earlier (along with one built in dependency):
 
-```js
+```js:title=gatsby-node.js
 const fetch = require("node-fetch")
 const queryString = require("query-string")
 ```
 
 Then you implemented Gatsby's [`sourceNodes` API](/docs/node-apis/#sourceNodes) which Gatsby will run as part of its bootstrap process. Gatsby expects sourceNodes to return either a promise or a callback (3rd parameter). This is important as it tells Gatsby to wait to move on to next stages until your nodes are sourced, ensuring your nodes are created before the schema is generated.
 
-```js
+```js:title=gatsby-node.js
 exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOptions) => {
 ```
 
 You do some initial setup:
 
-```js
+```js:title=gatsby-node.js
 const { createNode } = actions
 
 // Gatsby adds a configOption that's not needed for this plugin, delete it
@@ -159,7 +159,7 @@ delete configOptions.plugins
 
 And finally add a placeholder message:
 
-```js
+```js:title=gatsby-node.js
 // plugin code goes here...
 console.log("Testing my plugin", configOptions)
 ```

--- a/docs/docs/sourcing-from-contentful.md
+++ b/docs/docs/sourcing-from-contentful.md
@@ -22,7 +22,7 @@ As far as pushing data out to your site goes, we suggest to you to use this fant
 
 ## Install
 
-```bash
+```shell
 npm install --save gatsby-source-contentful
 ```
 

--- a/docs/docs/sourcing-from-the-filesystem.md
+++ b/docs/docs/sourcing-from-the-filesystem.md
@@ -16,7 +16,7 @@ It will also be useful if you are familiar with [Graph_i_QL](/docs/introducing-g
 
 Install the plugin at the root of your Gatsby project:
 
-```sh
+```shell
 npm install --save gatsby-source-filesystem
 ```
 

--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -22,7 +22,7 @@ gatsby new styled-components-tutorial https://github.com/gatsbyjs/gatsby-starter
 
 Second, we'll install the Gatsby plugin for Styled Components.
 
-```sh
+```shell
 npm install --save gatsby-plugin-styled-components styled-components babel-plugin-styled-components
 ```
 

--- a/docs/docs/submit-to-plugin-library.md
+++ b/docs/docs/submit-to-plugin-library.md
@@ -10,7 +10,7 @@ After doing so, Algolia will take up to 12 hours to add it to the library search
 
 **NOTE:** You can include other _relevant_ keywords to your `package.json` file to help interested users in finding it. As an example, a Markdown MathJax transformer would include:
 
-```
+```json:title=package.json
 "keywords": [
   "gatsby",
   "gatsby-plugin",

--- a/docs/docs/testing-components-with-graphql.md
+++ b/docs/docs/testing-components-with-graphql.md
@@ -227,7 +227,7 @@ test.
 Here is the example of a header component that queries the page data itself,
 rather than needing it to be passed from the layout:
 
-```js:title=src/components/Header.js
+```jsx:title=src/components/Header.js
 import React from "react"
 import { StaticQuery } from "gatsby"
 
@@ -256,7 +256,7 @@ export default props => (
 This is almost ready: all you need to do is export the pure component that you
 are passing to StaticQuery. Rename it first to avoid confusion:
 
-```js:title=src/components/Header.js
+```jsx:title=src/components/Header.js
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 

--- a/docs/docs/testing-css-in-js.md
+++ b/docs/docs/testing-css-in-js.md
@@ -12,7 +12,7 @@ For this example we'll use emotion. The testing utilities of emotion and glamor 
 
 ## Installation
 
-```sh
+```shell
 npm install --save-dev jest-emotion babel-plugin-emotion
 ```
 

--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -14,7 +14,7 @@ It provides light utility functions on top of `react-dom` and `react-dom/test-ut
 
 Install the library as one of your project's `devDependencies`. Optionally you may install `jest-dom` to use its [custom jest matchers](https://github.com/gnapse/jest-dom#custom-matchers).
 
-```sh
+```shell
 npm install --save-dev react-testing-library jest-dom
 ```
 

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -23,7 +23,7 @@ concepts should be the same or very similar for your site._
 First you need to install Jest and some more required packages. You need to
 install Babel 7 as it's required by Jest.
 
-```sh
+```shell
 npm install --save-dev jest babel-jest react-test-renderer identity-obj-proxy babel-core@^7.0.0-bridge.0 @babel/core babel-preset-gatsby
 ```
 
@@ -219,7 +219,7 @@ they are changed.
 
 Now, run `npm run test` and you should immediately get an error like this:
 
-```sh
+```shell
  @font-face {
     ^
 
@@ -254,7 +254,7 @@ by running `npm run test -- -u`.
 If you are using TypeScript, you need to make a couple of small changes to your
 config. First install `ts-jest`:
 
-```sh
+```shell
 npm install --save-dev ts-jest
 ```
 

--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -44,7 +44,7 @@ The GraphQL query creates multiple thumbnails with optimized JPEG and PNG compre
 
 Here’s what a really simple Gatsby page component using gatsby-image would look like:
 
-```js
+```jsx
 import React from "react"
 import Img from "gatsby-image"
 

--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -13,13 +13,13 @@ As your project grows over time having this information available will be invalu
 
 To set up Storybook you need to install dependencies and do some custom configuration. First, install the Storybook CLI.
 
-```sh
+```shell
 npm install -g @storybook/cli
 ```
 
 Once the CLI is installed, the next step is to run the `sb init` command that is now available from the root directory of your Gatsby project.
 
-```sh
+```shell
 cd my-awesome-gatsby-project
 sb init
 ```
@@ -91,7 +91,7 @@ module.exports = (baseConfig, env, defaultConfig) => {
 
 Once you have this configured you should run Storybook to ensure it can start up properly and you can see the default stories installed by the CLI. To run storybook:
 
-```sh
+```shell
 npm run storybook
 ```
 

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -31,7 +31,7 @@ First you need to create a production build of your Gatsby site. The Gatsby deve
 
 1.  Stop the development server (if it's still running) and run:
 
-```bash
+```shell
 gatsby build
 ```
 
@@ -39,7 +39,7 @@ gatsby build
 
 2.  View the production site locally. Run:
 
-```bash
+```shell
 gatsby serve
 ```
 
@@ -81,7 +81,7 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 
 1.  Install the plugin:
 
-```bash
+```shell
 npm install --save gatsby-plugin-manifest
 ```
 
@@ -120,7 +120,7 @@ Another requirement for a website to qualify as a PWA is the use of a [service w
 
 1.  Install the plugin:
 
-```bash
+```shell
 npm install --save gatsby-plugin-offline
 ```
 
@@ -156,7 +156,7 @@ Gatsby's [react helmet plugin](/packages/gatsby-plugin-react-helmet/) provides d
 
 1.  Install both packages:
 
-```bash
+```shell
 npm install --save gatsby-plugin-react-helmet react-helmet
 ```
 

--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -42,7 +42,7 @@ explore how it works.
 
 First install the plugin at the root of the project:
 
-```sh
+```shell
 npm install --save gatsby-source-filesystem
 ```
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -275,7 +275,7 @@ It worked! 🎉
 
 The basic GraphQL query that retrieves the `title` in our `about.js` changes above is:
 
-```
+```graphql:title=src/pages/about.js
 {
   site {
     siteMetadata {

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -9,13 +9,13 @@ In the [**previous section**](/tutorial/part-zero/), you prepared your local dev
 
 In [**tutorial part zero**](/tutorial/part-zero/), you created a new site based on the “hello world” starter using the following command:
 
-```bash
+```shell
 gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 ```
 
 When creating a new Gatsby site, you can use the following command structure to create a new site based on any existing Gatsby starter:
 
-```bash
+```shell
 gatsby new [SITE_DIRECTORY_NAME] [URL_OF_STARTER_GITHUB_REPO]
 ```
 
@@ -354,7 +354,7 @@ deploy Gatsby sites.
 
 If you haven't previously installed & set up Surge, open a new terminal window and install their terminal tool:
 
-```bash
+```shell
 npm install --global surge
 
 # Then create a (free) account with them
@@ -363,7 +363,7 @@ surge
 
 Next, build your site by running the following command in the terminal at the root of your site (tip: make sure you're running this command at the root of your site, in this case in the hello-world folder, which you can do by opening a new tab in the same window you used to run `gatsby develop`):
 
-```bash
+```shell
 gatsby build
 ```
 
@@ -371,13 +371,13 @@ The build should take 15-30 seconds. Once the build is finished, it's interestin
 
 Take a look at a list of the generated files by typing in the following terminal command into the root of your site, which will let you look at the `public` directory:
 
-```bash
+```shell
 ls public
 ```
 
 Then finally deploy your site by publishing the generated files to surge.sh.
 
-```bash
+```shell
 surge public/
 ```
 

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -241,13 +241,13 @@ Earlier you defined React components as reusable pieces of code describing a UI.
 
 In `about.js` you passed a `headerText` prop with the value of `"About Gatsby"` to the imported `Header` sub-component:
 
-```jsx
+```jsx:title=src/pages/about.js
 <Header headerText="About Gatsby" />
 ```
 
 Over in `header.js`, the header component expects to receive the `headerText` prop (because you’ve written it to expect that) So you can access it like so:
 
-```jsx
+```jsx:title=src/pages/header.js
 <h1>{props.headerText}</h1>
 ```
 
@@ -255,7 +255,7 @@ Over in `header.js`, the header component expects to receive the `headerText` pr
 
 If you had passed another prop to our `<Header />` component, like so...
 
-```jsx
+```jsx:title=src/pages/about.js
 <Header headerText="About Gatsby" arbitraryPhrase="is arbitrary" />
 ```
 

--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -89,7 +89,7 @@ cd tutorial-part-two
 
 This creates a new site with the following structure.
 
-```shell
+```text
 ├── package.json
 ├── src
 │   └── pages

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -78,7 +78,7 @@ The Gatsby CLI tool lets you quickly create new Gatsby-powered sites and run com
 
 A couple of different things are happening here.
 
-```bash
+```shell
 npm install --global gatsby-cli
 ```
 
@@ -112,7 +112,7 @@ Now you are ready to use Gatsby CLI tool to create your first Gatsby site. Using
 
 What just happened?
 
-```bash
+```shell
 gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 ```
 
@@ -121,13 +121,13 @@ gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 - Here, `hello-world` is an arbitrary title — you could pick anything. The CLI tool will place the code for your new site in a new folder called “hello-world”.
 - Lastly, the GitHub URL specified points to a code repository that holds the starter code you want to use.
 
-```bash
+```shell
 cd hello-world
 ```
 
 - This says 'I want to change directories (`cd`) to the “hello-world” subfolder'. Whenever you want to run any commands for your site, you need to be in the context for that site (aka, your terminal needs to be pointed at the directory where your site code lives).
 
-```bash
+```shell
 gatsby develop
 ```
 


### PR DESCRIPTION
Following #10515:
- make sure snippets have a title where needed
- correct language is used
- uniformly change instances of `sh` and `bash` to just `shell`, as discussed
