### PR TITLE
fix(gatsby-image): use the cache to tell if the image was already loaded

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -189,14 +189,15 @@ class Image extends React.Component {
   handleRef(ref) {
     if (this.state.IOSupported && ref) {
       listenToIntersections(ref, () => {
+        const imageInCache = inImageCache(this.props)
         if (
           !this.state.isVisible &&
           typeof this.props.onStartLoad === `function`
         ) {
-          this.props.onStartLoad({ wasCached: inImageCache(this.props) })
+          this.props.onStartLoad({ wasCached: imageInCache })
         }
 
-        this.setState({ isVisible: true, imgLoaded: false })
+        this.setState({ isVisible: true, imgLoaded: imageInCache })
       })
     }
   }


### PR DESCRIPTION
## Description

I found a weird issue while browsing the gatsby store earlier today. When I reloaded the product detail page the images were not loaded correctly.
It turns out that the order of the IntersectionObserver and the image load event is not deterministic. By using the image cache to tell if the image was loaded or not, the call order will no longer be an issue.

Before:

![kapture 2019-01-25 at 23 31 32](https://user-images.githubusercontent.com/2036823/51778192-af85aa00-2100-11e9-8680-1990966de973.gif)

After:

![kapture 2019-01-25 at 23 36 00](https://user-images.githubusercontent.com/2036823/51778198-b7dde500-2100-11e9-84a7-ccd7f7e85d4f.gif)

## Related Issues
Fixes: #11298

