### PR TITLE
fix(www): use full starter repo name for screenshot alt text

### DIFF
--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -77,7 +77,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                 <ThumbnailLink
                   slug={`/starters${slug}`}
                   image={starter.childScreenshot}
-                  title={name}
+                  title={`${owner}/${name}`}
                 />
                 <div
                   css={{

--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -78,7 +78,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                 <ThumbnailLink
                   slug={`/starters${slug}`}
                   image={starter.childScreenshot}
-                  title={starter.name}
+                  title={name}
                 />
                 <div
                   css={{
@@ -109,7 +109,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                     </span>
                   </div>
                   <div>
-                    <Link to={`/starters/${stub}`}>
+                    <Link to={`/starters/${slug}`}>
                       <h5 css={{ margin: 0 }}>
                         <strong className="title">{name}</strong>
                       </h5>


### PR DESCRIPTION
## Description

Hi, buddies, there are two small problems in Starter Library | GatsbyJS site page, `starter name` can not be rightly navigated to its page, showing `Page not found`... so, I fixed it, please review! thank u!

## Related Issues

no