### PR TITLE
Add missing break statements

### DIFF
--- a/packages/gatsby-source-contentful/fetch-data.js
+++ b/packages/gatsby-source-contentful/fetch-data.js
@@ -68,6 +68,7 @@ module.exports = function () {
             // someone develop a contentful site even if not connected to the internet.
             // For prod builds though always fail if we can't get the latest data.
             process.exit(1);
+            break;
 
           case 18:
             currentSyncData = void 0;
@@ -87,6 +88,7 @@ module.exports = function () {
 
             console.log("error fetching contentful data", _context.t1);
             process.exit(1);
+            break;
 
           case 30:
 
@@ -107,6 +109,7 @@ module.exports = function () {
             _context.t2 = _context["catch"](31);
 
             console.log("error fetching content types", _context.t2);
+            break;
 
           case 40:
             console.log("contentTypes fetched", contentTypes.items.length);


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
A switch case entry should have always a `break` statement to ensure that the logical flow is also stopped there.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
