### PR TITLE
fix(gatsby-dev-cli): move package.json file check after pathToRepo handling

### DIFF
--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -36,12 +36,6 @@ You typically only need to configure this once.`
 const conf = new Configstore(pkg.name)
 
 const fs = require(`fs-extra`)
-const havePackageJsonFile = fs.existsSync(`package.json`)
-
-if (!havePackageJsonFile) {
-  console.error(`Current folder must have a package.json file!`)
-  process.exit()
-}
 
 let pathToRepo = argv.setPathToRepo
 
@@ -50,6 +44,13 @@ if (pathToRepo) {
     pathToRepo = path.join(os.homedir(), pathToRepo.split(`~`).pop())
   }
   conf.set(`gatsby-location`, path.resolve(pathToRepo))
+  process.exit()
+}
+
+const havePackageJsonFile = fs.existsSync(`package.json`)
+
+if (!havePackageJsonFile) {
+  console.error(`Current folder must have a package.json file!`)
   process.exit()
 }
 


### PR DESCRIPTION
## Description

Moved the `hasPackageJson` check after the `pathToRepo` handling in `packages/gatsby-dev-cli/src/index.js`.

Fixes #11535.