### PR TITLE
Fix broken Gatsby Starters link

### DIFF
--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -173,4 +173,4 @@ Check out tutorials listed on the [Awesome Gatsby](/docs/awesome-gatsby/#gatsby-
 
 ## Gatsby markdown starters
 
-There are a number of [Gatsby starters](/starters/) that come preconfigured to work with markdown.
+There are a number of [Gatsby starters](/starters?c=Markdown) that come preconfigured to work with markdown.

--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -173,4 +173,4 @@ Check out tutorials listed on the [Awesome Gatsby](/docs/awesome-gatsby/#gatsby-
 
 ## Gatsby markdown starters
 
-There are a number of [Gatsby starters](/docs/gatsby-starters/) that come preconfigured to work with markdown.
+There are a number of [Gatsby starters](/starters/) that come preconfigured to work with markdown.


### PR DESCRIPTION
## Description
Updates broken Gatsby Starters link in "Adding Markdown Pages" docs to new route.


