### PR TITLE
fix(docs): add description of contentDigest and clean up doc

### DIFF
--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -14,6 +14,10 @@ parent: String,
 // Reserved for plugins who wish to extend other nodes.
 fields: Object,
 internal: {
+  // Digest "Hash" (for example `md5sum`) of the content of this node.
+  // The digest should be unique to the content of this node since it's used for cacheing.
+  // If the content changes, this digest should also change.
+  // Helper function to create an `md5` digest: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js
   contentDigest: String,
   // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate
   // to transformer plugins this node has data they can further process.

--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -31,7 +31,7 @@ Reserved for plugins who wish to extend other nodes.
 
 Digest "Hash" (for example `md5sum`) of the content of this node.
 
-The digest should be unique to the content of this node since it's used for cacheing. If the content changes, this digest should also change. There's a helper function to create an `md5` digest: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js
+The digest should be unique to the content of this node since it's used for caching. If the content changes, this digest should also change. There's a helper function to create an `md5` digest: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js
 
 ### `mediaType`
 
@@ -43,11 +43,11 @@ A globally unique node type chosen by the plugin owner.
 
 ### `owner`
 
-The plugin which created this node.
+The plugin which created this node. This field is added by gatsby itself (and not the plugin).
 
 ### `fieldOwners`
 
-Stores which plugins created which fields.
+Stores which plugins created which fields. This field is added by gatsby itself (and not the plugin).
 
 ### `content`
 

--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -31,11 +31,11 @@ Reserved for plugins who wish to extend other nodes.
 
 Digest "Hash" (for example `md5sum`) of the content of this node.
 
-The digest should be unique to the content of this node since it's used for caching. If the content changes, this digest should also change. There's a helper function to create an `md5` digest: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js
+The digest should be unique to the content of this node since it's used for caching. If the content changes, this digest should also change. There's a helper function called [createContentDigest](/packages/gatsby/src/utils/create-content-digest.js) to create an `md5` digest.
 
 ### `mediaType`
 
-Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate to transformer plugins this node has data they can further process.
+Optional [media type](https://en.wikipedia.org/wiki/Media_type) to indicate to transformer plugins this node has data they can further process.
 
 ### `type`
 

--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -11,29 +11,47 @@ The basic node data structure is as follows:
 id: String,
 children: Array[String],
 parent: String,
-// Reserved for plugins who wish to extend other nodes.
 fields: Object,
 internal: {
-  // Digest "Hash" (for example `md5sum`) of the content of this node.
-  // The digest should be unique to the content of this node since it's used for cacheing.
-  // If the content changes, this digest should also change.
-  // Helper function to create an `md5` digest: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js
   contentDigest: String,
-  // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate
-  // to transformer plugins this node has data they can further process.
   mediaType: String,
-  // A globally unique node type chosen by the plugin owner.
   type: String,
-  // The plugin which created this node.
   owner: String,
-  // Stores which plugins created which fields.
   fieldOwners: Object,
-  // Optional field exposing the raw content for this node
-  // that transformer plugins can take and further process.
   content: String,
 }
 ...other fields specific to this type of node
 ```
+
+### `parent`
+
+Reserved for plugins who wish to extend other nodes.
+
+### `contentDigest`
+
+Digest "Hash" (for example `md5sum`) of the content of this node.
+
+The digest should be unique to the content of this node since it's used for cacheing. If the content changes, this digest should also change. There's a helper function to create an `md5` digest: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js
+
+### `mediaType`
+
+Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate to transformer plugins this node has data they can further process.
+
+### `type`
+
+A globally unique node type chosen by the plugin owner.
+
+### `owner`
+
+The plugin which created this node.
+
+### `fieldOwners`
+
+Stores which plugins created which fields.
+
+### `content`
+
+Optional field exposing the raw content for this node that transformer plugins can take and further process.
 
 ## Source plugins
 


### PR DESCRIPTION
## Description

Add a brief description of `contentDigest` field, and a link to an example digest function.
This field was undocumented and (if not set correctly) may cause significant caching problems.