### PR TITLE
fix(examples): Update Gatsby version in example

### DIFF
--- a/examples/graphql-reference/package.json
+++ b/examples/graphql-reference/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "LekoArts <hello@lekoarts.de>",
   "dependencies": {
-    "gatsby": "^2.0.83",
+    "gatsby": "^2.0.85",
     "gatsby-image": "^2.0.22",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.6",


### PR DESCRIPTION
## Description

A version of Gatsby with the correct fix has been published, this is the same as https://github.com/gatsbyjs/gatsby/pull/10807
