### PR TITLE
refactor(gatsby): clean up gatsby webpack stats extractor

### DIFF
--- a/docs/docs/how-code-splitting-works.md
+++ b/docs/docs/how-code-splitting-works.md
@@ -89,7 +89,7 @@ To do this, we need to be able to create `<link>` and `<script>` tags in the HTM
 
 #### webpack.stats.json
 
-It turns out that webpack provides a way to record the mapping. It provides a compilation hook called [done](https://webpack.js.org/api/compiler-hooks/#done) that you can register for. It provides a [stats](https://webpack.js.org/api/stats/) data structure that contains all the `chunkGroups` (remember that the chunk Group is the `componentChunkName`). Each chunk group contains a list of the chunks it depends on. Gatsby provides a custom webpack plugin called [gatsby-webpack-stats-extractor](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js#L201) that implements this hook and writes the chunk information to `/public/webpack.stats.json` (under the `assetsByChunkName` key). E.g
+It turns out that webpack provides a way to record the mapping. It provides a compilation hook called [done](https://webpack.js.org/api/compiler-hooks/#done) that you can register for. It provides a [stats](https://webpack.js.org/api/stats/) data structure that contains all the `chunkGroups` (remember that the chunk Group is the `componentChunkName`). Each chunk group contains a list of the chunks it depends on. Gatsby provides a custom webpack plugin called [GatsbyWebpackStatsExtractor](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.js) that implements this hook and writes the chunk information to `/public/webpack.stats.json` (under the `assetsByChunkName` key). E.g
 
 ```javascript
 {

--- a/docs/docs/production-app.md
+++ b/docs/docs/production-app.md
@@ -36,16 +36,8 @@ The config is quite large, but here are some of the important values in the fina
     splitChunks: false
   }
   plugins: [
-    {
-      apply: function(compiler) {
-        compiler.hooks.done.tapAsync(
-          `gatsby-webpack-stats-extractor`,
-          (stats, done) => {
-            // logic to write out chunk-map.json and webpack.stats.json
-          }
-        )
-      },
-    }
+    // A custom webpack plugin that implements logic to write out chunk-map.json and webpack.stats.json
+    plugins.extractStats(),
   ]
 }
 ```

--- a/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.js
+++ b/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.js
@@ -1,0 +1,49 @@
+const fs = require(`fs-extra`)
+const path = require(`path`)
+
+class GatsbyWebpackStatsExtractor {
+  constructor(options) {
+    this.plugin = { name: "GatsbyWebpackStatsExtractor" }
+    this.options = options || {}
+  }
+  apply(compiler) {
+    const { options } = this
+    compiler.hooks.done.tapAsync(this.plugin, (stats, done) => {
+      let assets = {}
+      let assetsMap = {}
+      for (let chunkGroup of stats.compilation.chunkGroups) {
+        if (chunkGroup.name) {
+          let files = []
+          for (let chunk of chunkGroup.chunks) {
+            files.push(...chunk.files)
+          }
+          assets[chunkGroup.name] = files.filter(f => f.slice(-4) !== `.map`)
+          assetsMap[chunkGroup.name] = files
+            .filter(
+              f =>
+                f.slice(-4) !== `.map` &&
+                f.slice(0, chunkGroup.name.length) === chunkGroup.name
+            )
+            .map(filename => `/${filename}`)
+        }
+      }
+      const webpackStats = {
+        ...stats.toJson({ all: false, chunkGroups: true }),
+        assetsByChunkName: assets,
+      }
+      fs.writeFile(
+        path.join(`public`, `chunk-map.json`),
+        JSON.stringify(assetsMap),
+        () => {
+          fs.writeFile(
+            path.join(`public`, `webpack.stats.json`),
+            JSON.stringify(webpackStats),
+            done
+          )
+        }
+      )
+    })
+  }
+}
+
+module.exports = GatsbyWebpackStatsExtractor

--- a/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.js
+++ b/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.js
@@ -3,11 +3,10 @@ const path = require(`path`)
 
 class GatsbyWebpackStatsExtractor {
   constructor(options) {
-    this.plugin = { name: "GatsbyWebpackStatsExtractor" }
+    this.plugin = { name: `GatsbyWebpackStatsExtractor` }
     this.options = options || {}
   }
   apply(compiler) {
-    const { options } = this
     compiler.hooks.done.tapAsync(this.plugin, (stats, done) => {
       let assets = {}
       let assetsMap = {}

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -6,6 +6,8 @@ const TerserPlugin = require(`terser-webpack-plugin`)
 const MiniCssExtractPlugin = require(`mini-css-extract-plugin`)
 const OptimizeCssAssetsPlugin = require(`optimize-css-assets-webpack-plugin`)
 
+const GatsbyWebpackStatsExtractor = require(`./gatsby-webpack-stats-extractor`)
+
 const builtinPlugins = require(`./webpack-plugins`)
 const eslintConfig = require(`./eslint-config`)
 
@@ -91,6 +93,7 @@ export type PluginUtils = BuiltinPlugins & {
   extractText: PluginFactory,
   uglify: PluginFactory,
   moment: PluginFactory,
+  extractStats: PluginFactory,
 }
 
 /**
@@ -477,6 +480,8 @@ module.exports = async ({
     })
 
   plugins.moment = () => plugins.ignore(/^\.\/locale$/, /moment$/)
+
+  plugins.extractStats = options => new GatsbyWebpackStatsExtractor(options)
 
   return {
     loaders,

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -201,53 +201,7 @@ module.exports = async (
           plugins.extractText(),
           // Write out stats object mapping named dynamic imports (aka page
           // components) to all their async chunks.
-          {
-            apply: function(compiler) {
-              compiler.hooks.done.tapAsync(
-                `gatsby-webpack-stats-extractor`,
-                (stats, done) => {
-                  let assets = {}
-                  let assetsMap = {}
-                  for (let chunkGroup of stats.compilation.chunkGroups) {
-                    if (chunkGroup.name) {
-                      let files = []
-                      for (let chunk of chunkGroup.chunks) {
-                        files.push(...chunk.files)
-                      }
-                      assets[chunkGroup.name] = files.filter(
-                        f => f.slice(-4) !== `.map`
-                      )
-                      assetsMap[chunkGroup.name] = files
-                        .filter(
-                          f =>
-                            f.slice(-4) !== `.map` &&
-                            f.slice(0, chunkGroup.name.length) ===
-                              chunkGroup.name
-                        )
-                        .map(filename => `/${filename}`)
-                    }
-                  }
-
-                  const webpackStats = {
-                    ...stats.toJson({ all: false, chunkGroups: true }),
-                    assetsByChunkName: assets,
-                  }
-
-                  fs.writeFile(
-                    path.join(`public`, `chunk-map.json`),
-                    JSON.stringify(assetsMap),
-                    () => {
-                      fs.writeFile(
-                        path.join(`public`, `webpack.stats.json`),
-                        JSON.stringify(webpackStats),
-                        done
-                      )
-                    }
-                  )
-                }
-              )
-            },
-          },
+          plugins.extractStats(),
         ])
         break
       }


### PR DESCRIPTION
This moves our currently inlined gatsby-webpack-stats-extractor to a separate file and makes it a named class. Why?

Because sometimes plugins use our webpack config — gatsby-plugin-netlify-cms does in https://github.com/gatsbyjs/gatsby/blob/7dc7c5f1ec8b934d328b92f36e035d5a6fe3cc5f/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js#L83

Having an _unnamed, locally inlined_ plugin makes excluding them in instances like these difficult 