### PR TITLE
Indicate code sample is JS

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -32,7 +32,7 @@ npm install --save-dev jest babel-jest react-test-renderer identity-obj-proxy ba
 Because Gatsby handles its own Babel configuration, you will need to manually
 tell Jest to use `babel-jest`. The easiest way to do this is to add a `jest.config.js`. You can set up some useful defaults at the same time:
 
-```json:title=jest.config.js
+```js:title=jest.config.js
 module.exports = {
   "transform": {
     "^.+\\.jsx?$": "<rootDir>/jest-preprocess.js"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Changes the code to indicate that it is JavaScript. This doesn't seem to make a different on Github, but changing it will help clarify the filetype on the docs webpage.