### PR TITLE
fix(website) showcase has a duplicate category

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -3949,7 +3949,7 @@
   url: "https://theagencyproject.co"
   description: Agency model, without agency overhead.
   categories:
-    - agency
+    - Agency
   built_by: JV-LA
   built_by_url: https://jv-la.com
 - title: Karen Hou's portfolio


### PR DESCRIPTION
In the showcase section, there are 2 categories for "Agency" because of their case (Agency and agency). This PR just moves the single item in the "agency" category and moves it to "Agency".