### PR TITLE
chore(gatsby): Remove unused prop pluginCreatorName

### DIFF
--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -22,7 +22,7 @@ export const pageSchema = Joi.object()
     componentChunkName: Joi.string().required(),
     context: Joi.object(),
     pluginCreator___NODE: Joi.string(),
-    pluginCreatorName: Joi.string(),
+    pluginCreatorId: Joi.string(),
   })
   .unknown()
 

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.js.snap
@@ -40,7 +40,7 @@ The following fields are used by the page object and should be avoided.
   * \\"component\\"
   * \\"componentChunkName\\"
   * \\"pluginCreator___NODE\\"
-  * \\"pluginCreatorName\\"
+  * \\"pluginCreatorId\\"
 
             "
 `;

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -137,7 +137,7 @@ actions.createPage = (
       `component`,
       `componentChunkName`,
       `pluginCreator___NODE`,
-      `pluginCreatorName`,
+      `pluginCreatorId`,
     ]
     const invalidFields = Object.keys(_.pick(page.context, reservedFields))
 


### PR DESCRIPTION
`pluginCreatorName` is apparently not used by anything, but `pluginCreatorId` is.