### PR TITLE
Add gatsby-starter-tailwind-purgecss starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1558,3 +1558,12 @@
     - SASS/SCSS
     - Comes with React Helmet for adding site meta tags
     - Includes plugins for offline support out of the box
+- url: https://gatsby-starter-tailwind-purgecss.netlify.com
+  repo: https://github.com/lukebennett88/gatsby-starter-tailwind-purgecss
+  description: Gatsby starter with Tailwind and PurgeCSS
+  tags:
+    - Styling:Tailwind
+    - Styling:PostCSS
+    - Styling:postcss-preset-env
+  features:
+    - Extremely lightweight Gatsby starter using Tailwind for styling and PurgeCSS to remove unused classes.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Add gatsby-starter-tailwind-purgecss starter
Another Tailwind starter, but using PurgeCSS to remove unused classes on build.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->