### PR TITLE
fix(www): skip showcase entries that don't have screenshots

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -210,7 +210,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
               main_url
               fields {
                 slug
-                hasScrenshoot
+                hasScreenshot
               }
             }
           }
@@ -379,7 +379,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
       result.data.allSitesYaml.edges.forEach(edge => {
         if (!edge.node.fields) return
         if (!edge.node.fields.slug) return
-        if (!edge.node.fields.hasScrenshoot) {
+        if (!edge.node.fields.hasScreenshot) {
           reporter.warn(
             `Site showcase entry "${
               edge.node.main_url
@@ -536,7 +536,7 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
       .map(childID => getNode(childID))
       .find(node => node.internal.type === `Screenshot`)
 
-    createNodeField({ node, name: `hasScrenshoot`, value: !!screenshotNode })
+    createNodeField({ node, name: `hasScreenshot`, value: !!screenshotNode })
   } else if (node.internal.type === `StartersYaml` && node.repo) {
     // To develop on the starter showcase, you'll need a GitHub
     // personal access token. Check the `www` README for details.

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -44,7 +44,7 @@ const slugToAnchor = slug =>
     .filter(item => item !== ``) // remove empty values
     .pop() // take last item
 
-exports.createPages = ({ graphql, actions }) => {
+exports.createPages = ({ graphql, actions, reporter }) => {
   const { createPage, createRedirect } = actions
 
   createRedirect({
@@ -207,8 +207,10 @@ exports.createPages = ({ graphql, actions }) => {
         allSitesYaml(filter: { main_url: { ne: null } }) {
           edges {
             node {
+              main_url
               fields {
                 slug
+                hasScrenshoot
               }
             }
           }
@@ -377,6 +379,14 @@ exports.createPages = ({ graphql, actions }) => {
       result.data.allSitesYaml.edges.forEach(edge => {
         if (!edge.node.fields) return
         if (!edge.node.fields.slug) return
+        if (!edge.node.fields.hasScrenshoot) {
+          reporter.warn(
+            `Site showcase entry "${
+              edge.node.main_url
+            }" seems offline. Skipping.`
+          )
+          return
+        }
         createPage({
           path: `${edge.node.fields.slug}`,
           component: slash(showcaseTemplate),
@@ -520,6 +530,13 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
     const cleaned = parsed.hostname + parsed.pathname
     slug = `/showcase/${slugify(cleaned)}`
     createNodeField({ node, name: `slug`, value: slug })
+
+    // determine if screenshot is available
+    const screenshotNode = node.children
+      .map(childID => getNode(childID))
+      .find(node => node.internal.type === `Screenshot`)
+
+    createNodeField({ node, name: `hasScrenshoot`, value: !!screenshotNode })
   } else if (node.internal.type === `StartersYaml` && node.repo) {
     // To develop on the starter showcase, you'll need a GitHub
     // personal access token. Check the `www` README for details.

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -103,7 +103,11 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
     query={graphql`
       query {
         allSitesYaml(
-          filter: { featured: { eq: true }, main_url: { ne: null } }
+          filter: {
+            featured: { eq: true }
+            main_url: { ne: null }
+            fields: { hasScrenshoot: { eq: true } }
+          }
         ) {
           edges {
             node {

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -106,7 +106,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
           filter: {
             featured: { eq: true }
             main_url: { ne: null }
-            fields: { hasScrenshoot: { eq: true } }
+            fields: { hasScreenshot: { eq: true } }
           }
         ) {
           edges {

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -19,7 +19,7 @@ export const showcaseQuery = graphql`
     featured: allSitesYaml(
       filter: {
         featured: { eq: true }
-        fields: { hasScrenshoot: { eq: true } }
+        fields: { hasScreenshot: { eq: true } }
       }
     ) {
       edges {
@@ -46,7 +46,7 @@ export const showcaseQuery = graphql`
     allSitesYaml(
       filter: {
         main_url: { ne: null }
-        fields: { hasScrenshoot: { eq: true } }
+        fields: { hasScreenshot: { eq: true } }
       }
     ) {
       edges {

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -16,7 +16,12 @@ export default ShowcasePage
 
 export const showcaseQuery = graphql`
   query {
-    featured: allSitesYaml(filter: { featured: { eq: true } }) {
+    featured: allSitesYaml(
+      filter: {
+        featured: { eq: true }
+        fields: { hasScrenshoot: { eq: true } }
+      }
+    ) {
       edges {
         node {
           id
@@ -38,7 +43,12 @@ export const showcaseQuery = graphql`
         }
       }
     }
-    allSitesYaml(filter: { main_url: { ne: null } }) {
+    allSitesYaml(
+      filter: {
+        main_url: { ne: null }
+        fields: { hasScrenshoot: { eq: true } }
+      }
+    ) {
       edges {
         node {
           id

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -225,46 +225,45 @@ class CreatorTemplate extends Component {
                 {creator.location}
               </p>
             </MetaSection>
-            {creator.portfolio === true &&
-              sites.length > 0 && (
-                <MetaSection background="transparent" last>
-                  <MetaTitle>Worked On</MetaTitle>
-                  <div
-                    css={{
-                      display: `flex`,
-                      alignItems: `flex-start`,
-                    }}
-                  >
-                    {sites.map(site => (
-                      <Link
-                        key={site.node.title}
-                        css={{
-                          "&&": {
-                            marginRight: rhythm(3 / 4),
-                            borderBottom: `none`,
-                            boxShadow: `none`,
-                            transition: `all ${
-                              presets.animation.speedDefault
-                            } ${presets.animation.curveDefault}`,
-                            "&:hover": {
-                              background: `none`,
-                            },
+            {creator.portfolio === true && sites.length > 0 && (
+              <MetaSection background="transparent" last>
+                <MetaTitle>Worked On</MetaTitle>
+                <div
+                  css={{
+                    display: `flex`,
+                    alignItems: `flex-start`,
+                  }}
+                >
+                  {sites.map(site => (
+                    <Link
+                      key={site.node.title}
+                      css={{
+                        "&&": {
+                          marginRight: rhythm(3 / 4),
+                          borderBottom: `none`,
+                          boxShadow: `none`,
+                          transition: `all ${presets.animation.speedDefault} ${
+                            presets.animation.curveDefault
+                          }`,
+                          "&:hover": {
+                            background: `none`,
                           },
-                        }}
-                        to={site.node.fields.slug}
-                      >
-                        <Img
-                          alt={`${site.node.title}`}
-                          fixed={
-                            site.node.childScreenshot.screenshotFile
-                              .childImageSharp.fixed
-                          }
-                        />
-                      </Link>
-                    ))}
-                  </div>
-                </MetaSection>
-              )}
+                        },
+                      }}
+                      to={site.node.fields.slug}
+                    >
+                      <Img
+                        alt={`${site.node.title}`}
+                        fixed={
+                          site.node.childScreenshot.screenshotFile
+                            .childImageSharp.fixed
+                        }
+                      />
+                    </Link>
+                  ))}
+                </div>
+              </MetaSection>
+            )}
           </div>
         </main>
       </Layout>

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -296,7 +296,7 @@ export const pageQuery = graphql`
         slug
       }
     }
-    allSitesYaml {
+    allSitesYaml(filter: { fields: { hasScrenshoot: { eq: true } } }) {
       edges {
         node {
           built_by

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -225,45 +225,46 @@ class CreatorTemplate extends Component {
                 {creator.location}
               </p>
             </MetaSection>
-            {creator.portfolio === true && sites.length > 0 && (
-              <MetaSection background="transparent" last>
-                <MetaTitle>Worked On</MetaTitle>
-                <div
-                  css={{
-                    display: `flex`,
-                    alignItems: `flex-start`,
-                  }}
-                >
-                  {sites.map(site => (
-                    <Link
-                      key={site.node.title}
-                      css={{
-                        "&&": {
-                          marginRight: rhythm(3 / 4),
-                          borderBottom: `none`,
-                          boxShadow: `none`,
-                          transition: `all ${presets.animation.speedDefault} ${
-                            presets.animation.curveDefault
-                          }`,
-                          "&:hover": {
-                            background: `none`,
+            {creator.portfolio === true &&
+              sites.length > 0 && (
+                <MetaSection background="transparent" last>
+                  <MetaTitle>Worked On</MetaTitle>
+                  <div
+                    css={{
+                      display: `flex`,
+                      alignItems: `flex-start`,
+                    }}
+                  >
+                    {sites.map(site => (
+                      <Link
+                        key={site.node.title}
+                        css={{
+                          "&&": {
+                            marginRight: rhythm(3 / 4),
+                            borderBottom: `none`,
+                            boxShadow: `none`,
+                            transition: `all ${
+                              presets.animation.speedDefault
+                            } ${presets.animation.curveDefault}`,
+                            "&:hover": {
+                              background: `none`,
+                            },
                           },
-                        },
-                      }}
-                      to={site.node.fields.slug}
-                    >
-                      <Img
-                        alt={`${site.node.title}`}
-                        fixed={
-                          site.node.childScreenshot.screenshotFile
-                            .childImageSharp.fixed
-                        }
-                      />
-                    </Link>
-                  ))}
-                </div>
-              </MetaSection>
-            )}
+                        }}
+                        to={site.node.fields.slug}
+                      >
+                        <Img
+                          alt={`${site.node.title}`}
+                          fixed={
+                            site.node.childScreenshot.screenshotFile
+                              .childImageSharp.fixed
+                          }
+                        />
+                      </Link>
+                    ))}
+                  </div>
+                </MetaSection>
+              )}
           </div>
         </main>
       </Layout>
@@ -296,7 +297,7 @@ export const pageQuery = graphql`
         slug
       }
     }
-    allSitesYaml(filter: { fields: { hasScrenshoot: { eq: true } } }) {
+    allSitesYaml(filter: { fields: { hasScreenshot: { eq: true } } }) {
       edges {
         node {
           built_by


### PR DESCRIPTION
this makes gatsbyjs.org builds more resilient to problems with site showcase entries going offline