### PR TITLE
fix(tests): delay going back in path-prefix E2E test

### DIFF
--- a/e2e-tests/path-prefix/cypress/integration/path-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/path-prefix.js
@@ -39,6 +39,8 @@ describe(`Production pathPrefix`, () => {
     it(`can go back`, () => {
       cy.getTestElement(`page-2-link`).click()
 
+      cy.getTestElement(`index-link`)
+
       cy.go(`back`)
 
       cy.location(`pathname`, { timeout: 10000 }).should(


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This is an attempt at fixing the `e2e_tests_path-prefix` CI job which often fails but will succeed upon simply running the test again. I believe the test is trying to call `cy.go('back')` before everything has settled, so the assertion following that instruction times out waiting for something that is never going to arrive (just an educated guess, though). This change waits for an expected element to exist in the DOM prior to calling `cy.go('back')` to give poor Cypress time to catch its breath.
