### PR TITLE
feat(gatsby-plugin-sharp): Remove sharp SIMD instructions

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -56,12 +56,6 @@ exports.setPluginOptions = opts => {
 // raw) callback-accepting toBuffer(...) method
 Promise.promisifyAll(sharp.prototype, { multiArgs: true })
 
-// Try to enable the use of SIMD instructions. Seems to provide a smallish
-// speedup on resizing heavy loads (~10%). Sharp disables this feature by
-// default as there's been problems with segfaulting in the past but we'll be
-// adventurous and see what happens with it on.
-sharp.simd(true)
-
 const bar = new ProgressBar(
   `Generating image thumbnails [:bar] :current/:total :elapsed secs :percent`,
   {


### PR DESCRIPTION
## Description

On larger builds where the gatsby-plugin-sharp is used to transform large amounts of images, the build sometimes fails in an operation ‘close to the metal‘. This change increases the build time a little bit but it should prevent the issue. Further testing is required, to ensure the error doesn't occur again.

## Related Issues

This should fix #6291.