### PR TITLE
chore(docs): replace broken packages link with correct plugins

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -62,7 +62,7 @@ See the [Using Gatsby without GraphQL](/docs/using-gatsby-without-graphql/) guid
 
 If you're building a small site, one efficient way to build it is to pull in unstructured data as outlined in this guide, using `createPages` API, and then if the site becomes more complex later on, you move on to building more complex sites, or you'd like to transform your data, follow these steps:
 
-1.  Check out the [Plugin Library](/packages/) to see if the source plugins and/or transformer plugins you'd like to use already exist
+1.  Check out the [Plugin Library](/plugins/) to see if the source plugins and/or transformer plugins you'd like to use already exist
 2.  If they don't exist, read the [Plugin Authoring](/docs/plugin-authoring/) guide and consider building your own!
 
 ### How Gatsby's data layer uses GraphQL to pull data into components


### PR DESCRIPTION
## Description

This change fixes the broken link reference to the Plugins page in the Gatsby Tutorial Part Four in the "When do I use unstructured data vs GraphQL?" section. It replaces the '/packages/' link ref with '/plugins'.

## Related Issues

Fixes #12029 
