### PR TITLE
fix(gatsby-transformer-remark): correctly pass cache to sub plugins

### DIFF
--- a/e2e-tests/development-runtime/content/2018-12-14-hello-world.md
+++ b/e2e-tests/development-runtime/content/2018-12-14-hello-world.md
@@ -6,3 +6,5 @@ date: 2018-12-14
 This is a truly meaningful blog post
 
 <h2 data-testid="sub-title">%SUB_TITLE%</h2>
+
+<h2 data-testid="gatsby-remark-subcache-value"></h2>

--- a/e2e-tests/development-runtime/cypress/integration/functionality/sub-plugin-caching.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/sub-plugin-caching.js
@@ -1,0 +1,16 @@
+/*
+ * This e2e test validates that the cache structure
+ * is unique per plugin (even sub-plugins)
+ * and can interact between Gatsby lifecycles and a plugin
+ */
+describe(`sub-plugin caching`, () => {
+  beforeEach(() => {
+    cy.visit(`/2018-12-14-hello-world/`).waitForAPI(`onRouteUpdate`)
+  })
+
+  it(`has access to custom sub-plugin cache`, () => {
+    cy.getTestElement(`gatsby-remark-subcache-value`)
+      .invoke(`text`)
+      .should(`eq`, `Hello World`)
+  })
+})

--- a/e2e-tests/development-runtime/gatsby-config.js
+++ b/e2e-tests/development-runtime/gatsby-config.js
@@ -24,7 +24,7 @@ module.exports = {
     {
       resolve: `gatsby-transformer-remark`,
       options: {
-        plugins: [],
+        plugins: [`gatsby-remark-subcache`],
       },
     },
     `gatsby-plugin-sharp`,

--- a/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/constants.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/constants.js
@@ -1,0 +1,1 @@
+exports.id = `gatsby-remark-subcache-value`

--- a/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/gatsby-node.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/gatsby-node.js
@@ -1,0 +1,5 @@
+const { id } = require(`./constants`)
+
+exports.onPreBootstrap = async ({ cache }) => {
+  await cache.set(id, `Hello World`)
+}

--- a/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/index.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/index.js
@@ -1,0 +1,11 @@
+const visit = require(`unist-util-visit`)
+const { id } = require(`./constants`)
+
+module.exports = function remarkPlugin({ cache, markdownAST }) {
+  visit(markdownAST, `html`, async node => {
+    if (node.value.match(id)) {
+      const value = await cache.get(id)
+      node.value = node.value.replace(/></, () => `>${value}<`)
+    }
+  })
+}

--- a/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/package.json
+++ b/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "gatsby-remark-subcache"
+}

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -67,7 +67,16 @@ const withPathPrefix = (url, pathPrefix) =>
 const ASTPromiseMap = new Map()
 
 module.exports = (
-  { type, store, pathPrefix, getNode, getNodesByType, cache, reporter },
+  {
+    type,
+    pathPrefix,
+    getNode,
+    getNodesByType,
+    cache,
+    getCache,
+    reporter,
+    ...rest
+  },
   pluginOptions
 ) => {
   if (type.name !== `MarkdownRemark`) {
@@ -150,7 +159,9 @@ module.exports = (
               files: fileNodes,
               getNode,
               reporter,
-              cache,
+              cache: getCache(plugin.name),
+              getCache,
+              ...rest,
             },
             plugin.pluginOptions
           )
@@ -218,7 +229,9 @@ module.exports = (
               files: fileNodes,
               pathPrefix,
               reporter,
-              cache,
+              cache: getCache(plugin.name),
+              getCache,
+              ...rest,
             },
             plugin.pluginOptions
           )

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -3,7 +3,7 @@ const crypto = require(`crypto`)
 const _ = require(`lodash`)
 
 module.exports = async function onCreateNode(
-  { node, getNode, loadNodeContent, actions, createNodeId, reporter },
+  { node, loadNodeContent, actions, createNodeId, reporter },
   pluginOptions
 ) {
   const { createNode, createParentChildLink } = actions


### PR DESCRIPTION
## Description

Separate some changes from #10146, specifically so we can make this a non-breaking change if the right version of Gatsby isn't specified.

Note: I will add a warning/log (or error?) if the API doesn't exist so the user can update.

## Related Issues

Related to #10146