### PR TITLE
chore(babel-preset-gatsby): Adds the missing peer dependency on @babel/core

### DIFF
--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -10,6 +10,9 @@
     "@babel/preset-react": "^7.0.0",
     "babel-plugin-macros": "^2.4.2"
   },
+  "peerDependencies": {
+    "@babel/core": "*"
+  },
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -11,7 +11,7 @@
     "babel-plugin-macros": "^2.4.2"
   },
   "peerDependencies": {
-    "@babel/core": "*"
+    "@babel/core": "^7.0.0"
   },
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
## Description

The Babel plugins have a peer dependency on `@babel/core`, and since `babel-preset-gatsby` doesn't provide it it needs to list it as a peer dependency itself.
