### PR TITLE
docs(tutorial): fix highlighting line on tutorial part-two

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -174,9 +174,8 @@ in the middle of the page. To create this, add the following styles to the
 import React from "react"
 
 export default () => (
+  {/* highlight-next-line */}
   <div style={{ margin: `3rem auto`, maxWidth: 600 }}>
-    {" "}
-    {/* highlight-line */}
     <h1>Richard Hamming on Luck</h1>
     <div>
       <p>

--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -174,7 +174,7 @@ in the middle of the page. To create this, add the following styles to the
 import React from "react"
 
 export default () => (
-  {/* highlight-next-line */}
+  // highlight-next-line
   <div style={{ margin: `3rem auto`, maxWidth: 600 }}>
     <h1>Richard Hamming on Luck</h1>
     <div>
@@ -189,7 +189,8 @@ export default () => (
         <p>
           There is indeed an element of luck, and no, there isn’t. The prepared
           mind sooner or later finds something important and does it. So yes, it
-          is luck.{" "}
+          is luck.
+          {` `}
           <em>
             The particular thing you do is luck, but that you do something is
             not.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Fixes highlighting the line and removes unnecessary symbols in the second part of the tutorial.

<img width="708" alt="2019-01-03 0 48 46" src="https://user-images.githubusercontent.com/1014262/50599820-79cf1600-0ef2-11e9-8e4d-aaab92a3802e.png">

## Related Issues
This is same kind of #10628 .
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
