### PR TITLE
chore(gatsby): Update typings to contain PageRenderer & parsePath (fixes #11796)

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { WindowLocation } from "@reach/router";
+import * as React from "react"
+import { WindowLocation } from "@reach/router"
 
 export {
   default as Link,
@@ -8,8 +8,8 @@ export {
   navigateTo,
   push,
   replace,
-  withPrefix
-} from "gatsby-link";
+  withPrefix,
+} from "gatsby-link"
 
 type RenderCallback = (data: any) => React.ReactNode
 
@@ -21,14 +21,14 @@ export interface StaticQueryProps {
 
 export class StaticQuery extends React.Component<StaticQueryProps> {}
 
-export const useStaticQuery: <TData = any>(query: any) => TData;
+export const useStaticQuery: <TData = any>(query: any) => TData
 
-export const graphql: (query: TemplateStringsArray) => void;
+export const graphql: (query: TemplateStringsArray) => void
 
-export const parsePath: (path: string) => WindowLocation;
+export const parsePath: (path: string) => WindowLocation
 
 export interface PageRendererProps {
-  location: WindowLocation;
+  location: WindowLocation
 }
 
 export class PageRenderer extends React.Component<PageRendererProps> {}

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1,4 +1,5 @@
-import * as React from "react"
+import * as React from "react";
+import { WindowLocation } from "@reach/router";
 
 export {
   default as Link,
@@ -7,8 +8,8 @@ export {
   navigateTo,
   push,
   replace,
-  withPrefix,
-} from "gatsby-link"
+  withPrefix
+} from "gatsby-link";
 
 type RenderCallback = (data: any) => React.ReactNode
 
@@ -20,6 +21,14 @@ export interface StaticQueryProps {
 
 export class StaticQuery extends React.Component<StaticQueryProps> {}
 
-export const useStaticQuery: <TData = any>(query: any) => TData
+export const useStaticQuery: <TData = any>(query: any) => TData;
 
-export const graphql: (query: TemplateStringsArray) => void
+export const graphql: (query: TemplateStringsArray) => void;
+
+export const parsePath: (path: string) => WindowLocation;
+
+export interface PageRendererProps {
+  location: WindowLocation;
+}
+
+export class PageRenderer extends React.Component<PageRendererProps> {}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Update typings to contain PageRenderer & parsePath (both of which were missing)

## Related Issues

fixes #11796