### PR TITLE
Broken link line 66

### DIFF
--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -63,6 +63,6 @@ So this is all very nice and it’s far better to be able to use this from NPM v
 - [Plugin READme file](/packages/gatsby-image/)
 - [Source code for an example site using gatsby-image](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-gatsby-image)
 - [Blog articles about gatsby-image](/blog/tags/gatsby-image/)
-- [Starters that use gatsby-image](/starter-showcase/?d=gatsby-image)
+- [Starters that use gatsby-image](/starters/?d=gatsby-image&v=2)
 - [Other image plugins](/plugins/?=image)
 - ["Ridiculously easy image optimization with gatsby-image" by Kyle Gill](https://medium.com/@kyle.robert.gill/ridiculously-easy-image-optimization-with-gatsby-js-59d48e15db6e)


### PR DESCRIPTION
There is a broken link for the the section 'Starters that use gatsby-image'
Line: 66

[It currently points here](/starter-showcase/?d=gatsby-image)
[I think it should point here]((/starters/?d=gatsby-image&v=2))

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
