### PR TITLE
Fix Doc Links

### DIFF
--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -8,8 +8,11 @@ On this page:
 
 - [Top priorities](#top-priorities)
 - [Options for contributing to the Gatsby docs](#options-for-contributing-to-the-gatsby-docs)
-- [Modifying markdown files](#modifying-markdown-docs)
+- [Modifying markdown files](#modifying-markdown-files)
+  - [Converting a document from a stub](#converting-a-document-from-a-stub)
 - [Docs site setup instructions](#docs-site-setup-instructions)
+- [Claim your swag](#claim-your-swag)
+- [Want more?](#want-more)
 
 ## Top priorities
 

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -38,7 +38,7 @@ Run `npx gatsby --help` for full help.
 
 `npx gatsby new gatsby-site`
 
-See the [Gatsby starters docs](https://www.gatsbyjs.org/docs/gatsby-starters/)
+See the [Gatsby starters docs](https://www.gatsbyjs.org/starters/)
 for a comprehensive list of starters to get started with Gatsby.
 
 ### `develop`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I noticed two pages with small issues. The first is [Docs Contributions](https://www.gatsbyjs.org/contributing/docs-contributions/), where the anchor link for **Modifying markdown files** isn't working, and are missing some sections. The second is [Gatsby CLI](https://www.gatsbyjs.org/docs/gatsby-cli/), where the link for **Gatsby starters docs** isn't working too.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

No issues are related.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
