### PR TITLE
Fix typo on babel.md page

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -22,7 +22,7 @@ browsers.
 ## How to use a custom .babelrc file
 
 Gatsby ships with a default .babelrc setup that should work for most sites. If you'd like
-to add custom Babel presets or plugins, you can create your own `.babelrc` at the root of your site, import [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby), and overwrite the `target` option.
+to add custom Babel presets or plugins, you can create your own `.babelrc` at the root of your site, import [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby), and overwrite the `targets` option.
 
 ```shell
 npm install --save-dev babel-preset-gatsby


### PR DESCRIPTION
Fixes typo `target` -> `targets`