### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
     ```sh
     cd my-blazing-fast-site/
-    gatsby develop
+    npm run develop
     ```
 
 3.  **Open the source code and start editing!**


### PR DESCRIPTION
## Description

Provides a quick fix to the Getting Started section.  
Because the first command uses `npx` to run the `gatsby new` command, it's not globally available to run the `develop` command. Instead, the user can access it via `npm run` 