### PR TITLE
Warn users when sharp is used for large images

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -74,6 +74,26 @@ Object {
 }
 `;
 
+exports[`gatsby-plugin-sharp optimization warnings warns when dimension exceeds 1`] = `
+Array [
+  Array [
+    "
+Image test exceeds the warning threshold for image optimization. Read more on image optimization link!
+",
+  ],
+]
+`;
+
+exports[`gatsby-plugin-sharp optimization warnings warns when size exceeds 1`] = `
+Array [
+  Array [
+    "
+Image test exceeds the warning threshold for image optimization. Read more on image optimization link!
+",
+  ],
+]
+`;
+
 exports[`gatsby-plugin-sharp tracedSVG runs on demand 1`] = `
 Object {
   "aspectRatio": 1,


### PR DESCRIPTION
Contributes: #11798

This ia draft because:

- [ ] i am not sure how to generate shortened link
- [ ]  Should we update the documentation to talk about the thresholds and how to configure them?
- [ ] I think it is a little hacky to export the warn function but at the same time it enables me to unit-test this easily. Or maybe I should put it in a different file ?
- [ ] i need to test this on using-remark or similar to see if the output is too much or ..

