### PR TITLE
docs(www): Add docs for partially matching a Link to a url

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -76,6 +76,8 @@ const PartialNavLink = props => (
 )
 ```
 
+Check out this [codesandbox](https://codesandbox.io/s/p92vm09m37) for a working example!
+
 ## Replacing history entry
 
 You can pass boolean `replace` property to replace previous history entry.

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -59,9 +59,9 @@ class Page extends React.Component {
 The `activeStyle` or `activeClassName` prop are only set on a `<Link>` component if the current URL matches its `to` prop _exactly_. Sometimes, we may want to style a `<Link>` as active even if it partially matches the current URL. For example:
 
 - We may want `/blog/hello-world` to match `<Link to="/blog">`
-- or `/gatsby-link/#passing-state-through-link-and-navigate` to match `<Link to="/gatsby-link">`
+- Or `/gatsby-link/#passing-state-through-link-and-navigate` to match `<Link to="/gatsby-link">`
 
-In instances like these, we can use [@reach/router's](https://reach.tech/router/api/Link) `getProps` API to to set active styles
+In instances like these, we can use [@reach/router's](https://reach.tech/router/api/Link) `getProps` API to to set active styles like in the following example:
 
 ```jsx
 import React from "react"

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -56,7 +56,7 @@ class Page extends React.Component {
 
 ## Partial Link matching
 
-The `activeStyle` or `activeClassName` prop are only set to a `<Link>` component if the current URL matches it _exactly_. Sometimes, we may want to style a `<Link>` as active even if it partially matches the current URL. For example:
+The `activeStyle` or `activeClassName` prop are only set on a `<Link>` component if the current URL matches its `to` prop _exactly_. Sometimes, we may want to style a `<Link>` as active even if it partially matches the current URL. For example:
 
 - We may want `/blog/hello-world` to match `<Link to="/blog">`
 - or `/gatsby-link/#passing-state-through-link-and-navigate` to match `<Link to="/gatsby-link">`

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -54,6 +54,28 @@ class Page extends React.Component {
 }
 ```
 
+## Partial Link matching
+
+The `activeStyle` or `activeClassName` prop are only set to a `<Link>` component if the current URL matches it _exactly_. Sometimes, we may want to style a `<Link>` as active even if it partially matches the current URL. For example:
+
+- We may want `/blog/hello-world` to match `<Link to="/blog">`
+- or `/gatsby-link/#passing-state-through-link-and-navigate` to match `<Link to="/gatsby-link">`
+
+In instances like these, we can use [@reach/router's](https://reach.tech/router/api/Link) `getProps` API to to set active styles
+
+```jsx
+import React from "react"
+import { Link } from "gatsby"
+// This link will get the active class when it partially matches the current URL
+const PartialNavLink = props => (
+  <Link
+    getProps={({ isPartiallyCurrent }) => {
+      return isPartiallyCurrent ? { className: "active" } : null
+    }}
+  />
+)
+```
+
 ## Replacing history entry
 
 You can pass boolean `replace` property to replace previous history entry.


### PR DESCRIPTION
Add documentation for using [reach/router's](https://reach.tech/router) isPartiallyCurrent to partially match a Gatsby Link

Partially addresses https://github.com/gatsbyjs/gatsby/issues/7208 and https://github.com/gatsbyjs/gatsby/issues/7737