### PR TITLE
fix: reevaluate page query when page context is modified

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -15,7 +15,6 @@ const queue = require(`./query-queue`)
 const { store, emitter } = require(`../../redux`)
 
 let queuedDirtyActions = []
-let queuedDirtyPathnames = []
 
 let active = false
 let running = false
@@ -50,10 +49,7 @@ const runQueries = async () => {
     ...runQueriesForPathnamesQueue,
     ...dirtyIds,
     ...cleanIds,
-    ...queuedDirtyPathnames,
   ])
-
-  queuedDirtyPathnames = []
 
   runQueriesForPathnamesQueue.clear()
 
@@ -72,7 +68,7 @@ emitter.on(`DELETE_NODE`, action => {
 
 emitter.on(`CREATE_PAGE`, action => {
   if (action.contextModified) {
-    queuedDirtyPathnames.push(action.payload.path)
+    exports.queueQueryForPathname(action.payload.path)
   }
 })
 

--- a/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js
@@ -15,6 +15,8 @@ const queue = require(`./query-queue`)
 const { store, emitter } = require(`../../redux`)
 
 let queuedDirtyActions = []
+let queuedDirtyPathnames = []
+
 let active = false
 let running = false
 
@@ -48,7 +50,10 @@ const runQueries = async () => {
     ...runQueriesForPathnamesQueue,
     ...dirtyIds,
     ...cleanIds,
+    ...queuedDirtyPathnames,
   ])
+
+  queuedDirtyPathnames = []
 
   runQueriesForPathnamesQueue.clear()
 
@@ -63,6 +68,12 @@ emitter.on(`CREATE_NODE`, action => {
 
 emitter.on(`DELETE_NODE`, action => {
   queuedDirtyActions.push({ payload: action.payload })
+})
+
+emitter.on(`CREATE_PAGE`, action => {
+  if (action.contextModified) {
+    queuedDirtyPathnames.push(action.payload.path)
+  }
 })
 
 const runQueuedActions = async () => {

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
@@ -76,6 +76,7 @@ Map {
 
 exports[`Add pages allows you to add pages 1`] = `
 Object {
+  "contextModified": false,
   "payload": Object {
     "component": "/whatever/index.js",
     "componentChunkName": "component---whatever-index-js",
@@ -115,6 +116,7 @@ Map {
 
 exports[`Add pages allows you to add pages with context 1`] = `
 Object {
+  "contextModified": false,
   "payload": Object {
     "component": "/whatever/index.js",
     "componentChunkName": "component---whatever-index-js",
@@ -158,6 +160,7 @@ Map {
 
 exports[`Add pages allows you to add pages with matchPath 1`] = `
 Object {
+  "contextModified": false,
   "payload": Object {
     "component": "/whatever/index.js",
     "componentChunkName": "component---whatever-index-js",

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -294,9 +294,14 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
     fileOkCache[internalPage.component] = true
   }
 
+  const oldPage: Page = store.getState().pages.get(internalPage.path)
+  const contextModified =
+    !!oldPage && !_.isEqual(oldPage.context, internalPage.context)
+
   return {
     ...actionOptions,
     type: `CREATE_PAGE`,
+    contextModified,
     plugin,
     payload: internalPage,
   }


### PR DESCRIPTION
## Description

When page context is updated by `createPage` the path is not marked as dirty and page query is not reevaluated resulting in the page not updating in develop mode.

## Related Issues

Fixes #6097
