### PR TITLE
chore(gatsby): Correct fieldOwners in joi schema

### DIFF
--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -38,7 +38,7 @@ export const nodeSchema = Joi.object()
         mediaType: Joi.string(),
         type: Joi.string().required(),
         owner: Joi.string().required(),
-        fieldOwners: Joi.array(),
+        fieldOwners: Joi.object(),
         content: Joi.string().allow(``),
         description: Joi.string(),
         ignoreType: Joi.boolean(),


### PR DESCRIPTION
The `internal.fieldOwners` node property [is an object](https://github.com/gatsbyjs/gatsby/blob/2ba3f799054a854aefba5ca0627366bc11401b5c/packages/gatsby/src/redux/actions.js#L722), but the joi schema marks it as an array. This has been reported before as #2144.