### PR TITLE
fix(www): Change tag of one starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1895,7 +1895,7 @@
     - ReasonML
     - BuckleScript
     - Blog
-    - bs-css
+    - Styling:CSS-in-JS
   features:
     - Gatsby v2 support
     - bs-platform v4 support


### PR DESCRIPTION
`bs-css` is kinda a one-off tag, others were grouped under Styling:CSS-in-JS in the past @sidharthachatterjee 	