### PR TITLE
Updating documentation to support defval option

### DIFF
--- a/packages/gatsby-transformer-excel/README.md
+++ b/packages/gatsby-transformer-excel/README.md
@@ -126,15 +126,14 @@ module.exports = {
     {
       resolve: `gatsby-transformer-excel`,
       options: {
-        defval: '',
+        defval: "",
       },
     },
   ],
 }
 ```
 
-This will make sure that any blank cells are assigned the `defval` value. 
-
+This will make sure that any blank cells are assigned the `defval` value.
 
 ### Field Type Conflicts
 

--- a/packages/gatsby-transformer-excel/README.md
+++ b/packages/gatsby-transformer-excel/README.md
@@ -113,6 +113,29 @@ Which would return:
 
 ## Troubleshooting
 
+### Default Values
+
+If your spreadsheet contains column headers with only blank cells, the default behaviour is to exclude this column in the graphql output as per the [documentation](https://docs.sheetjs.com/#json)
+
+> If `defval` is not specified, `null` and `undefined` values are skipped normally. If specified, all `null` and `undefined` points will be filled with `defval`.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-transformer-excel`,
+      options: {
+        defval: '',
+      },
+    },
+  ],
+}
+```
+
+This will make sure that any blank cells are assigned the `defval` value. 
+
+
 ### Field Type Conflicts
 
 If your columns have different data types, e.g. numbers and strings graphql will omit these values and provide you with a field type conflicts warning during build.
@@ -132,6 +155,6 @@ module.exports = {
 }
 ```
 
-_NOTE 1_: A previous version of this library used the attribute name `rawOutput`. This name still works, but is an alias for the correct attribute `raw`. If both attributes are specified, the value for `raw` takes precedence.
+This will make sure that all field types are converted to strings.
 
-This will make sure, that all field types are converted to strings.
+_NOTE 1_: A previous version of this library used the attribute name `rawOutput`. This name still works, but is an alias for the correct attribute `raw`. If both attributes are specified, the value for `raw` takes precedence.


### PR DESCRIPTION
`defval` option was added in [PR-8980](https://github.com/gatsbyjs/gatsby/pull/8980).

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
