### PR TITLE
fix(www): fix scroll when filtering showcase

### DIFF
--- a/www/src/utils/scroll-to-anchor.js
+++ b/www/src/utils/scroll-to-anchor.js
@@ -65,7 +65,9 @@ const scrollToLocation = (element, targetPos, duration, callback) =>
   })
 
 const scrollToAnchor = (target, callback) => event => {
-  event.preventDefault()
+  if (event) {
+    event.preventDefault()
+  }
   const rootElement = getScrollableElement()
   const targetOffset = target.offsetTop
 

--- a/www/src/views/showcase/collapsible-filter-list.js
+++ b/www/src/views/showcase/collapsible-filter-list.js
@@ -12,7 +12,7 @@ const CollapsibleFilterList = ({
   filters,
   categoryKeys,
   aggregatedCategories,
-  updateQuery,
+  setFilters,
   heading,
 }) => (
   <Collapsible heading={heading}>
@@ -22,13 +22,9 @@ const CollapsibleFilterList = ({
         className={filters.includes(c) ? `selected` : ``}
         onClick={() => {
           if (filters.includes(c)) {
-            updateQuery(() => {
-              return { filters: filters.filter(f => f !== c) }
-            })
+            setFilters(filters.filter(f => f !== c))
           } else {
-            updateQuery(() => {
-              return { filters: [...filters, c] }
-            })
+            setFilters([...filters, c])
           }
         }}
         css={styles.filterButton}

--- a/www/src/views/showcase/featured-sites.js
+++ b/www/src/views/showcase/featured-sites.js
@@ -8,26 +8,21 @@ import MdArrowForward from "react-icons/lib/md/arrow-forward"
 import ShowcaseItemCategories from "./showcase-item-categories"
 import FeaturedSitesIcon from "../../assets/featured-sites-icons.svg"
 import { ShowcaseIcon } from "../../assets/mobile-nav-icons"
-import URLQuery from "../../components/url-query"
 import { options, rhythm, scale } from "../../utils/typography"
 import presets, { colors } from "../../utils/presets"
-import scrollToAnchor from "../../utils/scroll-to-anchor"
 import { svgStyles } from "../../utils/styles"
 import Button from "../../components/button"
 import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
 
 class FeaturedSites extends Component {
-  onClickHandler = (target, updateQuery, filter) =>
-    target.current
-      ? scrollToAnchor(target.current, () => {
-          updateQuery(({ filters }) => {
-            return { filters: [filter] }
-          })
-        })
-      : () => {}
+  setFilterToFeatured = e => {
+    e.preventDefault()
 
-  render = () => {
-    const { featured, showcase } = this.props
+    this.props.setFilters(`Featured`)
+  }
+
+  render() {
+    const { featured, setFilters } = this.props
 
     return (
       <section
@@ -82,40 +77,34 @@ class FeaturedSites extends Component {
           >
             Featured Sites
           </h1>
-          <URLQuery>
-            {(_, updateQuery) => (
-              <a
-                href="#showcase"
-                css={{
-                  ...styles.withTitleHover,
-                  display: `none`,
-                  [presets.Phablet]: {
-                    display: `block`,
-                  },
-                  "&&": {
-                    ...scale(-1 / 6),
-                    boxShadow: `none`,
-                    borderBottom: 0,
-                    color: colors.lilac,
-                    cursor: `pointer`,
-                    fontFamily: options.headerFontFamily.join(`,`),
-                    fontWeight: `normal`,
-                    "&:hover": {
-                      background: `transparent`,
-                      color: colors.gatsby,
-                    },
-                  },
-                }}
-                onClick={this.onClickHandler(showcase, updateQuery, `Featured`)}
-              >
-                <span className="title">View all</span>
-                &nbsp;
-                <MdArrowForward
-                  style={{ marginLeft: 4, verticalAlign: `sub` }}
-                />
-              </a>
-            )}
-          </URLQuery>
+          <a
+            href="#showcase"
+            css={{
+              ...styles.withTitleHover,
+              display: `none`,
+              [presets.Phablet]: {
+                display: `block`,
+              },
+              "&&": {
+                ...scale(-1 / 6),
+                boxShadow: `none`,
+                borderBottom: 0,
+                color: colors.lilac,
+                cursor: `pointer`,
+                fontFamily: options.headerFontFamily.join(`,`),
+                fontWeight: `normal`,
+                "&:hover": {
+                  background: `transparent`,
+                  color: colors.gatsby,
+                },
+              },
+            }}
+            onClick={this.setFilterToFeatured}
+          >
+            <span className="title">View all</span>
+            &nbsp;
+            <MdArrowForward style={{ marginLeft: 4, verticalAlign: `sub` }} />
+          </a>
           <div
             css={{
               display: `flex`,
@@ -219,8 +208,7 @@ class FeaturedSites extends Component {
                   )}
                   <ShowcaseItemCategories
                     categories={node.categories}
-                    onClickHandler={this.onClickHandler}
-                    showcase={showcase}
+                    onCategoryClick={c => setFilters(c)}
                   />
                 </div>
               </div>
@@ -230,84 +218,71 @@ class FeaturedSites extends Component {
                 display: `flex`,
               }}
             >
-              <URLQuery>
-                {(_, updateQuery) => (
-                  <a
-                    href="#showcase"
+              <a
+                href="#showcase"
+                css={{
+                  marginRight: `${rhythm(3 / 4)} !important`,
+                  backgroundColor: hex2rgba(colors.ui.light, 0.25),
+                  borderRadius: presets.radius,
+                  textAlign: `center`,
+                  "&&": {
+                    border: `1px solid ${colors.ui.light}`,
+                    boxShadow: `none`,
+                    transition: `all ${presets.animation.speedDefault} ${
+                      presets.animation.curveDefault
+                    }`,
+                    "&:hover": {
+                      background: `#fff`,
+                      transform: `translateY(-3px)`,
+                      boxShadow: `0 8px 20px ${hex2rgba(colors.lilac, 0.5)}`,
+                    },
+                  },
+                  ...styles.featuredSitesCard,
+                }}
+                onClick={this.setFilterToFeatured}
+              >
+                <div
+                  css={{
+                    borderRadius: presets.radius,
+                    display: `flex`,
+                    alignItems: `center`,
+                    position: `relative`,
+                    flexBasis: `100%`,
+                  }}
+                >
+                  <span
                     css={{
-                      marginRight: `${rhythm(3 / 4)} !important`,
-                      backgroundColor: hex2rgba(colors.ui.light, 0.25),
-                      borderRadius: presets.radius,
-                      textAlign: `center`,
-                      "&&": {
-                        border: `1px solid ${colors.ui.light}`,
-                        boxShadow: `none`,
-                        transition: `all ${presets.animation.speedDefault} ${
-                          presets.animation.curveDefault
-                        }`,
-                        "&:hover": {
-                          background: `#fff`,
-                          transform: `translateY(-3px)`,
-                          boxShadow: `0 8px 20px ${hex2rgba(
-                            colors.lilac,
-                            0.5
-                          )}`,
-                        },
-                      },
-                      ...styles.featuredSitesCard,
+                      margin: `0 auto`,
+                      color: colors.gatsby,
                     }}
-                    onClick={this.onClickHandler(
-                      showcase,
-                      updateQuery,
-                      `Featured`
-                    )}
                   >
-                    <div
+                    <span
                       css={{
-                        borderRadius: presets.radius,
-                        display: `flex`,
-                        alignItems: `center`,
-                        position: `relative`,
-                        flexBasis: `100%`,
+                        height: 44,
+                        width: `auto`,
+                        display: `block`,
+                        margin: `0 auto ${rhythm(options.blockMarginBottom)}`,
+                        [presets.Tablet]: {
+                          height: 64,
+                        },
+                        [presets.Hd]: {
+                          height: 72,
+                        },
+
+                        "& svg": {
+                          height: `100%`,
+                          ...svgStyles.active,
+                        },
                       }}
                     >
                       <span
-                        css={{
-                          margin: `0 auto`,
-                          color: colors.gatsby,
-                        }}
-                      >
-                        <span
-                          css={{
-                            height: 44,
-                            width: `auto`,
-                            display: `block`,
-                            margin: `0 auto ${rhythm(
-                              options.blockMarginBottom
-                            )}`,
-                            [presets.Tablet]: {
-                              height: 64,
-                            },
-                            [presets.Hd]: {
-                              height: 72,
-                            },
-
-                            "& svg": {
-                              height: `100%`,
-                              ...svgStyles.active,
-                            },
-                          }}
-                        >
-                          <span
-                            dangerouslySetInnerHTML={{ __html: ShowcaseIcon }}
-                          />
-                        </span>
-                        View all Featured Sites
-                      </span>
-                    </div>
-                  </a>
-                )}
-              </URLQuery>
+                        dangerouslySetInnerHTML={{ __html: ShowcaseIcon }}
+                      />
+                    </span>
+                    View all Featured Sites
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
           <div

--- a/www/src/views/showcase/filters.js
+++ b/www/src/views/showcase/filters.js
@@ -8,26 +8,18 @@ const Filters = ({
   filters,
   categoryKeys,
   aggregatedCategories,
-  updateQuery,
+  setFilters,
 }) => (
   <SidebarContainer>
     <SidebarHeader />
     <SidebarBody>
-      {filters.length > 0 && (
-        <ResetFilters
-          onClick={() => {
-            updateQuery(() => {
-              return { filters: [] }
-            })
-          }}
-        />
-      )}
+      {filters.length > 0 && <ResetFilters onClick={() => setFilters([])} />}
       <CollapsibleFilterList
         aggregatedCategories={aggregatedCategories}
         categoryKeys={categoryKeys}
         filters={filters}
         heading="Category"
-        updateQuery={updateQuery}
+        setFilters={setFilters}
       />
     </SidebarBody>
   </SidebarContainer>

--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -8,8 +8,25 @@ import Layout from "../../components/layout"
 class ShowcaseView extends Component {
   showcase = React.createRef()
 
-  render = () => {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      filters: [],
+    }
+  }
+
+  updateFilters = filters => {
+    this.setState({
+      filters: [].concat(filters),
+    })
+  }
+
+  render() {
     const { location, data } = this.props
+    const { filters } = this.state
+
+    console.log(`implemented`, filters)
 
     return (
       <Layout location={location}>
@@ -17,11 +34,16 @@ class ShowcaseView extends Component {
           <title>Showcase</title>
         </Helmet>
         <FeaturedSites
+          setFilters={this.updateFilters}
           featured={data.featured.edges}
           showcase={this.showcase}
         />
         <div id="showcase" css={{ height: 0 }} ref={this.showcase} />
-        <FilteredShowcase data={data} />
+        <FilteredShowcase
+          filters={filters}
+          setFilters={this.updateFilters}
+          data={data}
+        />
       </Layout>
     )
   }

--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -1,32 +1,52 @@
 import React, { Component } from "react"
 import { Helmet } from "react-helmet"
-
+import qs from "qs"
+import { navigate } from "gatsby"
+import scrollToAnchor from "../../utils/scroll-to-anchor"
 import FeaturedSites from "./featured-sites"
 import FilteredShowcase from "./filtered-showcase"
 import Layout from "../../components/layout"
 
 class ShowcaseView extends Component {
   showcase = React.createRef()
+  state = {
+    filters: [],
+  }
 
-  constructor(props) {
-    super(props)
+  componentDidMount() {
+    const {
+      location: { search },
+    } = this.props
 
-    this.state = {
-      filters: [],
+    const { filters } = qs.parse(search.replace(`?`, ``))
+
+    if (filters && filters.length) {
+      this.setFilters(filters)
     }
   }
 
-  updateFilters = filters => {
+  componentDidUpdate() {
+    const {
+      location: { pathname, search },
+    } = this.props
+    const queryString = qs.stringify(this.state)
+
+    if (search !== `?${queryString}`) {
+      navigate(`${pathname}?${queryString}`, { replace: true })
+    }
+  }
+
+  setFilters = filters => {
     this.setState({
       filters: [].concat(filters),
     })
+
+    scrollToAnchor(this.showcase.current, () => {})()
   }
 
   render() {
     const { location, data } = this.props
     const { filters } = this.state
-
-    console.log(`implemented`, filters)
 
     return (
       <Layout location={location}>
@@ -34,14 +54,14 @@ class ShowcaseView extends Component {
           <title>Showcase</title>
         </Helmet>
         <FeaturedSites
-          setFilters={this.updateFilters}
+          setFilters={this.setFilters}
           featured={data.featured.edges}
           showcase={this.showcase}
         />
         <div id="showcase" css={{ height: 0 }} ref={this.showcase} />
         <FilteredShowcase
           filters={filters}
-          setFilters={this.updateFilters}
+          setFilters={this.setFilters}
           data={data}
         />
       </Layout>

--- a/www/src/views/showcase/showcase-item-categories.js
+++ b/www/src/views/showcase/showcase-item-categories.js
@@ -1,29 +1,12 @@
 import React, { Fragment } from "react"
 import { Link } from "gatsby"
 import qs from "qs"
-
-import URLQuery from "../../components/url-query"
 import { colors } from "../../utils/presets"
 
-const ScrollToLink = ({ onClick, category, showcase, ...rest }) => {
-  const onClickHandler = onClick
-  return (
-    <URLQuery>
-      {(_, updateQuery) => (
-        <a
-          href="#showcase"
-          onClick={onClickHandler(showcase, updateQuery, category)}
-          {...rest}
-        >
-          {category}
-        </a>
-      )}
-    </URLQuery>
-  )
-}
+const ScrollToLink = ({ to, ...rest }) => <a href={to} {...rest} />
 
-const ShowcaseItemCategories = ({ categories, onClickHandler, showcase }) => {
-  const LinkComponent = onClickHandler ? ScrollToLink : Link
+const ShowcaseItemCategories = ({ categories, onCategoryClick }) => {
+  const LinkComponent = onCategoryClick ? ScrollToLink : Link
 
   return categories.map((c, i) => (
     <Fragment key={c}>
@@ -43,8 +26,12 @@ const ShowcaseItemCategories = ({ categories, onClickHandler, showcase }) => {
         to={`/showcase?${qs.stringify({
           filters: [c],
         })}`}
-        onClick={onClickHandler}
-        showcase={showcase}
+        onClick={e => {
+          e.preventDefault()
+          if (onCategoryClick) {
+            onCategoryClick(c)
+          }
+        }}
         category={c}
       >
         {c}

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -13,7 +13,7 @@ import GithubIcon from "react-icons/lib/go/mark-github"
 import LaunchSiteIcon from "react-icons/lib/md/launch"
 import FeaturedIcon from "../../assets/featured-sites-icons--white.svg"
 
-const ShowcaseList = ({ items, count, filters }) => {
+const ShowcaseList = ({ items, count, filters, onCategoryClick }) => {
   if (count) items = items.slice(0, count)
 
   return (
@@ -50,7 +50,10 @@ const ShowcaseList = ({ items, count, filters }) => {
                     lineHeight: 1.3,
                   }}
                 >
-                  <ShowcaseItemCategories categories={node.categories} />
+                  <ShowcaseItemCategories
+                    categories={node.categories}
+                    onCategoryClick={onCategoryClick}
+                  />
                 </div>
                 <div css={{ flex: `0 0 auto`, textAlign: `right` }}>
                   {node.source_url && (


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Fixes scrolling when clicking on filters in the showcase. All filters do exactly the same now. I moved state up.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
#11001 
#12003
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
