### PR TITLE
fix(www): fix starter redirects

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -120,10 +120,10 @@ exports.createPages = ({ graphql, actions }) => {
     isPermanent: true,
   })
 
-  Object.entries(startersRedirects).forEach(([fromPath, toPath]) => {
+  Object.entries(startersRedirects).forEach(([fromSlug, toSlug]) => {
     createRedirect({
-      fromPath,
-      toPath,
+      fromPath: `/starters${fromSlug}`,
+      toPath: `/starters${toSlug}`,
       isPermanent: true,
     })
   })


### PR DESCRIPTION
The redirects I added in #9304 were wrong - they were using just stubs and not full url, so they currently don't work as expected - this *should* fix the issue - here's example of redirect entry when using that change:

```
/starters/gatsby-advanced-starter/  /starters/Vagr9K/gatsby-advanced-starter/  301
```

And before it was 
```
/gatsby-advanced-starter/  /Vagr9K/gatsby-advanced-starter/  301
```