### PR TITLE
chore(docs): add missing redirects for contributing docs

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -83,6 +83,16 @@ exports.createPages = ({ graphql, actions, reporter }) => {
     isPermanent: true,
   })
   createRedirect({
+    fromPath: `/docs/how-to-create-an-issue/`,
+    toPath: `/contributing/how-to-create-an-issue/`,
+    isPermanent: true,
+  })
+  createRedirect({
+    fromPath: `/docs/how-to-label-an-issue/`,
+    toPath: `/contributing/how-to-label-an-issue/`,
+    isPermanent: true,
+  })
+  createRedirect({
     fromPath: `/docs/contributor-swag/`,
     toPath: `/contributing/contributor-swag/`,
     isPermanent: true,


### PR DESCRIPTION
## Description

I missed a few redirects in the last edits of the contributing docs, so the How to File an Issue and How to Label an Issue pages are still coming up in Google with their old URLs. 

Note: it would be cool to have an automated check that warns you of moving a page without adding a redirect.