### PR TITLE
Fix link that search for issues on GitHub

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -222,7 +222,7 @@ Well, not quite. Just for this tutorial. This is just the beginning. Keep going!
 
 - Did you build something cool? Share it on Twitter, tag [#buildwithgatsby](https://twitter.com/search?q=%23buildwithgatsby), and [@mention us](https://twitter.com/gatsbyjs)!
 - Did you write a cool blog post about what you learned? Share that, too!
-- Contribute! Take a stroll through [open issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%93%8D+status%3A+help+wanted%22) on the gatsby repo and [become a contributor](/contributing/how-to-contribute/).
+- Contribute! Take a stroll through [open issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) on the gatsby repo and [become a contributor](/contributing/how-to-contribute/).
 
 Check out the ["how to contribute"](/contributing/how-to-contribute/) docs for even more ideas.
 


### PR DESCRIPTION
Fix mistake in the search for open issue link, the search didn't return any result. The label filter was `📍 status: help wanted`, the right one should contain only `help wanted`.

Old link: https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%93%8D+status%3A+help+wanted%22
New link: https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22