### PR TITLE
fix(gatsby-source-wordpress): add a check for namespaces in response from wp

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -445,9 +445,9 @@ function getValidRoutes({
   if (_useACF) {
     let defaultAcfNamespace = `acf/v3`
     // Grab ACF Version from namespaces
-    const acfNamespace = allRoutes.data.namespaces.find(namespace =>
-      namespace.includes(`acf`)
-    )
+    const acfNamespace = allRoutes.data.namespaces
+      ? allRoutes.data.namespaces.find(namespace => namespace.includes(`acf`))
+      : null
     const acfRestNamespace = acfNamespace ? acfNamespace : defaultAcfNamespace
     _includedRoutes.push(`/${acfRestNamespace}/**`)
 


### PR DESCRIPTION
When using Wordpress.com, `namespaces` doesn't exist in the API response and a code block that tries to access it (when `useACF` is set to `true` in `gatsby-config`) breaks and throws a big red _irrelevant_ error 

This fix adds a defensive check for the above

Note: Use of ACF with Wordpress.com still remains untested

Fixes https://github.com/gatsbyjs/gatsby/issues/10883