### PR TITLE
Fix casing of GitHub and GitLab

### DIFF
--- a/docs/blog/2017-12-07-taking-gatsby-for-a-spin/index.md
+++ b/docs/blog/2017-12-07-taking-gatsby-for-a-spin/index.md
@@ -39,7 +39,7 @@ Even though Gatsby is pretty new, the developers using it seem really involved. 
 
 ## Some thoughts on Gatsby
 
-It's telling that [most of the websites that are made with Gatsby](https://github.com/gatsbyjs/gatsby#showcase) are developer portfolios and documentation websites. It shows that Gatsby is still a bit in its early-adopters phase. But seeing what kind of sites are already made with Gatsby, I'm sure the future is bright. I've had a blast creating my own site with Gatsby ([checkout the github repo here](https://github.com/aderaaij/ardennl-gatsby)) and in the end it didn't take more than a weekend to complete, including doing the [tutorial](/tutorial/) and experimenting with the [Gatsby starters](/docs/gatsby-starters/).
+It's telling that [most of the websites that are made with Gatsby](https://github.com/gatsbyjs/gatsby#showcase) are developer portfolios and documentation websites. It shows that Gatsby is still a bit in its early-adopters phase. But seeing what kind of sites are already made with Gatsby, I'm sure the future is bright. I've had a blast creating my own site with Gatsby ([checkout the GitHub repo here](https://github.com/aderaaij/ardennl-gatsby)) and in the end it didn't take more than a weekend to complete, including doing the [tutorial](/tutorial/) and experimenting with the [Gatsby starters](/docs/gatsby-starters/).
 
 Some other thoughts I had while working with Gatsby:
 

--- a/docs/blog/2018-04-11-trying-out-gatsby-at-work-and-co/index.md
+++ b/docs/blog/2018-04-11-trying-out-gatsby-at-work-and-co/index.md
@@ -283,7 +283,7 @@ Of course, this is something developers do all the time. They push their fork to
 }
 ```
 
-Gatsby, however, uses a monorepo architecture, so pushing up a fork with a change to a specific package is not such a trivial manner; npm and yarn just don’t support it. (If you feel like being depressed, check out the npm thread about [supporting github paths to monorepo packages](https://github.com/npm/npm/issues/2974).)
+Gatsby, however, uses a monorepo architecture, so pushing up a fork with a change to a specific package is not such a trivial manner; npm and yarn just don’t support it. (If you feel like being depressed, check out the npm thread about [supporting GitHub paths to monorepo packages](https://github.com/npm/npm/issues/2974).)
 
 Our workaround was to create a new repo for the package in question and push the build directly to GitHub. Here’s how it would work if you were making an update to, say, `gatsby-source-contentful`:
 

--- a/docs/blog/2018-10-18-vscode-gatsby-development/index.md
+++ b/docs/blog/2018-10-18-vscode-gatsby-development/index.md
@@ -48,7 +48,7 @@ Of course once you start browsing the Extensions Marketplace you'll want to inst
 - [Rainbow Brackets](https://marketplace.visualstudio.com/items?itemName=2gua.rainbow-brackets)
 - [vscode-icons](https://marketplace.visualstudio.com/items?itemName=robertohuertasm.vscode-icons)
 
-You can take a look at my ["dotfiles" Github](https://github.com/mikelax/dotfiles/tree/master/vscode) for a README on the VS Code Extensions I am using along with editor settings.
+You can take a look at my ["dotfiles" GitHub](https://github.com/mikelax/dotfiles/tree/master/vscode) for a README on the VS Code Extensions I am using along with editor settings.
 
 ## 🚀 Debugging in Chrome 🚀
 
@@ -80,6 +80,6 @@ In this article we have learned some of the basics about configuring and using V
 
 You may want to browse through the [VS Code Updates page](https://code.visualstudio.com/updates/) to see some of the recent features added. You'll notice they publish major updates monthly. It seems they are listening to the user community and continually adding features to the Editor and improvements to the user expereince.
 
-A great way to contribute is to browse the [open issues on Github](https://github.com/gatsbyjs/gatsby/issues), and find some that look interesting! Armed with some of the techniques I've shown here today, authoring these fixes, features, and more will be a breeze thanks to some of the great features of VS Code.
+A great way to contribute is to browse the [open issues on GitHub](https://github.com/gatsbyjs/gatsby/issues), and find some that look interesting! Armed with some of the techniques I've shown here today, authoring these fixes, features, and more will be a breeze thanks to some of the great features of VS Code.
 
 Do you use an Extension that I missed in this tutorial? Send send a message to [@mikelax on Twitter](https://twitter.com/mikelax) to let me know.

--- a/docs/blog/2018-11-01-hacktoberfest-wrapup/index.md
+++ b/docs/blog/2018-11-01-hacktoberfest-wrapup/index.md
@@ -29,7 +29,7 @@ Most of the [Docs issues](https://github.com/gatsbyjs/gatsby/issues/7928) stemme
 Thanks to everyone's contributions, throughout October we merged 439 pull requests from 250 different authors into the Gatsby repo!
 
 <figure>
-  <img alt="Github insights for the Gatsby repo, October 1 - November 1, 2018" height="400" src="./gatsby-hacktoberfest.png" />
+  <img alt="GitHub insights for the Gatsby repo, October 1 - November 1, 2018" height="400" src="./gatsby-hacktoberfest.png" />
   <figcaption>
     An awesome community response for Hacktoberfest!
   </figcaption>

--- a/docs/blog/2018-11-03-building-an-accessible-lightbox/index.md
+++ b/docs/blog/2018-11-03-building-an-accessible-lightbox/index.md
@@ -6,7 +6,7 @@ tags: ["lightbox", "gatsby-image", "accessibility"]
 canonicalLink: "https://416serg.me/building-a-custom-accessible-image-lightbox-in-gatsbyjs"
 ---
 
-In this tutorial you're going to cover the steps to creating a simple, custom, accessible image lightbox inside a [GatsbyJS](/) application. You can check out the finished example on [Github](https://github.com/416serg/GatsbyLightbox) ([Demo](https://gatsbylightboxv2.416serg.me/)) or continue reading to dive right into the magic.
+In this tutorial you're going to cover the steps to creating a simple, custom, accessible image lightbox inside a [GatsbyJS](/) application. You can check out the finished example on [GitHub](https://github.com/416serg/GatsbyLightbox) ([Demo](https://gatsbylightboxv2.416serg.me/)) or continue reading to dive right into the magic.
 
 ## Getting started
 
@@ -45,7 +45,7 @@ You'll take a similar approach.
 
 ### Configure `gatsby-config.js`
 
-You'll put all of the images in a folder inside `src/cars` (You can get them from the [Github repo](https://github.com/416serg/GatsbyLightbox/tree/master/src/cars) or use your own, just make sure to follow a similar format). Then, you'll edit the `gatsby-config.js` file to expose that folder to a GraphQL query.
+You'll put all of the images in a folder inside `src/cars` (You can get them from the [GitHub repo](https://github.com/416serg/GatsbyLightbox/tree/master/src/cars) or use your own, just make sure to follow a similar format). Then, you'll edit the `gatsby-config.js` file to expose that folder to a GraphQL query.
 
 ```js
 {

--- a/docs/blog/2018-11-07-gatsby-for-apps/index.md
+++ b/docs/blog/2018-11-07-gatsby-for-apps/index.md
@@ -220,7 +220,7 @@ and even a light/dark theme, because why not! You can see all of these concepts 
 
 ![App Shell with Gatsby Mail](./images/gatsby-mail-app-shell.gif)
 
-Check out the [Github repo][gatsby-mail-repo] to learn more about how it was built and adopt some of the techniques as you build your next great Gatsby web **application**.
+Check out the [GitHub repo][gatsby-mail-repo] to learn more about how it was built and adopt some of the techniques as you build your next great Gatsby web **application**.
 
 We can't wait to see what you build.
 

--- a/docs/blog/2018-12-04-per-link-gatsby-page-transitions-with-transitionlink/index.md
+++ b/docs/blog/2018-12-04-per-link-gatsby-page-transitions-with-transitionlink/index.md
@@ -134,7 +134,7 @@ Here's an example of a more complicated TransitionLink using [gsap](https://gree
 </TransitionLink>
 ```
 
-The animation code for `this.createRipple` would be a bit much to copy here but you can check it out on the [TransitionLink github](https://github.com/TylerBarnes/gatsby-plugin-transition-link/blob/master/src/AniLink/PaintDrip.js). If you'd like you can also try it out with AniLink's paintDrip transition (check the [AniLink docs](https://transitionlink.tylerbarnes.ca/docs/anilink/) for usage).
+The animation code for `this.createRipple` would be a bit much to copy here but you can check it out on the [TransitionLink GitHub](https://github.com/TylerBarnes/gatsby-plugin-transition-link/blob/master/src/AniLink/PaintDrip.js). If you'd like you can also try it out with AniLink's paintDrip transition (check the [AniLink docs](https://transitionlink.tylerbarnes.ca/docs/anilink/) for usage).
 
 As you can see, TransitionLink offers quite a wide variety of control for page transitions! You're able to set the length, delay, state, and a trigger function for both entering and exiting pages, allowing you to use both declarative and imperative animations and as many transitions as you need.
 

--- a/docs/docs/gatsby-style-guide.md
+++ b/docs/docs/gatsby-style-guide.md
@@ -563,7 +563,7 @@ Here is how we measure the quality of the tutorial and docs. We will use ([cohor
 - daily, weekly, monthly active users
 - weekly retention rate
 
-## Why we chose Github for writing and maintaining docs
+## Why we chose GitHub for writing and maintaining docs
 
 The way the Gatsby community maintains docs and tutorials must meet the following requirements:
 
@@ -574,4 +574,4 @@ The way the Gatsby community maintains docs and tutorials must meet the followin
 - version control
 - a way to get feedback on each doc
 
-Github meets this requirements.
+GitHub meets this requirements.

--- a/docs/docs/hosting-on-netlify.md
+++ b/docs/docs/hosting-on-netlify.md
@@ -48,7 +48,7 @@ As written on the website, we only need to drag and drop our `public` folder ove
 
 #### Git Repository Setup
 
-We can use git with Netlify to host our website. There are many benefits of this such as we can have past versions of our website so that we can rollback to previous versions whenever we want, no need to manually build our website and upload it everytime we change anything. Netlify supports [Github](https://github.com/), [Gitlab](https://about.gitlab.com/) and [Bitbucket](https://bitbucket.org/). All we have to do is push our code to the respective repository. Our repository can be private or public.
+We can use git with Netlify to host our website. There are many benefits of this such as we can have past versions of our website so that we can rollback to previous versions whenever we want, no need to manually build our website and upload it everytime we change anything. Netlify supports [GitHub](https://github.com/), [GitLab](https://about.gitlab.com/) and [Bitbucket](https://bitbucket.org/). All we have to do is push our code to the respective repository. Our repository can be private or public.
 
 Now, login to Netlify and we will see a `New site from git` button at the top right corner on our screen. Click on it and connect with the same git provider that you used to host your website and authorize Netlify to use your account. Choose your website repository and it will take you to deploy settings with below options.
 

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -70,7 +70,7 @@ Gatsby, unsurprisingly, uses Gatsby for its documentation website. Thank you in 
 
 #### Top priorities
 
-Check the Github repo for issues labeled with ["documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or ["documentation" and "status: help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22status%3A+help+wanted%22) to see all documentation issues that are ready for community help. Once you start a PR to address one of these issues, you can remove the "help wanted" label.
+Check the GitHub repo for issues labeled with ["documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or ["documentation" and "status: help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22status%3A+help+wanted%22) to see all documentation issues that are ready for community help. Once you start a PR to address one of these issues, you can remove the "help wanted" label.
 
 #### Modifying markdown files in Gatsby documentation
 

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1139,7 +1139,7 @@
     - Blog page
     - Syntax highlighting in code blocks
     - Pagination Ready
-    - Ready to deploy to Github pages
+    - Ready to deploy to GitHub pages
     - Automatic RSS generation
     - Automatic Sitemap generation
 - url: https://gatsby-starter-kentico-cloud.netlify.com/

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -65,7 +65,7 @@ The steps to download and install Git depend on your operating system. Follow th
 - [Install Git on Windows](https://www.atlassian.com/git/tutorials/install-git#windows)
 - [Install Git on Linux](https://www.atlassian.com/git/tutorials/install-git#linux)
 
-> 💡 You will not need to know Git to complete this tutorial, but it is a very useful tool. If you are interested in learning more about version control, Git, and Github, check out Github's [Git Handbook](https://guides.github.com/introduction/git-handbook/).
+> 💡 You will not need to know Git to complete this tutorial, but it is a very useful tool. If you are interested in learning more about version control, Git, and GitHub, check out GitHub's [Git Handbook](https://guides.github.com/introduction/git-handbook/).
 
 ## Install Gatsby CLI
 

--- a/examples/using-cxs/README.md
+++ b/examples/using-cxs/README.md
@@ -5,4 +5,4 @@ Example site that demonstrates how to build Gatsby sites with
 
 ## References
 
-- [cxs Github](https://github.com/cxs-css/cxs)
+- [cxs GitHub](https://github.com/cxs-css/cxs)

--- a/translations/es/CONTRIBUTING_ES.md
+++ b/translations/es/CONTRIBUTING_ES.md
@@ -17,7 +17,7 @@ Queremos contribuir con Gatsby para que sea divertido, agradable y educativo par
 - Buscar a Gatsby en [Discord](https://discordapp.com/invite/jUFVxtB) o [Spectrum](https://spectrum.chat/gatsby-js) y ayudar a alguien más que lo necesite
 - ¡Enseñar a otros cómo contribuir al repositorio de Gatsby!
 
-Si estás preocupado o no sabes por dónde empezar, siempre puedes comunicarte con Shannon Soper (@shannonb_ux) en Twitter o simplemente presentar el problema en github y una persona encargada del mantenimiento podrá ayudarlo a orientarse.
+Si estás preocupado o no sabes por dónde empezar, siempre puedes comunicarte con Shannon Soper (@shannonb_ux) en Twitter o simplemente presentar el problema en GitHub y una persona encargada del mantenimiento podrá ayudarlo a orientarse.
 
 ¿Quieres dar una charla de Gatsby? ¡Nos encantaría revisar tus ideas para la charla! ¡Puedes enviarlo por correo electrónico a shannon [arroba] gatsbyjs [punto] com y podemos darte consejos o sugerencias!
 


### PR DESCRIPTION
Changes are:

- GitHub not Github 
- GitHub not github
- GitLab not Gitlab


