### PR TITLE
Update template-blog-post.js

### DIFF
--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -24,6 +24,25 @@ const renderAst = new rehypeReact({
   },
 }).Compiler
 
+function extractHostname(url) {
+    var hostname;
+    //find & remove protocol (http, ftp, etc.) and get hostname
+
+    if (url.indexOf("//") > -1) {
+        hostname = url.split('/')[2];
+    }
+    else {
+        hostname = url.split('/')[0];
+    }
+
+    //find & remove port number
+    hostname = hostname.split(':')[0];
+    //find & remove "?"
+    hostname = hostname.split('?')[0];
+
+    return hostname;
+}
+
 class BlogPostTemplate extends React.Component {
   render() {
     const post = this.props.data.markdownRemark
@@ -213,7 +232,9 @@ class BlogPostTemplate extends React.Component {
                       (originally published at
                       {` `}
                       <a href={post.frontmatter.canonicalLink}>
-                        {post.frontmatter.publishedAt}
+                        {post.frontmatter.publishedAt
+                            ? post.frontmatter.publishedAt
+                            : extractHostname(post.frontmatter.canonicalLink)}
                       </a>
                       )
                     </span>


### PR DESCRIPTION
Fixed [issue](https://github.com/gatsbyjs/gatsby/issues/10800)


## Description
Some blog posts on gatsbyjs.org have a canonicalLink, but no publishedAt key in their frontmatter. This leads to the blog post header saying (originally published at ), instead of (originally published at example.com).
if publishedAt doesn't exist i extracted the host name from the canonicalLink and rendered a `<a>` tag 
with the  host name



## Related Issues

<!--
 Fixes #10800 
-->
