### PR TITLE
Fix JSON in `.babelrc` example.

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -30,12 +30,12 @@ npm install --save-dev babel-preset-gatsby
 
 ```json5:title=.babelrc
 {
-  presets: [
+  "presets": [
     [
       "babel-preset-gatsby",
       {
-        targets: {
-          browsers: [">0.25%", "not dead"],
+        "targets": {
+          "browsers": [">0.25%", "not dead"],
         },
       },
     ],


### PR DESCRIPTION
Thank you for this project!

## Description

The example `.babelrc` configuration was not valid JSON, I've converted the keys to strings.

