### PR TITLE
docs(gatsby-source-wordpress): add ACF option pages troubleshooting

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -70,6 +70,8 @@ module.exports = {
         // Must be using V3 of ACF to REST to include these routes
         // Example: `["option_page_1", "option_page_2"]` will include the proper ACF option
         // routes with the ID option_page_1 and option_page_2
+        // The IDs provided to this array should correspond to the `post_id` value when defining your
+        // options page using the provided `acf_add_options_page` method, in your WordPress setup
         // Dashes in IDs will be converted to underscores for use in GraphQL
         acfOptionPageIds: [],
         auth: {
@@ -887,6 +889,12 @@ When the post an image is attached to becomes inaccessible (e.g. from changing v
 which prevents Gatsby from retrieving it.
 
 In order to resolve this, you can manually change the `post_parent` value of the image record to `0` in the database. The only side effect of this change is that the image will no longer appear in the "Uploaded to this post" filter in the Add Media dialog in the WordPress administration area.
+
+### ACF Option Pages - Option page data not showing or not updating
+
+This issue occurs when you are trying to pull in data from your ACF Option pages. On certain occasions (initial setup or rebuilding) the data will not appear or won't update to the latest data.
+
+To resolve this issue, make sure that your ids in the `acfOptionPageIds` array, in the plugin config, corresponds to the `post_id` value when defining your Options page with the `acf_add_options_page` method provided by ACF.
 
 ### Self-signed certificates
 


### PR DESCRIPTION
## Description

Added some troubleshooting notes for ACF Option pages after running into issues relating to data not updating or not showing up during setup.