### PR TITLE
Gracefully scale down starter/showcase content header

### DIFF
--- a/www/src/views/shared/sidebar.js
+++ b/www/src/views/shared/sidebar.js
@@ -26,8 +26,10 @@ export const ContentContainer = ({ children }) => (
   <div css={{ width: `100%` }}>{children}</div>
 )
 
-export const ContentHeader = ({ children }) => (
-  <div css={{ ...styles.contentHeader, ...styles.sticky }}>{children}</div>
+export const ContentHeader = ({ children, cssOverrides = {} }) => (
+  <div css={{ ...styles.contentHeader, ...styles.sticky, ...cssOverrides }}>
+    {children}
+  </div>
 )
 
 export const ContentTitle = ({

--- a/www/src/views/shared/styles.js
+++ b/www/src/views/shared/styles.js
@@ -246,16 +246,11 @@ const styles = {
     display: `flex`,
     flexDirection: `row`,
     flexWrap: `wrap`,
-    height: `6rem`,
+    height: presets.headerHeight,
     justifyContent: `space-between`,
     paddingLeft: `${rhythm(3 / 4)}`,
     paddingRight: `${rhythm(3 / 4)}`,
-    paddingTop: `${rhythm(3 / 4)}`,
     zIndex: 1,
-    [presets.Phablet]: {
-      height: presets.headerHeight,
-      paddingTop: `0px`,
-    },
   },
   contentTitle: {
     color: colors.gatsby,

--- a/www/src/views/shared/styles.js
+++ b/www/src/views/shared/styles.js
@@ -245,11 +245,17 @@ const styles = {
     borderBottom: `1px solid ${colors.ui.light}`,
     display: `flex`,
     flexDirection: `row`,
-    height: presets.headerHeight,
+    flexWrap: `wrap`,
+    height: `6rem`,
     justifyContent: `space-between`,
     paddingLeft: `${rhythm(3 / 4)}`,
     paddingRight: `${rhythm(3 / 4)}`,
+    paddingTop: `${rhythm(3 / 4)}`,
     zIndex: 1,
+    [presets.Phablet]: {
+      height: presets.headerHeight,
+      paddingTop: `0px`,
+    },
   },
   contentTitle: {
     color: colors.gatsby,

--- a/www/src/views/shared/styles.js
+++ b/www/src/views/shared/styles.js
@@ -246,6 +246,7 @@ const styles = {
     display: `flex`,
     flexDirection: `row`,
     height: presets.headerHeight,
+    justifyContent: `space-between`,
     paddingLeft: `${rhythm(3 / 4)}`,
     paddingRight: `${rhythm(3 / 4)}`,
     zIndex: 1,

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -213,7 +213,7 @@ export default class FilteredStarterLibrary extends Component {
                     paddingLeft: rhythm(1),
                     width: rhythm(6),
                     ":focus": {
-                      outline: 0,
+                      outline: `${colors.wisteria} solid thin`,
                       backgroundColor: colors.ui.light,
                       borderRadius: presets.radiusLg,
                       transition: `width ${presets.animation.speedDefault} ${

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -155,7 +155,16 @@ export default class FilteredStarterLibrary extends Component {
           </SidebarBody>
         </SidebarContainer>
         <ContentContainer>
-          <ContentHeader>
+          <ContentHeader
+            cssOverrides={{
+              height: `6rem`,
+              paddingTop: `${rhythm(3 / 4)}`,
+              [presets.Phablet]: {
+                height: presets.headerHeight,
+                paddingTop: `0px`,
+              },
+            }}
+          >
             <ContentTitle
               search={urlState.s}
               filters={filters}
@@ -170,7 +179,6 @@ export default class FilteredStarterLibrary extends Component {
                 display: `flex`,
                 justifyContent: `space-between`,
                 marginBottom: `.4rem`,
-                minWidth: `270px`,
                 width: `100%`,
                 [presets.Phablet]: {
                   justifyContent: `flex-end`,

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -174,7 +174,6 @@ export default class FilteredStarterLibrary extends Component {
               what="size"
             />
             <div
-              className="wrapper"
               css={{
                 display: `flex`,
                 justifyContent: `space-between`,

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -179,6 +179,26 @@ export default class FilteredStarterLibrary extends Component {
                 },
               }}
             >
+              {/* @todo: add sorting. */}
+              <label
+                css={{
+                  display: `none`,
+                  [presets.Desktop]: {
+                    border: 0,
+                    borderRadius: presets.radiusLg,
+                    color: colors.gatsby,
+                    fontFamily: options.headerFontFamily.join(`,`),
+                    paddingTop: rhythm(1 / 8),
+                    paddingRight: rhythm(1 / 5),
+                    paddingBottom: rhythm(1 / 8),
+                    width: rhythm(5),
+                  },
+                }}
+                onClick={toggleSort}
+              >
+                <MdSort css={{ marginRight: 8 }} />
+                {urlState.sort === `recent` ? `Most recent` : `Most stars`}
+              </label>
               <label css={{ position: `relative` }}>
                 <DebounceInput
                   css={{

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -164,26 +164,21 @@ export default class FilteredStarterLibrary extends Component {
               edges={starters}
               what="size"
             />
-            <div css={{ marginLeft: `auto` }}>
-              <label
-                css={{
-                  display: `none`,
-                  [presets.Desktop]: {
-                    color: colors.gatsby,
-                    border: 0,
-                    borderRadius: presets.radiusLg,
-                    fontFamily: options.headerFontFamily.join(`,`),
-                    paddingTop: rhythm(1 / 8),
-                    paddingRight: rhythm(1 / 5),
-                    paddingBottom: rhythm(1 / 8),
-                    width: rhythm(5),
-                  },
-                }}
-                onClick={toggleSort}
-              >
-                <MdSort css={{ marginRight: 8 }} />
-                {urlState.sort === `recent` ? `Most recent` : `Most stars`}
-              </label>
+            <div
+              className="wrapper"
+              css={{
+                display: `flex`,
+                justifyContent: `space-between`,
+                marginBottom: `.4rem`,
+                minWidth: `270px`,
+                width: `100%`,
+                [presets.Phablet]: {
+                  justifyContent: `flex-end`,
+                  marginBottom: `0rem`,
+                  width: `50%`,
+                },
+              }}
+            >
               <label css={{ position: `relative` }}>
                 <DebounceInput
                   css={{
@@ -191,6 +186,7 @@ export default class FilteredStarterLibrary extends Component {
                     borderRadius: presets.radiusLg,
                     color: colors.gatsby,
                     fontFamily: options.headerFontFamily.join(`,`),
+                    marginTop: rhythm(1 / 8),
                     paddingTop: rhythm(1 / 8),
                     paddingRight: rhythm(1 / 5),
                     paddingBottom: rhythm(1 / 8),
@@ -212,32 +208,32 @@ export default class FilteredStarterLibrary extends Component {
                   placeholder="Search starters"
                   aria-label="Search starters"
                 />
-                <Button
-                  to="https://gatsbyjs.org/docs/submit-to-starter-library/"
-                  tag="href"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  small
-                  icon={<ArrowForwardIcon />}
-                  overrideCSS={{
-                    marginLeft: 10,
-                  }}
-                >
-                  Submit a Starter
-                </Button>
                 <SearchIcon
                   overrideCSS={{
                     fill: colors.lilac,
-                    position: `absolute`,
-                    left: `5px`,
-                    top: `50%`,
-                    width: `16px`,
                     height: `16px`,
+                    left: `5px`,
                     pointerEvents: `none`,
+                    position: `absolute`,
+                    top: `50%`,
                     transform: `translateY(-50%)`,
+                    width: `16px`,
                   }}
                 />
               </label>
+              <Button
+                to="https://gatsbyjs.org/docs/submit-to-starter-library/"
+                tag="href"
+                target="_blank"
+                rel="noopener noreferrer"
+                small
+                icon={<ArrowForwardIcon />}
+                overrideCSS={{
+                  marginLeft: 10,
+                }}
+              >
+                Submit a Starter
+              </Button>
             </div>
           </ContentHeader>
           <StarterList


### PR DESCRIPTION
Relates to PR #8969. @fk @Manoz -- went ahead and put something together.

* adds override styles for the starters header to scale down gracefully
* adds an outline style to the input (suggestions welcome, @fk. just shouldn't be removed.)
* generally reordered some stuff


<img width="801" alt="screen shot 2018-12-19 at 4 07 35 pm" src="https://user-images.githubusercontent.com/3461087/50251089-5790b080-03a8-11e9-979c-1dbdaa40cd47.png">

Leaves showcase header (shared) intact:

<img width="801" alt="screen shot 2018-12-19 at 4 07 11 pm" src="https://user-images.githubusercontent.com/3461087/50251097-5fe8eb80-03a8-11e9-9499-067b742c5679.png">
