### PR TITLE
chore(*): add binary designation for more file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,11 @@
 *.mp4 binary
 *.mp3 binary
 *.ttf binary
+*.otf binary
 *.eot binary
 *.woff binary
+*.woff2 binary
 *.pdf binary
+*.tar.gz binary
+*.zip binary
+*.7z binary


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/pull/11569 I added several file extensions to the `.gitattributes` file with the `binary` designation, which will prevent git from manipulating their line endings. Trying to manipulate line endings in image files was causing image corruption, and is otherwise undesirable for non-text files.

This PR identifies a few more file extensions as binary to prevent manipulation of these files by git.

## Related Issues

Concerns were raised by the Gatsby team regarding arbitrary file modifications in this commit: https://github.com/gatsbyjs/gatsby/pull/11749/commits/7a6a5d2e9a5e32d385851ef4c176f460f037b5c9

Once this PR is merged I anticipate a subsequent commit automatically reverting the modifications to the `.otf`, `.woff2`, and `tar.gz` files altered in that commit.