### PR TITLE
Fix youtube link in Gatsby Theme blog post

### DIFF
--- a/docs/blog/2019-02-11-gatsby-themes-livestream-and-example/index.md
+++ b/docs/blog/2019-02-11-gatsby-themes-livestream-and-example/index.md
@@ -30,7 +30,7 @@ No code. No assembling plugins. Just writing content.
 Recently I had the pleasure of building a theme from scratch with Gatsby’s own [John Otander](https://twitter.com/4lpine) live on [my weekly livestream](https://twitch.tv/jlengstorf).
 
 <iframe id="ytplayer" title="Theme livestream on YouTube" type="text/html" width="720" height="405"
-src="https://www.youtube.com/embed/?list=PLz8Iz-Fnk_eTpvd49Sa77NiF8Uqq5Iykx&listType=playlist"
+src="https://www.youtube.com/embed/PS2784YfPpw?list=PLz8Iz-Fnk_eTpvd49Sa77NiF8Uqq5Iykx"
 frameborder="0" allowfullscreen />
 
 On the stream, we covered multiple topics:


### PR DESCRIPTION
This is related to blog post  **"Gatsby Themes: Watch Us Build a Theme Live"** written by @jlengstorf  on gatsby blog recently. 

Noticed that the youtube url which was linked is incorrectly pointing to one video where they discuss "Learn React Hooks" instead of pointing to "Build a Gatsby Theme With John Otander" video. 
Fixed the link to avoid confusion.