### PR TITLE
Add dedicated redux namespace for nodesByType

### DIFF
--- a/packages/gatsby/src/redux/index.js
+++ b/packages/gatsby/src/redux/index.js
@@ -46,6 +46,15 @@ try {
   }
   if (initialState.nodes) {
     initialState.nodes = objectToMap(initialState.nodes)
+
+    initialState.nodesByType = new Map()
+    initialState.nodes.forEach(node => {
+      const { type } = node.internal
+      if (!initialState.nodesByType.has(type)) {
+        initialState.nodesByType.set(type, new Map())
+      }
+      initialState.nodesByType.get(type).set(node.id, node)
+    })
   }
 } catch (e) {
   // ignore errors.

--- a/packages/gatsby/src/redux/nodes.js
+++ b/packages/gatsby/src/redux/nodes.js
@@ -16,17 +16,40 @@ const getNodes = () => {
 
 exports.getNodes = getNodes
 
-const getNode = id => store.getState().nodes.get(id)
-
 /** Get node by id from store.
  *
  * @param {string} id
  * @returns {Object}
  */
+const getNode = id => store.getState().nodes.get(id)
+
 exports.getNode = getNode
 
-exports.getNodesByType = type =>
-  getNodes().filter(node => node.internal.type === type)
+/**
+ * Get all nodes of type from redux store.
+ *
+ * @param {string} type
+ * @returns {Array}
+ */
+const getNodesByType = type => {
+  const nodes = store.getState().nodesByType.get(type)
+  if (nodes) {
+    return Array.from(nodes.values())
+  } else {
+    return []
+  }
+}
+
+exports.getNodesByType = getNodesByType
+
+/**
+ * Get all types from redux store.
+ *
+ * @returns {Array}
+ */
+const getTypes = () => Array.from(store.getState().nodesByType.keys())
+
+exports.getTypes = getTypes
 
 /**
  * Determine if node has changed.

--- a/packages/gatsby/src/redux/reducers/index.js
+++ b/packages/gatsby/src/redux/reducers/index.js
@@ -23,6 +23,7 @@ function getNodesReducer() {
 module.exports = {
   program: require(`./program`),
   nodes: getNodesReducer(),
+  nodesByType: require(`./nodes-by-type`),
   nodesTouched: require(`./nodes-touched`),
   lastAction: require(`./last-action`),
   plugins: require(`./plugins`),

--- a/packages/gatsby/src/redux/reducers/nodes-by-type.js
+++ b/packages/gatsby/src/redux/reducers/nodes-by-type.js
@@ -1,0 +1,60 @@
+const getNodesOfType = (node, state) => {
+  const { type } = node.internal
+  if (!state.has(type)) {
+    state.set(type, new Map())
+  }
+  return state.get(type)
+}
+
+module.exports = (state = new Map(), action) => {
+  switch (action.type) {
+    case `DELETE_CACHE`:
+      return new Map()
+
+    case `CREATE_NODE`: {
+      const node = action.payload
+      const nodesOfType = getNodesOfType(node, state)
+      nodesOfType.set(node.id, node)
+      return state
+    }
+
+    case `ADD_FIELD_TO_NODE`:
+    case `ADD_CHILD_NODE_TO_PARENT_NODE`: {
+      const node = action.payload
+      const nodesOfType = getNodesOfType(node, state)
+      nodesOfType.set(node.id, node)
+      return state
+    }
+
+    case `DELETE_NODE`: {
+      const node = action.payload
+      const nodesOfType = getNodesOfType(node, state)
+      nodesOfType.delete(node.id)
+      if (!nodesOfType.size) {
+        state.delete(node.internal.type)
+      }
+      return state
+    }
+
+    // Deprecated, will be removed in Gatsby v3.
+    case `DELETE_NODES`: {
+      const ids = action.payload
+      ids.forEach(id => {
+        Array.from(state).some(([type, nodes]) => {
+          if (nodes.has(id)) {
+            nodes.delete(id)
+            if (!nodes.size) {
+              state.delete(type)
+            }
+            return true
+          }
+          return false
+        })
+      })
+      return state
+    }
+
+    default:
+      return state
+  }
+}

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -18,20 +18,6 @@ const enhancedNodeCacheId = ({ node, args }) =>
       })
     : null
 
-const nodesCache = new Map()
-
-function loadNodes(type) {
-  let nodes
-  // this caching can be removed if we move to loki
-  if (process.env.NODE_ENV === `production` && nodesCache.has(type)) {
-    nodes = nodesCache.get(type)
-  } else {
-    nodes = getNodesByType(type)
-    nodesCache.set(type, nodes)
-  }
-  return nodes
-}
-
 /////////////////////////////////////////////////////////////////////
 // Parse filter
 /////////////////////////////////////////////////////////////////////
@@ -306,7 +292,7 @@ module.exports = (args: Object) => {
   const clonedArgs = JSON.parse(JSON.stringify(queryArgs))
 
   // If nodes weren't provided, then load them from the DB
-  const nodes = args.nodes || loadNodes(gqlType.name)
+  const nodes = args.nodes || getNodesByType(gqlType.name)
 
   const { siftArgs, fieldsToSift } = parseFilter(clonedArgs.filter)
 

--- a/packages/gatsby/src/schema/build-node-types.js
+++ b/packages/gatsby/src/schema/build-node-types.js
@@ -17,7 +17,7 @@ const {
   inferInputObjectStructureFromNodes,
 } = require(`./infer-graphql-input-fields`)
 const { nodeInterface } = require(`./node-interface`)
-const { getNodes, getNode } = require(`../db/nodes`)
+const { getNodesByType, getTypes, getNode } = require(`../db/nodes`)
 const pageDependencyResolver = require(`./page-dependency-resolver`)
 const { setFileNodeRootType } = require(`./types/type-file`)
 const {
@@ -234,18 +234,11 @@ async function buildProcessedType({ nodes, typeName, processedTypes, span }) {
   }
 }
 
-function groupNodesByType(nodes) {
-  return _.groupBy(
-    nodes.filter(node => node.internal && !node.internal.ignoreType),
-    node => node.internal.type
-  )
-}
-
 async function buildAll({ parentSpan }) {
   const spanArgs = parentSpan ? { childOf: parentSpan } : {}
   const span = tracer.startSpan(`build schema`, spanArgs)
 
-  const types = groupNodesByType(getNodes())
+  const types = getTypes()
   const processedTypes: TypeMap = {}
 
   clearTypeExampleValues()
@@ -255,7 +248,12 @@ async function buildAll({ parentSpan }) {
 
   // Create node types and node fields for nodes that have a resolve function.
   await Promise.all(
-    _.map(types, async (nodes, typeName) => {
+    _.map(types, async typeName => {
+      const nodes = getNodesByType(typeName).filter(
+        node => node.internal && !node.internal.ignoreType
+      )
+      if (!nodes.length) return
+
       const fieldName = _.camelCase(typeName)
       const processedType = await buildProcessedType({
         nodes,


### PR DESCRIPTION
`getNodesByType` currently has to search through all nodes in the store to return nodes of a type. This is mitigated in `run-sift` by using a local cache, but only for production builds. This PR proposes a dedicated redux namespace to keep a Map of nodes by type.

I ran the "query" benchmark with these results (5 run average):
```
NUM_TYPES=20 NUM_PAGES=20000 yarn develop
```
current master: 66.10 queries/second
this PR: 161.58 queries/second

```sh
NUM_TYPES=50 NUM_PAGES=50000 yarn develop
```
current master: 24.83 queries/second
this PR: 85.11 queries/second