### PR TITLE
fix(gatsby-starter-blog): Fix global access to graphql in blog starter's 404

### DIFF
--- a/starters/blog/src/pages/404.js
+++ b/starters/blog/src/pages/404.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/Layout'
 import SEO from '../components/seo'


### PR DESCRIPTION
Global access to `graphql` (which is deprecated) got added accidentally in https://github.com/gatsbyjs/gatsby/pull/10865/files

This fixes that and gets rids of the annoying warning in the output
![screenshot 2019-01-08 22 52 33](https://user-images.githubusercontent.com/7701981/50847634-1af91900-1398-11e9-97f5-a5ea812fc873.png)

