### PR TITLE
fix: handle escaped regex string

### DIFF
--- a/packages/gatsby/src/utils/__tests__/prepare-regex.js
+++ b/packages/gatsby/src/utils/__tests__/prepare-regex.js
@@ -4,10 +4,53 @@ describe(`Prepare regex for Sift.js`, () => {
   it(`handles simple regex`, () => {
     expect(prepareRegex(`/blue/`)).toMatchSnapshot()
   })
+
   it(`handles flags regex`, () => {
     expect(prepareRegex(`/blue/i`)).toMatchSnapshot()
   })
+
   it(`handles slashes`, () => {
     expect(prepareRegex(`/bl/ue/i`)).toMatchSnapshot()
+  })
+
+  it(`handles escape sequences`, () => {
+    const expected = /^\w+\d{2}\.$/
+    expect(prepareRegex(`/^\\w+\\d{2}\\.$/`)).toEqual(expected)
+  })
+
+  it(`handles regex string passed as graphql arg`, async () => {
+    const {
+      GraphQLSchema,
+      GraphQLObjectType,
+      GraphQLString,
+      graphql,
+    } = require(`graphql`)
+    const QueryType = new GraphQLObjectType({
+      name: `Query`,
+      fields: {
+        regex: {
+          type: GraphQLString,
+          args: {
+            regex: { type: GraphQLString },
+          },
+          resolve: (source, args) => args.regex,
+        },
+      },
+    })
+    const schema = new GraphQLSchema({ query: QueryType })
+    /* prettier-ignore */
+    const results = await graphql(
+      schema,
+      `
+        {
+          regex(regex: "/\\\\w+/")
+        }
+      `
+    )
+    expect(results.errors).toBeUndefined()
+    expect(results.data).toEqual({ regex: `/\\w+/` })
+
+    const expected = /\w+/
+    expect(prepareRegex(results.data.regex)).toEqual(expected)
   })
 })

--- a/packages/gatsby/src/utils/prepare-regex.js
+++ b/packages/gatsby/src/utils/prepare-regex.js
@@ -6,8 +6,9 @@ module.exports = str => {
     exploded
       .slice(1, -1)
       .join(`/`)
-      // Double escaping is needed to get passed the GraphQL parser,
-      // but single escaping is needed for the RegExp constructor.
+      // Double escaping is needed to get past the GraphQL parser,
+      // but single escaping is needed for the RegExp constructor,
+      // i.e. `"\\\\w+"` for `/\w+/`.
       .replace(/\\\\/, `\\`),
     _.last(exploded)
   )

--- a/packages/gatsby/src/utils/prepare-regex.js
+++ b/packages/gatsby/src/utils/prepare-regex.js
@@ -2,6 +2,14 @@ const _ = require(`lodash`)
 
 module.exports = str => {
   const exploded = str.split(`/`)
-  const regex = new RegExp(exploded.slice(1, -1).join(`/`), _.last(exploded))
+  const regex = new RegExp(
+    exploded
+      .slice(1, -1)
+      .join(`/`)
+      // Double escaping is needed to get passed the GraphQL parser,
+      // but single escaping is needed for the RegExp constructor.
+      .replace(/\\\\/, `\\`),
+    _.last(exploded)
+  )
   return regex
 }


### PR DESCRIPTION
Should fix #10989, #9944 
Apparently we need to escape backslashes twice to get past the graphql parser, but need single escaped string for the RegExp constructor, i.e. `"\\\\w+"` to get `/\w+/`