### PR TITLE
docs(gatsby-transformer-javascript-frontmatter): update accepted extensions

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/README.md
+++ b/packages/gatsby-transformer-javascript-frontmatter/README.md
@@ -31,7 +31,7 @@ module.exports = {
 This plugin uses [@babel/parser](https://www.npmjs.com/package/@babel/parser) and [@babel/traverse](https://www.npmjs.com/package/@babel/traverse) to
 statically read the frontmatter exports.
 
-In a `.js` file, export a frontmatter object to set your metadata variables, like so:
+In a `.js` (or `.jsx` / `.ts` / `.tsx`) file, export a frontmatter object to set your metadata variables, like so:
 
 ```javascript
 import React from "react"


### PR DESCRIPTION
Updated with readme noting `jsx` and typescript extensions. 