### PR TITLE
chore(ci): fix integration tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,9 +212,9 @@ workflows:
           requires:
             - bootstrap
       - integration_tests_long_term_caching:
-          <<: *ignore_docs
+          <<: *e2e-test-workflow
       - integration_tests_gatsby_pipeline:
-          <<: *ignore_docs
+          <<: *e2e-test-workflow
       - e2e_tests_gatsbygram:
           <<: *e2e-test-workflow
       - e2e_tests_path-prefix:


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/1120926/52645409-02bd7200-2ee1-11e9-964b-8ad4dc793265.png)

integration tests should be dependant on bootstrap
![image](https://user-images.githubusercontent.com/1120926/52645521-38625b00-2ee1-11e9-812e-a3259c7ff3f6.png)
