### PR TITLE
feat(create-gatsby): add a simple CLI forwarder to use with npm init

### DIFF
--- a/packages/create-gatsby/.gitignore
+++ b/packages/create-gatsby/.gitignore
@@ -1,0 +1,2 @@
+/lib
+/node_modules

--- a/packages/create-gatsby/README.md
+++ b/packages/create-gatsby/README.md
@@ -1,0 +1,17 @@
+# create-gatsby
+
+A utility that invokes [`gatsby-cli`][gatsby-cli] (that's it!). This exists simply to forward any arguments and commands to gatsby-cli in a specific context, e.g. when invoked with `npm init gatsby`
+
+This should _never_ be used in place of `gatsby-cli`, but rather should be used only in conjunction with `npm init` (see [Usage below](#usage)).
+
+## Usage
+
+All options, commands, etc. should be referenced from [`gatsby-cli`][gatsby-cli], however the most general use case will be creating a new gatsby project, like so:
+
+```shell
+npm init gatsby new my-great-app
+```
+
+See: [`npm init`](https://docs.npmjs.com/cli/init) documentation for more info.
+
+[gatsby-cli]: (https://www.gatsbyjs.org/docs/gatsby-cli/)

--- a/packages/create-gatsby/README.md
+++ b/packages/create-gatsby/README.md
@@ -14,4 +14,4 @@ npm init gatsby new my-great-app
 
 See: [`npm init`](https://docs.npmjs.com/cli/init) documentation for more info.
 
-[gatsby-cli]: (https://www.gatsbyjs.org/docs/gatsby-cli/)
+[gatsby-cli]: https://www.gatsbyjs.org/docs/gatsby-cli/

--- a/packages/create-gatsby/__tests__/__snapshots__/cli.js.snap
+++ b/packages/create-gatsby/__tests__/__snapshots__/cli.js.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it throws if new command not specified 1`] = `
+"create-gatsby can only be used with the new command, e.g. \`npm init gatsby new your-gatsby-app\`
+See gatsby.app/cli for more info."
+`;

--- a/packages/create-gatsby/__tests__/cli.js
+++ b/packages/create-gatsby/__tests__/cli.js
@@ -1,0 +1,17 @@
+jest.mock('gatsby-cli/lib/create-cli', () => jest.fn())
+const createCli = require(`gatsby-cli/lib/create-cli`)
+const createGatsbyCli = require(`../cli`)
+
+test(`it forwards arguments to gatsby-cli`, () => {
+  const args = [`new`, `my-gatsby-app`, `--leeoroy`, `--jenkins`]
+
+  createGatsbyCli(args)
+
+  expect(createCli).toHaveBeenCalledWith(args)
+})
+
+test(`it throws if new command not specified`, () => {
+  const args = [`gatsby-app`]
+
+  expect(() => createGatsbyCli(args)).toThrowErrorMatchingSnapshot()
+})

--- a/packages/create-gatsby/__tests__/cli.js
+++ b/packages/create-gatsby/__tests__/cli.js
@@ -2,6 +2,10 @@ jest.mock('gatsby-cli/lib/create-cli', () => jest.fn())
 const createCli = require(`gatsby-cli/lib/create-cli`)
 const createGatsbyCli = require(`../cli`)
 
+beforeEach(() => {
+  createCli.mockClear()
+})
+
 test(`it forwards arguments to gatsby-cli`, () => {
   const args = [`new`, `my-gatsby-app`, `--leeoroy`, `--jenkins`]
 

--- a/packages/create-gatsby/__tests__/index.js
+++ b/packages/create-gatsby/__tests__/index.js
@@ -1,0 +1,20 @@
+jest.mock(`../cli`, () => jest.fn())
+const cli = require(`../cli`)
+
+beforeEach(() => {
+  cli.mockClear()
+})
+
+const getCreateGatsbyCli = argv => {
+  process.argv = argv
+
+  return require(`../`)
+}
+
+test(`it invokes the cli`, () => {
+  const args = ['new', 'gatsby-project']
+  getCreateGatsbyCli(args)
+
+  expect(cli).toHaveBeenCalledWith(args)
+  expect(cli).toHaveBeenCalledTimes(1)
+})

--- a/packages/create-gatsby/cli.js
+++ b/packages/create-gatsby/cli.js
@@ -1,0 +1,18 @@
+const createCli = require(`gatsby-cli/lib/create-cli`)
+const { stripIndent } = require(`common-tags`)
+
+module.exports = argv => {
+  /*
+   * Restrict usage to solely the `new` command
+   */
+  if (!argv.some(arg => arg === `new`)) {
+    throw new Error(
+      stripIndent`
+        create-gatsby can only be used with the new command, e.g. \`npm init gatsby new your-gatsby-app\`
+        See gatsby.app/cli for more info.
+      `
+    )
+  }
+  
+  createCli(argv)
+}

--- a/packages/create-gatsby/index.js
+++ b/packages/create-gatsby/index.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const createCli = require(`gatsby-cli/lib/create-cli`)
+
+createCli(process.argv)

--- a/packages/create-gatsby/index.js
+++ b/packages/create-gatsby/index.js
@@ -1,4 +1,19 @@
 #!/usr/bin/env node
 const createCli = require(`gatsby-cli/lib/create-cli`)
+const { stripIndent } = require(`common-tags`)
 
-createCli(process.argv)
+const argv = process.argv
+
+/*
+ * Restrict usage to solely the `new` command
+ */
+if (!argv.some(arg => arg === `new`)) {
+  throw new Error(
+    stripIndent`
+      create-gatsby can only be used with the new command, e.g. \`npm init gatsby new your-gatsby-app\`
+      See gatsby.app/cli for more info.
+    `
+  )
+}
+
+createCli(argv)

--- a/packages/create-gatsby/index.js
+++ b/packages/create-gatsby/index.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require(`./cli`)
+require(`./cli`)(process.argv)

--- a/packages/create-gatsby/index.js
+++ b/packages/create-gatsby/index.js
@@ -1,19 +1,2 @@
 #!/usr/bin/env node
-const createCli = require(`gatsby-cli/lib/create-cli`)
-const { stripIndent } = require(`common-tags`)
-
-const argv = process.argv
-
-/*
- * Restrict usage to solely the `new` command
- */
-if (!argv.some(arg => arg === `new`)) {
-  throw new Error(
-    stripIndent`
-      create-gatsby can only be used with the new command, e.g. \`npm init gatsby new your-gatsby-app\`
-      See gatsby.app/cli for more info.
-    `
-  )
-}
-
-createCli(argv)
+require(`./cli`)

--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-gatsby",
-  "description": "A CLI to invoke gatsby-cli, primarily from npm init command",
+  "description": "A CLI to invoke gatsby-cli solely from the npm init command",
   "version": "0.0.0",
   "author": "Dustin Schau <dustin@gatsbyjs.com>",
   "license": "MIT",
@@ -8,13 +8,14 @@
     "create-gatsby": "index.js"
   },
   "dependencies": {
+    "common-tags": "^1.8.0",
     "gatsby-cli": "^2.4.10"
   },
   "files": [
     "index.js"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/create-gatsby#readme",
   "keywords": [

--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "create-gatsby",
+  "description": "A CLI to invoke gatsby-cli, primarily from npm init command",
+  "version": "0.0.0",
+  "author": "Dustin Schau <dustin@gatsbyjs.com>",
+  "license": "MIT",
+  "bin": {
+    "create-gatsby": "index.js"
+  },
+  "dependencies": {
+    "gatsby-cli": "^2.4.10"
+  },
+  "files": [
+    "index.js"
+  ],
+  "engines": {
+    "node": ">=6"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/create-gatsby#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/create-gatsby",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  }
+}

--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -12,6 +12,7 @@
     "gatsby-cli": "^2.4.10"
   },
   "files": [
+    "cli.js",
     "index.js"
   ],
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,10 +983,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.1.tgz#8529b7412a6eb4b48bdf6e720cc1b8e6e1e17628"
   integrity sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg==
 
-"@gatsbyjs/relay-compiler@2.0.0-printer-fix":
-  version "2.0.0-printer-fix"
-  resolved "https://registry.yarnpkg.com/@gatsbyjs/relay-compiler/-/relay-compiler-2.0.0-printer-fix.tgz#542b3eb8e7f28142ccbde051dfc47c6ce506d022"
-  integrity sha512-oxUgELwerXuQWQhQz+G3xXAP9H4uMgj8aNGmNp0IYKv9D0puvUw+W6884jae57Ng+Vj2K5rxUkn0ApivSTvutQ==
+"@gatsbyjs/relay-compiler@2.0.0-printer-fix.2":
+  version "2.0.0-printer-fix.2"
+  resolved "https://registry.yarnpkg.com/@gatsbyjs/relay-compiler/-/relay-compiler-2.0.0-printer-fix.2.tgz#214db0e6072d40ea78ad5fabdb49d56bc95f4e99"
+  integrity sha512-7GeCCEQ7O15lMTT/SXy9HuRde4cv5vs465ZnLK2QCajSDLior+20yrMqHn1PGsJYK6nNZH7p3lw9qTCpqmuc7Q==
   dependencies:
     "@babel/generator" "^7.0.0"
     "@babel/parser" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5214,7 +5214,7 @@ common-path-prefix@^1.0.0:
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-1.0.0.tgz#cd52f6f0712e0baab97d6f9732874f22f47752c0"
   integrity sha1-zVL28HEuC6q5fW+XModPIvR3UsA=
 
-common-tags@^1.4.0:
+common-tags@^1.4.0, common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==


### PR DESCRIPTION
## Description

This PR introduces an alternate means of initializing a Gatsby project using `npm init`. Why?

- `npm init` requires a convention of `create-<command-name>`, e.g. `create-react-app` can be used with `npm init react-app name-of-my-app`
- `npm init gatsby new my-gatsby-app` seems slightly nicer than `npx gatsby new my-gatsby-app`
  - Note: I can also tweak this to be `npm init gatsby your-blog gatsbyjs/gatsby-starter-blog`, but wanted to keep it flexible in case/when we augment the CLI with plugin capabilities (alternatively, maybe we create npm init gatsby-plugin?)

Consider this an experimental PR. Is this easier to teach? Use? Thoughts and opinions welcome!

cc @marcysutton @jlengstorf 