### PR TITLE
chore(www): update twitter link title tag

### DIFF
--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -186,10 +186,7 @@ const Navigation = ({ pathname }) => {
             >
               <DiscordIcon overrideCSS={{ verticalAlign: `text-top` }} />
             </SocialNavItem>
-            <SocialNavItem
-              href="https://twitter.com/gatsbyjs"
-              title="@gatsbyjs"
-            >
+            <SocialNavItem href="https://twitter.com/gatsbyjs" title="Twitter">
               <TwitterIcon style={{ verticalAlign: `text-top` }} />
             </SocialNavItem>
           </div>


### PR DESCRIPTION
This is a really small thing - but I've just noticed that the title tag for the Twitter link is different to the other social media title tags. Instead of "Github, Discord, @gatsby, gatsbyjs.com" it now reads "Github, Discord, Twitter, gatsbyjs.com"