### PR TITLE
docs(api-proxy): add section about self-signed certificates

### DIFF
--- a/docs/docs/api-proxy.md
+++ b/docs/docs/api-proxy.md
@@ -62,7 +62,6 @@ If you proxy to local APIs with self-signed certificates, set the option `secure
 
 ```javascript:title=gatsby-config.js
 var proxy = require("http-proxy-middleware")
-
 module.exports = {
   developMiddleware: app => {
     app.use(
@@ -78,4 +77,3 @@ module.exports = {
   },
 }
 ```
-

--- a/docs/docs/api-proxy.md
+++ b/docs/docs/api-proxy.md
@@ -55,3 +55,27 @@ module.exports = {
 ```
 
 Keep in mind that middleware only has effect in development (with `gatsby develop`).
+
+### Self-signed certificates
+
+If you proxy to local APIs with self-signed certificates, set the option `secure` to `false`.
+
+```javascript:title=gatsby-config.js
+var proxy = require("http-proxy-middleware")
+
+module.exports = {
+  developMiddleware: app => {
+    app.use(
+      "/.netlify/functions/",
+      proxy({
+        target: "http://localhost:9000",
+        secure: false, // Do not reject self-signed certificates.
+        pathRewrite: {
+          "/.netlify/functions/": "",
+        },
+      })
+    )
+  },
+}
+```
+


### PR DESCRIPTION
## Description

For a beginner, it is not obvious why proxying to targets with self-signed certificates fails.