### PR TITLE
fix(gatsby): Adapt Loki workaround for eq:null

### DIFF
--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -117,8 +117,7 @@ function toMongoArgs(gqlFilter, lastFieldType) {
         const mm = new Minimatch(v)
         mongoArgs[`$regex`] = mm.makeRe()
       } else if (k === `eq` && v === null) {
-        // Use `aeq` to catch both `null` and `undefined`
-        mongoArgs[`$aeq`] = null
+        mongoArgs[`$in`] = [null, undefined]
       } else if (
         k === `eq` &&
         lastFieldType &&


### PR DESCRIPTION
The previous Loki workaround for `eq:null` only worked for non-indexed fields. Not 100% sure how loose equality is treated differently on indexed fields, but this at least fixes the tests in the schema refactor branch. For the future: we should always expand `null` to `[null, undefined]`, not only for `eq` queries.