### PR TITLE
fix(www): Prefix unbird env keys with GATSBY_

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -34,8 +34,8 @@ Several areas of the site include feedback widgets (currently starter library an
 If you have access to the keys, add them like so:
 
 ```
-UNBIRD_FEEDBACK_KEY_PLUGINLIB=ADD_KEY
-UNBIRD_FEEDBACK_KEY_STARTERLIB=ADD_KEY
+GATSBY_UNBIRD_FEEDBACK_KEY_PLUGINLIB=ADD_KEY
+GATSBY_UNBIRD_FEEDBACK_KEY_STARTERLIB=ADD_KEY
 ```
 
 If there's a problem with the feedback widgets, please open an issue in the repo.

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -68,7 +68,7 @@ class Plugins extends Component {
         </div>
         <Unbird
           dataSetId="5c1ac24b4a828a169b6c235c"
-          publicKey={process.env.UNBIRD_FEEDBACK_KEY_PLUGINLIB}
+          publicKey={process.env.GATSBY_UNBIRD_FEEDBACK_KEY_PLUGINLIB}
           feedbackPrompt="Have feedback on the Plugin Library?"
         />
       </Container>

--- a/www/src/views/starter-library/index.js
+++ b/www/src/views/starter-library/index.js
@@ -58,7 +58,7 @@ class StarterLibraryPage extends Component {
         />
         <Unbird
           dataSetId="5c113a828240aa564734d954"
-          publicKey={process.env.UNBIRD_FEEDBACK_KEY_STARTERLIB}
+          publicKey={process.env.GATSBY_UNBIRD_FEEDBACK_KEY_STARTERLIB}
           feedbackPrompt="Have feedback on the Starter Library?"
         />
       </Layout>


### PR DESCRIPTION
Potentially fixes UNBIRD keys which are not in an .env file and therefore need to be prefixed

- [ ] Needs to be tested with Preview

Fixes https://github.com/gatsbyjs/gatsby/issues/11143