### PR TITLE
[gatsby-source-filesystem] Add progress bar

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -17,6 +17,7 @@
     "md5-file": "^3.1.1",
     "mime": "^2.2.0",
     "pretty-bytes": "^4.0.2",
+    "progress": "^1.1.8",
     "read-chunk": "^3.0.0",
     "slash": "^1.0.0",
     "valid-url": "^1.0.9",

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -6,10 +6,19 @@ const { isWebUri } = require(`valid-url`)
 const Queue = require(`better-queue`)
 const readChunk = require(`read-chunk`)
 const fileType = require(`file-type`)
+const ProgressBar = require(`progress`)
 
 const { createFileNode } = require(`./create-file-node`)
 const { getRemoteFileExtension, getRemoteFileName } = require(`./utils`)
 const cacheId = url => `create-remote-file-node-${url}`
+
+const bar = new ProgressBar(
+  `Downloading remote content [:bar] :current/:total :elapsed secs :percent`,
+  {
+    total: 0,
+    width: 30,
+  }
+)
 
 /********************
  * Type Definitions *
@@ -278,6 +287,9 @@ const pushTask = task =>
       })
   })
 
+// Keep track of the total number of jobs we push in the queue
+let totalJobs = 0
+
 /***************
  * Entry Point *
  ***************/
@@ -332,7 +344,10 @@ module.exports = ({
     return Promise.resolve()
   }
 
-  return (processingCache[url] = pushTask({
+  totalJobs += 1
+  bar.total = totalJobs
+
+  const fileDownloadPromise = pushTask({
     url,
     store,
     cache,
@@ -340,5 +355,10 @@ module.exports = ({
     createNodeId,
     auth,
     ext,
-  }))
+  })
+
+  fileDownloadPromise.then(() => bar.tick())
+
+  processingCache[url] = fileDownloadPromise
+  return fileDownloadPromise
 }

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -13,7 +13,7 @@ const { getRemoteFileExtension, getRemoteFileName } = require(`./utils`)
 const cacheId = url => `create-remote-file-node-${url}`
 
 const bar = new ProgressBar(
-  `Downloading remote content [:bar] :current/:total :elapsed secs :percent`,
+  `Downloading remote files [:bar] :current/:total :elapsed secs :percent`,
   {
     total: 0,
     width: 30,


### PR DESCRIPTION
Fix: #10948

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Add a progress bar while downloading remote content, so that user gets a live feedback instead of thinking build is stuck or so
<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
