### PR TITLE
Remove extra brackets in line 201

### DIFF
--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -198,8 +198,7 @@ this powerful set of operators, you can select any data you want—in the format
 need.
 
 In your index page's GraphQL query, change `allMarkdownRemark` to
-`allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC })`. _Note: There are 3 underscores between `frontmatter` and `date`._ Save
-this and the sort order should be fixed.
+`allMarkdownRemark(sort: { fields: frontmatter___date, order: DESC })`. _Note: There are 3 underscores between `frontmatter` and `date`._ Save the index.js file and restart the development server. Now the sort order should be fixed.
 
 Try opening Graph_i_QL and playing with different sort options. You can sort the
 `allFile` connection along with other connections.


### PR DESCRIPTION
The brackets around frontmatter___date in line 201 must be removed for the query to work. I also had to restart my development server after saving to render the page. Before restarting the development server, I was throw an error: cannot read property of undefined <h4>{data.allMarkdownRemark.totalCount} Posts</h4>

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
