### PR TITLE
fix(docs): broken link in writing a stub

### DIFF
--- a/docs/contributing/how-to-write-a-stub.md
+++ b/docs/contributing/how-to-write-a-stub.md
@@ -23,7 +23,7 @@ If you have any questions about titles or other details related to creating stub
 ## Community Pair Programming Sessions
 
 If you create a stub or see an existing one on the Gatsby.js site and feel interested in filling out the content, check out the Gatsby.js
-[Pair Programming program](/contributing/pair-programming-sessions/"). We would love to work with you in your open source contributing journey!
+[Pair Programming program](/contributing/pair-programming/). We would love to work with you in your open source contributing journey!
 
 ## Converting a Stub to a Doc
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixes a broken link in the docs. They're erroneously linked to `https://www.gatsbyjs.org/contributing/pair-programming-sessions/"`. This fixes the link to `https://www.gatsbyjs.org/contributing/pair-programming/`.