### PR TITLE
feat(gatsby-plugin-typography): Hot Reloading for Google Fonts

### DIFF
--- a/packages/gatsby-plugin-typography/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-browser.js
@@ -1,0 +1,41 @@
+// Hot reload gatsby-plugin-typography in development
+
+let ReactDOMServer = null
+let React = null
+let GoogleFont = null
+let typography = null
+
+if (process.env.BUILD_STAGE === `develop`) {
+  ReactDOMServer = require(`react-dom/server`)
+  React = require(`react`)
+  GoogleFont = require(`react-typography`).GoogleFont
+  // typography links to the file set in "pathToConfigModule"
+  typography = require(`./.cache/typography.js`).default
+
+  exports.onClientEntry = () => {
+    // Inject the CSS Styles
+    typography.injectStyles()
+
+    // Hot reload Google CDN links
+    if (typography.options.googleFonts.length > 0) {
+      if (typeof document !== `undefined`) {
+        // Construct the <link /> tag
+        const googleFonts = ReactDOMServer.renderToStaticMarkup(
+          <GoogleFont key={`GoogleFont`} typography={typography} />
+        )
+        // Parse the tag
+        let doc = new DOMParser().parseFromString(googleFonts, `text/html`)
+        let linkElement = doc.head.firstChild
+        // Add custom identifier
+        linkElement.setAttribute(`data-gatsby-typography`, `true`)
+        const head = document.getElementsByTagName(`head`)[0]
+        const elem = document.querySelector(`[data-gatsby-typography]`)
+        // Remove old <link /> tag
+        if (elem) {
+          elem.remove()
+        }
+        head.appendChild(linkElement)
+      }
+    }
+  }
+}

--- a/packages/gatsby-plugin-typography/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-ssr.js
@@ -8,8 +8,10 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   ) : (
     <GoogleFont key={`GoogleFont`} typography={typography} />
   )
-  setHeadComponents([
-    <TypographyStyle key={`TypographyStyle`} typography={typography} />,
-    ...googleFont,
-  ])
+  if (process.env.BUILD_STAGE === `build-html`) {
+    setHeadComponents([
+      <TypographyStyle key={`TypographyStyle`} typography={typography} />,
+      ...googleFont,
+    ])
+  }
 }


### PR DESCRIPTION
So until now only the hot reloading for normal CSS styles worked but not the `<link />` tags for Google's CDN. With this PR also the links to Google will update.

PR https://github.com/gatsbyjs/gatsby/pull/9099 can be closed with this.
Closes https://github.com/gatsbyjs/gatsby/issues/7399
Closes https://github.com/gatsbyjs/gatsby/issues/9095

----

Changes explained:

`gatsby-browser`

- Only `require` stuff in develop to keep build bundle size down
- Use DOMParser workaround to set `data-gatsby-typography` to element to later be able to find it again
- Remove old instance of link tag when updating
- Only do this whole stuff if `googleFonts` is in the config

`gatsby-ssr`

- Only add it on build because otherwise we'd have duplicate content during development