### PR TITLE
Specify default sitemap path & that `gatsby build` is needed

### DIFF
--- a/docs/docs/creating-a-sitemap.md
+++ b/docs/docs/creating-a-sitemap.md
@@ -26,7 +26,7 @@ module.exports = {
 }
 ```
 
-This is all that's required to get a working sitemap with Gatsby! By default, the generated sitemap will include all of your site’s pages, but of course the plugin exposes options to configure this default functionality.
+Next run a `gatsby build` since the sitemap generation will only happen for production builds. This is all that's required to get a working sitemap with Gatsby! By default, the generated sitemap path is /sitemap.xml and will include all of your site’s pages, but of course the plugin exposes options to configure this default functionality.
 
 ### Additional Modification
 


### PR DESCRIPTION
## Description

Specify that the default sitemap path is /sitemap.xml and also specify that a `gatsby build` is needed and the sitemap is only generated in production builds.