### PR TITLE
fix(gatsby): avoid full page refresh when navigating to non-existant page

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -25,13 +25,40 @@ describe(`navigation`, () => {
     cy.location(`pathname`).should(`equal`, `/`)
   })
 
-  it(`displays 404 page on broken link`, () => {
-    cy.getTestElement(`broken-link`)
-      .click()
-      .waitForAPI(`onRouteUpdate`)
+  describe(`non-existant route`, () => {
+    beforeEach(() => {
+      cy.getTestElement(`broken-link`)
+        .click()
+        .waitForAPI(`onRouteUpdate`)
+    })
 
-    cy.get(`h1`)
-      .invoke(`text`)
-      .should(`eq`, `Gatsby.js development 404 page`)
+    it(`displays 404 page on broken link`, () => {
+      cy.get(`h1`)
+        .invoke(`text`)
+        .should(`eq`, `Gatsby.js development 404 page`)
+
+      /*
+       * Two route updates:
+       * - initial render of /
+       * - (default) development 404 page
+       */
+      cy.lifecycleCallCount(`onRouteUpdate`).should(`eq`, 2)
+    })
+
+    it(`can display a custom 404 page`, () => {
+      cy.get(`button`).click()
+
+      cy.getTestElement(`page-title`)
+        .invoke(`text`)
+        .should(`eq`, `NOT FOUND`)
+
+      /*
+       * Two route updates:
+       * - initial render
+       * - 404 page
+       * a re-render does not occur because the route remains the same
+       */
+      cy.lifecycleCallCount(`onRouteUpdate`).should(`eq`, 2)
+    })
   })
 })

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -13,7 +13,12 @@ let jsonDataPaths = {}
 let fetchHistory = []
 let fetchingPageResourceMapPromise = null
 let fetchedPageResourceMap = false
-let hasPageResourceMap = false
+/**
+ * Indicate if pages manifest is loaded
+ *  - in production it is split to separate "pages-manifest" chunk that need to be lazy loaded,
+ *  - in development it is part of single "common" chunk and is available from the start.
+ */
+let hasPageResourceMap = process.env.NODE_ENV !== `production`
 let apiRunner
 const failedPaths = {}
 const MAX_HISTORY = 5
@@ -172,6 +177,15 @@ const onPostPrefetchPathname = pathname => {
   }
 }
 
+/**
+ * Check if we should fallback to resources for 404 page if resources for a page are not found
+ *
+ * We can't do that when we don't have full pages manifest - we don't know if page exist or not if we don't have it.
+ * We also can't do that on initial render / mount in case we just can't load resources needed for first page.
+ * Not falling back to 404 resources will cause "EnsureResources" component to handle scenarios like this with
+ * potential reload
+ * @param {string} path Path to a page
+ */
 const shouldFallbackTo404Resources = path =>
   (hasPageResourceMap || inInitialRender) && path !== `/404.html`
 


### PR DESCRIPTION
Currently in development there is refresh when navigating to not existing page.

This fixes regression caused by https://github.com/gatsbyjs/gatsby/pull/10507