### PR TITLE
chore(www): Increase inline code background visibility

### DIFF
--- a/www/src/utils/colors.js
+++ b/www/src/utils/colors.js
@@ -36,7 +36,8 @@ const colors = {
     superLight: gray(96, 270),
   },
   code: {
-    bg: `#fdfaf6`, // colors.a[0] #fcf6f0
+    bgInline: `#fbf2e9`,
+    bg: `#fdfaf6`,
     border: `#faede5`,
     text: `#866c5b`,
     remove: `#e45c5c`,

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -93,7 +93,7 @@ const _options = {
         lineHeight: `inherit`,
       },
       "tt, code, kbd": {
-        background: colors.code.bg,
+        background: colors.code.bgInline,
         paddingTop: `0.2em`,
         paddingBottom: `0.2em`,
       },


### PR DESCRIPTION
Before/after:

![image](https://user-images.githubusercontent.com/21834/52213122-7ed70a80-288e-11e9-8919-3bdec144f8cc.png)

Fixes #11537 — thanks to @tsvetlin for reporting!