### PR TITLE
fix(blog): Fix quotes on blog post

### DIFF
--- a/docs/blog/2017-10-16-making-website-building-fun/index.md
+++ b/docs/blog/2017-10-16-making-website-building-fun/index.md
@@ -91,19 +91,17 @@ larger and larger.
 
 Fred Brooks wrote in his classic book _The Mythical Man-Month_:
 
-<pullquote>
-The programmer, like the poet, works only slightly removed from pure
-thought-stuff. He builds his castles in the air, from air, creating by
-exertion of the imagination. Few media of creation are so flexible, so easy to
-polish and rework, so readily capable of realizing grand conceptual
-structures…
-
-Yet the program construct, unlike the poet's words, is real in the sense that
-it moves and works, producing visible outputs separate from the construct
-itself. […] The magic of myth and legend has come true in our time. One types
-the correct incantation on a keyboard, and a display screen comes to life,
-showing things that never were nor could be.
-</pullquote>
+> The programmer, like the poet, works only slightly removed from pure
+> thought-stuff. He builds his castles in the air, from air, creating by
+> exertion of the imagination. Few media of creation are so flexible, so easy to
+> polish and rework, so readily capable of realizing grand conceptual
+> structures…
+>
+> Yet the program construct, unlike the poet's words, is real in the sense that
+> it moves and works, producing visible outputs separate from the construct
+> itself. […] The magic of myth and legend has come true in our time. One types
+> the correct incantation on a keyboard, and a display screen comes to life,
+> showing things that never were nor could be.
 
 Technology is incredibly fun when we, like the wizard of fantasy, can type an
 incantation on our computer and a new creation comes to life.


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/10530 this post somehow

<img width="856" alt="screenshot 2019-02-09 20 34 17" src="https://user-images.githubusercontent.com/71047/52529638-1f239980-2caa-11e9-9989-ab17f7468e19.png">

The entire post got pullquoted