### PR TITLE
feat(gatsby): extend core theming composition API to be recursive

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -11,11 +11,11 @@ const convertHrtime = require(`convert-hrtime`)
 const Promise = require(`bluebird`)
 
 const apiRunnerNode = require(`../utils/api-runner-node`)
-const mergeGatsbyConfig = require(`../utils/merge-gatsby-config`)
 const getBrowserslist = require(`../utils/browserslist`)
 const { graphql } = require(`graphql`)
 const { store, emitter } = require(`../redux`)
 const loadPlugins = require(`./load-plugins`)
+const loadThemes = require(`./load-themes`)
 const report = require(`gatsby-cli/lib/reporter`)
 const getConfigFile = require(`./get-config-file`)
 const tracer = require(`opentracing`).globalTracer()
@@ -84,32 +84,8 @@ module.exports = async (args: BootstrapArgs) => {
 
   // theme gatsby configs can be functions or objects
   if (config && config.__experimentalThemes) {
-    const themesConfig = await Promise.mapSeries(
-      config.__experimentalThemes,
-      async plugin => {
-        const themeName = plugin.resolve || plugin
-        const themeConfig = plugin.options || {}
-        const theme = await preferDefault(
-          getConfigFile(themeName, `gatsby-config`)
-        )
-        // if theme is a function, call it with the themeConfig
-        let themeConfigObj = theme
-        if (_.isFunction(theme)) {
-          themeConfigObj = theme(themeConfig)
-        }
-        // themes function as plugins too (gatsby-node, etc)
-        return {
-          ...themeConfigObj,
-          plugins: [
-            ...(themeConfigObj.plugins || []),
-            // theme plugin is last so it's gatsby-node, etc can override it's declared plugins, like a normal site.
-            { resolve: themeName, options: themeConfig },
-          ],
-        }
-      }
-    ).reduce(mergeGatsbyConfig, {})
-
-    config = mergeGatsbyConfig(themesConfig, config)
+    const themes = await loadThemes(config)
+    config = themes.config
   }
 
   if (config && config.polyfill) {

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -86,6 +86,11 @@ module.exports = async (args: BootstrapArgs) => {
   if (config && config.__experimentalThemes) {
     const themes = await loadThemes(config)
     config = themes.config
+
+    store.dispatch({
+      type: `SET_RESOLVED_THEMES`,
+      payload: themes.themes,
+    })
   }
 
   if (config && config.polyfill) {

--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -1,0 +1,71 @@
+const path = require("path")
+const mergeGatsbyConfig = require(`../../utils/merge-gatsby-config`)
+const Promise = require(`bluebird`)
+const _ = require("lodash")
+const debug = require("debug")("gatsby:load-themes")
+const preferDefault = require(`../prefer-default`)
+const getConfigFile = require(`../get-config-file`)
+
+const resolveTheme = async themeSpec => {
+  const themeName = themeSpec.resolve || themeSpec
+  const themeConfig = themeSpec.options || {}
+  const themeDir = path.dirname(require.resolve(themeName))
+  const theme = await preferDefault(getConfigFile(themeDir, `gatsby-config`))
+  // if theme is a function, call it with the themeConfig
+  let themeConfigObj = theme
+  if (_.isFunction(theme)) {
+    themeConfigObj = theme(themeSpec.options || {})
+  }
+  return { themeName, themeConfigObj, themeSpec }
+}
+
+// single iteration of a recursive function that resolve parent themes
+const processTheme = ({ themeName, themeConfigObj, themeSpec }) => {
+  // gatsby themes don't have to specify a gatsby-config.js (they might only use gatsby-node, etc)
+  if (themeConfigObj && themeConfigObj.__experimentalThemes) {
+    return Promise.mapSeries(
+      themeConfigObj.__experimentalThemes,
+      async spec => {
+        const themeObj = await resolveTheme(spec)
+        return processTheme(themeObj)
+      }
+    ).then(arr => {
+      console.log(arr)
+      return arr.concat([{ themeName, themeConfigObj, themeSpec }])
+    })
+  } else {
+    return [{ themeName, themeConfigObj, themeSpec }]
+  }
+}
+
+module.exports = async config => {
+  let themes = []
+  return await Promise.mapSeries(
+    config.__experimentalThemes,
+    async themeSpec => {
+      const themeObj = await resolveTheme(themeSpec)
+      return processTheme(themeObj)
+    }
+  )
+    .then(arr => {
+      const flatThemes = _.flattenDeep(arr)
+      debug(flatThemes)
+      themes = flatThemes
+      return flatThemes
+    })
+    .mapSeries(({ themeName, themeConfigObj = {}, themeSpec }) => {
+      return {
+        ...themeConfigObj,
+        plugins: [
+          ...(themeConfigObj.plugins || []),
+          // theme plugin is last so it's gatsby-node, etc can override it's declared plugins, like a normal site.
+          { resolve: themeName, options: themeSpec.options || {} },
+        ],
+      }
+    })
+    .reduce(mergeGatsbyConfig, {})
+    .then(newConfig => ({
+      config: mergeGatsbyConfig(newConfig, config),
+      themes,
+    }))
+}

--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -1,68 +1,86 @@
-const path = require("path")
+const path = require(`path`)
 const mergeGatsbyConfig = require(`../../utils/merge-gatsby-config`)
 const Promise = require(`bluebird`)
-const _ = require("lodash")
-const debug = require("debug")("gatsby:load-themes")
+const _ = require(`lodash`)
+const debug = require(`debug`)(`gatsby:load-themes`)
 const preferDefault = require(`../prefer-default`)
 const getConfigFile = require(`../get-config-file`)
 
+// get the gatsby-config file for a theme
 const resolveTheme = async themeSpec => {
   const themeName = themeSpec.resolve || themeSpec
-  const themeConfig = themeSpec.options || {}
   const themeDir = path.dirname(require.resolve(themeName))
   const theme = await preferDefault(getConfigFile(themeDir, `gatsby-config`))
   // if theme is a function, call it with the themeConfig
-  let themeConfigObj = theme
+  let themeConfig = theme
   if (_.isFunction(theme)) {
-    themeConfigObj = theme(themeSpec.options || {})
+    themeConfig = theme(themeSpec.options || {})
   }
-  return { themeName, themeConfigObj, themeSpec }
+  return { themeName, themeConfig, themeSpec }
 }
 
 // single iteration of a recursive function that resolve parent themes
-const processTheme = ({ themeName, themeConfigObj, themeSpec }) => {
+// It's recursive because we support child themes declaring parents and
+// have to resolve all the way `up the tree` of parent/children relationships
+//
+// Theoretically, there could be an infinite loop here but in practice there is
+// no use case for a loop so I expect that to only happen if someone is very
+// off track and creating their own set of themes
+const processTheme = ({ themeName, themeConfig, themeSpec }) => {
   // gatsby themes don't have to specify a gatsby-config.js (they might only use gatsby-node, etc)
-  if (themeConfigObj && themeConfigObj.__experimentalThemes) {
-    return Promise.mapSeries(
-      themeConfigObj.__experimentalThemes,
-      async spec => {
-        const themeObj = await resolveTheme(spec)
-        return processTheme(themeObj)
-      }
-    ).then(arr => arr.concat([{ themeName, themeConfigObj, themeSpec }]))
+  // in this case they're technically plugins, but we should support it anyway
+  // because we can't guarentee which files theme creators create first
+  if (themeConfig && themeConfig.__experimentalThemes) {
+    // for every parent theme a theme defines, resolve the parent's
+    // gatsby config and return it in order [parentA, parentB, child]
+    return Promise.mapSeries(themeConfig.__experimentalThemes, async spec => {
+      const themeObj = await resolveTheme(spec)
+      return processTheme(themeObj)
+    }).then(arr => arr.concat([{ themeName, themeConfig, themeSpec }]))
   } else {
-    return [{ themeName, themeConfigObj, themeSpec }]
+    // if a theme doesn't define additional themes, return the original theme
+    return [{ themeName, themeConfig, themeSpec }]
   }
 }
 
 module.exports = async config => {
-  let themes = []
-  return await Promise.mapSeries(
+  const themesA = await Promise.mapSeries(
     config.__experimentalThemes,
     async themeSpec => {
       const themeObj = await resolveTheme(themeSpec)
       return processTheme(themeObj)
     }
-  )
-    .then(arr => {
-      const flatThemes = _.flattenDeep(arr)
-      debug(flatThemes)
-      themes = flatThemes
-      return flatThemes
-    })
-    .mapSeries(({ themeName, themeConfigObj = {}, themeSpec }) => {
+  ).then(arr => _.flattenDeep(arr))
+
+  // log out flattened themes list to aid in debugging
+  debug(themesA)
+
+  // map over each theme, adding the theme itself to the plugins
+  // list in the config for the theme. This enables the usage of
+  // gatsby-node, etc in themes.
+  return (
+    Promise.mapSeries(themesA, ({ themeName, themeConfig = {}, themeSpec }) => {
       return {
-        ...themeConfigObj,
+        ...themeConfig,
         plugins: [
-          ...(themeConfigObj.plugins || []),
+          ...(themeConfig.plugins || []),
           // theme plugin is last so it's gatsby-node, etc can override it's declared plugins, like a normal site.
           { resolve: themeName, options: themeSpec.options || {} },
         ],
       }
     })
-    .reduce(mergeGatsbyConfig, {})
-    .then(newConfig => ({
-      config: mergeGatsbyConfig(newConfig, config),
-      themes,
-    }))
+      /**
+       * themes resolve to a gatsby-config, so here we merge all of the configs
+       * into a single config, making sure to maintain the order in which
+       * they were defined so that later configs, like the user's site and
+       * children, can override functionality in earlier themes.
+       */
+      .reduce(mergeGatsbyConfig, {})
+      .then(newConfig => {
+        return {
+          config: mergeGatsbyConfig(newConfig, config),
+          themes: themesA,
+        }
+      })
+  )
 }

--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -29,10 +29,7 @@ const processTheme = ({ themeName, themeConfigObj, themeSpec }) => {
         const themeObj = await resolveTheme(spec)
         return processTheme(themeObj)
       }
-    ).then(arr => {
-      console.log(arr)
-      return arr.concat([{ themeName, themeConfigObj, themeSpec }])
-    })
+    ).then(arr => arr.concat([{ themeName, themeConfigObj, themeSpec }]))
   } else {
     return [{ themeName, themeConfigObj, themeSpec }]
   }

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
@@ -6,7 +6,7 @@ exports.onCreateWebpackConfig = (
 ) => {
   const { program, themes } = store.getState()
 
-   if (themes.themes) {
+  if (themes.themes) {
     actions.setWebpackConfig({
       resolve: {
         plugins: [

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
@@ -4,14 +4,14 @@ exports.onCreateWebpackConfig = (
   { store, stage, getConfig, rules, loaders, actions },
   pluginOptions
 ) => {
-  const { config, program } = store.getState()
+  const { program, themes } = store.getState()
 
-  if (config.__experimentalThemes) {
+  if (themes) {
     actions.setWebpackConfig({
       resolve: {
         plugins: [
           new GatsbyThemeComponentShadowingResolverPlugin({
-            themes: config.__experimentalThemes.map(({ resolve }) => resolve),
+            themes: themes.themes.map(({ themeName }) => themeName),
             projectRoot: program.directory,
           }),
         ],

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
@@ -6,7 +6,7 @@ exports.onCreateWebpackConfig = (
 ) => {
   const { program, themes } = store.getState()
 
-  if (themes) {
+   if (themes.themes) {
     actions.setWebpackConfig({
       resolve: {
         plugins: [

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -1,13 +1,12 @@
 const path = require(`path`)
-const report = require(`gatsby-cli/lib/reporter`)
-const debug = require("debug")("gatsby:component-shadowing")
-const fs = require("fs")
+const debug = require(`debug`)(`gatsby:component-shadowing`)
+const fs = require(`fs`)
 
 module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
   cache = {}
 
   constructor({ projectRoot, themes }) {
-    debug("themes list", themes)
+    debug(`themes list`, themes)
     this.themes = themes
     this.projectRoot = projectRoot
   }
@@ -45,7 +44,7 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
 
       if (!builtComponentPath) {
         return resolver.doResolve(
-          "describedRelative",
+          `describedRelative`,
           request,
           null,
           {},
@@ -74,7 +73,7 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
     const themes = ogThemes.filter(t => t !== theme)
     if (!this.cache[`${theme}-${component}`]) {
       this.cache[`${theme}-${component}`] = [
-        path.join(path.resolve("."), `src`, theme),
+        path.join(path.resolve(`.`), `src`, theme),
       ]
         .concat(
           themes.map(aTheme =>
@@ -83,7 +82,7 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
         )
         .map(dir => path.join(dir, component))
         .find(possibleComponentPath => {
-          debug("possibleComponentPath", possibleComponentPath)
+          debug(`possibleComponentPath`, possibleComponentPath)
           let dir
           try {
             // we use fs/path instead of require.resolve to work with

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -16,7 +16,7 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
     resolver.plugin(`relative`, (request, callback) => {
       // find out which theme's src/components dir we're requiring from
       const matchingThemes = this.themes.filter(name =>
-        request.path.includes(path.join(name, `src`, `components`))
+        request.path.includes(path.join(name, `src`))
       )
       // 0 matching themes happens a lot fo rpaths we don't want to handle
       // > 1 matching theme means we have a path like
@@ -33,10 +33,8 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
       }
       // theme is the theme package from which we're requiring the relative component
       const [theme] = matchingThemes
-      // get the location of the component relative to src/components
-      const [, component] = request.path.split(
-        path.join(theme, `src`, `components`)
-      )
+      // get the location of the component relative to src/
+      const [, component] = request.path.split(path.join(theme, `src`))
 
       const builtComponentPath = this.resolveComponentPath({
         matchingTheme: theme,
@@ -76,16 +74,11 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
     const themes = ogThemes.filter(t => t !== theme)
     if (!this.cache[`${theme}-${component}`]) {
       this.cache[`${theme}-${component}`] = [
-        path.join(path.resolve("."), `src`, `components`, theme),
+        path.join(path.resolve("."), `src`, theme),
       ]
         .concat(
           themes.map(aTheme =>
-            path.join(
-              path.dirname(require.resolve(aTheme)),
-              `src`,
-              `components`,
-              theme
-            )
+            path.join(path.dirname(require.resolve(aTheme)), `src`, theme)
           )
         )
         .map(dir => path.join(dir, component))

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -1,5 +1,6 @@
 const path = require(`path`)
 const report = require(`gatsby-cli/lib/reporter`)
+const debug = require("debug")("gatsby:component-shadowing")
 
 module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
   cache = {}
@@ -36,7 +37,8 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
       )
 
       const builtComponentPath = this.resolveComponentPath({
-        theme,
+        matchingTheme: theme,
+        themes: this.themes,
         component,
         projectRoot: this.projectRoot,
       })
@@ -61,20 +63,14 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
 
   // check the cache, the user's project, and finally the theme files
   resolveComponentPath({ theme, component, projectRoot }) {
+    debug("path", path.resolve("."))
     if (!this.cache[`${theme}-${component}`]) {
       this.cache[`${theme}-${component}`] = [
         path.join(projectRoot, `src`, `components`, theme),
         path.join(path.dirname(require.resolve(theme)), `src`, `components`),
       ]
         .map(dir => path.join(dir, component))
-        .find(possibleComponentPath => {
-          try {
-            require.resolve(possibleComponentPath)
-            return true
-          } catch (e) {
-            return false
-          }
-        })
+        .find(possibleComponentPath => fs.existsSync(possibleComponentPath))
     }
 
     return this.cache[`${theme}-${component}`]

--- a/packages/gatsby/src/redux/reducers/index.js
+++ b/packages/gatsby/src/redux/reducers/index.js
@@ -41,4 +41,5 @@ module.exports = {
   babelrc: require(`./babelrc`),
   jsonDataPaths: require(`./json-data-paths`),
   thirdPartySchemas: require(`./thirdPartySchemas`),
+  themes: require(`./themes`),
 }

--- a/packages/gatsby/src/redux/reducers/themes.js
+++ b/packages/gatsby/src/redux/reducers/themes.js
@@ -1,0 +1,12 @@
+module.exports = (state = {}, action) => {
+  switch (action.type) {
+    case `SET_RESOLVED_THEMES`:
+      return {
+        ...state,
+        themes: action.payload,
+      }
+
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
## Description

Getting this up to reference from other PRs as ongoing work.

* extend the core theming composition API to be recursive, meaning themes can have parents and children.
* add theming to the redux store for usage in plugins like component shadowing
* [ ] update component shadowing for multiple themes


Related examples PR, showing the usage of the additions: https://github.com/ChristopherBiscardi/gatsby-theme-examples/pull/13