### PR TITLE
fixed format of preBodyComponents to work with Google Search Console …

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -37,14 +37,12 @@ exports.onRenderBody = (
         key="plugin-google-tagmanager"
         dangerouslySetInnerHTML={{
           __html: stripIndent`
-            <iframe
-              src="https://www.googletagmanager.com/ns.html?id=${
-                pluginOptions.id
-              }${environmentParamStr}"
-              height="0"
-              width="0"
-              style="display: none; visibility: hidden"
-            ></iframe>`,
+            <iframe `+
+              `src="https://www.googletagmanager.com/ns.html?id=${pluginOptions.id}${environmentParamStr}" `+
+              `height="0" `+
+              `width="0" `+
+              `style="display: none; visibility: hidden"`+
+            `></iframe>`,
         }}
       />,
     ])


### PR DESCRIPTION
When the line breaks are present in the iframe tag, Google Search Console is not able to verify ownership of the site. This pull request removes the line breaks so that the iframe tag is all on a single line.

This is response to issue #11014.
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
