### PR TITLE
feat(starters): Add font smoothing

### DIFF
--- a/starters/default/src/components/layout.css
+++ b/starters/default/src/components/layout.css
@@ -5,6 +5,8 @@ html {
 }
 body {
   margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 article,
 aside,


### PR DESCRIPTION
This PR adds font smoothing via `layout.css` to the default gatsby starter theme.