### PR TITLE
docs: Add stub articles for search guides

### DIFF
--- a/docs/docs/adding-search-with-algolia.md
+++ b/docs/docs/adding-search-with-algolia.md
@@ -1,0 +1,8 @@
+---
+title: Adding search with Algolia
+---
+
+This is a stub. Help our community expand it.
+
+Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+pull request gets accepted.

--- a/docs/docs/adding-search-with-elasticlunr.md
+++ b/docs/docs/adding-search-with-elasticlunr.md
@@ -1,0 +1,8 @@
+---
+title: Adding search with elasticlunr
+---
+
+This is a stub. Help our community expand it.
+
+Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+pull request gets accepted.

--- a/docs/docs/adding-search-with-js-search.md
+++ b/docs/docs/adding-search-with-js-search.md
@@ -1,0 +1,8 @@
+---
+title: Adding search with js-search
+---
+
+This is a stub. Help our community expand it.
+
+Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+pull request gets accepted.

--- a/docs/docs/adding-search.md
+++ b/docs/docs/adding-search.md
@@ -1,6 +1,13 @@
 ---
 title: "Adding search"
+overview: true
 ---
+
+See below for a list of guides in this section, or keep reading for an overview on adding search functionality to your site.
+
+[[guidelist]]
+
+## Site search overview
 
 Before we go through the steps for adding search to your Gatsby website, let's examine the components needed for adding search to a website.
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -191,6 +191,13 @@
       items:
         - title: Adding search
           link: /docs/adding-search/
+          items:
+            - title: "Adding search with Algolia*"
+              link: /docs/adding-search-with-algolia/
+            - title: "Adding search with elasticlunr*"
+              link: /docs/adding-search-with-elasticlunr/
+            - title: "Adding search with js-search*"
+              link: /docs/adding-search-with-js-search/
         - title: Adding analytics
           link: /docs/adding-analytics/
         - title: Adding authentication

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -196,7 +196,7 @@
               link: /docs/adding-search-with-algolia/
             - title: "Adding search with elasticlunr*"
               link: /docs/adding-search-with-elasticlunr/
-            - title: "Adding search with js-search*"
+            - title: Adding search with js-search*
               link: /docs/adding-search-with-js-search/
         - title: Adding analytics
           link: /docs/adding-analytics/

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -194,7 +194,7 @@
           items:
             - title: "Adding search with Algolia*"
               link: /docs/adding-search-with-algolia/
-            - title: "Adding search with elasticlunr*"
+            - title: Adding search with elasticlunr*
               link: /docs/adding-search-with-elasticlunr/
             - title: Adding search with js-search*
               link: /docs/adding-search-with-js-search/

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -192,7 +192,7 @@
         - title: Adding search
           link: /docs/adding-search/
           items:
-            - title: "Adding search with Algolia*"
+            - title: Adding search with Algolia*
               link: /docs/adding-search-with-algolia/
             - title: Adding search with elasticlunr*
               link: /docs/adding-search-with-elasticlunr/

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -15,9 +15,8 @@ import docsHierarchy from "../data/sidebars/doc-links.yaml"
 // Find the guides in the sidebar YAML.
 const guides = docsHierarchy.find(group => group.title === `Guides`).items
 
-// Search through the guides and their children to find the first item that
-// matches the given slug
-const findBySlug = (guides, slug) => {
+// Search through guides tree, which may be 2, 3 or more levels deep
+const childItemsBySlug = (guides, slug) => {
   let result
 
   const iter = a => {
@@ -29,28 +28,18 @@ const findBySlug = (guides, slug) => {
   }
 
   guides.some(iter)
-  return result
+  return result && result.items
 }
-
-// Finds child items for a given guide overview page using its slug.
-const getChildGuides = slug => {
-  const found = findBySlug(guides, slug)
-  return found ? found.items : []
-}
-
-// Create a table of contents from the child guides.
-const createGuideList = guides =>
-  guides
-    .map(guide => `<li><a href="${guide.link}">${guide.title}</a></li>`)
-    .join(``)
 
 const getPageHTML = page => {
   if (!page.frontmatter.overview) {
     return page.html
   }
 
-  const guidesForPage = getChildGuides(page.fields.slug)
-  const guideList = createGuideList(guidesForPage)
+  const guidesForPage = childItemsBySlug(guides, page.fields.slug) || []
+  const guideList = guidesForPage
+    .map(guide => `<li><a href="${guide.link}">${guide.title}</a></li>`)
+    .join(``)
   const toc = guideList
     ? `
     <h2>Guides in this section:</h2>


### PR DESCRIPTION
## Description

Update the existing search guide to act as an overview for more specific guides.

I've also updated the [[guidelist]] handler to remove the hardcoded paths (cc @jlengstorf)

![screenshot 2019-01-02 at 14 25 47](https://user-images.githubusercontent.com/381801/50595943-6728f280-0e9a-11e9-86fa-954ee227551d.png)

## Related Issues

Refs #10113