### PR TITLE
fix(gatsby-plugin-google-grag): add additional check to prevent crash in Safari (#11431)

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -55,7 +55,7 @@ exports.onRenderBody = (
           : `true`
       }) {
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
+        function gtag(){window.dataLayer && window.dataLayer.push(arguments);}
         gtag('js', new Date());
 
         ${pluginOptions.trackingIds


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR fixes an issue in Safari. When turned on 
1. `respectDNT`
2. Ask websites do not track me.
3. Enable Content Blockers.
4. Ka-Block! extension installed and launched.

the error `ReferenceError: Can't find variable: dataLayer` is thrown and no content loaded at all.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #11431.