### PR TITLE
feat(gatsby-link): support RefObject

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -177,4 +177,11 @@ describe(`ref forwarding`, () => {
     expect(innerRef).toHaveBeenCalledTimes(1)
     expect(innerRef).toHaveBeenCalledWith(expect.any(HTMLElement))
   })
+
+  it(`handles a RefObject (React >=16.4)`, () => {
+    const ref = React.createRef(null)
+    setup({ linkProps: { ref } })
+
+    expect(ref.current).toEqual(expect.any(HTMLElement))
+  })
 })

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -69,7 +69,9 @@ class GatsbyLink extends React.Component {
   }
 
   handleRef(ref) {
-    if (this.props.innerRef) {
+    if (this.props.innerRef && this.props.innerRef.hasOwnProperty(`current`)) {
+      this.props.innerRef.current = ref
+    } else if (this.props.innerRef) {
       this.props.innerRef(ref)
     }
 
@@ -161,7 +163,10 @@ class GatsbyLink extends React.Component {
 
 GatsbyLink.propTypes = {
   ...NavLinkPropTypes,
-  innerRef: PropTypes.func,
+  innerRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
   onClick: PropTypes.func,
   to: PropTypes.string.isRequired,
   replace: PropTypes.bool,

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -163,10 +163,6 @@ class GatsbyLink extends React.Component {
 
 GatsbyLink.propTypes = {
   ...NavLinkPropTypes,
-  innerRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   onClick: PropTypes.func,
   to: PropTypes.string.isRequired,
   replace: PropTypes.bool,


### PR DESCRIPTION
This PR adds support for passing a RefObject as a ref to the Link component. In other words, now something like this should be supported (previously resulted in a TypeError):

```js
  const linkRef = useRef(null);
  return (
    <Link
      ref={linkRef}
      to="https://github.com/gatsbyjs/gatsby-starter-hello-world"
    >
      Hello world!
    </Link>
  );
```

## Related Issues
#12014 
