### PR TITLE
fix(docs): change bound-action-creators links into actions links

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -214,7 +214,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
 
   if (noPageOrComponent) {
     report.panic(
-      `See the documentation for createPage https://www.gatsbyjs.org/docs/bound-action-creators/#createPage`
+      `See the documentation for createPage https://www.gatsbyjs.org/docs/actions/#createPage`
     )
   }
 


### PR DESCRIPTION
## Description

The panic still points to the old page. Updating it to point to the new page.