### PR TITLE
fix(gatsby-source-filesystem): report when downloading fails

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -114,7 +114,8 @@ async function pushToQueue(task, cb) {
     const node = await processRemoteNode(task)
     return cb(null, node)
   } catch (e) {
-    return cb(null, e)
+    console.warn(`Failed to process remote content ${task.url}`)
+    return cb(e)
   }
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
While working on #10979 i came across this. 
The queue was receiving the error as the result argument.
i Added a warn there in order to avoid failing silently
<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
