### PR TITLE
refactor(gatsby-source-mongodb): don't pull whole lodash and just important used modules

### DIFF
--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "lodash": "^4.17.10",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.isstring": "^4.0.1",
     "mongodb": "^2.2.30",
     "query-string": "^6.1.0"
   },

--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -1,7 +1,6 @@
 const MongoClient = require(`mongodb`).MongoClient
 const crypto = require(`crypto`)
 const prepareMappingChildNode = require(`./mapping`)
-const _ = require(`lodash`)
 const queryString = require(`query-string`)
 
 exports.sourceNodes = (
@@ -29,7 +28,7 @@ exports.sourceNodes = (
   return MongoClient.connect(connectionURL)
     .then(db => {
       let collection = pluginOptions.collection || [`documents`]
-      if (!_.isArray(collection)) {
+      if (!Array.isArray(collection)) {
         collection = [collection]
       }
 

--- a/packages/gatsby-source-mongodb/src/mapping.js
+++ b/packages/gatsby-source-mongodb/src/mapping.js
@@ -1,8 +1,9 @@
-const _ = require(`lodash`),
-  crypto = require(`crypto`)
+const camelCase = require(`lodash.camelcase`)
+const isString = require(`lodash.isstring`)
+const crypto = require(`crypto`)
 
 module.exports = function(node, key, text, mediaType, createNode) {
-  const str = _.isString(text) ? text : ` `
+  const str = isString(text) ? text : ` `
   const id = `${node.id}${key}MappingNode`
   const mappingNode = {
     id: id,
@@ -10,7 +11,7 @@ module.exports = function(node, key, text, mediaType, createNode) {
     [key]: str,
     children: [],
     internal: {
-      type: _.camelCase(`${node.internal.type} ${key} MappingNode`),
+      type: camelCase(`${node.internal.type} ${key} MappingNode`),
       mediaType: mediaType,
       content: str,
       contentDigest: crypto


### PR DESCRIPTION
## Description

- Remove lodash dependency from `gatsby-node.js` by using `Array.isArray` in place of `_.isArray`, which is deprecated.
- Use modularized builds of `camelCase` and `isString` in `mapping.js`

## Related Issues

Close #11307
