### PR TITLE
fix(gatsby): add sanity check before displaying path for static html build error

### DIFF
--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -61,7 +61,11 @@ module.exports = async function build(program: BuildArgs) {
   await buildHTML(program, activity).catch(err => {
     reportFailure(
       report.stripIndent`
-        Building static HTML failed for path "${chalk.bold(err.context.path)}"
+        Building static HTML failed${
+          err.context && err.context.path
+            ? ` for path "${chalk.bold(err.context.path)}"`
+            : ``
+        }
 
         See our docs page on debugging HTML builds for help https://gatsby.app/debug-html
       `,


### PR DESCRIPTION
We currently swallow errors and display `Cannot read property 'path' of undefined` if error wasn't decorating with `context[.path]`. This can happen if error is thrown just when requiring `render-page` module (in https://github.com/gatsbyjs/gatsby/blob/2032147f23d40fe8d986fd33996a8c5362e6c75d/packages/gatsby/src/utils/worker.js#L25)

It doesn't make sense to add path for page for those errors because it's not page specific and would throw for all pages, so instead let's add sanity check before trying to output path for page.

The bug can be reproduced by cloning https://github.com/dfds-frontend/gatsby-dfds-starter/tree/5f2568ebe3c79bfbc093a3d1fd7d78ae6da8f93e and commenting out en var sanity check in `gatsby-config.js`