### PR TITLE
chore: Update pre-commit hook error message

### DIFF
--- a/scripts/on-lint-error.js
+++ b/scripts/on-lint-error.js
@@ -1,14 +1,10 @@
-console.log(
-  `Gatsby uses precommit hooks to run our linting and style checks. We do this
-  to avoid additional hassle during pull request reviews, so please fix any linting
-  problems before submitting pull request, because all PRs must pass these checks.
+console.log(`Oops! Gatsby noticed some lint or style warnings in the code for this
+commit. Your changes have been committed, but you should fix the warnings before
+creating a Pull Request.
 
-  If you're doing something temporary, you can disable this hook with:
-    git commit --no-verify
+Use 'npm run lint' to manually re-run these checks. You can also disable these
+checks:
 
-  If you want disable this hook for all future commits:
-    npm run hooks:uninstall
-  `
-)
-
-process.exitCode = 1
+- for a single commit: git commit --no-verify
+- for all future commits: npm run hooks:uninstall
+`)

--- a/scripts/on-lint-error.js
+++ b/scripts/on-lint-error.js
@@ -1,6 +1,6 @@
 console.log(`Oops! Gatsby noticed some lint or style warnings in the code for this
 commit. Your changes have been committed, but you should fix the warnings before
-creating a Pull Request.
+creating a pull request.
 
 Use 'npm run lint' to manually re-run these checks. You can also disable these
 checks:


### PR DESCRIPTION
## Description

Make it clearer that you can ignore the pre-commit warnings. Also tidied up the formatting a bit and added a note on manually running the checks with `npm run lint`.

Before:
![screenshot 2019-02-15 at 12 10 21](https://user-images.githubusercontent.com/381801/52856723-12c19580-311d-11e9-9fe9-d2e60a6ce204.png)

After:
![screenshot 2019-02-15 at 12 23 30](https://user-images.githubusercontent.com/381801/52856729-15bc8600-311d-11e9-925e-fb95f5bc7737.png)