### PR TITLE
fix(docs): mention to add your own icon inside a directory

### DIFF
--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -24,7 +24,7 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 npm install --save gatsby-plugin-manifest
 ```
 
-2. If you intend to have a favicon for your app, add one under the `src/images/icon.png`.
+2. Add a favicon for your app under `src/images/icon.png`. An icon option is needed to not break the [`manifest.json`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md) file.
 
 3. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 
@@ -42,7 +42,6 @@ npm install --save gatsby-plugin-manifest
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
-        // Skip this if you don't wish to have a favicon for your app.
         icon: "src/images/icon.png", // This path is relative to the root of the site.
       },
     },

--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -24,7 +24,9 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 npm install --save gatsby-plugin-manifest
 ```
 
-2.  Add the plugin to the `plugins` array in your `gatsby-config.js` file.
+2. If you intend to have a favicon for your app, add one under the `src/images/icon.png`.
+
+3. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 
 ```javascript:title=gatsby-config.js
 {
@@ -40,6 +42,7 @@ npm install --save gatsby-plugin-manifest
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
+        // Skip this if you don't wish to have a favicon for your app.
         icon: "src/images/icon.png", // This path is relative to the root of the site.
       },
     },

--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -24,7 +24,7 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 npm install --save gatsby-plugin-manifest
 ```
 
-2. Add a favicon for your app under `src/images/icon.png`. An icon option is needed to not break the [`manifest.json`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md) file.
+2. Add a favicon for your app under `src/images/icon.png`. The icon is necessary to build all images for the manifest. For more information look at the docs of [`gatsby-plugin-manifest`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md).
 
 3. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -85,7 +85,9 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 npm install --save gatsby-plugin-manifest
 ```
 
-2.  Add the plugin to the `plugins` array in your `gatsby-config.js` file.
+2. If you intend to have a favicon for your app, add one under `src/images/icon.png`.
+
+3. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 
 ```javascript:title=gatsby-config.js
 {
@@ -101,6 +103,7 @@ npm install --save gatsby-plugin-manifest
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
+        // Skip this if you don't wish to have a favicon for your app.
         icon: "src/images/icon.png", // This path is relative to the root of the site.
       },
     },

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -85,7 +85,7 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 npm install --save gatsby-plugin-manifest
 ```
 
-2. Add a favicon for your app under `src/images/icon.png`. An icon option is needed to not break the [`manifest.json`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md) file.
+2. Add a favicon for your app under `src/images/icon.png`. The icon is necessary to build all images for the manifest. For more information look at the docs of [`gatsby-plugin-manifest`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md).
 
 3. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -85,7 +85,7 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 npm install --save gatsby-plugin-manifest
 ```
 
-2. If you intend to have a favicon for your app, add one under `src/images/icon.png`.
+2. Add a favicon for your app under `src/images/icon.png`. An icon option is needed to not break the [`manifest.json`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md) file.
 
 3. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 
@@ -103,7 +103,6 @@ npm install --save gatsby-plugin-manifest
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
-        // Skip this if you don't wish to have a favicon for your app.
         icon: "src/images/icon.png", // This path is relative to the root of the site.
       },
     },


### PR DESCRIPTION
Issue #8366 - To inform the user regarding the need to supply an icon in part 8 of the tutorial as well as in add a manifest file page of the documentation.

Addressing the issues mentioned in #9581  