### PR TITLE
feat(https): fix SSL naming error caused by @ scoped package name

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -249,9 +249,10 @@ module.exports = async (program: any) => {
 
   // Check if https is enabled, then create or get SSL cert.
   // Certs are named after `name` inside the project's package.json.
+  // Scoped names are converted from @npm/package-name to npm--package-name
   if (program.https) {
     program.ssl = await getSslCert({
-      name: program.sitePackageJson.name,
+      name: program.sitePackageJson.name.replace(`@`, ``).replace(`/`, `--`),
       certFile: program[`cert-file`],
       keyFile: program[`key-file`],
       directory: program.directory,


### PR DESCRIPTION
converts the package name from `@npm/package-name` to `npm--package-name` when generating a development environment SSL cert.

* Note that this change does not effect unscoped packages

fixes #10840 