### PR TITLE
fix(starter-showcase): added description field to mccrodp's starter repo

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -248,7 +248,7 @@
     - Responsive Design, optimized for Mobile devices
 - url: https://gatsby-starter-contentful-i18n.netlify.com/
   repo: https://github.com/mccrodp/gatsby-starter-contentful-i18n
-  description: n/a
+  description: Contentful starter repo with added i18n support and language switcher
   tags:
     - i18n
     - Contentful

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -248,7 +248,7 @@
     - Responsive Design, optimized for Mobile devices
 - url: https://gatsby-starter-contentful-i18n.netlify.com/
   repo: https://github.com/mccrodp/gatsby-starter-contentful-i18n
-  description: Contentful starter repo with added i18n support and language switcher
+  description: i18n support and language switcher for Contentful starter repo
   tags:
     - i18n
     - Contentful


### PR DESCRIPTION
## Description

Just a simple description field update on [my starter repo](https://github.com/mccrodp/gatsby-starter-contentful-i18n) added previously.

## Related Issues

Originally added for Gatsby v1 here: https://github.com/gatsbyjs/gatsby/pull/4138, but I just upgraded to v2 and checked the starters.md. Thanks for adding that! 🙇 
