### PR TITLE
Title and thumbnail of Starter card route to same place

### DIFF
--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -62,7 +62,6 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
             owner,
             slug,
             stars,
-            stub,
           } = starter.fields.starterShowcase
           const { url: demoUrl } = starter
 

--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -109,7 +109,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                     </span>
                   </div>
                   <div>
-                    <Link to={`/starters/${stub}`}>
+                    <Link to={`/starters${slug}`}>
                       <h5 css={{ margin: 0 }}>
                         <strong className="title">{name}</strong>
                       </h5>


### PR DESCRIPTION
## Description

Previously, the title of a Starter card would incorrectly route to `starters/${name}`, when it should be `starters/${author}/${name}`, which would result in a 404 page; the thumbnail does correctly route to the starter's page, so this would make the title copy its behavior.

## Related Issues
