### PR TITLE
docs(s3-cloudfront): update install doc (aws -> awscli)

### DIFF
--- a/docs/docs/deploying-to-s3-cloudfront.md
+++ b/docs/docs/deploying-to-s3-cloudfront.md
@@ -33,7 +33,7 @@ You'll need these in the next step.
 Install the AWS CLI and configure it (ensure python is installed before running these commands)
 
 ```shell
-pip install aws
+pip install awscli
 aws configure
 ```
 


### PR DESCRIPTION
## Description

Fix for the AWS CLI install command. `pip install aws` installs the AWS library and `pip install awscli` installs the CLI.

https://aws.amazon.com/cli/