### PR TITLE
fix(query-runner): replace .off with .removeListener

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -163,7 +163,7 @@ const runQueriesForPathnames = pathnames => {
 
   return new Promise(resolve => {
     const onDrain = () => {
-      queue.off(`drain`, onDrain)
+      queue.removeListener(`drain`, onDrain)
       resolve()
     }
     queue.on(`drain`, onDrain)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This fixes a bug introduced in #10593 by replacing the `.off` call with `.removeListener`. `.off` was introduced in Node v10.0.0 as an alias for `.removeListener` (https://github.com/nodejs/node/pull/17156).

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Related to #10612