### PR TITLE
feat(gatsby-plugin-sharp): add defaultQuality option 

### DIFF
--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -32,6 +32,7 @@ plugins: [
     options: {
       useMozJpeg: false,
       stripMetadata: true,
+      defaultQuality: 75,
     },
   },
 ]
@@ -248,6 +249,10 @@ fixed(
   tracedSVG
 }
 ```
+
+### Setting a default quality
+
+You can set a default quality by passing the `defaultQuality` option to the plugin.
 
 ### Using MozJPEG
 

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -252,7 +252,7 @@ fixed(
 
 ### Setting a default quality
 
-You can set a default quality by passing the `defaultQuality` option to the plugin.
+You can pass a default image quality to `sharp` by setting the `defaultQuality` option.
 
 ### Using MozJPEG
 

--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -15,14 +15,14 @@ Object {
   "aspectRatio": 2.0661764705882355,
   "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAYAAAC0VX7mAAAACXBIWXMAABYlAAAWJQFJUiTwAAABAklEQVQoz61R7WrCQBDM+7+Cv1qhlIogoUWMoH8KrfgOLVXRKDV4d7kkl6/pbsxpqBIo9mBuZ7N3k51bB7TKsrwZVsexyS2rKerwFhYFVI1DnkMQOHIuCaLB+ayuwXlMaApXgvMoxjTU8MIQE4rMx8SnNffUkU/qM/bbiPAeRfgw5n8tB+QgO1kmUvwROdm0kYHmUNoe+NoU2wZTdVjQH7Isg9YRpFIXor8vpGmKjb/FQQgslit8fi3wvQ/OHXLhxRvDHY7Qd5+x3e2udmNzTUN4fZvhoddH566L+8cn9AZuVcvpLR3e9kEAISWEkDAmbRXkGCcJ1r4PRRNPEkPu9Kn2Azs0CqJYU3JKAAAAAElFTkSuQmCC",
   "density": 144,
-  "originalImg": "/static/1234/76710/test.png",
+  "originalImg": "/static/1234/a3030/test.png",
   "originalName": undefined,
   "presentationHeight": 68,
   "presentationWidth": 141,
   "sizes": "(max-width: 141px) 100vw, 141px",
-  "src": "/static/1234/76710/test.png",
-  "srcSet": "/static/1234/f8282/test.png 200w,
-/static/1234/76710/test.png 281w",
+  "src": "/static/1234/a3030/test.png",
+  "srcSet": "/static/1234/56b42/test.png 200w,
+/static/1234/a3030/test.png 281w",
   "srcSetType": "image/png",
 }
 `;

--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -15,14 +15,14 @@ Object {
   "aspectRatio": 2.0661764705882355,
   "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAYAAAC0VX7mAAAACXBIWXMAABYlAAAWJQFJUiTwAAABAklEQVQoz61R7WrCQBDM+7+Cv1qhlIogoUWMoH8KrfgOLVXRKDV4d7kkl6/pbsxpqBIo9mBuZ7N3k51bB7TKsrwZVsexyS2rKerwFhYFVI1DnkMQOHIuCaLB+ayuwXlMaApXgvMoxjTU8MIQE4rMx8SnNffUkU/qM/bbiPAeRfgw5n8tB+QgO1kmUvwROdm0kYHmUNoe+NoU2wZTdVjQH7Isg9YRpFIXor8vpGmKjb/FQQgslit8fi3wvQ/OHXLhxRvDHY7Qd5+x3e2udmNzTUN4fZvhoddH566L+8cn9AZuVcvpLR3e9kEAISWEkDAmbRXkGCcJ1r4PRRNPEkPu9Kn2Azs0CqJYU3JKAAAAAElFTkSuQmCC",
   "density": 144,
-  "originalImg": "/static/1234/a3030/test.png",
+  "originalImg": "/static/1234/76710/test.png",
   "originalName": undefined,
   "presentationHeight": 68,
   "presentationWidth": 141,
   "sizes": "(max-width: 141px) 100vw, 141px",
-  "src": "/static/1234/a3030/test.png",
-  "srcSet": "/static/1234/56b42/test.png 200w,
-/static/1234/a3030/test.png 281w",
+  "src": "/static/1234/76710/test.png",
+  "srcSet": "/static/1234/f8282/test.png 200w,
+/static/1234/76710/test.png 281w",
   "srcSetType": "image/png",
 }
 `;

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -96,12 +96,8 @@ const generalArgs = {
   sizeByPixelDensity: false,
 }
 
-const healOptions = (pluginOptions, args, defaultArgs) => {
-  const quality =
-    pluginOptions.defaultQuality && args.quality === 50
-      ? pluginOptions.defaultQuality
-      : args.quality
-  let options = _.defaults({}, { quality }, args, defaultArgs, generalArgs)
+const healOptions = ({ defaultQuality: quality }, args, defaultArgs) => {
+  let options = _.defaults({}, args, { quality }, defaultArgs, generalArgs)
   options.quality = parseInt(options.quality, 10)
   options.pngCompressionLevel = parseInt(options.pngCompressionLevel, 10)
   options.pngCompressionSpeed = parseInt(options.pngCompressionSpeed, 10)

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -137,7 +137,6 @@ const fixedNodeType = ({
       },
       quality: {
         type: GraphQLInt,
-        defaultValue: 50,
       },
       toFormat: {
         type: ImageFormatType,
@@ -263,7 +262,6 @@ const fluidNodeType = ({
       },
       quality: {
         type: GraphQLInt,
-        defaultValue: 50,
       },
       toFormat: {
         type: ImageFormatType,
@@ -413,7 +411,6 @@ module.exports = ({
         },
         quality: {
           type: GraphQLInt,
-          defaultValue: 50,
         },
         jpegProgressive: {
           type: GraphQLBoolean,


### PR DESCRIPTION
## Description
Enable passing a `defaultQuality` option to `gatsby-plugin-sharp`.  Should also work with `gatsby-transformer-sharp`.  Could easily be expanded to allow passing other defaults, but only pulling out `defaultQuality` in case I'm way off base on the approach/missing something/etc. 

Thanks!

## Related Issues
Fixes #4873
