### PR TITLE
update README - use npm script instead of CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
     ```sh
     cd my-blazing-fast-site/
-    gatsby develop
+    npm run develop
     ```
 
 3.  **Open the source code and start editing!**


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.app/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

In the **_Get Up and Running in 5 Minutes_** README section, in the 2nd step we should use `npm run develop` instead of `gatsby develop` (getting error message `command not found` which is normal).
Because in the previous step, we used `npx`, assuming that gatsby is not installed globally on the machine.

## Related Issues
None
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
