### PR TITLE
[WIP] feature(gatsby): Log asset size on build

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -110,6 +110,7 @@
     "shallow-compare": "^1.2.2",
     "sift": "^5.1.0",
     "signal-exit": "^3.0.2",
+    "size-plugin": "^1.1.1",
     "slash": "^1.0.0",
     "socket.io": "^2.0.3",
     "string-similarity": "^1.2.0",

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -4,6 +4,7 @@ const fs = require(`fs-extra`)
 const path = require(`path`)
 const dotenv = require(`dotenv`)
 const FriendlyErrorsWebpackPlugin = require(`friendly-errors-webpack-plugin`)
+const SizePlugin = require(`size-plugin`)
 const { store } = require(`../redux`)
 const { actions } = require(`../redux/actions`)
 const debug = require(`debug`)(`gatsby:webpack-config`)
@@ -252,6 +253,7 @@ module.exports = async (
               )
             },
           },
+          new SizePlugin(),
         ])
         break
       }


### PR DESCRIPTION
This is attempt number one at fixing our oldest open issue

Added https://github.com/GoogleChromeLabs/size-plugin

![screenshot 2018-12-27 22 25 58](https://user-images.githubusercontent.com/7701981/50487988-6588a600-0a26-11e9-9f84-64ca1299a179.png)

It looks ugly however because the output from `yurnalist` and `size-plugin` is interlaced

TODO
- [ ] Make output prettier
- [ ] Add gzipped size
- [ ] Sort output by size
- [ ] Add output from sharp etc as well?

Fixes https://github.com/gatsbyjs/gatsby/issues/430