### PR TITLE
docs(gatsby): Removing `pathname` of `wrapRootElement` SSR (jsdocs)

### DIFF
--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -142,7 +142,6 @@ exports.onPreRenderHTML = true
  * @param {object} $0
  * @param {object} $0.element The "Page" React Element built by Gatsby.
  * @param {object} $0.props Props object used by page.
- * @param {string} $0.pathname Path of page.
  * @example
  * import React from "react"
  * import Layout from "./src/components/layout"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR removes the property `pathname` in the docs to the `wrapRootElement` function [as it isn't passed](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/static-entry.js#L145)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
