### PR TITLE
feat(starters): pass through rest of the props, and support children

### DIFF
--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -94,7 +94,7 @@ const detailsQuery = graphql`
     site {
       siteMetadata {
         author
-        description
+        description(pruneLength: 160)
         title
       }
     }

--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -73,6 +73,7 @@ function SEO({ children, description, lang, meta, keywords, title, ...rest }) {
 SEO.defaultProps = {
   lang: `en`,
   meta: [],
+  link: [],
   keywords: [],
 }
 
@@ -80,6 +81,7 @@ SEO.propTypes = {
   children: PropTypes.node,
   description: PropTypes.string,
   lang: PropTypes.string,
+  link: PropTypes.array,
   meta: PropTypes.array,
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,

--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
 
-function SEO({ description, lang, meta, keywords, title }) {
+function SEO({ children, description, lang, meta, keywords, title, ...rest }) {
   return (
     <StaticQuery
       query={detailsQuery}
@@ -60,7 +60,10 @@ function SEO({ description, lang, meta, keywords, title }) {
                   : []
               )
               .concat(meta)}
-          />
+            {...rest}
+          >
+            {children}
+          </Helmet>
         )
       }}
     />
@@ -74,6 +77,7 @@ SEO.defaultProps = {
 }
 
 SEO.propTypes = {
+  children: PropTypes.node,
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.array,
@@ -87,9 +91,9 @@ const detailsQuery = graphql`
   query DefaultSEOQuery {
     site {
       siteMetadata {
-        title
-        description
         author
+        description
+        title
       }
     }
   }

--- a/starters/default/gatsby-config.js
+++ b/starters/default/gatsby-config.js
@@ -2,6 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby Default Starter`,
     description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
+    siteUrl: `https://your-site-here.com`,
     author: `@gatsbyjs`,
   },
   plugins: [

--- a/starters/default/src/components/seo.js
+++ b/starters/default/src/components/seo.js
@@ -94,7 +94,7 @@ const detailsQuery = graphql`
     site {
       siteMetadata {
         author
-        description
+        description(pruneLength: 160)
         title
       }
     }

--- a/starters/default/src/components/seo.js
+++ b/starters/default/src/components/seo.js
@@ -73,6 +73,7 @@ function SEO({ children, description, lang, meta, keywords, title, ...rest }) {
 SEO.defaultProps = {
   lang: `en`,
   meta: [],
+  link: [],
   keywords: [],
 }
 
@@ -80,6 +81,7 @@ SEO.propTypes = {
   children: PropTypes.node,
   description: PropTypes.string,
   lang: PropTypes.string,
+  link: PropTypes.array,
   meta: PropTypes.array,
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,

--- a/starters/default/src/components/seo.js
+++ b/starters/default/src/components/seo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
 
-function SEO({ description, lang, meta, keywords, title }) {
+function SEO({ children, description, lang, meta, keywords, title, ...rest }) {
   return (
     <StaticQuery
       query={detailsQuery}
@@ -60,7 +60,10 @@ function SEO({ description, lang, meta, keywords, title }) {
                   : []
               )
               .concat(meta)}
-          />
+            {...rest}
+          >
+            {children}
+          </Helmet>
         )
       }}
     />
@@ -74,6 +77,7 @@ SEO.defaultProps = {
 }
 
 SEO.propTypes = {
+  children: PropTypes.node,
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.array,
@@ -87,9 +91,9 @@ const detailsQuery = graphql`
   query DefaultSEOQuery {
     site {
       siteMetadata {
-        title
-        description
         author
+        description
+        title
       }
     }
   }


### PR DESCRIPTION
## Description

With some feedback from @khalwat I think it's prudent to enable some additional features in the SEO component. I want to balance _smart defaults_ with something that's also extensible, and I think this does this pretty well.

Specifically, this enables the (small) features like:

- Ability to pass an array of `link` items
- Pass through any additional props directly to the `<Helmet />` component
- Expose the `children` prop for an alternative API, which some could prefer

Ideally - I'd be able to show how to make images absolute (prefixing with siteUrl), link rel="canonical", etc. but I also want to strike the balance between not offering too opinionated of a component out of the box. We want something relatively simple that can be built upon, and I think building those features in makes too many decisions that are best left to the developer.

For instance, to add a `link rel="canonical"` it'd be something like the below:

```jsx
-function SEO({ children, description, lang, meta, keywords, title, ...rest }) {
+function SEO({ canonical, children, description, lang, link, meta, keywords, title, ...rest }) {
   return (
     <StaticQuery
       query={detailsQuery}
       render={data => {
         const metaDescription =
           description || data.site.siteMetadata.description
+        const siteUrl = data.site.siteMetadata.siteUrl
         return (
           <Helmet
             htmlAttributes={{
@@ -17,6 +18,16 @@ function SEO({ children, description, lang, meta, keywords, title, ...rest }) {
             }}
             title={title}
             titleTemplate={`%s | ${data.site.siteMetadata.title}`}
+            link={
+              []
+                .concat(canonical ? [
+                  {
+                    rel: 'canonical',
+                    href: `${siteUrl}/${canonical}`
+                  }
+                ] : [])
+                .concat(link)
+            }
             meta={[
               {
                 name: `description`,
@@ -72,11 +83,13 @@ function SEO({ children, description, lang, meta, keywords, title, ...rest }) {
 
 SEO.defaultProps = {
   lang: `en`,
+  link: [],
   meta: [],
   keywords: [],
 }
 
 SEO.propTypes = {
+  canonical: PropTypes.string,
   children: PropTypes.node,
   description: PropTypes.string,
   lang: PropTypes.string,
@@ -93,6 +106,7 @@ const detailsQuery = graphql`
       siteMetadata {
         author
         description
+        siteUrl
         title
       }
     }

```

My approach here will be I'll show _how_ to extend this component in #10780 so that it's clear how we can build upon this solid base.

## Related Issues

Related to #10780.