### PR TITLE
fix(gatsby): correctly inject static query in theme components

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
@@ -48,7 +48,11 @@ describe(`Runner`, () => {
 
     it(`compiles themes directory(s)`, async () => {
       const theme = `gatsby-theme-whatever`
-      const runner = new Runner(base, [path.join(`node_modules`, theme)], {})
+      const runner = new Runner(
+        base,
+        [path.join(base, `node_modules`, theme)],
+        {}
+      )
 
       await runner.parseEverything()
 
@@ -67,30 +71,30 @@ describe(`resolveThemes`, () => {
       [{ resolve: path.join(base, `gatsby-plugin-whatever`) }],
       undefined,
     ].forEach(testRun => {
-      expect(resolveThemes(base, testRun)).toEqual([])
+      expect(resolveThemes(testRun)).toEqual([])
     })
   })
 
   it(`returns plugins matching gatsby-theme prefix`, () => {
     const theme = `gatsby-theme-example`
     expect(
-      resolveThemes(base, [
+      resolveThemes([
         {
           resolve: path.join(base, `gatsby-theme-example`),
         },
       ])
-    ).toEqual([theme])
+    ).toEqual([expect.stringContaining(theme)])
   })
 
   it(`handles scoped packages`, () => {
     const theme = `@dschau/gatsby-theme-example`
 
     expect(
-      resolveThemes(base, [
+      resolveThemes([
         {
           resolve: path.join(base, theme),
         },
       ])
-    ).toEqual([theme])
+    ).toEqual([expect.stringContaining(theme.split(`/`).join(path.sep))])
   })
 })

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
@@ -81,4 +81,16 @@ describe(`resolveThemes`, () => {
       ])
     ).toEqual([theme])
   })
+
+  it(`handles scoped packages`, () => {
+    const theme = `@dschau/gatsby-theme-example`
+
+    expect(
+      resolveThemes(base, [
+        {
+          resolve: path.join(base, theme),
+        },
+      ])
+    ).toEqual([theme])
+  })
 })

--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
@@ -1,0 +1,84 @@
+jest.mock(`glob`, () => {
+  const sync = jest.fn().mockImplementation(() => [])
+  return {
+    sync,
+  }
+})
+const path = require(`path`)
+const glob = require(`glob`)
+const { resolveThemes, Runner } = require(`../query-compiler`)
+
+const base = path.resolve(``)
+
+describe(`Runner`, () => {
+  beforeEach(() => {
+    glob.sync.mockClear()
+  })
+
+  it(`returns a file parser instance`, async () => {
+    const runner = new Runner(base, [], {})
+
+    const parser = await runner.parseEverything()
+
+    expect(parser).toEqual(new Map())
+  })
+
+  describe(`expected directories`, () => {
+    it(`compiles src directory`, async () => {
+      const runner = new Runner(base, [], {})
+
+      await runner.parseEverything()
+
+      expect(glob.sync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(base, `src`)),
+        expect.any(Object)
+      )
+    })
+
+    it(`compiles fragments directory`, async () => {
+      const runner = new Runner(base, [], {})
+
+      await runner.parseEverything()
+
+      expect(glob.sync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(base, `src`)),
+        expect.any(Object)
+      )
+    })
+
+    it(`compiles themes directory(s)`, async () => {
+      const theme = `gatsby-theme-whatever`
+      const runner = new Runner(base, [path.join(`node_modules`, theme)], {})
+
+      await runner.parseEverything()
+
+      expect(glob.sync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(base, `node_modules`, theme)),
+        expect.any(Object)
+      )
+    })
+  })
+})
+
+describe(`resolveThemes`, () => {
+  it(`returns empty array if zero themes detected`, () => {
+    ;[
+      [],
+      [{ resolve: path.join(base, `gatsby-plugin-whatever`) }],
+      undefined,
+    ].forEach(testRun => {
+      expect(resolveThemes(base, testRun)).toEqual([])
+    })
+  })
+
+  it(`returns plugins matching gatsby-theme prefix`, () => {
+    const theme = `gatsby-theme-example`
+    expect(
+      resolveThemes(base, [
+        {
+          resolve: path.join(base, `gatsby-theme-example`),
+        },
+      ])
+    ).toEqual([theme])
+  })
+})

--- a/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
@@ -64,15 +64,24 @@ const validationRules = [
 let lastRunHadErrors = null
 const overlayErrorID = `graphql-compiler`
 
+const resolveThemes = (base, plugins = []) =>
+  plugins.reduce((merged, plugin) => {
+    if (plugin.resolve.includes(`gatsby-theme-`)) {
+      merged.push(path.relative(base, plugin.resolve))
+    }
+    return merged
+  }, [])
+
 class Runner {
-  baseDir: string
+  base: string
+  additional: string[]
   schema: GraphQLSchema
   errors: string[]
   fragmentsDir: string
 
-  constructor(baseDir: string, fragmentsDir: string, schema: GraphQLSchema) {
-    this.baseDir = baseDir
-    this.fragmentsDir = fragmentsDir
+  constructor(base: string, additional: string[], schema: GraphQLSchema) {
+    this.base = base
+    this.additional = additional
     this.schema = schema
   }
 
@@ -91,14 +100,20 @@ class Runner {
   }
 
   async parseEverything() {
-    // FIXME: this should all use gatsby's configuration to determine parsable
-    // files (and how to parse them)
-    let files = glob.sync(`${this.fragmentsDir}/**/*.+(t|j)s?(x)`, {
-      nodir: true,
-    })
-    files = files.concat(
-      glob.sync(`${this.baseDir}/**/*.+(t|j)s?(x)`, { nodir: true })
-    )
+    const filesRegex = `/**/*.+(t|j)s?(x)`
+    let files = [`${this.base}/src`, `${this.base}/.cache/fragments`]
+      .concat(
+        this.additional.map(additional => path.join(this.base, additional))
+      )
+      .reduce(
+        (merged, base) =>
+          merged.concat(
+            glob.sync(`${base}${filesRegex}`, {
+              nodir: true,
+            })
+          ),
+        []
+      )
     files = files.filter(d => !d.match(/\.d\.ts$/))
     files = files.map(normalize)
 
@@ -217,14 +232,14 @@ class Runner {
     return compiledNodes
   }
 }
-export { Runner }
+export { Runner, resolveThemes }
 
 export default async function compile(): Promise<Map<string, RootQuery>> {
-  const { program, schema } = store.getState()
+  const { program, schema, plugins } = store.getState()
 
   const runner = new Runner(
-    `${program.directory}/src`,
-    `${program.directory}/.cache/fragments`,
+    program.directory,
+    resolveThemes(program.directory, plugins),
     schema
   )
 

--- a/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
@@ -100,13 +100,16 @@ class Runner {
   }
 
   async parseEverything() {
-    const filesRegex = `/**/*.+(t|j)s?(x)`
-    let files = [`${this.base}/src`, `${this.base}/.cache/fragments`]
-      .concat(this.additional.map(additional => `${additional}/src`))
+    const filesRegex = path.join(`/**`, `*.+(t|j)s?(x)`)
+    let files = [
+      path.join(this.base, `src`),
+      path.join(this.base, `.cache`, `fragments`),
+    ]
+      .concat(this.additional.map(additional => path.join(additional, `src`)))
       .reduce(
         (merged, folderPath) =>
           merged.concat(
-            glob.sync(`${folderPath}${filesRegex}`, {
+            glob.sync(path.join(folderPath, filesRegex), {
               nodir: true,
             })
           ),


### PR DESCRIPTION
## Description

This PR (correctly) replaces static query content in themes. It does this with a probably naive algorithm, where it checks the plugins array, and if a plugins path matches (gatsby-theme-), that plugin will be added to the query compiler list. It also slightly cleans up some of the code in the query compiler and adds a few tests

Notes:
  - I validated with this repo -> https://github.com/DSchau/gatsby-theme-static-query-repro 
  - It may not be reasonable to impose `gatsby-theme-*` constraint for all themes, so another solution may be preferable
  - Can't really tie into webpack (e.g. to detect a custom loader targeting node_modules/whatever-custom-component) because we use webpack-merge to persist into redux state, which gets translated to an empty object; although I would like to find some solution to non-theme packages in node_modules, as well as themes not named gatsby-theme-*
  
Feedback welcome, cc @ChristopherBiscardi @jbolda

## Related Issues

Fixes #10785
