### PR TITLE
test(babel-preset-gatsby-package): add test for production mode

### DIFF
--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,181 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`babel-preset-gatsby-package in browser mode specifies proper presets 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "debug": false,
+      "loose": true,
+      "modules": "commonjs",
+      "shippedProposals": true,
+      "targets": Object {
+        "browsers": Array [
+          "last 2 versions",
+          "not ie <= 11",
+          "not android 4.4.3",
+        ],
+      },
+      "useBuiltIns": false,
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+    Object {
+      "development": true,
+    },
+  ],
+  "@babel/preset-flow",
+]
+`;
+
+exports[`babel-preset-gatsby-package in browser mode specifies proper presets for debugging 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "debug": true,
+      "loose": true,
+      "modules": "commonjs",
+      "shippedProposals": true,
+      "targets": Object {
+        "browsers": Array [
+          "last 2 versions",
+          "not ie <= 11",
+          "not android 4.4.3",
+        ],
+      },
+      "useBuiltIns": false,
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+    Object {
+      "development": true,
+    },
+  ],
+  "@babel/preset-flow",
+]
+`;
+
+exports[`babel-preset-gatsby-package in browser mode specifies proper presets for production 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "debug": false,
+      "loose": true,
+      "modules": "commonjs",
+      "shippedProposals": true,
+      "targets": Object {
+        "browsers": Array [
+          "last 4 versions",
+          "safari >= 7",
+          "ie >= 9",
+        ],
+      },
+      "useBuiltIns": false,
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+    Object {
+      "development": false,
+    },
+  ],
+  "@babel/preset-flow",
+]
+`;
+
+exports[`babel-preset-gatsby-package in browser mode specifies the proper plugins 1`] = `
+Array [
+  "@babel/plugin-proposal-class-properties",
+  "@babel/plugin-proposal-optional-chaining",
+  "@babel/plugin-transform-runtime",
+  "@babel/plugin-syntax-dynamic-import",
+]
+`;
+
+exports[`babel-preset-gatsby-package in node mode specifies proper presets 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "debug": false,
+      "loose": true,
+      "modules": "commonjs",
+      "shippedProposals": true,
+      "targets": Object {
+        "node": "current",
+      },
+      "useBuiltIns": "entry",
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+    Object {
+      "development": true,
+    },
+  ],
+  "@babel/preset-flow",
+]
+`;
+
+exports[`babel-preset-gatsby-package in node mode specifies proper presets for debugging 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "debug": true,
+      "loose": true,
+      "modules": "commonjs",
+      "shippedProposals": true,
+      "targets": Object {
+        "node": "current",
+      },
+      "useBuiltIns": "entry",
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+    Object {
+      "development": true,
+    },
+  ],
+  "@babel/preset-flow",
+]
+`;
+
+exports[`babel-preset-gatsby-package in node mode specifies proper presets for production 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "debug": false,
+      "loose": true,
+      "modules": "commonjs",
+      "shippedProposals": true,
+      "targets": Object {
+        "node": 6,
+      },
+      "useBuiltIns": "entry",
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+    Object {
+      "development": false,
+    },
+  ],
+  "@babel/preset-flow",
+]
+`;
+
+exports[`babel-preset-gatsby-package in node mode specifies the proper plugins 1`] = `
+Array [
+  "@babel/plugin-proposal-class-properties",
+  "@babel/plugin-proposal-optional-chaining",
+  "@babel/plugin-transform-runtime",
+  "@babel/plugin-syntax-dynamic-import",
+]
+`;

--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -58,35 +58,6 @@ Array [
 ]
 `;
 
-exports[`babel-preset-gatsby-package in browser mode specifies proper presets for production 1`] = `
-Array [
-  Array [
-    "@babel/preset-env",
-    Object {
-      "debug": false,
-      "loose": true,
-      "modules": "commonjs",
-      "shippedProposals": true,
-      "targets": Object {
-        "browsers": Array [
-          "last 4 versions",
-          "safari >= 7",
-          "ie >= 9",
-        ],
-      },
-      "useBuiltIns": false,
-    },
-  ],
-  Array [
-    "@babel/preset-react",
-    Object {
-      "development": false,
-    },
-  ],
-  "@babel/preset-flow",
-]
-`;
-
 exports[`babel-preset-gatsby-package in browser mode specifies the proper plugins 1`] = `
 Array [
   "@babel/plugin-proposal-class-properties",
@@ -146,7 +117,45 @@ Array [
 ]
 `;
 
-exports[`babel-preset-gatsby-package in node mode specifies proper presets for production 1`] = `
+exports[`babel-preset-gatsby-package in node mode specifies the proper plugins 1`] = `
+Array [
+  "@babel/plugin-proposal-class-properties",
+  "@babel/plugin-proposal-optional-chaining",
+  "@babel/plugin-transform-runtime",
+  "@babel/plugin-syntax-dynamic-import",
+]
+`;
+
+exports[`babel-preset-gatsby-package in production mode specifies proper presets for browser mode 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "debug": false,
+      "loose": true,
+      "modules": "commonjs",
+      "shippedProposals": true,
+      "targets": Object {
+        "browsers": Array [
+          "last 4 versions",
+          "safari >= 7",
+          "ie >= 9",
+        ],
+      },
+      "useBuiltIns": false,
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+    Object {
+      "development": false,
+    },
+  ],
+  "@babel/preset-flow",
+]
+`;
+
+exports[`babel-preset-gatsby-package in production mode specifies proper presets for node mode 1`] = `
 Array [
   Array [
     "@babel/preset-env",
@@ -168,14 +177,5 @@ Array [
     },
   ],
   "@babel/preset-flow",
-]
-`;
-
-exports[`babel-preset-gatsby-package in node mode specifies the proper plugins 1`] = `
-Array [
-  "@babel/plugin-proposal-class-properties",
-  "@babel/plugin-proposal-optional-chaining",
-  "@babel/plugin-transform-runtime",
-  "@babel/plugin-syntax-dynamic-import",
 ]
 `;

--- a/packages/babel-preset-gatsby-package/__tests__/index.js
+++ b/packages/babel-preset-gatsby-package/__tests__/index.js
@@ -148,3 +148,51 @@ it(`Specifies proper presets and plugins in debug browser mode`, () => {
     ),
   ])
 })
+
+it(`Specifies proper presets and plugins in production browser mode`, () => {
+  const currentBabelEnv = process.env.BABEL_ENV
+  let presets
+  let plugins
+
+  try {
+    process.env.BABEL_ENV = `production`
+    const config = preset(null, { browser: true })
+    presets = config.presets
+    plugins = config.plugins
+  } finally {
+    process.env.BABEL_ENV = currentBabelEnv
+  }
+
+  expect(presets).toEqual([
+    [
+      expect.stringContaining(path.join(`@babel`, `preset-env`)),
+      {
+        debug: false,
+        loose: true,
+        modules: `commonjs`,
+        shippedProposals: true,
+        targets: {
+          browsers: [`last 4 versions`, `safari >= 7`, `ie >= 9`],
+        },
+        useBuiltIns: false,
+      },
+    ],
+    [
+      expect.stringContaining(path.join(`@babel`, `preset-react`)),
+      { development: false },
+    ],
+    expect.stringContaining(path.join(`@babel`, `preset-flow`)),
+  ])
+  expect(plugins).toEqual([
+    expect.stringContaining(
+      path.join(`@babel`, `plugin-proposal-class-properties`)
+    ),
+    expect.stringContaining(
+      path.join(`@babel`, `plugin-proposal-optional-chaining`)
+    ),
+    expect.stringContaining(path.join(`@babel`, `plugin-transform-runtime`)),
+    expect.stringContaining(
+      path.join(`@babel`, `plugin-syntax-dynamic-import`)
+    ),
+  ])
+})

--- a/packages/babel-preset-gatsby-package/__tests__/index.js
+++ b/packages/babel-preset-gatsby-package/__tests__/index.js
@@ -18,21 +18,6 @@ describe(`babel-preset-gatsby-package`, () => {
       const { presets } = preset(null, { debug: true })
       expect(presets).toMatchSnapshot()
     })
-
-    it(`specifies proper presets for production`, () => {
-      const currentBabelEnv = process.env.BABEL_ENV
-      process.env.BABEL_ENV = `production`
-      let presets
-
-      try {
-        const config = preset(null)
-        presets = config.presets
-      } finally {
-        process.env.BABEL_ENV = currentBabelEnv
-      }
-
-      expect(presets).toMatchSnapshot()
-    })
   })
 
   describe(`in browser mode`, () => {
@@ -50,19 +35,27 @@ describe(`babel-preset-gatsby-package`, () => {
       const { presets } = preset(null, { browser: true, debug: true })
       expect(presets).toMatchSnapshot()
     })
+  })
 
-    it(`specifies proper presets for production`, () => {
-      const currentBabelEnv = process.env.BABEL_ENV
+  describe(`in production mode`, () => {
+    let env
+
+    beforeAll(() => {
+      env = process.env.BABEL_ENV
       process.env.BABEL_ENV = `production`
-      let presets
+    })
 
-      try {
-        const config = preset(null, { browser: true })
-        presets = config.presets
-      } finally {
-        process.env.BABEL_ENV = currentBabelEnv
-      }
+    afterAll(() => {
+      process.env.BABEL_ENV = env
+    })
 
+    it(`specifies proper presets for node mode`, () => {
+      const { presets } = preset(null)
+      expect(presets).toMatchSnapshot()
+    })
+
+    it(`specifies proper presets for browser mode`, () => {
+      const { presets } = preset(null, { browser: true })
       expect(presets).toMatchSnapshot()
     })
   })

--- a/packages/babel-preset-gatsby-package/__tests__/index.js
+++ b/packages/babel-preset-gatsby-package/__tests__/index.js
@@ -1,198 +1,69 @@
 const preset = require(`../`)
-const path = require(`path`)
 
-it(`Specifies proper presets and plugins in Node mode`, () => {
-  const { presets, plugins } = preset()
+jest.mock(`../resolver`, () => jest.fn(moduleName => moduleName))
 
-  expect(presets).toEqual([
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-env`)),
-      {
-        debug: false,
-        loose: true,
-        modules: `commonjs`,
-        shippedProposals: true,
-        targets: {
-          node: `current`,
-        },
-        useBuiltIns: `entry`,
-      },
-    ],
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-react`)),
-      { development: true },
-    ],
-    expect.stringContaining(path.join(`@babel`, `preset-flow`)),
-  ])
-  expect(plugins).toEqual([
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-class-properties`)
-    ),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-optional-chaining`)
-    ),
-    expect.stringContaining(path.join(`@babel`, `plugin-transform-runtime`)),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-syntax-dynamic-import`)
-    ),
-  ])
-})
+describe(`babel-preset-gatsby-package`, () => {
+  describe(`in node mode`, () => {
+    it(`specifies the proper plugins`, () => {
+      const { plugins } = preset()
+      expect(plugins).toMatchSnapshot()
+    })
 
-it(`Specifies proper presets and plugins in debug Node mode`, () => {
-  const { presets, plugins } = preset(null, { debug: true })
+    it(`specifies proper presets`, () => {
+      const { presets } = preset()
+      expect(presets).toMatchSnapshot()
+    })
 
-  expect(presets).toEqual([
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-env`)),
-      {
-        debug: true,
-        loose: true,
-        modules: `commonjs`,
-        shippedProposals: true,
-        targets: {
-          node: `current`,
-        },
-        useBuiltIns: `entry`,
-      },
-    ],
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-react`)),
-      { development: true },
-    ],
-    expect.stringContaining(path.join(`@babel`, `preset-flow`)),
-  ])
-  expect(plugins).toEqual([
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-class-properties`)
-    ),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-optional-chaining`)
-    ),
-    expect.stringContaining(path.join(`@babel`, `plugin-transform-runtime`)),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-syntax-dynamic-import`)
-    ),
-  ])
-})
+    it(`specifies proper presets for debugging`, () => {
+      const { presets } = preset(null, { debug: true })
+      expect(presets).toMatchSnapshot()
+    })
 
-it(`Specifies proper presets and plugins in browser mode`, () => {
-  const { presets, plugins } = preset(null, { browser: true })
+    it(`specifies proper presets for production`, () => {
+      const currentBabelEnv = process.env.BABEL_ENV
+      process.env.BABEL_ENV = `production`
+      let presets
 
-  expect(presets).toEqual([
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-env`)),
-      {
-        debug: false,
-        loose: true,
-        modules: `commonjs`,
-        shippedProposals: true,
-        targets: {
-          browsers: [`last 2 versions`, `not ie <= 11`, `not android 4.4.3`],
-        },
-        useBuiltIns: false,
-      },
-    ],
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-react`)),
-      { development: true },
-    ],
-    expect.stringContaining(path.join(`@babel`, `preset-flow`)),
-  ])
-  expect(plugins).toEqual([
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-class-properties`)
-    ),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-optional-chaining`)
-    ),
-    expect.stringContaining(path.join(`@babel`, `plugin-transform-runtime`)),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-syntax-dynamic-import`)
-    ),
-  ])
-})
+      try {
+        const config = preset(null)
+        presets = config.presets
+      } finally {
+        process.env.BABEL_ENV = currentBabelEnv
+      }
 
-it(`Specifies proper presets and plugins in debug browser mode`, () => {
-  const { presets, plugins } = preset(null, { browser: true, debug: true })
+      expect(presets).toMatchSnapshot()
+    })
+  })
 
-  expect(presets).toEqual([
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-env`)),
-      {
-        debug: true,
-        loose: true,
-        modules: `commonjs`,
-        shippedProposals: true,
-        targets: {
-          browsers: [`last 2 versions`, `not ie <= 11`, `not android 4.4.3`],
-        },
-        useBuiltIns: false,
-      },
-    ],
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-react`)),
-      { development: true },
-    ],
-    expect.stringContaining(path.join(`@babel`, `preset-flow`)),
-  ])
-  expect(plugins).toEqual([
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-class-properties`)
-    ),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-optional-chaining`)
-    ),
-    expect.stringContaining(path.join(`@babel`, `plugin-transform-runtime`)),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-syntax-dynamic-import`)
-    ),
-  ])
-})
+  describe(`in browser mode`, () => {
+    it(`specifies the proper plugins`, () => {
+      const { plugins } = preset(null, { browser: true })
+      expect(plugins).toMatchSnapshot()
+    })
 
-it(`Specifies proper presets and plugins in production browser mode`, () => {
-  const currentBabelEnv = process.env.BABEL_ENV
-  let presets
-  let plugins
+    it(`specifies proper presets`, () => {
+      const { presets } = preset(null, { browser: true })
+      expect(presets).toMatchSnapshot()
+    })
 
-  try {
-    process.env.BABEL_ENV = `production`
-    const config = preset(null, { browser: true })
-    presets = config.presets
-    plugins = config.plugins
-  } finally {
-    process.env.BABEL_ENV = currentBabelEnv
-  }
+    it(`specifies proper presets for debugging`, () => {
+      const { presets } = preset(null, { browser: true, debug: true })
+      expect(presets).toMatchSnapshot()
+    })
 
-  expect(presets).toEqual([
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-env`)),
-      {
-        debug: false,
-        loose: true,
-        modules: `commonjs`,
-        shippedProposals: true,
-        targets: {
-          browsers: [`last 4 versions`, `safari >= 7`, `ie >= 9`],
-        },
-        useBuiltIns: false,
-      },
-    ],
-    [
-      expect.stringContaining(path.join(`@babel`, `preset-react`)),
-      { development: false },
-    ],
-    expect.stringContaining(path.join(`@babel`, `preset-flow`)),
-  ])
-  expect(plugins).toEqual([
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-class-properties`)
-    ),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-proposal-optional-chaining`)
-    ),
-    expect.stringContaining(path.join(`@babel`, `plugin-transform-runtime`)),
-    expect.stringContaining(
-      path.join(`@babel`, `plugin-syntax-dynamic-import`)
-    ),
-  ])
+    it(`specifies proper presets for production`, () => {
+      const currentBabelEnv = process.env.BABEL_ENV
+      process.env.BABEL_ENV = `production`
+      let presets
+
+      try {
+        const config = preset(null, { browser: true })
+        presets = config.presets
+      } finally {
+        process.env.BABEL_ENV = currentBabelEnv
+      }
+
+      expect(presets).toMatchSnapshot()
+    })
+  })
 })

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -1,4 +1,4 @@
-const r = m => require.resolve(m)
+const r = require(`./resolver`)
 
 function preset(context, options = {}) {
   const { browser = false, debug = false } = options

--- a/packages/babel-preset-gatsby-package/resolver.js
+++ b/packages/babel-preset-gatsby-package/resolver.js
@@ -1,0 +1,3 @@
+const r = m => require.resolve(m)
+
+module.exports = r;


### PR DESCRIPTION
## Description
Adding a test case for `babel-preset-gatsby-package` to make sure that the correct presets and plugins are used in production.
