### PR TITLE
fix(gatsby): Fix Loki query operators special casing

### DIFF
--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -275,14 +275,11 @@ function handleMany(siftArgs, nodes, sort) {
  */
 module.exports = (args: Object) => {
   const { queryArgs, gqlType, firstOnly = false } = args
-  // Clone args as for some reason graphql-js removes the constructor
-  // from nested objects which breaks a check in sift.js.
-  const clonedArgs = JSON.parse(JSON.stringify(queryArgs))
 
   // If nodes weren't provided, then load them from the DB
   const nodes = args.nodes || getNodesByType(gqlType.name)
 
-  const { siftArgs, fieldsToSift } = parseFilter(clonedArgs.filter)
+  const { siftArgs, fieldsToSift } = parseFilter(queryArgs.filter)
 
   // If the the query for single node only has a filter for an "id"
   // using "eq" operator, then we'll just grab that ID and return it.
@@ -304,7 +301,7 @@ module.exports = (args: Object) => {
     if (firstOnly) {
       return handleFirst(siftArgs, resolvedNodes)
     } else {
-      return handleMany(siftArgs, resolvedNodes, clonedArgs.sort)
+      return handleMany(siftArgs, resolvedNodes, queryArgs.sort)
     }
   })
 }

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -415,10 +415,7 @@ describe(`Filter fields`, () => {
     let result = await runFilter({ boolean: { nin: [true, null] } })
 
     expect(result.length).toEqual(1)
-    result.forEach(edge => {
-      expect(edge.boolean).not.toEqual(null)
-      expect(edge.boolean).not.toEqual(true)
-    })
+    expect(result[0].boolean).toBe(false)
   })
 
   it(`handles the glob operator`, async () => {
@@ -434,6 +431,20 @@ describe(`Filter fields`, () => {
     expect(result.length).toEqual(2)
     expect(result[0].index).toEqual(0)
     expect(result[1].index).toEqual(2)
+  })
+
+  it(`handles the eq operator for array field values`, async () => {
+    const result = await runFilter({ anArray: { eq: 5 } })
+
+    expect(result.length).toBe(1)
+    expect(result[0].index).toBe(1)
+  })
+
+  it(`handles the ne operator for array field values`, async () => {
+    const result = await runFilter({ anArray: { ne: 1 } })
+
+    expect(result.length).toBe(1)
+    expect(result[0].index).toBe(2)
   })
 })
 

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -51,6 +51,7 @@ const makeNodes = () => [
     anArray: [1, 2, 5, 4],
     waxOnly: {
       foo: true,
+      bar: { baz: true },
     },
     anotherKey: {
       withANested: {
@@ -199,8 +200,22 @@ describe(`Filter fields`, () => {
     expect(result[0].hair).toEqual(1)
   })
 
+  it(`handles ne: true operator`, async () => {
+    let result = await runFilter({ boolean: { ne: true } })
+
+    expect(result.length).toEqual(2)
+  })
+
   it(`handles nested ne: true operator`, async () => {
     let result = await runFilter({ waxOnly: { foo: { ne: true } } })
+
+    expect(result.length).toEqual(2)
+  })
+
+  it(`handles deeply nested ne: true operator`, async () => {
+    let result = await runFilter({
+      waxOnly: { bar: { baz: { ne: true } } },
+    })
 
     expect(result.length).toEqual(2)
   })


### PR DESCRIPTION
There are subtle differences between Loki and Sift query operators that we are trying to account for. This fixes some of those:
* Sift allows querying arrays with `$eq` and `$ne`, which translates to `$contains` and `$containsNone` in Loki
* The special case for `$nin` added `false`, which should be `undefined`. This also needed removing cloning the query args with JSON.parse/stringify, because undefined=>null, but it does not seem to serve a purpose anymore anyway.
* The fix for `{ $ne: true }` now handles nesting levels > 2, e.g. ` { "foo.bar.baz": { $ne: true } }`
* The conversion to dotted query fields was producing `{ "": {} }` for an empty object.