### PR TITLE
fix(www): add gatsby-remark-embed-video to www/package.json

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -59,6 +59,7 @@ module.exports = {
       options: {
         plugins: [
           `gatsby-remark-graphviz`,
+          `gatsby-remark-embed-video`,
           `gatsby-remark-code-titles`,
           {
             resolve: `gatsby-remark-images`,

--- a/www/package.json
+++ b/www/package.json
@@ -39,6 +39,7 @@
     "gatsby-remark-autolink-headers": "^2.0.10",
     "gatsby-remark-code-titles": "^1.0.2",
     "gatsby-remark-copy-linked-files": "^2.0.5",
+    "gatsby-remark-embed-video": "^1.7.0",
     "gatsby-remark-graphviz": "^1.0.0",
     "gatsby-remark-images": "^2.0.1",
     "gatsby-remark-normalize-paths": "^1.0.0",


### PR DESCRIPTION
- enables markdown video embedding from sources such as YouTube, Vimeo, etc.
- fixes non-functional embed at the very end of the [Adding search with algolia](https://www.gatsbyjs.org/docs/adding-search-with-algolia)