### PR TITLE
feat(gatsby-remark-prismjs): Add class when using highlighted lines

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -195,6 +195,50 @@ Object {
 }
 `;
 
+exports[`remark prism plugin generates a <pre> tag with highlighted lines 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "js{2}",
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 5,
+          "offset": 27,
+        },
+        "indent": Array [
+          1,
+          1,
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight has-highlighted-lines\\" data-language=\\"js\\"><pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// 1</span>
+<span class=\\"gatsby-highlight-code-line\\"><span class=\\"token comment\\">// 2</span></span><span class=\\"token comment\\">// 3</span></code></pre></div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 4,
+      "line": 5,
+      "offset": 27,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
 exports[`remark prism plugin generates an inline <code> tag that handles language specifiers 1`] = `
 Object {
   "children": Array [

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -23,6 +23,13 @@ describe(`remark prism plugin`, () => {
       plugin({ markdownAST }, { aliases: { foobar: `javascript` } })
       expect(markdownAST).toMatchSnapshot()
     })
+
+    it(`with highlighted lines`, () => {
+      const code = `\`\`\`js{2}\n// 1\n// 2\n// 3\n\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST })
+      expect(markdownAST).toMatchSnapshot()
+    })
   })
 
   describe(`generates an inline <code> tag`, () => {

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -63,7 +63,7 @@ module.exports = (
 
     let highlightClassName = `gatsby-highlight`
     if (highlightLines && highlightLines.length > 0)
-      highlightClassName += ` gatsby-highlight-with-lines`
+      highlightClassName += ` has-highlighted-lines`
 
     // prettier-ignore
     node.value = ``

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -61,8 +61,10 @@ module.exports = (
     // 100% width highlighted code lines work
     node.type = `html`
     // prettier-ignore
+    let highlightClassName = 'gatsby-highlight'
+    if (highlightLines) highlightClassName += ' gatsby-highlight-with-lines'
     node.value = ``
-    + `<div class="gatsby-highlight" data-language="${languageName}">`
+    + `<div class="${highlightClassName}" data-language="${languageName}">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`
     +     `<code class="${className}">`
     +       `${highlightCode(language, node.value, highlightLines)}`

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -62,7 +62,7 @@ module.exports = (
     node.type = `html`
     // prettier-ignore
     let highlightClassName = 'gatsby-highlight'
-    if (highlightLines) highlightClassName += ' gatsby-highlight-with-lines'
+    if (highlightLines.length > 0) highlightClassName += ' gatsby-highlight-with-lines'
     node.value = ``
     + `<div class="${highlightClassName}" data-language="${languageName}">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -60,9 +60,12 @@ module.exports = (
     // Replace the node with the markup we need to make
     // 100% width highlighted code lines work
     node.type = `html`
-    // prettier-ignore
+
     let highlightClassName = `gatsby-highlight`
-    if (highlightLines && highlightLines.length > 0) highlightClassName += ` gatsby-highlight-with-lines`
+    if (highlightLines && highlightLines.length > 0)
+      highlightClassName += ` gatsby-highlight-with-lines`
+
+    // prettier-ignore
     node.value = ``
     + `<div class="${highlightClassName}" data-language="${languageName}">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -61,8 +61,8 @@ module.exports = (
     // 100% width highlighted code lines work
     node.type = `html`
     // prettier-ignore
-    let highlightClassName = 'gatsby-highlight'
-    if (highlightLines.length > 0) highlightClassName += ' gatsby-highlight-with-lines'
+    let highlightClassName = `gatsby-highlight`
+    if (highlightLines && highlightLines.length > 0) highlightClassName += ` gatsby-highlight-with-lines`
     node.value = ``
     + `<div class="${highlightClassName}" data-language="${languageName}">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`


### PR DESCRIPTION
## Description

Hiya! This PR adds an additional class to `.gatsby-highlight` if the code block has any highlighted lines. This is necessary for styling like this:

<img width="697" alt="image" src="https://user-images.githubusercontent.com/10660468/51572061-38d37d00-1e72-11e9-9fde-8d00e5e4fa93.png">

With the given code snippet:

    ```docker{3}
    # Every Action needs a Dockerfile
    FROM alpine
    RUN apk add --no-cache bash curl jq
    COPY comment /usr/bin/comment
    ENTRYPOINT ["comment"]
    ```

The key point here is that I'm able to style the block but still target the highlighted lines - here's the CSS, but my actual design choice isn't relevant:

```css
.gatsby-highlight.gatsby-highlight-with-lines > pre > code,
.gatsby-highlight.gatsby-highlight-with-lines
  > pre
  > code
  > *:not(.gatsby-highlight-code-line) {
  color: #959da5 !important;
}

.gatsby-highlight-code-line {
  color: #393a34;
  display: block;
}
```

This will hopefully allow users to be a lot less restricted in terms of styling; currently only the highlighted lines can be styled specially, but now the whole block 😊

Let me know if I can clarify anything, or if this isn't an idea y'all would like to act on. Happy to chat through it 🙌 
