### PR TITLE
fix(docs): explicitly call out minimum node version (node 8)

### DIFF
--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -54,7 +54,7 @@ What does the code look like?
 
 A source plugin is a normal NPM package. It has a package.json with optional
 dependencies as well as a `gatsby-node.js` where you implement Gatsby's Node.js
-APIs. Gatsby supports node versions back to Node 4 and as it's common to want to
+APIs. Gatsby's minimum supported Node.js version is Node 8 and as it's common to want to
 use more modern Node.js and JavaScript syntax, many plugins write code in a
 source directory and compile the code. All plugins maintained in the Gatsby repo
 follow this pattern.

--- a/docs/docs/gatsby-style-guide.md
+++ b/docs/docs/gatsby-style-guide.md
@@ -417,10 +417,6 @@ wording.
 
 When Gatsby commits to support a specific version of software (e.g. Node 8 and up), this is reflected in documentation. Gatsby documentation should be usable by all people on supported software, which means we don't introduce any commands or practices that can't be used by people on versions we've committed to support. In rare circumstances, we'll consider mentioning a newly introduced command or practice as side notes.
 
-For example, npm 5.2.0 (which comes with Node 8) introduced a command called `npx` that is not available for versions of Node below 8. Since Gatsby recommends Node 8 and up but still technically supports Node 6 until the next major release, documentation should point out the requirements for `npx`:
-
-> npm 5.2.0--bundled with Node 8--introduced a command called `npx`. Gatsby recommends Node 8 and up, so we introduce `npx` here as limited to users of npm 5.2.0 or greater.
-
 ### Share best practices whenever possible
 
 When there are multiple ways to complete a task, the docs should explain the following:

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -29,6 +29,8 @@ Take a moment to locate and open up the command line interface (CLI) for your co
 
 Node.js is an environment that can run JavaScript code outside of a web browser. Gatsby is built with Node.js. To get up and running with Gatsby, you’ll need to have a recent version installed on your computer.
 
+_Note: Gatsby's minimum supported Node.js version is Node 8, but feel free to use a more recent version._
+
 ### ⌚ Download Node.js
 
 Visit the [**Node.js site**](https://nodejs.org/) and follow the instructions to download and install the recommended version for your operating system. Once you have followed the installation steps, make sure everything was installed properly:


### PR DESCRIPTION
## Description

Due to the [Node 8 RFC being merged](https://github.com/gatsbyjs/rfcs/pull/24), we can safely document that our minimum supported version is Node 8--even if technically it's Node 6 until we make an explicit breaking change in Gatsby 3.

This is done for a few reasons, specifically:

- Node 6 will be deprecated in a few months
- Generally, most of our users are going to be on Node 8
- Doing this as a gradual, technically non-breaking change offers a relatively seamless upgrade path
- Documenting "best practices" and a minimum supported version will encourage people to update to this minimum version, so again, we can ease the migration later

## Related Issues

Related to #11548 and #11547
