### PR TITLE
chore(docs): link stubs to pertinent issues

### DIFF
--- a/docs/docs/build-caching.md
+++ b/docs/docs/build-caching.md
@@ -1,5 +1,6 @@
 ---
 title: Build Caching
+issue: https://github.com/gatsbyjs/gatsby/issues/8103
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/create-a-starter.md
+++ b/docs/docs/create-a-starter.md
@@ -1,5 +1,6 @@
 ---
 title: Create a Starter
+issue: https://github.com/gatsbyjs/gatsby/issues/8103
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/dropping-images-into-static-folders.md
+++ b/docs/docs/dropping-images-into-static-folders.md
@@ -1,5 +1,6 @@
 ---
 title: Dropping Images into Static Folders
+issue: https://github.com/gatsbyjs/gatsby/issues/8103
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/gatsby-source-filesystem-programmatic-import.md
+++ b/docs/docs/gatsby-source-filesystem-programmatic-import.md
@@ -1,5 +1,6 @@
 ---
 title: gatsby-source-filesystem programmatic import
+issue: https://github.com/gatsbyjs/gatsby/issues/9018
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/how-to-pitch-gatsby.md
+++ b/docs/docs/how-to-pitch-gatsby.md
@@ -1,5 +1,6 @@
 ---
 title: How to pitch Gatsby
+issue: https://github.com/gatsbyjs/gatsby/issues/8103
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/how-to-run-a-gatsby-workshop.md
+++ b/docs/docs/how-to-run-a-gatsby-workshop.md
@@ -1,5 +1,6 @@
 ---
 title: How to run a Gatsby workshop
+issue: https://github.com/gatsbyjs/gatsby/issues/8847
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/importing-media-content.md
+++ b/docs/docs/importing-media-content.md
@@ -1,5 +1,6 @@
 ---
 title: Importing media content
+issue: https://github.com/gatsbyjs/gatsby/issues/8103
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/importing-single-files.md
+++ b/docs/docs/importing-single-files.md
@@ -1,5 +1,6 @@
 ---
 title: Importing single files
+issue: https://github.com/gatsbyjs/gatsby/issues/8103
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/rendering-sidebar-navigation-dynamically.md
+++ b/docs/docs/rendering-sidebar-navigation-dynamically.md
@@ -1,5 +1,6 @@
 ---
 title: Rendering sidebar navigation dynamically
+issue: https://github.com/gatsbyjs/gatsby/issues/9779
 ---
 
 This is a stub. Help our community expand it.


### PR DESCRIPTION
## Description

Update stubs to add issue links. Follow up to PR #11492 
There is also a lot of stubs that do not have there own issues, but are referenced in #8103 - Should I add that link to any that apply?

## Related Issues
#11342
