### PR TITLE
fix(gatsby-react-router-scroll): keep scroll positions in tact on reload

### DIFF
--- a/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
+++ b/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
@@ -33,18 +33,6 @@ class ScrollContext extends React.Component {
     }
   }
 
-  componentDidMount() {
-    /**
-     * scrollBehavior sets history.scrollRestoration to "manual" which means we have to take care of scrolling ourselves for pages.
-     * It works great in a client side SPA as the browser can't jump to the correct content because it's not there yet.
-     * Gatsby can because it's awesome (ships SSR html) so we don't want to disable scrollRestoration
-     * see #7454
-     */
-    if (`scrollRestoration` in window.history) {
-      window.history.scrollRestoration = `auto`
-    }
-  }
-
   componentDidUpdate(prevProps) {
     const { location } = this.props
     const prevLocation = prevProps.location

--- a/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
+++ b/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
@@ -25,14 +25,22 @@ class ScrollContext extends React.Component {
       getCurrentLocation: () => this.props.location,
       shouldUpdateScroll: this.shouldUpdateScroll,
     })
-
-    this.scrollBehavior.updateScroll(null, this.getRouterProps())
   }
 
   getChildContext() {
     return {
       scrollBehavior: this,
     }
+  }
+
+  componentDidMount() {
+    /**
+     * scrollBehavior sets history.scrollRestoration to "manual" which means we have to take care of scrolling ourselves for pages.
+     * It works great in a client side SPA as the browser can't jump to the correct content because it's not there yet.
+     * Gatsby can because it's awesome (ships SSR html) so we don't want to disable scrollRestoration
+     * see #7454
+     */
+    window.history.scrollRestoration = `auto`
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
+++ b/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
@@ -40,7 +40,9 @@ class ScrollContext extends React.Component {
      * Gatsby can because it's awesome (ships SSR html) so we don't want to disable scrollRestoration
      * see #7454
      */
-    window.history.scrollRestoration = `auto`
+    if (`scrollRestoration` in window.history) {
+      window.history.scrollRestoration = `auto`
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This should fix scroll restoration on refresh. The current solution relies on javascript to do the restoration of scroll which is great for Single Page Apps because no SSR is done. The node package scroll-behaviour sets the scrollRestoration to "manual" so we force it to be "auto" so the browser can do it's thing.

https://react-gatsby-scroll.surge.sh is a demo page of the react gatsby site. When running it on a good laptop, you won't see much difference but when you throttle your cpu you'll see the difference.

![image](https://user-images.githubusercontent.com/1120926/51606524-7d165a00-1f12-11e9-948f-dc9daec89d44.png)


<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/10884
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
