### PR TITLE
fix(gatsby): Ensure publicPath is always relative for gatsby develop

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -107,11 +107,7 @@ module.exports = async (
           // Add /* filename */ comments to generated require()s in the output.
           pathinfo: true,
           // Point sourcemap entries to original disk location (format as URL on Windows)
-          publicPath:
-            process.env.GATSBY_WEBPACK_PUBLICPATH ||
-            `${program.ssl ? `https` : `http`}://${
-              program.host
-            }:${webpackPort}/`,
+          publicPath: process.env.GATSBY_WEBPACK_PUBLICPATH || `/`,
           devtoolModuleFilenameTemplate: info =>
             path.resolve(info.absoluteResourcePath).replace(/\\/g, `/`),
           // Avoid React cross-origin errors


### PR DESCRIPTION
In `gatsby develop` we were setting `publicPath` for `webpack-dev-server` to an absolute url  _constructed_ from the program host, port and protocol

This is unnecessary and causes HMR and static links to break when viewed on a separate device over a network like in this screenshot below
![screenshot 2019-01-23 19 04 21](https://user-images.githubusercontent.com/7701981/51617923-3dbc2d80-1f53-11e9-86cf-d4c49ec18f42.png)
This pull request fixes this by making the publicPath _always_ relative 

Fixes https://github.com/gatsbyjs/gatsby/issues/11219 and https://github.com/gatsbyjs/gatsby/issues/5801