### PR TITLE
fix(docs): add missing import in storybook docs

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -32,6 +32,7 @@ To update your Storybook config open `.storybook/config.js` and modify the conte
 
 ```js:title=.storybook/config.js
 import { configure } from "@storybook/react"
+import { action } from '@storybook/addon-actions';
 
 // automatically import all files ending in *.stories.js
 // highlight-next-line

--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -32,7 +32,7 @@ To update your Storybook config open `.storybook/config.js` and modify the conte
 
 ```js:title=.storybook/config.js
 import { configure } from "@storybook/react"
-import { action } from '@storybook/addon-actions';
+import { action } from "@storybook/addon-actions"
 
 // automatically import all files ending in *.stories.js
 // highlight-next-line


### PR DESCRIPTION
Add missing import of storybook's action in the "Visual Testing With Storybook" page