### PR TITLE
fix(docs): update portion of gatsby-link docs with valid style

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -70,7 +70,7 @@ const SiteNavigation = () => (
     <Link
       to="/about/"
       {/* highlight-next-line */}
-      activeStyle={{ color: red }}
+      activeStyle={{ color: "red" }}
     >
       About
     </Link>


### PR DESCRIPTION
The activeStyle attribute takes an inline react style attribute so I changed it so the color field in it is a string so it will function properly