### PR TITLE
docs(www): Update npm run serve description

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -48,8 +48,7 @@ Gatsby will perform an optimized production build for your site, generating stat
 npm run serve
 ```
 
-Gatsby starts a local HTML server for testing your built site. You must use `npm run build` before using this command.
-
+Gatsby starts a local HTML server for testing your built site. Remember to build your site using  `npm run build` before using this command.
 ### Access documentation for CLI commands.
 
 To see detailed documentation for the CLI commands, run `npx gatsby --help` in the terminal.

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -48,7 +48,8 @@ Gatsby will perform an optimized production build for your site, generating stat
 npm run serve
 ```
 
-Gatsby starts a local HTML server for testing your built site. Remember to build your site using  `npm run build` before using this command.
+Gatsby starts a local HTML server for testing your built site. Remember to build your site using `npm run build` before using this command.
+
 ### Access documentation for CLI commands.
 
 To see detailed documentation for the CLI commands, run `npx gatsby --help` in the terminal.

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -48,7 +48,7 @@ Gatsby will perform an optimized production build for your site, generating stat
 npm run serve
 ```
 
-Gatsby starts a local HTML server for testing your built site.
+Gatsby starts a local HTML server for testing your built site. You must use `npm run build` before using this command.
 
 ### Access documentation for CLI commands.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
I recently started using gatsby so hadn't used the `npm run build` command yet. I tried to run the `npm run serve` command and got an error that didn't help me track down the reason. I worked out that I had to run the build script first

 I think by adding this to the docs may help others in the future.

<!-- Write a brief description of the changes introduced by this PR -->
Adding a sentence to the docs to show you must run the build script before serve.

## Related Issues
I didn't create an issue
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
