### PR TITLE
feat(gatsby-plugin-google-analytics): Pass event object to the user's onClick callback in OutboundLink

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/index.js
+++ b/packages/gatsby-plugin-google-analytics/src/index.js
@@ -7,7 +7,7 @@ function OutboundLink(props) {
       {...props}
       onClick={e => {
         if (typeof props.onClick === `function`) {
-          props.onClick()
+          props.onClick(e)
         }
         let redirect = true
         if (


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Pass event object to the user's onClick callback