### PR TITLE
fix(www/plugins): hide plugin search on package pages on mobile

### DIFF
--- a/www/src/components/layout/plugin-library-wrapper.js
+++ b/www/src/components/layout/plugin-library-wrapper.js
@@ -10,7 +10,7 @@ const PluginLibraryWrappedLayout = props => {
   return (
     <Layout location={location}>
       <PageWithPluginSearchBar
-        isPluginsIndex={location.pathname === "/plugins/"}
+        isPluginsIndex={location.pathname === `/plugins/`}
         location={location}
       >
         {children}


### PR DESCRIPTION
Fix hiding search pane on package pages on mobile.