### PR TITLE
chore: lint-staged commits even on error

### DIFF
--- a/scripts/on-lint-error.js
+++ b/scripts/on-lint-error.js
@@ -2,11 +2,13 @@ console.log(
   `Gatsby uses precommit hooks to run our linting and style checks. We do this
   to avoid additional hassle during pull request reviews, so please fix any linting
   problems before submitting pull request, because all PRs must pass these checks.
-  
+
   If you're doing something temporary, you can disable this hook with:
     git commit --no-verify
-  
+
   If you want disable this hook for all future commits:
     npm run hooks:uninstall
   `
 )
+
+process.exitCode = 1


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
I've noticed that lint-staged isn't blocking commits anymore when errors occur. It's because the node scripts on failure exits gracefully without an error code.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
