### PR TITLE
chore(*): convert id to string in benchmark

### DIFF
--- a/benchmarks/markdown/gatsby-node.js
+++ b/benchmarks/markdown/gatsby-node.js
@@ -26,7 +26,7 @@ exports.createPages = ({ actions: { createPage } }) => {
       path: `/path/${step}/`,
       component: require.resolve(`./src/templates/blank.js`),
       context: {
-        id: step,
+        id: step.toString(),
       },
     })
   }


### PR DESCRIPTION
`benchmarks/markdown` wasn't building because `context.id` must be a String. Fixed.
