### PR TITLE
fix(gatsby): Fix getExampleValues test for unsupported types

### DIFF
--- a/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
+++ b/packages/gatsby/src/schema/__tests__/data-tree-utils-test.js
@@ -170,11 +170,11 @@ describe(`Gatsby data tree utils`, () => {
 
   it(`skips unsupported types`, () => {
     // Skips functions
-    let example = getExampleValues([{ foo: () => {} }])
+    let example = getExampleValues({ nodes: [{ foo: () => {} }] })
     expect(example.foo).not.toBeDefined()
 
     // Skips array of functions
-    example = getExampleValues([{ foo: [() => {}] }])
+    example = getExampleValues({ nodes: [{ foo: [() => {}] }] })
     expect(example.foo).not.toBeDefined()
   })
 


### PR DESCRIPTION
`getExampleValues` expects the nodes on an object, not directly as an array arg.