### PR TITLE
fix(blog): Fix twitter link in getting started with gatsby themes blog post

### DIFF
--- a/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
+++ b/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
@@ -297,4 +297,4 @@ If you run into an error that your theme plugin can't be found, try clearing you
 
 to your _package.json_ file. Then you can use `npm run clean` in your terminal.
 
-If you happen to find this tutorial helpful, please feel free to let me know on Twitter [@KatieofCode](www.twitter.com/katieofcode)! I would love to see what kind of themes you build.
+If you happen to find this tutorial helpful, please feel free to let me know on Twitter [@KatieofCode](https://www.twitter.com/katieofcode)! I would love to see what kind of themes you build.


### PR DESCRIPTION
Fix Katie Fujihara's twitter link, it's broken and acted as a relative link inside the gatsby page instead of an absolute link to her twitter.