### PR TITLE
chore: remove unused parameter handlers

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -271,7 +271,7 @@ function isLocalGatsbySite() {
   return inGatsbySite
 }
 
-module.exports = (argv, handlers) => {
+module.exports = argv => {
   let cli = yargs()
   let isLocalSite = isLocalGatsbySite()
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
If I'm not wrong, the parameter `handlers` seems to be useless here since it hasn't been called in the whole project.
## Description

<!-- Write a brief description of the changes introduced by this PR -->
Remove useless parameter `handlers`
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
