### PR TITLE
fix(core): Disable HMR for CSS modules

### DIFF
--- a/packages/gatsby-plugin-less/src/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/gatsby-node.js
@@ -30,7 +30,7 @@ exports.onCreateWebpackConfig = (
   const lessRuleModules = {
     test: /\.module\.less$/,
     use: [
-      !isSSR && loaders.miniCssExtract(),
+      !isSSR && loaders.miniCssExtract({ hmr: false }),
       loaders.css({ ...cssLoaderOptions, modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       lessLoader,

--- a/packages/gatsby-plugin-postcss/src/gatsby-node.js
+++ b/packages/gatsby-plugin-postcss/src/gatsby-node.js
@@ -61,7 +61,7 @@ exports.onCreateWebpackConfig = (
 
   if (!isSSR) {
     postcssRule.use.unshift(loaders.miniCssExtract())
-    postcssRuleModules.use.unshift(loaders.miniCssExtract())
+    postcssRuleModules.use.unshift(loaders.miniCssExtract({ hmr: false }))
   }
 
   const postcssRules = { oneOf: [] }

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -30,7 +30,7 @@ exports.onCreateWebpackConfig = (
   const sassRuleModules = {
     test: /\.module\.s(a|c)ss$/,
     use: [
-      !isSSR && loaders.miniCssExtract(),
+      !isSSR && loaders.miniCssExtract({ hmr: false }),
       loaders.css({ ...cssLoaderOptions, modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       sassLoader,

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -53,7 +53,7 @@ exports.onCreateWebpackConfig = (
   const stylusRuleModules = {
     test: /\.module\.styl$/,
     use: [
-      !isSSR && loaders.miniCssExtract(),
+      !isSSR && loaders.miniCssExtract({ hmr: false }),
       loaders.css({ modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       stylusLoader,

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -386,7 +386,7 @@ module.exports = async ({
         loaders.css({ ...options, importLoaders: 1 }),
         loaders.postcss({ browsers }),
       ]
-      if (!isSSR) use.unshift(loaders.miniCssExtract())
+      if (!isSSR) use.unshift(loaders.miniCssExtract({ hmr: !options.modules }))
 
       return {
         use,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

CSS modules will not work correctly with style-loader when HMR is enabled (HMR was introduced in gatsby v2). For new styles to appear on a page, a full page refresh is required for css modules to work. Otherwise, an error is thrown. This PR disables HMR for css-modules as suggested by https://github.com/webpack-contrib/style-loader/issues/320 so that saving a `.module.scss` file will refresh the page and show any new styles. 

Here's a screencast showing the issue before the fix https://www.useloom.com/share/a1061fb2d4344942af1f9efa4870d965

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/10316

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
