### PR TITLE
fix(blog): Fixes broken link on government gatsby migration post

### DIFF
--- a/docs/blog/2019-02-08-government-open-data-site-with-gatsby/index.md
+++ b/docs/blog/2019-02-08-government-open-data-site-with-gatsby/index.md
@@ -16,7 +16,7 @@ _This post was originally published at [Open data design at the U.S. Department 
 
 A few months ago, our small team at the Office of Natural Resources Revenue (ONRR) decided we needed to refactor our [open-data website](https://revenuedata.doi.gov/). We knew we were in for a massive undertaking, as the site was originally built with the static-site generator [Jekyll](https://jekyllrb.com/), with significant custom coding to furnish bespoke features, automate data updates, and compile and deploy the site with [18F's](https://18f.gsa.gov/) fantastic static-site hosting service, [Federalist](https://federalist.18f.gov/).
 
-As covered in our [first post in this series](https://revenuedata.doi.gov/homepage-revamp/), we were simultaneously scoping a redesign of our homepage. Rebuilding the homepage would allow us to test some of our assumptions about how to address obstacles in our existing workflow.
+As covered in our [first post in this series](https://revenuedata.doi.gov/blog/homepage-revamp/), we were simultaneously scoping a redesign of our homepage. Rebuilding the homepage would allow us to test some of our assumptions about how to address obstacles in our existing workflow.
 
 ## Transition obstacles
 


### PR DESCRIPTION
Fixes broken link to part one of series at Department of the Interior open data blog.
