### PR TITLE
Removes mention about createPagesStatefully

### DIFF
--- a/docs/docs/gatsby-lifecycle-apis.md
+++ b/docs/docs/gatsby-lifecycle-apis.md
@@ -24,7 +24,7 @@ During "bootstrap" gatsby:
 - pulls in and preprocesses data ("source and transform nodes") into a GraphQL schema
 - creates pages in memory
   - from your `/pages` folder
-  - from your `gatsby-node.js` if you implement `createPages`/`createPagesStatefully` (e.g. templates)
+  - from your `gatsby-node.js` if you implement `createPages` (e.g. templates)
   - from any plugins that implement `createPages`/`createPagesStatefully`
 - extracts, runs, and replaces graphql queries for pages and `StaticQuery`s
 - writes out the pages to cache


### PR DESCRIPTION
### Description
`createPagesStatefully` is a left over API from prev-v1.

It's safe to remove it to avoid confusion.