### PR TITLE
fix(gatsby-transformer-remark): Handle inlineCode in headings

### DIFF
--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -14,6 +14,7 @@
     "hast-util-to-html": "^4.0.0",
     "lodash": "^4.17.10",
     "mdast-util-to-hast": "^3.0.0",
+    "mdast-util-to-string": "^1.0.5",
     "mdast-util-toc": "^2.0.1",
     "remark": "^9.0.0",
     "remark-parse": "^5.0.0",

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -13,6 +13,7 @@ const sanitizeHTML = require(`sanitize-html`)
 const _ = require(`lodash`)
 const visit = require(`unist-util-visit`)
 const toHAST = require(`mdast-util-to-hast`)
+const toString = require(`mdast-util-to-string`)
 const hastToHTML = require(`hast-util-to-html`)
 const mdastToToc = require(`mdast-util-toc`)
 const Promise = require(`bluebird`)
@@ -268,7 +269,7 @@ module.exports = (
         const ast = await getAST(markdownNode)
         const headings = select(ast, `heading`).map(heading => {
           return {
-            value: _.first(select(heading, `text`).map(text => text.value)),
+            value: toString(heading),
             depth: heading.depth,
           }
         })


### PR DESCRIPTION
Fixes #11879 
When extracting headings, don't only use `text` nodes.