### PR TITLE
feat(gatsby): add server instance on onCreateDevServer

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -171,8 +171,6 @@ async function startServer(program) {
     })
   }
 
-  await apiRunnerNode(`onCreateDevServer`, { app })
-
   // Render an HTML page and serve it.
   app.use((req, res, next) => {
     const parsedPath = parsePath(req.path)
@@ -200,6 +198,9 @@ async function startServer(program) {
   if (program.ssl) {
     server = require(`https`).createServer(program.ssl, app)
   }
+  
+  await apiRunnerNode(`onCreateDevServer`, { app, server })
+  
   websocketManager.init({ server, directory: program.directory })
   const socket = websocketManager.getSocket()
 

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -284,8 +284,9 @@ exports.onPreExtractQueries = true
  * to the dev server app
  * @param {object} $0
  * @param {Express} $0.app The [Express app](https://expressjs.com/en/4x/api.html#app) used to run the dev server
+ * @param {http.Server} $1.server The HTTP server instance
  * @example
- * exports.onCreateDevServer = ({ app }) => {
+ * exports.onCreateDevServer = ({ app, server }) => {
  *   app.get('/hello', function (req, res) {
  *     res.send('hello world')
  *   })


### PR DESCRIPTION
## Description

This pull request just adds the `server` instance on `onCreateDevServer` hook. This can be helpful if you need to reuse the server to create something (eg. another WebSocket instance).