### PR TITLE
fix(www): make sure state is set on location (showcase)

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -131,6 +131,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
       const allSitesYaml = staticData.allSitesYaml
       const nextSite = parent.getNext(allSitesYaml)
       const previousSite = parent.getPrevious(allSitesYaml)
+      const { filters } = parent.props.location.state || {}
 
       return (
         <Layout
@@ -144,7 +145,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               to={nextSite.fields.slug}
               state={{
                 isModal: true,
-                filters: parent.props.location.state.filters,
+                filters,
               }}
               css={{
                 display: `block`,
@@ -197,7 +198,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               to={previousSite.fields.slug}
               state={{
                 isModal: true,
-                filters: parent.props.location.state.filters,
+                filters,
               }}
               css={{
                 display: `block`,


### PR DESCRIPTION
Fixes
```
  145 |               state={{
  146 |                 isModal: true,
> 147 |                 filters: parent.props.location.state.filters,
      |                                                      ^
  148 |               }}
  149 |               css={{
  150 |                 display: `block`
```
  WebpackError: TypeError: Cannot read property 'filters' of undefined