### PR TITLE
fix(themes): reverse order of themes checked when shadowing

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -66,9 +66,11 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
         path.join(path.resolve(`.`), `src`, theme),
       ]
         .concat(
-          themes.map(aTheme =>
-            path.join(path.dirname(require.resolve(aTheme)), `src`, theme)
-          )
+          Array.from(themes)
+            .reverse()
+            .map(aTheme =>
+              path.join(path.dirname(require.resolve(aTheme)), `src`, theme)
+            )
         )
         .map(dir => path.join(dir, component))
         .find(possibleComponentPath => {


### PR DESCRIPTION
## Description

Component shadowing with a total number of potential shadowings >= 2 (excluding the theme with the component and the site itself, which are absolutely positioned in the order relative to other potential shadow paths) exhibit a bug due to the ordering in which potential theme paths are checked. The order should be reversed. This PR copies the themes array (not strictly necessary, but we shouldn't depend on the assumption that we can safely mutate) then reverses it.

## Related Issues

Fixes #11951