### PR TITLE
docs(gatsby-link): Added some information regarding the limitations with the link package

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -357,7 +357,7 @@ You can similarly check for file downloads:
 
 [egghead]: https://egghead.io/playlists/use-gatsby-s-link-component-to-improve-site-performance-and-simplify-site-development-7ed3ddfe
 
-## Limitations when appending query parameters or hash links programmatically
+## Recommendations for programmatic, in-app navigation
 
 Neither `<Link>` not `navigate` can be used for in-route navigation with a hash or query parameter. If you need this behavior, you should either use an anchor tag or import the `@reach/router` package to make use of its `navigate` function, like so:
 

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -359,7 +359,7 @@ You can similarly check for file downloads:
 
 ## Limitations when appending query parameters or hash links programmatically
 
-Neither `<Link>` not `navigate` can be used to add query parameters or send your user to a hash link due to their use of `withPrefix`. If you need this behavior, you should either use an anchor tag or load the `@reach/router` package to make use of its `navigate` function.
+Neither `<Link>` not `navigate` can be used for in-route navigation with a hash or query parameter. If you need this behavior, you should either use an anchor tag or import the `@reach/router` package to make use of its `navigate` function, like so:
 
 ```jsx
 import { navigate } from '@reach/router';

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -356,3 +356,19 @@ You can similarly check for file downloads:
 ```
 
 [egghead]: https://egghead.io/playlists/use-gatsby-s-link-component-to-improve-site-performance-and-simplify-site-development-7ed3ddfe
+
+## Limitations when appending query parameters or hash links programmatically
+
+Neither `<Link>` not `navigate` can be used to add query parameters or send your user to a hash link due to their use of `withPrefix`. If you need this behavior, you should either use an anchor tag or load the `@reach/router` package to make use of its `navigate` function.
+
+```jsx
+import { navigate } from '@reach/router';
+
+...
+
+onClick = () => {
+  navigate('#some-link');
+  // OR
+  navigate('?foo=bar');
+}
+```

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -359,7 +359,7 @@ You can similarly check for file downloads:
 
 ## Recommendations for programmatic, in-app navigation
 
-Neither `<Link>` not `navigate` can be used for in-route navigation with a hash or query parameter. If you need this behavior, you should either use an anchor tag or import the `@reach/router` package to make use of its `navigate` function, like so:
+Neither `<Link>` nor `navigate` can be used for in-route navigation with a hash or query parameter. If you need this behavior, you should either use an anchor tag or import the `@reach/router` package--which Gatsby already depends upon--to make use of its `navigate` function, like so:
 
 ```jsx
 import { navigate } from '@reach/router';


### PR DESCRIPTION
## Description

The `<Link>` component and the `navigate` function do not allow the user to replace to a hash-link nor a query parameter while `@reach/router` allows it. This PR adds a small section in the Link API docs to let users know of possible workarounds this limitation.

This was discussed in this PR: https://github.com/gatsbyjs/gatsby/pull/11625
