### PR TITLE
fix(docs): small wording change in blog-and-website-contributions.md 

### DIFF
--- a/docs/contributing/blog-and-website-contributions.md
+++ b/docs/contributing/blog-and-website-contributions.md
@@ -58,7 +58,7 @@ If you want to make changes, improvements, or add new functionality to the websi
 
 - Clone [the Gatsby repo](https://github.com/gatsbyjs/gatsby/) and navigate to `/www`
 - Run `yarn` to install all of the website's dependencies.
-- Run `npm run develop` to preview the blog at `http://localhost:8000/blog`.
+- Run `npm run develop` to preview the site at `http://localhost:8000/`.
 
 Now you can make and preview your changes before raising a pull request!
 


### PR DESCRIPTION
Near the end of the document where it discusses how to contribute the site, I made a quick change to the wording to reference that you run `npm run develop` to preview the site at localhost:8000.