### PR TITLE
[gatsby-link] warn when <link> is used for external links

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -86,9 +86,10 @@ describe(`<Link />`, () => {
     }
 
     it(`accepts to as a string`, () => {
+      jest.spyOn(global.console, `warn`)
       const location = `/courses?sort=name`
       const { link } = setup({ linkProps: { to: location } })
-
+      expect(console.warn).not.toBeCalled()
       expect(link.getAttribute(`href`)).toEqual(location)
     })
 
@@ -97,6 +98,13 @@ describe(`<Link />`, () => {
       const location = `/courses?sort=name`
       const { link } = setup({ linkProps: { to: location }, pathPrefix })
       expect(link.getAttribute(`href`)).toEqual(`${pathPrefix}${location}`)
+    })
+
+    it(`warns when not internal`, () => {
+      jest.spyOn(global.console, `warn`)
+      const to = `https://gatsby.org`
+      setup({ linkProps: { to } })
+      expect(console.warn).toBeCalled()
     })
   })
 

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -104,6 +104,12 @@ class GatsbyLink extends React.Component {
       ...rest
     } = this.props
 
+    if (process.env.NODE_ENV !== `production` && !/^\/(?!\/)/.test(to)) {
+      console.warn(
+        `Use <Link> only for internal links. Read more https://www.gatsbyjs.org/docs/gatsby-link/#use-link-only-for-internal-links`
+      )
+    }
+
     const prefixedTo = withPrefix(to)
 
     return (


### PR DESCRIPTION
Fix: #10978

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
