### PR TITLE
chore(*): ensure all prepare scripts set NODE_ENV

### DIFF
--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "babel-preset-gatsby-package": "^0.1.3"
+    "babel-preset-gatsby-package": "^0.1.3",
+    "cross-env": "^5.2.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs#readme",
   "keywords": [
@@ -29,7 +30,7 @@
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs",
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
-    "prepare": "npm run build",
+    "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
   }
 }

--- a/packages/gatsby-plugin-jss/package.json
+++ b/packages/gatsby-plugin-jss/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "babel-preset-gatsby-package": "^0.1.3"
+    "babel-preset-gatsby-package": "^0.1.3",
+    "cross-env": "^5.2.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss#readme",
   "keywords": [
@@ -29,7 +30,7 @@
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss",
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
-    "prepare": "npm run build",
+    "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
   }
 }

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "babel-preset-gatsby-package": "^0.1.3"
+    "babel-preset-gatsby-package": "^0.1.3",
+    "cross-env": "^5.2.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components#readme",
   "keywords": [
@@ -30,8 +31,7 @@
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components",
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
-    "prepare": "npm run build",
+    "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5697,7 +5697,7 @@ createerror@1.3.0, createerror@^1.2.0, createerror@^1.3.0:
   resolved "https://registry.yarnpkg.com/createerror/-/createerror-1.3.0.tgz#c666bd4cd6b94e35415396569d4649dd0cdb3313"
   integrity sha512-w9UZUtkaGd8MfS7eMG7Sa0lV5vCJghqQfiOnwNVrPhbZScUp5h0jwYoAF933MKlotlG1JAJOCCT3xU6r+SDKNw==
 
-cross-env@^5.0.5, cross-env@^5.1.4:
+cross-env@^5.0.5, cross-env@^5.1.4, cross-env@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==


### PR DESCRIPTION
This solves an issue where _jsxFileName is set upon publishing--which
seems to be a debugging/development mode tweak that Babel makes.

See the recently released [gatsby-plugin-cxs](https://unpkg.com/gatsby-plugin-cxs@2.0.5/gatsby-ssr.js) for an example (check the _jsxFileName in particular)

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
