### PR TITLE
chore(www): replace s3/cloudfront with amplify on home page

### DIFF
--- a/www/src/data/diagram/static-hosts.yml
+++ b/www/src/data/diagram/static-hosts.yml
@@ -1,5 +1,5 @@
-- title: Amazon S3
-  url: /docs/deploying-to-s3-cloudfront
+- title: AWS Amplify
+  url: /docs/deploying-to-aws-amplify
 - title: Netlify
   url: /docs/hosting-on-netlify
 - title: GitHub Pages


### PR DESCRIPTION
Add AWS Amplify to the marketing page for hosting.