### PR TITLE
feat(createRemoteFileNode): allow passing headers to request

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -183,6 +183,10 @@ createRemoteFileNode({
   auth: { htaccess_user: `USER`, htaccess_pass: `PASSWORD` },
 
   // OPTIONAL
+  // Adds extra http headers to download request if passed in.
+  httpHeaders: { Authorization: `Bearer someAccessToken` },
+
+  // OPTIONAL
   // Sets the file extension
   ext: ".jpg",
 })

--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -174,6 +174,23 @@ describe(`create-remote-file-node`, () => {
           })
         )
       })
+
+      it(`passes custom http heades, if defined`, async () => {
+        await setup({
+          httpHeaders: {
+            Authorization: `Bearer foobar`,
+          },
+        })
+
+        expect(got.stream).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: `Bearer foobar`,
+            }),
+          })
+        )
+      })
     })
   })
 

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -186,7 +186,7 @@ async function processRemoteNode({
   createNode,
   parentNodeId,
   auth = {},
-  headers = {},
+  httpHeaders = {},
   createNodeId,
   ext,
   name,
@@ -202,7 +202,7 @@ async function processRemoteNode({
   // See if there's response headers for this url
   // from a previous request.
   const cachedHeaders = await cache.get(cacheId(url))
-  const headers = {}
+  const headers = { httpHeaders }
   if (cachedHeaders && cachedHeaders.etag) {
     headers[`If-None-Match`] = cachedHeaders.etag
   }
@@ -315,7 +315,7 @@ module.exports = ({
   createNode,
   parentNodeId = null,
   auth = {},
-  headers = {},
+  httpHeaders = {},
   createNodeId,
   ext = null,
   name = null,
@@ -361,7 +361,7 @@ module.exports = ({
     parentNodeId,
     createNodeId,
     auth,
-    headers,
+    httpHeaders,
     ext,
     name,
   })

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -202,7 +202,7 @@ async function processRemoteNode({
   // See if there's response headers for this url
   // from a previous request.
   const cachedHeaders = await cache.get(cacheId(url))
-  const headers = { httpHeaders }
+  const headers = { ...httpHeaders }
   if (cachedHeaders && cachedHeaders.etag) {
     headers[`If-None-Match`] = cachedHeaders.etag
   }

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -186,6 +186,7 @@ async function processRemoteNode({
   createNode,
   parentNodeId,
   auth = {},
+  headers = {},
   createNodeId,
   ext,
   name,
@@ -314,6 +315,7 @@ module.exports = ({
   createNode,
   parentNodeId = null,
   auth = {},
+  headers = {},
   createNodeId,
   ext = null,
   name = null,
@@ -359,6 +361,7 @@ module.exports = ({
     parentNodeId,
     createNodeId,
     auth,
+    headers,
     ext,
     name,
   })


### PR DESCRIPTION
## Description
This allows a user to pass header to create-remote-file-node for fetching data which is in private mode in cms.

thanks to @datakurre who also helped me in creating this pr.