### PR TITLE
Docs: Add labels to form example

### DIFF
--- a/docs/docs/adding-forms.md
+++ b/docs/docs/adding-forms.md
@@ -88,18 +88,24 @@ export default class IndexPage extends React.Component {
   render() {
     return (
       <form>
-        <input
-          type="text"
-          name="firstName"
-          value={this.state.firstName}
-          onChange={this.handleInputChange}
-        />
-        <input
-          type="text"
-          name="lastName"
-          value={this.state.lastName}
-          onChange={this.handleInputChange}
-        />
+        <label>
+          First name
+          <input
+            type="text"
+            name="firstName"
+            value={this.state.firstName}
+            onChange={this.handleInputChange}
+          />
+        </label>
+        <label>
+          Last name
+          <input
+            type="text"
+            name="lastName"
+            value={this.state.lastName}
+            onChange={this.handleInputChange}
+          />
+        </label>
         <button type="submit">Submit</button>
       </form>
     )
@@ -136,18 +142,24 @@ export default class IndexPage extends React.Component {
   render() {
     return (
       <form onSubmit={this.handleSubmit}>
-        <input
-          type="text"
-          name="firstName"
-          value={this.state.firstName}
-          onChange={this.handleInputChange}
-        />
-        <input
-          type="text"
-          name="lastName"
-          value={this.state.lastName}
-          onChange={this.handleInputChange}
-        />
+        <label>
+          First name
+          <input
+            type="text"
+            name="firstName"
+            value={this.state.firstName}
+            onChange={this.handleInputChange}
+          />
+        </label>
+        <label>
+          Last name
+          <input
+            type="text"
+            name="lastName"
+            value={this.state.lastName}
+            onChange={this.handleInputChange}
+          />
+        </label>
         <button type="submit">Submit</button>
       </form>
     )


### PR DESCRIPTION
## Description

This change adds HTML labels to the form examples, because unlabeled inputs mean screen reader users can't really use them. We should show accessible examples in the docs at all times!