### PR TITLE
fix(blog): Emphasis of 2 words in Content Mesh Pt. 4

### DIFF
--- a/docs/blog/2018-10-16-why-mobile-performance-is-crucial/index.md
+++ b/docs/blog/2018-10-16-why-mobile-performance-is-crucial/index.md
@@ -148,7 +148,7 @@ Among the many implementation challenges are:
 
 Web performance is critical for retaining and engaging users, especially on mobile. If [every 100ms of latency costs 1% of sales](https://www.digitalrealty.com/blog/the-cost-of-latency/), reducing average page load times from 5 seconds to 1-2 seconds could generate 30-40% more sales.
 
-But just because performance is the *right *thing doesn’t make it the _easy_ thing. Implementing performance optimizations on a _per-site basis_ is often *difficult *and _costly_.
+But just because performance is the _right_ thing doesn’t make it the _easy_ thing. Implementing performance optimizations on a _per-site basis_ is often _difficult_ and _costly_.
 
 To overcome these obstacles, high-performing website teams should look to a content mesh that bakes in performance on a _framework_ level.
 


### PR DESCRIPTION
Spotted these while re-reading [Journey to the Content Mesh Part 4: Why Mobile Performance Is Crucial](https://www.gatsbyjs.org/blog/2018-10-16-why-mobile-performance-is-crucial/):

<img width="804" alt="foo" src="https://user-images.githubusercontent.com/21834/51130018-43679400-182c-11e9-80c5-d454cf0aad06.png">

