### PR TITLE
fix(docs): tweak s3/cloudfront doc to actually use s3 and cloudfront

### DIFF
--- a/docs/docs/caching.md
+++ b/docs/docs/caching.md
@@ -33,3 +33,4 @@ How you setup your caching depends on how you host your site. We encourage peopl
 The following plugins have been created:
 
 - [gatsby-plugin-netlify](/packages/gatsby-plugin-netlify/)
+- [gatsby-plugin-s3](https://github.com/jariz/gatsby-plugin-s3)

--- a/docs/docs/deploying-to-s3-cloudfront.md
+++ b/docs/docs/deploying-to-s3-cloudfront.md
@@ -2,9 +2,8 @@
 title: Deploying to S3/Cloudfront
 ---
 
-In this guide, we'll walk through how to host & publish your next Gatsby site to AWS using [S3](https://aws.amazon.com/s3/)
-
-Additionally, you can add [lambda functions](https://serverless.com/framework/docs/providers/aws/guide/functions/), [cloudfront](https://github.com/serverless/examples/tree/master/aws-node-single-page-app-via-cloudfront), and other AWS services later on as you expand.
+In this guide, we'll walk through how to host & publish your next Gatsby site to AWS using [S3](https://aws.amazon.com/s3/).
+Additionally - but very recommended - you can add CloudFront, a global CDN to make your site _even faster_.
 
 ## Getting Started - Gatsby
 
@@ -40,9 +39,9 @@ aws configure
 
 The AWS CLI will now prompt you for the key & secret, add them.
 
-## Getting Started - gatsby-plugin-s3
+## Setting up: S3
 
-Now that we have our Gatsby site up & running, let's add hosting & make the site live on AWS.
+Now that we have our Gatsby site up & running, and our AWS access sorted out: let's add hosting & make the site live on AWS.
 
 First, we'll install the Gatsby S3 plugin:
 
@@ -75,14 +74,58 @@ And finally, add the deployment script to your `package.json`:
 That's it!
 Run `npm run build && npm run deploy` to do a build and have it immediately deployed to S3!
 
-## Taking things a step further
+## Setting up: CloudFront
 
-Read on how to use the serverless framework to add lambda functions, cloudfront, and more:
+CloudFront is a global CDN and can be used to make your blazing fast Gatsby site load _even faster_, particularly for first-time visitors. Additionally, CloudFront provides the easiest way to give your S3 bucket a custom domain name and HTTPS support.
 
-- [Using serverless with gatsby-plugin-s3](https://github.com/jariz/gatsby-plugin-s3/blob/master/recipes/with-serverless.md)
+There are a couple of things that you need to consider when using gatsby-plugin-s3 to deploy a site which uses CloudFront.
+
+There are two ways that you can connect CloudFront to an S3 origin. The most obvious way, which the AWS Console will suggest, is to type the bucket name in the Origin Domain Name field. This sets up an S3 origin, and allows you to configure CloudFront to use IAM to access your bucket. Unfortunately, it also makes it impossible to perform serverside (301/302) redirects, and it also means that directory indexes (having index.html be served when someone tries to access a directory) will only work in the root directory. You might not initially notice these issues, because Gatsby's clientside JavaScript compensates for the latter and plugins such as `gatsby-plugin-meta-redirect` can compensate for the former. But just because you can't see these issues, doesn't mean they won't affect search engines.
+
+In order for all the features of your site to work correctly, you must instead use your S3 bucket's Static Website Hosting Endpoint as the CloudFront origin. This does (sadly) mean that your bucket will have to be configured for public-read, because when CloudFront is using an S3 Static Website Hosting Endpoint address as the Origin, it's incapable of authenticating via IAM.
+
+### gatsby-plugin-s3 configuration
+
+In the gatsby-plugin-s3 configuration file, there are a couple of optional parameters that you can usually leave blank, `protocol` and `hostname`. But when you're using CloudFront, these parameters are vital for ensuring redirects work correctly. If you omit these parameters, redirects will be performed relative to your S3 Static Website Hosting Endpoint. This means if a user visits your site via the CloudFront URL and hits a redirect, they will be redirected to your S3 Static Website Hosting Endpoint instead. This will disable HTTPS and (more importantly) will display an ugly and unprofessional URL in the user's address bar.
+
+By specifying the `protocol` and `hostname` parameters, you can cause redirects to be applied relative to a domain of your choosing.
+
+```javascript
+{
+    resolve: `gatsby-plugin-s3`,
+    options: {
+        bucketName: "my-example-bucket",
+        protocol: "https",
+        hostname: "www.example.com",
+    },
+}
+```
+
+If you use your site's URL elsewhere in gatsby-config.js, I have a tip for you. You can define the URL once at the top of the config:
+
+```javascript
+const siteAddress = new URL("https://www.example.com")
+```
+
+And then in the Gatsby config you can reference it like so:
+
+```javascript
+{
+    resolve: `gatsby-plugin-s3`,
+    options: {
+        bucketName: "my-example-bucket",
+        protocol: siteAddress.protocol.slice(0, -1),
+        hostname: siteAddress.hostname,
+    },
+}
+```
+
+If you need the full address elsewhere in your config, you can access it via `siteAddress.href`.
 
 ## References:
 
+- [Gatsby on AWS, the right way](https://blog.joshwalsh.me/aws-gatsby/)
+- [Using CloudFront with gatsby-plugin-s3](https://github.com/jariz/gatsby-plugin-s3/blob/master/recipes/with-cloudfront.md)
 - [Publishing Your Next Gatsby Site to AWS With AWS Amplify](https://www.gatsbyjs.org/blog/2018-08-24-gatsby-aws-hosting/)
 - [Escalade Sports: From $5000 to $5/month in Hosting With Gatsby](https://www.gatsbyjs.org/blog/2018-06-14-escalade-sports-from-5000-to-5-in-hosting/)
 - [Deploy your Gatsby.js Site to AWS S3](https://benenewton.com/deploy-your-gatsby-js-site-to-aws-s-3)

--- a/docs/docs/deploying-to-s3-cloudfront.md
+++ b/docs/docs/deploying-to-s3-cloudfront.md
@@ -51,6 +51,7 @@ npm i gatsby-plugin-s3
 ```
 
 Add it to your `gatsby-config.js`: (don't forget to change the bucket name)
+
 ```
 plugins: [
  {
@@ -63,6 +64,7 @@ plugins: [
 ```
 
 And finally, add the deployment script to your `package.json`:
+
 ```js
 "scripts": {
    ...
@@ -76,6 +78,7 @@ Run `npm run build && npm run deploy` to do a build and have it immediately depl
 ## Taking things a step further
 
 Read on how to use the serverless framework to add lambda functions, cloudfront, and more:
+
 - [Using serverless with gatsby-plugin-s3](https://github.com/jariz/gatsby-plugin-s3/blob/master/recipes/with-serverless.md)
 
 ## References:

--- a/docs/docs/deploying-to-s3-cloudfront.md
+++ b/docs/docs/deploying-to-s3-cloudfront.md
@@ -2,11 +2,9 @@
 title: Deploying to S3/Cloudfront
 ---
 
-In this guide, we'll walk through how to host & publish your next Gatsby site to AWS using [AWS Amplify](https://aws-amplify.github.io/).
+In this guide, we'll walk through how to host & publish your next Gatsby site to AWS using [S3](https://aws.amazon.com/s3/)
 
-AWS Amplify is a combination of client library, CLI toolchain, and UI components. Amplify allow developers to get up & running with full-stack cloud-powered applications with features like authentication, GraphQL, storage, REST APIs, analytics, Lambda functions, hosting & more.
-
-Using the **Hosting** feature, you can deploy your application to AWS as well as set up your site with Amazon Cloudfront CDN. This is what we'll be doing in this tutorial. Let's begin!
+Additionally, you can add [lambda functions](https://serverless.com/framework/docs/providers/aws/guide/functions/), [cloudfront](https://github.com/serverless/examples/tree/master/aws-node-single-page-app-via-cloudfront), and other AWS services later on as you expand.
 
 ## Getting Started - Gatsby
 
@@ -28,94 +26,57 @@ Finally, change into the new site directory:
 cd my-gatsby-site
 ```
 
-## Getting Started - AWS Amplify
+## Getting Started - AWS CLI
+
+Create a [IAM account](https://console.aws.amazon.com/iam/home?#) with administration permissions and create a access id and secret for it.
+You'll need these in the next step.
+
+Install the AWS CLI and configure it (ensure python is installed before running these commands)
+
+```shell
+pip install aws
+aws configure
+```
+
+The AWS CLI will now prompt you for the key & secret, add them.
+
+## Getting Started - gatsby-plugin-s3
 
 Now that we have our Gatsby site up & running, let's add hosting & make the site live on AWS.
 
-First, we'll install the AWS Amplify CLI:
+First, we'll install the Gatsby S3 plugin:
 
 ```shell
-npm i -g @aws-amplify/cli
+npm i gatsby-plugin-s3
 ```
 
-With the AWS Amplify CLI installed, we now need to configure it with an IAM User:
-
-```shell
-amplify configure
+Add it to your `gatsby-config.js`: (don't forget to change the bucket name)
+```
+plugins: [
+ {
+     resolve: `gatsby-plugin-s3`,
+     options: {
+         bucketName: 'my-website-bucket'
+     },
+ },
+]
 ```
 
-> For a video walkthrough of how to configure the AWS Amplify CLI, click [here](https://www.youtube.com/watch?v=fWbM5DLh25U).
-
-Now, we can create a new Amplify project in the root of our Gatsby project:
-
-```shell
-amplify init
+And finally, add the deployment script to your `package.json`:
+```js
+"scripts": {
+   ...
+   "deploy": "gatsby-plugin-s3 deploy"
+}
 ```
 
-- Choose your default editor: **(for me, this is Visual Studio Code)**
-- Please choose the type of app that you're building: **javascript**
-- What JavaScript framework are you using: **react**
-- Source Directory Path: **src**
-- Distribution Directory Path: **public**
-- Build Command: **npm run-script build**
-- Start Command: **npm run-script develop**
-- Do you want to use an AWS profile? **Y**
-- Please choose the profile you want to use: **default**
+That's it!
+Run `npm run build && npm run deploy` to do a build and have it immediately deployed to S3!
 
-Now, the Amplify project has been created. You will see that you have a new amplify folder in your project directory as well as an .amplifyrc file. Both of these contain your AWS Amplify project configuration.
+## Taking things a step further
 
-Next, we can type amplify into our command line & see all of the options that we have:
-
-```shell
-amplify
-```
-
-At the bottom, we can see the available categories available to us. Hosting is the category we would like to enable, so let's do so now:
-
-```shell
-amplify add hosting
-```
-
-Here, we'll be prompted for the following:
-
-- Select the environment setup: **DEV**
-- hosting bucket name: **gatsbyproj-20180808112129-hosting-bucket (or type whatever you'd like the bucket name to be)**
-
-This will set up our local project with everything we need, now we can publish the app to AWS. To do so, we'll run the following command:
-
-```shell
-amplify publish
-```
-
-Here, we'll be prompted for the following:
-
-- Are you sure you want to continue? **Y**
-
-Now, our resources will be pushed up to our account & our site will be published to a live url!
-
-What just happened? A few things:
-
-1. Amplify runs npm run build to build a new distribution of your app
-2. A new S3 bucket is created in your AWS account
-3. All code in the public directory is uploaded to the S3 bucket
-
-We should have also be given the URL that the site is hosted on. At any time that we would like to get the url for our site, we can run:
-
-```shell
-amplify status
-```
-
-This command should give us all of the info about our app including the url of our website.
-
-If we ever want to configure the hosting setup, including adding Cloudfront, we can run:
-
-```shell
-amplify configure hosting
-```
-
-Here, we'll be prompted for what we would like to change about the project configuration.
-
-> To learn more about AWS Amplify, check out the [Getting Started](https://aws-amplify.github.io/media/get_started) page.
+Read on how to use the serverless framework to add lambda functions, cloudfront, and more:
+- [Using serverless with gatsby-plugin-s3](https://github.com/jariz/gatsby-plugin-s3/blob/master/recipes/with-serverless.md)
 
 ## References:
 


### PR DESCRIPTION
## Description

Make deployment to S3 tutorial a bit simpler & add mention of gatsby-plugin-s3 to the caching docs.
Also adds a mention on how to integrate [serverless framework](https://serverless.com) later on if you wish to do so.

## Questions/Thoughts

Maybe removing amplify entirely from the docs is a bit extreme, however, here are a couple reasons why I think the current tutorial is not a good approach for gatsby projects:

- Redirects are lost (!)
- Client only routes will 404 (!!)
- Gatsby's [recommended caching rules](https://www.gatsbyjs.org/docs/caching/#caching) are not applied.
- Amplify CLI requires a lot of unnecessary setup steps that are identical between gatsby projects.
- Amplify CLI is very hard to use with CI environments (that aren't their own 🙄):
    - Amplify's CLI does not respect environment variables(?!), making it harder to use with a CI environment that isn't amplify.
    - Amplify's 'deploy' command has a prompt that can't be disabled making it impossible to use with CI environments.
- Serverless is a lot more established than amplify is.

I think people with this PR are getting a setup process that is a lot easier and more importantly, optimises a whole lot more, which kind of fits in line with the whole idea of gatsby in general.

Having said that, if people feel strongly on keeping amplify in the docs somehow, I'm all open for suggestions.
