### PR TITLE
fix(gatsby): Don't delete nodes multiple times

### DIFF
--- a/packages/gatsby/src/db/__tests__/nodes.js
+++ b/packages/gatsby/src/db/__tests__/nodes.js
@@ -3,10 +3,14 @@ const { getNode, getNodes } = require(`../nodes`)
 const { store } = require(`../../redux`)
 require(`./fixtures/ensure-loki`)()
 
+const report = require(`gatsby-cli/lib/reporter`)
+jest.mock(`gatsby-cli/lib/reporter`)
+
 describe(`nodes db tests`, () => {
   beforeEach(() => {
     store.dispatch({ type: `DELETE_CACHE` })
   })
+
   it(`deletes previously transformed children nodes when the parent node is updated`, () => {
     store.dispatch(
       actions.createNode(
@@ -196,6 +200,7 @@ describe(`nodes db tests`, () => {
     )
     expect(getNodes()).toHaveLength(1)
   })
+
   it(`deletes previously transformed children nodes when parent nodes are deleted`, () => {
     store.dispatch(
       actions.createNode(
@@ -277,39 +282,43 @@ describe(`nodes db tests`, () => {
     )
     expect(getNodes()).toHaveLength(0)
   })
+
   it(`allows deleting nodes`, () => {
-    actions.createNode(
-      {
-        id: `hi`,
-        children: [],
-        parent: `test`,
-        internal: {
-          contentDigest: `hasdfljds`,
-          type: `Test`,
+    store.dispatch(
+      actions.createNode(
+        {
+          id: `hi`,
+          children: [],
+          parent: `test`,
+          internal: {
+            contentDigest: `hasdfljds`,
+            type: `Test`,
+          },
+          pickle: true,
+          deep: {
+            array: [
+              0,
+              1,
+              {
+                boom: true,
+              },
+            ],
+          },
         },
-        pickle: true,
-        deep: {
-          array: [
-            0,
-            1,
-            {
-              boom: true,
-            },
-          ],
-        },
-      },
-      {
-        name: `tests`,
-      }
+        {
+          name: `tests`,
+        }
+      )
     )
-    actions.deleteNode({
-      node: getNode(`hi`),
-    })
+    store.dispatch(
+      actions.deleteNode({
+        node: getNode(`hi`),
+      })
+    )
     expect(getNode(`hi`)).toBeUndefined()
   })
 
   it(`warns when using old deleteNode signature `, () => {
-    console.warn = jest.fn()
     store.dispatch(
       actions.createNode(
         {
@@ -333,9 +342,11 @@ describe(`nodes db tests`, () => {
       })
     )
     expect(getNode(`hi`)).toBeUndefined()
-    const deprecationNotice = `Calling "deleteNode" with a nodeId is deprecated. Please pass an object containing a full node instead: deleteNode({ node })`
-    expect(console.warn).toHaveBeenCalledWith(deprecationNotice)
-    console.warn.mockRestore()
+    const deprecationNotice =
+      `Calling "deleteNode" with a nodeId is deprecated. Please pass an ` +
+      `object containing a full node instead: deleteNode({ node }). ` +
+      `"deleteNode" was called by tests`
+    expect(report.warn).toHaveBeenCalledWith(deprecationNotice)
   })
 
   it(`does not crash when delete node is called on undefined`, () => {

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -381,7 +381,7 @@ actions.deleteNodes = (nodes: any[], plugin: Plugin) => {
   const deleteNodesAction = {
     type: `DELETE_NODES`,
     plugin,
-    payload: nodes.concat(descendantNodes),
+    payload: [...nodes, ...descendantNodes],
   }
   return deleteNodesAction
 }

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -314,44 +314,44 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
  * @example
  * deleteNode({node: node})
  */
-actions.deleteNode = (options: any, plugin: Plugin, ...args) => {
+actions.deleteNode = (options: any, plugin: Plugin, args: any) => {
   let node = _.get(options, `node`)
 
   // Check if using old method signature. Warn about incorrect usage but get
   // node from nodeID anyway.
   if (typeof options === `string`) {
-    console.warn(
-      `Calling "deleteNode" with a nodeId is deprecated. Please pass an object containing a full node instead: deleteNode({ node })`
-    )
-
-    if (args[0] && args[0].name) {
+    let msg =
+      `Calling "deleteNode" with a nodeId is deprecated. Please pass an ` +
+      `object containing a full node instead: deleteNode({ node }).`
+    if (args && args.name) {
       // `plugin` used to be the third argument
-      console.log(`"deleteNode" was called by ${args[0].name}`)
+      plugin = args
+      msg = msg + ` "deleteNode" was called by ${plugin.name}`
     }
+    report.warn(msg)
 
     node = getNode(options)
   }
 
-  let deleteDescendantsActions
-  // It's possible the file node was never created as sometimes tools will
-  // write and then immediately delete temporary files to the file system.
-  if (node) {
-    // Also delete any nodes transformed from this one.
-    const descendantNodes = findChildrenRecursively(node.children)
-    if (descendantNodes.length > 0) {
-      deleteDescendantsActions = descendantNodes.map(n =>
-        actions.deleteNode({ node: getNode(n) }, plugin)
-      )
+  const createDeleteAction = node => {
+    return {
+      type: `DELETE_NODE`,
+      plugin,
+      payload: node,
     }
   }
 
-  const deleteAction = {
-    type: `DELETE_NODE`,
-    plugin,
-    payload: node,
-  }
+  const deleteAction = createDeleteAction(node)
 
-  if (deleteDescendantsActions) {
+  // It's possible the file node was never created as sometimes tools will
+  // write and then immediately delete temporary files to the file system.
+  const deleteDescendantsActions =
+    node &&
+    findChildrenRecursively(node.children)
+      .map(getNode)
+      .map(createDeleteAction)
+
+  if (deleteDescendantsActions && deleteDescendantsActions.length) {
     return [...deleteDescendantsActions, deleteAction]
   } else {
     return deleteAction
@@ -365,35 +365,25 @@ actions.deleteNode = (options: any, plugin: Plugin, ...args) => {
  * deleteNodes([`node1`, `node2`])
  */
 actions.deleteNodes = (nodes: any[], plugin: Plugin) => {
-  console.log(
-    `The "deleteNodes" action is now deprecated and will be removed in Gatsby v3. Please use "deleteNode" instead.`
-  )
+  let msg =
+    `The "deleteNodes" action is now deprecated and will be removed in ` +
+    `Gatsby v3. Please use "deleteNode" instead.`
   if (plugin && plugin.name) {
-    console.log(`"deleteNodes" was called by ${plugin.name}`)
+    msg = msg + ` "deleteNodes" was called by ${plugin.name}`
   }
+  report.warn(msg)
 
   // Also delete any nodes transformed from these.
   const descendantNodes = _.flatten(
     nodes.map(n => findChildrenRecursively(getNode(n).children))
   )
-  let deleteDescendantsActions
-  if (descendantNodes.length > 0) {
-    deleteDescendantsActions = descendantNodes.map(n =>
-      actions.deleteNode({ node: getNode(n) }, plugin)
-    )
-  }
 
   const deleteNodesAction = {
     type: `DELETE_NODES`,
     plugin,
-    payload: nodes,
+    payload: nodes.concat(descendantNodes),
   }
-
-  if (deleteDescendantsActions) {
-    return [...deleteDescendantsActions, deleteNodesAction]
-  } else {
-    return deleteNodesAction
-  }
+  return deleteNodesAction
 }
 
 const typeOwners = {}
@@ -581,7 +571,7 @@ actions.createNode = (
     actionOptions.parentSpan.setTag(`nodeType`, node.id)
   }
 
-  let deleteAction
+  let deleteActions
   let updateNodeAction
   // Check if the node has already been processed.
   if (oldNode && !hasNodeChanged(node.id, node.internal.contentDigest)) {
@@ -595,12 +585,17 @@ actions.createNode = (
     // Remove any previously created descendant nodes as they're all due
     // to be recreated.
     if (oldNode) {
-      const descendantNodes = findChildrenRecursively(oldNode.children)
-      if (descendantNodes.length > 0) {
-        deleteAction = descendantNodes.map(n =>
-          actions.deleteNode({ node: getNode(n) })
-        )
+      const createDeleteAction = node => {
+        return {
+          type: `DELETE_NODE`,
+          plugin,
+          ...actionOptions,
+          payload: node,
+        }
       }
+      deleteActions = findChildrenRecursively(oldNode.children)
+        .map(getNode)
+        .map(createDeleteAction)
     }
 
     updateNodeAction = {
@@ -612,8 +607,8 @@ actions.createNode = (
     }
   }
 
-  if (deleteAction) {
-    return [deleteAction, updateNodeAction]
+  if (deleteActions && deleteActions.length) {
+    return [...deleteActions, updateNodeAction]
   } else {
     return updateNodeAction
   }


### PR DESCRIPTION
Currently we are trying to delete nodes multiple times because we collect all child nodes recursively, and then call the `deleteNode` action creator for every one of those, which will again collect all child nodes recursively.