### PR TITLE
feat(www): add AWS Amplify Auth starter to Gatsby listings

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1687,7 +1687,7 @@
     - Code referenced in repo
 - url: https://master.d2f5ek3dnwfe9v.amplifyapp.com/
   repo: https://github.com/dabit3/gatsby-auth-starter-aws-amplify
-  description: This Gatsby starter uses AWS Amplify to implement authentication flow for signing up signing in users as well as protected client side routing.
+  description: This Gatsby starter uses AWS Amplify to implement authentication flow for signing up/signing in users as well as protected client side routing.
   tags:
     - AWS
     - Authentication


### PR DESCRIPTION
## Description

Add the AWS Amplify + Gatsby Auth starter to the starter library.


## Related Issues

Original PR: https://github.com/gatsbyjs/gatsby/pull/11089
