### PR TITLE
fix: don't change default node_modules resolution

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -363,11 +363,6 @@ module.exports = async (
       // Use the program's extension list (generated via the
       // 'resolvableExtensions' API hook).
       extensions: [...program.extensions],
-      // Default to using the site's node_modules directory to look for
-      // modules. But also make it possible to install modules within the src
-      // directory if you need to install a specific version of a module for a
-      // part of your site.
-      modules: [directoryPath(path.join(`node_modules`)), `node_modules`],
       alias: {
         gatsby$: directoryPath(path.join(`.cache`, `gatsby-browser-entry.js`)),
         // Using directories for module resolution is mandatory because


### PR DESCRIPTION
I feel like i fixed this before, but couldn't find anything :P 

we can't do this. what happens is that module resolution _always_ checks the root node_modules before any other `node_modules`, this essentially breaks any dependency that shares a root dep of a different version

```
/node_modules
 - lodash@v4
 - some-pkg
   - node_modules
     - lodash@v3
```

Given the above structure `some-pkg` will resolve lodash@4 *not* lodash@3. when there are incompatible versions like this it causes extremely hard to debug issues, because the dep tree on disk is correct.