### PR TITLE
chore: tweak package.json to get a new release out

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -18,9 +18,10 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion#readme",
   "keywords": [
-    "emotion",
     "gatsby",
-    "gatsby-plugin"
+    "gatsby-plugin",
+    "emotion",
+    "css-in-js"
   ],
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
This is a simple no-op change that will cause a new release of `gatsby-plugin-emotion` to get out.

In [this comment](https://github.com/gatsbyjs/gatsby/pull/10500#issuecomment-448723473) we can see that additional assets (e.g. `gatsby-ssr.js`) made their way into the deploy, which means that the plugin functionality is changed.

There's a few other ways we could solve this, e.g.

- Using the `files` array to limit what files are published (but this could cause further errors in the future that are easy to miss)
- Adding a `clean` step run before `bootstrap` that will wipe out any built files

I can work on integrating those, but for now, we should get `4.0.1` published with a clean deploy.