### PR TITLE
fix(gatsby-link): Adds the ability to not pass the pathPrefix on navigate

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -159,6 +159,15 @@ describe(`navigate`, () => {
       undefined
     )
   })
+
+  it(`will ignore pathPrefix is asked to`, () => {
+    const to = `#some-id`
+    const options = { withoutPrefix: true }
+    global.__PATH_PREFIX__ = `/blog`
+    getNavigate()(to)
+
+    expect(global.___navigate).toHaveBeenCalledWith(`${to}`, options)
+  })
 })
 
 describe(`ref forwarding`, () => {

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -160,11 +160,11 @@ describe(`navigate`, () => {
     )
   })
 
-  it(`will ignore pathPrefix is asked to`, () => {
+  it(`will ignore pathPrefix if asked to`, () => {
     const to = `#some-id`
     const options = { withoutPrefix: true }
     global.__PATH_PREFIX__ = `/blog`
-    getNavigate()(to)
+    getNavigate()(to, options)
 
     expect(global.___navigate).toHaveBeenCalledWith(`${to}`, options)
   })

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -169,7 +169,10 @@ export default React.forwardRef((props, ref) => (
 ))
 
 export const navigate = (to, options) => {
-  window.___navigate(options.withoutPrefix ? to : withPrefix(to), options)
+  window.___navigate(
+    options && options.withoutPrefix ? to : withPrefix(to),
+    options
+  )
 }
 
 export const push = to => {

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -169,7 +169,7 @@ export default React.forwardRef((props, ref) => (
 ))
 
 export const navigate = (to, options) => {
-  window.___navigate(withPrefix(to), options)
+  window.___navigate(options.withoutPrefix ? to : withPrefix(to), options)
 }
 
 export const push = to => {


### PR DESCRIPTION
## Packages/files changed

This changes the `gatsby-link` package (Should I update the version anywhere?) and the files `src/index.js` and `src/__tests__/index.test.js` in that package.

## Description

The automatically added pathPrefix to the `to` in the `navigate` function of the Link package makes it so that navigating to ids in a page is impossible without specifying the current page. For example, trying to do `navigate('#some-id')` would send you directly to the home page rather than add the hashtag to the URL. At this moment, the only way to fix this is by using the `window.___navigate` version.

Since this behavior is probably intended as the base behavior, this changes adds the ability to remove the pathPrefix rather than to add it, so keep backwards compatibility.

# How to test

Someone who would like to navigate to the url `something.com/page-1#some-id` can now use navigate like this: `navigate('#some-id', { withoutPrefix: true })`. The newly added test should confirm this works.