### PR TITLE
Update Tutorial about CSS Modules line 245 for the correct path

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -242,7 +242,7 @@ In this section, you'll create a list of people with names, avatars, and short l
 ```javascript:title=src/pages/about-css-modules.js
 import React from "react"
 // highlight-next-line
-import styles from "./about-css-modules.module.css"
+import styles from "../components/about-css-modules.module.css"
 import Container from "../components/container"
 
 // highlight-next-line


### PR DESCRIPTION
The old path `./about-css-modules.module.css` will trigger an error: `Module not found: Error: Can't resolve './about-css-modules.module.css'`.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This is a simple update on the tutorial about CSS Modules. The old path will trigger an error, so I propose to update the path to the correct one.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
