### PR TITLE
Pass-through query from graphql function

### DIFF
--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -36,7 +36,11 @@ StaticQuery.propTypes = {
   children: PropTypes.func,
 }
 
-function graphql() {
+function graphql(query) {
+  if (process.env.GATSBY_GRAPHQL_PASSTHROUGH) {
+    return query
+  }
+
   throw new Error(
     `It appears like Gatsby is misconfigured. Gatsby related \`graphql\` calls ` +
       `are supposed to only be evaluated at compile time, and then compiled away,. ` +


### PR DESCRIPTION
I have a use case where I need to pass through the value of the `graphql` function's query for use in node. Specifically, I want to define a fragment that I can use both in page queries and in `gatsby-node.js`:

<details>
<summary>Details</summary>

```js
// src/fragments/foo.js

import { graphql } from "gatsby";

export const query = graphql`
  fragment Foo on Bar {
    // ...
  }
`;
```

```js
// src/pages/index.js

import { graphql } from "gatsby";

export const query = graphql`
  query {
    ...Foo
  }
`;
```

```js
// gatsby-node.js

require(`@babel/register`);
const fooFragment = require(`./src/fragments/foo`);

exports.createPages = async ({ actions, graphql }) => {
  // ...

  const result = await graphql(`
    ${fooFragment.query}
    
    query {
      ...Foo
    }
  `)

  // ...
};
```

</details>
<br />

Since the `graphql` function throws an error when actually called, regardless of environment, I can't use it in `gatsby-node.js`. This PR changes this so that you can opt-in via an env variable to let the `graphql` function simply pass through its query instead of throwing. This enables the use case described above as well as potential use cases of having access to the query in the browser.