### PR TITLE
fix(blog): wrap title containing colon in quotes

### DIFF
--- a/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
+++ b/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
@@ -1,5 +1,5 @@
 ---
-title: Turning the Static Dynamic: Gatsby + Netlify Functions + Netlify Identity
+title: "Turning the Static Dynamic: Gatsby + Netlify Functions + Netlify Identity"
 date: 2018-12-26
 author: swyx
 tags: ["apps"]


### PR DESCRIPTION
fixes:
```
error Error processing Markdown file /Users/misiek/dev/gatsby/docs/blog/2018-12-17-turning-the-static-dynamic/index.md:

      incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 2, column 34:
    title: Turning the Static Dynamic: Gatsby + Netlify Functions + N ...
```