### PR TITLE
feat(gatsby-plugin-page-creator): add validatePath and createPath options

### DIFF
--- a/packages/gatsby-plugin-page-creator/README.md
+++ b/packages/gatsby-plugin-page-creator/README.md
@@ -43,6 +43,25 @@ module.exports = {
         path: `${__dirname}/src/settings/pages`,
       },
     },
+    // You can also provide "createPath" and "validatePath" functions
+    // to override default behaviour, if needed
+    {
+      resolve: `gatsby-plugin-page-creator`,
+      options: {
+        path: `${__dirname}/src/articles`,
+        createPath: (basePath, filePath) => {
+          // Creates a custom URL based on filename
+          return `/articles/${slugify(basename(filePath))}/`
+        },
+        validatePath: (relativePath, isValid) => {
+          // Filter page creation based on criteria,
+          // the second argument is the default validatePath function
+          if (!isValid(relativePath)) return false
+          if (basename(relativePath).startsWith("draft-")) return false
+          return true
+        },
+      },
+    },
   ],
 }
 ```

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.js
@@ -30,12 +30,6 @@ exports.createPagesStatefully = async (
   const { createPage, deletePage } = actions
   const program = store.getState().program
   const exts = program.extensions.map(e => `${e.slice(1)}`).join(`,`)
-  const create = _createPage(
-    createPage,
-    validatePath,
-    createPath,
-    pagesDirectory
-  )
 
   if (!pagesPath) {
     reporter.panic(
@@ -62,6 +56,12 @@ exports.createPagesStatefully = async (
 
   const pagesDirectory = systemPath.posix.join(pagesPath)
   const pagesGlob = `${pagesDirectory}/**/*.{${exts}}`
+  const create = _createPage(
+    createPage,
+    validatePath,
+    createPath,
+    pagesDirectory
+  )
 
   // Get initial list of files.
   let files = await glob(pagesGlob)


### PR DESCRIPTION
## Description

adds custom validation and url creation to `gatsby-plugin-page-creator`.

allows for filtering files (eg: drafts) and changing url (eg: nesting or translating) while keeping the filesystem clean.

#### example added in `README.md`

```javascript
{
  resolve: `gatsby-plugin-page-creator`,
  options: {
    path: `${__dirname}/src/articles`,
    createPath: (basePath, filePath) => {
      // Creates a custom URL based on filename
      return `/articles/${slugify(basename(filePath))}/`
    },
    validatePath: (relativePath, isValid) => {
      // Filter page creation based on criteria,
      // the second argument is the default validatePath function
      if (basename(relativePath).startsWith('draft-')) return false
      return isValid(relativePath)
    },
  },
},
```