### PR TITLE
panic on undefined error due to theme's import

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -1,4 +1,5 @@
 const path = require(`path`)
+const report = require(`gatsby-cli/lib/reporter`);
 
 module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
   cache = {}
@@ -34,13 +35,16 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
         path.join(theme, `src`, `components`)
       )
 
-      const resolvedComponentPath = require.resolve(
-        this.resolveComponentPath({
-          theme,
-          component,
-          projectRoot: this.projectRoot,
-        })
-      )
+      const builtComponentPath = this.resolveComponentPath({
+        theme,
+        component,
+        projectRoot: this.projectRoot
+      })
+      if (!builtComponentPath) {
+        // if you mess up your component imports in a theme, resolveComponentPath will return undefined
+        report.panic(`We can't find the component located at ${request.path} and imported in ${request.context.issuer}`)
+      }
+      const resolvedComponentPath = require.resolve(builtComponentPath)
       // this callbackends the resolver fallthrough chain.
       return callback(null, {
         directory: request.directory,

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -1,5 +1,5 @@
 const path = require(`path`)
-const report = require(`gatsby-cli/lib/reporter`);
+const report = require(`gatsby-cli/lib/reporter`)
 
 module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
   cache = {}
@@ -38,11 +38,15 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
       const builtComponentPath = this.resolveComponentPath({
         theme,
         component,
-        projectRoot: this.projectRoot
+        projectRoot: this.projectRoot,
       })
       if (!builtComponentPath) {
         // if you mess up your component imports in a theme, resolveComponentPath will return undefined
-        report.panic(`We can't find the component located at ${request.path} and imported in ${request.context.issuer}`)
+        report.panic(
+          `We can't find the component located at ${
+            request.path
+          } and imported in ${request.context.issuer}`
+        )
       }
       const resolvedComponentPath = require.resolve(builtComponentPath)
       // this callbackends the resolver fallthrough chain.


### PR DESCRIPTION
## Description
If you mess up your component imports in a theme, resolveComponentPath will return undefined. Catching it and error before it errors on something else and returns a cryptic error.

## Related Issues
None
