### PR TITLE
docs(showcase): add docs.wpgraphql.com to showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4229,3 +4229,19 @@
   built_by: Marcy Sutton
   built_by_url: https://marcysutton.com
   featured: true
+- title: WPGraphQL Docs
+  main_url: https://docs.wpgraphql.com
+  url: https://docs.wpgraphql.com
+  description: >
+    Documentation for WPGraphQL, a free open-source WordPress plugin that provides an extendable GraphQL schema and API for any WordPress site.
+  categories:
+    - API
+    - CMS
+    - Documentation
+    - GraphQL
+    - Technology
+    - Web Development
+    - WordPress
+  built_by: WPGraphQL
+  built_by_url: https://wpgraphql.com
+  featured: false


### PR DESCRIPTION
Just launched [https://docs.wpgraphql.com](https://docs.wpgraphql.com) tonight. Thought it would be good to add to the Gatsby showcase. 😄 