### PR TITLE
fix(docs): use correct prefix for docs

### DIFF
--- a/docs/docs/api-specification.md
+++ b/docs/docs/api-specification.md
@@ -11,7 +11,7 @@ on the back burner btw until after v1 comes out).
 
 ## Prerequisites
 
-If you’re not familiar with Gatsby’s lifecycle, see the overview [Gatsby Lifecycle APIs](/gatsby-lifecycle-apis/).
+If you’re not familiar with Gatsby’s lifecycle, see the overview [Gatsby Lifecycle APIs](/docs/gatsby-lifecycle-apis/).
 
 ## Plugins
 


### PR DESCRIPTION
Link to lifecycle documentation is missing `/docs` prefix from API specification. Add prefix to fix broken link.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
