### PR TITLE
feat(gatsby): add support for ExportSpecifier in API files

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
@@ -111,6 +111,10 @@ describe(`Resolve module exports`, () => {
       exports.__esModule = true;
       exports.foo = '';
     `,
+    "/export/named": `const foo = ''; export { foo };`,
+    "/export/named/from": `export { Component } from 'react';`,
+    "/export/named/as": `const foo = ''; export { foo as bar };`,
+    "/export/named/multiple": `const foo = ''; const bar = ''; const baz = ''; export { foo, bar, baz };`,
   }
 
   beforeEach(() => {
@@ -173,5 +177,25 @@ describe(`Resolve module exports`, () => {
   it(`Ignores exports.__esModule`, () => {
     const result = resolveModuleExports(`/esmodule/export`, resolver)
     expect(result).toEqual([`foo`])
+  })
+
+  it(`Resolves a named export`, () => {
+    const result = resolveModuleExports(`/export/named`, resolver)
+    expect(result).toEqual([`foo`])
+  })
+
+  it(`Resolves a named export from`, () => {
+    const result = resolveModuleExports(`/export/named/from`, resolver)
+    expect(result).toEqual([`Component`])
+  })
+
+  it(`Resolves a named export as`, () => {
+    const result = resolveModuleExports(`/export/named/as`, resolver)
+    expect(result).toEqual([`bar`])
+  })
+
+  it(`Resolves multiple named exports`, () => {
+    const result = resolveModuleExports(`/export/named/multiple`, resolver)
+    expect(result).toEqual([`foo`, `bar`, `baz`])
   })
 })

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -70,6 +70,15 @@ module.exports = (modulePath, resolver = require.resolve) => {
       isES6 = true
       if (exportName) exportNames.push(exportName)
     },
+
+    // get foo from `export { foo } from 'bar'`
+    // get foo from `export { foo }`
+    ExportSpecifier: function ExportSpecifier(astPath) {
+      const exportName = get(astPath, `node.exported.name`)
+      isES6 = true
+      if (exportName) exportNames.push(exportName)
+    },
+
     AssignmentExpression: function AssignmentExpression(astPath) {
       const nodeLeft = astPath.node.left
 


### PR DESCRIPTION
## Description

This PR allows named exports to be used in
- `gatsby-node`
- `gatsby-ssr`
- `gatsby-browser`

### *example*

**`some-random-file.js`**
```js
export const wrapRootElement = ({ element }) => element
```

**`gatsby-ssr.js`**
```js
export { wrapRootElement } from './some-random-file'
```

## Related Issues

Fixes #10553