### PR TITLE
feat(gatsby-plugin-google-analytics): add support for google optimize experiment and variation id

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -26,6 +26,10 @@ module.exports = {
         exclude: ["/preview/**", "/do-not-track/me/too/"],
         // Enables Google Optimize using your container Id
         optimizeId: "YOUR_GOOGLE_OPTIMIZE_TRACKING_ID",
+        // Enables Google Optimize Experiment ID
+        experimentId: "YOUR_GOOGLE_EXPERIMENT_ID",
+        // Set Variation ID. 0 for original 1,2,3....
+        variationId: "YOUR_GOOGLE_OPTIMIZE_VARIATION_ID"
         // Any additional create only fields (optional)
         sampleRate: 5,
         siteSpeedSampleRate: 10,
@@ -91,6 +95,14 @@ If you need to exclude any path from the tracking system, you can add it (one or
 ## The "optimizeId" option
 
 If you need to use Google Optimize for A/B testing, you can add this optional Optimize container id to allow Google Optimize to load the correct test parameters for your site.
+
+## The "experimentId" option
+
+If you need to setup SERVER_SIDE Google Optimize experiment, you can add the experiment ID. The experiment ID is shown on the right-hand panel on the experiment details page. [Server-side Experiments](https://developers.google.com/optimize/devguides/experiments)
+
+## The "variationId" option
+
+Besides the experiment ID you also need the variation ID for SERVER_SIDE experiments in Google Optimize. Set 0 for original version.
 
 ## Create Only Fields
 

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -87,6 +87,16 @@ exports.onRenderBody = (
         typeof pluginOptions.optimizeId !== `undefined`
           ? `ga('require', '${pluginOptions.optimizeId}');`
           : ``
+      }
+      ${
+        typeof pluginOptions.experimentId !== `undefined`
+          ? `ga('set', 'expId', '${pluginOptions.experimentId}');`
+          : ``
+      }
+      ${
+        typeof pluginOptions.variationId !== `undefined`
+          ? `ga('set', 'expVar', '${pluginOptions.variationId}');`
+          : ``
       }}
       `,
         }}


### PR DESCRIPTION
This PR adds support for google optimize experiment and variation id to make it possible to run server_side experiments. This works great with netlify because they have built-in split testing. 

All tests passed when running yarn test
