### PR TITLE
chore(docs): Change Discord invite links

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -11,7 +11,7 @@ about: Usage question or discussion about Gatsby.
 
   Gatsby has several community support channels, try asking your question on:
 
-  - Discord: https://discord.gg/0ZcbPKXt5bVoxkfV
+  - Discord: https://gatsby.app/discord
   - Spectrum: https://spectrum.chat/gatsby-js
   - Twitter: https://twitter.com/gatsbyjs
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
   <span> · </span>
   Support: <a href="https://spectrum.chat/gatsby-js">Spectrum</a>
   <span> & </span>
-  <a href="https://discord.gg/0ZcbPKXt5bVoxkfV">Discord</a>
+  <a href="https://gatsby.app/discord">Discord</a>
 </h3>
 
 Gatsby is a modern framework for blazing fast websites.

--- a/docs/blog/2017-02-21-1-0-progress-update-where-came-from-where-going/index.md
+++ b/docs/blog/2017-02-21-1-0-progress-update-where-came-from-where-going/index.md
@@ -354,6 +354,6 @@ reactions and what kind of problems you face that you think Gatsby will help
 with.
 
 If you're interested in contributing, please join the
-[#gatsby channel](https://discord.gg/0ZcbPKXt5bVoxkfV) on Discord, check out the
+[Gatsby Discord](https://gatsby.app/discord), check out the
 [issues](https://github.com/gatsbyjs/gatsby/issues), and help bikeshed on names
 and APIs and other ideas.

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -44,9 +44,8 @@ the [existing questions](http://stackoverflow.com/questions/tagged/gatsby)
 tagged with **gatsby** or
 [ask your own](http://stackoverflow.com/questions/ask?tags=gatsby)!
 
-### Reactiflux Chat
+### Discord
 
 If you need an answer right away, check out the
-[Reactiflux Discord](https://discord.gg/0ZcbPKXt5bVoxkfV) #gatsby channel. There
-are usually a number of Gatsby experts there who can help out or point you to
+[Gatsby Discord](https://gatsby.app/discord). Community & team members are happy to help you out or point you to
 useful resources.

--- a/docs/docs/gatsby-style-guide.md
+++ b/docs/docs/gatsby-style-guide.md
@@ -114,7 +114,7 @@ it in a clear, accurate, and objective manner. You'll likely go through several
 rounds of proofreading and editing before you're happy with your writing.
 
 Also, there's a community of contributors to support you. Bounce ideas off of them and ask for input on your writing in the
-[Discord chat room](https://discordapp.com/invite/0ZcbPKXt5bVoxkfV) and in the [GitHub repo](https://github.com/gatsbyjs/gatsby).
+[Gatsby Discord](https://gatsby.app/discord) and in the [GitHub repo](https://github.com/gatsbyjs/gatsby).
 
 ## Word choice
 

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -13,7 +13,7 @@ We want contributing to Gatsby to be fun, enjoyable, and educational for anyone 
 - Adding unit or functional tests
 - Triaging [GitHub issues](https://github.com/gatsbyjs/gatsby/issues) -- especially determining whether an issue still persists or is reproducible
 - [Reporting bugs or issues](/docs/how-to-file-an-issue/)
-- Searching for Gatsby on [Discord](https://discordapp.com/invite/jUFVxtB) or [Spectrum](https://spectrum.chat/gatsby-js) and helping someone else who needs help
+- Searching for Gatsby on [Discord](https://gatsby.app/discord) or [Spectrum](https://spectrum.chat/gatsby-js) and helping someone else who needs help
 - Teaching others how to contribute to Gatsby's repo!
 
 As our way of saying “thank you” to our contributors, **_all contributors_ are eligible for [free Gatsby swag](/docs/contributor-swag/)** — whether you’re contributing code, docs, a talk, an article, or something else that helps the Gatsby community. [Learn how to claim free swag for contributors.](/docs/contributor-swag/)

--- a/docs/docs/how-to-file-an-issue.md
+++ b/docs/docs/how-to-file-an-issue.md
@@ -11,7 +11,7 @@ If you want your issue to be resolved quickly, please include in your issue:
   `gatsby-node.js`, `gatsby-browser.js` `gatsby-ssr.js` files depending on
   changes you've made there.
 
-Please do not use the issue tracker for personal support requests. [Stack Overflow](http://stackoverflow.com/questions/ask?tags=gatsby) (**gatsby** tag) and the [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bVoxkfV) #gatsby channels are better places to get help.
+Please do not use the issue tracker for personal support requests. [Stack Overflow](http://stackoverflow.com/questions/ask?tags=gatsby) (**gatsby** tag) and the [Gatsby Discord](https://gatsby.app/discord) are better places to get help.
 
 ### Special Note on Issues
 

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -47,7 +47,7 @@
   <span> · </span>
   Support: <a href="https://spectrum.chat/gatsby-js">Spectrum</a>
   <span> & </span>
-  <a href="https://discord.gg/0ZcbPKXt5bVoxkfV">Discord</a>
+  <a href="https://gatsby.app/discord">Discord</a>
 </h3>
 
 Gatsby is a modern framework for blazing fast websites.

--- a/starters/README.md
+++ b/starters/README.md
@@ -47,7 +47,7 @@
   <span> · </span>
   Support: <a href="https://spectrum.chat/gatsby-js">Spectrum</a>
   <span> & </span>
-  <a href="https://discord.gg/0ZcbPKXt5bVoxkfV">Discord</a>
+  <a href="https://gatsby.app/discord">Discord</a>
 </h3>
 
 Gatsby is a modern framework for blazing fast websites. This repository is our monorepo for managing all the great GatsbyJS starters for the community.

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -180,10 +180,7 @@ const Navigation = ({ pathname }) => {
               [presets.Hd]: { display: `flex` },
             }}
           >
-            <SocialNavItem
-              href="https://discord.gg/0ZcbPKXt5bVoxkfV"
-              title="Discord"
-            >
+            <SocialNavItem href="https://gatsby.app/discord" title="Discord">
               <DiscordIcon overrideCSS={{ verticalAlign: `text-top` }} />
             </SocialNavItem>
             <SocialNavItem


### PR DESCRIPTION
You now can join the official Gatsby Discord 🎉
https://gatsby.app/discord

I tried to find every link with `git grep` 👍 

Ref: https://github.com/gatsbyjs/gatsby/issues/4349