### PR TITLE
feat(docs): link stub to github issue

### DIFF
--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -81,7 +81,19 @@ Check the GitHub repo for issues labeled with ["documentation" and "good first i
    > Note: If your issue and/or PR doesn't meet the above contribution criteria, it may receive a comment reminding you to do so. If, after two weeks, these updates haven't been made, your issue and/or PR may be closed, which helps us triage issues and PRs efficiently. You can request that it be reopened if and when you are ready to make the updates required.
 3. GitHub then allows you to commit the change and raise a PR right in the UI. This is the _easiest_ way you can contribute to the project!
 
-If you wrote a new document that was previously a stub, update `www/src/data/sidebars/doc-links.yaml` accordingly by removing the asterisk behind the document's title:
+If you wrote a new document that was previously a stub, there is two things you need to update.
+
+1. Remove the frontmatter that links to the issue
+
+```diff:title=docs/docs/example-doc.md
+  ...
+    title: Example Document
+- - issue: https://github.com/gatsbyjs/gatsby/issues/00000
++ -
+  ...
+```
+
+2. Edit `www/src/data/sidebars/doc-links.yaml` by removing the asterisk behind the document's title:
 
 ```diff:title=www/src/data/sidebars/doc-links.yaml
   ...

--- a/docs/docs/how-to-contribute.md
+++ b/docs/docs/how-to-contribute.md
@@ -81,7 +81,7 @@ Check the GitHub repo for issues labeled with ["documentation" and "good first i
    > Note: If your issue and/or PR doesn't meet the above contribution criteria, it may receive a comment reminding you to do so. If, after two weeks, these updates haven't been made, your issue and/or PR may be closed, which helps us triage issues and PRs efficiently. You can request that it be reopened if and when you are ready to make the updates required.
 3. GitHub then allows you to commit the change and raise a PR right in the UI. This is the _easiest_ way you can contribute to the project!
 
-If you wrote a new document that was previously a stub, there is two things you need to update.
+If you wrote a new document that was previously a stub, there are two things you need to update.
 
 1. Remove the frontmatter that links to the issue
 

--- a/docs/docs/how-to-run-a-gatsby-workshop.md
+++ b/docs/docs/how-to-run-a-gatsby-workshop.md
@@ -1,5 +1,6 @@
 ---
 title: How to run a Gatsby workshop
+issue: https://github.com/gatsbyjs/gatsby/issues/8847
 ---
 
 This is a stub. Help our community expand it.

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -181,6 +181,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
                 draft
                 canonicalLink
                 publishedAt
+                issue
                 tags
               }
             }

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -87,6 +87,15 @@ class DocsTemplate extends React.Component {
                   __html: html,
                 }}
               />
+              {page.frontmatter.issue && (
+                <a
+                  href={page.frontmatter.issue}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  See The Issue realting to this stub On Github
+                </a>
+              )}
               <MarkdownPageFooter page={page} />
             </Container>
           </DocSearchContent>

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -93,7 +93,7 @@ class DocsTemplate extends React.Component {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  See The Issue realting to this stub On Github
+                  See the issue relating to this stub on GitHub
                 </a>
               )}
               <MarkdownPageFooter page={page} />
@@ -120,6 +120,7 @@ export const pageQuery = graphql`
       frontmatter {
         title
         overview
+        issue
       }
       ...MarkdownPageFooter
     }


### PR DESCRIPTION
## Description
- Adds a field to docs frontmatter to link to an issue on GitHub
- If this field is present it will generate a link to the issue on GitHub
- Updates documentation on removing the link to issue when a `stub` is converted to a `doc`

## Related Issues
Closes #11342

Not sure the style of the link is the best way to display this. Happy to have someone provide contribution to this. 
