### PR TITLE
Fix import babel traverse

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
+++ b/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
@@ -1,7 +1,7 @@
 const _ = require(`lodash`)
 const crypto = require(`crypto`)
 const babylon = require(`@babel/parser`)
-const traverse = require(`babel-traverse`).default
+const traverse = require(`@babel/traverse`).default
 
 async function onCreateNode({ node, getNode, actions, loadNodeContent }) {
   const { createNode, createParentChildLink } = actions


### PR DESCRIPTION
I'm getting an error after running my app because it can't find `babel-traverse`. I detected that the dependency declared actually is `@babel/traverse`, so I updated it properly.