### PR TITLE
fix(gatsby): theme component shadow fails when extension is used

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -89,7 +89,7 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
               const filenameWithoutExtension = path.basename(filepath, ext)
               return filenameWithoutExtension
             })
-            .includes(path.basename(possibleComponentPath))
+            .includes(path.basename(possibleComponentPath, path.extname(possibleComponentPath)))
           return exists
         })
     }

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -89,7 +89,12 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
               const filenameWithoutExtension = path.basename(filepath, ext)
               return filenameWithoutExtension
             })
-            .includes(path.basename(possibleComponentPath, path.extname(possibleComponentPath)))
+            .includes(
+              path.basename(
+                possibleComponentPath,
+                path.extname(possibleComponentPath)
+              )
+            )
           return exists
         })
     }


### PR DESCRIPTION
## Description
[Imports that include an extension](https://github.com/jbolda/gatsby-theme-bulma/blob/de293e0a417f5f391fef93460a90eb1ae18fcfb0/packages/gatsby-theme-bulma-homepage/src/Hero/HeroTemplateWithArticles.js#L2) will fail component shadowing. Add the extension to `path.basename` that imports with or without will work.

## Related Issues
None
