### PR TITLE
chore(*): Remove babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",
     "@babel/runtime": "^7.0.0",
-    "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "8.2.1",
     "babel-jest": "^24.0.0",
     "chokidar": "^1.7.0",

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
@@ -1,4 +1,4 @@
-const babel = require(`babel-core`)
+const babel = require(`@babel/core`)
 const plugin = require(`../`)
 
 function matchesSnapshot(query) {


### PR DESCRIPTION
Follow-up to #11293

We can now safely remove the `babel-core` bridge that was still needed with Jest 23.
See also: ["Make sure to remove the babel-core@^7.0.0-bridge.0 as it's not needed now."](https://jestjs.io/blog/2019/01/25/jest-24-refreshing-polished-typescript-friendly#typescript-support)