### PR TITLE
feat(www): use blog post preview component on tags pages

### DIFF
--- a/docs/blog/2019-01-31-why-themes/index.md
+++ b/docs/blog/2019-01-31-why-themes/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Why Themes?"
-date: "2019-01-31"
+date: 2019-01-31
 author: "Kyle Mathews"
 tags: ["themes"]
 ---

--- a/www/package.json
+++ b/www/package.json
@@ -93,7 +93,7 @@
   "scripts": {
     "build": "gatsby build",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
-    "develop": "gatsby develop",
+    "develop": "GATSBY_GRAPHQL_IDE=playground gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -1,9 +1,10 @@
 import React from "react"
-import PropTypes from "prop-types"
 import { Link, graphql } from "gatsby"
 
+import BlogPostPreviewItem from "../components/blog-post-preview-item"
 import Container from "../components/container"
 import Layout from "../components/layout"
+import { rhythm } from "../utils/typography"
 
 const Tags = ({ pageContext, data, location }) => {
   const { tag } = pageContext
@@ -16,43 +17,17 @@ const Tags = ({ pageContext, data, location }) => {
     <Layout location={location}>
       <Container>
         <h1>{tagHeader}</h1>
-        <ul>
-          {edges.map(({ node }) => {
-            const {
-              frontmatter: { title },
-              fields: { slug },
-            } = node
-            return (
-              <li key={slug}>
-                <Link to={slug}>{title}</Link>
-              </li>
-            )
-          })}
-        </ul>
+        {edges.map(({ node }) => (
+          <BlogPostPreviewItem
+            post={node}
+            key={node.fields.slug}
+            css={{ marginBottom: rhythm(2) }}
+          />
+        ))}
         <Link to="/blog/tags">All tags</Link>
       </Container>
     </Layout>
   )
-}
-
-Tags.propTypes = {
-  pageContext: PropTypes.shape({
-    tag: PropTypes.string.isRequired,
-  }),
-  data: PropTypes.shape({
-    allMarkdownRemark: PropTypes.shape({
-      totalCount: PropTypes.number.isRequired,
-      edges: PropTypes.arrayOf(
-        PropTypes.shape({
-          node: PropTypes.shape({
-            frontmatter: PropTypes.shape({
-              title: PropTypes.string.isRequired,
-            }),
-          }),
-        }).isRequired
-      ),
-    }),
-  }),
 }
 
 export default Tags
@@ -61,7 +36,7 @@ export const pageQuery = graphql`
   query($tag: String) {
     allMarkdownRemark(
       limit: 2000
-      sort: { fields: [frontmatter___date, fields___slug], order: DESC }
+      sort: { fields: [frontmatter___date], order: DESC }
       filter: {
         frontmatter: { tags: { in: [$tag] } }
         fileAbsolutePath: { regex: "/docs.blog/" }
@@ -71,12 +46,7 @@ export const pageQuery = graphql`
       totalCount
       edges {
         node {
-          fields {
-            slug
-          }
-          frontmatter {
-            title
-          }
+          ...BlogPostPreview_item
         }
       }
     }

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -36,7 +36,7 @@ export const pageQuery = graphql`
   query($tag: String) {
     allMarkdownRemark(
       limit: 2000
-      sort: { fields: [frontmatter___date], order: DESC }
+      sort: { fields: [frontmatter___date, fields___slug], order: DESC }
       filter: {
         frontmatter: { tags: { in: [$tag] } }
         fileAbsolutePath: { regex: "/docs.blog/" }


### PR DESCRIPTION
## Improvements to Tags Page
Adding more details to the tags Page. To accomplish that, I reused the `BlogPostPreviewItem` component that is already used by the `contributor`-template.

This shoud fix #11491

It looks like this now:

<img width="1427" alt="screenshot 2019-02-02 at 10 45 39" src="https://user-images.githubusercontent.com/1507057/52162666-b780b380-26d7-11e9-9ad1-ec93be699364.png">
