### PR TITLE
docs(www): Add documentation about adding a custom service worker

### DIFF
--- a/docs/docs/add-offline-support-with-a-service-worker.md
+++ b/docs/docs/add-offline-support-with-a-service-worker.md
@@ -60,6 +60,10 @@ exports.onServiceWorkerUpdateFound = () => {
 }
 ```
 
+### Using a custom service worker in Gatsby
+
+If your use case requires something that `gatsby-plugin-offline` doesn't support and you'd like to write your own custom service worker, you can add a file called `sw.js` in `/static` and Gatsby will register it as the service worker.
+
 ## References
 
 - [Service Workers: an Introduction](https://developers.google.com/web/fundamentals/primers/service-workers/)

--- a/docs/docs/add-offline-support-with-a-service-worker.md
+++ b/docs/docs/add-offline-support-with-a-service-worker.md
@@ -62,7 +62,17 @@ exports.onServiceWorkerUpdateFound = () => {
 
 ### Using a custom service worker in Gatsby
 
-If your use case requires something that `gatsby-plugin-offline` doesn't support and you'd like to write your own custom service worker, you can add a file called `sw.js` in `/static` and Gatsby will register it as the service worker.
+You can add a custom service worker if your use case requires something that `gatsby-plugin-offline` doesn't support.
+
+Add a file called `sw.js` in the `static` folder.
+
+Use the [`registerServiceWorker`](/docs/browser-apis/#registerServiceWorker) browser API in your `gatsby-browser.js` file.
+
+```javascript:title=gatsby-browser.js
+exports.registerServiceWorker = () => true
+```
+
+That's all! Gatsby will register your custom service worker.
 
 ## References
 


### PR DESCRIPTION
Documentation was missing a note on adding a custom service worker implementation

Fixes #10678 