### PR TITLE
docs(www): Add note about BEM with CSS Modules

### DIFF
--- a/docs/docs/component-css.md
+++ b/docs/docs/component-css.md
@@ -40,3 +40,9 @@ Also make sure to notice that the `.container` style that you created is referre
 Following the same logic, you have the ability of creating multiple `module.css` files for multiple React components.
 
 You may take a look at a more in-depth [Component CSS tutorial](https://www.gatsbyjs.org/tutorial/part-two/#component-css) if you would like to see an example with explanation of multiple complex React components utilizing multiple `module.css` files and why you may want to use CSS Modules in your next project.
+
+### CSS Modules and BEM
+
+If you're used to writing CSS with the [BEM](http://getbem.com/) methodology, a quick thing to note is that CSS Modules camelizes class names that contain dashes.
+
+For example: `block--modifier` turns into `blockModifier`.

--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -490,6 +490,14 @@ The finished page should now look like:
 
 ![css-modules-final](css-modules-final.png)
 
+### CSS Modules and BEM
+
+If you're used to writing CSS with the [BEM](http://getbem.com/) methodology, a quick thing to note is that Gatsby camelizes class names that contain dashes.
+
+For example: `block--modifier` turns into `blockModifier`.
+
+We do this to make access in JavaScript easier.
+
 ### Other CSS options
 
 Gatsby supports almost every possible styling option (if there isn't a plugin

--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -490,14 +490,6 @@ The finished page should now look like:
 
 ![css-modules-final](css-modules-final.png)
 
-### CSS Modules and BEM
-
-If you're used to writing CSS with the [BEM](http://getbem.com/) methodology, a quick thing to note is that Gatsby camelizes class names that contain dashes.
-
-For example: `block--modifier` turns into `blockModifier`.
-
-We do this to make access in JavaScript easier.
-
 ### Other CSS options
 
 Gatsby supports almost every possible styling option (if there isn't a plugin


### PR DESCRIPTION
Adds a note mentioning that we camelize class names with dashes and its effect on in context of BEM

- Previously opened in https://github.com/gatsbyjs/gatsby/pull/10888
- Moved into documentation for CSS Modules as advised

Fixes #10852
