### PR TITLE
fix(gatsby): add history fallback for client-only routes

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -56,7 +56,6 @@
     "eslint-plugin-react": "^7.8.2",
     "express": "^4.16.3",
     "express-graphql": "^0.6.12",
-    "express-history-api-fallback": "^2.2.1",
     "fast-levenshtein": "~2.0.4",
     "file-loader": "^1.1.11",
     "flat": "^4.0.0",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -86,6 +86,7 @@
     "lokijs": "^1.5.6",
     "md5": "^2.2.1",
     "md5-file": "^3.1.1",
+    "micromatch": "^3.1.10",
     "mime": "^2.2.0",
     "mini-css-extract-plugin": "^0.4.0",
     "mitt": "^1.1.2",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -86,7 +86,6 @@
     "lokijs": "^1.5.6",
     "md5": "^2.2.1",
     "md5-file": "^3.1.1",
-    "micromatch": "^3.1.10",
     "mime": "^2.2.0",
     "mini-css-extract-plugin": "^0.4.0",
     "mitt": "^1.1.2",

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -22,8 +22,8 @@ const historyRouter = (pages, options) => {
     .map(page => page.matchPath)
   return (req, res, next) => {
     const { url } = req
-    if (clientOnlyRoutes.some(route => reachMatch(route, url) !== null)) {
-      if (req.accepts(`html`)) {
+    if (req.accepts(`html`)) {
+      if (clientOnlyRoutes.some(route => reachMatch(route, url) !== null)) {
         return res.sendFile(`index.html`, options, err => {
           if (err) {
             next()

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -16,7 +16,7 @@ const getPages = directory =>
     .then(contents => JSON.parse(contents))
     .catch(() => [])
 
-const historyRouter = (pages, options) => {
+const clientOnlyPathsRouter = (pages, options) => {
   const clientOnlyRoutes = pages
     .filter(page => page.matchPath)
     .map(page => page.matchPath)
@@ -53,7 +53,7 @@ module.exports = async program => {
   const router = express.Router()
   router.use(compression())
   router.use(express.static(`public`))
-  router.use(historyRouter(pages, { root }))
+  router.use(clientOnlyPathsRouter(pages, { root }))
   router.use((req, res, next) => {
     if (req.accepts(`html`)) {
       return res.status(404).sendFile(`404.html`, { root })

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -1,11 +1,39 @@
 /* @flow weak */
+const path = require(`path`)
 const openurl = require(`better-opn`)
+const fs = require(`fs-extra`)
 const signalExit = require(`signal-exit`)
 const compression = require(`compression`)
 const express = require(`express`)
 const getConfigFile = require(`../bootstrap/get-config-file`)
 const preferDefault = require(`../bootstrap/prefer-default`)
 const chalk = require(`chalk`)
+const mm = require(`micromatch`)
+
+const getPages = directory =>
+  fs
+    .readFile(path.join(directory, `.cache`, `pages.json`))
+    .then(contents => JSON.parse(contents))
+    .catch(() => [])
+
+const historyRouter = (pages, options) => {
+  const clientOnlyRoutes = pages
+    .filter(page => page.matchPath)
+    .map(page => page.matchPath)
+  return (req, res, next) => {
+    const { url } = req
+    if (clientOnlyRoutes.some(route => mm.isMatch(url, route))) {
+      if (req.accepts(`html`)) {
+        return res.sendFile(`index.html`, options, err => {
+          if (err) {
+            next()
+          }
+        })
+      }
+    }
+    return next()
+  }
+}
 
 module.exports = async program => {
   let { prefixPaths, port, open, host } = program
@@ -18,13 +46,17 @@ module.exports = async program => {
   let pathPrefix = config && config.pathPrefix
   pathPrefix = prefixPaths && pathPrefix ? pathPrefix : `/`
 
+  const root = path.join(program.directory, `public`)
+  const pages = await getPages(program.directory)
+
   const app = express()
   const router = express.Router()
   router.use(compression())
   router.use(express.static(`public`))
+  router.use(historyRouter(pages, { root }))
   router.use((req, res, next) => {
     if (req.accepts(`html`)) {
-      res.status(404).sendFile(`404.html`, { root: `public` })
+      res.status(404).sendFile(`404.html`, { root })
     } else {
       next()
     }
@@ -50,7 +82,5 @@ module.exports = async program => {
     }
   })
 
-  signalExit((code, signal) => {
-    server.close()
-  })
+  signalExit(() => server.close())
 }

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -1,4 +1,5 @@
 /* @flow weak */
+const path = require(`path`)
 const openurl = require(`better-opn`)
 const fs = require(`fs-extra`)
 const signalExit = require(`signal-exit`)

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -1,10 +1,8 @@
 /* @flow weak */
-const path = require(`path`)
 const openurl = require(`better-opn`)
 const signalExit = require(`signal-exit`)
 const compression = require(`compression`)
 const express = require(`express`)
-const historyFallback = require(`express-history-api-fallback`)
 const getConfigFile = require(`../bootstrap/get-config-file`)
 const preferDefault = require(`../bootstrap/prefer-default`)
 const chalk = require(`chalk`)
@@ -20,16 +18,13 @@ module.exports = async program => {
   let pathPrefix = config && config.pathPrefix
   pathPrefix = prefixPaths && pathPrefix ? pathPrefix : `/`
 
-  const root = path.join(program.directory, `public`)
-
   const app = express()
   const router = express.Router()
   router.use(compression())
   router.use(express.static(`public`))
-  router.use(historyFallback(`index.html`, { root }))
   router.use((req, res, next) => {
     if (req.accepts(`html`)) {
-      res.status(404).sendFile(`404.html`, { root })
+      res.status(404).sendFile(`404.html`, { root: `public` })
     } else {
       next()
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7597,11 +7597,6 @@ express-graphql@^0.6.12:
     http-errors "^1.3.0"
     raw-body "^2.3.2"
 
-express-history-api-fallback@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/express-history-api-fallback/-/express-history-api-fallback-2.2.1.tgz#3a2ad27f7bebc90fc533d110d7c6d83097bcd057"
-  integrity sha1-OirSf3vryQ/FM9EQ18bYMJe80Fc=
-
 express@^4.16.2, express@^4.16.3:
   version "4.16.3"
   resolved "http://registry.npmjs.org/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"


### PR DESCRIPTION
## Description

Quick fix for an issue introduced in #11581 that is causing e2e failures in production_runtime.

The main issue is that the history fallback is not smart enough to understand the underlying page/routing structure of a Gatsby application and is over-eager in handling 404 routes. In other words--it consumes _meaningful_ 404 errors that we use in our e2e tests.

~The longer term fix that @pieh proposed is to tie into `.cache/pages.json` and intelligently match on client-only routes (using `matchPath`) which would check the `req.url` against the matchPath pattern. If it matches, it should serve the `index.html` route, otherwise it should fallback to 404 behavior.~

Implemented in f999abb