### PR TITLE
feat(gatsby-source-wordpress): add jwt_base_path option

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -91,9 +91,11 @@ module.exports = {
           wpcom_pass: process.env.WORDPRESS_PASSWORD,
 
           // If you use "JWT Authentication for WP REST API" (https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/)
+          // or (https://github.com/jonathan-dejong/simple-jwt-authentication) requires jwt_base_path, path can be found in wordpress wp-api.
           // plugin, you can specify user and password to obtain access token and use authenticated requests against wordpress REST API.
           jwt_user: process.env.JWT_USER,
           jwt_pass: process.env.JWT_PASSWORD,
+          jwt_base_path: "/jwt-auth/v1/token" # Default - can skip if you are using https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
         },
         // Set verboseOutput to true to display a verbose output on `npm run develop` or `npm run build`
         // It can help you debug specific API Endpoints problems.

--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -212,7 +212,7 @@ async function getWPCOMAccessToken(_auth) {
  */
 async function getJWToken(_auth, url) {
   let result
-  let authUrl = `${url}/jwt-auth/v1/token`
+  let authUrl = `${url}${_auth.jwt_base_path || `/jwt-auth/v1/token`}`
   try {
     const options = {
       url: authUrl,


### PR DESCRIPTION
## Description

Removes hardcoded JWT token path in gatsby-source-wordpress and passes it in auth options, to support other Wordpress JWT plugins. 

Test Passed and the functionality works locally. 