### PR TITLE
fix(docs): add level 2 swag to contribution guide

### DIFF
--- a/docs/docs/contributor-swag.md
+++ b/docs/docs/contributor-swag.md
@@ -10,7 +10,7 @@ To show our appreciation, _**everyone who contributes to Gatsby is eligible to r
 
 ### How to claim your free swag
 
-If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
+If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Store](https://store.gatsbyjs.org/) and requesting a discount code.
 
 If you contribute five or more times, you can claim your _**Level 2**_ swag.
 

--- a/docs/docs/contributor-swag.md
+++ b/docs/docs/contributor-swag.md
@@ -12,7 +12,7 @@ To show our appreciation, _**everyone who contributes to Gatsby is eligible to r
 
 If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
 
-If you contribute to the Gatsby org on GitHub five times, you can claim your _**Level 2**_ swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
+If you contribute five or more times, you can claim your _**Level 2**_ swag. 
 
 If you’ve contributed in other ways, such as giving talks about Gatsby, teaching others to use it, writing Gatsby articles/tutorials, participating in a Gatsby research project, or any other way, please email <mailto:jason@gatsbyjs.com> or [tweet at Gatsby on Twitter](https://twitter.com/gatsbyjs) to claim your swag.
 

--- a/docs/docs/contributor-swag.md
+++ b/docs/docs/contributor-swag.md
@@ -12,7 +12,7 @@ To show our appreciation, _**everyone who contributes to Gatsby is eligible to r
 
 If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
 
-If you contribute to Gatsby org on GitHub five times, you can claim your _**Level 2**_ swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
+If you contribute to the Gatsby org on GitHub five times, you can claim your _**Level 2**_ swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
 
 If you’ve contributed in other ways, such as giving talks about Gatsby, teaching others to use it, writing Gatsby articles/tutorials, participating in a Gatsby research project, or any other way, please email <mailto:jason@gatsbyjs.com> or [tweet at Gatsby on Twitter](https://twitter.com/gatsbyjs) to claim your swag.
 

--- a/docs/docs/contributor-swag.md
+++ b/docs/docs/contributor-swag.md
@@ -12,6 +12,8 @@ To show our appreciation, _**everyone who contributes to Gatsby is eligible to r
 
 If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
 
+If you contribute to Gatsby org on GitHub five times, you can claim your _**Level 2**_ swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
+
 If you’ve contributed in other ways, such as giving talks about Gatsby, teaching others to use it, writing Gatsby articles/tutorials, participating in a Gatsby research project, or any other way, please email <mailto:jason@gatsbyjs.com> or [tweet at Gatsby on Twitter](https://twitter.com/gatsbyjs) to claim your swag.
 
 ### Details about free swag

--- a/docs/docs/contributor-swag.md
+++ b/docs/docs/contributor-swag.md
@@ -10,9 +10,7 @@ To show our appreciation, _**everyone who contributes to Gatsby is eligible to r
 
 ### How to claim your free swag
 
-If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Store](https://store.gatsbyjs.org/) and requesting a discount code.
-
-If you contribute five or more times, you can claim your _**Level 2**_ swag.
+If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Store](https://store.gatsbyjs.org/) and requesting a discount code. With five or more contributions, you can claim your _**Level 2**_ swag.
 
 If you’ve contributed in other ways, such as giving talks about Gatsby, teaching others to use it, writing Gatsby articles/tutorials, participating in a Gatsby research project, or any other way, please email <mailto:jason@gatsbyjs.com> or [tweet at Gatsby on Twitter](https://twitter.com/gatsbyjs) to claim your swag.
 

--- a/docs/docs/contributor-swag.md
+++ b/docs/docs/contributor-swag.md
@@ -12,7 +12,7 @@ To show our appreciation, _**everyone who contributes to Gatsby is eligible to r
 
 If you contribute to the Gatsby org on GitHub, you can claim your swag by [logging into the Gatsby Maintainer Dashboard](https://store.gatsbyjs.org/login) and requesting a discount code.
 
-If you contribute five or more times, you can claim your _**Level 2**_ swag. 
+If you contribute five or more times, you can claim your _**Level 2**_ swag.
 
 If you’ve contributed in other ways, such as giving talks about Gatsby, teaching others to use it, writing Gatsby articles/tutorials, participating in a Gatsby research project, or any other way, please email <mailto:jason@gatsbyjs.com> or [tweet at Gatsby on Twitter](https://twitter.com/gatsbyjs) to claim your swag.
 


### PR DESCRIPTION
I've added a line to mention the Level 2 swag which was added recently. Please let me know what other additions can be made to make the Level 2 swag more 'highlighted' so to speak

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
