### PR TITLE
fix(gatsby-cli): use host option if it is passed

### DIFF
--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -8,7 +8,7 @@ const preferDefault = require(`../bootstrap/prefer-default`)
 const chalk = require(`chalk`)
 
 module.exports = async program => {
-  let { prefixPaths, port, open } = program
+  let { prefixPaths, port, open, host } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 
   const config = await preferDefault(
@@ -31,8 +31,8 @@ module.exports = async program => {
   })
   app.use(pathPrefix, router)
 
-  const server = app.listen(port, () => {
-    let openUrlString = `http://localhost:${port}${pathPrefix}`
+  const server = app.listen(port, host, () => {
+    let openUrlString = `http://${host}:${port}${pathPrefix}`
     console.log(
       `${chalk.blue(`info`)} gatsby serve running at: ${chalk.bold(
         openUrlString


### PR DESCRIPTION
## Description

The serve command didn't use the "--host" option and just used localhost.
It got deleted in commit https://github.com/gatsbyjs/gatsby/commit/bff0cd377359ad1432a1da042349793096cb8d37

## Related Issues

Related to #8080 
