### PR TITLE
fix(www): Persist showcase filters while browsing more than one item

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -144,6 +144,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               to={nextSite.fields.slug}
               state={{
                 isModal: true,
+                filters: parent.props.location.state.filters,
               }}
               css={{
                 display: `block`,
@@ -196,6 +197,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               to={previousSite.fields.slug}
               state={{
                 isModal: true,
+                filters: parent.props.location.state.filters,
               }}
               css={{
                 display: `block`,


### PR DESCRIPTION
Fixes #10971 

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The filters were not persisted when browsing more than one item in site showcase. This PR fixes the issue.