### PR TITLE
fix(www): quick fix for regression in site showcase navigation

### DIFF
--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -15,7 +15,7 @@ class ShowcaseView extends Component {
 
   componentDidMount() {
     const {
-      location: { search },
+      location: { search = `` },
     } = this.props
 
     const { filters } = qs.parse(search.replace(`?`, ``))


### PR DESCRIPTION
## Description

This is a quick fix for a regression introduced in navigating the site
showcase.

To reproduce the (current) bug, go to https://www.gatsbyjs.org/showcase,
and navigate to any site. You'll see an error in your console because
(somehow?) location.search is undefined rather than an empty string.

I believe this was introduced in #12105
