### PR TITLE
fix(www): make GitHub icon above plugin readme clearer

### DIFF
--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -42,7 +42,6 @@ const PackageReadMe = props => {
           }}
           href={githubUrl}
           aria-label={`${packageName} source`}
-          title={`View plugin on GitHub`}
         >
           <GithubIcon focusable="false" style={{ verticalAlign: `text-top` }} />&nbsp;&nbsp;<span>View plugin on GitHub</span>
         </a>

--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -27,13 +27,12 @@ const PackageReadMe = props => {
         <a
           css={{
             "&&": {
-              display: githubUrl ? `inline-block` : `none`,
+              display: githubUrl ? `flex` : `none`,
               fontWeight: `normal`,
               border: 0,
               color: colors.gray.calm,
               boxShadow: `none`,
-              display: 'flex',
-              alignItems: 'center',
+              alignItems: `center`,
               "&:hover": {
                 background: `none`,
                 color: colors.gatsby,
@@ -41,9 +40,22 @@ const PackageReadMe = props => {
             },
           }}
           href={githubUrl}
-          aria-label={`${packageName} source`}
+          aria-labelledby="github-link-label"
         >
-          <GithubIcon focusable="false" style={{ verticalAlign: `text-top` }} />&nbsp;&nbsp;<span>View plugin on GitHub</span>
+          <GithubIcon
+            focusable="false"
+            style={{ verticalAlign: `text-top`, marginRight: 10 }}
+          />
+          <span
+            id="github-link-label"
+            css={{
+              "@media screen and (max-width: 385px)": {
+                display: `none`,
+              },
+            }}
+          >
+            View plugin on GitHub
+          </span>
         </a>
         {githubUrl && (
           <Link to={`/starters?d=${packageName}`}>

--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -32,6 +32,8 @@ const PackageReadMe = props => {
               border: 0,
               color: colors.gray.calm,
               boxShadow: `none`,
+              display: 'flex',
+              alignItems: 'center',
               "&:hover": {
                 background: `none`,
                 color: colors.gatsby,
@@ -40,9 +42,9 @@ const PackageReadMe = props => {
           }}
           href={githubUrl}
           aria-label={`${packageName} source`}
-          title={`View source on GitHub`}
+          title={`View plugin on GitHub`}
         >
-          <GithubIcon focusable="false" style={{ verticalAlign: `text-top` }} />
+          <GithubIcon focusable="false" style={{ verticalAlign: `text-top` }} />&nbsp;&nbsp;<span>View plugin on GitHub</span>
         </a>
         {githubUrl && (
           <Link to={`/starters?d=${packageName}`}>
@@ -54,9 +56,6 @@ const PackageReadMe = props => {
       <div
         css={{
           position: `relative`,
-          "& h1": {
-            marginTop: 0,
-          },
         }}
         dangerouslySetInnerHTML={{
           __html: html,


### PR DESCRIPTION
It was hard to find and isn't very clear.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Adds 'View plugin on GitHub' next to the GitHub icon, and introduces some spacing to make it easier to find. It wasn't very clear earlier where it goes (view source on GitHub could mean either page source or plugin source.)

Just a minor something I've clashed with a few times 😄 
<!-- Write a brief description of the changes introduced by this PR -->
<img width="781" alt="screen shot 2019-02-27 at 2 59 46 am" src="https://user-images.githubusercontent.com/13417496/53447728-d571d780-3a3b-11e9-9ad7-81d3d0669c59.png">