### PR TITLE
fix(using-redux): create a fresh store for each SSR page

### DIFF
--- a/examples/using-redux/wrap-with-provider.js
+++ b/examples/using-redux/wrap-with-provider.js
@@ -7,5 +7,5 @@ import createStore from "./src/state/createStore"
 export default ({ element }) => {
   // Create a fresh store for each SSR page:
   const store = createStore()
-  return (<Provider store={store}>{element}</Provider>)
+  return <Provider store={store}>{element}</Provider>
 }

--- a/examples/using-redux/wrap-with-provider.js
+++ b/examples/using-redux/wrap-with-provider.js
@@ -5,7 +5,9 @@ import createStore from "./src/state/createStore"
 
 // eslint-disable-next-line react/display-name,react/prop-types
 export default ({ element }) => {
-  // Create a fresh store for each SSR page:
+  // Instantiating store in `wrapRootElement` handler ensures:
+  //  - there is fresh store for each SSR page
+  //  - it will be called only once in browser, when React mounts
   const store = createStore()
   return <Provider store={store}>{element}</Provider>
 }

--- a/examples/using-redux/wrap-with-provider.js
+++ b/examples/using-redux/wrap-with-provider.js
@@ -3,7 +3,9 @@ import { Provider } from "react-redux"
 
 import createStore from "./src/state/createStore"
 
-const store = createStore()
-
 // eslint-disable-next-line react/display-name,react/prop-types
-export default ({ element }) => <Provider store={store}>{element}</Provider>
+export default ({ element }) => {
+  // Create a fresh store for each SSR page:
+  const store = createStore()
+  return (<Provider store={store}>{element}</Provider>)
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

As I'd mentioned in #10912, the current [using-redux](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-redux) example creates a static store that persists across multiple SSR pages.

It seems that the **expected** behavior should likely be that each page's initial load is from a fresh store, in order to match the behavior of the browser rendering.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Related to #10912
