### PR TITLE
fix(gatsby): Ignore fields with key set to empty string in getExampleValues

### DIFF
--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -93,6 +93,7 @@ describe(`Gatsby data tree utils`, () => {
           someOtherProperty: 3,
         },
       },
+      "": ``,
     },
   ]
 
@@ -102,6 +103,10 @@ describe(`Gatsby data tree utils`, () => {
 
   it(`skips null fields`, () => {
     expect(getExampleValues({ nodes }).iAmNull).not.toBeDefined()
+  })
+
+  it(`skips fields with key set to empty string`, () => {
+    expect(getExampleValues({ nodes })[``]).not.toBeDefined()
   })
 
   it(`should not mutate the nodes`, () => {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -244,6 +244,9 @@ const extractFieldExamples = (
   const example = {}
   for (let key of allKeys) {
     if (ignoreFields.includes(key)) continue
+    // Unfortunately an empty string as an Object key is perfectly valid JavaScript
+    // We ignore these because our schema generation requires keys to have names
+    if (key === ``) continue
     const nextSelector = selector ? `${selector}.${key}` : key
 
     const nodeWithValues = nodes.filter(node => {

--- a/packages/gatsby/src/schema/data-tree-utils.js
+++ b/packages/gatsby/src/schema/data-tree-utils.js
@@ -245,7 +245,7 @@ const extractFieldExamples = (
   for (let key of allKeys) {
     if (ignoreFields.includes(key)) continue
     // Unfortunately an empty string as an Object key is perfectly valid JavaScript
-    // We ignore these because our schema generation requires keys to have names
+    // We ignore these because GraphQL requires keys to have names
     if (key === ``) continue
     const nextSelector = selector ? `${selector}.${key}` : key
 


### PR DESCRIPTION
Unfortunately, an Object property with an empty string as the key is valid JavaScript. This however breaks schema generation because `graphql` asserts that every key has a [valid](https://github.com/graphql/graphql-js/blob/958eb961513de1147c19508d66f97920c26e99e5/src/type/validate.js#L220) name. 

### Example scenario

[hast-util-raw](https://github.com/syntax-tree/hast-util-raw) seems to produce an AST with `"": ""` (which breaks build) in #10480 

This fix makes schema generation more defensive by ignoring all instances of `key === ""`
