### PR TITLE
Make docs sidebar more browsable

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -17,27 +17,6 @@
           link: /docs/gatsby-on-windows/
         - title: Gatsby on Linux
           link: /docs/gatsby-on-linux/
-    - title: Deploying & hosting
-      link: /docs/deploying-and-hosting/
-      items:
-        - title: Preparing your site for deployment*
-          link: /docs/preparing-for-deployment/
-        - title: Deploying to S3 and CloudFront
-          link: /docs/deploying-to-s3-cloudfront
-        - title: Deploying to Aerobatic
-          link: /docs/deploying-to-aerobatic/
-        - title: Deploying to Heroku
-          link: /docs/deploying-to-heroku/
-        - title: Deploying to Now
-          link: /docs/deploying-to-now/
-        - title: Deploying to GitLab Pages
-          link: /docs/deploying-to-gitlab-pages/
-        - title: Hosting on Netlify
-          link: /docs/hosting-on-netlify
-        - title: Path Prefix
-          link: /docs/path-prefix/
-        - title: How Gatsby works with GitHub pages
-          link: /docs/how-gatsby-works-with-github-pages/
     - title: Custom configuration
       link: /docs/customization/
       items:
@@ -87,11 +66,9 @@
           link: /docs/sourcing-from-saas-services/
         - title: Sourcing from private APIs*
           link: /docs/sourcing-from-private-apis/
-        - title: Headless CMS
+        - title: Sourcing fom (headless) CMSs
           link: /docs/headless-cms/
           items:
-            - title: Sourcing from Netlify CMS
-              link: /docs/sourcing-from-netlify-cms/
             - title: Sourcing from WordPress
               link: /docs/sourcing-from-wordpress/
             - title: Sourcing from Drupal
@@ -100,6 +77,8 @@
               link: /docs/sourcing-from-contentful/
             - title: Sourcing from Prismic
               link: /docs/sourcing-from-prismic/
+            - title: Sourcing from Netlify CMS
+              link: /docs/sourcing-from-netlify-cms/
     - title: Querying your data with GraphQL
       link: /docs/graphql/
       items:
@@ -141,7 +120,7 @@
       items:
         - title: Create a Starter*
           link: /docs/create-a-starter/
-    - title: Styling
+    - title: Styling your site
       link: /docs/styling/
       items:
         - title: Layout Components
@@ -160,7 +139,7 @@
           link: /docs/component-css/
         - title: PostCSS
           link: /docs/post-css/
-    - title: Testing
+    - title: Adding testing
       link: /docs/testing/
       items:
         - title: Unit testing
@@ -175,7 +154,7 @@
           link: /docs/testing-react-components/
         - title: Visual testing with Storybook
           link: /docs/visual-testing-with-storybook/
-    - title: Debugging
+    - title: Debugging Gatsby
       link: /docs/debugging/
       items:
         - title: Debugging HTML builds
@@ -186,11 +165,6 @@
           link: /docs/debugging-the-build-process/
         - title: Trace Gatsby builds
           link: /docs/performance-tracing/
-    - title: Use cases with Gatsby (including apps)
-      link: /docs/building-apps-with-gatsby/
-      items:
-        - title: Building a site with authentication
-          link: /docs/building-a-site-with-authentication/
     - title: Adding website functionality
       link: /docs/adding-website-functionality/
       items:
@@ -198,6 +172,8 @@
           link: /docs/adding-search/
         - title: Adding analytics
           link: /docs/adding-analytics/
+        - title: Adding authentication
+          link: /docs/building-a-site-with-authentication/
         - title: Adding forms
           link: /docs/adding-forms/
         - title: Adding a 404 Page
@@ -225,7 +201,7 @@
               link: /docs/centralizing-your-sites-navigation/
             - title: Rendering sidebar navigation dynamically*
               link: /docs/rendering-sidebar-navigation-dynamically/
-    - title: Performance
+    - title: Improving performance
       link: /docs/performance/
       items:
         - title: Progressive web app (PWA)
@@ -246,6 +222,27 @@
           link: /docs/seo/
         - title: Optimize Prefetching with Guess.js*
           link: /docs/optimize-prefetching-with-guessjs/
+    - title: Deploying & hosting
+      link: /docs/deploying-and-hosting/
+      items:
+        - title: Preparing your site for deployment*
+          link: /docs/preparing-for-deployment/
+        - title: Deploying to S3 and CloudFront
+          link: /docs/deploying-to-s3-cloudfront
+        - title: Deploying to Aerobatic
+          link: /docs/deploying-to-aerobatic/
+        - title: Deploying to Heroku
+          link: /docs/deploying-to-heroku/
+        - title: Deploying to Now
+          link: /docs/deploying-to-now/
+        - title: Deploying to GitLab Pages
+          link: /docs/deploying-to-gitlab-pages/
+        - title: Hosting on Netlify
+          link: /docs/hosting-on-netlify
+        - title: Path Prefix
+          link: /docs/path-prefix/
+        - title: How Gatsby works with GitHub pages
+          link: /docs/how-gatsby-works-with-github-pages/
 - title: Ecosystem
   link: /ecosystem/
   items:

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -17,6 +17,27 @@
           link: /docs/gatsby-on-windows/
         - title: Gatsby on Linux
           link: /docs/gatsby-on-linux/
+    - title: Deploying & hosting
+      link: /docs/deploying-and-hosting/
+      items:
+        - title: Preparing your site for deployment*
+          link: /docs/preparing-for-deployment/
+        - title: Deploying to S3 and CloudFront
+          link: /docs/deploying-to-s3-cloudfront
+        - title: Deploying to Aerobatic
+          link: /docs/deploying-to-aerobatic/
+        - title: Deploying to Heroku
+          link: /docs/deploying-to-heroku/
+        - title: Deploying to Now
+          link: /docs/deploying-to-now/
+        - title: Deploying to GitLab Pages
+          link: /docs/deploying-to-gitlab-pages/
+        - title: Hosting on Netlify
+          link: /docs/hosting-on-netlify
+        - title: Path Prefix
+          link: /docs/path-prefix/
+        - title: How Gatsby works with GitHub pages
+          link: /docs/how-gatsby-works-with-github-pages/
     - title: Custom configuration
       link: /docs/customization/
       items:
@@ -222,27 +243,6 @@
           link: /docs/seo/
         - title: Optimize Prefetching with Guess.js*
           link: /docs/optimize-prefetching-with-guessjs/
-    - title: Deploying & hosting
-      link: /docs/deploying-and-hosting/
-      items:
-        - title: Preparing your site for deployment*
-          link: /docs/preparing-for-deployment/
-        - title: Deploying to S3 and CloudFront
-          link: /docs/deploying-to-s3-cloudfront
-        - title: Deploying to Aerobatic
-          link: /docs/deploying-to-aerobatic/
-        - title: Deploying to Heroku
-          link: /docs/deploying-to-heroku/
-        - title: Deploying to Now
-          link: /docs/deploying-to-now/
-        - title: Deploying to GitLab Pages
-          link: /docs/deploying-to-gitlab-pages/
-        - title: Hosting on Netlify
-          link: /docs/hosting-on-netlify
-        - title: Path Prefix
-          link: /docs/path-prefix/
-        - title: How Gatsby works with GitHub pages
-          link: /docs/how-gatsby-works-with-github-pages/
 - title: Ecosystem
   link: /ecosystem/
   items:


### PR DESCRIPTION
This PR:
* ~Rearranges "Deploying and hosting" to where it would logically go in the progression of site development (ie, the end)~
* Combines the "Use cases" and "website functionality" sections to simplify things
* Retitles sections to tell a story of website development & improve consistency ("Headless CMS" => "Sourcing from Headless CMS"). 