### PR TITLE
fix(docs): update key name for jest@24 support

### DIFF
--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -33,7 +33,7 @@ Lastly you need to tell Jest where to find this file. Open your `jest.config.js`
 
 ```js:title=jest.config.js
 module.exports = {
-  setupTestFrameworkScriptFile: "<rootDir>/setup-test-env.js",
+  setupFilesAfterEnv: ["<rootDir>/setup-test-env.js"],
 }
 ```
 


### PR DESCRIPTION
## Description

Jest recently added a "Deprecation Warning" saying 
> Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.

This PR fixes the docs to match the newly updated configuration.

![screen shot 2019-01-25 at 3 34 06 pm](https://user-images.githubusercontent.com/3806031/51776858-29457580-20b8-11e9-80b1-76b955e01191.png)
