### PR TITLE
chore(gatsby-plugin-remove-trailing-slashes): Fix typo in test

### DIFF
--- a/packages/gatsby-plugin-remove-trailing-slashes/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-remove-trailing-slashes/src/__tests__/gatsby-node.js
@@ -7,7 +7,7 @@ describe(`gatsby-plugin-remove-trailing-slashes`, () => {
   }
 
   it(`correctly keeps index /`, () => {
-    onCreatePage({ actions, page: { page: `/` } })
+    onCreatePage({ actions, page: { path: `/` } })
     expect(actions.createPage).not.toBeCalled()
     expect(actions.deletePage).not.toBeCalled()
   })


### PR DESCRIPTION
`page` should be `path`.