### PR TITLE
fix(Docs): Un-stubbing "Sourcing from private APIs" link in sidebar

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -87,7 +87,7 @@
           link: /docs/sourcing-from-databases/
         - title: Sourcing from SaaS services*
           link: /docs/sourcing-from-saas-services/
-        - title: Sourcing from private APIs*
+        - title: Sourcing from private APIs
           link: /docs/sourcing-from-private-apis/
         - title: Sourcing from (headless) CMSs
           link: /docs/headless-cms/


### PR DESCRIPTION
As the [Sourcing from Private APIs](https://www.gatsbyjs.org/docs/sourcing-from-private-apis/) page no longer seems to be a stub, I removed the stub asterisk.