### PR TITLE
docs: Replace "gatsby develop" with "npm run develop" in second part of tutorial

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -120,7 +120,7 @@ import "./src/styles/global.css"
 3. Start the development server:
 
 ```shell
-gatsby develop
+npm run develop
 ```
 
 If you take a look at your project in the browser, you should see a lavender background applied to the "hello world" starter:


### PR DESCRIPTION
I was trying to follow this tutorial, but `gatsby develop` didn't work as I don't have a global version of Gatsby installed. Replaced it with `npm run develop` as that's what the first part of the tutorial uses.