### PR TITLE
fix(gatsby-starter-blog): ESLint 'ecmaVersion' in 'parserOptions'

### DIFF
--- a/starters/blog/.eslintrc.js
+++ b/starters/blog/.eslintrc.js
@@ -11,8 +11,8 @@ module.exports = {
   },
   "parserOptions": {
     "sourceType": "module",
+    "ecmaVersion": 2018,
     "ecmaFeatures": {
-      "ecmaVersion": 2018,
       "jsx": true,
     },
   }


### PR DESCRIPTION
## Description

Summary: This was causing the linting tests to fail as the option was not taken into account, being under `parserOptions.ecmaFeatures` instead of `parserOptions`.

