### PR TITLE
fix: support cjs modules when loading typography config

### DIFF
--- a/packages/gatsby-plugin-typography/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-browser.js
@@ -10,7 +10,8 @@ if (process.env.BUILD_STAGE === `develop`) {
   React = require(`react`)
   GoogleFont = require(`react-typography`).GoogleFont
   // typography links to the file set in "pathToConfigModule"
-  typography = require(`./.cache/typography.js`).default
+  const typographyConfig = require(`./.cache/typography.js`)
+  typography = typographyConfig.default || typographyConfig
 
   exports.onClientEntry = () => {
     // Inject the CSS Styles


### PR DESCRIPTION
## Description

After PR #10545 typography is loaded using `require(...).default`:
https://github.com/gatsbyjs/gatsby/blob/93bf83b94f603388dc1b97bbfa674ce5e89bb546/packages/gatsby-plugin-typography/src/gatsby-browser.js#L12-L13
It works with custom configs (which are ES6 modules), but it doesn't work with CommonJS modules.
Default config uses CommonJS export:
https://github.com/gatsbyjs/gatsby/blob/93bf83b94f603388dc1b97bbfa674ce5e89bb546/packages/gatsby-plugin-typography/src/gatsby-node.js#L19-L23
This is why `typography` is not properly loaded and page crashes on load when using default config.

## Related Issues

Fixes #10609