### PR TITLE
Added AWS Amplify Auth starter to Gatsby listings

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1647,3 +1647,15 @@
     - Comes with React Helmet for adding site meta tags
     - Add Disqus
     - Nice Pagination
+- url: https://master.d2f5ek3dnwfe9v.amplifyapp.com/
+  repo: https://github.com/dabit3/gatsby-auth-starter-aws-amplify
+  description: This Gatsby starter uses AWS Amplify to implement authentication flow for signing up signing in users as well as protected client side routing.
+  tags:
+    - aws
+    - authentication
+    - amplify
+  features:
+    - User sign up
+    - User sign in
+    - Multi-factor Authentication
+    - User sign-out


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Add the AWS Amplify + Gatsby Auth starter to the starter library.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
