### PR TITLE
Add borderRadius to Bio pic to fix issue in Safari (starter-blog)

### DIFF
--- a/starters/blog/src/components/Bio.js
+++ b/starters/blog/src/components/Bio.js
@@ -26,6 +26,9 @@ function Bio() {
                 minWidth: 50,
                 borderRadius: `100%`,
               }}
+              imgStyle={{
+                borderRadius: `50%`,
+              }}
             />
             <p>
               Written by <strong>{author}</strong> who lives and works in San


### PR DESCRIPTION
## Description

By default, there's a small issue in **Safari** with profile picture and how it's displayed. I've attached an example below. Notice how on page load the image is square and then it changes to being circular.

![before](https://user-images.githubusercontent.com/1460800/50909945-1fbbdc80-142d-11e9-8ce0-ad63a32fcbcc.gif)

This is only an issue in Safari as far as I can tell. Here's en example of the same page being loaded after the small change.

![after](https://user-images.githubusercontent.com/1460800/50910011-3c581480-142d-11e9-8b6f-86903bf4f7df.gif)

I had this issue myself a couple of weeks ago when starting a project with this starter and wanting a circular profile picture. It seems that the starter was updated in a similar way but also has the issue.

I hope this helps.