### PR TITLE
fix #11006 ServiceWorker registration causes a quick blank page on website loading/refresh

### DIFF
--- a/packages/gatsby-plugin-offline/src/sw-append.js
+++ b/packages/gatsby-plugin-offline/src/sw-append.js
@@ -12,6 +12,10 @@ const navigationRoute = new workbox.routing.NavigationRoute(({ event }) => {
       const offlineShell = `%pathPrefix%/offline-plugin-app-shell-fallback/index.html`
       const cacheName = workbox.core.cacheNames.precache
 
+      if (navigator.onLine) {
+        return fetch(event.request)
+      }
+
       return caches.match(offlineShell, { cacheName }).then(cachedResponse => {
         if (cachedResponse) return cachedResponse
 


### PR DESCRIPTION
## Description

Since plugin fallback to `app-shell` ( the blank page ) each time so just add a checking before.

## Related Issues

Fixes #11006
