### PR TITLE
fix(gatsby-plugin-google-gtag): page view and title mismatch

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
@@ -10,10 +10,22 @@ exports.onRouteUpdate = ({ location }) => {
 
   if (pathIsExcluded) return null
 
-  const pagePath = location
-    ? location.pathname + location.search + location.hash
-    : undefined
-  window.gtag(`event`, `page_view`, { page_path: pagePath })
+  // wrap inside a timeout to make sure react-helmet is done with its changes (https://github.com/gatsbyjs/gatsby/issues/11592)
+  const sendPageView = () => {
+    const pagePath = location
+      ? location.pathname + location.search + location.hash
+      : undefined
+    window.gtag(`event`, `page_view`, { page_path: pagePath })
+  }
+
+  if (`requestAnimationFrame` in window) {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(sendPageView)
+    })
+  } else {
+    // simulate 2 rAF calls
+    setTimeout(sendPageView, 32)
+  }
 
   return null
 }


### PR DESCRIPTION
Fixes #11592. As was noted in the issue, the google analytics plugin had the same problem, and [this PR](https://github.com/gatsbyjs/gatsby/pull/10917) to the analytics plugin solves the issue for the gtag plugin as well. So I only applied the same changes to the gtag plugin.