### PR TITLE
feat(gatsby-plugin-netlify): Allow status codes in redirects (#11255) 

### DIFF
--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -113,10 +113,9 @@ You can create redirects using the [`createRedirect`](https://www.gatsbyjs.org/d
 
 In addition to the options provided by the Gatsby API, you can pass these options specific to this plugin:
 
-| Attribute | Description                                                                                                                                                                                                        |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Attribute | Description |
+| --------- | ----------- |
 | `force`   | Overrides existing content in the path. This is particularly useful for domain alias redirects. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#structured-configuration). |
-
 | `statusCode` | Overrides the HTTP status code whih is `302` by default, or `301` when [`isPermanent`](https://www.gatsbyjs.org/docs/actions/#createRedirect) is `true`. Since Netlify supports more status codes, this allows you to set a different status code. Like `200` for a rewrite, or `404` for a custom error page. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#http-status-codes). |
 
 An example:

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -116,7 +116,7 @@ In addition to the options provided by the Gatsby API, you can pass these option
 | Attribute | Description |
 | --------- | ----------- |
 | `force`   | Overrides existing content in the path. This is particularly useful for domain alias redirects. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#structured-configuration). |
-| `statusCode` | Overrides the HTTP status code whih is `302` by default, or `301` when [`isPermanent`](https://www.gatsbyjs.org/docs/actions/#createRedirect) is `true`. Since Netlify supports more status codes, this allows you to set a different status code. Like `200` for a rewrite, or `404` for a custom error page. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#http-status-codes). |
+| `statusCode` | Overrides the HTTP status code which is set to `302`  by default or `301` when [`isPermanent`](https://www.gatsbyjs.org/docs/actions/#createRedirect) is `true`. Since Netlify supports custom status codes, you can set one here. For example, `200` for rewrites, or `404` for a custom error page. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#http-status-codes). |
 
 An example:
 

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -123,6 +123,7 @@ An example:
 ```javascript
 createRedirect({ fromPath: "/old-url", toPath: "/new-url", isPermanent: true })
 createRedirect({ fromPath: "/url", toPath: "/zn-CH/url", Language: "zn" })
+createRedirect({ fromPath: "/url_that_is/not_pretty", toPath: "/pretty/url", statusCode: 200 })
 ```
 
 You can also create a `_redirects` file in the `static` folder for the same effect. Any programmatically created redirects will be appended to the file.

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -113,17 +113,21 @@ You can create redirects using the [`createRedirect`](https://www.gatsbyjs.org/d
 
 In addition to the options provided by the Gatsby API, you can pass these options specific to this plugin:
 
-| Attribute | Description |
-| --------- | ----------- |
-| `force`   | Overrides existing content in the path. This is particularly useful for domain alias redirects. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#structured-configuration). |
-| `statusCode` | Overrides the HTTP status code which is set to `302`  by default or `301` when [`isPermanent`](https://www.gatsbyjs.org/docs/actions/#createRedirect) is `true`. Since Netlify supports custom status codes, you can set one here. For example, `200` for rewrites, or `404` for a custom error page. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#http-status-codes). |
+| Attribute    | Description                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `force`      | Overrides existing content in the path. This is particularly useful for domain alias redirects. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#structured-configuration).                                                                                                                                                                                               |
+| `statusCode` | Overrides the HTTP status code which is set to `302` by default or `301` when [`isPermanent`](https://www.gatsbyjs.org/docs/actions/#createRedirect) is `true`. Since Netlify supports custom status codes, you can set one here. For example, `200` for rewrites, or `404` for a custom error page. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#http-status-codes). |
 
 An example:
 
 ```javascript
 createRedirect({ fromPath: "/old-url", toPath: "/new-url", isPermanent: true })
 createRedirect({ fromPath: "/url", toPath: "/zn-CH/url", Language: "zn" })
-createRedirect({ fromPath: "/url_that_is/not_pretty", toPath: "/pretty/url", statusCode: 200 })
+createRedirect({
+  fromPath: "/url_that_is/not_pretty",
+  toPath: "/pretty/url",
+  statusCode: 200,
+})
 ```
 
 You can also create a `_redirects` file in the `static` folder for the same effect. Any programmatically created redirects will be appended to the file.

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -111,14 +111,20 @@ You can validate the `_headers` config through the
 
 You can create redirects using the [`createRedirect`](https://www.gatsbyjs.org/docs/actions/#createRedirect) action.
 
+In addition to the options provided by the Gatsby API, you can pass these options specific to this plugin:
+
+| Attribute | Description                                                                                                                                                                                                        |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `force`   | Overrides existing content in the path. This is particularly useful for domain alias redirects. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#structured-configuration). |
+
+| `statusCode` | Overrides the HTTP status code whih is `302` by default, or `301` when [`isPermanent`](https://www.gatsbyjs.org/docs/actions/#createRedirect) is `true`. Since Netlify supports more status codes, this allows you to set a different status code. Like `200` for a rewrite, or `404` for a custom error page. See [the Netlify documentation for this option](https://www.netlify.com/docs/redirects/#http-status-codes). |
+
 An example:
 
 ```javascript
 createRedirect({ fromPath: "/old-url", toPath: "/new-url", isPermanent: true })
 createRedirect({ fromPath: "/url", toPath: "/zn-CH/url", Language: "zn" })
 ```
-
-> NOTE: You can pass the `force` option to override existing content in the path. This is particularly useful for domain alias redirects. See the Netlify documentation on this option [here](https://www.netlify.com/docs/redirects/#structured-configuration).
 
 You can also create a `_redirects` file in the `static` folder for the same effect. Any programmatically created redirects will be appended to the file.
 

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -21,7 +21,7 @@ export default async function writeRedirectsFile(
       redirectInBrowser, // eslint-disable-line no-unused-vars
       force,
       toPath,
-      statusCode, // eslint-disable-line no-unused-vars
+      statusCode,
       ...rest
     } = redirect
 

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -21,10 +21,12 @@ export default async function writeRedirectsFile(
       redirectInBrowser, // eslint-disable-line no-unused-vars
       force,
       toPath,
+      statusCode, // eslint-disable-line no-unused-vars
       ...rest
     } = redirect
 
     let status = isPermanent ? `301` : `302`
+    if (statusCode) status = statusCode
 
     if (force) status = status.concat(`!`)
 

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1072,16 +1072,20 @@ actions.setPluginStatus = (
  * Create a redirect from one page to another. Server redirects don't work out
  * of the box. You must have a plugin setup to integrate the redirect data with
  * your hosting technology e.g. the [Netlify
- * plugin](/packages/gatsby-plugin-netlify/)).
+ * plugin](/packages/gatsby-plugin-netlify/), or the [Amazon S3
+ * plugin](/packages/gatsby-plugin-s3/).
  *
  * @param {Object} redirect Redirect data
  * @param {string} redirect.fromPath Any valid URL. Must start with a forward slash
  * @param {boolean} redirect.isPermanent This is a permanent redirect; defaults to temporary
  * @param {string} redirect.toPath URL of a created page (see `createPage`)
  * @param {boolean} redirect.redirectInBrowser Redirects are generally for redirecting legacy URLs to their new configuration. If you can't update your UI for some reason, set `redirectInBrowser` to true and Gatsby will handle redirecting in the client as well.
+ * @param {boolean} redirect.force (Plugin-specific) Will trigger the redirect even if the `fromPath` matches a piece of content. This is not part of the Gatsby API, but implemented by (some) plugins that configure hosting provider redirects
+ * @param {number} redirect.statusCode (Plugin-specific) Manually set the HTTP status code. This allows you to create a rewrite (status code 200) or custom error page (status code 404). Note that this will override the `isPermanent` option which also sets the status code. This is not part of the Gatsby API, but implemented by (some) plugins that configure hosting provider redirects
  * @example
  * createRedirect({ fromPath: '/old-url', toPath: '/new-url', isPermanent: true })
  * createRedirect({ fromPath: '/url', toPath: '/zn-CH/url', Language: 'zn' })
+ * createRedirect({ fromPath: '/not_so-pretty_url', toPath: '/pretty/url', statusCode: 200 })
  */
 actions.createRedirect = ({
   fromPath,


### PR DESCRIPTION
## Description

This addresses #11255. A request to implement support for status
codes other that 301/302 for this plugin, as Netlify also supports
other status codes.

@sidharthachatterjee suggested I submitted a PR
with my proposed changes, and this is that PR.

It adds one option to the `createRedirect` call which is `statusCode`.
You can use it to manually set the status code. If it's not set, the
status code will be determined by the `isPermanent` option as before
(`301` if `true` or `302` if not (the default) ).

I've also updated the README to document this new feature.

## Related Issues

Fixes #11255 