### PR TITLE
style: remove extra bottom margin in figures during develop

### DIFF
--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -261,11 +261,14 @@ const _options = {
         fontSize: `102%`,
         color: colors.gatsby,
       },
+      ".post-body figure img": {
+        marginBottom: 0,
+      },
       ".post-body figcaption": {
         color: colors.gray.calm,
         fontFamily: headerFontFamily.join(`,`),
         fontSize: `87.5%`,
-        marginTop: rhythm(1 / 2),
+        marginTop: rhythm(1 / 4),
       },
       ".main-body a:hover": {
         background: colors.ui.bright,


### PR DESCRIPTION
Before this fix, using `figure` with `figcaption` in `develop` added extra margin to the bottom of `img` tags, which made the captions look weird and disconnected from the image. This fixes that.

<img width="764" alt="screen shot 2019-02-10 at 1 01 38 pm" src="https://user-images.githubusercontent.com/163561/52539573-81c17780-2d34-11e9-8764-04fcb2c8c503.png">
