### PR TITLE
docs: added aria-label to link

### DIFF
--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -39,13 +39,10 @@ const PackageReadMe = props => {
             },
           }}
           href={githubUrl}
-          aria-label={`Github source code for ${packageName}`}
+          aria-label={`${packageName} source`}
+          title={`View source on GitHub`}
         >
-          <GithubIcon
-            focusable="false"
-            title={`Github source code for ${packageName}`}
-            style={{ verticalAlign: `text-top` }}
-          />
+          <GithubIcon focusable="false" style={{ verticalAlign: `text-top` }} />
         </a>
         {githubUrl && (
           <Link to={`/starters?d=${packageName}`}>

--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -39,8 +39,13 @@ const PackageReadMe = props => {
             },
           }}
           href={githubUrl}
+          aria-label={`Github source code for ${packageName}`}
         >
-          <GithubIcon style={{ verticalAlign: `text-top` }} />
+          <GithubIcon
+            focusable="false"
+            title={`Github source code for ${packageName}`}
+            style={{ verticalAlign: `text-top` }}
+          />
         </a>
         {githubUrl && (
           <Link to={`/starters?d=${packageName}`}>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Add aria-label for the anchor tag for screen readers.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/11633

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
