### PR TITLE
chore(docs): update headless CMS ordering

### DIFF
--- a/docs/docs/headless-cms.md
+++ b/docs/docs/headless-cms.md
@@ -15,22 +15,27 @@ The guides in this section will walk through the process of setting up content s
 
 [[guidelist]]
 
+<!--
+  Ordering in this section is driven by Gatsby plugin downloads (https://www.gatsbyjs.org/plugins/?=gatsby-source-) & CMS vendor size/adoption. 
+-->
+
 Other CMS systems you can connect to include:
 
-- [Cosmic JS](https://www.gatsbyjs.org/packages/gatsby-source-cosmicjs)
-- [ButterCMS](https://www.gatsbyjs.org/packages/gatsby-source-buttercms)
-- [Shopify](https://www.gatsbyjs.org/packages/gatsby-source-shopify)
-- [Contentstack](https://www.gatsbyjs.org/packages/gatsby-source-contentstack)
-- [Ghost](https://www.gatsbyjs.org/packages/gatsby-source-ghost)
-- [Prismic](https://www.gatsbyjs.org/packages/gatsby-source-prismic)
-- [Strapi](https://www.gatsbyjs.org/packages/gatsby-source-strapi)
-- [Directus](https://www.gatsbyjs.org/packages/gatsby-source-directus)
-- [Cockpit](https://www.gatsbyjs.org/packages/gatsby-plugin-cockpit)
-- [GraphCMS](https://www.gatsbyjs.org/packages/gatsby-source-graphcms-beta-patch)
-- [CraftCMS](https://www.gatsbyjs.org/packages/gatsby-source-craftcms)
-- [DatoCMS](https://www.gatsbyjs.org/packages/gatsby-source-datocms)
-- [Storyblok](https://www.gatsbyjs.org/packages/gatsby-source-storyblok)
-- [Kentico Cloud](https://www.gatsbyjs.org/packages/gatsby-source-kentico-cloud)
+- [Shopify](/packages/gatsby-source-shopify)
+- [Strapi](/packages/gatsby-source-strapi)
+- DatoCMS [docs](/packages/gatsby-source-datocms), [business case](https://www.gatsbyjs.com/guides/datocms/)
+- [Sanity](/packages/gatsby-source-sanity/)
+- Contentstack [docs](/packages/gatsby-source-contentstack), [guide](https://www.contentstack.com/docs/example-apps/build-a-sample-website-using-gatsby-and-contentstack), [starter](/starters/contentstack/gatsby-starter-contentstack/)
+- [ButterCMS](/packages/gatsby-source-buttercms)
+- Ghost [docs[(/packages/gatsby-source-ghost), [guide[(/blog/2019-01-14-modern-publications-with-gatsby-ghost/), [starter](/starters/TryGhost/gatsby-starter-ghost/)
+- Kentico Cloud [docs](/packages/gatsby-source-kentico-cloud), [guide](/blog/2018-12-19-kentico-cloud-and-gatsby-take-you-beyond-static-websites/), [starter](/starters/Kentico/gatsby-starter-kentico-cloud/)
+- [Directus](/packages/gatsby-source-directus)
+- [GraphCMS](/packages/gatsby-source-graphcms-beta-patch)
+- Cosmic JS [docs](/packages/gatsby-source-cosmicjs), [guide](/blog/2018-06-07-build-a-gatsby-blog-using-the-cosmic-js-source-plugin/)
+- [Cockpit](/packages/gatsby-plugin-cockpit)
+- [Storyblok](/packages/gatsby-source-storyblok)
+- [CraftCMS](/packages/gatsby-source-craftcms)
+
 
 ## How to add new guides to this section
 

--- a/docs/docs/headless-cms.md
+++ b/docs/docs/headless-cms.md
@@ -16,7 +16,7 @@ The guides in this section will walk through the process of setting up content s
 [[guidelist]]
 
 <!--
-  Ordering in this section is driven by Gatsby plugin downloads (https://www.gatsbyjs.org/plugins/?=gatsby-source-) & CMS vendor size/adoption. 
+  Ordering in this section is driven by Gatsby plugin downloads (https://www.gatsbyjs.org/plugins/?=gatsby-source-) & CMS vendor size/adoption.
 -->
 
 Other CMS systems you can connect to include:
@@ -35,7 +35,6 @@ Other CMS systems you can connect to include:
 - [Cockpit](/packages/gatsby-plugin-cockpit)
 - [Storyblok](/packages/gatsby-source-storyblok)
 - [CraftCMS](/packages/gatsby-source-craftcms)
-
 
 ## How to add new guides to this section
 


### PR DESCRIPTION
* Added note about ordering
* Reordered links to reflect usage
* Used gatsby-link
* Added links to guides and starters