### PR TITLE
Changing backticks to single quotes

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -114,7 +114,7 @@ Copy the following into `gatsby-config.js`
 
 ```javascript:title=gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-plugin-typography`],
+  plugins: ['gatsby-plugin-typography'],
 }
 ```
 
@@ -174,7 +174,7 @@ in the middle of the page. To create this, add the following styles to the
 import React from "react"
 
 export default () => (
-  <div style={{ margin: `3rem auto`, maxWidth: 600 }}>
+  <div style={{ margin: '3rem auto', maxWidth: 600 }}>
     {" "}
     {/* highlight-line */}
     <h1>Richard Hamming on Luck</h1>
@@ -229,9 +229,9 @@ module.exports = {
   // highlight-start
   plugins: [
     {
-      resolve: `gatsby-plugin-typography`,
+      resolve: 'gatsby-plugin-typography',
       options: {
-        pathToConfigModule: `src/utils/typography.js`,
+        pathToConfigModule: 'src/utils/typography.js',
       },
     },
   ],


### PR DESCRIPTION
Some of the code samples had backticks where there should have been single quotes.

## Description

I've modified this tutorial page to correct all the instances I could find. Here is an example of one such area:

```js
plugins: [
    {
      resolve: `gatsby-plugin-typography`,
      options: {
        pathToConfigModule: `src/utils/typography.js`,
      },
    },
  ],
```

I've corrected things like ```resolve: `gatsby-plugin-typography`,``` in the above example to `resolve: 'gatsby-plugin-typography',`.

Let me know if you have any questions.

