### PR TITLE
feat(examples): Add "Edit on Codesandbox" button

### DIFF
--- a/examples/image-processing/README.md
+++ b/examples/image-processing/README.md
@@ -5,3 +5,5 @@ https://image-processing.gatsbyjs.org
 Example site that demonstrates how to use [gatsby-plugin-sharp][1].
 
 [1]: https://www.gatsbyjs.org/packages/gatsby-plugin-sharp/
+
+[![Edit gatsby-example-image-processing](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/image-processing)

--- a/examples/using-gatsby-image/README.md
+++ b/examples/using-gatsby-image/README.md
@@ -3,3 +3,5 @@
 https://using-gatsby-image.gatsbyjs.org
 
 Gatsby example site that shows how to use the [gatsby-image](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image) plugin.
+
+[![Edit using-gatsby-image](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/using-gatsby-image)


### PR DESCRIPTION
As per discussion with @m-allanson we'll add two "edit on codesandbox" buttons in the READMEs of the examples. These examples/sources get linked on several doc pages so it's not totally necessary to change the docs about these, too.
We can track with the views/forks how many people use this offer.