### PR TITLE
Add Technica11y to sites showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4335,3 +4335,15 @@
   built_by: Incremental
   built_by_url: https://www.incremental.com.au
   featured: false
+- title: Technica11y
+  main_url: https://www.technica11y.org
+  url: https://www.technica11y.org
+  description: >
+    Discussing challenges in technical accessibility.
+  categories:
+    - Accessibility
+    - Education
+    - Video
+  built_by: Tenon.io
+  built_by_url: https://tenon.io
+  featured: false


### PR DESCRIPTION
## Description

Our affiliate accessibility webinar site is built in Gatsby.

![image](https://user-images.githubusercontent.com/5063473/52945306-b73c1580-3371-11e9-8985-0c8462664755.png)

I would like to propose adding this website to the sites showcase.