### PR TITLE
Fix gatsby-plugin-react-helmet for v6.0.0

### DIFF
--- a/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
+++ b/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
@@ -260,7 +260,7 @@ We'll want to create the file `src/templates/blog-post.js` (please create the
 
 ```javascript:title=src/templates/blog-post.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 // import '../css/blog-post.css'; // make it pretty!
 
@@ -302,7 +302,7 @@ specified earlier.
 
 ```javascript:title=src/templates/blog-post.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { graphql } from "gatsby"
 
 // import '../css/blog-post.css';
@@ -546,7 +546,7 @@ available within the browser and the statically generated site.
 ```javascript:title=src/pages/index.js
 import React from "react"
 import { Link, graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 // import '../css/index.css'; // add some style if you want!
 

--- a/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
+++ b/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
@@ -432,7 +432,7 @@ that Gatsby delivers the HTML page at `/admin`.
 
 ```jsx
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 const AdminPage = () => (
   <div className="admin">

--- a/docs/blog/2018-06-07-build-a-gatsby-blog-using-the-cosmic-js-source-plugin/index.md
+++ b/docs/blog/2018-06-07-build-a-gatsby-blog-using-the-cosmic-js-source-plugin/index.md
@@ -122,7 +122,7 @@ First, we want to display the list of posts on the homepage. To do so, add the f
 import React from "react"
 import { Link } from "gatsby"
 import get from "lodash/get"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import Bio from "../components/Bio"
 import { rhythm } from "../utils/typography"
@@ -211,7 +211,7 @@ Create the template at `src/templates/blog-post.js`:
 
 ```javascript
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { Link } from "gatsby"
 import get from "lodash/get"
 

--- a/docs/docs/add-seo-component.md
+++ b/docs/docs/add-seo-component.md
@@ -30,7 +30,7 @@ Create a new component with this initial boilerplate:
 
 ```jsx:title=src/components/SEO.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import PropTypes from "prop-types"
 import { StaticQuery, graphql } from "gatsby"
 
@@ -124,7 +124,7 @@ The last step is to return this data with the help of `Helmet`. Your complete SE
 
 ```jsx:title=src/components/SEO.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import PropTypes from "prop-types"
 import { StaticQuery, graphql } from "gatsby"
 

--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -241,7 +241,7 @@ import PropTypes from "prop-types"
 import kebabCase from "lodash/kebabCase"
 
 // Components
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { Link, graphql } from "gatsby"
 
 const TagsPage = ({

--- a/docs/docs/authentication-tutorial.md
+++ b/docs/docs/authentication-tutorial.md
@@ -65,7 +65,7 @@ And edit the layout component to include it:
 ```jsx:title=src/components/layout.js
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { StaticQuery, graphql } from "gatsby"
 
 import Header from "./header"

--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -215,7 +215,7 @@ Replacing a layout's query with `StaticQuery`:
 
 ```diff:title=src/components/layout.js
 import React, { Fragment } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 + import { StaticQuery, graphql } from "gatsby"
 
 - export default ({ children, data }) => (

--- a/e2e-tests/gatsby-image/src/components/layout.js
+++ b/e2e-tests/gatsby-image/src/components/layout.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
+import { Helmet } from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
 
 import Header from './header'

--- a/e2e-tests/path-prefix/src/components/layout.js
+++ b/e2e-tests/path-prefix/src/components/layout.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
+import { Helmet } from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
 
 import Header from './header'

--- a/e2e-tests/production-runtime/src/components/layout.js
+++ b/e2e-tests/production-runtime/src/components/layout.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
+import { Helmet } from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
 
 import Header from './header'

--- a/examples/simple-auth/src/components/Layout/index.js
+++ b/examples/simple-auth/src/components/Layout/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import Header from "../Header"
 

--- a/examples/using-cxs/src/pages/index.js
+++ b/examples/using-cxs/src/pages/index.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import cxs from "cxs"
 
 // Create a Title component that'll render an <h1> tag with some styles

--- a/examples/using-emotion-prismjs/src/components/layout.js
+++ b/examples/using-emotion-prismjs/src/components/layout.js
@@ -2,7 +2,7 @@ import React, { Fragment } from "react"
 import { Link, StaticQuery, graphql } from "gatsby"
 import PropTypes from "prop-types"
 import { css } from "react-emotion"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import { rhythm } from "../utils/typography"
 import "../prism-styles"

--- a/examples/using-emotion/src/pages/index.js
+++ b/examples/using-emotion/src/pages/index.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import styled from "@emotion/styled"
 import { css, Global } from "@emotion/core"
 

--- a/examples/using-faker/src/layouts/index.js
+++ b/examples/using-faker/src/layouts/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { Link, graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import "./index.css"
 

--- a/examples/using-javascript-transforms/src/components/HelmetBlock/index.js
+++ b/examples/using-javascript-transforms/src/components/HelmetBlock/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import moment from "moment"
 
 class HelmetBlock extends React.Component {

--- a/examples/using-javascript-transforms/src/components/Layouts/master.js
+++ b/examples/using-javascript-transforms/src/components/Layouts/master.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import "../../static/css/base.scss"
 
 class MasterLayout extends React.Component {

--- a/examples/using-jest/src/components/layout.js
+++ b/examples/using-jest/src/components/layout.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
+import { Helmet } from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
 
 import Header from './header'

--- a/examples/using-mongodb/src/layouts/index.js
+++ b/examples/using-mongodb/src/layouts/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 class DefaultLayout extends React.Component {
   render() {

--- a/examples/using-page-transitions/src/layouts/index.js
+++ b/examples/using-page-transitions/src/layouts/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import Transition from "../components/transition"
 
 import "./layout.css"

--- a/examples/using-prefetching-preloading-modules/src/pages/index.js
+++ b/examples/using-prefetching-preloading-modules/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import styled from "styled-components"
 import DynamicComponent from "../components/DynamicComponent"
 import "./style.css"

--- a/examples/using-redirects/src/components/layout.js
+++ b/examples/using-redirects/src/components/layout.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import "./layout.css"
 import "./selected.css"

--- a/examples/using-remark-copy-linked-files/src/pages/index.js
+++ b/examples/using-remark-copy-linked-files/src/pages/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
 import get from "lodash/get"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import Bio from "../components/Bio"

--- a/examples/using-remark-copy-linked-files/src/templates/blog-post.js
+++ b/examples/using-remark-copy-linked-files/src/templates/blog-post.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { graphql } from "gatsby"
 import get from "lodash/get"
 

--- a/examples/using-styled-components/src/pages/index.js
+++ b/examples/using-styled-components/src/pages/index.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import styled, { createGlobalStyle } from "styled-components"
 
 const GlobalStyle = createGlobalStyle`

--- a/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
@@ -1,9 +1,10 @@
 import { Helmet } from "react-helmet"
 
-exports.onRenderBody = (
-  { setHeadComponents, setHtmlAttributes, setBodyAttributes },
-  pluginOptions
-) => {
+exports.onRenderBody = ({
+  setHeadComponents,
+  setHtmlAttributes,
+  setBodyAttributes,
+}) => {
   const helmet = Helmet.renderStatic()
   // These action functions were added partway through the Gatsby 1.x cycle.
   if (setHtmlAttributes) {

--- a/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
@@ -1,4 +1,4 @@
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 exports.onRenderBody = (
   { setHeadComponents, setHtmlAttributes, setBodyAttributes },

--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -73,7 +73,7 @@ exports.replaceRenderer = true
  * is merged with other body props and passed to `html.js` as `bodyProps`.
  * @param {Object} pluginOptions
  * @example
- * const Helmet = require("react-helmet")
+ * const { Helmet } = require("react-helmet")
  *
  * exports.onRenderBody = (
  *   { setHeadComponents, setHtmlAttributes, setBodyAttributes },

--- a/www/src/components/layout/layout-with-heading.js
+++ b/www/src/components/layout/layout-with-heading.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { SkipNavLink } from "@reach/skip-nav"
 import { OutboundLink } from "gatsby-plugin-google-analytics"
 import styled from "react-emotion"

--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import { Link } from "gatsby"
 import { colors } from "../utils/presets"

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import url from "url"
 import Img from "gatsby-image"
 import qs from "qs"

--- a/www/src/components/site-metadata.js
+++ b/www/src/components/site-metadata.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { graphql, StaticQuery } from "gatsby"
 
 import gatsbyIcon from "../assets/gatsby-icon.png"

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -6,7 +6,7 @@ import { graphql } from "gatsby"
 import kebabCase from "lodash/kebabCase"
 
 // Components
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { Link } from "gatsby"
 import Layout from "../../components/layout"
 import Container from "../../components/container"

--- a/www/src/pages/docs/actions.js
+++ b/www/src/pages/docs/actions.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import sortBy from "lodash/sortBy"
 
 import Functions from "../../components/function-list"

--- a/www/src/pages/docs/browser-apis.js
+++ b/www/src/pages/docs/browser-apis.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import sortBy from "lodash/sortBy"
 
 import Functions from "../../components/function-list"

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import Layout from "../../components/layout"
 import { itemListDocs } from "../../utils/sidebar/item-list"

--- a/www/src/pages/docs/node-apis.js
+++ b/www/src/pages/docs/node-apis.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import sortBy from "lodash/sortBy"
 
 import Functions from "../../components/function-list"

--- a/www/src/pages/docs/ssr-apis.js
+++ b/www/src/pages/docs/ssr-apis.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import sortBy from "lodash/sortBy"
 
 import Functions from "../../components/function-list"

--- a/www/src/pages/features.js
+++ b/www/src/pages/features.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react"
 import { graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import EvaluationTable from "../components/evaluation-table"

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import Layout from "../components/layout"
 import presets, { colors } from "../utils/presets"
 import { rhythm } from "../utils/typography"

--- a/www/src/pages/newsletter.js
+++ b/www/src/pages/newsletter.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { rhythm } from "../utils/typography"
 import { colors } from "../utils/presets"
 

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import Container from "../components/container"

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { Link, graphql } from "gatsby"
 import rehypeReact from "rehype-react"
 import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react"
 import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import typography, { rhythm, scale, options } from "../utils/typography"
 import Img from "gatsby-image"
 import CreatorsHeader from "../views/creators/creators-header"

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { graphql } from "gatsby"
 
 import Layout from "../components/layout"

--- a/www/src/templates/template-starter-page.js
+++ b/www/src/templates/template-starter-page.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { graphql } from "gatsby"
 
 import Layout from "../components/layout"

--- a/www/src/views/creators/index.js
+++ b/www/src/views/creators/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import typography, { rhythm, scale } from "../../utils/typography"
 import Layout from "../../components/layout"
 import CreatorsHeader from "./creators-header"

--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 import FeaturedSites from "./featured-sites"
 import FilteredShowcase from "./filtered-showcase"

--- a/www/src/views/starter-library/index.js
+++ b/www/src/views/starter-library/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import Layout from "../../components/layout"
 import Unbird from "../../components/unbird"
 import RRSM from "../../utils/reach-router-state-manager"


### PR DESCRIPTION
## Description

In version 6.0.0 of react-helmet, the default export has been removed. There is now only a named export, e.g.

```
import { Helmet } from 'react-helmet';
```

In v5.x.x, both a default export and named are exported. Change is here:

https://github.com/nfl/react-helmet/commit/20ea3858f503ec521ad5b1facdac5816a0019317#diff-cc54072daf5278847980b841520c8fffL287

This is a backwards compatible change. v5 has an annoying bug (https://github.com/nfl/react-helmet/issues/373) which v6 seems to fix. 
