### PR TITLE
fix(gatsby-source-wordpress): check response exists before accessing its properties

### DIFF
--- a/packages/gatsby-source-wordpress/src/__tests__/http-exception-handler.js
+++ b/packages/gatsby-source-wordpress/src/__tests__/http-exception-handler.js
@@ -1,0 +1,7 @@
+const httpExceptionHandler = require(`../http-exception-handler`)
+
+describe(`http-exception-handler`, () => {
+  it(`handles errors that lack responses without crashing`, () => {
+    expect(() => httpExceptionHandler({})).not.toThrowError()
+  })
+})

--- a/packages/gatsby-source-wordpress/src/http-exception-handler.js
+++ b/packages/gatsby-source-wordpress/src/http-exception-handler.js
@@ -7,12 +7,6 @@ const colorized = require(`./output-color`)
  */
 function httpExceptionHandler(e) {
   const { response, code } = e
-  console.log(
-    colorized.out(
-      `\nPath: ${response.request.path}`,
-      colorized.color.Font.FgRed
-    )
-  )
   if (!response) {
     console.log(
       colorized.out(
@@ -22,6 +16,12 @@ function httpExceptionHandler(e) {
     )
     return
   }
+  console.log(
+    colorized.out(
+      `\nPath: ${response.request.path}`,
+      colorized.color.Font.FgRed
+    )
+  )
   const {
     status,
     statusText,


### PR DESCRIPTION
## Description

This fixes a small bug in the error handler in gatsby-source-wordpress. The error handler actually introduces errors of its own at the moment by accessing `response.request.path` before it's confirmed there's a `response` object to rummage around in. I've fixed it by moving the offending `console.log()` down a line so that it happens after the `if (!response)` check immediately below.

Here's an example of how it looks when this happens:

```
error Plugin gatsby-source-wordpress returned an error


  TypeError: Cannot read property 'request' of undefined

  - http-exception-handler.js:14 httpExceptionHandler
    [abc]/[gatsby-source-wordpress]/http-exception-handler.js:14:49
```

## Related Issues

Doesn't look like anyone's reported this yet 😅