### PR TITLE
feat(gatsby-plugin-manifest): add option for crossorigin in manifest

### DIFF
--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -41,9 +41,9 @@ npm install --save gatsby-plugin-manifest
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
         icon: "src/images/icon.png", // This path is relative to the root of the site.
+        // see https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes
+        // defaults to `anonymous`
         crossOrigin: `use-credentials`,
-        // An optional attribute which provides support for CORS check.
-        // If you do not provide a crossOrigin option, it will skip CORS for manifest.
       },
     },
   ]

--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -41,7 +41,7 @@ npm install --save gatsby-plugin-manifest
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
         icon: "src/images/icon.png", // This path is relative to the root of the site.
-        crossOrigin: `use-credentials`, // Anything else will be treated as `anonymous`.
+        crossOrigin: `use-credentials`,
         // An optional attribute which provides support for CORS check.
         // If you do not provide a crossOrigin option, it will skip CORS for manifest.
       },

--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -41,6 +41,9 @@ npm install --save gatsby-plugin-manifest
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
         icon: "src/images/icon.png", // This path is relative to the root of the site.
+        crossOrigin: `use-credentials`, // Anything else will be treated as `anonymous`.
+        // An optional attribute which provides support for CORS check.
+        // If you do not provide a crossOrigin option, it will skip CORS for manifest.
       },
     },
   ]

--- a/docs/docs/add-a-manifest-file.md
+++ b/docs/docs/add-a-manifest-file.md
@@ -41,8 +41,9 @@ npm install --save gatsby-plugin-manifest
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
         display: "standalone",
         icon: "src/images/icon.png", // This path is relative to the root of the site.
-        // see https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes
-        // defaults to `anonymous`
+        // An optional attribute which provides support for CORS check.
+        // If you do not provide a crossOrigin option, it will skip CORS for manifest.
+        // Any invalid keyword or empty string defaults to `anonymous`
         crossOrigin: `use-credentials`,
       },
     },

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -257,3 +257,32 @@ module.exports = {
   ],
 }
 ```
+
+## Include `crossorigin` in manifest
+
+Add a `crossorigin` attribute to the manifest `<link rel="manifest" crossorigin="use-credentials" href="/manifest.webmanifest" />` link tag.
+
+You can set `crossOrigin` plugin option to `'use-credentials'` to enable sharing resources via cookies.
+You can find more information about `crossorigin` on MDN.
+
+[https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
+
+```javascript:title=gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-manifest`,
+      options: {
+        name: `GatsbyJS`,
+        short_name: `GatsbyJS`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#a2466c`,
+        display: `standalone`,
+        icon: `src/images/icon.png`, // This path is relative to the root of the site.
+        crossOrigin: `use-credentials`,
+      },
+    },
+  ],
+}
+```

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -258,11 +258,12 @@ module.exports = {
 }
 ```
 
-## Include `crossorigin` in manifest
+## Enable CORS using `crossorigin` attribute
 
 Add a `crossorigin` attribute to the manifest `<link rel="manifest" crossorigin="use-credentials" href="/manifest.webmanifest" />` link tag.
 
-You can set `crossOrigin` plugin option to `'use-credentials'` to enable sharing resources via cookies.
+You can set `crossOrigin` plugin option to `'use-credentials'` to enable sharing resources via cookies. Any invalid keyword or empty string will fallback to `'anonymous'`.
+
 You can find more information about `crossorigin` on MDN.
 
 [https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -163,6 +163,56 @@ Array [
 ]
 `;
 
+exports[`gatsby-plugin-manifest Adds a crossorigin attribute to manifest link tag if provided 1`] = `
+Array [
+  <link
+    crossOrigin="use-credentials"
+    href="/manifest.webmanifest"
+    rel="manifest"
+  />,
+  <link
+    href="/icons/icon-48x48.png"
+    rel="apple-touch-icon"
+    sizes="48x48"
+  />,
+  <link
+    href="/icons/icon-72x72.png"
+    rel="apple-touch-icon"
+    sizes="72x72"
+  />,
+  <link
+    href="/icons/icon-96x96.png"
+    rel="apple-touch-icon"
+    sizes="96x96"
+  />,
+  <link
+    href="/icons/icon-144x144.png"
+    rel="apple-touch-icon"
+    sizes="144x144"
+  />,
+  <link
+    href="/icons/icon-192x192.png"
+    rel="apple-touch-icon"
+    sizes="192x192"
+  />,
+  <link
+    href="/icons/icon-256x256.png"
+    rel="apple-touch-icon"
+    sizes="256x256"
+  />,
+  <link
+    href="/icons/icon-384x384.png"
+    rel="apple-touch-icon"
+    sizes="384x384"
+  />,
+  <link
+    href="/icons/icon-512x512.png"
+    rel="apple-touch-icon"
+    sizes="512x512"
+  />,
+]
+`;
+
 exports[`gatsby-plugin-manifest Adds link favicon if "include_favicon" option is not provided 1`] = `
 Array [
   <link

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -13,6 +13,11 @@ describe(`gatsby-plugin-manifest`, () => {
     headComponents = []
   })
 
+  it(`Adds a crossorigin attribute to manifest link tag if provided`, () => {
+    onRenderBody(ssrArgs, { crossOrigin: `use-credentials` })
+    expect(headComponents).toMatchSnapshot()
+  })
+
   it(`Adds a "theme color" meta tag to head if "theme_color_in_head" is not provided`, () => {
     onRenderBody(ssrArgs, { theme_color: `#000000` })
     expect(headComponents).toMatchSnapshot()

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -32,6 +32,7 @@ exports.onPostBootstrap = (args, pluginOptions) =>
     delete manifest.plugins
     delete manifest.legacy
     delete manifest.theme_color_in_head
+    delete manifest.crossOrigin
 
     // If icons are not manually defined, use the default icon set.
     if (!manifest.icons) {

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -31,13 +31,25 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   }
 
   // Add manifest link tag.
-  headComponents.push(
-    <link
-      key={`gatsby-plugin-manifest-link`}
-      rel="manifest"
-      href={withPrefix(`/manifest.webmanifest`)}
-    />
-  )
+  if (pluginOptions.crossOrigin) {
+    headComponents.push(
+      <link
+        key={`gatsby-plugin-manifest-link`}
+        rel="manifest"
+        href={withPrefix(`/manifest.webmanifest`)}
+        crossOrigin={pluginOptions.crossOrigin}
+      />
+    )
+  } else {
+    headComponents.push(
+      <link
+        key={`gatsby-plugin-manifest-link`}
+        rel="manifest"
+        href={withPrefix(`/manifest.webmanifest`)}
+      />
+    )
+  }
+
   // The user has an option to opt out of the theme_color meta tag being inserted into the head.
   if (pluginOptions.theme_color) {
     let insertMetaTag = Object.keys(pluginOptions).includes(

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -31,24 +31,14 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   }
 
   // Add manifest link tag.
-  if (pluginOptions.crossOrigin) {
-    headComponents.push(
-      <link
-        key={`gatsby-plugin-manifest-link`}
-        rel="manifest"
-        href={withPrefix(`/manifest.webmanifest`)}
-        crossOrigin={pluginOptions.crossOrigin}
-      />
-    )
-  } else {
-    headComponents.push(
-      <link
-        key={`gatsby-plugin-manifest-link`}
-        rel="manifest"
-        href={withPrefix(`/manifest.webmanifest`)}
-      />
-    )
-  }
+  headComponents.push(
+    <link
+      key={`gatsby-plugin-manifest-link`}
+      rel="manifest"
+      href={withPrefix(`/manifest.webmanifest`)}
+      crossOrigin={pluginOptions.crossOrigin}
+    />
+  )
 
   // The user has an option to opt out of the theme_color meta tag being inserted into the head.
   if (pluginOptions.theme_color) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Added crossOrigin option to manifest plugin

```js
{
  plugins: [
    {
      resolve: `gatsby-plugin-manifest`,
      options: {
        name: "GatsbyJS",
        short_name: "GatsbyJS",
        start_url: "/",
        background_color: "#6b37bf",
        theme_color: "#6b37bf",
        // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
        // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
        display: "standalone",
        icon: "src/images/icon.png", // This path is relative to the root of the site.
		crossOrigin: `use-credentials`,
      },
    },
  ]
}
```
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Requested in #11877 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
