### PR TITLE
fix(gatsby): always respond with index html without checking path

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -96,7 +96,6 @@
     "null-loader": "^0.1.1",
     "opentracing": "^0.14.3",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
-    "parse-filepath": "^1.0.1",
     "physical-cpu-count": "^2.0.0",
     "postcss-flexbugs-fixes": "^3.0.0",
     "postcss-loader": "^2.1.3",

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -187,20 +187,11 @@ async function startServer(program) {
 
   // Render an HTML page and serve it.
   app.use((req, res, next) => {
-    const parsedPath = parsePath(req.path)
-    if (
-      parsedPath.extname === `` ||
-      parsedPath.extname.startsWith(`.html`) ||
-      parsedPath.path.endsWith(`/`)
-    ) {
-      res.sendFile(directoryPath(`public/index.html`), err => {
-        if (err) {
-          res.status(500).end()
-        }
-      })
-    } else {
-      next()
-    }
+    res.sendFile(directoryPath(`public/index.html`), err => {
+      if (err) {
+        res.status(500).end()
+      }
+    })
   })
 
   /**

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -9,7 +9,6 @@ const express = require(`express`)
 const graphqlHTTP = require(`express-graphql`)
 const graphqlPlayground = require(`graphql-playground-middleware-express`)
   .default
-const parsePath = require(`parse-filepath`)
 const request = require(`request`)
 const rl = require(`readline`)
 const webpack = require(`webpack`)


### PR DESCRIPTION
During develop, we currently check path before returning our static html:
https://github.com/gatsbyjs/gatsby/blob/aa4f9397665d6d1e7ea6cdd3bfd6f40b449daccf/packages/gatsby/src/commands/develop.js#L192

This seems unnecessary because if all handlers above haven't responded to the request yet (webpack dev middleware, express static etc) it is safe to say that the request _needs_ to be handled here. 

Currently the checks for path and non-exhaustive and we miss out of complicated cases like /reference/mono-v6.x.x (directory)

Fixes https://github.com/gatsbyjs/gatsby/issues/11348