### PR TITLE
docs(gatsby-plugin-react-helmet): Remove broken Example link

### DIFF
--- a/packages/gatsby-plugin-react-helmet/README.md
+++ b/packages/gatsby-plugin-react-helmet/README.md
@@ -26,4 +26,3 @@ plugins: [`gatsby-plugin-react-helmet`]
 ## Examples
 
 - [GatsbyJS.org](https://github.com/gatsbyjs/gatsby/blob/master/www/src/components/site-metadata.js)
-- [Jason Lengstorf personal website](https://github.com/jlengstorf/lengstorf.com/blob/master/src/components/SEO/SEO.js)

--- a/packages/gatsby-plugin-react-helmet/README.md
+++ b/packages/gatsby-plugin-react-helmet/README.md
@@ -26,3 +26,4 @@ plugins: [`gatsby-plugin-react-helmet`]
 ## Examples
 
 - [GatsbyJS.org](https://github.com/gatsbyjs/gatsby/blob/master/www/src/components/site-metadata.js)
+- [Jason Lengstorf personal website](https://github.com/jlengstorf/gatsby-theme-jason-blog/blob/master/src/components/SEO/SEO.js)


### PR DESCRIPTION
## Description
The second link in the examples of the gatsby-plugin-react-helmet,  does not work anymore, so I removed it.