### PR TITLE
[gatsby-docs] Use correct (absolute) link

### DIFF
--- a/docs/docs/ecommerce-tutorial/index.md
+++ b/docs/docs/ecommerce-tutorial/index.md
@@ -31,7 +31,7 @@ You can see the working demo hosted here: https://gatsby-ecommerce.netlify.com/
 
 # Prerequisites
 
-- Since this is a more advanced tutorial, building a site with Gatsby before will likely make this tutorial less time-consuming ([see the main tutorial here](/tutorial/))
+- Since this is a more advanced tutorial, building a site with Gatsby before will likely make this tutorial less time-consuming ([see the main tutorial here](https://www.gatsbyjs.org/tutorial/)
 - Stripe account: [register for an account here](https://dashboard.stripe.com/register)
 
 ## How does Gatsby work with Stripe?


### PR DESCRIPTION
Add an absolute link to the tutorial. Currently, it re-directs to a relative path /tutorial/ to 404 on Github. Replaced it with https://www.gatsbyjs.org/tutorial/

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
