### PR TITLE
fix(gatsby): test plugin name to handle symlinks, rather than path

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/__tests__/query-compiler.js
@@ -68,7 +68,12 @@ describe(`resolveThemes`, () => {
   it(`returns empty array if zero themes detected`, () => {
     ;[
       [],
-      [{ resolve: path.join(base, `gatsby-plugin-whatever`) }],
+      [
+        {
+          name: `gatsby-plugin-whatever`,
+          resolve: path.join(base, `gatsby-plugin-whatever`),
+        },
+      ],
       undefined,
     ].forEach(testRun => {
       expect(resolveThemes(testRun)).toEqual([])
@@ -80,6 +85,7 @@ describe(`resolveThemes`, () => {
     expect(
       resolveThemes([
         {
+          name: theme,
           resolve: path.join(base, `gatsby-theme-example`),
         },
       ])
@@ -92,6 +98,7 @@ describe(`resolveThemes`, () => {
     expect(
       resolveThemes([
         {
+          name: theme,
           resolve: path.join(base, theme),
         },
       ])

--- a/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js
@@ -66,7 +66,7 @@ const overlayErrorID = `graphql-compiler`
 
 const resolveThemes = (plugins = []) =>
   plugins.reduce((merged, plugin) => {
-    if (plugin.resolve.includes(`gatsby-theme-`)) {
+    if (plugin.name.includes(`gatsby-theme-`)) {
       merged.push(plugin.resolve)
     }
     return merged


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This simple PR augments the behavior to test the plugin's name, rather
than the plugin's resolved path, in the case that it could be
symlinked/linked. This seems to match the behavior we're expecting, and
_again_ will be cleaned up when #10787 lands.

## Related Issues

Related to #10787, #10786 