### PR TITLE
chore(gatsby-plugin-offline): Move cpx to devDependencies

### DIFF
--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "cheerio": "^1.0.0-rc.2",
-    "cpx": "^1.5.0",
     "idb-keyval": "^3.1.0",
     "lodash": "^4.17.10",
     "workbox-build": "^3.6.3"
@@ -18,7 +17,8 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.3",
-    "cross-env": "^5.1.4"
+    "cross-env": "^5.1.4",
+    "cpx": "^1.5.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline#readme",
   "keywords": [


### PR DESCRIPTION
Gets rid of audit warnings due to some deep dependencies of `cpx`