### PR TITLE
Fix loki regex operator on nested fields

### DIFF
--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -109,6 +109,8 @@ function toMongoArgs(gqlFilter, lastFieldType) {
     } else {
       if (k === `regex`) {
         const re = prepareRegex(v)
+        // To ensure that false is returned if a field doesn't
+        // exist. E.g `{nested.field: {$regex: /.*/}}`
         mongoArgs[`$where`] = obj => !_.isUndefined(obj) && re.test(obj)
       } else if (k === `glob`) {
         const Minimatch = require(`minimatch`).Minimatch

--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -107,9 +107,9 @@ function toMongoArgs(gqlFilter, lastFieldType) {
         mongoArgs[k] = toMongoArgs(v, gqlFieldType)
       }
     } else {
-      // Compile regex first.
       if (k === `regex`) {
-        mongoArgs[`$regex`] = prepareRegex(v)
+        const re = prepareRegex(v)
+        mongoArgs[`$where`] = obj => !_.isUndefined(obj) && re.test(obj)
       } else if (k === `glob`) {
         const Minimatch = require(`minimatch`).Minimatch
         const mm = new Minimatch(v)

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -36,6 +36,9 @@ const makeNodes = () => [
       { aString: `some string`, aNumber: 2, anArray: [1, 2] },
     ],
     boolean: true,
+    nestedRegex: {
+      field: `har har`,
+    },
   },
   {
     id: `1`,
@@ -76,6 +79,9 @@ const makeNodes = () => [
           },
         },
       ],
+    },
+    nestedRegex: {
+      field: ``,
     },
   },
   {
@@ -235,6 +241,13 @@ describe(`Filter fields`, () => {
     let result = await runFilter({ name: { regex: `/^the.*wax/i` } })
     expect(result.length).toEqual(2)
     expect(result[0].name).toEqual(`The Mad Wax`)
+  })
+
+  it(`handles the nested regex operator`, async () => {
+    let result = await runFilter({ nestedRegex: { field: { regex: `/.*/` } } })
+    expect(result.length).toEqual(2)
+    expect(result[0].id).toEqual(`0`)
+    expect(result[1].id).toEqual(`1`)
   })
 
   it(`handles the in operator for strings`, async () => {


### PR DESCRIPTION
While building a test site, I noticed that loki doesn't have the same behavior as sift for regex on nested fields. Sift first checks to see if a nested field exists before running the regex. Whereas loki happily runs the regex on `undefined`. And unfortunately in js, `/.*/.test(undefined)` returns true.

To test, run the tests with the env var `GATSBY_DB_NODES=loki`. E.g

```
GATSBY_DB_NODES=loki yarn test
```