### PR TITLE
fix gatsby-remark-autolink-headers scrolling on page load

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -43,7 +43,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   `
 
   const script = `
-    document.addEventListener("DOMContentLoaded", function(event) {
+    window.addEventListener("load", function(event) {
       var hash = window.decodeURI(location.hash.replace('#', ''))
       if (hash !== '') {
         var element = document.getElementById(hash)


### PR DESCRIPTION
Fixes the issue I described in https://github.com/gatsbyjs/gatsby/issues/10570!
