### PR TITLE
feat(ci): add a validation step for starters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,5 +194,5 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - ? starters:validate
+      - ? starters_validate
         <<: *ignore_master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,5 +194,5 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - ? starters_validate
-        <<: *ignore_master
+      - starters_validate:
+          <<: *ignore_master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,6 @@ jobs:
       - <<: *install_node_modules
       - <<: *persist_cache
       - run: yarn markdown
-      - run: sudo apt-get update && sudo apt-get install jq # jq is helpful for parsing json
       - run: git config --global user.name "GatsbyJS Bot"
       - run: git config --global user.email "admin@gatsbyjs.com"
       - run: sh ./scripts/clone-and-validate.sh starters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,16 @@ jobs:
       - e2e-test:
           test_path: e2e-tests/production-runtime
 
+  starters_validate:
+    executor: node
+    steps:
+      - checkout
+      - run: ./scripts/assert-changed-files.sh "starters/*|.circleci/*"
+      - <<: *restore_cache
+      - <<: *install_node_modules
+      - <<: *persist_cache
+      - run: sh ./scripts/clone-and-validate.sh starters false
+
   starters_publish:
     executor: node
     steps:
@@ -178,40 +188,11 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install jq # jq is helpful for parsing json
       - run: git config --global user.name "GatsbyJS Bot"
       - run: git config --global user.email "admin@gatsbyjs.com"
-      - run: sh ./scripts/clone-folder.sh starters
+      - run: sh ./scripts/clone-and-validate.sh starters
 
 workflows:
   version: 2
   build-test:
     jobs:
-      - bootstrap
-      - lint
-      - unit_tests_node6:
-          <<: *ignore_docs
-          requires:
-            - bootstrap
-      - unit_tests_node8:
-          <<: *ignore_docs
-          requires:
-            - bootstrap
-      - unit_tests_node10:
-          <<: *ignore_docs
-          requires:
-            - bootstrap
-      - integration_tests:
-          <<: *ignore_docs
-      - e2e_tests_gatsbygram:
-          <<: *e2e-test-workflow
-      - e2e_tests_path-prefix:
-          <<: *e2e-test-workflow
-      - e2e_tests_gatsby-image:
-          <<: *e2e-test-workflow
-      - e2e_tests_development_runtime:
-          <<: *e2e-test-workflow
-      - e2e_tests_production_runtime:
-          <<: *e2e-test-workflow
-      - starters_publish:
-          filters:
-            branches:
-              only:
-                - master
+      - ? starters:validate
+        <<: *ignore_master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,13 +185,45 @@ jobs:
       - <<: *install_node_modules
       - <<: *persist_cache
       - run: yarn markdown
+      - run: sudo apt-get update && sudo apt-get install jq # jq is helpful for parsing json
       - run: git config --global user.name "GatsbyJS Bot"
       - run: git config --global user.email "admin@gatsbyjs.com"
-      - run: sh ./scripts/clone-and-validate.sh starters
+      - run: sh ./scripts/clone-folder.sh starters
 
 workflows:
   version: 2
   build-test:
     jobs:
+      - bootstrap
+      - lint
+      - unit_tests_node6:
+          <<: *ignore_docs
+          requires:
+            - bootstrap
+      - unit_tests_node8:
+          <<: *ignore_docs
+          requires:
+            - bootstrap
+      - unit_tests_node10:
+          <<: *ignore_docs
+          requires:
+            - bootstrap
+      - integration_tests:
+          <<: *ignore_docs
+      - e2e_tests_gatsbygram:
+          <<: *e2e-test-workflow
+      - e2e_tests_path-prefix:
+          <<: *e2e-test-workflow
+      - e2e_tests_gatsby-image:
+          <<: *e2e-test-workflow
+      - e2e_tests_development_runtime:
+          <<: *e2e-test-workflow
+      - e2e_tests_production_runtime:
+          <<: *e2e-test-workflow
       - starters_validate:
           <<: *ignore_master
+      - starters_publish:
+          filters:
+            branches:
+              only:
+                - master

--- a/scripts/clone-and-validate.sh
+++ b/scripts/clone-and-validate.sh
@@ -25,7 +25,7 @@ for folder in $FOLDER/*; do
   # sync to read-only clones
   if [ "$CLONE" != false ]; then
     rm -rf yarn.lock
-    yarn import
+    yarn import # generate a new yarn.lock file based on package-lock.json
 
     git add .
     git commit --message "$COMMIT_MESSAGE"

--- a/scripts/clone-and-validate.sh
+++ b/scripts/clone-and-validate.sh
@@ -24,6 +24,7 @@ for folder in $FOLDER/*; do
   cp -r $BASE/$folder/. .
   
   # validate
+  npm audit
   npm install
   npm run build
 

--- a/scripts/clone-and-validate.sh
+++ b/scripts/clone-and-validate.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 FOLDER=$1
 CLONE=$2
+IS_CI="${CI:-false}"
 BASE=$(pwd)
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+
+if [ "$IS_CI" = true ]; then
+  sudo apt-get update && sudo apt-get install jq
+fi
 
 for folder in $FOLDER/*; do
   [ -d "$folder" ] || continue # only directories

--- a/scripts/clone-and-validate.sh
+++ b/scripts/clone-and-validate.sh
@@ -19,13 +19,14 @@ for folder in $FOLDER/*; do
   cp -r $BASE/$folder/. .
   
   # validate
-  yarn import
-  yarn
-  yarn build
+  npm install
+  npm run build
 
   # sync to read-only clones
   if [ "$CLONE" != false ]; then
-    echo "syncing to read-only clones"
+    rm -rf yarn.lock
+    yarn import
+
     git add .
     git commit --message "$COMMIT_MESSAGE"
     git push origin master

--- a/scripts/clone-and-validate.sh
+++ b/scripts/clone-and-validate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 FOLDER=$1
+CLONE=$2
 BASE=$(pwd)
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)
 
@@ -15,10 +16,19 @@ for folder in $FOLDER/*; do
   git clone --depth 1 https://$GITHUB_API_TOKEN@github.com/gatsbyjs/$NAME.git $CLONE_DIR
   cd $CLONE_DIR
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
-  cp -r $BASE/$folder/. . # copy all content
-  git add .
-  git commit --message "$COMMIT_MESSAGE"
-  git push origin master
+  cp -r $BASE/$folder/. .
+  
+  # validate
+  yarn import
+  yarn build
+
+  # sync to read-only clones
+  if [ "$CLONE" != false ]; then
+    echo "syncing to read-only clones"
+    git add .
+    git commit --message "$COMMIT_MESSAGE"
+    git push origin master
+  fi
 
   cd $BASE
 done

--- a/scripts/clone-and-validate.sh
+++ b/scripts/clone-and-validate.sh
@@ -20,6 +20,7 @@ for folder in $FOLDER/*; do
   
   # validate
   yarn import
+  yarn
   yarn build
 
   # sync to read-only clones


### PR DESCRIPTION
## Description

This PR will (start) to add some increased validation and checks for starters. In particular, it will generate a `yarn.lock` file in each starter (and add this to the read-only clone), as well as run the `build` script to validate a successful build.

During a *pull request*, it will:

- Run `npm install`
- Run `npm run build`

This will catch issues with a dependency change causing a failure, but it _will not_ (currently) catch something like a failure introduced in the _current_ changes in the PR (e.g. a change to Gatsby like in gatsbyjs/gatsby#10593). Fixing both of these are worth exploring, I just don't want to slow down the build _too_ much.

During a merge to master, it will:

- Run `npm install`
- Run `npm run build`
- Run `yarn import` (generate a yarn.lock file based on the contents of `package-lock.json`)
- Sync to gatsbyjs/gatsby-starter-NAME

My main concern with the merge to master is that it's possible to fail and not know it fails. We do merge to master enough that it's not a huge concern and we'd catch it the next pull request, but worth noting.

## Related Issues

Begins to address #10607
