### PR TITLE
feat(gatsby-transformer-remark): Note about gray-matter

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -155,6 +155,25 @@ It's also possible to ask Gatsby to return excerpts formatted as HTML. You might
 }
 ```
 
+## gray-matter options
+
+`gatsby-transformer-remark` uses [gray-matter](https://github.com/jonschlinkert/gray-matter) to parse markdown frontmatter, so you can specify any of the options mentioned [here](https://github.com/jonschlinkert/gray-matter#options) in the `gatsby-config.js` file.
+
+### Example: Excerpts
+
+If you don't want to use `pruneLength` for excerpts but a custom seperator, you can specify a `excerpt_separator`:
+
+```javascript
+{
+  "resolve": `gatsby-transformer-remark`,
+  "options": {
+    "excerpt_separator": `<!-- end -->`
+  }
+}
+```
+
+Any file that does not have the given `excerpt_separator` will fall back to the default pruning method.
+
 ## Troubleshooting
 
 ### Excerpts for non-latin languages


### PR DESCRIPTION
https://twitter.com/lekoarts_de/status/1078986568159895552
I couldn't find this note anywhere except on the using-remark example page. Therefore I added a short paragraph to the README