### PR TITLE
Change class names configurations

### DIFF
--- a/packages/gatsby-remark-custom-blocks/README.md
+++ b/packages/gatsby-remark-custom-blocks/README.md
@@ -33,10 +33,10 @@ plugins: [
           options: {
             blocks: {
               danger: {
-                classes: "custom-block-danger",
+                classes: "danger",
               },
               info: {
-                classes: "custom-block-info",
+                classes: "info",
                 title: "optional",
               },
             },
@@ -86,7 +86,7 @@ Here is an example configuration for using details:
 ```javascript
   blocks: {
     danger: {
-      classes: "custom-block-danger",
+      classes: "danger",
       details: true,
     },
     info: {


### PR DESCRIPTION
## Description

In [`gatsby-remark-custom-blocks`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks) docs outputed class names are wrong, because if we set this:
```js
options: {
  blocks: {
    danger: {
      classes: "custom-block-danger"
    // ...
}
```
we will get classes in html: `custom-block custom-block-danger` and not `custom-block-danger` only as in docs.

This PR fix the confusion
