### PR TITLE
fix(gatsby): use route path to serve _exact_ page in client routing

### DIFF
--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -17,18 +17,23 @@ const getPages = directory =>
     .catch(() => [])
 
 const clientOnlyPathsRouter = (pages, options) => {
-  const clientOnlyRoutes = pages
-    .filter(page => page.matchPath)
-    .map(page => page.matchPath)
+  const clientOnlyRoutes = pages.filter(page => page.matchPath)
   return (req, res, next) => {
     const { url } = req
     if (req.accepts(`html`)) {
-      if (clientOnlyRoutes.some(route => reachMatch(route, url) !== null)) {
-        return res.sendFile(`index.html`, options, err => {
-          if (err) {
-            next()
+      const route = clientOnlyRoutes.find(
+        route => reachMatch(route.matchPath, url) !== null
+      )
+      if (route && route.path) {
+        return res.sendFile(
+          path.join(route.path, `index.html`),
+          options,
+          err => {
+            if (err) {
+              next()
+            }
           }
-        })
+        )
       }
     }
     return next()

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -22,7 +22,7 @@ const clientOnlyPathsRouter = (pages, options) => {
     const { url } = req
     if (req.accepts(`html`)) {
       const route = clientOnlyRoutes.find(
-        route => reachMatch(route.matchPath, url) !== null
+        clientRoute => reachMatch(clientRoute.matchPath, url) !== null
       )
       if (route && route.path) {
         return res.sendFile(


### PR DESCRIPTION
## Description

Small fix to #11610 to route based on the matched sub-path. For example, given a route `/app/client/*` this will serve from the `public/app/client/index.html` path, rather than the root-level `index.html`.