### PR TITLE
docs(www): Fix link to withPrefix on Adding images docs

### DIFF
--- a/docs/docs/adding-images-fonts-files.md
+++ b/docs/docs/adding-images-fonts-files.md
@@ -126,7 +126,7 @@ If you put a file into the `static` folder, it will **not** be processed by
 Webpack. Instead, it will be copied into the public folder untouched. E.g. if you
 add a file named `sun.jpg` to the static folder, it'll be copied to
 `public/sun.jpg`. To reference assets in the `static` folder, you'll need to
-[import a helper function from `gatsby` named `withPrefix`](/docs/gatsby-link/#prefixed-paths-helper).
+[import a helper function from `gatsby` named `withPrefix`](/docs/gatsby-link/#add-the-path-prefix-to-paths-using-withprefix).
 You will need to make sure
 [you set `pathPrefix` in your gatsby-config.js for this to work](/docs/path-prefix/).
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Linked content was probably changed and link is not working anymore.