### PR TITLE
Update to CLI docs, plus a REPL stub

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -12,11 +12,11 @@ _We provide similar documentation available with the gatsby-cli [README](https:/
 
 The Gatsby CLI (`gatsby-cli`) is packaged as an executable that can be used globally--in fact, this was previously how we recommended using the CLI.
 
-However, global installs of the Gatsby CLI can sometimes lead to subtle bugs in behavior and functionality if the version of the globally installed executable does not match the version of Gatsby in your application. To avoid this, we highly recommend using the `package.json` script variant of these commands, typically exposed _for you_ with most starters.
+However, global installs of the Gatsby CLI can sometimes lead to subtle bugs in behavior and functionality if the version of the globally installed executable does not match the version of Gatsby in your application. To avoid this, we highly recommend using the `package.json` script variant of these commands, typically exposed _for you_ with most [starters](/docs/starters/).
 
 For example, if we want to make the [`gatsby develop`](#develop) command available in our application, we would open up `package.json` and add a script like so:
 
-```json:title
+```json:title=package.json
 {
   "scripts": {
     "develop": "gatsby develop"
@@ -38,13 +38,14 @@ Run `npx gatsby --help` for full help.
 
 `npx gatsby new gatsby-site`
 
-See the [Gatsby starters docs](https://www.gatsbyjs.org/starters/)
+See the [Gatsby starters docs](/docs/starters/)
 for a comprehensive list of starters to get started with Gatsby.
 
 ### `develop`
 
-At the root of a Gatsby app use the `gatsby develop` script to start the Gatsby
-development server.
+Once you've installed a Gatsby site, go to the root directory of your project and start the development server:
+
+`gatsby develop`
 
 #### Options
 
@@ -55,25 +56,28 @@ development server.
 | `-o`, `--open`  | Open the site in your (default) browser for you |
 | `-S`, `--https` | Use HTTPS                                       |
 
-Follow the [Local HTTPS guide](https://www.gatsbyjs.org/docs/local-https/)
+Follow the [Local HTTPS guide](/docs/local-https/)
 to find out how you can set up an HTTPS development server using Gatsby.
 
 ### `build`
 
-At the root of a Gatsby site run `gatsby build` script to compile your application and make it ready for deployment.
+At the root of a Gatsby site, compile your application and make it ready for deployment:
+
+`gatsby build`
 
 #### Options
 
-|            Option            | Description                                                                                                 |
-| :--------------------------: | ----------------------------------------------------------------------------------------------------------- |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                         |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                     |
-| `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |
+|            Option            | Description                                                                         |
+| :--------------------------: | ----------------------------------------------------------------------------------- |
+|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                 |
+|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                             |
+| `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See /docs/performance-tracing/ |
 
 ### `serve`
 
-At the root of a Gatsby site run `gatsby serve` to serve the production build of
-the site for testing.
+At the root of a Gatsby site, serve the production build of your site for testing:
+
+`gatsby serve`
 
 #### Options
 
@@ -86,7 +90,9 @@ the site for testing.
 
 ### `info`
 
-At the root of a Gatsby site run `npx gatsby info` to get helpful environment information which will be required when reporting a bug.
+At the root of a Gatsby site, get helpful environment information which will be required when reporting a bug:
+
+`npx gatsby info`
 
 #### Options
 
@@ -96,7 +102,11 @@ At the root of a Gatsby site run `npx gatsby info` to get helpful environment in
 
 ### `clean`
 
-At the root of a Gatsby app run gatsby clean to wipe out the cache (.cache folder) and public directories. This is useful as a last resort when your local project seems to have issues or content does not seem to be refreshing. Issues this may fix commonly include:
+At the root of a Gatsby site, wipe out the cache (`.cache` folder) and public directories:
+
+`gatsby clean`
+
+This is useful as a last resort when your local project seems to have issues or content does not seem to be refreshing. Issues this may fix commonly include:
 
 - Stale data, e.g. this file/resource/etc. isn't appearing
 - GraphQL error, e.g. this GraphQL resource should be present but is not

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -115,6 +115,32 @@ This is useful as a last resort when your local project seems to have issues or 
 
 ### Repl
 
-Get a Node.js REPL (interactive shell) with context of Gatsby environment
+Get a Node.js REPL (interactive shell) with context of your Gatsby environment:
+
+`gatsby repl`
+
+Gatsby will prompt you to type in commands and explore. When it shows this: `gatsby >`
+
+You can type in a command, such as one of these:
+
+`babelrc`
+
+`components`
+
+`dataPaths`
+
+`getNodes()`
+
+`nodes`
+
+`pages`
+
+`schema`
+
+`siteConfig`
+
+`staticQueries`
+
+When combined with the [GraphQL explorer](/docs/introducing-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
 
 <!-- TODO: add repl documentation link when ready -->

--- a/docs/docs/gatsby-repl.md
+++ b/docs/docs/gatsby-repl.md
@@ -1,0 +1,9 @@
+---
+title: Gatsby REPL
+issue: https://github.com/gatsbyjs/gatsby/issues/7484
+---
+
+This is a stub. Help our community expand it.
+
+Please use the [Gatsby Style Guide](/contributing/gatsby-style-guide/) to ensure your
+pull request gets accepted.

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -399,5 +399,7 @@
   link: /docs/glossary/
 - title: Commands (Gatsby CLI)
   link: /docs/gatsby-cli/
+- title: Gatsby REPL*
+  link: /docs/gatsby-repl/
 - title: Contributing
   link: /contributing/


### PR DESCRIPTION
## Description

When working on some Gatsby materials, I found the CLI docs could be easier to follow by putting each command on its own line. This was especially clear for the REPL section, which didn't even appear to be a command to me. 😜 So I added more details, and a stub to fill out the rest of the docs.

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/issues/7484, which when addressed will add a more complete doc on the REPL.
