### PR TITLE
fix(gatsby): fix eventemitter leak in page query runner

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -162,9 +162,11 @@ const runQueriesForPathnames = pathnames => {
   }
 
   return new Promise(resolve => {
-    queue.on(`drain`, () => {
+    const onDrain = () => {
+      queue.off(`drain`, onDrain)
       resolve()
-    })
+    }
+    queue.on(`drain`, onDrain)
   })
 }
 


### PR DESCRIPTION
## Description

The query queue can fire the `drain` event multiple times, and the page query runner listens for the drain event and resolves a promise once it does. When this happens, it doesn't currently clear the resolve event handler from the queue emitter.

This PR fixes that by simply unsubscribing once the drain event is fired.

I think this may properly fix #5510