### PR TITLE
docs(tutorial): tweak part seven to use graphql directly

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -177,23 +177,20 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
 // highlight-start
 exports.createPages = ({ graphql, actions }) => {
-  return new Promise((resolve, reject) => {
-    graphql(`
-      {
-        allMarkdownRemark {
-          edges {
-            node {
-              fields {
-                slug
-              }
+  return graphql(`
+    {
+      allMarkdownRemark {
+        edges {
+          node {
+            fields {
+              slug
             }
           }
         }
       }
-    `).then(result => {
-      console.log(JSON.stringify(result, null, 4))
-      resolve()
-    })
+    }
+  `).then(result => {
+    console.log(JSON.stringify(result, null, 4))
   })
 }
 // highlight-end
@@ -254,35 +251,32 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions // highlight-line
-  return new Promise((resolve, reject) => {
-    graphql(`
-      {
-        allMarkdownRemark {
-          edges {
-            node {
-              fields {
-                slug
-              }
+  return graphql(`
+    {
+      allMarkdownRemark {
+        edges {
+          node {
+            fields {
+              slug
             }
           }
         }
       }
-    `).then(result => {
-      // highlight-start
-      result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-        createPage({
-          path: node.fields.slug,
-          component: path.resolve(`./src/templates/blog-post.js`),
-          context: {
-            // Data passed to context is available
-            // in page queries as GraphQL variables.
-            slug: node.fields.slug,
-          },
-        })
+    }
+  `).then(result => {
+    // highlight-start
+    result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+      createPage({
+        path: node.fields.slug,
+        component: path.resolve(`./src/templates/blog-post.js`),
+        context: {
+          // Data passed to context is available
+          // in page queries as GraphQL variables.
+          slug: node.fields.slug,
+        },
       })
-      // highlight-end
-      resolve()
     })
+    // highlight-end
   })
 }
 ```


### PR DESCRIPTION
## Description

After watching @kyleshevlin live code his Gatsby powered blog, it's pretty clear that the `return new Promise()` stuff tends to be a little more confusing than needed. This PR tweaks the _tutorial_ to directly return the Promise returned by the `graphql` invocation.

We can (and probably should) tweak this elsewhere, but fixing it in the tutorial is one of the highest value places we can fix for now.

cc @KyleAMathews 

## Related Issues


