### PR TITLE
Remove unnecessary trailing backslash

### DIFF
--- a/docs/docs/eslint.md
+++ b/docs/docs/eslint.md
@@ -18,7 +18,7 @@ npm rm prettier
 npm install --save-dev eslint babel-eslint \
   eslint-config-standard eslint-plugin-node \
   eslint-plugin-standard eslint-plugin-react \
-  eslint-plugin-import eslint-plugin-promise \
+  eslint-plugin-import eslint-plugin-promise
 ```
 
 Now that we have our packages installed, remove `.prettierrc` from the root of your new Gatsby project and create a new file named `.eslintrc.js` using the commands below.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The documentation for installing `eslint` has a trailing backslash after the last line of the command, resulting in an expectation of additional input before executing the command.

This PR removes the trailing backslash.
