### PR TITLE
fix(docs): correct various grammatical errors and broken links

### DIFF
--- a/docs/docs/add-page-metadata.md
+++ b/docs/docs/add-page-metadata.md
@@ -4,7 +4,7 @@ title: Adding page metadata
 
 If you've run an [audit with Lighthouse](/docs/audit-with-lighthouse/), you may have noticed a lackluster score in the "SEO" category. Let's address how you can improve that score.
 
-Adding metadata to pages (such as a title or description) are key in helping search engines like Google understand your content, and decide when to surface it in search results.
+Adding metadata to pages (such as a title or description) is key in helping search engines like Google understand your content, and decide when to surface it in search results.
 
 [React Helmet](https://github.com/nfl/react-helmet) is a package that provides a React component interface for you to manage your [document head](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head).
 

--- a/docs/docs/glamor.md
+++ b/docs/docs/glamor.md
@@ -48,7 +48,7 @@ export default () => (
 )
 ```
 
-Let's add css styles to `Container` and add a inline `User` component using Glamor's `css` prop.
+Let's add css styles to `Container` and add an inline `User` component using Glamor's `css` prop.
 
 ```jsx:title=src/pages/index.js
 import React from "react"

--- a/docs/docs/making-your-site-accessible.md
+++ b/docs/docs/making-your-site-accessible.md
@@ -11,7 +11,7 @@ Back in the early days of the Web, Tim Berners-Lee, inventor of the World Wide W
 
 The web of today is an important resource in many aspects of life such as health care, education, or commerce. Accessibility is an important consideration when building for the web.
 
-[Web accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/#what) means that websites, tools, and technologies are designed and developed so that people with disabilities can use them. But not only people with permanent disabilities benefit from it. Accessibility also benefits people with temporary disabilities. For example imagine being in a environment where you cannot listen to audio or if you had a broken arm.
+[Web accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/#what) means that websites, tools, and technologies are designed and developed so that people with disabilities can use them. But not only people with permanent disabilities benefit from it. Accessibility also benefits people with temporary disabilities. For example imagine being in an environment where you cannot listen to audio or if you had a broken arm.
 
 Accessibility [supports](https://www.w3.org/standards/webdesign/accessibility#case) social inclusion for everyone, and has a strong business case.
 

--- a/docs/docs/plugin-authoring.md
+++ b/docs/docs/plugin-authoring.md
@@ -14,7 +14,7 @@ You may be looking to build a plugin that doesn't exist yet, or you may just be 
 
 - Each Gatsby plugin can be created as an npm package or as a [local plugin](#local-plugins)
 - A `package.json` is required
-- Plugin implement the Gatsby APIs for [Node](/docs/node-apis/), [server-side rendering](/docs/ssr-apis/), and the [browser](/docs/browser-apis/)
+- Plugins implement the Gatsby APIs for [Node](/docs/node-apis/), [server-side rendering](/docs/ssr-apis/), and the [browser](/docs/browser-apis/)
 
 ## Plugin naming conventions
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -9,7 +9,7 @@ Of the many possibilities, plugins can:
 - add external data or content (e.g. your CMS, static files, a REST API) to your Gatsby GraphQL data
 - transform data from other formats (e.g. Markdown, YAML, CSV) to JSON objects
 - add third-party services (e.g. Google Analytics, Instagram) to your site
-- anything you can dream up!
+- do anything you can dream up!
 
 Gatsby plugins are Node.js packages that implement Gatsby APIs. For larger, more complex sites, plugins let you modularize your site customizations into site-specific plugins.
 
@@ -115,4 +115,4 @@ Some examples:
 - Using React components or component libraries you want to include in your UI, such as `Ant Design`, `Material UI`, or the typeahead from your component library.
 - Integrating visualization libraries, such as `Highcharts` or `d3`.
 
-As a general rule, you may use _any_ npm package you might use without Gatsby, with Gatsby. What plugins offer is a prepackaged integration into the core Gatsby API's to save you time and energy, with minimal configuration. In the case of `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could just use `gatsby-plugin-styled-components` which takes care of this step for you in addition to any other difficulties you may run into configuring Styled Components to work with server side rendering.
+As a general rule, you may use _any_ npm package you might use without Gatsby, with Gatsby. What plugins offer is a prepackaged integration into the core Gatsby APIs to save you time and energy, with minimal configuration. In the case of `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could just use `gatsby-plugin-styled-components` which takes care of this step for you in addition to any other difficulties you may run into configuring Styled Components to work with server side rendering.

--- a/docs/docs/seo.md
+++ b/docs/docs/seo.md
@@ -24,7 +24,7 @@ Starting in January 2018, Google [rewards faster sites with a bump in search ran
 
 ### Page metadata
 
-Add metadata to pages, such as page title and description, helps search engines understand your content and when to show your pages in search results.
+Adding metadata to pages, such as page title and description, helps search engines understand your content and when to show your pages in search results.
 
 A common way to add metadata to pages is to add [react-helmet](https://github.com/nfl/react-helmet) components (together with the [Gatsby React Helmet plugin](/packages/gatsby-plugin-react-helmet) for SSR support) to your page components.
 

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -146,7 +146,7 @@ That's all you need to get started with service workers with Gatsby.
 
 ## Add page metadata
 
-Adding metadata to pages (such as a title or description) are key in helping search engines like Google understand your content, and decide when to surface it in search results.
+Adding metadata to pages (such as a title or description) is key in helping search engines like Google understand your content, and decide when to surface it in search results.
 
 [React Helmet](https://github.com/nfl/react-helmet) is a package that provides a React component interface for you to manage your [document head](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head).
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,18 +1,18 @@
 # End to End Tests
 
-These are end to end tests triggered via a CI job. You can run these tests locally by following the [running tests][#running-the-tests], and they're automatically run as part of a CI workflow which runs when packages/_ or the e2e-tests/_ directory is changed in a commit.
+These are end to end tests triggered via a CI job. You can run these tests locally by following the [instructions below](#running-the-tests), and they're automatically run as part of a CI workflow which runs when the _packages/_ or _e2e-tests/_ directory is changed in a commit.
 
 ## Adding a new e2e test
 
 - Create a folder `e2e-tests/name-of-the-test`
-- Copy structure from an existing test, e.g. [`e2e-tests/path-prefix`][./path-prefix]
+- Copy structure from an existing test, e.g. [_e2e-tests/path-prefix_](./path-prefix/)
 - Add your tests in `e2e-tests/name-of-the-test/cypress/integration/your-test-here.js`
 
 ## Running the Tests
 
 - `cd` to the test (e.g. `cd e2e-tests/gatsby-image`)
 - Install dependencies: `yarn` or `npm install`
-- OPTIONAL: [use `gatsby-dev` CLI to link current changes in packages/][gatsby-dev-cli]
+- OPTIONAL: Use [gatsby-dev-cli][gatsby-dev-cli] to link current changes in packages
 - Run the `test` script, e.g. `yarn test` or `npm test`
 
 Thanks for contributing to Gatsby! 💜

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Example websites sit on one or the other end of the spectrum from very basic
 to complex/complete.
 
-A basic example website should demonstrate a specific technology/plugin/technique to help other developers understand how to accomplish task. They should be named `using-*` e.g. `using-sass`.
+A basic example website should demonstrate a specific technology/plugin/technique to help other developers understand how to accomplish a task. They should be named `using-*` (e.g. `using-sass`).
 
 Complex/complete websites are for studying how to build more complex websites.
 


### PR DESCRIPTION
## Description
While consulting the e2e-tests _README_, I noticed a couple broken links. I fixed them, but felt bad about submitting such a tiny PR, so i took the opportunity to correct a few grammatical errors around the docs.

## Related Issues
N.A.
