### PR TITLE
fix(www): Change "updatedAt" to "pushedAt" for starters

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -559,7 +559,7 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
                   totalCount
                 }
                 createdAt
-                updatedAt
+                pushedAt
                 owner {
                   login
                 }
@@ -572,7 +572,7 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
           const [pkgjson, githubData] = results
           const {
             stargazers: { totalCount: stars },
-            updatedAt: lastUpdated,
+            pushedAt: lastUpdated,
             owner: { login: owner },
             name,
             nameWithOwner: githubFullName,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16143594/51912377-77b68500-23d4-11e9-972f-0f812cf0bb6b.png)

The left version uses "pushedAt" as it seems more reasonable than "updatedAt". It's not really clear why GitHub decides on those dates, e.g. [gatsby-starter](https://github.com/fabien0102/gatsby-starter) wasn't updated two days ago but rather ~ 2 months. "pushedAt" should make this clearer 👍 According to [SO](https://stackoverflow.com/a/15922637/10164092) the last commit to any branch counts but even that sounds like a better choice than the current one 😅 