### PR TITLE
fix(gatsby-source-filesystem): Do not re-download cached files from createRemoteFileNode

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -145,7 +145,7 @@ async function pushToQueue(task, cb) {
 const requestRemoteNode = (url, headers, tmpFilename) =>
   new Promise((resolve, reject) => {
     const responseStream = got.stream(url, {
-      ...headers,
+      headers,
       timeout: 30000,
       retries: 5,
     })

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -225,8 +225,11 @@ async function processRemoteNode({
 
   // Fetch the file.
   const response = await requestRemoteNode(url, headers, tmpFilename)
-  // Save the response headers for future requests.
-  await cache.set(cacheId(url), response.headers)
+
+  if (response.statusCode == 200) {
+    // Save the response headers for future requests.
+    await cache.set(cacheId(url), response.headers)
+  }
 
   // If the user did not provide an extension and we couldn't get one from remote file, try and guess one
   if (ext === ``) {


### PR DESCRIPTION
## Description

Fixes multiple issues in `createRemoteFileNode` that is causing the cache mechanism to not work correctly:

1. Pass the headers option in `got()` correctly.
2. Only encache response headers on success responses (so we don't overwrite the Etags – these are not returned in the 304 responses).

## Related Issues

Fixes #12053 

There are some issues reported in `gatsby-source-wordpress` about large downloads on restarts/builds that sound like they could be related.