### PR TITLE
chore(*): add binary designation for media files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
 * text=auto eol=lf
+
+# These files are binary and should be left untouched
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pdf binary


### PR DESCRIPTION
## Description

This identifies several file extensions as binary in `.gitattributes`. Without this, some systems are treating media files as text and attempting to manipulate the line endings, corrupting the files.

