### PR TITLE
chore(docs): grammatical/typo fixes

### DIFF
--- a/docs/docs/debugging-cache-issues.md
+++ b/docs/docs/debugging-cache-issues.md
@@ -2,7 +2,7 @@
 title: Debugging Cache Issues
 ---
 
-There can be certain scenarios in which the Gatsby caching mechanism appears to fail, which leads to issues like:
+There can be certain scenarios in which the Gatsby caching mechanism appears to fail, which can lead to issues like:
 
 - Content not appearing when it should
 - Changes to plugin source code not appearing to be invoked appropriately
@@ -17,9 +17,9 @@ and more! If you've found yourself writing a script like:
 }
 ```
 
-consider utilizing the `gatsby clean` command which will help to resolve caching issues for you.
+consider utilizing the `gatsby clean` command which can help resolve caching issues for you.
 
-First - make sure the version of `gatsby` specified in your `package.json` dependencies is _at least_ `2.1.1`, and then make the following change to `package.json`:
+First make sure the version of `gatsby` specified in your `package.json` dependencies is _at least_ `2.1.1`, and then make the following change to `package.json`:
 
 ```json:title=package.json
 {
@@ -29,7 +29,7 @@ First - make sure the version of `gatsby` specified in your `package.json` depen
 }
 ```
 
-Now when you issues arise that seem to be related to caching, you can use `npm run clean` to wipe out the cache and start from a fresh slate.
+Now when issues arise that seem to be related to caching, you can use `npm run clean` to wipe out the cache and start from a fresh slate.
 
 _Note: If you find yourself using this command regularly, consider helping us out and [responding to our Github Issue][github-issue] with clear reproduction steps._
 


### PR DESCRIPTION
## Description

This fixes a couple of small typos and changes around some grammar I found on the `debugging-cache-issues` doc.