### PR TITLE
docs(gatsby): Add documentation for useStaticQuery

### DIFF
--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -2,7 +2,7 @@
 title: Querying data in components with the useStaticQuery hook
 ---
 
-Gatsby v2.1.0 introduces `useStaticQuery`, a new [React Hook](https://reactjs.org/docs/hooks-intro.html) that. Just like the `StaticQuery` component, it allows your React components to retrieve data via a GraphQL query. But with the simplicity, shareability and elegance of Hooks.
+Gatsby v2.1.0 introduces `useStaticQuery`, a new Gatsby feature that provides the ability to use a [React Hook](https://reactjs.org/docs/hooks-intro.html) to query with GraphQL at _build time_. Just like the `StaticQuery` component, it allows your React components to retrieve data via a GraphQL query that will be parsed, evaluated, and the resulting data will be injected into the component. However--`useStaticQuery` uses a hook rather than a render prop!
 
 In this guide, we'll walk through an example using `useStaticQuery`. If you're not familiar with static queries in Gatsby, you might want to check out [the difference between a static query and a page query](/docs/static-query/#how-staticquery-differs-from-page-query).
 

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -1,0 +1,47 @@
+---
+title: Querying Data in Components with the useStaticQuery hook
+---
+
+Gatsby v2.1.0 introduces `useStaticQuery`, a new [React Hook](https://reactjs.org/docs/hooks-intro.html) that. Just like the `StaticQuery` component, it allows your React components to retrieve data via a GraphQL query. But with the simplicity, shareability and elegance of Hooks.
+
+In this guide, we'll walk through an example using `useStaticQuery`. If you're not familiar with static queries in Gatsby, you might want to check out [the difference between a static query and a page query](/docs/static-query/#how-staticquery-differs-from-page-query).
+
+## How to use `useStaticQuery` in components
+
+> 💡 You'll need React and ReactDOM 16.8.0 or later to use `useStaticQuery`.
+
+`useStaticQuery` is a React Hook. All the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) apply.
+
+It takes your `query` and returns your data. That's it!
+
+### Basic example
+
+Let's create our familiar `Header` component:
+
+```jsx:title=src/components/header.js
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export default () => {
+  const data = useStaticQuery(graphql`
+    query HeaderQuery {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+    }
+  `)
+
+  return (
+    <header>
+      <h1>{data.site.siteMetadata.title}</h1>
+    </header>
+  )
+}
+```
+
+## Known Limitations
+
+- `useStaticQuery` does not accept variables (hence the name "static"), but can be used in _any_ component, including pages
+- Because of how queries currently work in Gatsby, we support only a single instance of `useStaticQuery` in a file

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -12,7 +12,7 @@ In this guide, we'll walk through an example using `useStaticQuery`. If you're n
 
 > 💡 You'll need React and ReactDOM 16.8.0 or later to use `useStaticQuery`.
 >
-> 📦 `npm install react@^16.8.0 react-dom@16.8.0`
+> 📦 `npm install react@^16.8.0 react-dom@^16.8.0`
 
 `useStaticQuery` is a React Hook. All the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) apply.
 

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -12,7 +12,7 @@ In this guide, we'll walk through an example using `useStaticQuery`. If you're n
 
 `useStaticQuery` is a React Hook. All the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) apply.
 
-It takes your `query` and returns your data. That's it!
+It takes your GraphQL query and returns the requested data. That's it!
 
 ### Basic example
 

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -9,6 +9,8 @@ In this guide, we'll walk through an example using `useStaticQuery`. If you're n
 ## How to use `useStaticQuery` in components
 
 > 💡 You'll need React and ReactDOM 16.8.0 or later to use `useStaticQuery`.
+>
+> 📦 `npm install react@^16.8.0 react-dom@16.8.0`
 
 `useStaticQuery` is a React Hook. All the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) apply.
 

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -1,5 +1,5 @@
 ---
-title: Querying Data in Components with the useStaticQuery hook
+title: Querying data in components with the useStaticQuery hook
 ---
 
 Gatsby v2.1.0 introduces `useStaticQuery`, a new [React Hook](https://reactjs.org/docs/hooks-intro.html) that. Just like the `StaticQuery` component, it allows your React components to retrieve data via a GraphQL query. But with the simplicity, shareability and elegance of Hooks.

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -2,11 +2,13 @@
 title: Querying data in components with the useStaticQuery hook
 ---
 
-Gatsby v2.1.0 introduces `useStaticQuery`, a new Gatsby feature that provides the ability to use a [React Hook](https://reactjs.org/docs/hooks-intro.html) to query with GraphQL at _build time_. Just like the `StaticQuery` component, it allows your React components to retrieve data via a GraphQL query that will be parsed, evaluated, and the resulting data will be injected into the component. However--`useStaticQuery` uses a hook rather than a render prop!
+Gatsby v2.1.0 introduces `useStaticQuery`, a new Gatsby feature that provides the ability to use a [React Hook](https://reactjs.org/docs/hooks-intro.html) to query with GraphQL at _build time_.
+
+Just like the [StaticQuery](/docs/static-query/) component, it allows your React components to retrieve data via a GraphQL query that will be parsed, evaluated, and injected into the component. However, `useStaticQuery` is a hook rather than a component that takes a render prop!
 
 In this guide, we'll walk through an example using `useStaticQuery`. If you're not familiar with static queries in Gatsby, you might want to check out [the difference between a static query and a page query](/docs/static-query/#how-staticquery-differs-from-page-query).
 
-## How to use `useStaticQuery` in components
+## How to use useStaticQuery in components
 
 > 💡 You'll need React and ReactDOM 16.8.0 or later to use `useStaticQuery`.
 >

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -18,7 +18,7 @@ It takes your GraphQL query and returns the requested data. That's it!
 
 ### Basic example
 
-Let's create our familiar `Header` component:
+Let's create a `Header` component that queries for the site title from `gatsby-config.js`:
 
 ```jsx:title=src/components/header.js
 import React from "react"

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -118,6 +118,8 @@
           link: /docs/page-query/
         - title: Querying data in components with StaticQuery
           link: /docs/static-query/
+        - title: Querying data in components with the useStaticQuery hook
+          link: /docs/use-static-query/
         - title: Using GraphQL fragments
           link: /docs/using-fragments/
         - title: Creating slugs for pages


### PR DESCRIPTION
Adds documentation for upcoming hook `useStaticQuery` (https://github.com/gatsbyjs/gatsby/pull/11588)