### PR TITLE
feat(gatsby-image): Enhanced Blur-up CSS for placeholderImage

### DIFF
--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -54,7 +54,7 @@ exports[`<Img /> should render fluid images 1`] = `
       alt=""
       class="placeholder"
       src="string_of_base64"
-      style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1; color: red;"
+      style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 1; filter: blur(16px); transform: scale(1.04); color: red;"
       title="Title for the image"
     />
     <div

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -220,6 +220,7 @@ class Image extends React.Component {
       imgStyle = {},
       placeholderStyle = {},
       placeholderClassName,
+      blurSize,
       fluid,
       fixed,
       backgroundColor,
@@ -229,10 +230,20 @@ class Image extends React.Component {
     const bgColor =
       typeof backgroundColor === `boolean` ? `lightgray` : backgroundColor
 
+    // The scale transform improves the quality of the blur around the images bounding box
+    let enhancedBlur = {}
+    if (!(fluid && fluid.tracedSVG) && !(fixed && !fixed.tracedSVG)) {
+      enhancedBlur = {
+        filter: `blur(${blurSize})`,
+        transform: `scale(1.04)`,
+      }
+    }
+
     const imagePlaceholderStyle = {
       opacity: this.state.imgLoaded ? 0 : 1,
       transition: `opacity 0.5s`,
       transitionDelay: this.state.imgLoaded ? `0.5s` : `0.25s`,
+      ...enhancedBlur,
       ...imgStyle,
       ...placeholderStyle,
     }
@@ -436,6 +447,7 @@ Image.defaultProps = {
   fadeIn: true,
   alt: ``,
   Tag: `div`,
+  blurSize: `16px`,
 }
 
 const fixedObject = PropTypes.shape({
@@ -474,6 +486,7 @@ Image.propTypes = {
   imgStyle: PropTypes.object,
   placeholderStyle: PropTypes.object,
   placeholderClassName: PropTypes.string,
+  blurSize: PropTypes.string,
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onLoad: PropTypes.func,
   onError: PropTypes.func,


### PR DESCRIPTION
Adds CSS `filter: blur()` and `transform: scale()` properties. Blur size is configurable via the `blurSize` prop, defaults to `16px`(Not sure if this is a good default value or if there should be some heuristic based on stretched size). Conditionally checks to avoid applying to `tracedSVG` placeholders where it's unlikely to be desirable?

This improves the "blur-up" effect to be of a higher quality as the placeholder image is a stretched low pixel thumbnail(width of 20px) at the low quality, it can look rather awful especially for jpeg with artifacts and when representing a fairly large image size.

[Browser support is pretty good](https://caniuse.com/#feat=css-filters), 90% Global, 80% India, 74% China. Even for those that don't have support, the result is just without the nicer blur effect applied?