### PR TITLE
docs(env-variables): Add cURL example for refresh endpoint

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -137,6 +137,8 @@ Gatsby also allows you to specify another enviroment variable when running the l
 
 If set to true, this will expose a `/__refresh` webhook that is able to receive `POST` requests to _refresh_ the sourced content. This exposed webhook can be triggered whenever remote data changes, which means you can update your data without re-launching the development server.
 
+You can trigger this endpoint locally for example with `curl -X POST http://localhost:8000/__refresh`.
+
 ## Additional Environments (Staging, Test, etc)
 
 As noted above `NODE_ENV` is a reserved environment variable in Gatsby as it is needed by the build system to make key optimizations when compiling React and other modules. For this reason it is necessary to make use of a secondary environment variable for additional environment support, and manually make the environment variables available to the client-side code.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I added a cURL example for the refresh endpoint e.g. http://localhost:8000/__refresh.

## Related Issues

Related to #10328.