### PR TITLE
Prevent window issue on develop and build

### DIFF
--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -53,7 +53,7 @@ rendering.
 
 ```js:title=gatsby-node.js
 exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
-  if (stage === "build-html") {
+  if (stage === "build-html" || stage === "develop-html") {
     actions.setWebpackConfig({
       module: {
         rules: [


### PR DESCRIPTION
Looks like gatsby develop now issue window lack, here is a fix of documentation to help people prevent it.