### PR TITLE
docs(awesome-gatsby): Add link to official YouTube channel

### DIFF
--- a/docs/docs/awesome-gatsby.md
+++ b/docs/docs/awesome-gatsby.md
@@ -35,6 +35,7 @@ See the [library of official and community plugins](/plugins/)
 ## Videos
 
 - [Gatsby's official YouTube channel](https://www.youtube.com/channel/UCjnp770qk7ujOq8Q9wiC82w)
+- [Jason Lengstorf's "Learn stuff with Jason" playlist](https://www.youtube.com/playlist?list=PLz8Iz-Fnk_eTpvd49Sa77NiF8Uqq5Iykx)
 - [Gatsby Days Bay Area December 2018 - Kyle Mathews & Guest Speakers](https://www.youtube.com/playlist?list=PLCU2qJekvcN1wzgVKymbjbGtZ3VgAWOdj)
 - [Static Site Generation with Gatsby.js v0 — Scott Nonnenberg](https://blog.scottnonnenberg.com/static-site-generation-with-gatsby-js/)
 - [React.js Conf 2016 - Lightning Talks - Kyle Mathews](https://www.youtube.com/watch?v=RFkNRKL6ZoE)

--- a/docs/docs/awesome-gatsby.md
+++ b/docs/docs/awesome-gatsby.md
@@ -34,6 +34,7 @@ See the [library of official and community plugins](/plugins/)
 
 ## Videos
 
+- [Gatsby's official YouTube channel](https://www.youtube.com/channel/UCjnp770qk7ujOq8Q9wiC82w)
 - [Gatsby Days Bay Area December 2018 - Kyle Mathews & Guest Speakers](https://www.youtube.com/playlist?list=PLCU2qJekvcN1wzgVKymbjbGtZ3VgAWOdj)
 - [Static Site Generation with Gatsby.js v0 — Scott Nonnenberg](https://blog.scottnonnenberg.com/static-site-generation-with-gatsby-js/)
 - [React.js Conf 2016 - Lightning Talks - Kyle Mathews](https://www.youtube.com/watch?v=RFkNRKL6ZoE)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

There are already some videos linked from the official channel, but I thought it would make sense to bring (more) attention to the channel with a direct link that is titled accordingly. 

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
