### PR TITLE
feat(gatsby): Allow specifying sort order per sort field

### DIFF
--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -90,6 +90,8 @@ You can also sort on multiple fields but the `sort` keyword can only be used onc
 
 `Children's Anthology of Monsters` and `Break with Banshee` both have the same date (`1992-01-02`) but in the first query (only one sort field) the latter comes after the first. The additional sorting on the `title` puts `Break with Banshee` in the right order.
 
+By default, sort `fields` will be sorted in ascending order. Optionally, you can specify a sort `order` per field by providing an array of `ASC` (for ascending) or `DESC` (for descending) values. For example, to sort by `frontmatter.date` in ascending order, and additionally by `frontmatter.title` in descending order, you would use `sort: { fields: [frontmatter___date, frontmatter___title], order: [ASC, DESC] }`. Note that if you only provide a single sort `order` value, this will affect the first sort field only, the rest will be sorted in default ascending order.
+
 ## Format
 
 ### Dates

--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -226,7 +226,7 @@ function convertArgs(gqlArgs, gqlType) {
 //
 // {
 //   fields: [ `frontmatter___date`, `id` ],
-//   order: `desc`
+//   order: [`desc`]
 // }
 //
 // would return
@@ -242,7 +242,7 @@ function toSortFields(sortArgs) {
   const lokiSortFields = []
   for (let i = 0; i < fields.length; i++) {
     const dottedField = fields[i].replace(/___/g, `.`)
-    const isDesc = i === 0 ? _.lowerCase(order) === `desc` : false
+    const isDesc = order[i] === `desc`
     lokiSortFields.push([dottedField, isDesc])
   }
   return lokiSortFields

--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -233,10 +233,6 @@ function convertArgs(gqlArgs, gqlType) {
 //
 // [ [ `frontmatter.date`, true ], [ `id`, false ] ]
 //
-// Note that the GraphQL Sort API provided by Gatsby doesn't allow the
-// order to be specified per field. The sift implementation uses
-// lodash `orderBy`, but only applies the sort order to the first
-// field. So we do the same here
 function toSortFields(sortArgs) {
   const { fields, order } = sortArgs
   const lokiSortFields = []

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -255,13 +255,7 @@ function handleMany(siftArgs, nodes, sort) {
       .map(field => field.replace(/___/g, `.`))
       .map(field => v => _.get(v, field))
 
-    // Gatsby's sort interface only allows one sort order (e.g `desc`)
-    // to be specified. However, multiple sort fields can be
-    // provided. This is inconsistent. The API should allow the
-    // setting of an order per field. Until the API can be changed
-    // (probably v3), we apply the sort order to the first field only,
-    // implying asc order for the remaining fields.
-    result = _.orderBy(result, convertedFields, [sort.order])
+    result = _.orderBy(result, convertedFields, sort.order)
   }
   return result
 }

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -428,7 +428,7 @@ describe(`collection fields`, () => {
       limit: 10,
       sort: {
         fields: [`frontmatter___blue`],
-        order: `desc`,
+        order: [`desc`],
       },
     })
 
@@ -441,7 +441,7 @@ describe(`collection fields`, () => {
       limit: 10,
       sort: {
         fields: [`waxOnly`],
-        order: `desc`,
+        order: [`desc`],
       },
     })
 
@@ -456,7 +456,7 @@ describe(`collection fields`, () => {
       limit: 10,
       sort: {
         fields: [`waxOnly`],
-        order: `asc`,
+        order: [`asc`],
       },
     })
 
@@ -466,18 +466,33 @@ describe(`collection fields`, () => {
     expect(result[2].id).toEqual(`0`)
   })
 
-  it(`applies order (asc/desc) to all sort fields`, async () => {
+  it(`applies specified sort order, and sorts asc by default`, async () => {
     let result = await runQuery({
       limit: 10,
       sort: {
         fields: [`frontmatter___blue`, `id`],
-        order: `desc`,
+        order: [`desc`], // `id` field will be sorted asc
       },
     })
 
     expect(result.length).toEqual(3)
     expect(result[0].id).toEqual(`1`) // blue = 10010, id = 1
     expect(result[1].id).toEqual(`2`) // blue = 10010, id = 2
+    expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
+  })
+
+  it(`applies specified sort order per field`, async () => {
+    let result = await runQuery({
+      limit: 10,
+      sort: {
+        fields: [`frontmatter___blue`, `id`],
+        order: [`desc`, `desc`], // `id` field will be sorted desc
+      },
+    })
+
+    expect(result.length).toEqual(3)
+    expect(result[0].id).toEqual(`2`) // blue = 10010, id = 2
+    expect(result[1].id).toEqual(`1`) // blue = 10010, id = 1
     expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
   })
 })

--- a/packages/gatsby/src/schema/create-sort-field.js
+++ b/packages/gatsby/src/schema/create-sort-field.js
@@ -33,14 +33,16 @@ module.exports = function createSortField(
         },
         order: {
           name: _.camelCase(`${typeName} sortOrder`),
-          defaultValue: `ASC`,
-          type: new GraphQLEnumType({
-            name: _.camelCase(`${typeName} sortOrderValues`),
-            values: {
-              ASC: { value: `asc` },
-              DESC: { value: `desc` },
-            },
-          }),
+          defaultValue: [`asc`],
+          type: new GraphQLList(
+            new GraphQLEnumType({
+              name: _.camelCase(`${typeName} sortOrderValues`),
+              values: {
+                ASC: { value: `asc` },
+                DESC: { value: `desc` },
+              },
+            })
+          ),
         },
       },
     }),

--- a/packages/gatsby/src/schema/create-sort-field.js
+++ b/packages/gatsby/src/schema/create-sort-field.js
@@ -33,7 +33,7 @@ module.exports = function createSortField(
         },
         order: {
           name: _.camelCase(`${typeName} sortOrder`),
-          defaultValue: [`asc`],
+          defaultValue: [`ASC`],
           type: new GraphQLList(
             new GraphQLEnumType({
               name: _.camelCase(`${typeName} sortOrderValues`),


### PR DESCRIPTION
This PR allows specifying the sort order per sort field by using an array of SortOrderEnums. The current behavior (only the sort order of the first sort field can be specified, the rest will always sort ASC) is preserved, since GraphQL will parse a single value on a GraphQLList field as an array (see [valueFromAST](https://github.com/graphql/graphql-js/blob/9e404659a15d59c5ce12aae433dd2a636ea9eb82/src/utilities/valueFromAST.js#L111)). Thanks @pieh for the idea!

Fixes #10121