### PR TITLE
fix(gatsby-plugin-react-css-modules): fix generateScopedName in production

### DIFF
--- a/packages/gatsby-plugin-react-css-modules/src/gatsby-node.js
+++ b/packages/gatsby-plugin-react-css-modules/src/gatsby-node.js
@@ -1,6 +1,4 @@
 exports.onCreateBabelConfig = ({ actions }, pluginOptions) => {
-  const isDevelopment = process.env.NODE_ENV !== `production`
-
   if (pluginOptions.plugins) {
     delete pluginOptions.plugins
   }
@@ -8,9 +6,7 @@ exports.onCreateBabelConfig = ({ actions }, pluginOptions) => {
   actions.setBabelPlugin({
     name: `babel-plugin-react-css-modules`,
     options: {
-      generateScopedName: isDevelopment
-        ? `[name]--[local]--[hash:base64:5]`
-        : `[hash:base64:5]`,
+      generateScopedName: `[name]--[local]--[hash:base64:5]`,
       webpackHotModuleReloading: process.env.NODE_ENV !== `production`,
       ...pluginOptions,
     },


### PR DESCRIPTION
We'd added a shorter class name template for production in https://github.com/gatsbyjs/gatsby/pull/8496

Unfortunately this breaks `gatsby build` as reproducible in https://github.com/sidharthachatterjee/css-modules-test because `localIdentName` 
 is hard coded in https://github.com/gatsbyjs/gatsby/blob/97c98e9cf9229369892f5fee04458c9018cd2c07/packages/gatsby/src/utils/webpack-utils.js#L201

Ideally, we'd be able to get the localIdentName set in css.loaders() but `onCreateBabelConfig` only gets the `stage` and is _too_ early (store has an empty webpack config) in the process 

For now, we're hard coding the value to what is set in webpack-utils.js

Fixes https://github.com/gatsbyjs/gatsby/issues/11463