### PR TITLE
fix: correct capitalization for component imports in the blog starter

### DIFF
--- a/starters/blog/src/pages/404.js
+++ b/starters/blog/src/pages/404.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import Layout from '../components/layout'
+import Layout from '../components/Layout'
 import SEO from '../components/seo'
 
 class NotFoundPage extends React.Component {

--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Link, graphql } from 'gatsby'
 
-import Bio from '../components/bio'
-import Layout from '../components/layout'
+import Bio from '../components/Bio'
+import Layout from '../components/Layout'
 import SEO from '../components/seo'
 import { rhythm } from '../utils/typography'
 

--- a/starters/blog/src/templates/blog-post.js
+++ b/starters/blog/src/templates/blog-post.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Link, graphql } from 'gatsby'
 
-import Bio from '../components/bio'
-import Layout from '../components/layout'
+import Bio from '../components/Bio'
+import Layout from '../components/Layout'
 import SEO from '../components/seo'
 import { rhythm, scale } from '../utils/typography'
 


### PR DESCRIPTION
## Description

Using the blog starter currently fails due to the wrong capitalization being used in the file path for improts, resulting in errors such as these during build

```
These relative modules were not found:

* ../components/bio in ./src/pages/index.js, ./src/templates/blog-post.js
* ../components/layout in ./src/pages/404.js, ./src/pages/index.js and 1 other
```

This PR fixes the capitalization (changing `components/bio` to `components/Bio`) on the affected pages. 

The other starters are not affected by this problem.