### PR TITLE
feat(gatsby): Cache resolved nodes in develop

### DIFF
--- a/packages/gatsby/src/redux/reducers/index.js
+++ b/packages/gatsby/src/redux/reducers/index.js
@@ -24,6 +24,7 @@ module.exports = {
   program: require(`./program`),
   nodes: getNodesReducer(),
   nodesByType: require(`./nodes-by-type`),
+  resolvedNodesCache: require(`./resolved-nodes`),
   nodesTouched: require(`./nodes-touched`),
   lastAction: require(`./last-action`),
   plugins: require(`./plugins`),

--- a/packages/gatsby/src/redux/reducers/resolved-nodes.js
+++ b/packages/gatsby/src/redux/reducers/resolved-nodes.js
@@ -8,7 +8,8 @@ module.exports = (state = new Map(), action) => {
 
     case `SET_RESOLVED_NODES`: {
       const { key, nodes } = action.payload
-      return state.set(key, nodes)
+      state.set(key, nodes)
+      return state
     }
 
     default:

--- a/packages/gatsby/src/redux/reducers/resolved-nodes.js
+++ b/packages/gatsby/src/redux/reducers/resolved-nodes.js
@@ -1,0 +1,17 @@
+module.exports = (state = new Map(), action) => {
+  switch (action.type) {
+    case `DELETE_CACHE`:
+    case `CREATE_NODE`:
+    case `DELETE_NODE`:
+    case `DELETE_NODES`:
+      return new Map()
+
+    case `SET_RESOLVED_NODES`: {
+      const { key, nodes } = action.payload
+      return state.set(key, nodes)
+    }
+
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
Continues from #11141

Currently we cache resolved nodes only during production builds. This PR proposes to cache resolved nodes during development builds as well, and invalidate the cache if nodes are created/deleted. If this makes sense, this should be improved to cache by node type.