### PR TITLE
chore(gatsby-link): Adds a missing peer dependency on react-dom

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -12,6 +12,9 @@
     "@types/reach__router": "^1.0.0",
     "prop-types": "^15.6.1"
   },
+  "peerDependencies": {
+    "react-dom": "*"
+  },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -27,8 +27,8 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.0",
-    "react-dom": "^16.3",
-    "react": "^16.3"
+    "react-dom": "^16.4.2",
+    "react": "^16.4.2"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link",
   "scripts": {

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -12,9 +12,6 @@
     "@types/reach__router": "^1.0.0",
     "prop-types": "^15.6.1"
   },
-  "peerDependencies": {
-    "react-dom": "*"
-  },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
@@ -30,6 +27,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.0",
+    "react-dom": "^16.3",
     "react": "^16.3"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link",


### PR DESCRIPTION
## Description

The `@reach/router` package has a peer dependency on `react-dom`, and since `gatsby-link` doesn't provide it it needs to list it as a peer dependency itself.
