### PR TITLE
updated gatsby-plugin-typography to accept user defined absolute paths

### DIFF
--- a/packages/gatsby-plugin-typography/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-node.js
@@ -9,11 +9,12 @@ exports.onPreBootstrap = ({ store }, pluginOptions) => {
 
   let module
   if (pluginOptions.pathToConfigModule) {
-    module = `module.exports = require("${path.join(
-      program.directory,
-      pluginOptions.pathToConfigModule
-    )}")`
-    if (os.platform() == `win32`) {
+    module = `module.exports = require("${
+      path.isAbsolute(pluginOptions.pathToConfigModule)
+        ? pluginOptions.pathToConfigModule
+        : path.join(program.directory, pluginOptions.pathToConfigModule)
+    }")`
+    if (os.platform() === `win32`) {
       module = module.split(`\\`).join(`\\\\`)
     }
   } else {
@@ -22,7 +23,7 @@ const typography = new Typography()
 module.exports = typography`
   }
 
-  const dir = `${__dirname}/.cache`
+  const dir = `${program.directory}/.cache`
 
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)

--- a/packages/gatsby-plugin-typography/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-node.js
@@ -23,7 +23,7 @@ const typography = new Typography()
 module.exports = typography`
   }
 
-  const dir = `${program.directory}/.cache`
+  const dir = `${__dirname}/.cache`
 
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This is an update to allow gatsby-plugin-typography to accept an absolute path, addressing an issue by @ChristopherBiscardi. It is needed for the typography util to work with Gatsby themes.

## Related Issues

Addresses [this issue](https://github.com/ChristopherBiscardi/gatsby-theme-examples/pull/5#issue-231077246)
