### PR TITLE
Fix sort field compatibility with `graphql-tools`

### DIFF
--- a/packages/gatsby/src/schema/create-sort-field.js
+++ b/packages/gatsby/src/schema/create-sort-field.js
@@ -37,8 +37,8 @@ module.exports = function createSortField(
           type: new GraphQLEnumType({
             name: _.camelCase(`${typeName} sortOrderValues`),
             values: {
-              ASC: { value: `asc` },
-              DESC: { value: `desc` },
+              ASC: { value: `ASC` },
+              DESC: { value: `DESC` },
             },
           }),
         },


### PR DESCRIPTION
## Description

This uppercases the sort field's sort enum values.

## Related Issues

This fixes #10709 (or should, at least 😅).