### PR TITLE
docs(www): Amend pass context code snippet

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -147,6 +147,7 @@ exports.onCreatePage = ({ page, actions }) => {
   createPage({
     ...page,
     context: {
+      ...page.context,
       house: Gryffindor,
     },
   })


### PR DESCRIPTION
The previous code snippet would overwrite the entire contents of the context field of the page object if it already existed. This version adds or overwrites only the `house` field.