### PR TITLE
Add mention of options allowed

### DIFF
--- a/docs/docs/typography-js.md
+++ b/docs/docs/typography-js.md
@@ -67,6 +67,16 @@ export default typography
 
 Font sizes of all elements in Typography.js grow and shrink in relation to the `baseFontSize` defined above. Try playing around with this value and see the visual difference it can make to your website.
 
+`Typography` allows you to specify different kinds of options:
+
+- **googleFonts**: An array specifying Google Fonts for this project.
+- **headerColor**: (string, default: inherit) A css color string to be set on headers.
+- **bodyColor**: (string, default: hsl(0,0%,0%,0.8))  A css color string to be set for body text.
+- **headerWeight**: (string, default: bold) Specify the font weight for headers.
+- **bodyWeight**: (string, default: normal) Specify the font weight for body text.
+- **boldWeight**: (string, default: bold) Specify the font weight for "bold" (b, strong, dt, th)
+  elements.
+
 A full list of options that can be specified when defining a new typography can be found at [Typography.js](https://kyleamathews.github.io/typography.js/).
 
 ## Installing Typography themes


### PR DESCRIPTION
Hello, 

I had to look at how to add google fonts to my project so I thought it could be good to include these in the plugin documentation.

Not sure if this will be a good idea for others, but it might save some clicks and tabs 😄 

Thank you for the time

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
