### PR TITLE
fix(www): ensure released is set/filtered appropriately on blog posts

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -488,7 +488,10 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
         let released = false
         const date = _.get(node, `frontmatter.date`)
         if (date) {
-          released = moment().isSameOrAfter(moment.utc(date))
+          released = moment
+            .utc()
+            .startOf(`day`)
+            .isSameOrAfter(moment.utc(date))
         }
         createNodeField({ node, name: `released`, value: released })
 

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -488,10 +488,7 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
         let released = false
         const date = _.get(node, `frontmatter.date`)
         if (date) {
-          released = moment
-            .utc()
-            .startOf(`day`)
-            .isSameOrAfter(moment.utc(date))
+          released = moment.utc().isSameOrAfter(moment.utc(date))
         }
         createNodeField({ node, name: `released`, value: released })
 

--- a/www/package.json
+++ b/www/package.json
@@ -48,7 +48,7 @@
     "gatsby-source-npm-package-search": "^2.0.0",
     "gatsby-transformer-csv": "^2.0.0",
     "gatsby-transformer-documentationjs": "^2.0.0",
-    "gatsby-transformer-remark": "^2.2.4",
+    "gatsby-transformer-remark": "^2.2.5",
     "gatsby-transformer-screenshot": "^2.0.4",
     "gatsby-transformer-sharp": "^2.1.1",
     "gatsby-transformer-yaml": "^2.1.1",

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -175,7 +175,10 @@ export const pageQuery = graphql`
   query {
     allMarkdownRemark(
       limit: 2000
-      filter: { fileAbsolutePath: { regex: "/docs.blog/" } }
+      filter: {
+        fields: { released: { eq: true } }
+        fileAbsolutePath: { regex: "/docs.blog/" }
+      }
     ) {
       group(field: frontmatter___tags) {
         fieldValue

--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -107,6 +107,7 @@ export const pageQuery = graphql`
     allMarkdownRemark(
       sort: { order: DESC, fields: [frontmatter___date, fields___slug] }
       filter: {
+        fields: { released: { eq: true } }
         fileAbsolutePath: { regex: "/blog/" }
         frontmatter: { draft: { ne: true } }
       }


### PR DESCRIPTION
## Description

Not 100% sure this is the fix--but this is at least fixing a few things, specifically:

- Use UTC time for _now_ comparison and post release date
- Filter only released posts in various areas, e.g. contributor pages, tags, etc.

Specifically, it seems like the blog hasn't been updated with a post released today (https://www.gatsbyjs.org/blog) but if you go to a [contributor's page](https://www.gatsbyjs.org/contributors/linda-watkins/) you can see the post from today (sorted incorrectly at the bottom).