### PR TITLE
chore(gatsby-plugin-emotion): allow newer versions of babel-preset-css-prop

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@emotion/babel-preset-css-prop": "10.0.5"
+    "@emotion/babel-preset-css-prop": "^10.0.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR updates the `package.json` of gatsby-plugin-emotion to allow newer versions of babel-preset-css-prop to be used.

## Related Issues

This fixes #11915, as newer versions of babel-preset-css-prop have resolved that issue.