### PR TITLE
chore(babel-plugin-remove-graphql-queries): Add gatsby to peer dependencies

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
+    "gatsby": "^2.0.0",
     "graphql": "^14.1.1"
   },
   "scripts": {


### PR DESCRIPTION
## Description

The `babel-plugin-remove-graphql-queries` package depends on `gatsby` (via `index.js`), but it isn't listed in its peer dependencies. I've used `^2.0.0` as it seems to be used elsewhere (like `gatsby-plugin-no-sourcemaps`).
