### PR TITLE
chore(gatsby-cli): add Python to envinfo settings

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -227,6 +227,7 @@ function buildLocalCommands(cli, isLocalSite) {
             System: [`OS`, `CPU`, `Shell`],
             Binaries: [`Node`, `npm`, `Yarn`],
             Browsers: [`Chrome`, `Edge`, `Firefox`, `Safari`],
+            Languages: [`Python`],
             npmPackages: `gatsby*`,
             npmGlobalPackages: `gatsby*`,
           },


### PR DESCRIPTION
This adds Python to output of `gatsby info`

`gatsby-plugin-sharp` is very widely used and is included in the default starter. `sharp` uses `nodegyp` which needs `python` and according to its documentation

> v2.7 recommended, v3.x.x is not supported

We've seen several issues where building breaks due to `sharp` not working like https://github.com/gatsbyjs/gatsby/issues/10620 and https://github.com/gatsbyjs/gatsby/issues/9511

Knowing the python version in the env helps in these cases