### PR TITLE
[gatsby-source-wordpress] Feature: Add custom routes with parameters

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -19,6 +19,7 @@ let _hostingWPCOM
 let _auth
 let _perPage
 let _concurrentRequests
+let _allRoutes
 let _includedRoutes
 let _excludedRoutes
 let _normalizer
@@ -36,6 +37,7 @@ exports.sourceNodes = async (
     perPage = 100,
     searchAndReplaceContentUrls = {},
     concurrentRequests = 10,
+    allRoutes = [],
     includedRoutes = [`**`],
     excludedRoutes = [],
     normalizer,
@@ -52,6 +54,7 @@ exports.sourceNodes = async (
   _auth = auth
   _perPage = perPage
   _concurrentRequests = concurrentRequests
+  _allRoutes = allRoutes
   _includedRoutes = includedRoutes
   _excludedRoutes = excludedRoutes
   _normalizer = normalizer
@@ -66,6 +69,7 @@ exports.sourceNodes = async (
     _auth,
     _perPage,
     _concurrentRequests,
+    _allRoutes,
     _includedRoutes,
     _excludedRoutes,
     typePrefix,


### PR DESCRIPTION
This is my first contribution that adds a feature to a core Gatsby package.
**All kind of suggestions are very welcome!**

## Description

`gatsby-source-wordpress` fetches the main API endpoint to identify available routes and compare them to whitelisted/blacklisted ones.

But some routes are only available with parameters and do not appear on the WordPress REST API _index_ (wp-json). Example: [WPML REST API](https://github.com/shawnhooper/wpml-rest-api) allows language switching by appending `?lang=LANG` or `?wpml_lang=LANG` to the request url.

### Usage

**gatsby-config.js**

```js
// Add to plugin options.
allRoutes: [
  { // Example with WPML.
    namespace: `wp/v2`,
    endpoint: `/pages/?lang=en`,
  },
],
includedRoutes: [
  // ... other whitelisted routes ...
  `/*/*/pages/?lang=*`,
],
```

## Issues

I was able to fetch the route and handle parameters that are appended to the entity type. In this example: `/pages/?lang=en` becomes `wordpress__wp_pages_lang_en`, but there is no GraphQL query like `allWordPressPageLangEn`. I thought Gatsby would create that out of the new entity.

So how do I fetch `wordpress__wp_pages_lang_en` in GraphQL?

## Related Issues

Fixes #10915.
