### PR TITLE
chore(renovate): Set semantic commit scope to starters

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
   "prConcurrentLimit": 20,
   "rebaseStalePrs": false,
   "rangeStrategy": "bump",
-  "bumpVersion": null
+  "bumpVersion": null,
+  "semanticCommitScope": "starters"
 }


### PR DESCRIPTION
Sets `semanticCommitScope` to `starters` since this configuration only handles packages for starters at the moment
