### PR TITLE
fix(gatsby-source-shopify): fix query pagination

### DIFF
--- a/packages/gatsby-source-shopify/src/lib.js
+++ b/packages/gatsby-source-shopify/src/lib.js
@@ -39,8 +39,8 @@ export const queryAll = async (
   path,
   query,
   first = 250,
-  after,
-  aggregatedResponse
+  after = null,
+  aggregatedResponse = null
 ) => {
   const data = await queryOnce(client, query, first, after)
 
@@ -51,8 +51,8 @@ export const queryAll = async (
     ? aggregatedResponse.concat(nodes)
     : nodes
 
-  if (get([...path, `pageInfo`, `hasNextPage`], false, data))
-    return queryAll(
+  if (get([...path, `pageInfo`, `hasNextPage`], data)) {
+    return await queryAll(
       client,
       path,
       query,
@@ -60,6 +60,7 @@ export const queryAll = async (
       last(edges).cursor,
       aggregatedResponse
     )
+  }
 
   return aggregatedResponse
 }

--- a/packages/gatsby-source-shopify/src/lib.js
+++ b/packages/gatsby-source-shopify/src/lib.js
@@ -52,7 +52,7 @@ export const queryAll = async (
     : nodes
 
   if (get([...path, `pageInfo`, `hasNextPage`], data)) {
-    return await queryAll(
+    return queryAll(
       client,
       path,
       query,


### PR DESCRIPTION
Main fix here is that `get` was using `false` argument (for unknown reason) in place for data object, so the condition was never true.

Just in case - issue that this PR is fixing can be reproduced by using https://github.com/gatsbyjs/store.gatsbyjs.org and monkey-patching https://github.com/gatsbyjs/gatsby/blob/67c0131a0dbaac4d9b535197f70bcbde0f37f49c/packages/gatsby-source-shopify/src/lib.js#L41 to default to for example 5.

250 default limit is shopify's maximum (using more would cause query to error out)

fixes #11724