### PR TITLE
chore: use top level (e.g. monorepo) commit message instead of starter

### DIFF
--- a/scripts/clone-folder.sh
+++ b/scripts/clone-folder.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 FOLDER=$1
 BASE=$(pwd)
+COMMIT_MESSAGE=$(git log -1 --pretty=%B)
 
 for folder in $FOLDER/*; do
   [ -d "$folder" ] || continue # only directories
@@ -9,12 +10,15 @@ for folder in $FOLDER/*; do
   NAME=$(cat $folder/package.json | jq -r '.name')
   CLONE_DIR="__${NAME}__clone__"
 
+  # clone, delete files in the clone, and copy (new) files over
+  # this handles file deletions, additions, and changes seamlessly
   git clone --depth 1 https://$GITHUB_API_TOKEN@github.com/gatsbyjs/$NAME.git $CLONE_DIR
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   cp -r $BASE/$folder/. . # copy all content
   git add .
-  git commit --message "$(git log -1 --pretty=%B)"
+  git commit --message "$COMMIT_MESSAGE"
   git push origin master
+
   cd $BASE
 done


### PR DESCRIPTION
## Description

Quick fix for using the correct commit message when pushing to the read-only cloned starters.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
