### PR TITLE
feat(gatsby-plugin-netlify-cms): add webpack hot reloading plugin

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -103,6 +103,8 @@ exports.onCreateWebpackConfig = (
             },
           }),
 
+        stage === `develop` && new webpack.HotModuleReplacementPlugin(),
+
         /**
          * Use a simple filename with no hash so we can access from source by
          * path.


### PR DESCRIPTION
Adds webpack's HotModuleReplacementPlugin in gatsby-plugin-netlify-cms

Fixes https://github.com/gatsbyjs/gatsby/issues/10767