### PR TITLE
fix: use require instead if the ESM import statement

### DIFF
--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -94,14 +94,14 @@ const preferDefault = m => m && m.default || m
   asyncRequires += `exports.components = {\n${components
     .map(
       c =>
-        `  "${c.componentChunkName}": () => import("${joinPath(
+        `  "${c.componentChunkName}": () => require("${joinPath(
           c.component
         )}" /* webpackChunkName: "${c.componentChunkName}" */)`
     )
     .join(`,\n`)}
 }\n\n`
 
-  asyncRequires += `exports.data = () => import(/* webpackChunkName: "pages-manifest" */ "${joinPath(
+  asyncRequires += `exports.data = () => require(/* webpackChunkName: "pages-manifest" */ "${joinPath(
     program.directory,
     `.cache`,
     `data.json`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This fixes an issue with the `build` script.

In the dev mode it seems we have the babel transform plugin for the engine and dynamic require / import.

But the build does not and we have to use `require`. In fact the code in this file uses `exports` but not the `require`. I guess this was overseen.

We should use the CJS way to use them (require) instead of the ESM one (import).

https://github.com/gatsbyjs/gatsby/blame/master/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js#L97

https://github.com/gatsbyjs/gatsby/blame/master/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js#L104

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

https://github.com/gatsbyjs/gatsby/issues/11198