### PR TITLE
fix(www): add check to compare and remove hash with slug when navigating to search results

### DIFF
--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -272,7 +272,11 @@ class SearchForm extends Component {
     const a = document.createElement(`a`)
     a.href = e._args[0].url
     this.searchInput.blur()
-    navigate(`${a.pathname}${a.hash}`)
+    // Compare hash and slug and remove hash if both are same
+    const paths = a.pathname.split(`/`).filter(el => el !== ``)
+    const slug = paths[paths.length - 1]
+    const path = `#${slug}` === a.hash ? `${a.pathname}` : `${a.pathname}${a.hash}`
+    navigate(path)
   }
   init() {
     if (this.algoliaInitialized) {

--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -275,7 +275,8 @@ class SearchForm extends Component {
     // Compare hash and slug and remove hash if both are same
     const paths = a.pathname.split(`/`).filter(el => el !== ``)
     const slug = paths[paths.length - 1]
-    const path = `#${slug}` === a.hash ? `${a.pathname}` : `${a.pathname}${a.hash}`
+    const path =
+      `#${slug}` === a.hash ? `${a.pathname}` : `${a.pathname}${a.hash}`
     navigate(path)
   }
   init() {


### PR DESCRIPTION


## Description

[www] fix messy URLs, in cases where the slug and fragment of the URL are the same. 

Example: https://www.gatsbyjs.org/docs/debugging-replace-renderer-api/#debugging-replace-renderer-api becomes https://www.gatsbyjs.org/docs/debugging-replace-renderer-api/

## Related Issues

Addresses #10950 
