### PR TITLE
Add highlight to changed line

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -120,9 +120,8 @@ fields.
 
 ```javascript:title=gatsby-node.js
 const { createFilePath } = require(`gatsby-source-filesystem`)
-
+// highlight-next-line
 exports.onCreateNode = ({ node, getNode, actions }) => {
-  // highlight-line
   const { createNodeField } = actions // highlight-line
   if (node.internal.type === `MarkdownRemark`) {
     // highlight-start

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -121,8 +121,7 @@ fields.
 ```javascript:title=gatsby-node.js
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
-exports.onCreateNode = ({ node, getNode, actions }) => {
-  // highlight-line
+exports.onCreateNode = ({ node, getNode, actions }) => { // highlight-line
   const { createNodeField } = actions // highlight-line
   if (node.internal.type === `MarkdownRemark`) {
     // highlight-start

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -121,7 +121,8 @@ fields.
 ```javascript:title=gatsby-node.js
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
-exports.onCreateNode = ({ node, getNode, actions }) => { // highlight-line
+exports.onCreateNode = ({ node, getNode, actions }) => {
+  // highlight-line
   const { createNodeField } = actions // highlight-line
   if (node.internal.type === `MarkdownRemark`) {
     // highlight-start


### PR DESCRIPTION
Following [the tutorial](https://www.gatsbyjs.org/tutorial/part-seven/#creating-slugs-for-pages) and in the previous step the line is:

```
exports.onCreateNode = ({ node, getNode }) => {
```

In the next section it changes, but the highlight is missing:

```
exports.onCreateNode = ({ node, getNode, actions }) => {
```