### PR TITLE
ci(azure-pipelines): remove optional field that seems to cause problems

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,6 @@ steps:
     condition: succeededOrFailed()
     inputs:
       testResultsFiles: "**junit*.xml"
-      testRunTitle: TestRun ${{ parameters.name }} $(node_version)
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish code coverage results"


### PR DESCRIPTION
just testing - seems to azure pipelines seems to fail recently because `parameters` is unrecognized :O
