### PR TITLE
Added gatsby-transformer-yaml info to Documentation about markdown

### DIFF
--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -41,7 +41,7 @@ Now that we've "sourced" the markdown files from the filesystem, we can now "tra
 
 ### Transforming markdown — `gatsby-transformer-remark`
 
-We'll use the plugin [`gatsby-transformer-remark`](/packages/gatsby-transformer-remark/) to recognise files which are markdown and read its content. It will convert the frontmatter metadata part of your markdown file as `frontmatter` and the content part as HTML.
+We'll use the plugin [`gatsby-transformer-remark`](/packages/gatsby-transformer-remark/) (or [`gatsby-transformer-yaml`](/packages/gatsby-transformer-yaml/) for .yml files) to recognise files which are markdown and read its content. It will convert the frontmatter metadata part of your markdown file as `frontmatter` and the content part as HTML.
 
 `npm install --save gatsby-transformer-remark`
 


### PR DESCRIPTION
Came to this page from https://www.gatsbyjs.org/docs/sourcing-from-netlify-cms/#processing-netlify-cms-output-with-gatsby and was confused why gatsby-transformer-remark cannot parse my files. After while i discovered, it parses only .md files, but files from Netlify CMS are .yaml, for which i need different plugin!

I dont know how exactly incorporate that link into documentation, but it definitely needs to mention gatsby-transformer-yaml somehow.
