### PR TITLE
fix(gatsby-transformer-remark): don't convert Date objects

### DIFF
--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,6 +1,5 @@
 const grayMatter = require(`gray-matter`)
 const crypto = require(`crypto`)
-const yaml = require(`js-yaml`)
 
 module.exports = async function onCreateNode(
   { node, loadNodeContent, actions, createNodeId, reporter },
@@ -19,10 +18,7 @@ module.exports = async function onCreateNode(
   const content = await loadNodeContent(node)
 
   try {
-    const data = grayMatter(content, {
-      schema: yaml.CORE_SCHEMA,
-      ...pluginOptions,
-    })
+    const data = grayMatter(content, pluginOptions)
 
     const markdownNode = {
       id: createNodeId(`${node.id} >>> MarkdownRemark`),

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,9 +1,9 @@
 const grayMatter = require(`gray-matter`)
 const crypto = require(`crypto`)
-const _ = require(`lodash`)
+const yaml = require(`js-yaml`)
 
 module.exports = async function onCreateNode(
-  { node, getNode, loadNodeContent, actions, createNodeId, reporter },
+  { node, loadNodeContent, actions, createNodeId, reporter },
   pluginOptions
 ) {
   const { createNode, createParentChildLink } = actions
@@ -19,18 +19,10 @@ module.exports = async function onCreateNode(
   const content = await loadNodeContent(node)
 
   try {
-    let data = grayMatter(content, pluginOptions)
-    // Convert date objects to string. Otherwise there's type mismatches
-    // during inference as some dates are strings and others date objects.
-    if (data.data) {
-      data.data = _.mapValues(data.data, v => {
-        if (_.isDate(v)) {
-          return v.toJSON()
-        } else {
-          return v
-        }
-      })
-    }
+    const data = grayMatter(content, {
+      schema: yaml.CORE_SCHEMA,
+      ...pluginOptions,
+    })
 
     const markdownNode = {
       id: createNodeId(`${node.id} >>> MarkdownRemark`),


### PR DESCRIPTION
`gatsby-transformer-remark` parses frontmatter with `gray-matter` and then iterates through frontmatter fields again to transform Dates into strings.

This PR proposes to only allow types from the YAML 1.2 spec, which has no `timestamp` type anymore (the 1.1 spec has). This way, dates will automatically be parsed as strings.

For the different `schema` options that the yaml parser accepts [see here](https://github.com/nodeca/js-yaml#safeload-string---options-).