### PR TITLE
fix(starters): Add landmarks to default & blog starters

### DIFF
--- a/starters/blog/src/components/Layout.js
+++ b/starters/blog/src/components/Layout.js
@@ -60,8 +60,8 @@ class Layout extends React.Component {
           padding: `${rhythm(1.5)} ${rhythm(3 / 4)}`,
         }}
       >
-        {header}
-        {children}
+        <header>{header}</header>
+        <main>{children}</main>
         <footer>
           © {new Date().getFullYear()}, Built with
           {` `}

--- a/starters/default/src/components/header.js
+++ b/starters/default/src/components/header.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import React from "react"
 
 const Header = ({ siteTitle }) => (
-  <div
+  <header
     style={{
       background: `rebeccapurple`,
       marginBottom: `1.45rem`,
@@ -28,7 +28,7 @@ const Header = ({ siteTitle }) => (
         </Link>
       </h1>
     </div>
-  </div>
+  </header>
 )
 
 Header.propTypes = {

--- a/starters/default/src/components/layout.js
+++ b/starters/default/src/components/layout.js
@@ -27,7 +27,7 @@ const Layout = ({ children }) => (
             paddingTop: 0,
           }}
         >
-          {children}
+          <main>{children}</main>
           <footer>
             © {new Date().getFullYear()}, Built with
             {` `}


### PR DESCRIPTION
## Description

When I pulled in the default starter to to build my website, one of the first things I changed was to add more HTML landmarks. So that everyone can benefit from this accessibility improvement, I added `main` and `header` elements to the default and blog starters. That way, screen reader users can navigate Gatsby sites by landmarks. 

More information: https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html