### PR TITLE
[schema] Better example

### DIFF
--- a/examples/using-type-definitions/gatsby-node.js
+++ b/examples/using-type-definitions/gatsby-node.js
@@ -51,7 +51,9 @@ exports.createResolvers = ({ createResolvers }) => {
       },
     },
     AuthorJson: {
-      // Add a field to an existing type by providing a field config
+      // Add a field to an existing type by providing a field config.
+      // Note that added fields will not be available in the input filter
+      // when no type definitions are provided wth `createTypes`.
       posts: {
         type: [`BlogJson`],
         resolve(source, args, context, info) {

--- a/examples/using-type-definitions/gatsby-node.js
+++ b/examples/using-type-definitions/gatsby-node.js
@@ -1,78 +1,89 @@
-exports.sourceNodes = ({ actions: { addTypes } }) => {
+exports.sourceNodes = ({ actions }) => {
+  const { createTypes } = actions
   const typeDefs = `
     type AuthorJson implements Node {
       name: String!
+      firstName: String!
       email: String!
-      picture: File @link(by: "relativePath")
-      posts: [BlogJson] @link(by: "authors.email", from: "email")
+      picture: File
     }
 
     type BlogJson implements Node {
       title: String!
-      authors: [AuthorJson] @link(by: "email")
+      authors: [AuthorJson]
       text: String
-      date: Date @dateformat(formatString: "yyyy/MM/dd")
+      date: Date
       tags: [String]
     }
   `
-  addTypes(typeDefs)
+  createTypes(typeDefs)
 }
 
 exports.createResolvers = ({ createResolvers }) => {
-  // const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
-  // const { createNode } = actions
-  // const resolvers = {
-  //   GraphCMS_BlogPost: {
-  //     // Wrap the resolver on an existing field by providing a function.
-  //     // The original resolver is available on `info.resolver`.
-  //     // This approach works fine if the returnType stays the same.
-  //     post: async (source, args, context, info) => {
-  //       const remark = require(`remark`)
-  //       const html = require(`remark-html`)
-  //       const result = await info.resolver(source, args, context, info)
-  //       // return a Promise with the markdown string converted to html
-  //       return remark()
-  //         .use(html)
-  //         .process(result)
-  //     },
-  //   },
-  //   GraphCMS_Asset: {
-  //     // Instead of a resolve function it is possible to provide a
-  //     // field config for a *new* field.
-  //     // This allows specifying a return type. The values of sibling fields
-  //     // are available from `source` if they are in the selection set.
-  //     // Be aware that without other fields in the selection set this will
-  //     // throw if the parent is NonNull, even if this resolver returns a value.
-  //     // This is because the delegated schema does not know about this field.
-  //     imageFile: {
-  //       type: `File`,
-  //       // Projection fields will be included in the selection set without
-  //       // having to be explicitly added to the query, i.e.
-  //       // they will be accessible from `source`.
-  //       projection: { url: true, fileName: true },
-  //       resolve: async (source, args, context, info) => {
-  //         const { fileName, url } = source
-  //         const ext = `.` + fileName.match(/[^.]*$/)
-  //         const node = await createRemoteFileNode({
-  //           url,
-  //           store,
-  //           cache,
-  //           createNode,
-  //           createNodeId,
-  //           ext,
-  //           // name: fileName, // Needs #11054
-  //         })
-  //         return node
-  //       },
-  //     },
-  //   },
-  // }
   createResolvers({
     Query: {
-      newField: {
+      // Create a new root query field.
+      allAuthorFullNames: {
         type: [`String!`],
-        resolve() {
-          return [`Foo`, `bar`, `baz`]
+        resolve(source, args, context, info) {
+          const authors = context.nodeModel.getAllNodes(
+            {
+              type: `AuthorJson`,
+            },
+            { path: context.path }
+          )
+          return authors.map(author => `${author.name}, ${author.firstName}`)
+        },
+      },
+      // Field resolvers can use all of Gatsby's querying capabilities
+      allPostsTaggedWithBaz: {
+        type: [`BlogJson`],
+        resolve(source, args, context, info) {
+          return context.nodeModel.runQuery(
+            {
+              query: { filter: { tags: { eq: `baz` } } },
+              type: `BlogJson`,
+              firstOnly: false,
+            },
+            { path: context.path }
+          )
+        },
+      },
+    },
+    AuthorJson: {
+      // Add a field to an existing type by providing a field config
+      posts: {
+        type: [`BlogJson`],
+        resolve(source, args, context, info) {
+          // We use an author's `email` as foreign key in `BlogJson.authors`
+          const fieldValue = source.email
+
+          const posts = context.nodeModel.getAllNodes(
+            {
+              type: `BlogJson`,
+            },
+            { path: context.path }
+          )
+          return posts.filter(post =>
+            (post.authors || []).some(author => author === fieldValue)
+          )
+        },
+      },
+    },
+    BlogJson: {
+      // Add a resolver to a field defined with `createTypes`.
+      authors: {
+        resolve(source, args, context, info) {
+          const emails = source[info.fieldName]
+          if (emails == null) return null
+
+          const authors = context.nodeModel.getAllNodes(
+            {
+              type: `AuthorJson`,
+            },
+            { path: context.path }
+          )
+          return authors.filter(author => emails.includes(author.email))
         },
       },
     },

--- a/examples/using-type-definitions/src/data/author.json
+++ b/examples/using-type-definitions/src/data/author.json
@@ -1,11 +1,13 @@
 [
   {
-    "name": "Mikhail Novikov",
+    "name": "Novikov",
+    "firstName": "Mikhail",
     "email": "m@example.com",
     "picture": "../images/gatsby-astronaut.png"
   },
   {
-    "name": "Stefan Probst",
+    "name": "Probst",
+    "firstName": "Stefan",
     "email": "s@example.com",
     "picture": "../images/gatsby-astronaut.png"
   }

--- a/examples/using-type-definitions/src/data/blog.json
+++ b/examples/using-type-definitions/src/data/blog.json
@@ -6,12 +6,12 @@
     "tags": ["foo", "bar"]
   },
   {
-    "title": "But Gatsby blog posts might not have author",
+    "title": "But Gatsby blog posts might not have an author",
     "date": "2018-01-01",
     "tags": ["baz", "bar"]
   },
   {
-    "title": "Or more than one author",
+    "title": "Or they might have more than one author",
     "authors": ["m@example.com", "s@example.com"],
     "date": "2017-01-01",
     "tags": ["baz"]

--- a/examples/using-type-definitions/src/pages/index.js
+++ b/examples/using-type-definitions/src/pages/index.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import { Link, graphql } from 'gatsby'
-import Img from 'gatsby-image'
 
 import Layout from '../components/layout'
-import Image from '../components/image'
 import SEO from '../components/seo'
 
 const IndexPage = ({ data }) => (
@@ -12,16 +10,16 @@ const IndexPage = ({ data }) => (
     <h1>Hi people</h1>
     <p>Welcome to your new Gatsby site.</p>
     <p>Now go build something great.</p>
-    <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-      <Image />
-    </div>
-    {data.cms.blogPosts.map(({ title, post, titleImage }, i) => (
-      <div key={i}>
-        <h2>{title}</h2>
-        <div dangerouslySetInnerHTML={{ __html: post }} />
-        {titleImage && (
-          <Img fixed={titleImage.imageFile.childImageSharp.fixed} />
-        )}
+    {data.allAuthorJson.edges.map(({ node }) => (
+      <div key={node.id}>
+        <h4>
+          Posts by {node.firstName} {node.name}
+        </h4>
+        <ul>
+          {node.posts.map(post => (
+            <li key={post.id}>{post.title}</li>
+          ))}
+        </ul>
       </div>
     ))}
     <Link to="/page-2/">Go to page 2</Link>
@@ -32,17 +30,15 @@ export default IndexPage
 
 export const query = graphql`
   {
-    cms {
-      blogPosts {
-        title
-        post
-        titleImage {
-          imageFile {
-            childImageSharp {
-              fixed {
-                ...GatsbyImageSharpFixed
-              }
-            }
+    allAuthorJson {
+      edges {
+        node {
+          id
+          name
+          firstName
+          posts {
+            id
+            title
           }
         }
       }


### PR DESCRIPTION
This is for #11480 

Improved the example a bit. Anything missing that would be good to showcase here?

TODO:
* [ ] Would probably be good to show extending third-party types
* [ ] Not sure how best to approach the issue where `source` changes when the field is in both the input filter and selection set. I had added a helper for this, but removed it again, because it seemed to not make things clearer, quite the contrary. I feel a resolvers-centered approach, and one with mongo-like query syntax, are sometimes a bit orthogonal. Nevertheless, we need to show some kind of best practice solution here.