### PR TITLE
Highlight-line on wrong line for tutorial part seven

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -73,8 +73,7 @@ the "node graph" to its _parent_ `File` node, as `File` nodes contain data you
 need about files on disk. To do that, modify your function again:
 
 ```javascript:title=gatsby-node.js
-exports.onCreateNode = ({ node, getNode }) => {
-  // highlight-line
+exports.onCreateNode = ({ node, getNode }) => { // highlight-line
   if (node.internal.type === `MarkdownRemark`) {
     // highlight-start
     const fileNode = getNode(node.parent)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The hightlight-line comment is on the wrong line at line 77 and should be on line 76. Therefore, it is not showing the highlight of the new getNode function introduced as a parameter to the onCreateNode function.

Screenshot from tutorial on part seven:
<img width="753" alt="screen shot 2018-12-23 at 12 49 14 pm" src="https://user-images.githubusercontent.com/9094342/50386304-1226f880-06b2-11e9-98f2-444bdc859db7.png">

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
