### PR TITLE
feat(gatsby-image): add itemProp prop

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -40,6 +40,7 @@ interface GatsbyImageProps {
   onStartLoad?: (param: { wasCached: boolean }) => void
   onError?: (event: any) => void
   Tag?: string
+  itemProp?: string
 }
 
 export default class GatsbyImage extends React.Component<

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -28,6 +28,7 @@ exports[`<Img /> should render fixed size images 1`] = `
       <img
         alt="Alt text for the image"
         height="100"
+        itemprop="item-prop-for-the-image"
         src="test_image.jpg"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 0;"
         title="Title for the image"
@@ -73,6 +74,7 @@ exports[`<Img /> should render fluid images 1`] = `
       />
       <img
         alt="Alt text for the image"
+        itemprop="item-prop-for-the-image"
         src="test_image.jpg"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; opacity: 0;"
         title="Title for the image"

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -35,6 +35,7 @@ const setup = (fluid = false, onLoad = () => {}, onError = () => {}) => {
       {...!fluid && { fixed: fixedShapeMock }}
       onLoad={onLoad}
       onError={onError}
+      itemProp={`item-prop-for-the-image`}
       placeholderStyle={{ color: `red` }}
       placeholderClassName={`placeholder`}
     />

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -224,6 +224,7 @@ class Image extends React.Component {
       fixed,
       backgroundColor,
       Tag,
+      itemProp,
     } = convertProps(this.props)
 
     const bgColor =
@@ -320,6 +321,7 @@ class Image extends React.Component {
                 ref={this.imageRef}
                 onLoad={this.handleImageLoaded}
                 onError={this.props.onError}
+                itemProp={itemProp}
               />
             </picture>
           )}
@@ -405,6 +407,7 @@ class Image extends React.Component {
                 ref={this.imageRef}
                 onLoad={this.handleImageLoaded}
                 onError={this.props.onError}
+                itemProp={itemProp}
               />
             </picture>
           )}
@@ -479,6 +482,7 @@ Image.propTypes = {
   onError: PropTypes.func,
   onStartLoad: PropTypes.func,
   Tag: PropTypes.string,
+  itemProp: PropTypes.string,
 }
 
 export default Image


### PR DESCRIPTION
## Description

Allows itemProp attribute to be passed to the image in a Gatsby Image component. Useful for adding schema.org tags to a page for SEO purposes.

## Related Issues

Fixes #11005 

