### PR TITLE
Update README.md of gatsby-plugin-layout

### DIFF
--- a/packages/gatsby-plugin-layout/README.md
+++ b/packages/gatsby-plugin-layout/README.md
@@ -101,7 +101,7 @@ import React from "react"
 const defaultContextValue = {
   data: {
     // set your initial data shape here
-    showMenu: false,
+    menuOpen: false,
   },
   set: () => {},
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Theres a mistake in the Documentation for gatsby-plugin-layout. 
In context.js (first Code example of troubleshooting) the key in the `data` object is called `showMenu`
But below when it gets used it’s referred by `data.menuOpen`
To fix this I've changed `showMenu` to `menuOpen`

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->