### PR TITLE
chore(docs): fix default port for gatsby-serve

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -84,7 +84,7 @@ At the root of a Gatsby site, serve the production build of your site for testin
 |      Option      | Description                                                                              |
 | :--------------: | ---------------------------------------------------------------------------------------- |
 |  `-H`, `--host`  | Set host. Defaults to localhost                                                          |
-|  `-p`, `--port`  | Set port. Defaults to 8000                                                               |
+|  `-p`, `--port`  | Set port. Defaults to 9000                                                               |
 |  `-o`, `--open`  | Open the site in your (default) browser for you                                          |
 | `--prefix-paths` | Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js). |
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -74,7 +74,7 @@ At the root of a Gatsby app run `gatsby serve` to serve the production build of 
 |      Option      | Description                                                                              |
 | :--------------: | ---------------------------------------------------------------------------------------- |
 |  `-H`, `--host`  | Set host. Defaults to localhost                                                          |
-|  `-p`, `--port`  | Set port. Defaults to 8000                                                               |
+|  `-p`, `--port`  | Set port. Defaults to 9000                                                               |
 |  `-o`, `--open`  | Open the site in your (default) browser for you                                          |
 | `--prefix-paths` | Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js). |
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The documentation mentions 8000 as the default port for gatsby-serve, which is actually the default port for gatsby-develop. It should be set to 9000, as per:

https://github.com/gatsbyjs/gatsby/blob/ea58c81502ec57b60784a224c579686a5476ea7f/packages/gatsby-cli/src/create-cli.js#L193-L197