### PR TITLE
feat(gatsby-plugin-manifest): make favicon link tag optional

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -233,9 +233,9 @@ module.exports = {
 }
 ```
 
-## Include `favicon` link tag
+## Exclude `favicon` link tag
 
-Inserts `<link rel="shortcut icon" href="/favicon.png" />` link tag to html output. You can set `include_favicon` plugin option to `true` to opt-in of this behaviour.
+Excludes `<link rel="shortcut icon" href="/favicon.png" />` link tag to html output. You can set `include_favicon` plugin option to `false` to opt-out of this behaviour.
 
 ```javascript:title=gatsby-config.js
 module.exports = {
@@ -251,7 +251,7 @@ module.exports = {
         display: `standalone`,
         icon: `src/images/icon.png`, // This path is relative to the root of the site.
         theme_color_in_head: false, // This will avoid adding theme-color meta tag.
-        include_favicon: true, // Include favicon
+        include_favicon: false, // This will exclude favicon link tag
       },
     },
   ],

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -50,6 +50,7 @@ module.exports = {
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: `standalone`,
         icon: `src/images/icon.png`, // This path is relative to the root of the site.
+        include_favicon: true, // Include favicon
       },
     },
   ],
@@ -226,6 +227,31 @@ module.exports = {
         display: `standalone`,
         icon: `src/images/icon.png`, // This path is relative to the root of the site.
         theme_color_in_head: false, // This will avoid adding theme-color meta tag.
+      },
+    },
+  ],
+}
+```
+
+## Include `favicon` link tag
+
+Inserts `<link rel="shortcut icon" href="/favicon.png" />` link tag to html output. You can set `include_favicon` plugin option to `true` to opt-in of this behaviour.
+
+```javascript:title=gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-manifest`,
+      options: {
+        name: `GatsbyJS`,
+        short_name: `GatsbyJS`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#a2466c`,
+        display: `standalone`,
+        icon: `src/images/icon.png`, // This path is relative to the root of the site.
+        theme_color_in_head: false, // This will avoid adding theme-color meta tag.
+        include_favicon: true, // Include favicon
       },
     },
   ],

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -163,6 +163,165 @@ Array [
 ]
 `;
 
+exports[`gatsby-plugin-manifest Adds link favicon if "include_favicon" option as is not provided  1`] = `
+Array [
+  <link
+    href="/icons/icon-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Adds link favicon if include_favicon option as is not provided  1`] = `
+Array [
+  <link
+    href="/icons/icon-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Adds link favicon tag if "include_favicon" is set to true 1`] = `
+Array [
+  <link
+    href="/icons/icon-48x48.png"
+    rel="shortcut icon"
+  />,
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
 exports[`gatsby-plugin-manifest Creates legacy apple touch links Using default set of icons 1`] = `
 Array [
   <link
@@ -349,7 +508,7 @@ Array [
 ]
 `;
 
-exports[`gatsby-plugin-manifest Does not add a link favicon if include_favicon option as false 1`] = `
+exports[`gatsby-plugin-manifest Does not add a link favicon if "include_favicon" option is set to false 1`] = `
 Array [
   <link
     href="/manifest.webmanifest"
@@ -398,7 +557,7 @@ Array [
 ]
 `;
 
-exports[`gatsby-plugin-manifest Does not add a link favicon if include_favicon option as is not provided  1`] = `
+exports[`gatsby-plugin-manifest Does not add a link favicon if include_favicon option is set to false 1`] = `
 Array [
   <link
     href="/manifest.webmanifest"

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -163,60 +163,7 @@ Array [
 ]
 `;
 
-exports[`gatsby-plugin-manifest Adds link favicon if "include_favicon" option as is not provided  1`] = `
-Array [
-  <link
-    href="/icons/icon-48x48.png"
-    rel="shortcut icon"
-  />,
-  <link
-    href="/manifest.webmanifest"
-    rel="manifest"
-  />,
-  <link
-    href="/icons/icon-48x48.png"
-    rel="apple-touch-icon"
-    sizes="48x48"
-  />,
-  <link
-    href="/icons/icon-72x72.png"
-    rel="apple-touch-icon"
-    sizes="72x72"
-  />,
-  <link
-    href="/icons/icon-96x96.png"
-    rel="apple-touch-icon"
-    sizes="96x96"
-  />,
-  <link
-    href="/icons/icon-144x144.png"
-    rel="apple-touch-icon"
-    sizes="144x144"
-  />,
-  <link
-    href="/icons/icon-192x192.png"
-    rel="apple-touch-icon"
-    sizes="192x192"
-  />,
-  <link
-    href="/icons/icon-256x256.png"
-    rel="apple-touch-icon"
-    sizes="256x256"
-  />,
-  <link
-    href="/icons/icon-384x384.png"
-    rel="apple-touch-icon"
-    sizes="384x384"
-  />,
-  <link
-    href="/icons/icon-512x512.png"
-    rel="apple-touch-icon"
-    sizes="512x512"
-  />,
-]
-`;
-
-exports[`gatsby-plugin-manifest Adds link favicon if include_favicon option as is not provided  1`] = `
+exports[`gatsby-plugin-manifest Adds link favicon if "include_favicon" option is not provided 1`] = `
 Array [
   <link
     href="/icons/icon-48x48.png"
@@ -509,55 +456,6 @@ Array [
 `;
 
 exports[`gatsby-plugin-manifest Does not add a link favicon if "include_favicon" option is set to false 1`] = `
-Array [
-  <link
-    href="/manifest.webmanifest"
-    rel="manifest"
-  />,
-  <link
-    href="/icons/icon-48x48.png"
-    rel="apple-touch-icon"
-    sizes="48x48"
-  />,
-  <link
-    href="/icons/icon-72x72.png"
-    rel="apple-touch-icon"
-    sizes="72x72"
-  />,
-  <link
-    href="/icons/icon-96x96.png"
-    rel="apple-touch-icon"
-    sizes="96x96"
-  />,
-  <link
-    href="/icons/icon-144x144.png"
-    rel="apple-touch-icon"
-    sizes="144x144"
-  />,
-  <link
-    href="/icons/icon-192x192.png"
-    rel="apple-touch-icon"
-    sizes="192x192"
-  />,
-  <link
-    href="/icons/icon-256x256.png"
-    rel="apple-touch-icon"
-    sizes="256x256"
-  />,
-  <link
-    href="/icons/icon-384x384.png"
-    rel="apple-touch-icon"
-    sizes="384x384"
-  />,
-  <link
-    href="/icons/icon-512x512.png"
-    rel="apple-touch-icon"
-    sizes="512x512"
-  />,
-]
-`;
-
-exports[`gatsby-plugin-manifest Does not add a link favicon if include_favicon option is set to false 1`] = `
 Array [
   <link
     href="/manifest.webmanifest"

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -349,6 +349,104 @@ Array [
 ]
 `;
 
+exports[`gatsby-plugin-manifest Does not add a link favicon if include_favicon option as false 1`] = `
+Array [
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
+exports[`gatsby-plugin-manifest Does not add a link favicon if include_favicon option as is not provided  1`] = `
+Array [
+  <link
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
 exports[`gatsby-plugin-manifest Does not create legacy apple touch links If "legacy" options is false and using default set of icons 1`] = `
 Array [
   <link

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -36,12 +36,26 @@ describe(`gatsby-plugin-manifest`, () => {
   })
 
   it(`Adds "shortcut icon" and "manifest" links and "theme_color" meta tag to head`, () => {
-    onRenderBody(ssrArgs, { icon: true, theme_color: `#000000` })
+    onRenderBody(ssrArgs, {
+      icon: true,
+      theme_color: `#000000`,
+      include_favicon: true,
+    })
+    expect(headComponents).toMatchSnapshot()
+  })
+
+  it(`Does not add a link favicon if include_favicon option as is not provided `, () => {
+    onRenderBody(ssrArgs, { icon: true })
+    expect(headComponents).toMatchSnapshot()
+  })
+
+  it(`Does not add a link favicon if include_favicon option as false`, () => {
+    onRenderBody(ssrArgs, { icon: true, include_favicon: false })
     expect(headComponents).toMatchSnapshot()
   })
 
   it(`Does not add a "theme_color" meta tag to head if "theme_color" option is not provided or is an empty string`, () => {
-    onRenderBody(ssrArgs, { icon: true })
+    onRenderBody(ssrArgs, { icon: true, include_favicon: true })
     expect(headComponents).toMatchSnapshot()
   })
 
@@ -50,6 +64,7 @@ describe(`gatsby-plugin-manifest`, () => {
       onRenderBody(ssrArgs, {
         icon: true,
         theme_color: `#000000`,
+        include_favicon: true,
       })
       expect(headComponents).toMatchSnapshot()
     })
@@ -58,6 +73,7 @@ describe(`gatsby-plugin-manifest`, () => {
       onRenderBody(ssrArgs, {
         icon: true,
         theme_color: `#000000`,
+        include_favicon: true,
         icons: [
           {
             src: `/favicons/android-chrome-48x48.png`,
@@ -81,6 +97,7 @@ describe(`gatsby-plugin-manifest`, () => {
         icon: true,
         theme_color: `#000000`,
         legacy: false,
+        include_favicon: true,
       })
       expect(headComponents).toMatchSnapshot()
     })
@@ -90,6 +107,7 @@ describe(`gatsby-plugin-manifest`, () => {
         icon: true,
         theme_color: `#000000`,
         legacy: false,
+        include_favicon: true,
         icons: [
           {
             src: `/favicons/android-chrome-48x48.png`,

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -47,7 +47,7 @@ describe(`gatsby-plugin-manifest`, () => {
     expect(headComponents).toMatchSnapshot()
   })
 
-  it(`Adds link favicon if "include_favicon" option as is not provided `, () => {
+  it(`Adds link favicon if "include_favicon" option is not provided`, () => {
     onRenderBody(ssrArgs, { icon: true })
     expect(headComponents).toMatchSnapshot()
   })

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -1,4 +1,3 @@
-// const { shallow } = require(`enzyme`)
 const { onRenderBody } = require(`../gatsby-ssr`)
 
 let headComponents
@@ -39,23 +38,27 @@ describe(`gatsby-plugin-manifest`, () => {
     onRenderBody(ssrArgs, {
       icon: true,
       theme_color: `#000000`,
-      include_favicon: true,
     })
     expect(headComponents).toMatchSnapshot()
   })
 
-  it(`Does not add a link favicon if include_favicon option as is not provided `, () => {
+  it(`Adds link favicon tag if "include_favicon" is set to true`, () => {
+    onRenderBody(ssrArgs, { icon: true, include_favicon: true })
+    expect(headComponents).toMatchSnapshot()
+  })
+
+  it(`Adds link favicon if "include_favicon" option as is not provided `, () => {
     onRenderBody(ssrArgs, { icon: true })
     expect(headComponents).toMatchSnapshot()
   })
 
-  it(`Does not add a link favicon if include_favicon option as false`, () => {
+  it(`Does not add a link favicon if "include_favicon" option is set to false`, () => {
     onRenderBody(ssrArgs, { icon: true, include_favicon: false })
     expect(headComponents).toMatchSnapshot()
   })
 
   it(`Does not add a "theme_color" meta tag to head if "theme_color" option is not provided or is an empty string`, () => {
-    onRenderBody(ssrArgs, { icon: true, include_favicon: true })
+    onRenderBody(ssrArgs, { icon: true })
     expect(headComponents).toMatchSnapshot()
   })
 
@@ -64,7 +67,6 @@ describe(`gatsby-plugin-manifest`, () => {
       onRenderBody(ssrArgs, {
         icon: true,
         theme_color: `#000000`,
-        include_favicon: true,
       })
       expect(headComponents).toMatchSnapshot()
     })
@@ -73,7 +75,6 @@ describe(`gatsby-plugin-manifest`, () => {
       onRenderBody(ssrArgs, {
         icon: true,
         theme_color: `#000000`,
-        include_favicon: true,
         icons: [
           {
             src: `/favicons/android-chrome-48x48.png`,
@@ -97,7 +98,6 @@ describe(`gatsby-plugin-manifest`, () => {
         icon: true,
         theme_color: `#000000`,
         legacy: false,
-        include_favicon: true,
       })
       expect(headComponents).toMatchSnapshot()
     })
@@ -107,7 +107,6 @@ describe(`gatsby-plugin-manifest`, () => {
         icon: true,
         theme_color: `#000000`,
         legacy: false,
-        include_favicon: true,
         icons: [
           {
             src: `/favicons/android-chrome-48x48.png`,

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -14,11 +14,10 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   if (pluginOptions.icon) {
     let favicon = icons && icons.length ? icons[0].src : null
 
-    const insertFaviconLinkTag = typeof pluginOptions.include_favicon !== `undefined` ? pluginOptions.include_favicon : true
-      `include_favicon`
-    )
-      ? pluginOptions.include_favicon
-      : true
+    const insertFaviconLinkTag =
+      typeof pluginOptions.include_favicon !== `undefined`
+        ? pluginOptions.include_favicon
+        : true
 
     if (favicon && insertFaviconLinkTag) {
       headComponents.push(

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -11,10 +11,16 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     typeof pluginOptions.legacy !== `undefined` ? pluginOptions.legacy : true
 
   // The user has an option to opt out of the favicon link tag being inserted into the head.
-  if (pluginOptions.icon && pluginOptions.include_favicon) {
+  if (pluginOptions.icon) {
     let favicon = icons && icons.length ? icons[0].src : null
 
-    if (favicon) {
+    let insertFaviconLinkTag = Object.keys(pluginOptions).includes(
+      `include_favicon`
+    )
+      ? pluginOptions.include_favicon
+      : true
+
+    if (favicon && insertFaviconLinkTag) {
       headComponents.push(
         <link
           key={`gatsby-plugin-manifest-icon-link`}

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -10,8 +10,8 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   const legacy =
     typeof pluginOptions.legacy !== `undefined` ? pluginOptions.legacy : true
 
-  // If icons were generated, also add a favicon link.
-  if (pluginOptions.icon) {
+  // The user has an option to opt out of the favicon link tag being inserted into the head.
+  if (pluginOptions.icon && pluginOptions.include_favicon) {
     let favicon = icons && icons.length ? icons[0].src : null
 
     if (favicon) {

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -14,7 +14,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   if (pluginOptions.icon) {
     let favicon = icons && icons.length ? icons[0].src : null
 
-    let insertFaviconLinkTag = Object.keys(pluginOptions).includes(
+    const insertFaviconLinkTag = typeof pluginOptions.include_favicon !== `undefined` ? pluginOptions.include_favicon : true
       `include_favicon`
     )
       ? pluginOptions.include_favicon


### PR DESCRIPTION
Related issue - https://github.com/gatsbyjs/gatsby/issues/11308

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Makes favicon link tag optional using plugin option `include_favicon`

## Related Issues

<!--
 Related issue - https://github.com/gatsbyjs/gatsby/issues/11308
Fixes #11308 
-->
