### PR TITLE
Update gatsby-plugin-layout README

### DIFF
--- a/packages/gatsby-plugin-layout/README.md
+++ b/packages/gatsby-plugin-layout/README.md
@@ -46,6 +46,8 @@ module.exports = {
 ];
 ```
 
+Once the plugin is added, you don't need to manually wrap your pages with the Layout component. The plugin does this automatically.
+
 ## Why would you want to reimplement the V1 layout behavior?
 
 There are a few scenarios where it makes sense to reimplement the V1 layout handling:


### PR DESCRIPTION
It is not clear whether there is a need to wrap pages manually with Layout or not when using the plugin as seen in #10551

This adds a point clearing this up