### PR TITLE
Add plugins option to gatsby-transformer-json

### DIFF
--- a/packages/gatsby-transformer-json/README.md
+++ b/packages/gatsby-transformer-json/README.md
@@ -140,6 +140,23 @@ Which would return:
 
 ## Configuration options
 
+**`plugins`** [string[]][optional]
+
+By default, all JSON nodes are transformed. Use the `plugins` array option as an opt-in performance enhancement to only transform nodes created by specific plugins. This will also reduce the amount of unused queries and types in your GraphQL schema.
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-transformer-json`,
+      options: {
+        plugins: [`gatsby-source-filesystem`],
+      },
+    },
+  ],
+}
+```
+
 **`typeName`** [string|function][optional]
 
 The default naming convention documented above can be changed with

--- a/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
@@ -208,4 +208,59 @@ describe(`Process JSON nodes correctly`, () => {
       expect(createParentChildLink).toHaveBeenCalledTimes(1)
     })
   })
+
+  it(`process node that is listed in plugins pluginOption`, async () => {
+    const data = { id: `foo`, blue: true, funny: `yup` }
+    const node = {
+      ...baseNonFileNode,
+      content: JSON.stringify(data),
+      internal: {
+        ...baseNonFileNode.internal,
+        owner: `gatsby-source-filesystem`,
+      },
+    }
+    const createNode = jest.fn()
+    const createParentChildLink = jest.fn()
+    const loadNodeContent = jest.fn()
+    loadNodeContent.mockReturnValue(JSON.stringify(data))
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
+
+    await onCreateNode(
+      { node, actions, loadNodeContent, createContentDigest },
+      { plugins: [`gatsby-source-filesystem`] }
+    )
+    expect(createNode).toHaveBeenCalled()
+    expect(createParentChildLink).toHaveBeenCalled()
+    expect(loadNodeContent).toHaveBeenCalled()
+  })
+
+  it(`does not process node that is NOT listed in plugins pluginOption`, async () => {
+    const data = { id: `foo`, blue: true, funny: `yup` }
+    const node = {
+      ...baseNonFileNode,
+      content: JSON.stringify(data),
+      internal: {
+        ...baseNonFileNode.internal,
+        owner: `gatsby-some-plugin`,
+      },
+    }
+    const createNode = jest.fn()
+    const createParentChildLink = jest.fn()
+    const loadNodeContent = jest.fn()
+    loadNodeContent.mockReturnValue(JSON.stringify(data))
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
+
+    await onCreateNode(
+      { node, actions, loadNodeContent, createContentDigest },
+      { plugins: [`gatsby-source-filesystem`] }
+    )
+    expect(actions.createNode).not.toHaveBeenCalled()
+    expect(actions.createParentChildLink).not.toHaveBeenCalled()
+  })
 })

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -36,6 +36,12 @@ async function onCreateNode(
 
   const { createNode, createParentChildLink } = actions
 
+  const { plugins } = pluginOptions
+
+  if (plugins && plugins.length > 0 && !plugins.includes(node.internal.owner)) {
+    return
+  }
+
   // We only care about JSON content.
   if (node.internal.mediaType !== `application/json`) {
     return


### PR DESCRIPTION
## Description

`Enhancement`:  Wanted an option to limit the nodes that `gatsby-transformer-json` performs transformations on.  This would be a performance improvement and limit the amount of unused types and queries polluting your schema when using this plugin.

Thoughts? 
