### PR TITLE
fix(gatsby-transformer-remark): remove unused _PARENT field from frontmatter

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -7,7 +7,6 @@ Array [
       "children": Array [],
       "excerpt": "",
       "frontmatter": Object {
-        "_PARENT": "whatever",
         "date": "2017-09-18T23:19:51.246Z",
         "title": "my little pony",
       },
@@ -15,7 +14,7 @@ Array [
       "internal": Object {
         "content": "Where oh where is my little pony?
             ",
-        "contentDigest": "e33e9489dc1352bfac2577e99155c1b3",
+        "contentDigest": "26a9a60af333645b5ca69261c7d9aa53",
         "type": "MarkdownRemark",
       },
       "parent": "whatever",
@@ -34,7 +33,6 @@ Array [
         "children": Array [],
         "excerpt": "",
         "frontmatter": Object {
-          "_PARENT": "whatever",
           "date": "2017-09-18T23:19:51.246Z",
           "title": "my little pony",
         },
@@ -42,7 +40,7 @@ Array [
         "internal": Object {
           "content": "Where oh where is my little pony?
             ",
-          "contentDigest": "e33e9489dc1352bfac2577e99155c1b3",
+          "contentDigest": "26a9a60af333645b5ca69261c7d9aa53",
           "type": "MarkdownRemark",
         },
         "parent": "whatever",
@@ -79,7 +77,6 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
 
 ",
       "frontmatter": Object {
-        "_PARENT": "whatever",
         "date": "2017-09-18T23:19:51.246Z",
         "title": "my little pony",
       },
@@ -97,7 +94,7 @@ Sed eu gravida mauris. Suspendisse potenti. Praesent sit amet egestas mi, sed he
 
 Sed bibendum sem iaculis, pellentesque leo sed, imperdiet ante. Sed consequat mattis dui nec pretium. Donec vel consectetur est. Nam sagittis, libero vitae pretium pharetra, velit est dignissim erat, at cursus quam massa vitae ligula. Suspendisse potenti. In hac habitasse platea dictumst. Donec sit amet finibus justo. Mauris ante dolor, pulvinar vitae feugiat eu, rhoncus nec diam. In ut accumsan diam, faucibus fringilla odio. Nunc id ultricies turpis. Quisque justo quam, tristique sit amet interdum quis, facilisis at mi. Fusce porttitor vel sem ut condimentum. Praesent at libero congue, vulputate elit ut, rhoncus erat.
             ",
-        "contentDigest": "e9f6c76d1bc3cb15f402ed2c24b815bd",
+        "contentDigest": "024ff0e6141e2121fe04090114c7535a",
         "type": "MarkdownRemark",
       },
       "parent": "whatever",
@@ -130,7 +127,6 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
 
 ",
         "frontmatter": Object {
-          "_PARENT": "whatever",
           "date": "2017-09-18T23:19:51.246Z",
           "title": "my little pony",
         },
@@ -148,7 +144,7 @@ Sed eu gravida mauris. Suspendisse potenti. Praesent sit amet egestas mi, sed he
 
 Sed bibendum sem iaculis, pellentesque leo sed, imperdiet ante. Sed consequat mattis dui nec pretium. Donec vel consectetur est. Nam sagittis, libero vitae pretium pharetra, velit est dignissim erat, at cursus quam massa vitae ligula. Suspendisse potenti. In hac habitasse platea dictumst. Donec sit amet finibus justo. Mauris ante dolor, pulvinar vitae feugiat eu, rhoncus nec diam. In ut accumsan diam, faucibus fringilla odio. Nunc id ultricies turpis. Quisque justo quam, tristique sit amet interdum quis, facilisis at mi. Fusce porttitor vel sem ut condimentum. Praesent at libero congue, vulputate elit ut, rhoncus erat.
             ",
-          "contentDigest": "e9f6c76d1bc3cb15f402ed2c24b815bd",
+          "contentDigest": "024ff0e6141e2121fe04090114c7535a",
           "type": "MarkdownRemark",
         },
         "parent": "whatever",

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -45,7 +45,6 @@ module.exports = async function onCreateNode(
     markdownNode.frontmatter = {
       title: ``, // always include a title
       ...data.data,
-      _PARENT: node.id,
     }
 
     markdownNode.excerpt = data.excerpt


### PR DESCRIPTION
`gatsby-transformer-remark` puts a `_PARENT` field on frontmatter, that does not seem to be used. Maybe from a time before node-tracking?