### PR TITLE
fix(gatsby-plugin-cxs): Publish plugin files properly

### DIFF
--- a/packages/gatsby-plugin-cxs/.npmignore
+++ b/packages/gatsby-plugin-cxs/.npmignore
@@ -32,5 +32,3 @@ flow-typed
 coverage
 decls
 examples
-/*.js
-!/index.js


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
## Description
`gatsby-ssr.js` is not included in the NPM package. Due to two rules below in `.npmignore`
```
/*.js
!/index.js
```
After PR, the file will be published to the npm.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
N/A