### PR TITLE
fix accessibility of linked headers plugin

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -10,7 +10,7 @@ function patch(context, key, value) {
   return context[key]
 }
 
-const svgIcon = `<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`
+const svgIcon = `<svg aria-hidden="true" focusable="false" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`
 
 module.exports = (
   { markdownAST },
@@ -29,13 +29,14 @@ module.exports = (
     patch(data.hProperties, `id`, id)
 
     if (icon !== false) {
+      const label = id.split('-').join(' ')
       node.children.unshift({
         type: `link`,
         url: `#${id}`,
         title: null,
         data: {
           hProperties: {
-            "aria-hidden": true,
+            "aria-label": `${label} permalink`,
             class: className,
           },
           hChildren: [


### PR DESCRIPTION
## Description

The plugin for auto-linking Markdown headers is super slick, but it had some accessibility issues. Specifically:

- With `icon` being truthy, the plugin introduces an anchor tag wrapping an SVG icon inside of the heading.
- The link receives `aria-hidden="true"` but isn't disabled from the keyboard with `tabindex="-1"`, so it effectively becomes a "ghost control" in screen readers since the accessibility information is stripped out.

Instead of hiding them, this PR makes those links keyboard and screen reader accessible so they can be used by more people.

- Added an `aria-label` to the link using a version of the header slug with spaces instead of dashes and the word "permalink" at the end making it clear what these links are for. 
- Added `focusable: false` to the default SVG so it won't receive focus in some assistive technologies (since it's not supposed to be interactive).

## To-do

I could use some help with the tests, if we want some test coverage for this. There wasn't any precedent for testing the links, only header IDs and icon children.