### PR TITLE
chore(gatsby): adds missing prop-types dependency

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -101,6 +101,7 @@
     "physical-cpu-count": "^2.0.0",
     "postcss-flexbugs-fixes": "^3.0.0",
     "postcss-loader": "^2.1.3",
+    "prop-types": "^15.6.1",
     "raw-loader": "^0.5.1",
     "react-dev-utils": "^4.2.1",
     "react-error-overlay": "^3.0.0",


### PR DESCRIPTION
## Description

The `gatsby` package is missing `prop-types` in its dependencies (used by `cache-dir/default-html.js`).

## Related Issues

#10245 