### PR TITLE
fix(gatsby-transformer-documentationjs): Remove duplicate description prop

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -145,6 +145,7 @@ exports.onCreateNode = async ({
               actions,
               createNodeId
             )
+            delete ret.description
           }
 
           return ret


### PR DESCRIPTION
The documentationjs transformer creates description fields that link to nodes on `description___NODE`, but does not always remove the `description` field. Having both `description` and `description___NODE` is bad for type inference.