### PR TITLE
fix(gatsby-transformer-remark): Fix excerpt_separator test

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -47,7 +47,8 @@ Object {
 
 exports[`Excerpt is generated correctly from schema correctly uses excerpt separator 1`] = `
 Object {
-  "excerpt": "Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla…",
+  "excerpt": "Where oh where is my little pony?
+",
   "frontmatter": Object {
     "title": "my little pony",
   },

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -186,7 +186,7 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
       expect(node).toMatchSnapshot()
       expect(node.excerpt).toMatch(`Where oh where is my little pony?`)
     },
-    { pluginOptions: { excerpt_separator: `<!-- end -->` } }
+    { additionalParameters: { excerpt_separator: `<!-- end -->` } }
   )
 
   const content = `---


### PR DESCRIPTION
Pass plugin options to `onCreateNode` so `gray-matter` can handle the `excerpt_separator`. Also update the snapshot.