### PR TITLE
fix(gatsby-remark-prismjs): use aliased name for highlighters

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -154,6 +154,47 @@ Object {
 }
 `;
 
+exports[`remark prism plugin generates a <pre> tag with aliases that do not exist 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "foobar",
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 3,
+          "offset": 21,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"foobar\\"><pre class=\\"language-foobar\\"><code class=\\"language-foobar\\">// Fake</code></pre></div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 4,
+      "line": 3,
+      "offset": 21,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`remark prism plugin generates a <pre> tag with class="language-*" prefix by default 1`] = `
 Object {
   "children": Array [

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -135,7 +135,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"javascript\\"><pre class=\\"language-javascript\\"><code class=\\"language-javascript\\">// Fake</code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"javascript\\"><pre class=\\"language-javascript\\"><code class=\\"language-javascript\\"><span class=\\"token comment\\">// Fake</span></code></pre></div>",
     },
   ],
   "position": Object {

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -24,6 +24,13 @@ describe(`remark prism plugin`, () => {
       expect(markdownAST).toMatchSnapshot()
     })
 
+    it(`with aliases that do not exist`, () => {
+      const code = `\`\`\`foobar\n// Fake\n\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST }, { aliases: { baz: `javascript` } })
+      expect(markdownAST).toMatchSnapshot()
+    })
+
     it(`with highlighted lines`, () => {
       const code = `\`\`\`js{2}\n// 1\n// 2\n// 3\n\`\`\``
       const markdownAST = remark.parse(code)

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -70,7 +70,7 @@ module.exports = (
     + `<div class="${highlightClassName}" data-language="${languageName}">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`
     +     `<code class="${className}">`
-    +       `${highlightCode(language, node.value, highlightLines)}`
+    +       `${highlightCode(languageName, node.value, highlightLines)}`
     +     `</code>`
     +     `${numLinesNumber}`
     +   `</pre>`


### PR DESCRIPTION
## Description

When having a configuration with an aliased name like below, `gatsby-remark-prismjs` does not handle them properly.

```js
{
  resolve: 'gatsby-transformer-remark',
  options: {
    plugins: [
      {
        resolve: 'gatsby-remark-prismjs',
        options: {
          aliases: {
            xaml: 'xml',
          },
        },
      },
    ],
  },
}
```

Currently, the highlighter uses the original name (`xaml`) but the code block is wrapped with the aliased name (`xml`).

The documentation reads:

```js
// This lets you set up language aliases.  For example,
// setting this to '{ sh: "bash" }' will let you use
// the language "sh" which will highlight using the
// bash highlighter.
```

which does not match the current behavior.

Thanks.

