### PR TITLE
fix(gatsby-starter-blog): import graphql in 404 page of blog starter

### DIFF
--- a/starters/blog/src/pages/404.js
+++ b/starters/blog/src/pages/404.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/Layout'
 import SEO from '../components/seo'


### PR DESCRIPTION
## Description

Import `graphql` in the 404 page of the blog starter, to prevent deprecation warnings for everyone using this starter.
