### PR TITLE
Add node model

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -1,26 +1,13 @@
-const {
-  graphql,
-  GraphQLObjectType,
-  GraphQLList,
-  GraphQLSchema,
-} = require(`gatsby/graphql`)
+const { graphql } = require(`gatsby/graphql`)
 const { onCreateNode } = require(`../gatsby-node`)
-const {
-  inferObjectStructureFromNodes,
-} = require(`../../../gatsby/src/schema/infer-graphql-type`)
 const extendNodeType = require(`../extend-node-type`)
 
 // given a set of nodes and a query, return the result of the query
 async function queryResult(
   nodes,
   fragment,
-  { types = [] } = {},
   { additionalParameters = {}, pluginOptions = {} }
 ) {
-  const inferredFields = inferObjectStructureFromNodes({
-    nodes,
-    types: [...types],
-  })
   const extendNodeTypeFields = await extendNodeType(
     {
       type: { name: `MarkdownRemark` },
@@ -37,32 +24,27 @@ async function queryResult(
     }
   )
 
-  const markdownRemarkFields = {
-    ...inferredFields,
-    ...extendNodeTypeFields,
-  }
+  const { SchemaComposer } = require(`graphql-compose`)
+  const {
+    addInferredFields,
+  } = require(`../../../gatsby/src/schema/infer/infer`)
+  const {
+    getExampleValue,
+  } = require(`../../../gatsby/src/schema/infer/example-value`)
 
-  const schema = new GraphQLSchema({
-    query: new GraphQLObjectType({
-      name: `RootQueryType`,
-      fields: () => {
-        return {
-          listNode: {
-            name: `LISTNODE`,
-            type: new GraphQLList(
-              new GraphQLObjectType({
-                name: `MarkdownRemark`,
-                fields: markdownRemarkFields,
-              })
-            ),
-            resolve() {
-              return nodes
-            },
-          },
-        }
-      },
-    }),
+  const sc = new SchemaComposer()
+  const typeName = `MarkdownRemark`
+  const tc = sc.createTC(typeName)
+  addInferredFields({
+    schemaComposer: sc,
+    typeComposer: tc,
+    exampleValue: getExampleValue({ nodes, typeName }),
   })
+  tc.addFields(extendNodeTypeFields)
+  sc.Query.addFields({
+    listNode: { type: [tc], resolve: () => nodes },
+  })
+  const schema = sc.buildSchema()
 
   const result = await graphql(
     schema,
@@ -97,14 +79,10 @@ const bootstrapTest = (
   it(label, async done => {
     node.content = content
     const createNode = markdownNode => {
-      queryResult(
-        [markdownNode],
-        query,
-        {
-          types: [{ name: `MarkdownRemark` }],
-        },
-        { additionalParameters, pluginOptions }
-      ).then(result => {
+      queryResult([markdownNode], query, {
+        additionalParameters,
+        pluginOptions,
+      }).then(result => {
         try {
           test(result.data.listNode[0])
           done()

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -71,7 +71,7 @@
     "graphql-playground-middleware-express": "^1.7.10",
     "graphql-relay": "^0.6.0",
     "graphql-skip-limit": "^2.0.5",
-    "graphql-compose": "^5.7.0",
+    "graphql-compose": "^5.10.1",
     "graphql-tools": "^3.0.4",
     "graphql-type-json": "^0.2.1",
     "hash-mod": "^0.0.5",

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -21,7 +21,7 @@ const getConfigFile = require(`./get-config-file`)
 const tracer = require(`opentracing`).globalTracer()
 const preferDefault = require(`./prefer-default`)
 const nodeTracking = require(`../db/node-tracking`)
-const nodeStore = require(`../db/nodes`)
+const withResolverContext = require(`../schema/context`)
 require(`../db`).startAutosave()
 
 // Show stack trace on unhandled promises.
@@ -390,10 +390,7 @@ module.exports = async (args: BootstrapArgs) => {
       schema,
       query,
       context,
-      {
-        ...context,
-        nodeModel: nodeStore,
-      },
+      withResolverContext(context),
       context
     )
   }

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -23,7 +23,7 @@ const launchEditor = require(`react-dev-utils/launchEditor`)
 const formatWebpackMessages = require(`react-dev-utils/formatWebpackMessages`)
 const chalk = require(`chalk`)
 const address = require(`address`)
-const nodeStore = require(`../db/nodes`)
+const withResolverContext = require(`../schema/context`)
 const sourceNodes = require(`../utils/source-nodes`)
 const websocketManager = require(`../utils/websocket-manager`)
 const getSslCert = require(`../utils/get-ssl-cert`)
@@ -109,9 +109,7 @@ async function startServer(program) {
     graphqlHTTP({
       schema: store.getState().schema,
       graphiql: process.env.GATSBY_GRAPHQL_IDE === `playground` ? false : true,
-      context: {
-        nodeModel: nodeStore,
-      },
+      context: withResolverContext(),
     })
   )
 

--- a/packages/gatsby/src/db/__tests__/node-tracking-test.js
+++ b/packages/gatsby/src/db/__tests__/node-tracking-test.js
@@ -4,7 +4,6 @@ const {
 } = require(`../../redux/actions`)
 const { getNode } = require(`../../db/nodes`)
 const { findRootNodeAncestor, trackDbNodes } = require(`../node-tracking`)
-const nodeTypes = require(`../../schema/build-node-types`)
 const { run: runQuery } = require(`../nodes-query`)
 require(`./fixtures/ensure-loki`)()
 
@@ -18,7 +17,7 @@ function makeNode() {
     },
     inlineArray: [1, 2, 3],
     internal: {
-      type: `TestNode`,
+      type: `Test`,
       contentDigest: `digest1`,
       owner: `test`,
     },
@@ -43,7 +42,7 @@ describe(`track root nodes`, () => {
         },
         inlineArray: [1, 2, 3],
         internal: {
-          type: `TestNode`,
+          type: `Test`,
           contentDigest: `digest2`,
         },
       },
@@ -89,7 +88,19 @@ describe(`track root nodes`, () => {
     let type
 
     beforeAll(async () => {
-      type = (await nodeTypes.buildAll({})).testNode.nodeObjectType
+      const { SchemaComposer } = require(`graphql-compose`)
+      const { addInferredFields } = require(`../../schema/infer/infer`)
+      const { getExampleValue } = require(`../../schema/infer/example-value`)
+
+      const sc = new SchemaComposer()
+      const typeName = `Test`
+      const tc = sc.createTC(typeName)
+      addInferredFields({
+        schemaComposer: sc,
+        typeComposer: tc,
+        exampleValue: getExampleValue({ nodes: [makeNode()], typeName }),
+      })
+      type = tc.getType()
     })
 
     it(`Tracks objects when running query without filter`, async () => {

--- a/packages/gatsby/src/db/loki/__tests__/nodes-query-test.js
+++ b/packages/gatsby/src/db/loki/__tests__/nodes-query-test.js
@@ -1,6 +1,6 @@
 if (process.env.GATSBY_DB_NODES === `loki`) {
   const _ = require(`lodash`)
-  const nodeTypes = require(`../../../schema/build-node-types`)
+  const { GraphQLObjectType } = require(`graphql`)
   const { store } = require(`../../../redux`)
   const runQuery = require(`../nodes-query`)
   const { getNodeTypeCollection } = require(`../nodes`)
@@ -21,11 +21,11 @@ if (process.env.GATSBY_DB_NODES === `loki`) {
     for (const node of nodes) {
       store.dispatch({ type: `CREATE_NODE`, payload: node })
     }
-    const gqlType = nodeTypes.buildNodeObjectType({
-      typeName: `Test`,
-      nodes,
-      pluginFields: [],
-      processedTypes: {},
+    const gqlType = new GraphQLObjectType({
+      name: `Test`,
+      fields: {
+        foo: { type: `String` },
+      },
     })
     const queryArgs = { filter: { foo: { eq: `bar` } } }
     const args = { gqlType, queryArgs }

--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -280,7 +280,7 @@ function ensureFieldIndexes(coll, lokiArgs) {
  * @returns {promise} A promise that will eventually be resolved with
  * a collection of matching objects (even if `firstOnly` is true)
  */
-async function runQuery({ gqlType, queryArgs, context = {}, firstOnly }) {
+async function runQuery({ gqlType, queryArgs, firstOnly }) {
   // Clone args as for some reason graphql-js removes the constructor
   // from nested objects which breaks a check in sift.js.
   const gqlArgs = JSON.parse(JSON.stringify(queryArgs))

--- a/packages/gatsby/src/db/loki/nodes.js
+++ b/packages/gatsby/src/db/loki/nodes.js
@@ -142,7 +142,7 @@ function getNodesByType(typeName) {
  */
 function getNodes() {
   const nodeTypes = getTypes()
-  return _.flatMap(nodeTypes, nodeType => getNodesByType(nodeType.type))
+  return _.flatMap(nodeTypes, nodeType => getNodesByType(nodeType))
 }
 
 /**

--- a/packages/gatsby/src/db/nodes-query.js
+++ b/packages/gatsby/src/db/nodes-query.js
@@ -1,12 +1,66 @@
-const backend = process.env.GATSBY_DB_NODES || `redux`
+const _ = require(`lodash`)
+const { getNamedType } = require(`graphql`)
+const deepmerge = require(`deepmerge`)
+
 const lokiRunQuery = require(`./loki/nodes-query`)
 const siftRunQuery = require(`../redux/run-sift`)
-const lazyFields = require(`../schema/lazy-fields`)
+
+const pathToObject = path => {
+  if (path && typeof path === `string`) {
+    return path.split(`.`).reduceRight((acc, key) => {
+      return { [key]: acc }
+    }, true)
+  }
+  return {}
+}
+
+const withSortFields = (fields, sortFields = []) =>
+  sortFields.reduce((acc, field) => {
+    const sortField = pathToObject(field.replace(/___/g, `.`))
+    return deepmerge(acc, sortField)
+  }, fields)
+
+// FIXME: This is duplicate code (`extractFieldsToSift`)
+const dropQueryOperators = filter =>
+  Object.keys(filter).reduce((acc, key) => {
+    let value = filter[key]
+    let k = Object.keys(value)[0]
+    let v = value[k]
+    if (_.isPlainObject(value) && _.isPlainObject(v)) {
+      acc[key] =
+        k === `elemMatch` ? dropQueryOperators(v) : dropQueryOperators(value)
+    } else {
+      acc[key] = true
+    }
+    return acc
+  }, {})
+
+const hasFieldResolvers = (type, filterFields) => {
+  const fields = type.getFields()
+  return Object.keys(filterFields).some(fieldName => {
+    const filterValue = filterFields[fieldName]
+    const field = fields[fieldName]
+    return (
+      Boolean(field.resolve) ||
+      (filterValue !== true &&
+        hasFieldResolvers(getNamedType(field.type), filterValue))
+    )
+  })
+}
 
 function chooseQueryEngine(args) {
+  const { backend } = require(`./nodes`)
+
   const { queryArgs, gqlType } = args
-  const { filter } = queryArgs
-  if (backend === `loki` && !lazyFields.contains(filter, gqlType)) {
+  // FIXME: Need to get group and distinct `field` arg from projection
+  const { filter, sort } = queryArgs
+  const filterFields = filter ? dropQueryOperators(filter) : {}
+  const fields = sort ? withSortFields(filterFields, sort.fields) : filterFields
+
+  // TODO: Where to handle abstract types? This is related to refactoring
+  // all of the query/resolving nodes stuff
+  // TODO: `hasFieldResolvers` is also true for Date fields
+  if (backend === `loki` && !hasFieldResolvers(gqlType, fields)) {
     return lokiRunQuery
   } else {
     return siftRunQuery
@@ -16,15 +70,15 @@ function chooseQueryEngine(args) {
 /**
  * Runs the query over all nodes of type. It must first select the
  * appropriate query engine. Sift, or Loki. Sift is used by default,
- * or if the query includes "lazy fields", those that need to be
- * resolved before being queried. These could be either plugin fields,
- * i.e those declared by plugins during the
- * `setFieldsOnGraphQLNodeType` API, or they could be linked
- * fields. See `../redux/run-sift.js` for more.
+ * or if the query includes fields with custom resolver functions,
+ * those that need to be resolved before being queried.
+ * These could be either plugin fields, i.e those declared by plugins during
+ * the `setFieldsOnGraphQLNodeType` API, or they could be linked fields.
+ * See `../redux/run-sift.js` for more.
  *
- * If the query does *not* include lazy fields, and environment
- * variable `GATSBY_DB_NODES` = `loki` then we can perform a much
- * faster pure data query using loki. See `loki/nodes-query.js` for
+ * If the query does *not* include fields with custom resolver functions,
+ * and environment variable `GATSBY_DB_NODES` = `loki` then we can perform
+ * a much faster pure data query using loki. See `loki/nodes-query.js` for
  * more.
  *
  * @param {Object} args. Object with:

--- a/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/query-runner.js
@@ -7,7 +7,7 @@ const websocketManager = require(`../../utils/websocket-manager`)
 
 const path = require(`path`)
 const { store } = require(`../../redux`)
-const nodeStore = require(`../../db/nodes`)
+const withResolverContext = require(`../../schema/context`)
 const { generatePathChunkName } = require(`../../utils/js-chunk-names`)
 const { formatErrorDetails } = require(`./utils`)
 const mod = require(`hash-mod`)(999)
@@ -33,10 +33,7 @@ module.exports = async (queryJob: QueryJob, component: Any) => {
       schema,
       query,
       context,
-      {
-        ...context,
-        nodeModel: nodeStore,
-      },
+      withResolverContext(context),
       context
     )
 

--- a/packages/gatsby/src/redux/prepare-nodes.js
+++ b/packages/gatsby/src/redux/prepare-nodes.js
@@ -1,0 +1,127 @@
+const _ = require(`lodash`)
+const { trackInlineObjectsInRootNode } = require(`../db/node-tracking`)
+const { store } = require(`../redux`)
+const { getNullableType, getNamedType } = require(`graphql`)
+
+const resolvedNodesCache = new Map()
+const enhancedNodeCache = new Map()
+const enhancedNodePromiseCache = new Map()
+const enhancedNodeCacheId = ({ node, args }) =>
+  node && node.internal && node.internal.contentDigest
+    ? JSON.stringify({
+        nodeid: node.id,
+        digest: node.internal.contentDigest,
+        ...args,
+      })
+    : null
+
+/////////////////////////////////////////////////////////////////////
+// Resolve nodes
+/////////////////////////////////////////////////////////////////////
+
+function awaitSiftField(fields, node, k) {
+  const field = fields[k]
+  if (field.resolve) {
+    const withResolverContext = require(`../schema/context`)
+    const { schema } = store.getState()
+    return field.resolve(node, {}, withResolverContext(), {
+      fieldName: k,
+      schema,
+      returnType: field.type,
+    })
+  } else if (node[k] !== undefined) {
+    return node[k]
+  }
+
+  return undefined
+}
+
+// Resolves every field used in the node.
+function resolveRecursive(node, siftFieldsObj, gqFields) {
+  return Promise.all(
+    _.keys(siftFieldsObj).map(k =>
+      Promise.resolve(awaitSiftField(gqFields, node, k))
+        .then(v => {
+          const innerSift = siftFieldsObj[k]
+          const innerGqConfig = gqFields[k]
+
+          const innerType = getNullableType(innerGqConfig.type)
+          const innerListType = getNamedType(innerType)
+
+          if (_.isObject(innerSift) && v != null && innerType) {
+            if (_.isFunction(innerType.getFields)) {
+              // this is single object
+              return resolveRecursive(v, innerSift, innerType.getFields())
+            } else if (_.isArray(v) && _.isFunction(innerListType.getFields)) {
+              // this is array
+              return Promise.all(
+                v.map(item =>
+                  resolveRecursive(item, innerSift, innerListType.getFields())
+                )
+              )
+            }
+          }
+
+          return v
+        })
+        .then(v => [k, v])
+    )
+  ).then(resolvedFields => {
+    const myNode = {
+      ...node,
+    }
+    resolvedFields.forEach(([k, v]) => (myNode[k] = v))
+    return myNode
+  })
+}
+
+function resolveNodes(nodes, typeName, firstOnly, fieldsToSift, gqlFields) {
+  const nodesCacheKey = JSON.stringify({
+    // typeName + count being the same is a pretty good
+    // indication that the nodes are the same.
+    typeName,
+    firstOnly,
+    nodesLength: nodes.length,
+    ...fieldsToSift,
+  })
+  if (
+    process.env.NODE_ENV === `production` &&
+    resolvedNodesCache.has(nodesCacheKey)
+  ) {
+    return Promise.resolve(resolvedNodesCache.get(nodesCacheKey))
+  } else {
+    return Promise.all(
+      nodes.map(node => {
+        const cacheKey = enhancedNodeCacheId({
+          node,
+          args: fieldsToSift,
+        })
+        if (cacheKey && enhancedNodeCache.has(cacheKey)) {
+          return Promise.resolve(enhancedNodeCache.get(cacheKey))
+        } else if (cacheKey && enhancedNodePromiseCache.has(cacheKey)) {
+          return enhancedNodePromiseCache.get(cacheKey)
+        }
+
+        const enhancedNodeGenerationPromise = new Promise(resolve => {
+          resolveRecursive(node, fieldsToSift, gqlFields).then(resolvedNode => {
+            trackInlineObjectsInRootNode(resolvedNode)
+            if (cacheKey) {
+              enhancedNodeCache.set(cacheKey, resolvedNode)
+            }
+            resolve(resolvedNode)
+          })
+        })
+        enhancedNodePromiseCache.set(cacheKey, enhancedNodeGenerationPromise)
+        return enhancedNodeGenerationPromise
+      })
+    ).then(resolvedNodes => {
+      resolvedNodesCache.set(nodesCacheKey, resolvedNodes)
+      return resolvedNodes
+    })
+  }
+}
+
+module.exports = {
+  resolveNodes,
+  resolveRecursive,
+}

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -2,22 +2,7 @@
 const sift = require(`sift`)
 const _ = require(`lodash`)
 const prepareRegex = require(`../utils/prepare-regex`)
-const Promise = require(`bluebird`)
-const { trackInlineObjectsInRootNode } = require(`../db/node-tracking`)
-const { store } = require(`../redux`)
-const { getNullableType, getNamedType } = require(`graphql`)
-
-const resolvedNodesCache = new Map()
-const enhancedNodeCache = new Map()
-const enhancedNodePromiseCache = new Map()
-const enhancedNodeCacheId = ({ node, args }) =>
-  node && node.internal && node.internal.contentDigest
-    ? JSON.stringify({
-        nodeid: node.id,
-        digest: node.internal.contentDigest,
-        ...args,
-      })
-    : null
+const { resolveNodes, resolveRecursive } = require(`./prepare-nodes`)
 
 /////////////////////////////////////////////////////////////////////
 // Parse filter
@@ -86,7 +71,7 @@ function parseFilter(filter) {
 }
 
 /////////////////////////////////////////////////////////////////////
-// Resolve nodes
+// Run Sift
 /////////////////////////////////////////////////////////////////////
 
 function isEqId(firstOnly, fieldsToSift, siftArgs) {
@@ -98,112 +83,6 @@ function isEqId(firstOnly, fieldsToSift, siftArgs) {
     Object.keys(siftArgs[0].id)[0] === `$eq`
   )
 }
-
-function awaitSiftField(fields, node, k) {
-  const field = fields[k]
-  if (field.resolve) {
-    const withResolverContext = require(`../schema/context`)
-    const { schema } = store.getState()
-    return field.resolve(node, {}, withResolverContext(), {
-      fieldName: k,
-      schema,
-      returnType: field.type,
-    })
-  } else if (node[k] !== undefined) {
-    return node[k]
-  }
-
-  return undefined
-}
-
-// Resolves every field used in the node.
-function resolveRecursive(node, siftFieldsObj, gqFields) {
-  return Promise.all(
-    _.keys(siftFieldsObj).map(k =>
-      Promise.resolve(awaitSiftField(gqFields, node, k))
-        .then(v => {
-          const innerSift = siftFieldsObj[k]
-          const innerGqConfig = gqFields[k]
-
-          const innerType = getNullableType(innerGqConfig.type)
-          const innerListType = getNamedType(innerType)
-
-          if (_.isObject(innerSift) && v != null && innerType) {
-            if (_.isFunction(innerType.getFields)) {
-              // this is single object
-              return resolveRecursive(v, innerSift, innerType.getFields())
-            } else if (_.isArray(v) && _.isFunction(innerListType.getFields)) {
-              // this is array
-              return Promise.all(
-                v.map(item =>
-                  resolveRecursive(item, innerSift, innerListType.getFields())
-                )
-              )
-            }
-          }
-
-          return v
-        })
-        .then(v => [k, v])
-    )
-  ).then(resolvedFields => {
-    const myNode = {
-      ...node,
-    }
-    resolvedFields.forEach(([k, v]) => (myNode[k] = v))
-    return myNode
-  })
-}
-
-function resolveNodes(nodes, typeName, firstOnly, fieldsToSift, gqlFields) {
-  const nodesCacheKey = JSON.stringify({
-    // typeName + count being the same is a pretty good
-    // indication that the nodes are the same.
-    typeName,
-    firstOnly,
-    nodesLength: nodes.length,
-    ...fieldsToSift,
-  })
-  if (
-    process.env.NODE_ENV === `production` &&
-    resolvedNodesCache.has(nodesCacheKey)
-  ) {
-    return Promise.resolve(resolvedNodesCache.get(nodesCacheKey))
-  } else {
-    return Promise.all(
-      nodes.map(node => {
-        const cacheKey = enhancedNodeCacheId({
-          node,
-          args: fieldsToSift,
-        })
-        if (cacheKey && enhancedNodeCache.has(cacheKey)) {
-          return Promise.resolve(enhancedNodeCache.get(cacheKey))
-        } else if (cacheKey && enhancedNodePromiseCache.has(cacheKey)) {
-          return enhancedNodePromiseCache.get(cacheKey)
-        }
-
-        const enhancedNodeGenerationPromise = new Promise(resolve => {
-          resolveRecursive(node, fieldsToSift, gqlFields).then(resolvedNode => {
-            trackInlineObjectsInRootNode(resolvedNode)
-            if (cacheKey) {
-              enhancedNodeCache.set(cacheKey, resolvedNode)
-            }
-            resolve(resolvedNode)
-          })
-        })
-        enhancedNodePromiseCache.set(cacheKey, enhancedNodeGenerationPromise)
-        return enhancedNodeGenerationPromise
-      })
-    ).then(resolvedNodes => {
-      resolvedNodesCache.set(nodesCacheKey, resolvedNodes)
-      return resolvedNodes
-    })
-  }
-}
-
-/////////////////////////////////////////////////////////////////////
-// Run Sift
-/////////////////////////////////////////////////////////////////////
 
 function handleFirst(siftArgs, nodes) {
   const index = _.isEmpty(siftArgs)

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -272,6 +272,8 @@ module.exports = (args: Object) => {
   const nodes = args.nodes || getNodesByType(gqlType.name)
 
   const { siftArgs, fieldsToSift } = parseFilter(clonedArgs.filter)
+  // FIXME: fieldsToSift must include `sort.fields` as well as the
+  // `field` arg on `group` and `distinct`
 
   // If the the query for single node only has a filter for an "id"
   // using "eq" operator, then we'll just grab that ID and return it.

--- a/packages/gatsby/src/schema/context.js
+++ b/packages/gatsby/src/schema/context.js
@@ -1,0 +1,7 @@
+const nodeModel = require(`./node-model`)
+
+const withResolverContext = context => {
+  return { ...context, nodeModel }
+}
+
+module.exports = withResolverContext

--- a/packages/gatsby/src/schema/infer/__tests__/__snapshots__/example-value.js.snap
+++ b/packages/gatsby/src/schema/infer/__tests__/__snapshots__/example-value.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Get example value for type inference build enum values for fields from array on nodes 1`] = `
+Object {
+  "anArray": Object {
+    "field": "anArray",
+  },
+  "context___nestedObject___name": Object {
+    "field": "context___nestedObject___name",
+  },
+  "context___nestedObject___someOtherProperty": Object {
+    "field": "context___nestedObject___someOtherProperty",
+  },
+  "date": Object {
+    "field": "date",
+  },
+  "frontmatter___blue": Object {
+    "field": "frontmatter___blue",
+  },
+  "frontmatter___circle": Object {
+    "field": "frontmatter___circle",
+  },
+  "frontmatter___date": Object {
+    "field": "frontmatter___date",
+  },
+  "frontmatter___draft": Object {
+    "field": "frontmatter___draft",
+  },
+  "frontmatter___title": Object {
+    "field": "frontmatter___title",
+  },
+  "hair": Object {
+    "field": "hair",
+  },
+  "key_with__unsupported_values": Object {
+    "field": "key-with..unsupported-values",
+  },
+  "name": Object {
+    "field": "name",
+  },
+  "nestedArrays": Object {
+    "field": "nestedArrays",
+  },
+  "objectsInArray": Object {
+    "field": "objectsInArray",
+  },
+}
+`;
+
+exports[`Get example value for type inference builds field examples from an array of nodes 1`] = `
+Object {
+  "anArray": Array [
+    1,
+  ],
+  "context": Object {
+    "nestedObject": Object {
+      "name": "Inner name",
+      "someOtherProperty": 1,
+    },
+  },
+  "date": "2006-07-22T22:39:53.000Z",
+  "frontmatter": Object {
+    "blue": 100,
+    "circle": "happy",
+    "date": "2006-07-22T22:39:53.000Z",
+    "draft": false,
+    "title": "The world of dash and adventure",
+  },
+  "hair": 1,
+  "key-with..unsupported-values": true,
+  "name": "The Mad Max",
+  "nestedArrays": Array [
+    Array [
+      1,
+    ],
+  ],
+  "objectsInArray": Array [
+    Object {
+      "field1": true,
+      "field2": 1,
+      "field3": "foo",
+    },
+  ],
+}
+`;

--- a/packages/gatsby/src/schema/infer/__tests__/example-value.js
+++ b/packages/gatsby/src/schema/infer/__tests__/example-value.js
@@ -1,0 +1,537 @@
+const { getExampleValue } = require(`../example-value`)
+
+const INVALID_VALUE = undefined
+
+// NOTE: Previously `data-tree-utils-test.js`
+describe(`Get example value for type inference`, () => {
+  const nodes = [
+    {
+      name: `The Mad Max`,
+      hair: 1,
+      date: `2006-07-22T22:39:53.000Z`,
+      "key-with..unsupported-values": true,
+      emptyArray: [],
+      anArray: [1, 2, 3, 4],
+      nestedArrays: [[1, 2, 3], [4, 5, 6]],
+      objectsInArray: [{ field1: true }, { field2: 1 }],
+      frontmatter: {
+        date: `2006-07-22T22:39:53.000Z`,
+        title: `The world of dash and adventure`,
+        blue: 100,
+      },
+      context: {
+        nestedObject: null,
+      },
+    },
+    {
+      name: `The Mad Wax`,
+      hair: 2,
+      date: `2006-07-22T22:39:53.000Z`,
+      emptyArray: [undefined, null],
+      anArray: [1, 2, 5, 4],
+      iAmNull: null,
+      nestedArrays: [[1, 2, 3]],
+      objectsInArray: [{ field3: `foo` }],
+      frontmatter: {
+        date: `2006-07-22T22:39:53.000Z`,
+        title: `The world of slash and adventure`,
+        blue: 10010,
+        circle: `happy`,
+        draft: false,
+      },
+      context: {
+        nestedObject: {
+          someOtherProperty: 1,
+        },
+      },
+    },
+    {
+      name: `The Mad Wax`,
+      hair: 3,
+      date: `2006-07-22T22:39:53.000Z`,
+      anArray: [],
+      iAmNull: null,
+      frontmatter: {
+        date: `2006-07-22T22:39:53.000Z`,
+        title: `The world of slash and adventure`,
+        blue: 10010,
+        circle: `happy`,
+        draft: false,
+      },
+      context: {
+        nestedObject: {
+          someOtherProperty: 2,
+        },
+      },
+    },
+    {
+      name: `The Mad Wax`,
+      hair: 4,
+      date: `2006-07-22T22:39:53.000Z`,
+      anArray: [4, 6, 2],
+      iAmNull: null,
+      frontmatter: {
+        date: `2006-07-22T22:39:53.000Z`,
+        title: `The world of slash and adventure`,
+        blue: 10010,
+        circle: `happy`,
+        draft: false,
+      },
+      context: {
+        nestedObject: {
+          name: `Inner name`,
+          someOtherProperty: 3,
+        },
+      },
+      "": ``,
+    },
+  ]
+
+  it(`builds field examples from an array of nodes`, () => {
+    expect(getExampleValue({ nodes })).toMatchSnapshot()
+  })
+
+  it(`skips null fields`, () => {
+    expect(getExampleValue({ nodes }).iAmNull).not.toBeDefined()
+  })
+
+  it(`skips fields with key set to empty string`, () => {
+    expect(getExampleValue({ nodes })[``]).not.toBeDefined()
+  })
+
+  it(`should not mutate the nodes`, () => {
+    getExampleValue({ nodes })
+    expect(nodes[0].context.nestedObject).toBeNull()
+    expect(nodes[1].context.nestedObject.someOtherProperty).toEqual(1)
+    expect(nodes[2].context.nestedObject.someOtherProperty).toEqual(2)
+    expect(nodes[3].context.nestedObject.someOtherProperty).toEqual(3)
+  })
+
+  it(`skips empty or sparse arrays`, () => {
+    expect(getExampleValue({ nodes }).emptyArray).not.toBeDefined()
+    expect(getExampleValue({ nodes }).hair).toBeDefined()
+  })
+
+  it(`skips ignoredFields at the top level`, () => {
+    const example = getExampleValue({
+      nodes,
+      ignoreFields: [`name`, `anArray`],
+    })
+
+    expect(example.name).not.toBeDefined()
+    expect(example.anArray).not.toBeDefined()
+    expect(example.hair).toBeDefined()
+    expect(example.context.nestedObject.name).toBeDefined()
+  })
+
+  it(`build enum values for fields from array on nodes`, () => {
+    // TODO: Should be moved to `types/__tests__/sort.js`
+    const { SchemaComposer } = require(`graphql-compose`)
+    const { addInferredFields } = require(`../infer`)
+    const { getExampleValue } = require(`../example-value`)
+    const { getFieldsEnum } = require(`../../types/sort`)
+
+    const sc = new SchemaComposer()
+    const tc = sc.createTC(`Fields`)
+    addInferredFields({
+      schemaComposer: sc,
+      typeComposer: tc,
+      exampleValue: getExampleValue({ nodes }),
+    })
+
+    const fields = getFieldsEnum({
+      schemaComposer: sc,
+      typeComposer: tc,
+      inputTypeComposer: tc.getITC(),
+    })
+      .getType()
+      .getValues()
+      .reduce((acc, { name, value }) => {
+        acc[name] = { field: value }
+        return acc
+      }, {})
+
+    expect(fields).toMatchSnapshot()
+  })
+
+  it(`turns polymorphic fields null`, () => {
+    let example = getExampleValue({
+      nodes: [{ foo: null }, { foo: [1] }, { foo: { field: 1 } }],
+    })
+    expect(example.foo).toBe(INVALID_VALUE)
+  })
+
+  it(`handles polymorphic arrays`, () => {
+    let example = getExampleValue({
+      nodes: [{ foo: [[`foo`, `bar`]] }, { foo: [{ field: 1 }] }],
+    })
+    expect(example.foo).toBe(INVALID_VALUE)
+  })
+
+  it(`doesn't confuse empty fields for polymorhpic ones`, () => {
+    let example = getExampleValue({
+      nodes: [{ foo: { bar: 1 } }, { foo: null }, { foo: { field: 1 } }],
+    })
+    expect(example.foo).toEqual({ field: 1, bar: 1 })
+
+    example = getExampleValue({
+      nodes: [
+        { foo: [{ bar: 1 }] },
+        { foo: null },
+        { foo: [{ field: 1 }, { baz: 1 }] },
+      ],
+    })
+    expect(example.foo).toEqual([{ field: 1, bar: 1, baz: 1 }])
+  })
+
+  it(`skips unsupported types`, () => {
+    // Skips functions
+    let example = getExampleValue({ nodes: [{ foo: () => {} }] })
+    expect(example.foo).not.toBeDefined()
+
+    // Skips array of functions
+    example = getExampleValue({ nodes: [{ foo: [() => {}] }] })
+    expect(example.foo).not.toBeDefined()
+  })
+
+  it(`prefers float when multiple number types`, () => {
+    let example
+
+    // nodes starting with 32-bit integer ("big" ints are float)
+    example = getExampleValue({ nodes: [{ number: 5 }, { number: 2.5 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(2.5)
+    example = getExampleValue({
+      nodes: [{ number: 5 }, { number: 3000000000 }],
+    })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(3000000000)
+
+    // with node not containing number field
+    example = getExampleValue({ nodes: [{ number: 5 }, {}, { number: 2.5 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(2.5)
+
+    // nodes starting with float ("big" ints are float)
+    example = getExampleValue({ nodes: [{ number: 2.5 }, { number: 5 }] })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(2.5)
+    example = getExampleValue({
+      nodes: [{ number: 3000000000 }, { number: 5 }],
+    })
+    expect(example.number).toBeDefined()
+    expect(example.number).toEqual(3000000000)
+
+    // array of numbers - starting with float
+    example = getExampleValue({ nodes: [{ numbers: [2.5, 5] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(2.5)
+    example = getExampleValue({ nodes: [{ numbers: [3000000000, 5] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(3000000000)
+
+    // array of numbers - starting with 32-bit integer
+    example = getExampleValue({ nodes: [{ numbers: [5, 2.5] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(2.5)
+    example = getExampleValue({ nodes: [{ numbers: [5, 3000000000] }] })
+    expect(example.numbers).toBeDefined()
+    expect(Array.isArray(example.numbers)).toBe(true)
+    expect(example.numbers.length).toBe(1)
+    expect(example.numbers[0]).toBe(3000000000)
+  })
+
+  it(`handles mix of date strings and date objects`, () => {
+    let example
+
+    // should be valid
+    example = getExampleValue({
+      nodes: [
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+        { date: `2017-01-12T18:13:38.326Z` },
+      ],
+    })
+    expect(example.date).not.toBe(INVALID_VALUE)
+
+    // should be invalid (string is not a date)
+    example = getExampleValue({
+      nodes: [
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+        { date: `This is not a date!!!!!!` },
+      ],
+    })
+    expect(example.date).toBe(INVALID_VALUE)
+
+    // should be valid - reversed order
+    example = getExampleValue({
+      nodes: [
+        { date: `2017-01-12T18:13:38.326Z` },
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+      ],
+    })
+    expect(example.date).not.toBe(INVALID_VALUE)
+
+    // should be invalid (string is not a date) - reversed order
+    example = getExampleValue({
+      nodes: [
+        { date: `This is not a date!!!!!!` },
+        { date: new Date(`2017-12-01T14:59:45.600Z`) },
+      ],
+    })
+    expect(example.date).toBe(INVALID_VALUE)
+  })
+
+  it(`handles arrays with mix of date strings and date objects`, () => {
+    let example
+
+    // should be valid - separate arrays of unique types
+    example = getExampleValue({
+      nodes: [
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`2017-01-12T18:13:38.326Z`] },
+      ],
+    })
+    expect(example.dates).not.toBe(INVALID_VALUE)
+
+    // should be invalid - separate arrays of unique types (string is not a date)
+    example = getExampleValue({
+      nodes: [
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`This is not a date!!!!!!`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - single array of mixed types
+    example = getExampleValue({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `2017-01-12T18:13:38.326Z`,
+          ],
+        },
+      ],
+    })
+    expect(example.dates).not.toBe(INVALID_VALUE)
+
+    // should be invalid - single array of mixed types (string is not a date)
+    example = getExampleValue({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `This is not a date!!!!!!`,
+          ],
+        },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types
+    example = getExampleValue({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `2017-01-12T18:13:38.326Z`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`2017-01-12T18:13:38.326Z`] },
+      ],
+    })
+    expect(example.dates).not.toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types (string is not a date) #1
+    example = getExampleValue({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `This is not a date!!!!!!`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`2017-01-12T18:13:38.326Z`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types (string is not a date) #2
+    example = getExampleValue({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `2017-01-12T18:13:38.326Z`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`This is not a date!!!!!!`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+
+    // should be valid - separate arrays of both unique types and mixed types (string is not a date) #2
+    example = getExampleValue({
+      nodes: [
+        {
+          dates: [
+            new Date(`2017-12-01T14:59:45.600Z`),
+            `This is not a date!!!!!!`,
+          ],
+        },
+        { dates: [new Date(`2017-12-01T14:59:45.600Z`)] },
+        { dates: [`This is not a date!!!!!!`] },
+      ],
+    })
+    expect(example.dates).toBe(INVALID_VALUE)
+  })
+})
+
+describe(`Type conflicts`, () => {
+  const {
+    TypeConflictReporter,
+    TypeConflictEntry,
+  } = require(`../type-conflict-reporter`)
+
+  let addConflictSpy = jest.spyOn(TypeConflictReporter.prototype, `addConflict`)
+  let addConflictExampleSpy = jest.spyOn(
+    TypeConflictEntry.prototype,
+    `addExample`
+  )
+
+  beforeEach(() => {
+    addConflictExampleSpy.mockClear()
+  })
+
+  afterAll(() => {
+    addConflictSpy.mockRestore()
+    addConflictExampleSpy.mockRestore()
+  })
+
+  it(`Doesn't report conflicts if there are none`, () => {
+    const nodes = [
+      {
+        id: `id1`,
+        string: `string`,
+        number: 5,
+        boolean: true,
+        arrayOfStrings: [`string1`],
+      },
+      {
+        id: `id2`,
+        string: `other string`,
+        number: 3.5,
+        boolean: false,
+        arrayOfStrings: null,
+      },
+    ]
+
+    getExampleValue({ nodes, typeName: `NoConflict` })
+
+    expect(addConflictExampleSpy).not.toBeCalled()
+  })
+
+  it(`Report type conflicts and its origin`, () => {
+    const nodes = [
+      {
+        id: `id1`,
+        stringOrNumber: `string`,
+        number: 5,
+        boolean: true,
+        arrayOfStrings: [`string1`],
+      },
+      {
+        id: `id2`,
+        stringOrNumber: 5,
+        number: 3.5,
+        boolean: false,
+        arrayOfStrings: null,
+      },
+    ]
+
+    getExampleValue({ nodes, typeName: `Conflict_1` })
+
+    expect(addConflictSpy).toBeCalled()
+    expect(addConflictSpy).toBeCalledWith(
+      `Conflict_1.stringOrNumber`,
+      expect.any(Array)
+    )
+
+    expect(addConflictExampleSpy).toHaveBeenCalledTimes(2)
+    expect(addConflictExampleSpy).toBeCalledWith(
+      expect.objectContaining({
+        value: nodes[0].stringOrNumber,
+        type: `string`,
+        parent: nodes[0],
+      })
+    )
+    expect(addConflictExampleSpy).toBeCalledWith(
+      expect.objectContaining({
+        value: nodes[1].stringOrNumber,
+        type: `number`,
+        parent: nodes[1],
+      })
+    )
+  })
+
+  it(`Report conflict when array has mixed types and its origin`, () => {
+    const nodes = [
+      {
+        id: `id1`,
+        arrayOfMixedType: [`string1`, 5, `string2`, true],
+      },
+    ]
+
+    getExampleValue({ nodes, typeName: `Conflict_2` })
+    expect(addConflictSpy).toBeCalled()
+    expect(addConflictSpy).toBeCalledWith(
+      `Conflict_2.arrayOfMixedType`,
+      expect.any(Array)
+    )
+
+    expect(addConflictExampleSpy).toBeCalled()
+    expect(addConflictExampleSpy).toHaveBeenCalledTimes(1)
+    expect(addConflictExampleSpy).toBeCalledWith(
+      expect.objectContaining({
+        value: nodes[0].arrayOfMixedType,
+        type: `[string,number,boolean]`,
+        parent: nodes[0],
+      })
+    )
+  })
+
+  it(`Doesn't report ignored fields`, () => {
+    const nodes = [
+      {
+        id: `id1`,
+        stringOrNumber: `string`,
+        other: 1,
+      },
+      {
+        id: `id2`,
+        stringOrNumber: 5,
+        other: `foo`,
+      },
+    ]
+
+    getExampleValue({
+      nodes,
+      typeName: `Conflict_3`,
+      ignoreFields: [`stringOrNumber`],
+    })
+
+    expect(addConflictSpy).toBeCalled()
+    expect(addConflictSpy).toBeCalledWith(`Conflict_3.other`, expect.any(Array))
+    expect(addConflictSpy).not.toBeCalledWith(`Conflict_3.stringOrNumber`)
+    expect(addConflictExampleSpy).toBeCalled()
+  })
+})

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -3,8 +3,14 @@ const { TypeConflictReporter } = require(`./type-conflict-reporter`)
 const is32BitInteger = require(`./is-32-bit-integer`)
 const { isDate } = require(`../types/Date`)
 
+const typeConflictReporter = new TypeConflictReporter()
+
 const getExampleValue = ({ nodes, typeName, ignoreFields }) => {
-  const exampleValue = getExampleObject({ nodes, typeName, ignoreFields })
+  const exampleValue = getExampleObject({
+    nodes,
+    prefix: typeName,
+    ignoreFields,
+  })
   return exampleValue
 }
 
@@ -58,10 +64,7 @@ const getExampleObject = ({ nodes, prefix, ignoreFields = [] }) => {
         // InvalidValue.
         value = `String`
       } else {
-        TypeConflictReporter.addConflict(
-          selector,
-          Object.keys(entriesByType).map(k => entriesByType[k])
-        )
+        typeConflictReporter.addConflict(selector, entriesByType)
         return acc
       }
     }

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -1,5 +1,5 @@
 const _ = require(`lodash`)
-const { reportConflict } = require(`./type-conflict-reporter`)
+const { TypeConflictReporter } = require(`./type-conflict-reporter`)
 const is32BitInteger = require(`./is-32-bit-integer`)
 const { isDate } = require(`../types/Date`)
 
@@ -58,7 +58,7 @@ const getExampleObject = ({ nodes, prefix, ignoreFields = [] }) => {
         // InvalidValue.
         value = `String`
       } else {
-        reportConflict(
+        TypeConflictReporter.addConflict(
           selector,
           Object.keys(entriesByType).map(k => entriesByType[k])
         )
@@ -67,12 +67,7 @@ const getExampleObject = ({ nodes, prefix, ignoreFields = [] }) => {
     }
 
     let exampleFieldValue
-    if (
-      _.isObject(value) &&
-      !_.isArray(value) &&
-      !_.isString(value) &&
-      !_.isDate(value)
-    ) {
+    if (_.isPlainObject(value)) {
       const objects = entries.reduce((acc, entry) => {
         let { value } = entry
         let arrays = arrayWrappers - 1

--- a/packages/gatsby/src/schema/infer/infer.js
+++ b/packages/gatsby/src/schema/infer/infer.js
@@ -85,13 +85,16 @@ const addInferredFieldsImpl = ({
     // Proxy resolver to unsanitized fieldName in case it contained invalid characters
     if (key !== unsanitizedKey) {
       // Don't create a field with the sanitized key if a field with that name already exists
-      if (!(exampleObject[key] == null && !typeComposer.hasField(key))) {
+      if (exampleObject[key] == null && !typeComposer.hasField(key)) {
         const resolver = fieldConfig.resolve || defaultFieldResolver
-        fieldConfig.resolve = (source, args, context, info) =>
-          resolver(source, args, context, {
-            ...info,
-            fieldName: unsanitizedKey,
-          })
+        fieldConfig = {
+          ...fieldConfig,
+          resolve: (source, args, context, info) =>
+            resolver(source, args, context, {
+              ...info,
+              fieldName: unsanitizedKey,
+            }),
+        }
       }
     }
 

--- a/packages/gatsby/src/schema/infer/infer.js
+++ b/packages/gatsby/src/schema/infer/infer.js
@@ -97,7 +97,7 @@ const addInferredFieldsImpl = ({
 
     if (typeComposer.hasField(key)) {
       let fieldType = typeComposer.getFieldType(key)
-      if (_.isObject(value) /* && depth < MAX_DEPTH */) {
+      if (_.isPlainObject(value) /* && depth < MAX_DEPTH */) {
         // TODO: Use helper (similar to dropTypeModifiers)
         let lists = 0
         while (fieldType.ofType) {
@@ -198,17 +198,12 @@ const getFieldConfigFromFieldNameConvention = (
   // (ii) hinders reusing types.
   if (linkedTypes.length > 1) {
     const typeName = linkedTypes.sort().join(``) + `Union`
-    schemaComposer.getOrCreateUTC(typeName, utc => {
+    type = schemaComposer.getOrCreateUTC(typeName, utc => {
       const types = linkedTypes.map(typeName =>
         schemaComposer.getOrCreateTC(typeName)
       )
       utc.setTypes(types)
-      types.forEach(type => {
-        utc.addTypeResolver(
-          type,
-          obj => obj.internal.type === type.getTypeName()
-        )
-      })
+      utc.setResolveType(node => node.internal.type)
     })
   } else {
     type = linkedTypes[0]

--- a/packages/gatsby/src/schema/infer/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/infer/type-conflict-reporter.js
@@ -120,7 +120,7 @@ class TypeConflictReporter {
   addConflict(selector: string, examples: TypeConflictExample[]) {
     if (selector.substring(0, 11) === `SitePlugin.`) {
       // Don't store and print out type conflicts in plugins.
-      // This is out of user control so he can't do anything
+      // This is out of user control so he/she can't do anything
       // to hide those.
       return
     }

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -1,3 +1,4 @@
+const _ = require(`lodash`)
 const {
   getNodes,
   getNode,
@@ -46,8 +47,18 @@ const toNodeTypeNames = gqlTypeName => {
     .map(type => type.name)
 }
 
+const getNodeById = id => {
+  // This is for cases when the `id` has already been resolved
+  // to a full Node for the input filter, and is also in the selection
+  // set. E.g. `{ foo(parent: { id: { eq: 1 } } ) { parent { id }} }`.
+  if (_.isPlainObject(id) && id.id) {
+    return id
+  }
+  return id != null && getNode(id)
+}
+
 const getNodeByGQLTypeName = ({ id, type }) => {
-  const node = getNode(id)
+  const node = getNodeById(id)
   const nodeTypeNames = toNodeTypeNames(type)
   return node && nodeTypeNames.includes(node.internal.type) ? node : null
 }
@@ -74,7 +85,7 @@ const runQueryForGQLType = async args => {
 
 const nodeModel = {
   findRootNodeAncestor,
-  getNode: withPageDependencies(getNode),
+  getNode: withPageDependencies(getNodeById),
   getNodeByType: withPageDependencies(getNodeByGQLTypeName),
   getNodes: withPageDependencies(getNodes),
   getNodesByType: withPageDependencies(getNodesByGQLTypeName),

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -1,4 +1,6 @@
 const _ = require(`lodash`)
+const { isAbstractType } = require(`graphql`)
+
 const {
   getNodes,
   getNode,
@@ -6,12 +8,12 @@ const {
   getTypes,
   // hasNodeChanged,
   // getNodeAndSavePathDependency,
+  // TODO: Rethink the signature of runQuery!
   runQuery,
 } = require(`../db/nodes`)
 const { findRootNodeAncestor } = require(`../db/node-tracking`)
 const createPageDependency = require(`../redux/actions/add-page-dependency`)
 const { store } = require(`../redux`)
-const { isAbstractType } = require(`graphql`)
 
 const withPageDependencies = fn => async (args, pageDependencies) => {
   const result = await fn(args)

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -1,0 +1,86 @@
+const {
+  getNodes,
+  getNode,
+  getNodesByType,
+  getTypes,
+  // hasNodeChanged,
+  // getNodeAndSavePathDependency,
+  runQuery,
+} = require(`../db/nodes`)
+const { findRootNodeAncestor } = require(`../db/node-tracking`)
+const createPageDependency = require(`../redux/actions/add-page-dependency`)
+const { store } = require(`../redux`)
+const { isAbstractType } = require(`graphql`)
+
+const withPageDependencies = fn => (args, pageDependencies) => {
+  const result = fn(args)
+
+  const { path, connectionType } = pageDependencies || {}
+  if (path) {
+    if (connectionType) {
+      createPageDependency({ path, connection: connectionType })
+    } else {
+      const nodes = Array.isArray(result) ? result : [result]
+      nodes
+        .filter(Boolean)
+        .map(node => createPageDependency({ path, nodeId: node.id }))
+    }
+  }
+
+  return result
+}
+
+const toNodeTypeNames = gqlTypeName => {
+  const { schema } = store.getState()
+  const gqlType =
+    typeof gqlTypeName === `string` ? schema.getType(gqlTypeName) : gqlTypeName
+
+  if (!gqlType) return null
+
+  const possibleTypes = isAbstractType(gqlType)
+    ? schema.getPossibleTypes(gqlType)
+    : [gqlType]
+
+  return possibleTypes
+    .filter(type => type.getInterfaces().some(iface => iface.name === `Node`))
+    .map(type => type.name)
+}
+
+const getNodeByGQLTypeName = ({ id, type }) => {
+  const node = getNode(id)
+  const nodeTypeNames = toNodeTypeNames(type)
+  return node && nodeTypeNames.includes(node.internal.type) ? node : null
+}
+
+const getNodesByGQLTypeName = type => {
+  const nodeTypeNames = toNodeTypeNames(type)
+  return nodeTypeNames.reduce(
+    (acc, typeName) => acc.concat(getNodesByType(typeName)),
+    []
+  )
+}
+
+const runQueryForGQLType = async args => {
+  // TODO: should runQuery handle abstract types by itself?
+  const result = await runQuery(args)
+  if (args.firstOnly) {
+    if (result && result.length > 0) {
+      return result[0]
+    }
+    return null
+  }
+  return result
+}
+
+const nodeModel = {
+  findRootNodeAncestor,
+  getNode: withPageDependencies(getNode),
+  getNodeByType: withPageDependencies(getNodeByGQLTypeName),
+  getNodes: withPageDependencies(getNodes),
+  getNodesByType: withPageDependencies(getNodesByGQLTypeName),
+  // TODO: What should this return? Schema types? Types in the store?
+  getTypes: getTypes,
+  runQuery: withPageDependencies(runQueryForGQLType),
+}
+
+module.exports = nodeModel

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -12,8 +12,8 @@ const createPageDependency = require(`../redux/actions/add-page-dependency`)
 const { store } = require(`../redux`)
 const { isAbstractType } = require(`graphql`)
 
-const withPageDependencies = fn => (args, pageDependencies) => {
-  const result = fn(args)
+const withPageDependencies = fn => async (args, pageDependencies) => {
+  const result = await fn(args)
 
   const { path, connectionType } = pageDependencies || {}
   if (path) {

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -96,7 +96,7 @@ const getValueAtSelector = (obj, selector) => {
   }, obj)
 }
 
-const link = ({ by, from }) => (source, args, context, info) => {
+const link = ({ by, from }) => async (source, args, context, info) => {
   const fieldValue = source && source[from || info.fieldName]
 
   if (fieldValue == null || _.isPlainObject(fieldValue)) return fieldValue
@@ -112,14 +112,15 @@ const link = ({ by, from }) => (source, args, context, info) => {
 
   if (by === `id`) {
     if (Array.isArray(fieldValue)) {
-      return fieldValue
-        .map(id =>
+      const result = await Promise.all(
+        fieldValue.map(id =>
           context.nodeModel.getNodeByType(
             { id, type: type.name },
             { path: context.path }
           )
         )
-        .filter(Boolean)
+      )
+      return result.filter(Boolean)
     } else {
       return context.nodeModel.getNodeByType(
         { id: fieldValue, type: type.name },

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -11,7 +11,7 @@ const findMany = typeName => ({ args, context, info }) =>
       firstOnly: false,
       gqlType: info.schema.getType(typeName),
     },
-    { path: context.path, connection: typeName }
+    { path: context.path, connectionType: typeName }
   )
 
 const findOne = typeName => ({ args, context, info }) =>
@@ -172,7 +172,7 @@ const fileByPath = (source, args, context, info) => {
     return null
   }
 
-  const findLinkedFileNode = relativePath => {
+  const findLinkedFileNode = async relativePath => {
     // Use the parent File node to create the absolute path to
     // the linked file.
     const fileLinkPath = normalize(
@@ -181,7 +181,7 @@ const fileByPath = (source, args, context, info) => {
 
     // Use that path to find the linked File node.
     const linkedFileNode = _.find(
-      context.nodeModel.getNodesByType(`File`),
+      await context.nodeModel.getNodesByType(`File`),
       n => n.absolutePath === fileLinkPath
     )
     return linkedFileNode
@@ -193,7 +193,7 @@ const fileByPath = (source, args, context, info) => {
 
   // Find the linked File node(s)
   if (isArray) {
-    return fieldValue.map(findLinkedFileNode)
+    return Promise.all(fieldValue.map(findLinkedFileNode))
   } else {
     return findLinkedFileNode(fieldValue)
   }

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -2,83 +2,30 @@ const systemPath = require(`path`)
 const normalize = require(`normalize-path`)
 const _ = require(`lodash`)
 const { findRootNodeAncestor } = require(`../db/node-tracking`)
-const {
-  GraphQLList,
-  getNullableType,
-  getNamedType,
-  isAbstractType,
-} = require(`graphql`)
-const createPageDependency = require(`../redux/actions/add-page-dependency`)
+const { GraphQLList, getNullableType, getNamedType } = require(`graphql`)
 
-const withPageDependencies = resolve => type => async rp => {
-  const result = await resolve(type)(rp)
-  const { path } = rp.context || {}
-  if (!path || result == null) return result
+const findMany = typeName => ({ args, context, info }) =>
+  context.nodeModel.runQuery(
+    {
+      queryArgs: args,
+      firstOnly: false,
+      gqlType: info.schema.getType(typeName),
+    },
+    { path: context.path, connection: typeName }
+  )
 
-  if (Array.isArray(result)) {
-    const isConnection =
-      rp.info.parentType && rp.info.parentType.name === `Query`
-    if (isConnection) {
-      createPageDependency({ path, connection: type })
-    } else {
-      result
-        .filter(node => node != null)
-        .map(node => createPageDependency({ path, nodeId: node.id }))
-    }
-  } else {
-    createPageDependency({ path, nodeId: result.id })
-  }
-
-  return result
-}
-
-const findById = typeName => ({ args, context }) => {
-  const result = context.nodeModel.getNode(args.id)
-  if (typeName && result && result.internal.type === typeName) {
-    return result
-  } else if (!typeName && result != null) {
-    return result
-  } else {
-    return null
-  }
-}
-
-const findByIds = typeName => ({ args, context }) => {
-  if (Array.isArray(args.ids)) {
-    return args.ids.map(context.nodeModel.getNode).filter(node => {
-      if (typeName && node && node.internal.type === typeName) {
-        return true
-      } else {
-        return node != null
-      }
-    })
-  } else {
-    return []
-  }
-}
-
-const findMany = typeName => async ({ args, context, info }) =>
-  context.nodeModel.runQuery({
-    queryArgs: args,
-    firstOnly: false,
-    gqlType: info.schema.getType(typeName),
-  })
-
-const findOne = typeName => async ({ args, context, info }) => {
-  const result = await context.nodeModel.runQuery({
-    queryArgs: { filter: args },
-    firstOnly: true,
-    gqlType: info.schema.getType(typeName),
-  })
-  if (result.length > 0) {
-    return result[0]
-  } else {
-    return null
-  }
-}
+const findOne = typeName => ({ args, context, info }) =>
+  context.nodeModel.runQuery(
+    {
+      queryArgs: { filter: args },
+      firstOnly: true,
+      gqlType: info.schema.getType(typeName),
+    },
+    { path: context.path }
+  )
 
 const findManyPaginated = typeName => async rp => {
-  const result = await withPageDependencies(findMany)(typeName)(rp)
+  const result = await findMany(typeName)(rp)
   return paginate(result, { skip: rp.args.skip, limit: rp.args.limit })
 }
 
@@ -119,14 +66,7 @@ const paginate = (results, { skip = 0, limit }) => {
   const count = results.length
   const items = results.slice(skip, limit && skip + limit)
 
-  // const pageCount = limit
-  //   ? Math.ceil(skip / limit) + Math.ceil((count - skip) / limit)
-  //   : skip
-  //   ? 2
-  //   : 1
-  // const currentPage = limit ? Math.ceil(skip / limit) + 1 : skip ? 2 : 1 // Math.min(currentPage, pageCount)
-  // // const hasPreviousPage = currentPage > 1
-  const hasNextPage = skip + limit < count // currentPage < pageCount
+  const hasNextPage = skip + limit < count
 
   return {
     totalCount: items.length,
@@ -139,11 +79,6 @@ const paginate = (results, { skip = 0, limit }) => {
     }),
     pageInfo: {
       hasNextPage,
-      // currentPage,
-      // hasPreviousPage,
-      // itemCount: count,
-      // pageCount,
-      // perPage: limit,
     },
   }
 }
@@ -161,30 +96,36 @@ const getValueAtSelector = (obj, selector) => {
   }, obj)
 }
 
-// FIXME: Handle array of arrays
-// Maybe TODO: should we check fieldValue *and* info.returnType?
-const link = ({ by, from }) => async (source, args, context, info) => {
+const link = ({ by, from }) => (source, args, context, info) => {
   const fieldValue = source && source[from || info.fieldName]
 
-  if (fieldValue == null || _.isObject(fieldValue)) return fieldValue
+  if (fieldValue == null || _.isPlainObject(fieldValue)) return fieldValue
   if (
     Array.isArray(fieldValue) &&
-    // TODO: Do we have to look with fieldValue.some(v => isObject(v))?
-    (fieldValue[0] == null || _.isObject(fieldValue[0]))
+    (fieldValue[0] == null || _.isPlainObject(fieldValue[0]))
   ) {
     return fieldValue
   }
 
+  const returnType = getNullableType(info.returnType)
+  const type = getNamedType(returnType)
+
   if (by === `id`) {
-    const [resolve, key] = Array.isArray(fieldValue)
-      ? [withPageDependencies(findByIds), `ids`]
-      : [withPageDependencies(findById), `id`]
-    return resolve()({
-      source,
-      args: { [key]: fieldValue },
-      context,
-      info,
-    })
+    if (Array.isArray(fieldValue)) {
+      return fieldValue
+        .map(id =>
+          context.nodeModel.getNodeByType(
+            { id, type: type.name },
+            { path: context.path }
+          )
+        )
+        .filter(Boolean)
+    } else {
+      return context.nodeModel.getNodeByType(
+        { id: fieldValue, type: type.name },
+        { path: context.path }
+      )
+    }
   }
 
   const equals = value => {
@@ -200,37 +141,24 @@ const link = ({ by, from }) => async (source, args, context, info) => {
     }
   }, fieldValue)
 
-  const returnType = getNullableType(info.returnType)
-  const type = getNamedType(returnType)
-  const possibleTypes = isAbstractType(type)
-    ? info.schema.getPossibleTypes(type)
-    : [type]
-
   if (returnType instanceof GraphQLList) {
-    const results = await Promise.all(
-      possibleTypes.map(type =>
-        findMany(type.name)({
-          source,
-          args,
-          context,
-          info,
-        })
-      )
-    )
-    return results.reduce((acc, r) => acc.concat(r))
-  } else {
-    let result
-    for (const type of possibleTypes) {
-      result = await context.nodeModel.runQuery({
+    return context.nodeModel.runQuery(
+      {
         queryArgs: args,
+        firstOnly: false,
+        gqlType: type,
+      },
+      { path: context.path }
+    )
+  } else {
+    return context.nodeModel.runQuery(
+      {
+        queryArgs: { filter: args },
         firstOnly: true,
         gqlType: type,
-      })
-      if (result && result.length > 0) {
-        return result[0]
-      }
-    }
-    return null
+      },
+      { path: context.path }
+    )
   }
 }
 
@@ -271,14 +199,9 @@ const fileByPath = (source, args, context, info) => {
 }
 
 module.exports = {
-  findById: withPageDependencies(findById),
-  findByIds: withPageDependencies(findByIds),
-  findByIdAndType: withPageDependencies(findById),
-  findByIdsAndType: withPageDependencies(findByIds),
-  findMany: withPageDependencies(findMany),
-  findManyPaginated: findManyPaginated,
-  findOne: withPageDependencies(findOne),
-  fileByPath: fileByPath,
+  findManyPaginated,
+  findOne,
+  fileByPath,
   link,
   distinct,
   group,

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -272,13 +272,14 @@ function createChildrenField(typeName) {
   return {
     [_.camelCase(`children ${typeName}`)]: {
       type: () => [typeName],
-      resolve(source, args, context) {
+      async resolve(source, args, context) {
         const { path } = context
-        return source.children
-          .map(id =>
+        const result = await Promise.all(
+          source.children.map(id =>
             context.nodeModel.getNodeByType({ id, type: typeName }, { path })
           )
-          .filter(Boolean)
+        )
+        return result.filter(Boolean)
       },
     },
   }
@@ -288,13 +289,14 @@ function createChildField(typeName) {
   return {
     [_.camelCase(`child ${typeName}`)]: {
       type: () => typeName,
-      resolve(source, args, context) {
+      async resolve(source, args, context) {
         const { path } = context
-        return source.children
-          .map(id =>
+        const result = await Promise.all(
+          source.children.map(id =>
             context.nodeModel.getNodeByType({ id, type: typeName }, { path })
           )
-          .find(Boolean)
+        )
+        return result.find(Boolean)
       },
     },
   }

--- a/packages/gatsby/src/schema/types/Date.js
+++ b/packages/gatsby/src/schema/types/Date.js
@@ -61,7 +61,34 @@ export function isDate(value) {
   return momentDate.isValid() && typeof value !== `number`
 }
 
-export const dateResolver = Object.freeze({
+const formatDate = ({
+  date,
+  fromNow,
+  difference,
+  formatString,
+  locale = `en`,
+}) => {
+  const normalizedDate = JSON.parse(JSON.stringify(date))
+  if (formatString) {
+    return moment
+      .utc(normalizedDate, ISO_8601_FORMAT, true)
+      .locale(locale)
+      .format(formatString)
+  } else if (fromNow) {
+    return moment
+      .utc(normalizedDate, ISO_8601_FORMAT, true)
+      .locale(locale)
+      .fromNow()
+  } else if (difference) {
+    return moment().diff(
+      moment.utc(normalizedDate, ISO_8601_FORMAT, true).locale(locale),
+      difference
+    )
+  }
+  return normalizedDate
+}
+
+export const dateResolver = {
   type: GraphQLDate,
   args: {
     formatString: {
@@ -92,33 +119,11 @@ export const dateResolver = Object.freeze({
     },
   },
   resolve(source, args, context, { fieldName }) {
-    let date
-    if (source[fieldName]) {
-      date = JSON.parse(JSON.stringify(source[fieldName]))
-    } else {
-      return null
-    }
+    const date = source[fieldName]
+    if (date == null) return null
 
-    if (_.isPlainObject(args)) {
-      const { fromNow, difference, formatString, locale = `en` } = args
-      if (formatString) {
-        return moment
-          .utc(date, ISO_8601_FORMAT, true)
-          .locale(locale)
-          .format(formatString)
-      } else if (fromNow) {
-        return moment
-          .utc(date, ISO_8601_FORMAT, true)
-          .locale(locale)
-          .fromNow()
-      } else if (difference) {
-        return moment().diff(
-          moment.utc(date, ISO_8601_FORMAT, true).locale(locale),
-          difference
-        )
-      }
-    }
-
-    return date
+    return Array.isArray(date)
+      ? date.map(d => formatDate({ date: d, ...args }))
+      : formatDate({ date, ...args })
   },
-})
+}

--- a/packages/gatsby/src/schema/types/NodeInterface.js
+++ b/packages/gatsby/src/schema/types/NodeInterface.js
@@ -1,7 +1,6 @@
 const getOrCreateNodeInterface = schemaComposer => {
   // TODO: why is `mediaType` on Internal? Applies only to File!?
-  // Is `fieldOwners` actually set anywhere? And is it supposed to be an array,
-  // as the Joi schema claims, or an object, which is the default in `redux/actions.js`
+  // `fieldOwners` is an object
   const InternalTC = schemaComposer.getOrCreateTC(`Internal`, tc => {
     tc.addFields({
       content: `String`,
@@ -22,13 +21,19 @@ const getOrCreateNodeInterface = schemaComposer => {
       id: `String!`,
       parent: {
         type: `Node`,
-        resolve: async (source, args, context, info) =>
-          context.nodeModel.getNode(source.parent),
+        resolve: async (source, args, context, info) => {
+          const { path } = context
+          return context.nodeModel.getNode(source.parent, { path })
+        },
       },
       children: {
         type: `[Node]!`,
-        resolve: async (source, args, context, info) =>
-          source.children.map(context.nodeModel.getNode),
+        resolve: async (source, args, context, info) => {
+          const { path } = context
+          return source.children.map(id =>
+            context.nodeModel.getNode(id, { path })
+          )
+        },
       },
       internal: `Internal`,
     })
@@ -41,39 +46,21 @@ const getOrCreateNodeInterface = schemaComposer => {
 const addNodeInterface = ({ schemaComposer, typeComposer }) => {
   const NodeInterfaceTC = getOrCreateNodeInterface(schemaComposer)
   typeComposer.addInterface(NodeInterfaceTC)
-  NodeInterfaceTC.addTypeResolver(
-    typeComposer,
-    node => node.internal.type === typeComposer.getTypeName()
-  )
   addNodeInterfaceFields({ schemaComposer, typeComposer })
 }
 
 const addNodeInterfaceFields = ({ schemaComposer, typeComposer }) => {
   const NodeInterfaceTC = getOrCreateNodeInterface(schemaComposer)
   typeComposer.addFields(NodeInterfaceTC.getFields())
-  NodeInterfaceTC.addTypeResolver(
-    typeComposer,
-    node => node.internal.type === typeComposer.getTypeName()
-  )
-  // FIXME: UPSTREAM: addSchemaMustHaveType adds to an array,
-  // should be Set/Map to avoid duplicates?
+  NodeInterfaceTC.setResolveType(node => node.internal.type)
   schemaComposer.addSchemaMustHaveType(typeComposer)
 }
 
 const getNodeInterface = ({ schemaComposer }) =>
   getOrCreateNodeInterface(schemaComposer)
 
-const hasNodeInterface = ({ schemaComposer, typeComposer }) => {
-  const NodeInterfaceTC = getOrCreateNodeInterface(schemaComposer)
-  return (
-    typeComposer.hasInterface(NodeInterfaceTC) ||
-    typeComposer.hasInterface(NodeInterfaceTC.getType())
-  )
-}
-
 module.exports = {
   addNodeInterface,
   addNodeInterfaceFields,
   getNodeInterface,
-  hasNodeInterface,
 }

--- a/packages/gatsby/src/schema/types/NodeInterface.js
+++ b/packages/gatsby/src/schema/types/NodeInterface.js
@@ -21,14 +21,14 @@ const getOrCreateNodeInterface = schemaComposer => {
       id: `String!`,
       parent: {
         type: `Node`,
-        resolve: async (source, args, context, info) => {
+        resolve: (source, args, context, info) => {
           const { path } = context
           return context.nodeModel.getNode(source.parent, { path })
         },
       },
       children: {
         type: `[Node]!`,
-        resolve: async (source, args, context, info) => {
+        resolve: (source, args, context, info) => {
           const { path } = context
           return source.children.map(id =>
             context.nodeModel.getNode(id, { path })


### PR DESCRIPTION
This is for #11480

Questions:
* should nodeModel methods be called with `context`, or with `{ path: context: path }`?
* `getNodesByType` and `getNodeByType` handle GraphQL abstract types, what about `runQuery`?
* what else to put on nodeModel?
* `runQuery` signature (e.g. GraphQL type or typeName as arg)?
* why do we have `TypeConflictReporter` (instead of logging conflict right away)?