### PR TITLE
Fix highlighting the line in the first part of the tutorial

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -90,8 +90,7 @@ export default () => (
   <div style={{ color: `purple` }}>
     <h1>Hello Gatsby!</h1>
     <p>What a world.</p>
-    <img src="https://source.unsplash.com/random/400x200" alt="" />{" "}
-    {/* highlight-next-line */}
+    <img src="https://source.unsplash.com/random/400x200" alt="" /> {/* highlight-line */}
   </div>
 )
 ```


### PR DESCRIPTION
## Description
Fixes highlighting the line and removes unnecessary symbols in the first part of the tutorial

![image](https://user-images.githubusercontent.com/20713191/50380751-37583e80-0693-11e9-9feb-45ee1ffeebc3.png)