### PR TITLE
feat(gatsby-transformer-remark): add excerptAst to be exported as a GraphQL field

### DIFF
--- a/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/index.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-remark-subcache/index.js
@@ -2,10 +2,18 @@ const visit = require(`unist-util-visit`)
 const { id } = require(`./constants`)
 
 module.exports = function remarkPlugin({ cache, markdownAST }) {
-  visit(markdownAST, `html`, async node => {
-    if (node.value.match(id)) {
-      const value = await cache.get(id)
-      node.value = node.value.replace(/%SUBCACHE_VALUE%/, value)
-    }
+  const promises = []
+
+  visit(markdownAST, `html`, node => {
+    promises.push(
+      (async () => {
+        if (node.value.match(id)) {
+          const value = await cache.get(id)
+          node.value = node.value.replace(/%SUBCACHE_VALUE%/, value)
+        }
+      })()
+    )
   })
+
+  return Promise.all(promises)
 }

--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -3,6 +3,13 @@
 exports[`Excerpt is generated correctly from schema correctly loads a default excerpt 1`] = `
 Object {
   "excerpt": "",
+  "excerptAst": Object {
+    "children": Array [],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -12,6 +19,17 @@ Object {
 exports[`Excerpt is generated correctly from schema correctly loads an excerpt 1`] = `
 Object {
   "excerpt": "Where oh where is my little pony?",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "type": "text",
+        "value": "Where oh where is my little pony?",
+      },
+    ],
+    "properties": Object {},
+    "tagName": "p",
+    "type": "element",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -21,6 +39,17 @@ Object {
 exports[`Excerpt is generated correctly from schema correctly prunes length to default value 1`] = `
 Object {
   "excerpt": "Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla…",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "type": "text",
+        "value": "Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla…",
+      },
+    ],
+    "properties": Object {},
+    "tagName": "p",
+    "type": "element",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -30,6 +59,17 @@ Object {
 exports[`Excerpt is generated correctly from schema correctly prunes length to provided parameter 1`] = `
 Object {
   "excerpt": "Where oh where is my little pony? Lorem ipsum…",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "type": "text",
+        "value": "Where oh where is my little pony? Lorem ipsum…",
+      },
+    ],
+    "properties": Object {},
+    "tagName": "p",
+    "type": "element",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -39,6 +79,17 @@ Object {
 exports[`Excerpt is generated correctly from schema correctly prunes length to provided parameter with truncate 1`] = `
 Object {
   "excerpt": "Where oh where is my little pony? Lorem ipsum dol…",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "type": "text",
+        "value": "Where oh where is my little pony? Lorem ipsum dol…",
+      },
+    ],
+    "properties": Object {},
+    "tagName": "p",
+    "type": "element",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -49,6 +100,30 @@ exports[`Excerpt is generated correctly from schema correctly uses excerpt separ
 Object {
   "excerpt": "Where oh where is my little pony?
 ",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony?",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
+      },
+      Object {
+        "type": "text",
+        "value": "
+",
+      },
+    ],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -58,6 +133,76 @@ Object {
 exports[`Excerpt is generated correctly from schema given an html format, it correctly maps nested markdown to html 1`] = `
 Object {
   "excerpt": "<p>Where oh <a href=\\"nick.com\\"><em>where</em></a> <strong><em>is</em></strong> <img src=\\"pony.png\\" alt=\\"that pony\\">?</p>",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "type": "text",
+        "value": "Where oh ",
+      },
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "where",
+              },
+            ],
+            "properties": Object {},
+            "tagName": "em",
+            "type": "element",
+          },
+        ],
+        "properties": Object {
+          "href": "nick.com",
+        },
+        "tagName": "a",
+        "type": "element",
+      },
+      Object {
+        "type": "text",
+        "value": " ",
+      },
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "is",
+              },
+            ],
+            "properties": Object {},
+            "tagName": "em",
+            "type": "element",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "strong",
+        "type": "element",
+      },
+      Object {
+        "type": "text",
+        "value": " ",
+      },
+      Object {
+        "children": Array [],
+        "properties": Object {
+          "alt": "that pony",
+          "src": "pony.png",
+        },
+        "tagName": "img",
+        "type": "element",
+      },
+      Object {
+        "type": "text",
+        "value": "?",
+      },
+    ],
+    "properties": Object {},
+    "tagName": "p",
+    "type": "element",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -67,6 +212,17 @@ Object {
 exports[`Excerpt is generated correctly from schema given an html format, it prunes large excerpts 1`] = `
 Object {
   "excerpt": "<p>Where oh where is that pony? Is he in the stable…</p>",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "type": "text",
+        "value": "Where oh where is that pony? Is he in the stable…",
+      },
+    ],
+    "properties": Object {},
+    "tagName": "p",
+    "type": "element",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -77,6 +233,45 @@ exports[`Excerpt is generated correctly from schema given an html format, it res
 Object {
   "excerpt": "<p>Where oh where is that <em>pony</em>? Is he in the stable or by the stream?</p>
 ",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is that ",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "pony",
+              },
+            ],
+            "properties": Object {},
+            "tagName": "em",
+            "type": "element",
+          },
+          Object {
+            "type": "text",
+            "value": "? Is he in the stable or by the stream?",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
+      },
+      Object {
+        "type": "text",
+        "value": "
+",
+      },
+    ],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },
@@ -86,6 +281,32 @@ Object {
 exports[`Excerpt is generated correctly from schema given raw html in the text body, this html is not escaped 1`] = `
 Object {
   "excerpt": "<p>Where is my <code>pony</code> named leo?</p>",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "type": "text",
+        "value": "Where is my ",
+      },
+      Object {
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "pony",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "code",
+        "type": "element",
+      },
+      Object {
+        "type": "text",
+        "value": " named leo?",
+      },
+    ],
+    "properties": Object {},
+    "tagName": "p",
+    "type": "element",
+  },
   "frontmatter": Object {
     "title": "my little pony",
   },

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -124,7 +124,7 @@ const bootstrapTest = (
         actions,
         createNodeId,
       },
-      { ...additionalParameters }
+      { ...additionalParameters, ...pluginOptions }
     )
   })
 }
@@ -230,7 +230,7 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
         type: `root`,
       })
     },
-    { additionalParameters: { excerpt_separator: `<!-- end -->` } }
+    { pluginOptions: { excerpt_separator: `<!-- end -->` } }
   )
 
   const content = `---

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -138,6 +138,7 @@ date: "2017-09-18T23:19:51.246Z"
 ---
 Where oh where is my little pony?`,
     `excerpt
+      excerptAst
       frontmatter {
           title
       }
@@ -145,6 +146,17 @@ Where oh where is my little pony?`,
     node => {
       expect(node).toMatchSnapshot()
       expect(node.excerpt).toMatch(`Where oh where is my little pony?`)
+      expect(node.excerptAst).toMatchObject({
+        children: [
+          {
+            type: `text`,
+            value: `Where oh where is my little pony?`,
+          },
+        ],
+        properties: {},
+        tagName: `p`,
+        type: `element`,
+      })
     }
   )
 
@@ -155,6 +167,7 @@ title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---`,
     `excerpt
+      excerptAst
       frontmatter {
           title
       }
@@ -162,6 +175,13 @@ date: "2017-09-18T23:19:51.246Z"
     node => {
       expect(node).toMatchSnapshot()
       expect(node.excerpt).toMatch(``)
+      expect(node.excerptAst).toMatchObject({
+        children: [],
+        data: {
+          quirksMode: false,
+        },
+        type: `root`,
+      })
     }
   )
 
@@ -178,6 +198,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet v
 In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
       `,
     `excerpt
+      excerptAst
       frontmatter {
           title
       }
@@ -185,6 +206,29 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     node => {
       expect(node).toMatchSnapshot()
       expect(node.excerpt).toMatch(`Where oh where is my little pony?`)
+      expect(node.excerptAst).toMatchObject({
+        children: [
+          {
+            children: [
+              {
+                type: `text`,
+                value: `Where oh where is my little pony?`,
+              },
+            ],
+            properties: {},
+            tagName: `p`,
+            type: `element`,
+          },
+          {
+            type: `text`,
+            value: `\n`,
+          },
+        ],
+        data: {
+          quirksMode: false,
+        },
+        type: `root`,
+      })
     },
     { additionalParameters: { excerpt_separator: `<!-- end -->` } }
   )
@@ -201,6 +245,7 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     `correctly prunes length to default value`,
     content,
     `excerpt
+      excerptAst
       frontmatter {
           title
       }
@@ -208,6 +253,8 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     node => {
       expect(node).toMatchSnapshot()
       expect(node.excerpt.length).toBe(139)
+      expect(node.excerptAst.children.length).toBe(1)
+      expect(node.excerptAst.children[0].value.length).toBe(139)
     }
   )
 
@@ -215,6 +262,7 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     `correctly prunes length to provided parameter`,
     content,
     `excerpt(pruneLength: 50)
+      excerptAst(pruneLength: 50)
       frontmatter {
           title
       }
@@ -222,6 +270,8 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     node => {
       expect(node).toMatchSnapshot()
       expect(node.excerpt.length).toBe(46)
+      expect(node.excerptAst.children.length).toBe(1)
+      expect(node.excerptAst.children[0].value.length).toBe(46)
     }
   )
 
@@ -229,6 +279,7 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     `correctly prunes length to provided parameter with truncate`,
     content,
     `excerpt(pruneLength: 50, truncate: true)
+      excerptAst(pruneLength: 50, truncate: true)
       frontmatter {
           title
       }
@@ -236,6 +287,8 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     node => {
       expect(node).toMatchSnapshot()
       expect(node.excerpt.length).toBe(50)
+      expect(node.excerptAst.children.length).toBe(1)
+      expect(node.excerptAst.children[0].value.length).toBe(50)
     }
   )
 
@@ -248,6 +301,7 @@ date: "2017-09-18T23:19:51.246Z"
 
 Where oh [*where*](nick.com) **_is_** ![that pony](pony.png)?`,
     `excerpt(format: HTML)
+      excerptAst
       frontmatter {
           title
       }
@@ -257,6 +311,76 @@ Where oh [*where*](nick.com) **_is_** ![that pony](pony.png)?`,
       expect(node.excerpt).toMatch(
         `<p>Where oh <a href="nick.com"><em>where</em></a> <strong><em>is</em></strong> <img src="pony.png" alt="that pony">?</p>`
       )
+      expect(node.excerptAst).toMatchObject({
+        children: [
+          {
+            type: `text`,
+            value: `Where oh `,
+          },
+          {
+            children: [
+              {
+                children: [
+                  {
+                    type: `text`,
+                    value: `where`,
+                  },
+                ],
+                properties: {},
+                tagName: `em`,
+                type: `element`,
+              },
+            ],
+            properties: {
+              href: `nick.com`,
+            },
+            tagName: `a`,
+            type: `element`,
+          },
+          {
+            type: `text`,
+            value: ` `,
+          },
+          {
+            children: [
+              {
+                children: [
+                  {
+                    type: `text`,
+                    value: `is`,
+                  },
+                ],
+                properties: {},
+                tagName: `em`,
+                type: `element`,
+              },
+            ],
+            properties: {},
+            tagName: `strong`,
+            type: `element`,
+          },
+          {
+            type: `text`,
+            value: ` `,
+          },
+          {
+            children: [],
+            properties: {
+              alt: `that pony`,
+              src: `pony.png`,
+            },
+            tagName: `img`,
+            type: `element`,
+          },
+          {
+            type: `text`,
+            value: `?`,
+          },
+        ],
+        properties: {},
+        tagName: `p`,
+        type: `element`,
+      })
     }
   )
 
@@ -269,6 +393,7 @@ date: "2017-09-18T23:19:51.246Z"
 
 Where is my <code>pony</code> named leo?`,
     `excerpt(format: HTML)
+      excerptAst
       frontmatter {
           title
       }
@@ -278,6 +403,32 @@ Where is my <code>pony</code> named leo?`,
       expect(node.excerpt).toMatch(
         `<p>Where is my <code>pony</code> named leo?</p>`
       )
+      expect(node.excerptAst).toMatchObject({
+        children: [
+          {
+            type: `text`,
+            value: `Where is my `,
+          },
+          {
+            children: [
+              {
+                type: `text`,
+                value: `pony`,
+              },
+            ],
+            properties: {},
+            tagName: `code`,
+            type: `element`,
+          },
+          {
+            type: `text`,
+            value: ` named leo?`,
+          },
+        ],
+        properties: {},
+        tagName: `p`,
+        type: `element`,
+      })
     },
     { pluginOptions: { excerpt_separator: `<!-- end -->` } }
   )
@@ -291,6 +442,7 @@ date: "2017-09-18T23:19:51.246Z"
 
 Where oh where is that pony? Is he in the stable or down by the stream?`,
     `excerpt(format: HTML, pruneLength: 50)
+      excerptAst(pruneLength: 50)
       frontmatter {
           title
       }
@@ -300,6 +452,17 @@ Where oh where is that pony? Is he in the stable or down by the stream?`,
       expect(node.excerpt).toMatch(
         `<p>Where oh where is that pony? Is he in the stable…</p>`
       )
+      expect(node.excerptAst).toMatchObject({
+        children: [
+          {
+            type: `text`,
+            value: `Where oh where is that pony? Is he in the stable…`,
+          },
+        ],
+        properties: {},
+        tagName: `p`,
+        type: `element`,
+      })
     }
   )
 
@@ -316,6 +479,7 @@ Where oh where is that *pony*? Is he in the stable or by the stream?
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
 `,
     `excerpt(format: HTML, pruneLength: 50)
+    excerptAst(pruneLength: 50)
     frontmatter {
         title
     }
@@ -325,6 +489,44 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet v
       expect(node.excerpt).toMatch(
         `<p>Where oh where is that <em>pony</em>? Is he in the stable or by the stream?</p>`
       )
+      expect(node.excerptAst).toMatchObject({
+        children: [
+          {
+            children: [
+              {
+                type: `text`,
+                value: `Where oh where is that `,
+              },
+              {
+                children: [
+                  {
+                    type: `text`,
+                    value: `pony`,
+                  },
+                ],
+                properties: {},
+                tagName: `em`,
+                type: `element`,
+              },
+              {
+                type: `text`,
+                value: `? Is he in the stable or by the stream?`,
+              },
+            ],
+            properties: {},
+            tagName: `p`,
+            type: `element`,
+          },
+          {
+            type: `text`,
+            value: `\n`,
+          },
+        ],
+        data: {
+          quirksMode: false,
+        },
+        type: `root`,
+      })
     },
     { pluginOptions: { excerpt_separator: `<!-- end -->` } }
   )

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -46,10 +46,6 @@ const htmlAstCacheKey = node =>
   `transformer-remark-markdown-html-ast-${
     node.internal.contentDigest
   }-${pluginsCacheStr}-${pathPrefixCacheStr}`
-const excerptCacheKey = (node, format) =>
-  `transformer-remark-markdown-excerpt-${format}-${
-    node.internal.contentDigest
-  }-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const headingsCacheKey = node =>
   `transformer-remark-markdown-headings-${
     node.internal.contentDigest
@@ -371,12 +367,6 @@ module.exports = (
       markdownNode,
       { pruneLength, truncate, excerptSeparator }
     ) {
-      const format = `ast`
-      const cachedAst = await cache.get(excerptCacheKey(markdownNode, format))
-      if (cachedAst) {
-        return cachedAst
-      }
-
       const fullAST = await getHTMLAst(markdownNode)
       if (excerptSeparator) {
         return cloneTreeUntil(
@@ -386,7 +376,6 @@ module.exports = (
         )
       }
       if (!fullAST.children.length) {
-        cache.set(excerptCacheKey(markdownNode, format), fullAST)
         return fullAST
       }
 
@@ -399,7 +388,6 @@ module.exports = (
         !unprunedExcerpt ||
         (pruneLength && unprunedExcerpt.length < pruneLength)
       ) {
-        cache.set(excerptCacheKey(markdownNode, format), excerptAST)
         return excerptAST
       }
 
@@ -418,7 +406,6 @@ module.exports = (
           omission: `…`,
         })
       }
-      cache.set(excerptCacheKey(markdownNode, format), excerptAST)
       return excerptAST
     }
 
@@ -426,13 +413,6 @@ module.exports = (
       markdownNode,
       { format, pruneLength, truncate, excerptSeparator }
     ) {
-      const cachedExcerpt = await cache.get(
-        excerptCacheKey(markdownNode, format)
-      )
-      if (cachedExcerpt) {
-        return cachedExcerpt
-      }
-
       if (format === `html`) {
         const excerptAST = await getExcerptAst(markdownNode, {
           pruneLength,
@@ -442,7 +422,6 @@ module.exports = (
         const html = hastToHTML(excerptAST, {
           allowDangerousHTML: true,
         })
-        cache.set(excerptCacheKey(markdownNode, format), html)
         return html
       }
 
@@ -466,7 +445,6 @@ module.exports = (
           omission: `…`,
         })
       })
-      cache.set(excerptCacheKey(markdownNode, format), text)
       return text
     }
 

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -50,10 +50,6 @@ const excerptCacheKey = (node, format) =>
   `transformer-remark-markdown-excerpt-${format}-${
     node.internal.contentDigest
   }-${pluginsCacheStr}-${pathPrefixCacheStr}`
-const excerptAstCacheKey = node =>
-  `transformer-remark-markdown-excerpt-ast-${
-    node.internal.contentDigest
-  }-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const headingsCacheKey = node =>
   `transformer-remark-markdown-headings-${
     node.internal.contentDigest
@@ -375,7 +371,8 @@ module.exports = (
       markdownNode,
       { pruneLength, truncate, excerptSeparator }
     ) {
-      const cachedAst = await cache.get(excerptAstCacheKey(markdownNode))
+      const format = `ast`
+      const cachedAst = await cache.get(excerptCacheKey(markdownNode, format))
       if (cachedAst) {
         return cachedAst
       }
@@ -389,7 +386,7 @@ module.exports = (
         )
       }
       if (!fullAST.children.length) {
-        cache.set(excerptAstCacheKey(markdownNode), fullAST)
+        cache.set(excerptCacheKey(markdownNode, format), fullAST)
         return fullAST
       }
 
@@ -402,7 +399,7 @@ module.exports = (
         !unprunedExcerpt ||
         (pruneLength && unprunedExcerpt.length < pruneLength)
       ) {
-        cache.set(excerptAstCacheKey(markdownNode), excerptAST)
+        cache.set(excerptCacheKey(markdownNode, format), excerptAST)
         return excerptAST
       }
 
@@ -421,7 +418,7 @@ module.exports = (
           omission: `…`,
         })
       }
-      cache.set(excerptAstCacheKey(markdownNode), excerptAST)
+      cache.set(excerptCacheKey(markdownNode, format), excerptAST)
       return excerptAST
     }
 

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -389,7 +389,7 @@ module.exports = (
         )
       }
       if (!fullAST.children.length) {
-        cache.set(excerptAstCacheKey(markdownNode, fullAST))
+        cache.set(excerptAstCacheKey(markdownNode), fullAST)
         return fullAST
       }
 
@@ -402,7 +402,7 @@ module.exports = (
         !unprunedExcerpt ||
         (pruneLength && unprunedExcerpt.length < pruneLength)
       ) {
-        cache.set(excerptAstCacheKey(markdownNode, excerptAST))
+        cache.set(excerptAstCacheKey(markdownNode), excerptAST)
         return excerptAST
       }
 
@@ -421,7 +421,7 @@ module.exports = (
           omission: `…`,
         })
       }
-      cache.set(excerptAstCacheKey(markdownNode, excerptAST))
+      cache.set(excerptAstCacheKey(markdownNode), excerptAST)
       return excerptAST
     }
 

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -453,7 +453,7 @@ module.exports = (
         return markdownNode.excerpt
       }
 
-      const text = getAST(markdownNode).then(ast => {
+      const text = await getAST(markdownNode).then(ast => {
         const excerptNodes = []
         visit(ast, node => {
           if (node.type === `text` || node.type === `inlineCode`) {


### PR DESCRIPTION
## Description

This PR adds/refactors excerpt + excerptAst (which is a new field) because I personally found it incovenient `gatsby-transformer-remark` not exporting an excerpt field in AST. What I did was basically refactoring by splitting out the resolver of `excerpt` that was internally converting ASTs to HTML to two functions that have similar signatures to the `getHtml()` and `getHtmlAst()`, with some caching feature as well. The tests have been added for these ASTs.

Documentation could be added something like this:
```diff
diff --git a/packages/gatsby-transformer-remark/README.md b/packages/gatsby-transformer-remark/README.md
index 423329b..36a0d59 100644
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -119,6 +119,7 @@ By default, excerpts have a maximum length of 140 characters. You can change the
       node {
         html
         excerpt(pruneLength: 500)
+        excerptAst(pruneLength: 500)
       }
     }
   }
@@ -178,14 +181,15 @@ Any file that does not have the given `excerpt_separator` will fall back to the

 ### Excerpts for non-latin languages

-By default, `excerpt` uses `underscore.string/prune` which doesn't handle non-latin characters ([https://github.com/epeli/underscore.string/issues/418](https://github.com/epeli/underscore.string/issues/418)).
+By default, `excerpt` and `excerptAst` use `underscore.string/prune` which doesn't handle non-latin characters ([https://github.com/epeli/underscore.string/issues/418](https://github.com/epeli/underscore.string/issues/418)).

-If that is the case, you can set `truncate` option on `excerpt` field, like:
+If that is the case, you can set `truncate` option on `excerpt` and `excerptAst` field, like:

 ```graphql
 {
   markdownRemark {
     excerpt(truncate: true)
+    excerptAst(truncate: true)
   }
 }
```
