### PR TITLE
feat(www): update tags design, add 'View All Tags' buttons

### DIFF
--- a/www/src/components/tags-section.js
+++ b/www/src/components/tags-section.js
@@ -1,5 +1,8 @@
 import React from "react"
 import { Link } from "gatsby"
+import TagsIcon from "react-icons/lib/ti/tags"
+
+import Button from "./button"
 import { rhythm, scale } from "../utils/typography"
 const _ = require(`lodash`)
 
@@ -15,15 +18,27 @@ const TagsSection = ({ tags }) => {
     )
   })
   return (
-    <em
-      style={{
-        ...scale(-1 / 5),
-        display: `block`,
-        marginBottom: rhythm(1),
+    <div
+      css={{
+        display: `flex`,
+        flexFlow: `row nowrap`,
+        justifyContent: `space-between`,
+        alignItems: `baseline`,
       }}
     >
-      Tagged with {tagLinks}
-    </em>
+      <em
+        style={{
+          ...scale(-1 / 5),
+          display: `block`,
+          marginBottom: rhythm(1),
+        }}
+      >
+        Tagged with {tagLinks}
+      </em>
+      <Button tiny key="blog-post-view-all-tags-button" to="/blog/tags">
+        View All Tags <TagsIcon />
+      </Button>
+    </div>
   )
 }
 

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -10,60 +10,134 @@ import { Helmet } from "react-helmet"
 import { Link } from "gatsby"
 import Layout from "../../components/layout"
 import Container from "../../components/container"
+import presets, { colors } from "../../utils/presets"
+import { rhythm, options } from "../../utils/typography"
 
-const TagsPage = ({
-  data: {
-    allMarkdownRemark: { group },
-  },
-  location,
-}) => {
-  const uniqGroup = group.reduce((lookup, tag) => {
-    const key = kebabCase(tag.fieldValue.toLowerCase())
-    if (!lookup[key]) {
-      lookup[key] = Object.assign(tag, {
-        slug: `/blog/tags/${key}`,
-      })
-    }
-    return lookup
-  }, {})
-
-  return (
-    <Layout location={location}>
-      <Container>
-        <Helmet title="Tags" />
-        <div>
-          <h1>Tags</h1>
-          <ul>
-            {Object.keys(uniqGroup)
-              .sort((tagA, tagB) => tagA.localeCompare(tagB))
-              .map(key => {
-                const tag = uniqGroup[key]
-                return (
-                  <li key={tag.fieldValue}>
-                    <Link to={tag.slug}>
-                      {tag.fieldValue} ({tag.totalCount})
-                    </Link>
-                  </li>
-                )
-              })}
-          </ul>
-        </div>
-      </Container>
-    </Layout>
-  )
-}
-
-TagsPage.propTypes = {
-  data: PropTypes.shape({
-    allMarkdownRemark: PropTypes.shape({
-      group: PropTypes.arrayOf(
-        PropTypes.shape({
-          fieldValue: PropTypes.string.isRequired,
-          totalCount: PropTypes.number.isRequired,
-        }).isRequired
-      ),
+class TagsPage extends React.Component {
+  static propTypes = {
+    data: PropTypes.shape({
+      allMarkdownRemark: PropTypes.shape({
+        group: PropTypes.arrayOf(
+          PropTypes.shape({
+            fieldValue: PropTypes.string.isRequired,
+            totalCount: PropTypes.number.isRequired,
+          }).isRequired
+        ),
+      }),
     }),
-  }),
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      filterQuery: ``,
+    }
+  }
+
+  handleChange = ({ target: { name, value } }) => {
+    this.setState({ [name]: value })
+  }
+
+  render() {
+    const {
+      data: {
+        allMarkdownRemark: { group },
+      },
+      location,
+    } = this.props
+    const { filterQuery } = this.state
+    const uniqGroup = group.reduce((lookup, tag) => {
+      const key = kebabCase(tag.fieldValue.toLowerCase())
+      if (!lookup[key]) {
+        lookup[key] = Object.assign(tag, {
+          slug: `/blog/tags/${key}`,
+        })
+      }
+      return lookup
+    }, {})
+
+    return (
+      <Layout location={location}>
+        <Container>
+          <Helmet title="Tags" />
+          <div>
+            <div
+              css={{
+                display: `flex`,
+                flexFlow: `row nowrap`,
+                justifyContent: `space-between`,
+                alignItems: `center`,
+                paddingTop: rhythm(options.blockMarginBottom * 2),
+                paddingBottom: rhythm(options.blockMarginBottom),
+                borderBottom: `1px solid ${colors.ui.border}`,
+              }}
+            >
+              <h1 css={{ margin: 0 }}>Tags</h1>
+              <input
+                id="tagsFilter"
+                name="filterQuery"
+                css={{
+                  appearance: `none`,
+                  backgroundColor: `#ffffff`,
+                  border: `1px solid ${colors.lilac}`,
+                  borderRadius: presets.radius,
+                  color: colors.lilac,
+                  paddingTop: rhythm(1 / 8),
+                  paddingRight: rhythm(1 / 4),
+                  paddingBottom: rhythm(1 / 8),
+                  paddingLeft: rhythm(5 / 4),
+                  overflow: `hidden`,
+                  width: `60%`,
+                  height: `45px`,
+                  marginLeft: `25px`,
+                  ":focus": {
+                    color: colors.gatsby,
+                    outline: 0,
+                  },
+                }}
+                type="search"
+                placeholder="Search tags"
+                aria-label="Tag Search"
+                title="Filter tag list"
+                value={filterQuery}
+                onChange={this.handleChange}
+              />
+            </div>
+            <ul
+              css={{
+                display: `flex`,
+                flexFlow: `row wrap`,
+                justifyContent: `center`,
+                padding: 0,
+                margin: 0,
+              }}
+            >
+              {Object.keys(uniqGroup)
+                .sort((tagA, tagB) => tagA.localeCompare(tagB))
+                .filter(key => uniqGroup[key].fieldValue.includes(filterQuery))
+                .map(key => {
+                  const tag = uniqGroup[key]
+                  return (
+                    <li
+                      key={tag.fieldValue}
+                      css={{
+                        padding: `10px 5px`,
+                        margin: `15px`,
+                        listStyleType: `none`,
+                      }}
+                    >
+                      <Link to={tag.slug}>
+                        {tag.fieldValue} ({tag.totalCount})
+                      </Link>
+                    </li>
+                  )
+                })}
+            </ul>
+          </div>
+        </Container>
+      </Layout>
+    )
+  }
 }
 
 export default TagsPage

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -13,6 +13,8 @@ import Container from "../../components/container"
 import presets, { colors } from "../../utils/presets"
 import { rhythm, options } from "../../utils/typography"
 
+let currentLetter = ``
+
 class TagsPage extends React.Component {
   static propTypes = {
     data: PropTypes.shape({
@@ -35,6 +37,7 @@ class TagsPage extends React.Component {
   }
 
   handleChange = ({ target: { name, value } }) => {
+    currentLetter = ``
     this.setState({ [name]: value })
   }
 
@@ -107,7 +110,7 @@ class TagsPage extends React.Component {
               css={{
                 display: `flex`,
                 flexFlow: `row wrap`,
-                justifyContent: `center`,
+                justifyContent: `start`,
                 padding: 0,
                 margin: 0,
               }}
@@ -117,7 +120,8 @@ class TagsPage extends React.Component {
                 .filter(key => uniqGroup[key].fieldValue.includes(filterQuery))
                 .map(key => {
                   const tag = uniqGroup[key]
-                  return (
+                  const firstLetter = tag.fieldValue.charAt(0).toLowerCase()
+                  const buildTag = (
                     <li
                       key={tag.fieldValue}
                       css={{
@@ -131,6 +135,19 @@ class TagsPage extends React.Component {
                       </Link>
                     </li>
                   )
+
+                  if (currentLetter !== firstLetter) {
+                    currentLetter = firstLetter
+                    return (
+                      <React.Fragment>
+                        <h4 css={{ width: `100%`, flexBasis: `100%` }}>
+                          {currentLetter.toUpperCase()}
+                        </h4>
+                        {buildTag}
+                      </React.Fragment>
+                    )
+                  }
+                  return buildTag
                 })}
             </ul>
           </div>

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -10,7 +10,9 @@ import { Helmet } from "react-helmet"
 import { Link } from "gatsby"
 import Layout from "../../components/layout"
 import Container from "../../components/container"
-import presets, { colors } from "../../utils/presets"
+import SearchIcon from "../../components/search-icon"
+import styles from "../../views/shared/styles"
+import { colors } from "../../utils/presets"
 import { rhythm, options } from "../../utils/typography"
 
 let currentLetter = ``
@@ -58,6 +60,9 @@ class TagsPage extends React.Component {
       }
       return lookup
     }, {})
+    const results = Object.keys(uniqGroup)
+      .sort((tagA, tagB) => tagA.localeCompare(tagB))
+      .filter(key => uniqGroup[key].fieldValue.includes(filterQuery))
 
     return (
       <Layout location={location}>
@@ -75,36 +80,38 @@ class TagsPage extends React.Component {
                 borderBottom: `1px solid ${colors.ui.border}`,
               }}
             >
-              <h1 css={{ margin: 0 }}>Tags</h1>
-              <input
-                id="tagsFilter"
-                name="filterQuery"
-                css={{
-                  appearance: `none`,
-                  backgroundColor: `#ffffff`,
-                  border: `1px solid ${colors.lilac}`,
-                  borderRadius: presets.radius,
-                  color: colors.lilac,
-                  paddingTop: rhythm(1 / 8),
-                  paddingRight: rhythm(1 / 4),
-                  paddingBottom: rhythm(1 / 8),
-                  paddingLeft: rhythm(5 / 4),
-                  overflow: `hidden`,
-                  width: `60%`,
-                  height: `45px`,
-                  marginLeft: `25px`,
-                  ":focus": {
-                    color: colors.gatsby,
-                    outline: 0,
-                  },
-                }}
-                type="search"
-                placeholder="Search tags"
-                aria-label="Tag Search"
-                title="Filter tag list"
-                value={filterQuery}
-                onChange={this.handleChange}
-              />
+              <h1 css={{ margin: 0 }}>
+                Tags ({Object.keys(uniqGroup).length || 0})
+              </h1>
+              <div>
+                <label css={{ position: `relative` }}>
+                  <input
+                    css={{
+                      ...styles.searchInput,
+                    }}
+                    id="tagsFilter"
+                    name="filterQuery"
+                    type="search"
+                    placeholder="Search tags"
+                    aria-label="Tag Search"
+                    title="Filter tag list"
+                    value={filterQuery}
+                    onChange={this.handleChange}
+                  />
+                  <SearchIcon
+                    overrideCSS={{
+                      fill: colors.lilac,
+                      position: `absolute`,
+                      left: `5px`,
+                      top: `50%`,
+                      width: `16px`,
+                      height: `16px`,
+                      pointerEvents: `none`,
+                      transform: `translateY(-50%)`,
+                    }}
+                  />
+                </label>
+              </div>
             </div>
             <ul
               css={{
@@ -115,10 +122,8 @@ class TagsPage extends React.Component {
                 margin: 0,
               }}
             >
-              {Object.keys(uniqGroup)
-                .sort((tagA, tagB) => tagA.localeCompare(tagB))
-                .filter(key => uniqGroup[key].fieldValue.includes(filterQuery))
-                .map(key => {
+              {results.length > 0 ? (
+                results.map(key => {
                   const tag = uniqGroup[key]
                   const firstLetter = tag.fieldValue.charAt(0).toLowerCase()
                   const buildTag = (
@@ -148,7 +153,14 @@ class TagsPage extends React.Component {
                     )
                   }
                   return buildTag
-                })}
+                })
+              ) : (
+                <h4>
+                  No tags found for &quot;
+                  {filterQuery}
+                  &quot; 😔
+                </h4>
+              )}
             </ul>
           </div>
         </Container>

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link, graphql } from "gatsby"
+import { graphql } from "gatsby"
 import TagsIcon from "react-icons/lib/ti/tags"
 
 import BlogPostPreviewItem from "../components/blog-post-preview-item"
@@ -19,6 +19,9 @@ const Tags = ({ pageContext, data, location }) => {
     <Layout location={location}>
       <Container>
         <h1>{tagHeader}</h1>
+        <Button tiny key="blog-post-view-all-tags-button" to="/blog/tags">
+          View All Tags <TagsIcon />
+        </Button>
         {edges.map(({ node }) => (
           <BlogPostPreviewItem
             post={node}
@@ -26,9 +29,6 @@ const Tags = ({ pageContext, data, location }) => {
             css={{ marginBottom: rhythm(2) }}
           />
         ))}
-        <Button tiny key="blog-post-view-all-tags-button" to="/blog/tags">
-          View All Tags <TagsIcon />
-        </Button>
       </Container>
     </Layout>
   )

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -1,7 +1,9 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { Link, graphql } from "gatsby"
+import TagsIcon from "react-icons/lib/ti/tags"
 
+import Button from "../components/button"
 import Container from "../components/container"
 import Layout from "../components/layout"
 
@@ -29,7 +31,9 @@ const Tags = ({ pageContext, data, location }) => {
             )
           })}
         </ul>
-        <Link to="/blog/tags">All tags</Link>
+        <Button tiny key="blog-post-view-all-tags-button" to="/blog/tags">
+          View All Tags <TagsIcon />
+        </Button>
       </Container>
     </Layout>
   )

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -1,8 +1,10 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { Helmet } from "react-helmet"
+import TagsIcon from "react-icons/lib/ti/tags"
 
 import Layout from "../components/layout"
+import Button from "../components/button"
 import Container from "../components/container"
 import BlogPostPreviewItem from "../components/blog-post-preview-item"
 import Pagination from "../components/pagination"
@@ -99,6 +101,18 @@ class BlogPostsIndex extends React.Component {
               />
             ))}
             <Pagination context={this.props.pageContext} />
+            <div
+              css={{
+                display: `flex`,
+                flexFlow: `row nowrap`,
+                width: `100%`,
+                justifyContent: `flex-end`,
+              }}
+            >
+              <Button key="blog-view-all-tags-button" to="/blog/tags" small>
+                View All Tags <TagsIcon />
+              </Button>
+            </div>
             <EmailCaptureForm signupMessage="Enjoying our blog? Receive the next post in your inbox!" />
           </Container>
         </main>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR adds the following UI updates:

- Update the TagsListing to allow filtering + UI updates
![search-gif](https://user-images.githubusercontent.com/16218249/50877046-58a47480-138d-11e9-91ec-6ac0880f5443.gif)

- Added 'View All Tags' button to Blog List underneath pagination
<img width="686" alt="bloglist" src="https://user-images.githubusercontent.com/16218249/50877110-96a19880-138d-11e9-9da6-ca0b8973a2a3.png">

- Added 'View All Tags' button to Blog Post - next to tag listing
<img width="650" alt="blogpost" src="https://user-images.githubusercontent.com/16218249/50877112-96a19880-138d-11e9-9bc7-7592e2cdbfe7.png">

- Update specific Tag page to match 'View All Tags' button added throughout
<img width="724" alt="viewtag" src="https://user-images.githubusercontent.com/16218249/50877082-7d005100-138d-11e9-983e-6ba6f652f2c9.png">

I am by no means a designer so _please_ let me know if I can update the designs here in any way. 

## Related Issues

Addresses #10907 
