### PR TITLE
fix(gatsby-plugin-netlify-cms): exclude gatsby-webpack-stats-extractor from being called

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0-beta.29",
+    "gatsby": "^2.0.101",
     "netlify-cms": "^2.0.6"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms",

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -82,7 +82,7 @@ exports.onCreateWebpackConfig = (
          */
         ...gatsbyConfig.plugins.filter(
           plugin =>
-            ![`MiniCssExtractPlugin`].find(
+            ![`MiniCssExtractPlugin`, `GatsbyWebpackStatsExtractor`].find(
               pluginName =>
                 plugin.constructor && plugin.constructor.name === pluginName
             )


### PR DESCRIPTION
The Netlify CMS plugin runs its own instance of webpack and uses Gatsby's plugins as a base webpack config

Unfortunately our previously inlined (fixed in https://github.com/gatsbyjs/gatsby/pull/11287) gatsby-webpack-stats-extractor gets called and overwrites `chunk-map.json` as seen in https://github.com/gatsbyjs/gatsby/issues/11281 and reproducible in https://github.com/asistapl/gatsby-plugin-netlify-cms-bug

As a result of chunk-map.json being overwritten by the plugin's version (which only contains cms.js) the entire app breaks because static-entry.js can't find the right chunks

This PR adds `GatsbyWebpackStatsExtractor` to the list of ignored plugins in this plugin's `onCreateWebpackConfig`

Fixes https://github.com/gatsbyjs/gatsby/issues/11281

This PR depends on https://github.com/gatsbyjs/gatsby/pull/11287 and needs that to be merged in first 