### PR TITLE
add `getTypes` to loki nodes.js

### DIFF
--- a/packages/gatsby/src/db/loki/nodes.js
+++ b/packages/gatsby/src/db/loki/nodes.js
@@ -146,6 +146,14 @@ function getNodes() {
 }
 
 /**
+ * Returns the unique collection of all node types
+ */
+function getTypes() {
+  const nodeTypes = getDb().getCollection(colls.nodeTypes.name).data
+  return nodeTypes.map(nodeType => nodeType.type)
+}
+
+/**
  * Looks up the node by id, records a dependency between the node and
  * the path, and then returns the node
  *
@@ -329,6 +337,7 @@ module.exports = {
   getNodesByType,
   hasNodeChanged,
   getNodeAndSavePathDependency,
+  getTypes,
 
   createNode,
   updateNode,


### PR DESCRIPTION
Recently in #11135 a `getTypes` function was added to the redux nodes.js. This adds the equivalent functionality to the loki implementation.

To test, run the tests with env var `GATSBY_DB_NODES=loki`. E.g

```
GATSBY_DB_NODES=loki yarn test
```

@stefanprobst @freiksenet The reason this wasn't caught in testing before is that I haven't gotten round to running the CI builds with the loki flag turned on. My bad. I'm working on that now. The end goal is to replace the redux nodes namespace with loki since it can make use of indexes during querying.