### PR TITLE
docs(404): replace setup => set up in 404 page

### DIFF
--- a/docs/docs/add-404-page.md
+++ b/docs/docs/add-404-page.md
@@ -8,7 +8,7 @@ To create a 404 page create a page whose path matches the regex
 
 Gatsby ensures that your 404 page is built as `404.html` as many static hosting
 platforms default to using this as your 404 error page. If you're hosting your
-site another way, you'll need to setup a custom rule to serve this file for 404
+site another way, you'll need to set up a custom rule to serve this file for 404
 errors.
 
 When developing, Gatsby adds a default 404 page that overrides your custom 404


### PR DESCRIPTION
`setup` (noun form) -> `set up` (verb form)

## Description

documentation tweak

## Related Issues

none