### PR TITLE
fix(gatsby): Resolve all fields before querying with Sift

### DIFF
--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -25,6 +25,19 @@ const mockNodes = [
     id: `id_3`,
     string: `baz`,
   },
+  {
+    id: `id_4`,
+    string: `qux`,
+    first: {
+      willBeResolved: `willBeResolved`,
+      second: {
+        willBeResolved: `willBeResolved`,
+        third: {
+          foo: `foo`,
+        },
+      },
+    },
+  },
 ]
 
 jest.mock(`../../db/nodes`, () => {
@@ -40,8 +53,36 @@ describe(`run-sift`, () => {
     name: typeName,
     fields: () => {
       return {
-        id: new GraphQLNonNull(GraphQLID),
-        string: GraphQLString,
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        string: { type: GraphQLString },
+        first: {
+          type: new GraphQLObjectType({
+            name: `First`,
+            fields: {
+              willBeResolved: {
+                type: GraphQLString,
+                resolve: () => `resolvedValue`,
+              },
+              second: {
+                type: new GraphQLObjectType({
+                  name: `Second`,
+                  fields: {
+                    willBeResolved: {
+                      type: GraphQLString,
+                      resolve: () => `resolvedValue`,
+                    },
+                    third: new GraphQLObjectType({
+                      name: `Third`,
+                      fields: {
+                        foo: GraphQLString,
+                      },
+                    }),
+                  },
+                }),
+              },
+            },
+          }),
+        },
       }
     },
   })
@@ -91,7 +132,31 @@ describe(`run-sift`, () => {
       })
 
       expect(resultSingular).toEqual([nodes[0]])
-      expect(resultMany).toEqual([nodes[0], nodes[2]])
+      expect(resultMany).toEqual([nodes[0], nodes[2], nodes[3]])
     })
+  })
+
+  it(`resolves fields before querying`, async () => {
+    const queryArgs = {
+      filter: {
+        first: {
+          willBeResolved: { eq: `resolvedValue` },
+          second: {
+            willBeResolved: { eq: `resolvedValue` },
+            third: {
+              foo: { eq: `foo` },
+            },
+          },
+        },
+      },
+    }
+
+    const results = await runSift({
+      gqlType,
+      queryArgs,
+      firstOnly: true,
+    })
+
+    expect(results[0].id).toBe(`id_4`)
   })
 })

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -63,14 +63,13 @@ function siftifyArgs(object) {
 // Build an object that excludes the innermost leafs,
 // this avoids including { eq: x } when resolving fields.
 const extractFieldsToSift = filter =>
-  Object.entries(filter).reduce((acc, [key, value]) => {
+  Object.keys(filter).reduce((acc, key) => {
+    const value = filter[key]
+    const k = Object.keys(value)[0]
+    const v = value[k]
     if (key === `elemMatch`) {
-      const [k, v] = Object.entries(value)[0]
       acc[k] = extractFieldsToSift(v)
-    } else if (
-      _.isPlainObject(value) &&
-      _.isPlainObject(Object.values(value)[0])
-    ) {
+    } else if (_.isPlainObject(value) && _.isPlainObject(v)) {
       acc[key] = extractFieldsToSift(value)
     } else {
       acc[key] = true

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -62,22 +62,21 @@ function siftifyArgs(object) {
 
 // Build an object that excludes the innermost leafs,
 // this avoids including { eq: x } when resolving fields.
-function extractFieldsToSift(prekey, key, preobj, obj, val) {
-  if (_.isPlainObject(val)) {
-    _.forEach((val: any), (v, k) => {
-      if (k === `elemMatch`) {
-        // elemMatch is operator for arrays and not field we want to prepare
-        // so we need to skip it
-        extractFieldsToSift(prekey, key, preobj, obj, v)
-        return
-      }
-      preobj[prekey] = obj
-      extractFieldsToSift(key, k, obj, {}, v)
-    })
-  } else {
-    preobj[prekey] = true
-  }
-}
+const extractFieldsToSift = filter =>
+  Object.entries(filter).reduce((acc, [key, value]) => {
+    if (key === `elemMatch`) {
+      const [k, v] = Object.entries(value)[0]
+      acc[k] = extractFieldsToSift(v)
+    } else if (
+      _.isPlainObject(value) &&
+      _.isPlainObject(Object.values(value)[0])
+    ) {
+      acc[key] = extractFieldsToSift(value)
+    } else {
+      acc[key] = true
+    }
+    return acc
+  }, {})
 
 /**
  * Parse filter and returns an object with two fields:
@@ -87,19 +86,16 @@ function extractFieldsToSift(prekey, key, preobj, obj, val) {
  */
 function parseFilter(filter) {
   const siftArgs = []
-  const fieldsToSift = {}
+  let fieldsToSift = {}
   if (filter) {
     _.each(filter, (v, k) => {
-      // Ignore connection and sorting args.
-      if (_.includes([`skip`, `limit`, `sort`], k)) return
-
       siftArgs.push(
         siftifyArgs({
           [k]: v,
         })
       )
-      extractFieldsToSift(``, k, {}, fieldsToSift, v)
     })
+    fieldsToSift = extractFieldsToSift(filter)
   }
   return { siftArgs, fieldsToSift }
 }


### PR DESCRIPTION
Fix `extractFieldsToSift` silently omitting fields that need to be resolved before querying. See:
```js
const _ = require('lodash')
const diff = require('jest-diff')

const filter = {
  foo: { eq: true },
  bar: {
    foo: { eq: true },
    bar: {
      foo: { eq: true },
      bar: {
        foo: { eq: true },
      },
    },
  },
  baz: { eq: true },
  qux: {
    foo: { eq: true },
  },
}

const expected = {
  foo: true,
  bar: {
    foo: true,
    bar: {
      foo: true,
      bar: {
        foo: true,
      },
    },
  },
  baz: true,
  qux: {
    foo: true,
  },
}

function extractFieldsToSift(prekey, key, preobj, obj, val) {
  if (_.isPlainObject(val)) {
    _.forEach(val, (v, k) => {
      if (k === `elemMatch`) {
        extractFieldsToSift(prekey, key, preobj, obj, v)
        return
      }
      preobj[prekey] = obj
      extractFieldsToSift(key, k, obj, {}, v)
    })
  } else {
    preobj[prekey] = true
  }
}

const fieldsToSift = {}
_.each(filter, (v, k) => {
  extractFieldsToSift(``, k, {}, fieldsToSift, v)
})

console.log(diff(fieldsToSift, expected))

```