### PR TITLE
Add Built with Gatsby footer to blog and default starter

### DIFF
--- a/starters/blog/src/components/Layout.js
+++ b/starters/blog/src/components/Layout.js
@@ -63,6 +63,9 @@ class Layout extends React.Component {
       >
         {header}
         {children}
+        <footer>
+          © 2018, Built with <a href="www.gatsbyjs.org">Gatsby</a>
+        </footer>
       </div>
     )
   }

--- a/starters/default/src/components/layout.js
+++ b/starters/default/src/components/layout.js
@@ -28,6 +28,9 @@ const Layout = ({ children }) => (
           }}
         >
           {children}
+          <footer>
+            © 2018, Built with <a href="www.gatsbyjs.org">Gatsby</a>
+          </footer>
         </div>
       </>
     )}


### PR DESCRIPTION
Left this out of the hello world starter because it is (and ought to be) as minimal as possible. We might want to style the text a little better before merging this in. 