### PR TITLE
fix(www): Showcase categories css fix.

### DIFF
--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -27,7 +27,7 @@ class Collapsible extends Component {
           display: collapsed ? false : `flex`,
           flex: collapsed ? `0 0 auto` : `1 1 auto`,
           minHeight: fixed ? `${fixed}px` : `initial`,
-          maxHeight: fixed ? `${fixed}px` : `initial`,
+          maxHeight: fixed ? `${fixed}px` : `100%`,
           flexBasis: 0,
           // paddingBottom: collapsed ? 0 : rhythm(options.blockMarginBottom),
         }}

--- a/www/src/views/shared/sidebar.js
+++ b/www/src/views/shared/sidebar.js
@@ -2,8 +2,8 @@ import React from "react"
 import MdFilterList from "react-icons/lib/md/filter-list"
 import styles from "../shared/styles"
 
-export const SidebarContainer = ({ children, className }) => (
-  <div className={className} css={[styles.sidebarContainer, styles.sticky]}>
+export const SidebarContainer = ({ children, ...rest }) => (
+  <div css={[styles.sidebarContainer, styles.sticky]} {...rest}>
     {children}
   </div>
 )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I found an issue, on the Showcase site, categories were invisible on some browsers. 
Details of the issue are in #11574

## Related Issues

 Link to the issue that is fixed by this PR (if there is one)
Fixes: #11574
