### PR TITLE
fix(www): Plugin library scrollbar issue

### DIFF
--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -34,7 +34,7 @@ const widthLarge = rhythm(16)
 const styles = {
   sidebar: {
     height: `calc(100vh - ${presets.headerHeight})`,
-    width: `100vw`,
+    width: `100%`,
     zIndex: 1,
     top: `calc(${presets.headerHeight} + ${presets.bannerHeight} - 1px)`,
     ...scrollbarStyles,

--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -10,7 +10,7 @@ const PageWithPluginSearchBar = ({ isPluginsIndex, location, children }) => (
       css={{
         ...styles.sidebar,
         // mobile: hide PluginSearchBar when on gatsbyjs.org/packages/foo, aka package README page
-        display: `${!isPluginsIndex && `none`}`,
+        display: !isPluginsIndex ? `none` : false,
       }}
     >
       <PluginSearchBar location={location} />
@@ -20,7 +20,7 @@ const PageWithPluginSearchBar = ({ isPluginsIndex, location, children }) => (
       css={{
         ...styles.content,
         // mobile: hide README on gatsbyjs.org/plugins index page
-        display: `${isPluginsIndex && `none`}`,
+        display: isPluginsIndex ? `none` : false,
       }}
     >
       {children}


### PR DESCRIPTION
Don’t set `display` CSS prop to empty string — ends up being interpreted as `false` by the browser 😉 😅. Instead we now explicitly return `false` so that `emotion` doesn't overwrite the `display` prop.

![image](https://user-images.githubusercontent.com/21834/52806055-56b68b00-3088-11e9-8e5d-44554201d48f.png)
