### PR TITLE
Add protocol requirement

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -152,7 +152,7 @@ const IndexLayout = ({ children, location }) => {
 
 ## Use `<Link>` only for internal links!
 
-This component is intended _only_ for links to pages handled by Gatsby. For links to pages on other domains or pages on the same domain not handled by the current Gatsby site, use the normal `<a>` element.
+This component is intended _only_ for links to pages handled by Gatsby. For links to pages on other domains or pages on the same domain not handled by the current Gatsby site, use the normal `<a>` element. Links using the `<a>` element require a URL protocol e.g. `http://` or `https://`. 
 
 Sometimes you won't know ahead of time whether a link will be internal or not,
 such as when the data is coming from a CMS.


### PR DESCRIPTION
Add additional line letting users know that the protocol is required when using the anchor tag, otherwise it will be taken over by internal routing and the link wont work.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
