### PR TITLE
fix(gatsby): add Safari 10 support to default terser options

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -446,6 +446,7 @@ module.exports = async ({
       sourceMap: true,
       terserOptions: {
         ie8: false,
+        safari10: true,
         parse: {
           ecma: 8,
         },

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -446,7 +446,9 @@ module.exports = async ({
       sourceMap: true,
       terserOptions: {
         ie8: false,
-        safari10: true,
+        mangle: {
+          safari10: true,
+        },
         parse: {
           ecma: 8,
         },


### PR DESCRIPTION
Parcel sets `safari10` to `true` it by default

https://github.com/parcel-bundler/parcel/blob/75310e15f6fa3c8a0ce6593ada1bcca00240ea54/packages/core/parcel-bundler/src/transforms/terser.js#L13

fixes #10513 mentions that site breaks in Safari 10