### PR TITLE
fix(www): make search placeholder full visible

### DIFF
--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -378,7 +378,7 @@ class SearchForm extends Component {
               },
               [presets.Desktop]: {
                 backgroundColor: !isHomepage && `#fff`,
-                width: !isHomepage && rhythm(3.5),
+                width: !isHomepage && rhythm(3.75),
                 ":focus": {
                   backgroundColor: colors.ui.light,
                 },
@@ -386,7 +386,7 @@ class SearchForm extends Component {
               [presets.Hd]: {
                 backgroundColor: isHomepage && colors.lilac,
                 color: isHomepage && colors.ui.light,
-                width: isHomepage && rhythm(3.5),
+                width: isHomepage && rhythm(3.75),
               },
             }}
             type="search"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Fixes the visibility of the search placeholder on home and other pages.

Before
![52912001-607eff00-32d1-11e9-9d08-16aec5b74da3](https://user-images.githubusercontent.com/31361983/52934985-16078c00-337e-11e9-94e6-97152926984f.PNG)
![52911998-58bf5a80-32d1-11e9-80a4-88d4be58466a](https://user-images.githubusercontent.com/31361983/52934990-199b1300-337e-11e9-8ee9-d48b53624af0.PNG)


After
![after](https://user-images.githubusercontent.com/31361983/52935030-3c2d2c00-337e-11e9-8e43-ac244805ab49.JPG)
![after2](https://user-images.githubusercontent.com/31361983/52935048-494a1b00-337e-11e9-87a8-297e643e9e78.JPG)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes #9694 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
