### PR TITLE
chore: bump fs-extra to 7.0.0

### DIFF
--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",
-    "fs-extra": "^7.0.1",
+    "fs-extra": "^7.0.0",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",
     "sharp": "^0.21.3"

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",
-    "fs-extra": "^4.0.2",
+    "fs-extra": "^7.0.1",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",
     "sharp": "^0.21.3"


### PR DESCRIPTION
## Description

This change bumps `fs-extra` to `7.0.0` (which was already used in the repo elsewhere, like `gatsby-plugin-sharp`). It would probably be a good idea to bump (and synchronize) all the `fs-extra`, but one fire at a time :))

## Related Issues

#10245 