### PR TITLE
chore: Switching Travis -> Circle CI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,4 +164,4 @@ Licensed under the [MIT License](./LICENSE).
 ## 💜 Thanks to Our Contributors and Sponsors
 
 Thanks to our many contributors and sponsors as well as the companies sponsoring
-our testing and hosting infrastructure: [Travis CI](https://travis-ci.com/), [Appveyor](https://www.appveyor.com/), and [Netlify](https://www.netlify.com/).
+our testing and hosting infrastructure: [Circle CI](https://circleci.com/), [Appveyor](https://www.appveyor.com/), and [Netlify](https://www.netlify.com/).


### PR DESCRIPTION
## Description

As we've transferred over to CircleCI for MacOS & Linux CI, I updated the README to make note of such.
