### PR TITLE
docs(blog): fix multi-line title issue

### DIFF
--- a/docs/blog/2018-12-31-how-we-do-high-impact-ux-research/index.md
+++ b/docs/blog/2018-12-31-how-we-do-high-impact-ux-research/index.md
@@ -1,10 +1,9 @@
 ---
-title: How Gatsby does high-impact, low-effort UX research
-(and you can too!)
+title: How Gatsby does high-impact, low-effort UX research (and you can too!)
 author: Shannon Soper
 date: 2018-12-31
-tags: 
-- ux
+tags:
+  - ux
 ---
 
 ## What this article is about:
@@ -23,8 +22,9 @@ In October 2017, when I first started asking developers if I could interview the
 To make sure it’s clear why we do UX research at Gatsby, here is the reason:
 
 We do UX research to live up to these two Gatsby values:
-1.Create awesome DX
-2.Create awesome UX
+
+1. Create awesome DX
+2. Create awesome UX
 
 Creating awesome DX and UX are two of the company’s values. We know that developers who use Gatsby and anyone who visits a Gatsby site are the experts on what makes their lives easier, so we make efforts to empathize deeply with our users so we can create the best available developer experience (DX) for making websites and best user experience (UX) for using websites. I think of these both as UX in a way, so will just use UX from here on out.
 


### PR DESCRIPTION
## Description

Fixes regression introduced in gatsbyjs/gatsby#10481, specifically:

```
yarn run v1.12.3
$ npm run develop

> gatsbyjs.org@2.0.0-beta develop /Users/dschau/Code/Work/gatsby/gatsby/www
> gatsby develop

success open and validate gatsby-configs — 0.010 s
success load plugins — 0.402 s
success onPreInit — 0.848 s
success delete html and css files from previous builds — 0.005 s
success initialize cache — 0.006 s
success copy gatsby files — 0.049 s
success onPreBootstrap — 0.020 s
error Error processing Markdown file /Users/dschau/Code/Work/gatsby/gatsby/docs/blog/2018-12-31-how-we-do-high-impact-ux-research/index.md:

      can not read a block mapping entry; a multiline key may not be an implicit key at line 4, column 7:
    author: Shannon Soper
          ^
error Cannot read property 'children' of undefined
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
