### PR TITLE
fix(gatsby-plugin-page-creator): Fix regular expression for validate path

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/gatsby-node.js
@@ -109,6 +109,14 @@ describe(`JavaScript page creator`, () => {
     )
   })
 
+  it(`doesn't filter out test.js`, () => {
+    const validFiles = [{ path: `src/pages/test.js` }]
+
+    expect(validFiles.filter(file => validatePath(file.path))).toEqual(
+      validFiles
+    )
+  })
+
   describe(`create-path`, () => {
     it(`should create unix paths`, () => {
       const basePath = `/a/`

--- a/packages/gatsby-plugin-page-creator/src/validate-path.js
+++ b/packages/gatsby-plugin-page-creator/src/validate-path.js
@@ -8,7 +8,7 @@ const jsonYamlExtTest = /\.(json|ya?ml)$/
 function isTestFile(filePath) {
   const testPatterns = [
     `**/__tests__/**/*.(js|ts)?(x)`,
-    `**/?(*.)+(spec|test).(js|ts)?(x)`,
+    `**/(*.)+(spec|test).(js|ts)?(x)`,
   ]
 
   return mm.isMatch(filePath, testPatterns)


### PR DESCRIPTION
Fixes the regex in gatsby-plugin-page-creator so that a page is created for `test.js`