### PR TITLE
fix: don't use EnsureResources for development 404 page

### DIFF
--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -64,27 +64,27 @@ class RouteHandler extends React.Component {
       )
     } else {
       const dev404Page = pages.find(p => /^\/dev-404-page\/?$/.test(p.path))
-      const custom404 = locationAndPageResources =>
-        loader.getPage(`/404.html`) ? (
-          <JSONStore
-            pages={pages}
-            {...this.props}
-            {...locationAndPageResources}
-          />
-        ) : null
+      const Dev404Page = syncRequires.components[dev404Page.componentChunkName]
+
+      if (!loader.getPage(`/404.html`)) {
+        return <Dev404Page pages={pages} {...this.props} />
+      }
 
       return (
         <EnsureResources location={location}>
-          {locationAndPageResources =>
-            createElement(
-              syncRequires.components[dev404Page.componentChunkName],
-              {
-                pages,
-                custom404: custom404(locationAndPageResources),
-                ...this.props,
+          {locationAndPageResources => (
+            <Dev404Page
+              pages={pages}
+              custom404={
+                <JSONStore
+                  pages={pages}
+                  {...this.props}
+                  {...locationAndPageResources}
+                />
               }
-            )
-          }
+              {...this.props}
+            />
+          )}
         </EnsureResources>
       )
     }


### PR DESCRIPTION
## Description

After PR #10224 `EnsureResources` throws if there are no resources available for a route. It won't throw if there is custom 404 page (in that case `hasResources` will return `true` as it will load a 404 page resource).

This PR checks if custom 404 page exists and if it doesn't `EnsureResources` won't be used (there isn't anything to load). If we hit 404 page and custom 404 page exists we continue using `EnsureResources` to make sure it loads properly.

## Related Issues

Fixes #10534
Fixes #10645