### PR TITLE
feat(browser-api): add previous location argument to navigation updates

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -34,15 +34,15 @@ function maybeRedirect(pathname) {
   }
 }
 
-const onPreRouteUpdate = location => {
+const onPreRouteUpdate = (location, prevLocation) => {
   if (!maybeRedirect(location.pathname)) {
-    apiRunner(`onPreRouteUpdate`, { location })
+    apiRunner(`onPreRouteUpdate`, { location, prevLocation })
   }
 }
 
-const onRouteUpdate = location => {
+const onRouteUpdate = (location, prevLocation) => {
   if (!maybeRedirect(location.pathname)) {
-    apiRunner(`onRouteUpdate`, { location })
+    apiRunner(`onRouteUpdate`, { location, prevLocation })
 
     // Temp hack while awaiting https://github.com/reach/router/issues/119
     window.__navigatingToLink = false
@@ -133,22 +133,22 @@ function init() {
 class RouteUpdates extends React.Component {
   constructor(props) {
     super(props)
-    onPreRouteUpdate(props.location)
+    onPreRouteUpdate(props.location, null)
   }
 
   componentDidMount() {
-    onRouteUpdate(this.props.location)
+    onRouteUpdate(this.props.location, null)
   }
 
   componentDidUpdate(prevProps, prevState, shouldFireRouteUpdate) {
     if (shouldFireRouteUpdate) {
-      onRouteUpdate(this.props.location)
+      onRouteUpdate(this.props.location, prevProps.location)
     }
   }
 
   getSnapshotBeforeUpdate(prevProps) {
     if (this.props.location.pathname !== prevProps.location.pathname) {
-      onPreRouteUpdate(this.props.location)
+      onPreRouteUpdate(this.props.location, prevProps.location)
       return true
     }
 

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -23,8 +23,9 @@ exports.onInitialClientRender = true
  * @param {object} $0.location A location object
  * @param {object} $0.action The "action" that caused the route change
  * @example
- * exports.onPreRouteUpdate = ({ location }) => {
- *   console.log("Gatsby started to change location", location.pathname)
+ * exports.onPreRouteUpdate = ({ location, prevLocation }) => {
+ *   console.log("Gatsby started to change location to", location.pathname)
+ *   console.log("Gatsby started to change location from", prevLocation ? prevLocation.pathname : null)
  * }
  */
 exports.onPreRouteUpdate = true
@@ -47,8 +48,9 @@ exports.onRouteUpdateDelayed = true
  * @param {object} $0.location A location object
  * @param {object} $0.action The "action" that caused the route change
  * @example
- * exports.onRouteUpdate = ({ location }) => {
+ * exports.onRouteUpdate = ({ location, prevLocation }) => {
  *   console.log('new pathname', location.pathname)
+ *   console.log('old pathname', prevLocation ? prevLocation.pathname : null)
  *
  *   // Track pageview with google analytics
  *   window.ga(

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -21,6 +21,7 @@ exports.onInitialClientRender = true
  * Called when changing location is started.
  * @param {object} $0
  * @param {object} $0.location A location object
+ * @param {object|null} $0.prevLocation The previous location object
  * @param {object} $0.action The "action" that caused the route change
  * @example
  * exports.onPreRouteUpdate = ({ location, prevLocation }) => {
@@ -46,6 +47,7 @@ exports.onRouteUpdateDelayed = true
  * Called when the user changes routes
  * @param {object} $0
  * @param {object} $0.location A location object
+ * @param {object|null} $0.prevLocation The previous location object
  * @param {object} $0.action The "action" that caused the route change
  * @example
  * exports.onRouteUpdate = ({ location, prevLocation }) => {

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -22,7 +22,6 @@ exports.onInitialClientRender = true
  * @param {object} $0
  * @param {object} $0.location A location object
  * @param {object|null} $0.prevLocation The previous location object
- * @param {object} $0.action The "action" that caused the route change
  * @example
  * exports.onPreRouteUpdate = ({ location, prevLocation }) => {
  *   console.log("Gatsby started to change location to", location.pathname)
@@ -48,7 +47,6 @@ exports.onRouteUpdateDelayed = true
  * @param {object} $0
  * @param {object} $0.location A location object
  * @param {object|null} $0.prevLocation The previous location object
- * @param {object} $0.action The "action" that caused the route change
  * @example
  * exports.onRouteUpdate = ({ location, prevLocation }) => {
  *   console.log('new pathname', location.pathname)


### PR DESCRIPTION
At the moment, `onRouteUpdate` and `onPreRouteUpdate` only pass in the current location, but it would be great to also have access to the previous location.

This issue was raised before in issue [#10708](https://github.com/gatsbyjs/gatsby/issues/10708)