### PR TITLE
docs: Fix wrong "locations" object name

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -184,7 +184,7 @@ Instead, Gatsby exports a `navigate` helper function that accepts `to` and `opti
 | Argument          | Required | Description                                                                                      |
 | ----------------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `to`              | yes      | The page to navigate to (e.g. `/blog/`).                                                         |
-| `options.state`   | no       | An object. Values passed here will be available in `locations.state` in the target page’s props. |
+| `options.state`   | no       | An object. Values passed here will be available in `location.state` in the target page’s props. |
 | `options.replace` | no       | A boolean value. If true, replaces the current URL in history.                                   |
 
 By default, `navigate` operates the same way as a clicked `Link` component.


### PR DESCRIPTION
Fixing wrong "locations" object name in Link options
