### PR TITLE
Fix file path typo in docs/authentication-tutorial.md

### DIFF
--- a/docs/docs/authentication-tutorial.md
+++ b/docs/docs/authentication-tutorial.md
@@ -310,7 +310,7 @@ Though the routing is working now, you still can access all routes without restr
 
 To check if a user can access the content, you can wrap the restricted content inside a PrivateRoute component:
 
-```jsx:title=scr/components/privateRoute.js
+```jsx:title=src/components/privateRoute.js
 import React from "react"
 import { navigate } from "gatsby"
 import { isLoggedIn } from "../services/auth"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixes a small typo in a file path header in one of the example code blocks.

## Related Issues

N/A