### PR TITLE
fix(e2e-tests): prevent flaky test runs by waiting for the correct API

### DIFF
--- a/e2e-tests/path-prefix/cypress/integration/path-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/path-prefix.js
@@ -1,4 +1,3 @@
-/* global cy */
 const { pathPrefix } = require(`../../gatsby-config`)
 
 const withTrailingSlash = url => `${url}/`
@@ -37,14 +36,13 @@ describe(`Production pathPrefix`, () => {
     })
 
     it(`can go back`, () => {
-      cy.getTestElement(`page-2-link`).click()
+      cy.getTestElement(`page-2-link`)
+        .click()
+        .waitForAPI(`onRouteUpdate`)
 
-      cy.go(`back`)
+      cy.go(`back`).waitForAPI(`onRouteUpdate`)
 
-      cy.location(`pathname`, { timeout: 10000 }).should(
-        `eq`,
-        withTrailingSlash(pathPrefix)
-      )
+      cy.location(`pathname`).should(`eq`, withTrailingSlash(pathPrefix))
     })
   })
 })


### PR DESCRIPTION
## Description

This fixes the flaky path-prefix test by appropriately invoking the `waitForAPI` helper in various phases of the failing test.

First, a little background:

- This annoying e2e-test fails infrequently, but often enough that people notice it and are confused by it
    - Note: it always fails on the same assertion ("expected blank to equal /blog")
- The test (seems to) always run fine locally, so it seems to be a CI and timing issue

To validate this fix, I `ssh`ed into the CircleCI container, ran the e2e-test _first_ to validate failures (it does fail! see below 👇). It appears to fail once every 10 runs or so. I made _this_ change to the test and then validated that after 30+ runs the e2e-test does not fail.

![download](https://user-images.githubusercontent.com/3924690/53196388-9972e880-35dd-11e9-9810-9082769e2216.png)


## Related Issues

Fixes #9233