### PR TITLE
fix(gatsby): wrap dev 404 component with route update

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -25,10 +25,7 @@ describe(`navigation`, () => {
     cy.location(`pathname`).should(`equal`, `/`)
   })
 
-  /*
-   * Browser API onRouteUpdate is not triggered on a 404
-   */
-  it.skip(`displays 404 page on broken link`, () => {
+  it(`displays 404 page on broken link`, () => {
     cy.getTestElement(`broken-link`)
       .click()
       .waitForAPI(`onRouteUpdate`)

--- a/e2e-tests/development-runtime/cypress/integration/page-not-found/404.js
+++ b/e2e-tests/development-runtime/cypress/integration/page-not-found/404.js
@@ -7,10 +7,10 @@ describe(`page not found`, () => {
       .invoke(`text`)
       .should(`eq`, `Gatsby.js development 404 page`)
   })
-  it.skip(`can preview 404 page`, () => {
+  it(`can preview 404 page`, () => {
     cy.get(`button`).click()
 
-    cy.get(`h1`)
+    cy.getTestElement(`page-title`)
       .invoke(`text`)
       .should(`eq`, `NOT FOUND`)
   })

--- a/e2e-tests/development-runtime/src/pages/404.js
+++ b/e2e-tests/development-runtime/src/pages/404.js
@@ -6,7 +6,7 @@ import SEO from "../components/seo"
 const NotFoundPage = () => (
   <Layout>
     <SEO title="404: Not found" />
-    <h1>NOT FOUND</h1>
+    <h1 data-testid="page-title">NOT FOUND</h1>
     <p>You just hit a route that does not exist... the sadness.</p>
   </Layout>
 )

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -67,23 +67,29 @@ class RouteHandler extends React.Component {
       const Dev404Page = syncRequires.components[dev404Page.componentChunkName]
 
       if (!loader.getPage(`/404.html`)) {
-        return <Dev404Page pages={pages} {...this.props} />
+        return (
+          <RouteUpdates location={location}>
+            <Dev404Page pages={pages} {...this.props} />
+          </RouteUpdates>
+        )
       }
 
       return (
         <EnsureResources location={location}>
           {locationAndPageResources => (
-            <Dev404Page
-              pages={pages}
-              custom404={
-                <JSONStore
-                  pages={pages}
-                  {...this.props}
-                  {...locationAndPageResources}
-                />
-              }
-              {...this.props}
-            />
+            <RouteUpdates location={location}>
+              <Dev404Page
+                pages={pages}
+                custom404={
+                  <JSONStore
+                    pages={pages}
+                    {...this.props}
+                    {...locationAndPageResources}
+                  />
+                }
+                {...this.props}
+              />
+            </RouteUpdates>
           )}
         </EnsureResources>
       )


### PR DESCRIPTION
We weren't able to catch the regression in #10534 because a test asserting this behaviour was marked as skipped—`onRouteUpdate` does not get called when navigating to a non-existent page making it difficult to test

This PR wraps the `Dev404Page` fallback component with `RouteUpdates` in `root` making it easier to test and adds back the following skipped tests:
- clicking on a broken link displays 404 page
- can preview 404 page in dev 404 page

Only the development runtime is affected by the change above 