### PR TITLE
feat(gatsby): show warning if createPage was called after createPages API finished

### DIFF
--- a/docs/docs/debugging-async-lifecycles.md
+++ b/docs/docs/debugging-async-lifecycles.md
@@ -4,7 +4,7 @@ title: Debugging Asynchronous Lifecycle Methods
 
 Various lifecycle methods (see: [Gatsby Node APIs](/docs/node-apis/)) within Gatsby are presumed to be asynchronous. In other words, these methods can _eventually_ resolve to a value and this value is a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). We wait for the `Promise` to resolve, and then mark the lifecycle method as completed when it does.
 
-In the context of Gatsby, this means that if you are invoking async functionality (e.g. data requests, `graphql` calls, etc.) and not correctly returning the Promise an internal issue can arise where the result of those call(s) happens _after_ the lifecycle method has already been marked as completed. Let's consider an example:
+In the context of Gatsby, this means that if you are invoking asynchronous functionality (e.g. data requests, `graphql` calls, etc.) and not correctly returning the Promise an internal issue can arise where the result of those call(s) happens _after_ the lifecycle method has already been marked as completed. Let's consider an example:
 
 ```js:title=gatsby-node.js
 exports.createPages = async function({ actions, graphql }) {
@@ -35,7 +35,7 @@ exports.createPages = async function({ actions, graphql }) {
 }
 ```
 
-Can you spot the error? In this case, an asyncronous action (`graphql`) was invoked but this async action was neither `return`ed nor `await`ed from `createPages`. This means that the lifecycle method will be marked as complete before it's actually completed--which leads to missing data errors and other hard-to-debug errors.
+Can you spot the error? In this case, an asynchronous action (`graphql`) was invoked but this asynchronous action was neither `return`ed nor `await`ed from `createPages`. This means that the lifecycle method will be marked as complete before it's actually completed--which leads to missing data errors and other hard-to-debug errors.
 
 The fix is surprisingly simple--just one line to change!
 

--- a/docs/docs/debugging-async-lifecycles.md
+++ b/docs/docs/debugging-async-lifecycles.md
@@ -1,0 +1,95 @@
+---
+title: Debugging Asynchronous Lifecycles
+---
+
+Various lifecycle methods (see: [Gatsby Node APIs](/docs/node-apis/)) within Gatsby are presumed to be asynchronous. In other words, these methods can _eventually_ resolve to a value and this value is a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). We wait for the `Promise` to resolve, and then mark the lifecycle method as completed when it does.
+
+In the context of Gatsby, this means that if you are invoking async functionality (e.g. data requests, `graphql` calls, etc.) and not correctly returning the Promise an internal issue can arise where the result of those call(s) happens _after_ the lifecycle method has already been marked as completed. Let's consider an example:
+
+```js:title=gatsby-node.js
+exports.createPages = async function({ actions, graphql }) {
+  // highlight-start
+  graphql(`
+    {
+      allMarkdownRemark {
+        edges {
+          node {
+            fields {
+              slug
+            }
+          }
+        }
+      }
+    }
+  `).then(res => {
+    res.data.allMarkdownRemark.edges.forEach(edge => {
+      const slug = edge.node.fields.slug
+      actions.createPage({
+        path: slug,
+        component: require.resolve(`./src/templates/post.js`),
+        context: { slug },
+      })
+    })
+  })
+  // highlight-end
+}
+```
+
+Can you spot the error? In this case, an asyncronous action (`graphql`) was invoked but this async action was neither `return`ed nor `await`ed from `createPages`. This means that the lifecycle method will be marked as complete before it's actually completed--which leads to missing data errors and other hard-to-debug errors.
+
+The fix is surprisingly simple--just one line to change!
+
+```js:title=gatsby-node.js
+exports.createPages = async function({ actions, graphql }) {
+  // highlight-next-line
+  await graphql(`
+    {
+      allMarkdownRemark {
+        edges {
+          node {
+            fields {
+              slug
+            }
+          }
+        }
+      }
+    }
+  `).then(res => {
+    res.data.allMarkdownRemark.edges.forEach(edge => {
+      const slug = edge.node.fields.slug
+      actions.createPage({
+        path: slug,
+        component: require.resolve(`./src/templates/post.js`),
+        context: { slug },
+      })
+    })
+  })
+}
+```
+
+## Best Practices
+
+### Use `async` / `await`
+
+With Node 8, Node is able to natively interpret `async` functions. This lets you write asynchronous code as if it were synchronous! This can clean up code that previously was using a `Promise` chain and tends to be a little simpler to understand!
+
+### Use `Promise.all` if necessary
+
+[`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) wraps up _multiple_ asynchronous actions and resolves when _each_ have completed. This can be especially helpful if you're pulling from multiple data sources or abstracted some code that returns a Promise into a helper. For instance, consider the following code:
+
+```js:title=gatsby-node.js
+const fetch = require("node-fetch")
+
+const getJSON = uri => fetch(uri).then(response => response.json())
+
+exports.createPages = async function({ actions, graphql }) {
+  // highlight-start
+  const [pokemonData, rickAndMortyData] = await Promise.all([
+    getJSON("https://some-rest-api.com/pokemon"),
+    getJSON("https://some-rest-api.com/rick-and-morty"),
+  ])
+  // highlight-end
+
+  // use data to create pages with actions.createPage
+}
+```

--- a/docs/docs/debugging-async-lifecycles.md
+++ b/docs/docs/debugging-async-lifecycles.md
@@ -1,5 +1,5 @@
 ---
-title: Debugging Asynchronous Lifecycles
+title: Debugging Asynchronous Lifecycle Methods
 ---
 
 Various lifecycle methods (see: [Gatsby Node APIs](/docs/node-apis/)) within Gatsby are presumed to be asynchronous. In other words, these methods can _eventually_ resolve to a value and this value is a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). We wait for the `Promise` to resolve, and then mark the lifecycle method as completed when it does.

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -113,6 +113,7 @@
     "signal-exit": "^3.0.2",
     "slash": "^1.0.0",
     "socket.io": "^2.0.3",
+    "stack-trace": "^0.0.10",
     "string-similarity": "^1.2.0",
     "style-loader": "^0.21.0",
     "terser-webpack-plugin": "^1.2.2",

--- a/packages/gatsby/src/utils/__tests__/stack-trace-utils.js
+++ b/packages/gatsby/src/utils/__tests__/stack-trace-utils.js
@@ -1,0 +1,74 @@
+jest.mock(`stack-trace`, () => {
+  const trace = jest.requireActual(`stack-trace`)
+  return {
+    ...trace,
+    get: jest.fn(),
+  }
+})
+jest.mock(`fs-extra`, () => {
+  const fs = jest.requireActual(`fs-extra`)
+  return {
+    ...fs,
+    readFileSync: jest.fn(),
+  }
+})
+const trace = require(`stack-trace`)
+const fs = require(`fs-extra`)
+const path = require(`path`)
+const { getNonGatsbyCodeFrame } = require(`../stack-trace-utils`)
+
+beforeEach(() => {
+  trace.get.mockClear()
+  fs.readFileSync.mockClear()
+})
+
+const setup = ({ columnNumber, fileName, lineNumber }, code = ``) => {
+  const stack = {
+    getFileName: jest.fn(() => fileName),
+    getLineNumber: jest.fn(() => lineNumber),
+    getColumnNumber: jest.fn(() => columnNumber),
+  }
+
+  trace.get.mockReturnValueOnce([stack])
+  fs.readFileSync.mockReturnValueOnce(code)
+
+  return getNonGatsbyCodeFrame({ highlightCode: false })
+}
+
+describe(`ignores gatsby stack traces`, () => {
+  it(`returns null if gatsby code path`, () => {
+    expect(
+      setup({ fileName: path.dirname(require.resolve(`gatsby/package.json`)) })
+    ).toBe(null)
+  })
+})
+
+describe(`formatting of error messages`, () => {
+  it(`invokes readFileSync with fileName`, () => {
+    const fileName = `gatsby-node.js`
+
+    setup({ fileName })
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(fileName, expect.any(Object))
+  })
+
+  it(`displays lineNumber, columnNumber, and fileName`, () => {
+    const fileName = `gatsby-node.js`
+    const lineNumber = 0
+    const columnNumber = 5
+    const code = `exports.createPages = {}`
+    const err = setup({ fileName, lineNumber, columnNumber }, code)
+
+    expect(err).toContain([fileName, lineNumber, columnNumber].join(`:`))
+  })
+
+  it(`displays code snippet`, () => {
+    const fileName = `gatsby-node.js`
+    const lineNumber = 0
+    const columnNumber = 5
+    const code = `exports.createPages = {}`
+    const err = setup({ fileName, lineNumber, columnNumber }, code)
+
+    expect(err).toContain(code)
+  })
+})

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -172,11 +172,10 @@ const runAPI = (plugin, api, args) => {
     } else {
       const result = gatsbyNode[api](...apiCallArgs)
       pluginSpan.finish()
-      const resultPromise = Promise.resolve(result)
-      resultPromise.then(() => {
+      return Promise.resolve(result).then(res => {
         apiFinished = true
+        return res
       })
-      return resultPromise
     }
   }
 

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -1,6 +1,7 @@
 const Promise = require(`bluebird`)
 const glob = require(`glob`)
 const _ = require(`lodash`)
+const chalk = require(`chalk`)
 
 const tracer = require(`opentracing`).globalTracer()
 const reporter = require(`gatsby-cli/lib/reporter`)
@@ -8,6 +9,7 @@ const getCache = require(`./get-cache`)
 const apiList = require(`./api-node-docs`)
 const createNodeId = require(`./create-node-id`)
 const createContentDigest = require(`./create-content-digest`)
+const { getNonGatsbyCodeFrame } = require(`./stack-trace-utils`)
 
 // Bind action creators per plugin so we can auto-add
 // metadata to actions they create.
@@ -94,6 +96,44 @@ const runAPI = (plugin, api, args) => {
 
     const cache = getCache(plugin.name)
 
+    // Ideally this would be more abstracted and applied to more situations, but right now
+    // this can be potentially breaking so targeting `createPages` API and `createPage` action
+    let apiFinished = false
+    if (api === `createPages`) {
+      let alreadyDisplayed = false
+      const createPageAction = doubleBoundActionCreators.createPage
+      doubleBoundActionCreators.createPage = (...args) => {
+        createPageAction(...args)
+        if (apiFinished && !alreadyDisplayed) {
+          const warning = [
+            reporter.stripIndent(`
+              Action ${chalk.bold(
+                `createPage`
+              )} was called outside of its expected asynchronous lifecycle ${chalk.bold(
+              `createPages`
+            )} in ${chalk.bold(plugin.name)}.
+              Ensure that you return a Promise from ${chalk.bold(
+                `createPages`
+              )} and are awaiting any asynchronous method invocations (like ${chalk.bold(
+              `graphql`
+            )} or http requests).
+              For more info and debugging tips: see ${chalk.bold(
+                `https://gatsby.app/sync-actions`
+              )}
+            `),
+          ]
+
+          const possiblyCodeFrame = getNonGatsbyCodeFrame()
+          if (possiblyCodeFrame) {
+            warning.push(possiblyCodeFrame)
+          }
+
+          reporter.warn(warning.join(`\n\n`))
+          alreadyDisplayed = true
+        }
+      }
+    }
+
     const apiCallArgs = [
       {
         ...args,
@@ -125,13 +165,18 @@ const runAPI = (plugin, api, args) => {
         const cb = (err, val) => {
           pluginSpan.finish()
           callback(err, val)
+          apiFinished = true
         }
         gatsbyNode[api](...apiCallArgs, cb)
       })
     } else {
       const result = gatsbyNode[api](...apiCallArgs)
       pluginSpan.finish()
-      return Promise.resolve(result)
+      const resultPromise = Promise.resolve(result)
+      resultPromise.then(() => {
+        apiFinished = true
+      })
+      return resultPromise
     }
   }
 

--- a/packages/gatsby/src/utils/stack-trace-utils.js
+++ b/packages/gatsby/src/utils/stack-trace-utils.js
@@ -1,0 +1,44 @@
+const stackTrace = require(`stack-trace`)
+const { codeFrameColumns } = require(`@babel/code-frame`)
+const fs = require(`fs-extra`)
+const path = require(`path`)
+const chalk = require(`chalk`)
+
+const gatsbyLocation = path.dirname(require.resolve(`gatsby/package.json`))
+
+const getNonGatsbyCallSite = () =>
+  stackTrace
+    .get()
+    .find(callSite => !callSite.getFileName().includes(gatsbyLocation))
+
+const getNonGatsbyCodeFrame = () => {
+  const callSite = getNonGatsbyCallSite()
+  if (!callSite) {
+    return null
+  }
+
+  const fileName = callSite.getFileName()
+  const line = callSite.getLineNumber()
+  const column = callSite.getColumnNumber()
+
+  const code = fs.readFileSync(fileName, { encoding: `utf-8` })
+  return [
+    `File ${chalk.bold(`${fileName}:${line}:${column}`)}`,
+    codeFrameColumns(
+      code,
+      {
+        start: {
+          line,
+          column,
+        },
+      },
+      {
+        highlightCode: true,
+      }
+    ),
+  ].join(`\n`)
+}
+
+module.exports = {
+  getNonGatsbyCodeFrame,
+}

--- a/packages/gatsby/src/utils/stack-trace-utils.js
+++ b/packages/gatsby/src/utils/stack-trace-utils.js
@@ -11,7 +11,7 @@ const getNonGatsbyCallSite = () =>
     .get()
     .find(callSite => !callSite.getFileName().includes(gatsbyLocation))
 
-const getNonGatsbyCodeFrame = () => {
+const getNonGatsbyCodeFrame = ({ highlightCode = true } = {}) => {
   const callSite = getNonGatsbyCallSite()
   if (!callSite) {
     return null
@@ -33,7 +33,7 @@ const getNonGatsbyCodeFrame = () => {
         },
       },
       {
-        highlightCode: true,
+        highlightCode,
       }
     ),
   ].join(`\n`)

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -197,6 +197,8 @@
           link: /docs/debugging-the-build-process/
         - title: Trace Gatsby builds
           link: /docs/performance-tracing/
+        - title: Debugging Async Lifecycles
+          link: /docs/debugging-async-lifecycles/
     - title: Adding website functionality
       link: /docs/adding-website-functionality/
       items:

--- a/www/src/pages/docs/node-apis.js
+++ b/www/src/pages/docs/node-apis.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import { Helmet } from "react-helmet"
 import sortBy from "lodash/sortBy"
 
@@ -34,7 +34,12 @@ class NodeAPIDocs extends React.Component {
             calling remote APIs, etc.) you must either return a promise or use
             the callback passed to the 3rd argument. Gatsby needs to know when
             plugins are finished as some APIs, to work correctly, require
-            previous APIs to be complete first.
+            previous APIs to be complete first. See{` `}
+            <Link to="/docs/debugging-async-lifecycles/">
+              Debugging Async Lifecycles
+            </Link>
+            {` `}
+            for more info.
           </p>
           <pre>
             <code


### PR DESCRIPTION
This adds warning if `createPage` was called after gatsby *thought* that createPages already completed.

This can happen most commonly when calling async functions and not returning promise / using `done` callback - for example:

```js
const path = require(`path`);

exports.createPages = ({ actions, graphql }) => {
  actions.createPage({
    path: `/on-time`,
    component: path.resolve(`./src/templates/index.js`)
  });

  graphql(`
    {
      site {
        siteMetadata {
          title
        }
      }
    }
  `).then(() => {
    actions.createPage({
      path: `/way-too-late`,
      component: path.resolve(`./src/templates/index.js`)
    });
  });
};
```
Promise is not returned - and it's very easy to miss and currently this can lead to very confusing errors like:

Scenario 1: `createPage` was called after we written out `pages.json`:
```
error Building static HTML failed for path "/some-path"

See our docs page on debugging HTML builds for help https://gatsby.app/debug-html

  114 | 
  115 |   let dataAndContext = {}
> 116 |   if (page.jsonName in dataPaths) {
      |            ^
  117 |     const pathToJsonData = `../public/` + dataPaths[page.jsonName]
  118 |     try {
  119 |       dataAndContext = JSON.parse(


  WebpackError: TypeError: Cannot read property 'jsonName' of undefined
```

Scenario 2: `createPage` was called after we run queries:
```
error Building static HTML failed for path "/some-path"

See our docs page on debugging HTML builds for help https://gatsby.app/debug-html

  15 | import {get} from 'lodash'
  16 | 
> 17 | export default function Post({data: {site, mdx}}) {
     |                                      ^
  18 |   const {
  19 |     isWriting,
  20 |     author = config.author,


  WebpackError: TypeError: Cannot read property 'site' of undefined
```

This change adds warning like this:
![screenshot 2019-02-19 at 03 53 06](https://user-images.githubusercontent.com/419821/52987037-f01fcd00-33f9-11e9-935e-5880d32eb3b0.png)

TO-DO:
 - [ ] Write docs for https://gatsby.app/sync-actions showing common problems and how to fix them.

AFAIK we currently only have `Async plugins` section in https://www.gatsbyjs.org/docs/node-apis/ that explain this, but as with any docs - it's very easy for users to miss this.  