### PR TITLE
docs: Add codesandbox sortorder example to graphql-reference

### DIFF
--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -92,6 +92,8 @@ You can also sort on multiple fields but the `sort` keyword can only be used onc
 
 By default, sort `fields` will be sorted in ascending order. Optionally, you can specify a sort `order` per field by providing an array of `ASC` (for ascending) or `DESC` (for descending) values. For example, to sort by `frontmatter.date` in ascending order, and additionally by `frontmatter.title` in descending order, you would use `sort: { fields: [frontmatter___date, frontmatter___title], order: [ASC, DESC] }`. Note that if you only provide a single sort `order` value, this will affect the first sort field only, the rest will be sorted in default ascending order.
 
+<iframe src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20sort%3A%20%7B%0A%20%20%20%20%20%20fields%3A%20%5Bfrontmatter___date%2C%20frontmatter___title%5D%0A%20%20%20%20%20%20order%3A%20%5BASC%2C%20DESC%5D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D" width="600" height="400"></iframe>
+
 ## Format
 
 ### Dates

--- a/examples/graphql-reference/package.json
+++ b/examples/graphql-reference/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "LekoArts <hello@lekoarts.de>",
   "dependencies": {
-    "gatsby": "^2.0.85",
+    "gatsby": "^2.0.107",
     "gatsby-image": "^2.0.22",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.6",


### PR DESCRIPTION
Add codesandbox for specifying sort order per sort field.
Will the codesandbox auto-update when `examples/graphql-reference/package.json` is changed?