### PR TITLE
fix(docs): add example for pageContext usage within a page

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -152,3 +152,19 @@ exports.onCreatePage = ({ page, actions }) => {
   })
 }
 ```
+
+On your pages and templates, you can access your context via the prop `pageContext` like this:
+
+```
+import React from 'react'
+
+const Page = ({ pageContext }) => {
+  return (
+    <div>
+      {pageContext.house}
+    </div>
+  )
+}
+
+export default Page
+```

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -156,14 +156,10 @@ exports.onCreatePage = ({ page, actions }) => {
 On your pages and templates, you can access your context via the prop `pageContext` like this:
 
 ```jsx
-import React from 'react'
+import React from "react"
 
 const Page = ({ pageContext }) => {
-  return (
-    <div>
-      {pageContext.house}
-    </div>
-  )
+  return <div>{pageContext.house}</div>
 }
 
 export default Page

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -155,7 +155,7 @@ exports.onCreatePage = ({ page, actions }) => {
 
 On your pages and templates, you can access your context via the prop `pageContext` like this:
 
-```
+```jsx
 import React from 'react'
 
 const Page = ({ pageContext }) => {


### PR DESCRIPTION
## Description

This page explains very well that you can pass `context` to a page automatically created, but it's missing an example of how to use it in a page via `pageContext`. I think it is important to explicitly explain it because the name of the variable is different to the prop name.
I added an example.

## Related Issues
I didn't find any related issues.