### PR TITLE
chore(www): add target blank to showcase url

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -12,7 +12,7 @@ import Layout from "../components/layout"
 import ShareMenu from "../components/share-menu"
 
 import MdArrowUpward from "react-icons/lib/md/arrow-upward"
-import MdLaunch from "react-icons/lib/md/launch"
+import MdLink from "react-icons/lib/md/link"
 import FeaturedIcon from "../assets/featured-detailpage-featuredicon.svg"
 import FeatherIcon from "../assets/showcase-feather.svg"
 import GithubIcon from "react-icons/lib/go/mark-github"
@@ -473,7 +473,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                         },
                       }}
                     >
-                      <MdLaunch
+                      <MdLink
                         style={{
                           verticalAlign: `sub`,
                         }}


### PR DESCRIPTION
It is quite annoying to go through the showcases and the link not opening a new tab.

This PR adds `target="_blank"` to the Showcase Details Modal.