### PR TITLE
fix(gatsby-plugin-sharp): bail early if sharp isn't working

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -2,11 +2,15 @@ exports.onPreInit = ({ actions, reporter }, pluginOptions) => {
   try {
     require(`sharp`)
   } catch (error) {
-    // Bail early if sharp isn't working
-    // TODO: Add link to docs
+    // Bail early if sharp isn't available
     reporter.panic(
-      `
-      "sharp" doesn't seem to have been built or installed correctly
+      reporter.stripIndent`
+        The dependency "sharp" does not seem to have been built or installed correctly.
+
+        - Try to reinstall packages and look for errors during installation
+        - Consult "sharp" installation page at http://sharp.pixelplumbing.com/en/stable/install/
+        
+        If neither of the above work, please open an issue in https://github.com/gatsbyjs/gatsby/issues
       `
     )
   }

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,20 +1,4 @@
 exports.onPreInit = ({ actions, reporter }, pluginOptions) => {
-  try {
-    require(`sharp`)
-  } catch (error) {
-    // Bail early if sharp isn't available
-    reporter.panic(
-      reporter.stripIndent`
-        The dependency "sharp" does not seem to have been built or installed correctly.
-
-        - Try to reinstall packages and look for errors during installation
-        - Consult "sharp" installation page at http://sharp.pixelplumbing.com/en/stable/install/
-        
-        If neither of the above work, please open an issue in https://github.com/gatsbyjs/gatsby/issues
-      `
-    )
-  }
-
   const { setBoundActionCreators, setPluginOptions } = require(`./index`)
 
   setBoundActionCreators(actions)

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,6 +1,55 @@
-exports.onPreInit = ({ actions, reporter }, pluginOptions) => {
-  const { setBoundActionCreators, setPluginOptions } = require(`./index`)
+const {
+  setBoundActionCreators,
+  setPluginOptions,
+  // queue: jobQueue,
+  // reportError,
+} = require(`./index`)
+// const { scheduleJob } = require(`./scheduler`)
+// let normalizedOptions = {}
 
+// const getQueueFromCache = store => {
+//   const pluginStatus = store.getState().status.plugins[`gatsby-plugin-sharp`]
+
+//   if (!pluginStatus || !pluginStatus.queue) {
+//     return new Map()
+//   }
+
+//   return new Map(pluginStatus.queue)
+// }
+
+// const saveQueueToCache = async (store, setPluginStatus, queue) => {
+//   const cachedQueue = getQueueFromCache(store)
+
+//   // merge both queues
+//   for (const [key, job] of cachedQueue) {
+//     if (!queue.has(key)) {
+//       queue.set(key, job)
+//     }
+//   }
+
+//   // JSON.stringify doesn't work on an Map so we need to convert it to an array
+//   setPluginStatus({ queue: Array.from(queue) })
+// }
+
+// const processQueue = (store, boundActionCreators, options) => {
+//   const cachedQueue = getQueueFromCache(store)
+
+//   const promises = []
+//   for (const [, job] of cachedQueue) {
+//     promises.push(scheduleJob(job, boundActionCreators, options))
+//   }
+
+//   return promises
+// }
+
+// const cleanupQueueAfterProcess = (imageJobs, setPluginStatus, reporter) =>
+//   Promise.all(imageJobs)
+//     .then(() => setPluginStatus({ queue: [] }))
+//     .catch(({ err, message }) => {
+//       reportError(message || err.message, err, reporter)
+//     })
+
+exports.onPreBootstrap = ({ actions }, pluginOptions) => {
   setBoundActionCreators(actions)
   setPluginOptions(pluginOptions)
   // normalizedOptions = setPluginOptions(pluginOptions)

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,55 +1,18 @@
-const {
-  setBoundActionCreators,
-  setPluginOptions,
-  // queue: jobQueue,
-  // reportError,
-} = require(`./index`)
-// const { scheduleJob } = require(`./scheduler`)
-// let normalizedOptions = {}
+exports.onPreInit = ({ actions, reporter }, pluginOptions) => {
+  try {
+    require(`sharp`)
+  } catch (error) {
+    // Bail early if sharp isn't working
+    // TODO: Add link to docs
+    reporter.panic(
+      `
+      "sharp" doesn't seem to have been built or installed correctly
+      `
+    )
+  }
 
-// const getQueueFromCache = store => {
-//   const pluginStatus = store.getState().status.plugins[`gatsby-plugin-sharp`]
+  const { setBoundActionCreators, setPluginOptions } = require(`./index`)
 
-//   if (!pluginStatus || !pluginStatus.queue) {
-//     return new Map()
-//   }
-
-//   return new Map(pluginStatus.queue)
-// }
-
-// const saveQueueToCache = async (store, setPluginStatus, queue) => {
-//   const cachedQueue = getQueueFromCache(store)
-
-//   // merge both queues
-//   for (const [key, job] of cachedQueue) {
-//     if (!queue.has(key)) {
-//       queue.set(key, job)
-//     }
-//   }
-
-//   // JSON.stringify doesn't work on an Map so we need to convert it to an array
-//   setPluginStatus({ queue: Array.from(queue) })
-// }
-
-// const processQueue = (store, boundActionCreators, options) => {
-//   const cachedQueue = getQueueFromCache(store)
-
-//   const promises = []
-//   for (const [, job] of cachedQueue) {
-//     promises.push(scheduleJob(job, boundActionCreators, options))
-//   }
-
-//   return promises
-// }
-
-// const cleanupQueueAfterProcess = (imageJobs, setPluginStatus, reporter) =>
-//   Promise.all(imageJobs)
-//     .then(() => setPluginStatus({ queue: [] }))
-//     .catch(({ err, message }) => {
-//       reportError(message || err.message, err, reporter)
-//     })
-
-exports.onPreBootstrap = ({ actions }, pluginOptions) => {
   setBoundActionCreators(actions)
   setPluginOptions(pluginOptions)
   // normalizedOptions = setPluginOptions(pluginOptions)

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -1,3 +1,21 @@
+try {
+  require(`sharp`)
+} catch (error) {
+  // Bail early if sharp isn't available
+  console.error(
+    `
+      The dependency "sharp" does not seem to have been built or installed correctly.
+
+      - Try to reinstall packages and look for errors during installation
+      - Consult "sharp" installation page at http://sharp.pixelplumbing.com/en/stable/install/
+      
+      If neither of the above work, please open an issue in https://github.com/gatsbyjs/gatsby/issues
+    `,
+    error
+  )
+  process.exit(1)
+}
+
 const sharp = require(`sharp`)
 const crypto = require(`crypto`)
 const imageSize = require(`probe-image-size`)

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -10,9 +10,10 @@ try {
       - Consult "sharp" installation page at http://sharp.pixelplumbing.com/en/stable/install/
       
       If neither of the above work, please open an issue in https://github.com/gatsbyjs/gatsby/issues
-    `,
-    error
+    `
   )
+  console.log()
+  console.error(error)
   process.exit(1)
 }
 

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -1,4 +1,16 @@
-const sharp = require(`sharp`)
+let sharp
+
+try {
+  sharp = require(`sharp`)
+} catch (error) {
+  // Bail early if sharp isn't working
+  reportError(
+    `Sharp doesn't seem to have been built or installed correctly`,
+    error
+  )
+  process.exit(1)
+}
+
 const crypto = require(`crypto`)
 const imageSize = require(`probe-image-size`)
 const { promisify } = require(`bluebird`)

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -1,16 +1,4 @@
-let sharp
-
-try {
-  sharp = require(`sharp`)
-} catch (error) {
-  // Bail early if sharp isn't working
-  reportError(
-    `Sharp doesn't seem to have been built or installed correctly`,
-    error
-  )
-  process.exit(1)
-}
-
+const sharp = require(`sharp`)
 const crypto = require(`crypto`)
 const imageSize = require(`probe-image-size`)
 const { promisify } = require(`bluebird`)


### PR DESCRIPTION
We've seen several issues where builds break because `gatsby-plugin-sharp` fails for some reason. 

Typically because `sharp` didn't build correctly during install like in https://github.com/gatsbyjs/gatsby/issues/10620 most likely due to an incorrect version of python

From https://github.com/nodejs/node-gyp
> python (v2.7 recommended, v3.x.x is not supported)

This PR adds a try-catch around requiring `sharp` and bails early if it fails
