### PR TITLE
fix(gatsby-source-contentful): checking if entryItemFieldValue[0] exists

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
@@ -362,9 +362,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
           },
         },
         "phone": Object {
-          "en-US": Array [
-            "+1 212 260 2269",
-          ],
+          "en-US": Array [],
         },
         "website": Object {
           "en-US": "http://www.lemnos.jp/en/",
@@ -2945,15 +2943,13 @@ Array [
       "email": "info@acgears.com",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "6f4e1ac05fd8ddf9416fd6817495171a",
+        "contentDigest": "519b0291d3d4f6b873db1e7041f8a8c6",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
       "node_locale": "en-US",
       "parent": "Brand",
-      "phone": Array [
-        "+1 212 260 2269",
-      ],
+      "phone": Array [],
       "product___NODE": Array [
         "uuid-from-gatsby",
       ],
@@ -3148,15 +3144,13 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "email": "info@acgears.com",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "b06eff771a044bee1ef9ed561dc4e655",
+        "contentDigest": "8e519d7f8faaffd4950e0ac610f60faf",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
       "node_locale": "de",
       "parent": "Brand",
-      "phone": Array [
-        "+1 212 260 2269",
-      ],
+      "phone": Array [],
       "product___NODE": Array [
         "uuid-from-gatsby",
       ],

--- a/packages/gatsby-source-contentful/src/__tests__/data.json
+++ b/packages/gatsby-source-contentful/src/__tests__/data.json
@@ -1634,7 +1634,7 @@
             "en-US": "info@acgears.com"
           },
           "phone": {
-            "en-US": ["+1 212 260 2269"]
+            "en-US": []
           }
         }
       },

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -297,6 +297,7 @@ exports.createContentTypeNodes = ({
           const entryItemFieldValue = entryItemFields[entryItemFieldKey]
           if (Array.isArray(entryItemFieldValue)) {
             if (
+              entryItemFieldValue[0] &&
               entryItemFieldValue[0].sys &&
               entryItemFieldValue[0].sys.type &&
               entryItemFieldValue[0].sys.id


### PR DESCRIPTION
## Description

On the _source-contentful plugin_, an error is being thrown in the `createContentTypeNodes` function when `entryItemFieldValue` is an empty array. This PR adds a condition to check whether it's safe to access that prop or not, to prevent that exception.

/cc @Khaledgarbaya @KyleAMathews @pieh 