### PR TITLE
Fix linking arrays by ___NODE___fieldName

### DIFF
--- a/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
+++ b/packages/gatsby/src/schema/__tests__/infer-graphql-type-test.js
@@ -682,6 +682,35 @@ describe(`GraphQL type inferance`, () => {
       expect(result.data.listNode[0].linked[1].hair).toEqual(`blonde`)
     })
 
+    it(`Links nodes by field`, async () => {
+      let result = await queryResult(
+        [{ linked___NODE___hair: `brown` }],
+        `
+          linked {
+            hair
+          }
+        `,
+        { types }
+      )
+      expect(result.errors).not.toBeDefined()
+      expect(result.data.listNode[0].linked.hair).toEqual(`brown`)
+    })
+
+    it(`Links an array of nodes by field`, async () => {
+      let result = await queryResult(
+        [{ linked___NODE___hair: [`brown`, `blonde`] }],
+        `
+          linked {
+            hair
+          }
+        `,
+        { types }
+      )
+      expect(result.errors).not.toBeDefined()
+      expect(result.data.listNode[0].linked[0].hair).toEqual(`brown`)
+      expect(result.data.listNode[0].linked[1].hair).toEqual(`blonde`)
+    })
+
     it(`Errors clearly when missing nodes`, async () => {
       expect(() => {
         inferObjectStructureFromNodes({

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -260,8 +260,7 @@ function inferFromFieldName(
             .sort()
             .join(`, `)}]`,
           types: fields.map(f => f.nodeObjectType),
-          resolveType: node =>
-            fields.find(f => f.name == node.internal.type).nodeObjectType,
+          resolveType: node => node.internal.type,
         })
         unionTypes.set(typeName, type)
       }

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -192,7 +192,7 @@ function findLinkedNodeByField(linkedField, value) {
   return getNodes().find(n => n[linkedField] === value)
 }
 
-export function findLinkedNode(value, linkedField, path) {
+export function findLinkedNode(value, linkedField) {
   let linkedNode
   // If the field doesn't link to the id, use that for searching.
   if (linkedField) {
@@ -270,12 +270,10 @@ function inferFromFieldName(
 
     return {
       type: new GraphQLList(type),
-      resolve: pageDependencyResolver((node, args, context = {}) => {
+      resolve: pageDependencyResolver(node => {
         let fieldValue = node[key]
         if (fieldValue) {
-          return fieldValue.map(value =>
-            findLinkedNode(value, linkedField, context.path)
-          )
+          return fieldValue.map(value => findLinkedNode(value, linkedField))
         } else {
           return null
         }

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -204,16 +204,13 @@ export function findLinkedNode(value, linkedField, path) {
   return linkedNode
 }
 
-function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
-  let isArray = false
-  if (_.isArray(value)) {
-    isArray = true
-    // Reduce values to nodes with unique types.
-    value = _.uniqBy(value, v => getNode(v).internal.type)
-  }
-
-  const key = selector.split(`.`).pop()
-  const [, , linkedField] = key.split(`___`)
+function inferFromFieldName(
+  value,
+  key,
+  selector,
+  types
+): GraphQLFieldConfig<*, *> {
+  const linkedField = key.split(`___NODE___`)[1]
 
   const validateLinkedNode = linkedNode => {
     invariant(
@@ -238,22 +235,19 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
     )
   }
 
-  const findNodeType = node =>
-    types.find(type => type.name === node.internal.type)
+  const findType = typeName => types.find(type => type.name === typeName)
 
-  if (isArray) {
-    const linkedNodes = value.map(getNode)
+  if (Array.isArray(value)) {
+    const linkedNodes = value.map(v => findLinkedNode(v, linkedField))
     linkedNodes.forEach(node => validateLinkedNode(node))
-    const fields = linkedNodes.map(node => findNodeType(node))
+    const linkedTypes = [...new Set(linkedNodes.map(n => n.internal.type))]
+    const fields = linkedTypes.map(findType)
     fields.forEach((field, i) => validateField(linkedNodes[i], field))
 
     let type
     // If there's more than one type, we'll create a union type.
     if (fields.length > 1) {
-      const typeName = `Union_${key}_${fields
-        .map(f => f.name)
-        .sort()
-        .join(`__`)}`
+      const typeName = `Union_${key}_${linkedTypes.sort().join(`__`)}`
 
       if (unionTypes.has(typeName)) {
         type = unionTypes.get(typeName)
@@ -262,13 +256,12 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
       if (!type) {
         type = new GraphQLUnionType({
           name: createTypeName(`Union_${key}`),
-          description: `Union interface for the field "${key}" for types [${fields
-            .map(f => f.name)
+          description: `Union interface for the field "${key}" for types [${linkedTypes
             .sort()
             .join(`, `)}]`,
           types: fields.map(f => f.nodeObjectType),
-          resolveType: data =>
-            fields.find(f => f.name == data.internal.type).nodeObjectType,
+          resolveType: node =>
+            fields.find(f => f.name == node.internal.type).nodeObjectType,
         })
         unionTypes.set(typeName, type)
       }
@@ -278,22 +271,22 @@ function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
 
     return {
       type: new GraphQLList(type),
-      resolve: (node, a, b = {}) => {
+      resolve: pageDependencyResolver((node, args, context = {}) => {
         let fieldValue = node[key]
         if (fieldValue) {
           return fieldValue.map(value =>
-            findLinkedNode(value, linkedField, b.path)
+            findLinkedNode(value, linkedField, context.path)
           )
         } else {
           return null
         }
-      },
+      }),
     }
   }
 
   const linkedNode = findLinkedNode(value, linkedField)
   validateLinkedNode(linkedNode)
-  const field = findNodeType(linkedNode)
+  const field = findType(linkedNode.internal.type)
   validateField(linkedNode, field)
   return {
     type: field.nodeObjectType,
@@ -360,11 +353,12 @@ function _inferObjectStructureFromNodes(
     if (mapping && _.includes(Object.keys(mapping), fieldSelector)) {
       inferredField = inferFromMapping(value, mapping, fieldSelector, types)
 
-      // Second if the field has a suffix of ___node. We use then the value
-      // (a node id) to find the node and use that node's type as the field
+      // Second if the field has a suffix of `___NODE`, we use the field value
+      // to find the linked node. By default we use the `id` as foreign key,
+      // but a foreign key can be specified with `___NODE___fieldName`.
     } else if (key.includes(`___NODE`)) {
+      inferredField = inferFromFieldName(value, key, nextSelector, types)
       ;[fieldName] = key.split(`___`)
-      inferredField = inferFromFieldName(value, nextSelector, types)
       lazyFields.add(typeName, fieldName)
     }
 


### PR DESCRIPTION
Linking nodes with the `___NODE` convention also allows specifying a foreign key field other than `id` with `___NODE___fieldName`. This PR fixes such links for array values.

Sidenote: Should we document more prominently somewhere that specifying a foreign key field is possible? I haven't found any mention in the docs apart from [here](https://www.gatsbyjs.org/docs/schema-gql-type/#foreign-key-reference-___node), even the [code comments assume linking by id](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L363-L364). And the fact that this has been broken for quite some time (since #1211) suggests that it is not a very widely known feature?