### PR TITLE
fix(gatsby-plugin-manifest): Legacy default to true

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -184,9 +184,9 @@ module.exports = {
 }
 ```
 
-## Legacy `apple-touch-icon` links
+## Legacy option
 
-iOS 11.3 added support for webmanifest spec, so this plugin doesn't add `apple-touch-icon` links to `<head>` by default. If you need or want to support older version of iOS you can set `legacy` option to `true` in plugin configuration:
+iOS 11.3 added support for service workers but not the complete webmanifest spec. Therefore iOS won't recognize the icons defined in the webmanifest and the creation of `apple-touch-icon` links in `<head>` is needed. This plugin creates them by default. If you don't want those icons to be generated you can set the `legacy` option to `false` in plugin configuration:
 
 ```javascript:title=gatsby-config.js
 module.exports = {
@@ -201,7 +201,7 @@ module.exports = {
         theme_color: `#a2466c`,
         display: `standalone`,
         icon: `src/images/icon.png`, // This path is relative to the root of the site.
-        legacy: true, // this will add apple-touch-icon links to <head>
+        legacy: false, // this will not add apple-touch-icon links to <head>
       },
     },
   ],

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -10,84 +10,50 @@ Array [
     content="#000000"
     name="theme-color"
   />,
-]
-`;
-
-exports[`gatsby-plugin-manifest Adds "shortcut icon" and "manifest" links and "theme_color" meta tag to head 1`] = `
-Array [
   <link
     href="/icons/icon-48x48.png"
-    rel="shortcut icon"
-  />,
-  <link
-    href="/manifest.webmanifest"
-    rel="manifest"
-  />,
-  <meta
-    content="#000000"
-    name="theme-color"
-  />,
-]
-`;
-
-exports[`gatsby-plugin-manifest Adds a "theme color" meta tag to head if "theme_color_in_head" is not provided 1`] = `
-Array [
-  <link
-    href="/manifest.webmanifest"
-    rel="manifest"
-  />,
-  <meta
-    content="#000000"
-    name="theme-color"
-  />,
-]
-`;
-
-exports[`gatsby-plugin-manifest Creates legacy apple touch links Using default set of icons 1`] = `
-Array [
-  <link
-    href="/icons/icon-48x48.png"
-    rel="shortcut icon"
-  />,
-  <link
-    href="/manifest.webmanifest"
-    rel="manifest"
-  />,
-  <meta
-    content="#000000"
-    name="theme-color"
-  />,
-]
-`;
-
-exports[`gatsby-plugin-manifest Creates legacy apple touch links Using user specified list of icons 1`] = `
-Array [
-  <link
-    href="/favicons/android-chrome-48x48.png"
-    rel="shortcut icon"
-  />,
-  <link
-    href="/manifest.webmanifest"
-    rel="manifest"
-  />,
-  <meta
-    content="#000000"
-    name="theme-color"
-  />,
-  <link
-    href="/favicons/android-chrome-48x48.png"
     rel="apple-touch-icon"
     sizes="48x48"
   />,
   <link
-    href="/favicons/android-chrome-512x512.png"
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
     rel="apple-touch-icon"
     sizes="512x512"
   />,
 ]
 `;
 
-exports[`gatsby-plugin-manifest Creates legacy apple touch links if opted in Using default set of icons 1`] = `
+exports[`gatsby-plugin-manifest Adds "shortcut icon" and "manifest" links and "theme_color" meta tag to head 1`] = `
 Array [
   <link
     href="/icons/icon-48x48.png"
@@ -144,7 +110,117 @@ Array [
 ]
 `;
 
-exports[`gatsby-plugin-manifest Creates legacy apple touch links if opted in Using user specified list of icons 1`] = `
+exports[`gatsby-plugin-manifest Adds a "theme color" meta tag to head if "theme_color_in_head" is not provided 1`] = `
+Array [
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Creates legacy apple touch links Using default set of icons 1`] = `
+Array [
+  <link
+    href="/icons/icon-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Creates legacy apple touch links Using user specified list of icons 1`] = `
 Array [
   <link
     href="/favicons/android-chrome-48x48.png"
@@ -177,6 +253,46 @@ Array [
     href="/manifest.webmanifest"
     rel="manifest"
   />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
 ]
 `;
 
@@ -189,6 +305,80 @@ Array [
   <link
     href="/manifest.webmanifest"
     rel="manifest"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Does not create legacy apple touch links If "legacy" options is false and using default set of icons 1`] = `
+Array [
+  <link
+    href="/icons/icon-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Does not create legacy apple touch links If "legacy" options is false and using user specified list of icons 1`] = `
+Array [
+  <link
+    href="/favicons/android-chrome-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
   />,
 ]
 `;

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -43,6 +43,50 @@ Array [
 ]
 `;
 
+exports[`gatsby-plugin-manifest Creates legacy apple touch links Using default set of icons 1`] = `
+Array [
+  <link
+    href="/icons/icon-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Creates legacy apple touch links Using user specified list of icons 1`] = `
+Array [
+  <link
+    href="/favicons/android-chrome-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <meta
+    content="#000000"
+    name="theme-color"
+  />,
+  <link
+    href="/favicons/android-chrome-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/favicons/android-chrome-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
 exports[`gatsby-plugin-manifest Creates legacy apple touch links if opted in Using default set of icons 1`] = `
 Array [
   <link

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -45,12 +45,11 @@ describe(`gatsby-plugin-manifest`, () => {
     expect(headComponents).toMatchSnapshot()
   })
 
-  describe(`Creates legacy apple touch links if opted in`, () => {
+  describe(`Creates legacy apple touch links`, () => {
     it(`Using default set of icons`, () => {
       onRenderBody(ssrArgs, {
         icon: true,
         theme_color: `#000000`,
-        legacy: true,
       })
       expect(headComponents).toMatchSnapshot()
     })

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -58,7 +58,38 @@ describe(`gatsby-plugin-manifest`, () => {
       onRenderBody(ssrArgs, {
         icon: true,
         theme_color: `#000000`,
-        legacy: true,
+        icons: [
+          {
+            src: `/favicons/android-chrome-48x48.png`,
+            sizes: `48x48`,
+            type: `image/png`,
+          },
+          {
+            src: `/favicons/android-chrome-512x512.png`,
+            sizes: `512x512`,
+            type: `image/png`,
+          },
+        ],
+      })
+      expect(headComponents).toMatchSnapshot()
+    })
+  })
+
+  describe(`Does not create legacy apple touch links`, () => {
+    it(`If "legacy" options is false and using default set of icons`, () => {
+      onRenderBody(ssrArgs, {
+        icon: true,
+        theme_color: `#000000`,
+        legacy: false,
+      })
+      expect(headComponents).toMatchSnapshot()
+    })
+
+    it(`If "legacy" options is false and using user specified list of icons`, () => {
+      onRenderBody(ssrArgs, {
+        icon: true,
+        theme_color: `#000000`,
+        legacy: false,
         icons: [
           {
             src: `/favicons/android-chrome-48x48.png`,
@@ -82,7 +113,6 @@ describe(`gatsby-plugin-manifest`, () => {
     onRenderBody(ssrArgs, {
       icon: true,
       theme_color: `#000000`,
-      legacy: true,
     })
 
     headComponents

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -7,7 +7,8 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   let headComponents = []
 
   const icons = pluginOptions.icons || defaultIcons
-  const legacy = pluginOptions.legacy || true
+  const legacy =
+    typeof pluginOptions.legacy !== `undefined` ? pluginOptions.legacy : true
 
   // If icons were generated, also add a favicon link.
   if (pluginOptions.icon) {

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -7,6 +7,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   let headComponents = []
 
   const icons = pluginOptions.icons || defaultIcons
+  const legacy = pluginOptions.legacy || true
 
   // If icons were generated, also add a favicon link.
   if (pluginOptions.icon) {
@@ -50,7 +51,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     }
   }
 
-  if (pluginOptions.legacy) {
+  if (legacy) {
     const iconLinkTags = icons.map(icon => (
       <link
         key={`gatsby-plugin-manifest-apple-touch-icon-${icon.sizes}`}


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/7256 added a `legacy` flag (defaulting to `false`) to include the apple-touch-icons. However, the assumption was wrong that iOS supports the icons from the webmanifest - they don't. That's why apple-touch-icons are still needed and the default state of `legacy` should be set to `true`.

I made those necessary changes.

Fixes https://github.com/gatsbyjs/gatsby/issues/10770