### PR TITLE
Update source-plugin-tutorial.md

### DIFF
--- a/docs/docs/source-plugin-tutorial.md
+++ b/docs/docs/source-plugin-tutorial.md
@@ -20,6 +20,8 @@ Source plugins convert data from any source into a format that can be processed 
 
 If you can't find a plugin for your data source you can create your own.
 
+_**NOTE:** if your data is local i.e. on your file system and part of your site's repo, then you generally don't want to create a new source plugin. Instead you want to use [gatsby-source-filesystem](/packages/gatsby-source-filesystem/) which handles reading and watching files for you. You can then use [transformer plugins](/plugins/?=gatsby-transformer) like [gatsby-transformer-yaml](/packages/gatsby-transformer-yaml/) to make queryable data from files._
+
 ## How to create a source plugin
 
 ### Overview


### PR DESCRIPTION
Several recent issues have suggested that people see the source-plugin tutorial and think they should use that when trying to pull in file system data. This PR adds a note saying that if your data is in the local file system, use gatsby-source-filesystem.

- https://github.com/gatsbyjs/gatsby/issues/11335
- https://github.com/gatsbyjs/gatsby/issues/11151