### PR TITLE
docs(building-with-components): convert class to functional components

### DIFF
--- a/docs/docs/building-with-components.md
+++ b/docs/docs/building-with-components.md
@@ -54,16 +54,14 @@ otherwise your build will fail.
 Example:
 
 ```jsx:title=src/pages/about.jsx
-import React, { Component } from "react"
+import React from "react"
 
-class AboutPage extends Component {
-  render() {
-    return (
-      <div className="about-container">
-        <p>About me.</p>
-      </div>
-    )
-  }
+function AboutPage(props) {
+  return (
+    <div className="about-container">
+      <p>About me.</p>
+    </div>
+  )
 }
 
 export default AboutPage
@@ -86,17 +84,14 @@ Example:
 import React from "react"
 import { graphql } from "gatsby"
 
-class BlogPostTemplate extends React.Component {
-  render() {
-    const post = this.props.data.markdownRemark
-
-    return (
-      <div>
-        <h1>{post.frontmatter.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: post.html }} />
-      </div>
-    )
-  }
+function BlogPostTemplate(props) {
+  const post = props.data.markdownRemark
+  return (
+    <div>
+      <h1>{post.frontmatter.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.html }} />
+    </div>
+  )
 }
 
 export default BlogPostTemplate
@@ -140,39 +135,31 @@ if (process.env.NODE_ENV === "production") {
   }
 }
 
-export default class HTML extends React.Component {
-  render() {
-    let css
-    if (process.env.NODE_ENV === "production") {
-      css = (
-        <style
-          id="gatsby-inlined-css"
-          dangerouslySetInnerHTML={{ __html: inlinedStyles }}
-        />
-      )
-    }
-    return (
-      <html lang="en">
-        <head>
-          <meta charSet="utf-8" />
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0"
-          />
-          {this.props.headComponents}
-          <link rel="shortcut icon" href={favicon} />
-          {css}
-        </head>
-        <body>
-          <div
-            id="___gatsby"
-            dangerouslySetInnerHTML={{ __html: this.props.body }}
-          />
-          {this.props.postBodyComponents}
-        </body>
-      </html>
+function HTML(props) {
+  let css
+  if (process.env.NODE_ENV === "production") {
+    css = (
+      <style
+        id="gatsby-inlined-css"
+        dangerouslySetInnerHTML={{ __html: inlinedStyles }}
+      />
     )
   }
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        {props.headComponents}
+        <link rel="shortcut icon" href={favicon} />
+        {css}
+      </head>
+      <body>
+        <div id="___gatsby" dangerouslySetInnerHTML={{ __html: props.body }} />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
 }
 ```
 


### PR DESCRIPTION
On the [building with components page](https://www.gatsbyjs.org/docs/building-with-components/) page, all the code examples are using class components. Even though it is only a small difference, using functional components will result in a smaller output. Also, class components will be much less common when hooks are part of the stable release.

This is similar to this PR: https://github.com/gatsbyjs/gatsby/pull/11146.