### PR TITLE
chore(sites): add algolia to site showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4428,5 +4428,6 @@
     - Web Development
     - Technology
     - Open Source
+    - Featured
   built_by: Algolia
-  featured: false
+  featured: true

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4419,3 +4419,14 @@
     - Portfolio
   built_by: Maxim Andries
   featured: false
+- title: Algolia
+  url: https://algolia.com
+  main_url: https://algolia.com
+  description: >
+    Algolia helps businesses across industries quickly create relevant, scalable, and lightning fast search and discovery experiences.
+  categories:
+    - Web Development
+    - Technology
+    - Open Source
+  built_by: Algolia
+  featured: false


### PR DESCRIPTION
At Algolia we recently (Yesterday) finished our marketing website migration to Gatsby! 🎉
