### PR TITLE
fix(www): update storybook docs to prefer Gatsby ES6 module in webpack config

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -85,6 +85,9 @@ module.exports = (baseConfig, env, defaultConfig) => {
     require.resolve("@babel/plugin-proposal-class-properties"),
   ]
 
+  // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
+  defaultConfig.resolve.mainFields = ["browser", "module", "main"]
+
   return defaultConfig
 }
 ```


### PR DESCRIPTION
The steps in the current documentation for using Storybook with Gatsby (https://www.gatsbyjs.org/docs/visual-testing-with-storybook/) don't work because importing Link from gatsby in any component breaks. 

This is because several internals get required as a result of requiring anything from the default commonjs build (which would have been tree shaken before https://github.com/gatsbyjs/gatsby/pull/9123) and eventually require a non-existent `pages.json`. 

More details are at https://github.com/gatsbyjs/gatsby/issues/10668

This pull request updates the documentation with a quick fix (setting resolve.mainFields in the storybook webpack config override thereby _preferring_ es6 gatsby over commonjs) 

Fixes https://github.com/gatsbyjs/gatsby/issues/10662