### PR TITLE
fix(gatsby): check type when querying by ID

### DIFF
--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -17,18 +17,30 @@ const mockNodes = [
   {
     id: `id_1`,
     string: `foo`,
+    internal: {
+      type: `notTest`,
+    },
   },
   {
     id: `id_2`,
     string: `bar`,
+    internal: {
+      type: `test`,
+    },
   },
   {
     id: `id_3`,
     string: `baz`,
+    internal: {
+      type: `test`,
+    },
   },
   {
     id: `id_4`,
     string: `qux`,
+    internal: {
+      type: `test`,
+    },
     first: {
       willBeResolved: `willBeResolved`,
       second: [
@@ -46,7 +58,8 @@ const mockNodes = [
 jest.mock(`../../db/nodes`, () => {
   return {
     getNode: id => mockNodes.find(node => node.id === id),
-    getNodesByType: () => mockNodes,
+    getNodesByType: type =>
+      mockNodes.filter(node => node.internal.type === type),
   }
 })
 
@@ -117,6 +130,30 @@ describe(`run-sift`, () => {
       expect(resultMany).toEqual([nodes[1]])
     })
 
+    it(`eq operator honors type`, async () => {
+      const queryArgs = {
+        filter: {
+          id: { eq: `id_1` },
+        },
+      }
+
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+      })
+
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+      })
+
+      // `id-1` node is not of queried type, so results should be empty
+      expect(resultSingular).toEqual([])
+      expect(resultMany).toEqual(null)
+    })
+
     it(`non-eq operator`, async () => {
       const queryArgs = {
         filter: {
@@ -136,8 +173,8 @@ describe(`run-sift`, () => {
         firstOnly: false,
       })
 
-      expect(resultSingular).toEqual([nodes[0]])
-      expect(resultMany).toEqual([nodes[0], nodes[2], nodes[3]])
+      expect(resultSingular).toEqual([nodes[2]])
+      expect(resultMany).toEqual([nodes[2], nodes[3]])
     })
   })
 

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -287,11 +287,15 @@ module.exports = (args: Object) => {
   // If the the query for single node only has a filter for an "id"
   // using "eq" operator, then we'll just grab that ID and return it.
   if (isEqId(firstOnly, fieldsToSift, siftArgs)) {
-    return resolveRecursive(
-      getNode(siftArgs[0].id[`$eq`]),
-      fieldsToSift,
-      gqlType.getFields()
-    ).then(node => (node ? [node] : []))
+    const node = getNode(siftArgs[0].id[`$eq`])
+
+    if (!node || (node.internal && node.internal.type !== gqlType.name)) {
+      return []
+    }
+
+    return resolveRecursive(node, fieldsToSift, gqlType.getFields()).then(
+      node => (node ? [node] : [])
+    )
   }
 
   return resolveNodes(


### PR DESCRIPTION
When querying/filter by id our special case doesn't check for type and can return nodes of wrong type ( https://github.com/gatsbyjs/gatsby/blob/2f79efeddd090c1d834625fedc011cf3b4d30b4b/packages/gatsby/src/redux/run-sift.js#L287-L295 )

This adds validation that return node is of correct type.

This fixes `Expected value of type "X" but got: [object Object].` errors when using queries like:
```
    wordpressWpTalk(id: { eq: $id }) {
      title
      content
    }
    wordpressPage(id: { eq: $id }) {
      title
      content
    }
```
where both fields would try to return same node even if it should only return node for one of them (one that matches the type)