### PR TITLE
Fix Built with Gatsby footer link in blog and default starter

### DIFF
--- a/starters/blog/src/components/Layout.js
+++ b/starters/blog/src/components/Layout.js
@@ -64,7 +64,7 @@ class Layout extends React.Component {
         {header}
         {children}
         <footer>
-          © 2018, Built with <a href="www.gatsbyjs.org">Gatsby</a>
+          © 2018, Built with <a href="https://www.gatsbyjs.org">Gatsby</a>
         </footer>
       </div>
     )

--- a/starters/default/src/components/layout.js
+++ b/starters/default/src/components/layout.js
@@ -29,7 +29,7 @@ const Layout = ({ children }) => (
         >
           {children}
           <footer>
-            © 2018, Built with <a href="www.gatsbyjs.org">Gatsby</a>
+            © 2018, Built with <a href="https://www.gatsbyjs.org">Gatsby</a>
           </footer>
         </div>
       </>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

https://github.com/gatsbyjs/gatsby/pull/10642 added the Built with Gatsby footer, but it incorrectly linked to `/www.gatsbyjs.org` instead of `https://www.gatsbyjs.org`. This PR fixes the issue.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
