### PR TITLE
fix(graphql):  findLinkedNodeByField not returning any value

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -189,7 +189,7 @@ function inferFromMapping(
 }
 
 function findLinkedNodeByField(linkedField, value) {
-  getNodes().find(n => n[linkedField] === value)
+  return getNodes().find(n => n[linkedField] === value)
 }
 
 export function findLinkedNode(value, linkedField, path) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
`findLinkedNodeByField` does not return anything. This PR adds the missing `return`.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
