### PR TITLE
feat(gatsby-source-contentful): Support storing assets locally

### DIFF
--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -1,0 +1,82 @@
+const ProgressBar = require('progress')
+const { createRemoteFileNode } = require('gatsby-source-filesystem')
+
+const bar = new ProgressBar(`Downloading Contentful Assets [:bar] :current/:total :elapsed secs :percent`, {
+  total: 0,
+  width: 30,
+})
+
+let totalJobs = 0
+
+/**
+ * @name downloadContentfulAssets
+ * @description Downloads Contentful assets to the local filesystem.
+ * The asset files will be downloaded and cached. Use `localFile` to link to them
+ * @param gatsbyFunctions - Gatsby's internal helper functions
+ */
+
+const downloadContentfulAssets = async (gatsbyFunctions) => {
+  const {
+    actions: { createNode, touchNode },
+    createNodeId,
+    store,
+    cache,
+    getNodes,
+  } = gatsbyFunctions
+
+  // Any ContentfulAsset nodes will be downloaded, cached and copied to public/static
+  // regardless of if you use `localFile` to link an asset or not.
+  const contentfulAssetNodes = getNodes()
+    .filter(n =>
+      (n.internal.owner === `gatsby-source-contentful`) &&
+      (n.internal.type === `ContentfulAsset`)
+    )
+
+  await Promise.all(contentfulAssetNodes.map(async node => {
+
+  totalJobs += 1
+  bar.total = totalJobs
+
+  let fileNodeID
+  const remoteDataCacheKey = `contentful-asset-${node.contentful_id}`
+  const cacheRemoteData = await cache.get(remoteDataCacheKey)
+  const url = "http://" + node.file.url.slice(2)
+
+  // Avoid downloading the asset again if it's been cached
+  // Note: Contentful Assets do not provide useful metadata
+  // to compare a modified asset to a cached version?
+  if (cacheRemoteData) {
+    fileNodeID = cacheRemoteData.fileNodeID // eslint-disable-line prefer-destructuring
+    touchNode({ nodeId: cacheRemoteData.fileNodeID })
+  }
+
+  // If we don't have cached data, download the file
+  if (!fileNodeID) {
+    try {
+      const fileNode = await createRemoteFileNode({
+        url,
+        store,
+        cache,
+        createNode,
+        createNodeId,
+      })
+
+      if (fileNode) {
+        bar.tick()
+        fileNodeID = fileNode.id
+
+        await cache.set(remoteDataCacheKey, { fileNodeID })
+      }
+    }  catch (err) {
+      // Ignore
+    }
+  }
+
+  if (fileNodeID) {
+    node.localFile___NODE = fileNodeID
+  }
+
+  return node
+  }))
+}
+exports.downloadContentfulAssets = downloadContentfulAssets

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -1,10 +1,13 @@
-const ProgressBar = require('progress')
-const { createRemoteFileNode } = require('gatsby-source-filesystem')
+const ProgressBar = require(`progress`)
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
-const bar = new ProgressBar(`Downloading Contentful Assets [:bar] :current/:total :elapsed secs :percent`, {
-  total: 0,
-  width: 30,
-})
+const bar = new ProgressBar(
+  `Downloading Contentful Assets [:bar] :current/:total :elapsed secs :percent`,
+  {
+    total: 0,
+    width: 30,
+  }
+)
 
 let totalJobs = 0
 
@@ -15,7 +18,7 @@ let totalJobs = 0
  * @param gatsbyFunctions - Gatsby's internal helper functions
  */
 
-const downloadContentfulAssets = async (gatsbyFunctions) => {
+const downloadContentfulAssets = async gatsbyFunctions => {
   const {
     actions: { createNode, touchNode },
     createNodeId,
@@ -26,57 +29,58 @@ const downloadContentfulAssets = async (gatsbyFunctions) => {
 
   // Any ContentfulAsset nodes will be downloaded, cached and copied to public/static
   // regardless of if you use `localFile` to link an asset or not.
-  const contentfulAssetNodes = getNodes()
-    .filter(n =>
-      (n.internal.owner === `gatsby-source-contentful`) &&
-      (n.internal.type === `ContentfulAsset`)
-    )
+  const contentfulAssetNodes = getNodes().filter(
+    n =>
+      n.internal.owner === `gatsby-source-contentful` &&
+      n.internal.type === `ContentfulAsset`
+  )
 
-  await Promise.all(contentfulAssetNodes.map(async node => {
+  await Promise.all(
+    contentfulAssetNodes.map(async node => {
+      totalJobs += 1
+      bar.total = totalJobs
 
-  totalJobs += 1
-  bar.total = totalJobs
+      let fileNodeID
+      const remoteDataCacheKey = `contentful-asset-${node.contentful_id}`
+      const cacheRemoteData = await cache.get(remoteDataCacheKey)
+      const url = `http://${node.file.url.slice(2)}`
 
-  let fileNodeID
-  const remoteDataCacheKey = `contentful-asset-${node.contentful_id}`
-  const cacheRemoteData = await cache.get(remoteDataCacheKey)
-  const url = "http://" + node.file.url.slice(2)
-
-  // Avoid downloading the asset again if it's been cached
-  // Note: Contentful Assets do not provide useful metadata
-  // to compare a modified asset to a cached version?
-  if (cacheRemoteData) {
-    fileNodeID = cacheRemoteData.fileNodeID // eslint-disable-line prefer-destructuring
-    touchNode({ nodeId: cacheRemoteData.fileNodeID })
-  }
-
-  // If we don't have cached data, download the file
-  if (!fileNodeID) {
-    try {
-      const fileNode = await createRemoteFileNode({
-        url,
-        store,
-        cache,
-        createNode,
-        createNodeId,
-      })
-
-      if (fileNode) {
-        bar.tick()
-        fileNodeID = fileNode.id
-
-        await cache.set(remoteDataCacheKey, { fileNodeID })
+      // Avoid downloading the asset again if it's been cached
+      // Note: Contentful Assets do not provide useful metadata
+      // to compare a modified asset to a cached version?
+      if (cacheRemoteData) {
+        fileNodeID = cacheRemoteData.fileNodeID // eslint-disable-line prefer-destructuring
+        touchNode({ nodeId: cacheRemoteData.fileNodeID })
       }
-    }  catch (err) {
-      // Ignore
-    }
-  }
 
-  if (fileNodeID) {
-    node.localFile___NODE = fileNodeID
-  }
+      // If we don't have cached data, download the file
+      if (!fileNodeID) {
+        try {
+          const fileNode = await createRemoteFileNode({
+            url,
+            store,
+            cache,
+            createNode,
+            createNodeId,
+          })
 
-  return node
-  }))
+          if (fileNode) {
+            bar.tick()
+            fileNodeID = fileNode.id
+
+            await cache.set(remoteDataCacheKey, { fileNodeID })
+          }
+        } catch (err) {
+          // Ignore
+        }
+      }
+
+      if (fileNodeID) {
+        node.localFile___NODE = fileNodeID
+      }
+
+      return node
+    })
+  )
 }
 exports.downloadContentfulAssets = downloadContentfulAssets

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -5,6 +5,7 @@ const fs = require(`fs-extra`)
 
 const normalize = require(`./normalize`)
 const fetchData = require(`./fetch`)
+const { downloadContentfulAssets } = require(`./downloadContentfulAssets`)
 
 const conflictFieldPrefix = `contentful`
 
@@ -32,7 +33,7 @@ exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`).extendNodeTyp
  */
 
 exports.sourceNodes = async (
-  { actions, getNode, getNodes, createNodeId, hasNodeChanged, store },
+  { actions, getNode, getNodes, createNodeId, hasNodeChanged, store, cache },
   options
 ) => {
   const { createNode, deleteNode, touchNode, setPluginStatus } = actions
@@ -209,6 +210,16 @@ exports.sourceNodes = async (
       locales,
     })
   })
+
+  if (options.downloadLocal) {
+    await downloadContentfulAssets({
+      actions,
+      createNodeId,
+      store,
+      cache,
+      getNodes,
+    })
+  }
 
   return
 }

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -5,7 +5,7 @@ const fs = require(`fs-extra`)
 
 const normalize = require(`./normalize`)
 const fetchData = require(`./fetch`)
-const { downloadContentfulAssets } = require(`./downloadContentfulAssets`)
+const { downloadContentfulAssets } = require(`./download-contentful-assets`)
 
 const conflictFieldPrefix = `contentful`
 


### PR DESCRIPTION
Downloads and caches Contentful Assets to the local filesystem. Useful for reduced data usage or projects where you want the assets copied locally with builds for deploying without links to Contentful CDN.

Resolves #10587 #5919