### PR TITLE
Add resolvePaths, get webpack instance to recognize react and es6 syntax

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -19,6 +19,10 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.4",
+    "@babel/preset-react": "^7.0.0",
+    "@babel/preset-env": "^7.3.1",
+    "@babel/plugin-proposal-class-properties": "^7.3.3",
+    "babel-loader": "^8.0.5",
     "cross-env": "^5.1.4",
     "react": "^16.4.1",
     "react-dom": "^16.4.1"

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -1,5 +1,27 @@
 import CMS from "netlify-cms"
 
+// The following window and global config settings below were taken from here.
+// https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/visual-testing-with-storybook.md
+// They're required because the netlify-cms runs on a separate webpack config,
+// and outside of Gatsby. This ensures any Gatsby components imported into the
+// CMS works without errors
+
+// highlight-start
+// Gatsby's Link overrides:
+// Gatsby defines a global called ___loader to prevent its method calls from creating console errors you override it here
+global.___loader = {
+  enqueue: () => {},
+  hovering: () => {},
+}
+
+// Gatsby internal mocking to prevent unnecessary errors
+global.__PATH_PREFIX__ = ``
+
+// This is to utilized to override the window.___navigate method Gatsby defines and uses to report what path a Link would be taking us to
+window.___navigate = pathname => {
+  alert(`This would navigate to: ${pathname}`)
+}
+
 /**
  * The stylesheet output from the modules at `modulePath` will be at `cms.css`.
  */

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -55,6 +55,7 @@ exports.onCreateWebpackConfig = (
     enableIdentityWidget = true,
     htmlTitle = `Content Manager`,
     manualInit = false,
+    resolvePaths = [],
   }
 ) => {
   if ([`develop`, `build-javascript`].includes(stage)) {
@@ -74,6 +75,9 @@ exports.onCreateWebpackConfig = (
       },
       output: {
         path: path.join(program.directory, `public`, publicPathClean),
+      },
+      resolve: {
+        modules: [...resolvePaths, `node_modules`],
       },
       module: {
         /**
@@ -160,6 +164,30 @@ exports.onCreateWebpackConfig = (
       optimization: {},
       devtool: stage === `develop` ? `cheap-module-source-map` : `source-map`,
     }
+
+    config.module.rules.push({
+      test: /gatsby\/cache-dir.*\.js$/,
+      loader: require.resolve(`babel-loader`),
+      options: {
+        presets: [
+          require.resolve(`@babel/preset-react`),
+          [
+            require.resolve(`@babel/preset-env`),
+            {
+              shippedProposals: true,
+              useBuiltIns: `entry`,
+            },
+          ],
+        ],
+        plugins: [require.resolve(`@babel/plugin-proposal-class-properties`)],
+      },
+    })
+
+    // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
+    config.module.rules.exclude = [/node_modules\/(?!(gatsby)\/)/]
+
+    // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
+    config.resolve.mainFields = [`browser`, `module`, `main`]
 
     if (stage === `develop`) {
       webpack(config).watch({}, () => {})

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -186,9 +186,6 @@ exports.onCreateWebpackConfig = (
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
     config.module.rules.exclude = [/node_modules\/(?!(gatsby)\/)/]
 
-    // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
-    config.resolve.mainFields = [`browser`, `module`, `main`]
-
     if (stage === `develop`) {
       webpack(config).watch({}, () => {})
     } else {

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -186,6 +186,9 @@ exports.onCreateWebpackConfig = (
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
     config.module.rules.exclude = [/node_modules\/(?!(gatsby)\/)/]
 
+    // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
+    config.resolve.mainFields = [`browser`, `module`, `main`]
+
     if (stage === `develop`) {
       webpack(config).watch({}, () => {})
     } else {


### PR DESCRIPTION
## Description
Changes:
- Currently gatsby-plugin-netlify-cms' webpack instance cannot recognize React or ES6 class syntax when components are pulled in and registered as templates. This adds react and es6 class syntax support.
- Adds the resolvePaths config option, which gets dumped into the webpack's resolve config. i.e., now referenced modules with absolute path imports work.
- Deal with components that import gatsby components.

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/11119
https://github.com/gatsbyjs/gatsby/issues/11137
