### PR TITLE
fix(gatsby-plugin-sitemap): add missing dependency pify and minimatch

### DIFF
--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
+    "pify": "^3.0.0",
     "sitemap": "^1.12.0"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
+    "minimatch": "^3.0.4",
     "pify": "^3.0.0",
     "sitemap": "^1.12.0"
   },


### PR DESCRIPTION
## Description

The npm module `pify` is required inside the `gatsby-plugin-sitemap` but not added as a dependency. It is implicitly required by the installation of the dependencies of `gatsby-plugin-feed`, therefore nothing fails until a strict module handling is used, e.g. by pnpm.

Therefore I added it to the `package.json` of `gatsby-plugin-sitemap` to fix this.
