### PR TITLE
docs: CSS modules class name reference fix (2lRF7)

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -254,7 +254,7 @@ The `console.log(styles)` code will log the resulting import so you can see the 
 ![css-modules-console](css-modules-console.png)
 
 If you compare that to your CSS file, you'll see that each class is now a key in the imported object pointing to a long string e.g. `avatar` points to
-`about-css-modules-module---avatar----hYcv`. These are the class names CSS
+`src-pages----about-css-modules-module---avatar---2lRF7`. These are the class names CSS
 Modules generates. They're guaranteed to be unique across your site. And because
 you have to import them to use the classes, there's never any question about
 where some CSS is being used.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The image and the text showing the value of the Avatar key do not currently match in the Styling Gatsby documentation.
