### PR TITLE
fix(docs): Update "gatsby" commands to "npm run"

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -32,7 +32,7 @@ First, you need to create a production build of your Gatsby site. The Gatsby dev
 1.  Stop the development server (if it's still running) and run:
 
 ```shell
-gatsby build
+npm run build
 ```
 
 > 💡 As you learned in [part 1](/tutorial/part-one/), this does a production build of your site and outputs the built static files into the `public` directory.
@@ -40,7 +40,7 @@ gatsby build
 2.  View the production site locally. Run:
 
 ```shell
-gatsby serve
+npm run serve
 ```
 
 Once this starts, you can now view your site at `localhost:9000`.

--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -65,7 +65,7 @@ The `gatsby-config.js` is another special file that Gatsby will automatically re
 3. Start the development server.
 
 ```shell
-gatsby develop
+npm run develop
 ```
 
 Once you load the site, if you inspect the generated HTML using the Chrome developer tools, you’ll see that the typography plugin added a `<style>` element to the `<head>` element with its generated CSS:


### PR DESCRIPTION
When working through the tutorial I noticed there were a number of places that had not yet been changed to use the proper "npm run" version of commands. This PR addresses all that I could find.