### PR TITLE
fix(gatsby): Construct input type for Date fields added in setFields... API

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js
@@ -129,7 +129,7 @@ function convertToInputFilter(
   type: GraphQLInputType
 ): ?GraphQLInputObjectType {
   if (type instanceof GraphQLScalarType) {
-    const name = type.name
+    const name = type.name === `Date` ? `String` : type.name
     const fields = scalarFilterMap[name]
 
     if (fields == null) return null


### PR DESCRIPTION
Currently when constructing the InputObjectType, we[ treat Date fields like String fields for fields whose type we infer](https://github.com/gatsbyjs/gatsby/blob/9bb587df3faed2f75af571d8d69e3bc4d7f65193/packages/gatsby/src/schema/infer-graphql-input-fields.js#L162), but we [don't do the same for fields added with `setFieldsOnGraphQLNodeType`](https://github.com/gatsbyjs/gatsby/blob/9bb587df3faed2f75af571d8d69e3bc4d7f65193/packages/gatsby/src/schema/infer-graphql-input-fields.js#L162), which means they won't show up in the input filter.

See https://github.com/gatsbyjs/gatsby/issues/11368#issuecomment-463834927