### PR TITLE
fix(docs): Remove gatsbyjswpexample.wordpress.com occurrences

### DIFF
--- a/docs/docs/image-tutorial.md
+++ b/docs/docs/image-tutorial.md
@@ -48,7 +48,7 @@ module.exports = {
       options: {
         /*
          * The base URL of the WordPress site without the trailingslash and the protocol. This is required.
-         * Example : 'gatsbyjswpexample.wordpress.com' or 'www.example-site.com'
+         * Example : 'dev-gatbsyjswp.pantheonsite.io' or 'www.example-site.com'
          */
         baseUrl: `dev-gatbsyjswp.pantheonsite.io`,
         // The protocol. This can be http or https.
@@ -95,7 +95,7 @@ module.exports = {
       options: {
         /*
          * The base URL of the WordPress site without the trailing slash and the protocol. This is required.
-         * Example : 'gatsbyjswpexample.wordpress.com' or 'www.example-site.com'
+         * Example : 'dev-gatbsyjswp.pantheonsite.io' or 'www.example-site.com'
          */
         baseUrl: `dev-gatbsyjswp.pantheonsite.io`,
         // The protocol. This can be http or https.

--- a/docs/docs/wordpress-source-plugin-tutorial.md
+++ b/docs/docs/wordpress-source-plugin-tutorial.md
@@ -54,7 +54,7 @@ module.exports = {
       options: {
         /*
          * The base URL of the WordPress site without the trailingslash and the protocol. This is required.
-         * Example : 'gatsbyjswpexample.wordpress.com' or 'www.example-site.com'
+         * Example : 'dev-gatbsyjswp.pantheonsite.io' or 'www.example-site.com'
          */
         baseUrl: `dev-gatbsyjswp.pantheonsite.io`,
         // The protocol. This can be http or https.

--- a/examples/using-wordpress/gatsby-config.js
+++ b/examples/using-wordpress/gatsby-config.js
@@ -14,7 +14,7 @@ module.exports = {
       options: {
         /*
          * The base URL of the Wordpress site without the trailingslash and the protocol. This is required.
-         * Example : 'gatsbyjswpexample.wordpress.com' or 'www.example-site.com'
+         * Example : 'dev-gatbsyjswp.pantheonsite.io' or 'www.example-site.com'
          */
         baseUrl: `dev-gatbsyjswp.pantheonsite.io`,
         // The protocol. This can be http or https.


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/commit/512245938cfd058775e42db77fee3f8f11fe6296 updated the WordPress example site to `dev-gatbsyjswp.pantheonsite.io`, but left some occurrences of the old example site `gatsbyjswpexample.wordpress.com`.

These leftovers are now also replaced.

Fixes #11806