### PR TITLE
[schema] Fix list inference

### DIFF
--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -28,7 +28,7 @@ const addInferredFields = ({
       nodeStore,
       exampleObject: exampleValue,
       prefix: typeComposer.getTypeName(),
-      typeMapping: typeMapping,
+      typeMapping,
       addDefaultResolvers: inferConfig ? inferConfig.addDefaultResolvers : true,
       depth: 0,
     })
@@ -82,12 +82,9 @@ const addInferredFieldsImpl = ({
         value,
         selector,
         depth,
-        typeMapping
+        typeMapping,
+        addDefaultResolvers
       )
-    }
-
-    while (arrays--) {
-      fieldConfig = { ...fieldConfig, type: [fieldConfig.type] }
     }
 
     // Proxy resolver to unsanitized fieldName in case it contained invalid characters
@@ -130,7 +127,7 @@ const addInferredFieldsImpl = ({
             nodeStore,
             prefix: selector,
             depth: depth + 1,
-            addDefaultResolvers: true,
+            addDefaultResolvers,
           })
         }
       }
@@ -153,6 +150,9 @@ const addInferredFieldsImpl = ({
         typeComposer.setField(key, field)
       }
     } else {
+      while (arrays--) {
+        fieldConfig = { ...fieldConfig, type: [fieldConfig.type] }
+      }
       fields[key] = fieldConfig
     }
   })
@@ -235,7 +235,8 @@ const getFieldConfig = (
   value,
   selector,
   depth,
-  typeMapping
+  typeMapping,
+  addDefaultResolvers
 ) => {
   switch (typeof value) {
     case `boolean`:
@@ -275,6 +276,7 @@ const getFieldConfig = (
             typeMapping,
             prefix: selector,
             depth: depth + 1,
+            addDefaultResolvers,
           }),
         }
       }


### PR DESCRIPTION
Don't re-wrap with arrays earlier, so we can compare `arrays===lists` when tc.hasField(key)