### PR TITLE
fix(gatsby-source-contentful): Fix check for fluid and fixed size fliters

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/extend-node-type.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/extend-node-type.js.snap
@@ -4,6 +4,19 @@ exports[`contentful extend node type createUrl allows you to create URls 1`] = `
 
 exports[`contentful extend node type createUrl ignores options it doesn't understand 1`] = `"//images.contentful.com/dsf/bl.jpg?"`;
 
+exports[`contentful extend node type resolveFixed filters out sizes larger than the image's width 1`] = `
+Object {
+  "aspectRatio": 0.75,
+  "baseUrl": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg",
+  "height": 3000,
+  "src": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250",
+  "srcSet": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 1x,
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 1.5x,
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=6000 2x",
+  "width": 2250,
+}
+`;
+
 exports[`contentful extend node type resolveFixed generates responsive resolution data for images 1`] = `
 Object {
   "aspectRatio": 0.75,
@@ -29,6 +42,20 @@ Object {
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=900&h=798&q=50&fit=fill&bg=rgb%3A000000 2x,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1350&h=1197&q=50&fit=fill&bg=rgb%3A000000 3x",
   "width": 450,
+}
+`;
+
+exports[`contentful extend node type resolveFluid filters out sizes larger than the image's width 1`] = `
+Object {
+  "aspectRatio": 0.75,
+  "baseUrl": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg",
+  "sizes": "(max-width: 2250px) 100vw, 2250px",
+  "src": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250",
+  "srcSet": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=563&h=751 563w,
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1125&h=1500 1125w,
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 2250w,
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 3375w,
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=6000 4500w",
 }
 `;
 

--- a/packages/gatsby-source-contentful/src/__tests__/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/__tests__/extend-node-type.js
@@ -85,6 +85,13 @@ describe(`contentful extend node type`, () => {
       })
       expect(resp).toBe(null)
     })
+    it(`filters out sizes larger than the image's width`, async () => {
+      const resp = await resolveFixed(image, {
+        width: 2250,
+      })
+      expect(resp.srcSet.split(`,`).length).toBe(3)
+      expect(resp).toMatchSnapshot()
+    })
   })
   describe(`resolveFluid`, () => {
     it(`generates responsive size data for images`, async () => {
@@ -107,6 +114,13 @@ describe(`contentful extend node type`, () => {
         maxWidth: 400,
       })
       expect(resp).toBe(null)
+    })
+    it(`filters out sizes larger than the image's width`, async () => {
+      const resp = await resolveFluid(image, {
+        maxWidth: 2250,
+      })
+      expect(resp.srcSet.split(`,`).length).toBe(5)
+      expect(resp).toMatchSnapshot()
     })
   })
   describe(`resolveResize`, () => {

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -199,9 +199,9 @@ const resolveFluid = (image, options) => {
   // Filter out sizes larger than the image's maxWidth.
   const filteredSizes = fluidSizes.filter(size => size <= width)
 
-  // Add the original image to ensure the largest image possible
+  // Add the original image (if it isn't already in there) to ensure the largest image possible
   // is available for small images.
-  filteredSizes.push(width)
+  if (!filteredSizes.includes(parseInt(width))) filteredSizes.push(width)
 
   // Sort sizes for prettiness.
   const sortedSizes = _.sortBy(filteredSizes)

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -108,7 +108,7 @@ const resolveFixed = (image, options) => {
   fixedSizes = fixedSizes.map(Math.round)
 
   // Filter out sizes larger than the image's width.
-  const filteredSizes = fixedSizes.filter(size => size < width)
+  const filteredSizes = fixedSizes.filter(size => size <= width)
 
   // Sort sizes for prettiness.
   const sortedSizes = _.sortBy(filteredSizes)
@@ -197,7 +197,7 @@ const resolveFluid = (image, options) => {
   fluidSizes = fluidSizes.map(Math.round)
 
   // Filter out sizes larger than the image's maxWidth.
-  const filteredSizes = fluidSizes.filter(size => size < width)
+  const filteredSizes = fluidSizes.filter(size => size <= width)
 
   // Add the original image to ensure the largest image possible
   // is available for small images.


### PR DESCRIPTION
Fixes three bugs
1. `resolveFixed` was incorrectly filtering out a size equal to the original size when creating `srcset` (https://github.com/gatsbyjs/gatsby/issues/10987—reproduction in https://github.com/sidharthachatterjee/contentful-playground)
2. `resolveFluid` was incorrectly filtering out a size equal to the original size when creating `srcset`
3. `resolveFluid` would add original size even if it was already in the sizes 

Adds two tests and updates snapshots to assert this behaviour