### PR TITLE
fix(www): fix inf loop on reset filters in showcase

### DIFF
--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -31,7 +31,7 @@ class ShowcaseView extends Component {
     } = this.props
     const queryString = qs.stringify(this.state)
 
-    if (search !== `?${queryString}`) {
+    if (search.replace(/^\?/, ``) !== queryString) {
       navigate(`${pathname}?${queryString}`, { replace: true })
     }
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
fixes infinite loop when clicking reset filter on [showcase page](https://www.gatsbyjs.org/showcase/).
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
https://github.com/gatsbyjs/gatsby/pull/12105#issuecomment-467986879
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
