### PR TITLE
fix(babel-plugin-remove-graphql-queries): remove bug where exported static queries are broken 

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+    "watch": "babel -w src --out-dir . --ignore **/__tests__",
+    "test": "jest"
   }
 }

--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
+    "gatsby": "^2.0.112",
     "graphql": "^14.1.1"
   },
   "scripts": {

--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -5,7 +5,9 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "babel-preset-gatsby-package": "^0.1.3"
+    "babel-preset-gatsby-package": "^0.1.3",
+    "cross-env": "^5.2.0",
+    "jest": "^24.0.0"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -42,6 +42,18 @@ export const siteMetaQuery = \\"2673797374\\";
 export const query = \\"2589775908\\";"
 `;
 
+exports[`Transforms exported queries defined in own variable in <StaticQuery> 1`] = `
+"import staticQueryData from \\"public/static/d/2626356014.json\\";
+import React from 'react';
+import { StaticQuery } from 'gatsby';
+export const query = \\"2626356014\\";
+export default (() => React.createElement(StaticQuery, {
+  query: query,
+  render: data => React.createElement(\\"div\\", null, data.site.siteMetadata.title),
+  data: staticQueryData
+}));"
+`;
+
 exports[`Transforms queries defined in own variable in <StaticQuery> 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import React from 'react';

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
@@ -39,6 +39,22 @@ it(`Transforms queries defined in own variable in <StaticQuery>`, () => {
   `)
 })
 
+it(`Transforms exported queries defined in own variable in <StaticQuery>`, () => {
+  matchesSnapshot(`
+  import React from 'react'
+  import { graphql, StaticQuery } from 'gatsby'
+
+  export const query = graphql\`{site { siteMetadata { title }}}\`
+
+  export default () => (
+    <StaticQuery
+      query={query}
+      render={data => <div>{data.site.siteMetadata.title}</div>}
+    />
+  )
+  `)
+})
+
 it(`Transforms queries in page components`, () => {
   matchesSnapshot(`
   import { graphql } from 'gatsby'

--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -184,13 +184,10 @@ export default function({ types: t }) {
           templatePath.replaceWith(t.StringLiteral(queryHash))
 
           // modify StaticQuery elements and import data only if query is inside StaticQuery
-          templatePath.parentPath.parentPath.parentPath.traverse(
-            nestedJSXVistor,
-            {
-              queryHash,
-              query,
-            }
-          )
+          path.traverse(nestedJSXVistor, {
+            queryHash,
+            query,
+          })
 
           return null
         }


### PR DESCRIPTION
Fixes a bug where if a query defined in its own variable is exported, StaticQuery breaks 

Fixes https://github.com/gatsbyjs/gatsby/issues/11477