### PR TITLE
Fix apply sort order on all fields

### DIFF
--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -232,15 +232,13 @@ function convertArgs(gqlArgs, gqlType) {
 // [ [ `frontmatter.date`, true ], [ `id`, false ] ]
 //
 // Note that the GraphQL Sort API provided by Gatsby doesn't allow the
-// order to be specified per field. The sift implementation uses
-// lodash `orderBy`, but only applies the sort order to the first
-// field. So we do the same here
+// order to be specified per field.
 function toSortFields(sortArgs) {
   const { fields, order } = sortArgs
   const lokiSortFields = []
   for (let i = 0; i < fields.length; i++) {
     const dottedField = fields[i].replace(/___/g, `.`)
-    const isDesc = i === 0 ? _.lowerCase(order) === `desc` : false
+    const isDesc = order.toLowerCase() === `desc`
     lokiSortFields.push([dottedField, isDesc])
   }
   return lokiSortFields

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -273,9 +273,12 @@ function handleMany(siftArgs, nodes, sort) {
     // to be specified. However, multiple sort fields can be
     // provided. This is inconsistent. The API should allow the
     // setting of an order per field. Until the API can be changed
-    // (probably v3), we apply the sort order to the first field only,
-    // implying asc order for the remaining fields.
-    result = _.orderBy(result, convertedFields, [sort.order])
+    // (probably v3), we apply the specified sort order to all sort fields.
+    result = _.orderBy(
+      result,
+      convertedFields,
+      Array(sort.fields.length).fill(sort.order)
+    )
   }
   return result
 }

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -463,8 +463,8 @@ describe(`collection fields`, () => {
     })
 
     expect(result.length).toEqual(3)
-    expect(result[0].id).toEqual(`1`) // blue = 10010, id = 1
-    expect(result[1].id).toEqual(`2`) // blue = 10010, id = 2
+    expect(result[0].id).toEqual(`2`) // blue = 10010, id = 2
+    expect(result[1].id).toEqual(`1`) // blue = 10010, id = 1
     expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
   })
 })


### PR DESCRIPTION
When specifying a `sort` arg on a connection field, we currently apply the specified sort order only to the first sort field (the other fields will always sort ASC). This PR applies sort order to all sort fields.

It is not 100% clear what the expectation is here - if you feel this is a breaking change, not a bug fix, feel free to close.

Fixes #10121