### PR TITLE
fix(themes): Remove require.resolve in component resolve path

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -50,15 +50,15 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
           {},
           callback
         )
+      } else {
+        return resolver.doResolve(
+          `describedRelative`,
+          { ...request, path: builtComponentPath },
+          null,
+          {},
+          callback
+        )
       }
-      const resolvedComponentPath = require.resolve(builtComponentPath)
-      // this callbackends the resolver fallthrough chain.
-      return callback(null, {
-        directory: request.directory,
-        path: resolvedComponentPath,
-        query: request.query,
-        request: ``,
-      })
     })
   }
 

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -42,23 +42,13 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
         projectRoot: this.projectRoot,
       })
 
-      if (!builtComponentPath) {
-        return resolver.doResolve(
-          `describedRelative`,
-          request,
-          null,
-          {},
-          callback
-        )
-      } else {
-        return resolver.doResolve(
-          `describedRelative`,
-          { ...request, path: builtComponentPath },
-          null,
-          {},
-          callback
-        )
-      }
+      return resolver.doResolve(
+        `describedRelative`,
+        { ...request, path: builtComponentPath || request.path },
+        null,
+        {},
+        callback
+      )
     })
   }
 


### PR DESCRIPTION
This fixes [a bug](https://github.com/ChristopherBiscardi/gatsby-theme-examples/issues/21) where `.jsx` files could not shadow `.js` files. It
does this by removing the `require.resolve` call, which is node's
resolution algorithm that only works on .js files, with a continuation
of webpack's resolving hooks. This allows us to replace a .js file in
a theme with a .jsx, .tsx, .re, etc file in a site.

This branch can be tested in the gatsby-theme-examples repo using the [`jsx-extension-bug`](https://github.com/ChristopherBiscardi/gatsby-theme-examples/tree/jsx-extension-bug) branch 