### PR TITLE
feat(starters): make copyright year dynamic

### DIFF
--- a/starters/blog/src/components/Layout.js
+++ b/starters/blog/src/components/Layout.js
@@ -64,7 +64,9 @@ class Layout extends React.Component {
         {header}
         {children}
         <footer>
-          © 2018, Built with <a href="https://www.gatsbyjs.org">Gatsby</a>
+          © {new Date().getFullYear()}, Built with
+          {` `}
+          <a href="https://www.gatsbyjs.org">Gatsby</a>
         </footer>
       </div>
     )

--- a/starters/default/src/components/layout.js
+++ b/starters/default/src/components/layout.js
@@ -29,7 +29,9 @@ const Layout = ({ children }) => (
         >
           {children}
           <footer>
-            © 2018, Built with <a href="https://www.gatsbyjs.org">Gatsby</a>
+            © {new Date().getFullYear()}, Built with
+            {` `}
+            <a href="https://www.gatsbyjs.org">Gatsby</a>
           </footer>
         </div>
       </>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Updated default and blog layout components to dynamically generate the copyright year in the footer using JavaScript.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Addresses https://github.com/gatsbyjs/gatsby/issues/10756.