### PR TITLE
feat(gatsby-remark-katex): support katex options

### DIFF
--- a/packages/gatsby-remark-katex/README.md
+++ b/packages/gatsby-remark-katex/README.md
@@ -16,7 +16,13 @@ plugins: [
     resolve: `gatsby-transformer-remark`,
     options: {
       plugins: [
-        `gatsby-remark-katex`,
+        resolve: `gatsby-remark-katex`,
+        options: {
+          katexOptions: {
+            // Add any KaTeX options from https://github.com/KaTeX/KaTeX/blob/master/docs/options.md here
+            strict: "ignore"
+          }
+        }
       ],
     },
   },

--- a/packages/gatsby-remark-katex/README.md
+++ b/packages/gatsby-remark-katex/README.md
@@ -18,10 +18,8 @@ plugins: [
       plugins: [
         resolve: `gatsby-remark-katex`,
         options: {
-          katexOptions: {
-            // Add any KaTeX options from https://github.com/KaTeX/KaTeX/blob/master/docs/options.md here
-            strict: "ignore"
-          }
+          // Add any KaTeX options from https://github.com/KaTeX/KaTeX/blob/master/docs/options.md here
+          strict: "ignore"
         }
       ],
     },

--- a/packages/gatsby-remark-katex/README.md
+++ b/packages/gatsby-remark-katex/README.md
@@ -16,10 +16,12 @@ plugins: [
     resolve: `gatsby-transformer-remark`,
     options: {
       plugins: [
-        resolve: `gatsby-remark-katex`,
-        options: {
-          // Add any KaTeX options from https://github.com/KaTeX/KaTeX/blob/master/docs/options.md here
-          strict: `ignore`
+        {
+          resolve: `gatsby-remark-katex`,
+          options: {
+            // Add any KaTeX options from https://github.com/KaTeX/KaTeX/blob/master/docs/options.md here
+            strict: `ignore`
+          }
         }
       ],
     },

--- a/packages/gatsby-remark-katex/README.md
+++ b/packages/gatsby-remark-katex/README.md
@@ -19,7 +19,7 @@ plugins: [
         resolve: `gatsby-remark-katex`,
         options: {
           // Add any KaTeX options from https://github.com/KaTeX/KaTeX/blob/master/docs/options.md here
-          strict: "ignore"
+          strict: `ignore`
         }
       ],
     },

--- a/packages/gatsby-remark-katex/src/index.js
+++ b/packages/gatsby-remark-katex/src/index.js
@@ -2,12 +2,12 @@ const visit = require(`unist-util-visit`)
 const katex = require(`katex`)
 const remarkMath = require(`remark-math`)
 
-module.exports = ({ markdownAST }, { katexOptions }) => {
+module.exports = ({ markdownAST }, pluginOptions = {}) => {
   visit(markdownAST, `inlineMath`, node => {
     node.type = `html`
     node.value = katex.renderToString(node.value, {
       displayMode: false,
-      ...katexOptions,
+      ...pluginOptions,
     })
   })
 
@@ -15,7 +15,7 @@ module.exports = ({ markdownAST }, { katexOptions }) => {
     node.type = `html`
     node.value = katex.renderToString(node.value, {
       displayMode: true,
-      ...katexOptions,
+      ...pluginOptions,
     })
   })
 }

--- a/packages/gatsby-remark-katex/src/index.js
+++ b/packages/gatsby-remark-katex/src/index.js
@@ -2,11 +2,12 @@ const visit = require(`unist-util-visit`)
 const katex = require(`katex`)
 const remarkMath = require(`remark-math`)
 
-module.exports = ({ markdownAST }) => {
+module.exports = ({ markdownAST }, { katexOptions }) => {
   visit(markdownAST, `inlineMath`, node => {
     node.type = `html`
     node.value = katex.renderToString(node.value, {
       displayMode: false,
+      ...katexOptions,
     })
   })
 
@@ -14,6 +15,7 @@ module.exports = ({ markdownAST }) => {
     node.type = `html`
     node.value = katex.renderToString(node.value, {
       displayMode: true,
+      ...katexOptions,
     })
   })
 }


### PR DESCRIPTION
Add support for passing in KaTeX options (https://github.com/KaTeX/KaTeX/blob/master/docs/options.md)

Fixes https://github.com/gatsbyjs/gatsby/issues/11320