### PR TITLE
feat(gatsby-remark-embed-snippet): support setup link filename resolve function in configuration

### DIFF
--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -185,8 +185,19 @@ module.exports = {
               // If you're unsure, it's best to use the default value.
               classPrefix: "language-",
 
-              // Example code links are relative to this dir.
-              // eg examples/path/to/file.js
+              // Can be string or function
+              //
+              // When string: Example code links are relative to this dir.
+              //               eg examples/path/to/file.js
+              //
+              // When function:  Map markdown filename (where link declared)
+              //                  and code link to result filename.
+              //                Example value: (mdFilenameFull, fileLink) => {
+              //                      let rv = path.dirname(mdFilenameFull);
+              //                      if (!rv.endsWith(`/`)) rv += `/`;
+              //                      return normalizePath(`${rv}${fileLink}`);
+              //                 }
+              //
               directory: `${__dirname}/examples/`,
             },
           },

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -31,7 +31,7 @@ module.exports = (
   { classPrefix = `language-`, directory } = {}
 ) => {
   if (!directory) {
-    throw Error(`Required option 'directory' not specified: must be absolute path OR function`)
+    throw Error(`Required option "directory" not specified`)
   }
 
   let filePathResolve

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -31,12 +31,12 @@ module.exports = (
   { classPrefix = `language-`, directory } = {}
 ) => {
   if (!directory) {
-    throw Error("Required option 'directory' not specified: must be absolute path OR function")
+    throw Error(`Required option 'directory' not specified: must be absolute path OR function`)
   }
 
   let filePathResolve
 
-  if(typeof directory === "string") {
+  if (typeof directory === `string`) {
     if (!fs.existsSync(directory)) {
       throw Error(`Invalid directory specified "${directory}"`)
     }
@@ -44,10 +44,10 @@ module.exports = (
       directory += `/`
     }
 
-    filePathResolve = file => normalizePath(`${directory}${file}`);
+    filePathResolve = file => normalizePath(`${directory}${file}`)
   } else {
     //its function
-    filePathResolve = file => directory(markdownNode.fileAbsolutePath, file);
+    filePathResolve = file => directory(markdownNode.fileAbsolutePath, file)
   }
 
   visit(markdownAST, `inlineCode`, node => {

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -31,12 +31,12 @@ module.exports = (
   { classPrefix = `language-`, directory } = {}
 ) => {
   if (!directory) {
-    throw Error(`Required option "directory" not specified: must be absolute path OR function`)
+    throw Error("Required option 'directory' not specified: must be absolute path OR function")
   }
-  
-  let filePathResolve;
 
-  if(typeof directory === 'string') {
+  let filePathResolve
+
+  if(typeof directory === "string") {
     if (!fs.existsSync(directory)) {
       throw Error(`Invalid directory specified "${directory}"`)
     }
@@ -44,10 +44,10 @@ module.exports = (
       directory += `/`
     }
 
-    filePathResolve = (file) => normalizePath(`${directory}${file}`);
+    filePathResolve = file => normalizePath(`${directory}${file}`);
   } else {
     //its function
-    filePathResolve = (file) => directory(markdownNode.fileAbsolutePath, file);
+    filePathResolve = file => directory(markdownNode.fileAbsolutePath, file);
   }
 
   visit(markdownAST, `inlineCode`, node => {
@@ -55,7 +55,7 @@ module.exports = (
 
     if (value.startsWith(`embed:`)) {
       const file = value.substr(6)
-      const path = filePathResolve(file);
+      const path = filePathResolve(file)
 
       if (!fs.existsSync(path)) {
         throw Error(`Invalid snippet specified; no such file "${path}"`)

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -45,9 +45,10 @@ module.exports = (
     }
 
     filePathResolve = file => normalizePath(`${directory}${file}`)
-  } else {
-    //its function
+  } else if (typeof directory === `function`) {
     filePathResolve = file => directory(markdownNode.fileAbsolutePath, file)
+  } else {
+    throw Error(`Invalid directory specified "${directory}": unsupported type "${typeof directory}"`)
   }
 
   visit(markdownAST, `inlineCode`, node => {


### PR DESCRIPTION
This PR implement support setup `directory` option to filename resolution function (in `gatsby-remark-embed-snippet` (plugin for `gatsby-transformer-remark`) configuration).

This allow use relative to 'parent' markdown file paths in code links and any other filename mapping.