### PR TITLE
chore(examples): remove unused dev-dependency from 'Using Jest' example

### DIFF
--- a/examples/using-jest/package.json
+++ b/examples/using-jest/package.json
@@ -35,7 +35,6 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.0.0",
     "jest-dom": "^3.0.0",
-    "react-test-renderer": "^16.7.0",
     "react-testing-library": "^5.4.4"
   },
   "repository": {


### PR DESCRIPTION
## Description

The package `react-test-renderer` is not used in this example, as it uses the `render` function from `react-testing-library`

## Related Issues

None
