### PR TITLE
feat(gatsby): show path to page that fails to render html

### DIFF
--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -53,7 +53,12 @@ module.exports = async (program: any, activity: any) => {
           return resolve(null, stats)
         })
         .catch(e => {
-          reject(createErrorFromString(e.stack, `${outputFile}.map`))
+          const prettyError = createErrorFromString(
+            e.stack,
+            `${outputFile}.map`
+          )
+          prettyError.context = e.context
+          reject(prettyError)
         })
     })
   })

--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -7,6 +7,7 @@ const bootstrap = require(`../bootstrap`)
 const apiRunnerNode = require(`../utils/api-runner-node`)
 const { copyStaticDir } = require(`../utils/get-static-dir`)
 const { initTracer, stopTracer } = require(`../utils/tracer`)
+const chalk = require(`chalk`)
 const tracer = require(`opentracing`).globalTracer()
 
 function reportFailure(msg, err: Error) {
@@ -60,7 +61,7 @@ module.exports = async function build(program: BuildArgs) {
   await buildHTML(program, activity).catch(err => {
     reportFailure(
       report.stripIndent`
-        Building static HTML for pages failed
+        Building static HTML failed for path "${chalk.bold(err.context.path)}"
 
         See our docs page on debugging HTML builds for help https://gatsby.app/debug-html
       `,

--- a/packages/gatsby/src/utils/worker.js
+++ b/packages/gatsby/src/utils/worker.js
@@ -28,6 +28,10 @@ export function renderHTML({ htmlComponentRendererPath, paths, envVars }) {
             resolve(fs.outputFile(generatePathToOutput(path), htmlString))
           })
         } catch (e) {
+          // add some context to error so we can display more helpful message
+          e.context = {
+            path,
+          }
           reject(e)
         }
       })


### PR DESCRIPTION
This adds a bit more context when html builds fail, by displaying problematic "path":
![screenshot 2019-01-29 at 17 00 42](https://user-images.githubusercontent.com/419821/51922002-99216c00-23e8-11e9-90ef-4c7373a8e322.png)
