### PR TITLE
fix(gatsby-transformer-sharp): Pick extension from file prop

### DIFF
--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -74,7 +74,7 @@ const fixedNodeType = ({
           resolve: ({ file, image, fieldArgs }) => {
             // If the file is already in webp format or should explicitly
             // be converted to webp, we do not create additional webp files
-            if (image.extension === `webp` || fieldArgs.toFormat === `webp`) {
+            if (file.extension === `webp` || fieldArgs.toFormat === `webp`) {
               return null
             }
             const args = { ...fieldArgs, pathPrefix, toFormat: `webp` }
@@ -91,7 +91,7 @@ const fixedNodeType = ({
         srcSetWebp: {
           type: GraphQLString,
           resolve: ({ file, image, fieldArgs }) => {
-            if (image.extension === `webp` || fieldArgs.toFormat === `webp`) {
+            if (file.extension === `webp` || fieldArgs.toFormat === `webp`) {
               return null
             }
             const args = { ...fieldArgs, pathPrefix, toFormat: `webp` }


### PR DESCRIPTION
The resolvers for `srcSetWebp` and `srcWebp` check the extension on `image` (which is the ImageSharp node that has no `extension` prop) instead of `file` (which is the parent File node).