### PR TITLE
[schema] Add schema query tests, inference fixes

### DIFF
--- a/examples/using-type-definitions/gatsby-config.js
+++ b/examples/using-type-definitions/gatsby-config.js
@@ -22,14 +22,5 @@ module.exports = {
         path: `./src/data/`,
       },
     },
-    {
-      resolve: `gatsby-source-graphql`,
-      options: {
-        fieldName: `cms`,
-        url: `https://api-euwest.graphcms.com/v1/cjjr1at6d0xb801c3scjrm0l0/master`,
-        typeName: `GraphCMS`,
-        refetchInterval: 60,
-      },
-    },
   ],
 }

--- a/examples/using-type-definitions/package.json
+++ b/examples/using-type-definitions/package.json
@@ -1,15 +1,13 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "using-type-definitions",
   "private": true,
-  "description": "A simple starter to get up and developing quickly with Gatsby",
+  "description": "An example site using createTypes action and createResolvers API",
   "version": "0.1.0",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "gatsby": "^2.0.55",
     "gatsby-image": "^2.0.20",
     "gatsby-plugin-sharp": "^2.0.14",
     "gatsby-source-filesystem": "^2.0.13",
-    "gatsby-source-graphql": "^2.0.0",
     "gatsby-transformer-json": "^2.1.7",
     "gatsby-transformer-sharp": "^2.1.8",
     "graphql": "0.13.2",

--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -249,7 +249,7 @@ function toSortFields(sortArgs) {
   const lokiSortFields = []
   for (let i = 0; i < fields.length; i++) {
     const dottedField = fields[i]
-    const isDesc = order[i] === `desc`
+    const isDesc = order[i] && order[i].toLowerCase() === `desc`
     lokiSortFields.push([dottedField, isDesc])
   }
   return lokiSortFields

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1178,8 +1178,65 @@ actions.addThirdPartySchema = (
   }
 }
 
+/**
+ * Add type definitions to the GraphQL schema.
+ *
+ * @param {(string|GraphQLOutputType|string[]|GraphQLOutputType[])} types Type definitions
+ *
+ * Type definitions can be provided either as
+ * [`graphql-js` types](https://graphql.org/graphql-js/), or in
+ * [GraphQL schema definition language (SDL)](https://graphql.org/learn/).
+ *
+ * Things to note:
+ * * needs to be called *before* schema generation. It is recommended to use
+ *   `createTypes` in the `sourceNodes` API.
+ * * type definitions targeting node types, i.e. `MarkdownRemark` and others
+ *   added in `sourceNodes` or `onCreateNode` APIs, need to implement the
+ *   `Node` interface. Interface fields will be added automatically, but it
+ *   is mandatory to label those types with `implements Node`.
+ * * by default, explicit type definitions from `createTypes` will be merged
+ *   with inferred field types, and default field resolvers for `Date` (which
+ *   adds formatting options) and `File` (which resolves the field value as
+ *   a `relativePath` foreign-key field) are added. This behavior can be
+ *   customised with `@infer` and `dontInfer` directives, and their
+ *   `noDefaultResolvers` argument.
+ *
+ * @example
+ * exports.sourceNodes = ({ actions }) => {
+ *   const { createTypes } = actions
+ *   const typeDefs = `
+ *     """
+ *     Markdown Node
+ *     """
+ *     type MarkdownRemark implements Node {
+ *       frontmatter: Frontmatter!
+ *     }
+ *
+ *     """
+ *     Markdown Frontmatter
+ *     """
+ *     type Frontmatter {
+ *       title: String!
+ *       author: AuthorJson!
+ *       date: Date!
+ *       published: Boolean!
+ *       tags: [String!]!
+ *     }
+ *
+ *     """
+ *     Author information
+ *     """
+ *     # Does not include automatically inferred fields
+ *     type AuthorJson implements Node @dontInfer(noFieldResolvers: true) {
+ *       name: String!
+ *       birthday: Date! # no default resolvers for Date formatting added
+ *     }
+ *   `
+ *   createTypes(typeDefs)
+ * }
+ */
 actions.createTypes = (
-  types: string | GraphQLType | Array<string | GraphQLType>,
+  types: string | GraphQLOutputType | Array<string | GraphQLOutputType>,
   plugin: Plugin,
   traceId?: string
 ) => {
@@ -1190,6 +1247,7 @@ actions.createTypes = (
     payload: types,
   }
 }
+
 /**
  * All action creators wrapped with a dispatch.
  */

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1181,7 +1181,7 @@ actions.addThirdPartySchema = (
 /**
  * Add type definitions to the GraphQL schema.
  *
- * @param {(string|GraphQLOutputType|string[]|GraphQLOutputType[])} types Type definitions
+ * @param {TypeDefinitions} types Type definitions, where `type TypeDefinitions = string | GraphQLOutputType | string[] | GraphQLOutputType[]`
  *
  * Type definitions can be provided either as
  * [`graphql-js` types](https://graphql.org/graphql-js/), or in

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -117,9 +117,10 @@ function handleMany(siftArgs, nodes, sort) {
   if (sort) {
     // create functions that return the item to compare on
     // uses _.get so nested fields can be retrieved
-    const convertedFields = sort.fields.map(field => v => _.get(v, field))
+    const sortFields = sort.fields.map(field => v => _.get(v, field))
+    const sortOrder = sort.order.map(order => order.toLowerCase())
 
-    result = _.orderBy(result, convertedFields, sort.order)
+    result = _.orderBy(result, sortFields, sortOrder)
   }
   return result
 }

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
@@ -41,33 +41,33 @@ Object {
         Object {
           "node": Object {
             "_3invalidKey": null,
-            "code": "BGiWipNM96D",
-            "comment": 1,
-            "id": "1270677182602272387",
-            "idWithDecoration": "decoration-1270677182602272387",
+            "code": "BShF_8qhtEv",
+            "comment": 0,
+            "id": "1486495736706552111",
+            "idWithDecoration": "decoration-1486495736706552111",
             "image": Object {
               "childImageSharp": Object {
-                "id": "081cbcc5-44ec-5f4e-ae7a-fc25e68ff615",
+                "id": "f5f0e564-899f-5bbc-92de-a2325b69cb75",
               },
             },
-            "likes": null,
-            "time": "12.06.2016",
+            "likes": 8,
+            "time": "05.04.2017",
           },
         },
         Object {
           "node": Object {
             "_3invalidKey": null,
-            "code": "BFur3Jfs94V",
+            "code": "BY6B8z5lR1F",
             "comment": 0,
-            "id": "1256134251849702933",
-            "idWithDecoration": "decoration-1256134251849702933",
+            "id": "1601601194425654597",
+            "idWithDecoration": "decoration-1601601194425654597",
             "image": Object {
               "childImageSharp": Object {
-                "id": "a0a75092-ed13-5117-a44b-7360940f99b5",
+                "id": "6ba97198-5331-53d6-a0e0-c9c063c5094e",
               },
             },
-            "likes": null,
-            "time": "23.05.2016",
+            "likes": 9,
+            "time": "11.09.2017",
           },
         },
       ],

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
@@ -41,33 +41,33 @@ Object {
         Object {
           "node": Object {
             "_3invalidKey": null,
-            "code": "BShF_8qhtEv",
-            "comment": 0,
-            "id": "1486495736706552111",
-            "idWithDecoration": "decoration-1486495736706552111",
+            "code": "BGiWipNM96D",
+            "comment": 1,
+            "id": "1270677182602272387",
+            "idWithDecoration": "decoration-1270677182602272387",
             "image": Object {
               "childImageSharp": Object {
-                "id": "f5f0e564-899f-5bbc-92de-a2325b69cb75",
+                "id": "081cbcc5-44ec-5f4e-ae7a-fc25e68ff615",
               },
             },
-            "likes": 8,
-            "time": "05.04.2017",
+            "likes": null,
+            "time": "12.06.2016",
           },
         },
         Object {
           "node": Object {
             "_3invalidKey": null,
-            "code": "BY6B8z5lR1F",
+            "code": "BFur3Jfs94V",
             "comment": 0,
-            "id": "1601601194425654597",
-            "idWithDecoration": "decoration-1601601194425654597",
+            "id": "1256134251849702933",
+            "idWithDecoration": "decoration-1256134251849702933",
             "image": Object {
               "childImageSharp": Object {
-                "id": "6ba97198-5331-53d6-a0e0-c9c063c5094e",
+                "id": "a0a75092-ed13-5117-a44b-7360940f99b5",
               },
             },
-            "likes": 9,
-            "time": "11.09.2017",
+            "likes": null,
+            "time": "23.05.2016",
           },
         },
       ],

--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -1,0 +1,63 @@
+const { store } = require(`../../redux`)
+const { build } = require(`..`)
+require(`../../db/__tests__/fixtures/ensure-loki`)()
+
+const nodes = require(`./fixtures/node-model`)
+
+describe(`Build schema`, () => {
+  let schema
+
+  beforeEach(async () => {
+    store.dispatch({ type: `DELETE_CACHE` })
+    nodes.forEach(node =>
+      store.dispatch({ type: `CREATE_NODE`, payload: node })
+    )
+
+    await build({})
+    schema = store.getState().schema
+  })
+
+  describe(`createTypes action`, () => {
+    it.todo(`allows adding graphql-js types`)
+
+    it.todo(`allows adding type in SDL`)
+
+    it.todo(`adds node interface fields`)
+
+    it.todo(`allows adding abstract types in SDL`)
+
+    it.todo(`adds type resolver to abstract types`)
+
+    it.todo(`handles being called multiple times`)
+  })
+
+  describe(`createResolvers API`, () => {
+    it.todo(`allows adding resolver to field`)
+
+    it.todo(`allows adding args to field`)
+
+    it.todo(`disallows overriding field type on field`)
+
+    it.todo(`allows overriding field type on field on third-party type`)
+
+    it.todo(`allows adding new field`)
+
+    it.todo(`warns if type does not exist`)
+
+    it.todo(`makes original field resolver available on info`)
+
+    it.todo(`handles being called multiple times`)
+  })
+
+  describe(`addThirdPartySchemas`, () => {
+    it.todo(`makes third-party schema available on root Query type`)
+
+    it.todo(`adds third-party types to schema`)
+  })
+
+  describe(`addSetFieldsOnGraphQLNodeTypeFields`, () => {
+    it.todo(`allows adding fields`)
+
+    it.todo(`allows adding nested fields`)
+  })
+})

--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -22,11 +22,15 @@ describe(`Build schema`, () => {
 
     it.todo(`allows adding type in SDL`)
 
+    it.todo(`allows adding array of types`)
+
     it.todo(`adds node interface fields`)
 
     it.todo(`allows adding abstract types in SDL`)
 
     it.todo(`adds type resolver to abstract types`)
+
+    it.todo(`adds args to field`)
 
     it.todo(`handles being called multiple times`)
   })

--- a/packages/gatsby/src/schema/__tests__/fixtures/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/fixtures/node-model.js
@@ -1,0 +1,85 @@
+const nodes = [
+  {
+    id: `person1`,
+    parent: null,
+    children: [],
+    internal: { type: `Author` },
+    name: `Person1`,
+    email: `person1@example.com`,
+  },
+  {
+    id: `person2`,
+    parent: null,
+    children: [],
+    internal: { type: `Contributor` },
+    name: `Person2`,
+    email: `person2@example.com`,
+  },
+  {
+    id: `person3`,
+    parent: null,
+    children: [],
+    internal: { type: `Author` },
+    name: `Person3`,
+    email: null,
+  },
+  {
+    id: `post1`,
+    parent: `file1`,
+    children: [],
+    internal: { type: `Post` },
+    frontmatter: {
+      authors: [`person1`],
+      reviewers: [`person1`, `person2`],
+      published: false,
+      date: new Date(Date.UTC(2019, 0, 1)),
+    },
+  },
+  {
+    id: `post2`,
+    parent: `file2`,
+    children: [],
+    internal: { type: `Post` },
+    frontmatter: {
+      authors: [`person1`, `person2`],
+      reviewers: [],
+      published: true,
+      date: new Date(Date.UTC(2018, 0, 1)),
+    },
+  },
+  {
+    id: `post3`,
+    parent: `file3`,
+    children: [],
+    internal: { type: `Post` },
+    frontmatter: {
+      authors: [],
+      reviewers: [`person3`],
+      published: false,
+      date: new Date(Date.UTC(2017, 0, 1)),
+    },
+  },
+  {
+    id: `file1`,
+    parent: null,
+    children: [`post1`],
+    internal: { type: `File` },
+    name: `File1`,
+  },
+  {
+    id: `file2`,
+    parent: null,
+    children: [`post2`],
+    internal: { type: `RemoteFile` },
+    url: `RemoteFile2`,
+  },
+  {
+    id: `file3`,
+    parent: null,
+    children: [`post3`],
+    internal: { type: `File` },
+    name: `File3`,
+  },
+]
+
+module.exports = nodes

--- a/packages/gatsby/src/schema/__tests__/fixtures/queries.js
+++ b/packages/gatsby/src/schema/__tests__/fixtures/queries.js
@@ -1,0 +1,84 @@
+const nodes = [
+  {
+    id: `file1`,
+    parent: null,
+    children: [`md1`],
+    internal: {
+      type: `File`,
+      contentDigest: `file1`,
+    },
+    name: `1.md`,
+  },
+  {
+    id: `file2`,
+    parent: null,
+    children: [`md2`],
+    internal: {
+      type: `File`,
+      contentDigest: `file2`,
+    },
+    name: `2.md`,
+  },
+  {
+    id: `file3`,
+    parent: null,
+    children: [`author2`, `author1`],
+    internal: {
+      type: `File`,
+      contentDigest: `file3`,
+    },
+    name: `authors.yaml`,
+  },
+  {
+    id: `md1`,
+    parent: `file1`,
+    children: [],
+    internal: {
+      type: `Markdown`,
+      contentDigest: `md1`,
+    },
+    frontmatter: {
+      title: `Markdown File 1`,
+      date: new Date(Date.UTC(2019, 0, 1)),
+      authors: [`author2@example.com`, `author1@example.com`],
+    },
+  },
+  {
+    id: `md2`,
+    parent: `file2`,
+    children: [],
+    internal: {
+      type: `Markdown`,
+      contentDigest: `md2`,
+    },
+    frontmatter: {
+      title: `Markdown File 2`,
+      published: false,
+      authors: [`author1@example.com`],
+    },
+  },
+  {
+    id: `author1`,
+    parent: `file3`,
+    children: [],
+    internal: {
+      type: `Author`,
+      contentDigest: `author1`,
+    },
+    name: `Author 1`,
+    email: `author1@example.com`,
+  },
+  {
+    id: `author2`,
+    parent: `file3`,
+    children: [],
+    internal: {
+      type: `Author`,
+      contentDigest: `author1`,
+    },
+    name: `Author 2`,
+    email: `author2@example.com`,
+  },
+]
+
+module.exports = nodes

--- a/packages/gatsby/src/schema/__tests__/kitchen-sink.js
+++ b/packages/gatsby/src/schema/__tests__/kitchen-sink.js
@@ -1,12 +1,5 @@
 // @flow
 
-// Children
-// childX
-// childrenX
-// NODE__ connections
-// addTypeDefs and corner cases
-// addResolvers
-
 const { SchemaComposer } = require(`graphql-compose`)
 const { graphql } = require(`graphql`)
 const { store } = require(`../../redux`)
@@ -42,7 +35,7 @@ describe(`Kichen sink schema test`, () => {
       store.dispatch({ type: `CREATE_NODE`, payload: node })
     )
     store.dispatch({
-      type: `ADD_TYPES`,
+      type: `CREATE_TYPES`,
       payload: `
         type PostsJson implements Node {
           id: String!

--- a/packages/gatsby/src/schema/__tests__/kitchen-sink.js
+++ b/packages/gatsby/src/schema/__tests__/kitchen-sink.js
@@ -56,7 +56,7 @@ describe(`Kichen sink schema test`, () => {
     expect(
       await runQuery(`
         {
-          sort: allPostsJson(sort: { fields: likes, order: DESC }, limit: 2) {
+          sort: allPostsJson(sort: { fields: likes, order: ASC }, limit: 2) {
             edges {
               node {
                 id

--- a/packages/gatsby/src/schema/__tests__/kitchen-sink.js
+++ b/packages/gatsby/src/schema/__tests__/kitchen-sink.js
@@ -56,7 +56,7 @@ describe(`Kichen sink schema test`, () => {
     expect(
       await runQuery(`
         {
-          sort: allPostsJson(sort: { fields: likes, order:DESC}, limit: 2) {
+          sort: allPostsJson(sort: { fields: likes, order: DESC }, limit: 2) {
             edges {
               node {
                 id

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -4,89 +4,7 @@ require(`../../db/__tests__/fixtures/ensure-loki`)()
 const { LocalNodeModel } = require(`../node-model`)
 const { build } = require(`..`)
 
-const nodes = [
-  {
-    id: `person1`,
-    parent: null,
-    children: [],
-    internal: { type: `Author` },
-    name: `Person1`,
-    email: `person1@example.com`,
-  },
-  {
-    id: `person2`,
-    parent: null,
-    children: [],
-    internal: { type: `Contributor` },
-    name: `Person2`,
-    email: `person2@example.com`,
-  },
-  {
-    id: `person3`,
-    parent: null,
-    children: [],
-    internal: { type: `Author` },
-    name: `Person3`,
-    email: null,
-  },
-  {
-    id: `post1`,
-    parent: `file1`,
-    children: [],
-    internal: { type: `Post` },
-    frontmatter: {
-      authors: [`person1`],
-      reviewers: [`person1`, `person2`],
-      published: false,
-      date: new Date(Date.UTC(2019, 0, 1)),
-    },
-  },
-  {
-    id: `post2`,
-    parent: `file2`,
-    children: [],
-    internal: { type: `Post` },
-    frontmatter: {
-      authors: [`person1`, `person2`],
-      reviewers: [],
-      published: true,
-      date: new Date(Date.UTC(2018, 0, 1)),
-    },
-  },
-  {
-    id: `post3`,
-    parent: `file3`,
-    children: [],
-    internal: { type: `Post` },
-    frontmatter: {
-      authors: [],
-      reviewers: [`person3`],
-      published: false,
-      date: new Date(Date.UTC(2017, 0, 1)),
-    },
-  },
-  {
-    id: `file1`,
-    parent: null,
-    children: [`post1`],
-    internal: { type: `File` },
-    name: `File1`,
-  },
-  {
-    id: `file2`,
-    parent: null,
-    children: [`post2`],
-    internal: { type: `RemoteFile` },
-    url: `RemoteFile2`,
-  },
-  {
-    id: `file3`,
-    parent: null,
-    children: [`post3`],
-    internal: { type: `File` },
-    name: `File3`,
-  },
-]
+const nodes = require(`./fixtures/node-model`)
 
 describe(`NodeModel`, () => {
   let nodeModel
@@ -105,9 +23,11 @@ describe(`NodeModel`, () => {
       interface TeamMember {
         name: String!
       }
+
       type Author implements TeamMember & Node {
         name: String!
       }
+
       type Contributor implements TeamMember & Node {
         name: String!
       }

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -1,0 +1,845 @@
+const { graphql } = require(`graphql`)
+const { store } = require(`../../redux`)
+const { build } = require(`..`)
+const withResolverContext = require(`../context`)
+require(`../../db/__tests__/fixtures/ensure-loki`)()
+
+jest.mock(`../../utils/api-runner-node`)
+const apiRunnerNode = require(`../../utils/api-runner-node`)
+
+const nodes = require(`./fixtures/queries`)
+
+describe(`Query schema`, () => {
+  let schema
+
+  const runQuery = query =>
+    graphql(schema, query, undefined, withResolverContext({}, schema))
+
+  beforeAll(async () => {
+    apiRunnerNode.mockImplementation(async (api, ...args) => {
+      if (api === `setFieldsOnGraphQLNodeType`) {
+        if (args[0].type.name === `Markdown`) {
+          return [
+            {
+              [`frontmatter.authorNames`]: {
+                type: `[String!]!`,
+                async resolve(source, args, context, info) {
+                  const authors = await context.nodeModel.runQuery({
+                    type: `Author`,
+                    query: { filter: { email: { in: source.authors } } },
+                    firstOnly: false,
+                  })
+                  return authors.map(author => author.name)
+                },
+              },
+              [`frontmatter.anotherField`]: {
+                type: `Boolean`,
+                resolve() {
+                  return true
+                },
+              },
+            },
+          ]
+        }
+        return []
+      } else if (api === `createResolvers`) {
+        return [
+          args[0].createResolvers({
+            MarkdownFrontmatter: {
+              authors: {
+                resolve(source, args, context, info) {
+                  // NOTE: When using the first field resolver argument (here called
+                  // `source`, also called `parent` or `root`), it is important to
+                  // take care of the fact that the resolver can be called more than once
+                  // in one query, e.g. when the field is referenced both in the input filter
+                  // and in the selection set. In this test example, the `authors` field will
+                  // already have been expanded to an array of full `Author` nodes when the
+                  // resolver is called the second time.
+                  if (
+                    source.authors.some(
+                      author => author && typeof author === `object`
+                    )
+                  ) {
+                    return source.authors
+                  }
+                  return context.nodeModel
+                    .getAllNodes({ type: `Author` })
+                    .filter(author => source.authors.includes(author.email))
+                },
+              },
+            },
+            Author: {
+              posts: {
+                resolve(source, args, context, info) {
+                  // NOTE: One of the differences between using `runQuery` and
+                  // `getAllNodes` is that the latter will always get the nodes
+                  // which will be queried directly from the store, while `runQuery`
+                  // will first try to call field resolvers, e.g. to expand
+                  // foreign-key fields to full nodes. Here for example we can
+                  // query `authors.email`.
+                  // Another thing to note is that we don't have to use the
+                  // `$elemMatch` operator when querying arrays of objects
+                  // (although we could).
+                  return context.nodeModel.runQuery({
+                    type: `Markdown`,
+                    query: {
+                      filter: {
+                        frontmatter: {
+                          authors: { email: { eq: source.email } },
+                          // authors: {
+                          //   elemMatch: { email: { eq: source.email } },
+                          // },
+                        },
+                      },
+                    },
+                    firstOnly: false,
+                  })
+                },
+              },
+            },
+          }),
+          args[0].createResolvers({
+            Query: {
+              allAuthorNames: {
+                type: `[String!]!`,
+                resolve(source, args, context, info) {
+                  return context.nodeModel
+                    .getAllNodes({ type: `Author` })
+                    .map(author => author.name)
+                },
+              },
+            },
+          }),
+        ]
+      } else {
+        return []
+      }
+    })
+
+    store.dispatch({ type: `DELETE_CACHE` })
+    nodes.forEach(node =>
+      store.dispatch({ type: `CREATE_NODE`, payload: node })
+    )
+
+    // FIXME: Needs to work when type is just called `Frontmatter`
+    const typeDefs = [
+      `type Test implements Node { isOnlyDefinedLater: Author } `,
+      `type Markdown implements Node { frontmatter: MarkdownFrontmatter! }`,
+      `type MarkdownFrontmatter { authors: [Author] }`,
+      `type Author implements Node { posts: [Markdown] }`,
+    ]
+    typeDefs.forEach(def =>
+      store.dispatch({ type: `CREATE_TYPES`, payload: def })
+    )
+
+    await build({})
+    schema = store.getState().schema
+  })
+
+  describe(`on children fields`, () => {
+    it(`handles Node interface children field`, async () => {
+      const query = `
+        {
+          allFile {
+            edges {
+              node {
+                children {
+                  ... on Markdown { frontmatter { title } }
+                  ... on Author { name }
+                }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allFile: {
+          edges: [
+            {
+              node: {
+                children: [{ frontmatter: { title: `Markdown File 1` } }],
+              },
+            },
+            {
+              node: {
+                children: [{ frontmatter: { title: `Markdown File 2` } }],
+              },
+            },
+            {
+              node: {
+                children: [{ name: `Author 2` }, { name: `Author 1` }],
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+
+    it(`handles convenience child fields`, async () => {
+      const query = `
+        {
+          allFile {
+            edges {
+              node {
+                childMarkdown { frontmatter { title } }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allFile: {
+          edges: [
+            {
+              node: {
+                childMarkdown: { frontmatter: { title: `Markdown File 1` } },
+              },
+            },
+            {
+              node: {
+                childMarkdown: { frontmatter: { title: `Markdown File 2` } },
+              },
+            },
+            {
+              node: {
+                childMarkdown: null,
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+
+    it(`handles convenience children fields`, async () => {
+      const query = `
+        {
+          allFile {
+            edges {
+              node {
+                childrenAuthor { name }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allFile: {
+          edges: [
+            {
+              node: {
+                childrenAuthor: [],
+              },
+            },
+            {
+              node: {
+                childrenAuthor: [],
+              },
+            },
+            {
+              node: {
+                childrenAuthor: [{ name: `Author 2` }, { name: `Author 1` }],
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+
+    // NOTE: Also tests handling children fields being in both
+    // input filter and selection set.
+    it(`handles query arguments on children fields`, async () => {
+      const query = `
+        {
+          allFile(
+            filter: {
+              children: {
+                elemMatch: { internal: { type: { eq: "Markdown" } } }
+              }
+            }
+            sort: { fields: [id], order: [DESC] }
+          ) {
+            edges {
+              node {
+                name
+                children {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allFile: {
+          edges: [
+            {
+              node: { name: `2.md`, children: [{ id: `md2` }] },
+            },
+            {
+              node: { name: `1.md`, children: [{ id: `md1` }] },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+  })
+
+  describe(`on fields added with createTypes`, () => {
+    it(`handles selection set`, async () => {
+      const query = `
+        query {
+          allMarkdown {
+            edges {
+              node {
+                frontmatter {
+                  title
+                  date(formatString: "MM-DD-YYYY")
+                  published
+                  authors {
+                    name
+                    email
+                    posts {
+                      frontmatter {
+                        title
+                      }
+                    }
+                  }
+                  authorNames
+                }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allMarkdown: {
+          edges: [
+            {
+              node: {
+                frontmatter: {
+                  authorNames: [`Author 1`, `Author 2`],
+                  authors: [
+                    {
+                      email: `author1@example.com`,
+                      name: `Author 1`,
+                      posts: [
+                        { frontmatter: { title: `Markdown File 1` } },
+                        { frontmatter: { title: `Markdown File 2` } },
+                      ],
+                    },
+                    {
+                      email: `author2@example.com`,
+                      name: `Author 2`,
+                      posts: [{ frontmatter: { title: `Markdown File 1` } }],
+                    },
+                  ],
+                  date: `01-01-2019`,
+                  published: null,
+                  title: `Markdown File 1`,
+                },
+              },
+            },
+            {
+              node: {
+                frontmatter: {
+                  authorNames: [`Author 1`],
+                  authors: [
+                    {
+                      email: `author1@example.com`,
+                      name: `Author 1`,
+                      posts: [
+                        { frontmatter: { title: `Markdown File 1` } },
+                        { frontmatter: { title: `Markdown File 2` } },
+                      ],
+                    },
+                  ],
+                  date: null,
+                  published: false,
+                  title: `Markdown File 2`,
+                },
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+
+    it(`handles query arguments`, async () => {
+      const query = `
+        query {
+          allMarkdown(
+            filter: {
+              frontmatter: {
+                authors: {
+                  elemMatch: {
+                    name: { regex: "/^Author/" }
+                    posts: {
+                      elemMatch: {
+                        frontmatter: {
+                          title: {
+                            eq: "Markdown File 2"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            sort: { fields: [frontmatter___title], order: [DESC] }
+          ) {
+            edges {
+              node {
+                id
+                frontmatter {
+                  authors {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allMarkdown: {
+          edges: [
+            {
+              node: {
+                id: `md2`,
+                frontmatter: { authors: [{ name: `Author 1` }] },
+              },
+            },
+            {
+              node: {
+                id: `md1`,
+                frontmatter: {
+                  authors: expect.arrayContaining([
+                    { name: `Author 1` },
+                    { name: `Author 2` },
+                  ]),
+                },
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+  })
+
+  describe(`on pagination fields`, () => {
+    describe(`edges { node }`, () => {
+      it(`paginates results`, async () => {
+        const query = `
+          query {
+            pages: allMarkdown {
+              totalCount
+              edges {
+                node {
+                  frontmatter {
+                    title
+                    authors {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+            skiplimit: allMarkdown(
+              skip: 1
+              limit: 1
+            ) {
+              totalCount
+              edges { node { id } }
+            }
+            findsort: allMarkdown(
+              filter: {
+                frontmatter: {
+                  authors: { elemMatch: { name: { regex: "/^Author\\\\s\\\\d/" } } }
+                }
+              }
+              sort: { fields: [frontmatter___title], order: [DESC] }
+            ) {
+              totalCount
+              edges {
+                node {
+                  frontmatter {
+                    title
+                    authors {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+        const results = await runQuery(query)
+        const expected = {
+          findsort: {
+            totalCount: 2,
+            edges: [
+              {
+                node: {
+                  frontmatter: {
+                    authors: [{ name: `Author 1` }],
+                    title: `Markdown File 2`,
+                  },
+                },
+              },
+              {
+                node: {
+                  frontmatter: {
+                    authors: expect.arrayContaining([
+                      { name: `Author 1` },
+                      { name: `Author 2` },
+                    ]),
+                    title: `Markdown File 1`,
+                  },
+                },
+              },
+            ],
+          },
+          pages: {
+            totalCount: 2,
+            edges: [
+              {
+                node: {
+                  frontmatter: {
+                    authors: expect.arrayContaining([
+                      { name: `Author 1` },
+                      { name: `Author 2` },
+                    ]),
+                    title: `Markdown File 1`,
+                  },
+                },
+              },
+              {
+                node: {
+                  frontmatter: {
+                    authors: [{ name: `Author 1` }],
+                    title: `Markdown File 2`,
+                  },
+                },
+              },
+            ],
+          },
+          skiplimit: { totalCount: 1, edges: [{ node: { id: `md2` } }] },
+        }
+        expect(results.errors).toBeUndefined()
+        expect(results.data).toEqual(expected)
+      })
+
+      it.todo(`paginaties null result`)
+
+      it(`adds nodes field as a convenience shortcut`, async () => {
+        const query = `
+          {
+            allMarkdown(
+              skip: 1
+              limit: 1
+            ) {
+              totalCount
+              nodes { id }
+            }
+          }
+        `
+        const results = await runQuery(query)
+        const expected = {
+          allMarkdown: {
+            totalCount: 1,
+            nodes: [{ id: `md2` }],
+          },
+        }
+        expect(results.errors).toBeUndefined()
+        expect(results.data).toEqual(expected)
+      })
+    })
+
+    describe(`group field`, () => {
+      it(`groups query results`, async () => {
+        const query = `
+          query {
+            allMarkdown {
+              group(field: frontmatter___title) {
+                fieldValue
+                edges {
+                  node {
+                    frontmatter {
+                      title
+                      date(formatString: "YYYY-MM-DD")
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+        const results = await runQuery(query)
+        const expected = {
+          allMarkdown: {
+            group: [
+              {
+                fieldValue: `Markdown File 1`,
+                edges: [
+                  {
+                    node: {
+                      frontmatter: {
+                        title: `Markdown File 1`,
+                        date: `2019-01-01`,
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                fieldValue: `Markdown File 2`,
+                edges: [
+                  {
+                    node: {
+                      frontmatter: {
+                        title: `Markdown File 2`,
+                        date: null,
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        }
+        expect(results.errors).toBeUndefined()
+        expect(results.data).toEqual(expected)
+      })
+
+      it(`groups query results by scalar field with resolver`, async () => {
+        const query = `
+          query {
+            allMarkdown {
+              group(field: frontmatter___date) {
+                fieldValue
+                edges {
+                  node {
+                    frontmatter {
+                      title
+                      date(formatString: "YYYY/MM/DD")
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+        const results = await runQuery(query)
+        const expected = {
+          allMarkdown: {
+            group: [
+              {
+                fieldValue: `2019-01-01T00:00:00.000Z`,
+                edges: [
+                  {
+                    node: {
+                      frontmatter: {
+                        title: `Markdown File 1`,
+                        date: `2019/01/01`,
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        }
+        expect(results.errors).toBeUndefined()
+        expect(results.data).toEqual(expected)
+      })
+
+      // FIXME: This is not yet possible
+      it.skip(`groups query results by foreign key field`, async () => {
+        const query = `
+          query {
+            allMarkdown {
+              group(field: frontmatter___authors___name) {
+                fieldValue
+                edges {
+                  node {
+                    frontmatter {
+                      title
+                      date
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+        const results = await runQuery(query)
+        const expected = {
+          allMarkdown: {
+            group: [
+              {
+                fieldValue: `Author 1`,
+                edges: [
+                  {
+                    node: {
+                      frontmatter: {
+                        title: `Markdown File 1`,
+                        date: `2019-01-01`,
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      frontmatter: {
+                        title: `Markdown File 2`,
+                        date: null,
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                fieldValue: `Author 2`,
+                edges: [
+                  {
+                    node: {
+                      frontmatter: {
+                        title: `Markdown File 1`,
+                        date: `2019-01-01`,
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        }
+        expect(results.errors).toBeUndefined()
+        expect(results.data).toEqual(expected)
+      })
+
+      it.todo(`groups null result`)
+    })
+
+    describe(`distinct field`, () => {
+      it(`returns distinct values`, async () => {
+        const query = `
+          query {
+            allMarkdown {
+              distinct(field: frontmatter___title)
+            }
+          }
+        `
+        const results = await runQuery(query)
+        const expected = {
+          allMarkdown: {
+            distinct: [`Markdown File 1`, `Markdown File 2`],
+          },
+        }
+        expect(results.errors).toBeUndefined()
+        expect(results.data).toEqual(expected)
+      })
+
+      // FIXME: This is not yet possible
+      it.skip(`returns distinct values on foreign-key field`, async () => {
+        const query = `
+          query {
+            allMarkdown {
+              distinct(field: frontmatter___authors___name)
+            }
+          }
+        `
+        const results = await runQuery(query)
+        const expected = {
+          allMarkdown: {
+            distinct: [`Author 1`, `Author 2`],
+          },
+        }
+        expect(results.errors).toBeUndefined()
+        expect(results.data).toEqual(expected)
+      })
+
+      it.todo(`returns distinct values on scalar field with resolver`)
+
+      it.todo(`handles null result`)
+    })
+  })
+
+  describe(`on fields added by setFieldsOnGraphQLNodeType API`, () => {
+    it(`returns correct results`, async () => {
+      const query = `
+        {
+          allMarkdown {
+            edges {
+              node {
+                frontmatter {
+                  authorNames
+                  anotherField
+                }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allMarkdown: {
+          edges: [
+            {
+              node: {
+                frontmatter: {
+                  anotherField: true,
+                  authorNames: [`Author 1`, `Author 2`],
+                },
+              },
+            },
+            {
+              node: {
+                frontmatter: {
+                  anotherField: true,
+                  authorNames: [`Author 1`],
+                },
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+  })
+
+  describe(`on fields added to the root Query type`, () => {
+    it(`returns correct results`, async () => {
+      const query = `
+      {
+        allAuthorNames
+      }
+    `
+      const results = await runQuery(query)
+      const expected = {
+        allAuthorNames: [`Author 1`, `Author 2`],
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+  })
+})

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -888,4 +888,14 @@ describe(`Query schema`, () => {
       expect(results.data).toEqual(expected)
     })
   })
+
+  describe(`on fields added from third-party schema`, () => {
+    it.todo(`returns correct results`)
+  })
+
+  describe(`on foreign-key fields`, () => {
+    it.todo(`with the ___NODE convention`)
+
+    it.todo(`with defined field mappings`)
+  })
 })

--- a/packages/gatsby/src/schema/__tests__/rebuild-schema.js
+++ b/packages/gatsby/src/schema/__tests__/rebuild-schema.js
@@ -1,0 +1,129 @@
+const { store } = require(`../../redux`)
+const { build, rebuildWithSitePage } = require(`..`)
+require(`../../db/__tests__/fixtures/ensure-loki`)()
+
+const firstPage = {
+  id: `page1`,
+  parent: null,
+  children: [],
+  internal: { type: `SitePage` },
+  keep: `Page`,
+  fields: {
+    oldKey: `value`,
+  },
+}
+
+const secondPage = {
+  id: `page2`,
+  parent: null,
+  children: [],
+  internal: { type: `SitePage` },
+  fields: {
+    key: `value`,
+  },
+  context: {
+    key: `value`,
+  },
+}
+
+const nodes = [firstPage]
+
+describe(`build and update schema`, () => {
+  let schema
+
+  beforeAll(async () => {
+    store.dispatch({ type: `DELETE_CACHE` })
+    nodes.forEach(node =>
+      store.dispatch({ type: `CREATE_NODE`, payload: node })
+    )
+
+    await build({})
+    schema = store.getState().schema
+  })
+
+  it(`updates SitePage on rebuild`, async () => {
+    let fields
+    let inputFields
+
+    const initialFields = [
+      `id`,
+      `parent`,
+      `children`,
+      `internal`,
+      `keep`,
+      `fields`,
+    ]
+
+    fields = Object.keys(schema.getType(`SitePage`).getFields())
+    expect(fields.length).toBe(6)
+    expect(fields).toEqual(initialFields)
+
+    inputFields = Object.keys(schema.getType(`SitePageFilterInput`).getFields())
+    expect(fields.length).toBe(6)
+    expect(inputFields).toEqual(initialFields)
+
+    // Rebuild Schema
+    store.dispatch({ type: `CREATE_NODE`, payload: secondPage })
+    await rebuildWithSitePage({})
+    schema = store.getState().schema
+
+    fields = Object.keys(schema.getType(`SitePage`).getFields())
+    expect(fields.length).toBe(7)
+    expect(fields).toEqual(initialFields.concat(`context`))
+
+    inputFields = Object.keys(schema.getType(`SitePageFilterInput`).getFields())
+    expect(fields.length).toBe(7)
+    expect(inputFields).toEqual(initialFields.concat(`context`))
+
+    const fieldsEnum = schema
+      .getType(`SitePageFieldsEnum`)
+      .getValue(`context___key`)
+    expect(fieldsEnum).toBeDefined()
+
+    const sortFieldsEnum = schema.getType(`SitePageSortInput`).getFields()
+      .fields.type.ofType
+    expect(sortFieldsEnum.getValue(`context___key`)).toBeDefined()
+  })
+
+  // FIXME: This is not a problem as long as the only use of rebuilding the
+  // schema to add a `context` field to `SitePage`. But it needs to work
+  // if we want to enable on-the-fly schema regeneration.
+  // This currently does not work because we need to invalidate all FilterInput
+  // composers on nested types as well. Alternatively, use a local cache
+  // in `filter.js` instead of checking `schemaComposer.has()`.
+  it.skip(`updates nested types on rebuild`, async () => {
+    let fields
+    let inputFields
+
+    fields = Object.keys(schema.getType(`SitePageFields`).getFields())
+    expect(fields.length).toBe(1)
+    expect(fields).toEqual([`oldKey`])
+    inputFields = Object.keys(
+      schema.getType(`SitePageSitePageFieldsFilterInput`).getFields()
+    )
+    expect(inputFields.length).toBe(1)
+    expect(inputFields).toEqual([`oldKey`])
+
+    // Rebuild Schema
+    store.dispatch({ type: `CREATE_NODE`, payload: secondPage })
+    await rebuildWithSitePage({})
+    schema = store.getState().schema
+
+    fields = Object.keys(schema.getType(`SitePageFields`).getFields())
+    expect(fields.length).toBe(2)
+    expect(fields).toEqual([`oldKey`, `key`])
+
+    inputFields = Object.keys(
+      schema.getType(`SitePageSitePageFieldsFilterInput`).getFields()
+    )
+    expect(inputFields.length).toBe(2)
+    expect(inputFields).toEqual([`oldKey`, `key`])
+
+    const fieldsEnum = schema
+      .getType(`SitePageFieldsEnum`)
+      .getValues()
+      .map(value => value.name)
+    expect(fieldsEnum.includes(`fields___oldKey`)).toBeTruthy()
+    expect(fieldsEnum.includes(`fields___key`)).toBeTruthy()
+  })
+})

--- a/packages/gatsby/src/schema/infer/__tests__/merge-types.js
+++ b/packages/gatsby/src/schema/infer/__tests__/merge-types.js
@@ -1,0 +1,137 @@
+const { store } = require(`../../../redux`)
+const { build } = require(`../..`)
+require(`../../../db/__tests__/fixtures/ensure-loki`)()
+
+const nodes = [
+  {
+    id: `id1`,
+    internal: { type: `Test` },
+    foo: true,
+    conflictType: 1,
+    conflictArray: [1],
+    conflictArrayType: [1],
+    conflictArrayReverse: 1,
+    conflictScalar: { foo: true },
+    conflictScalarReverse: 1,
+    conflictScalarArray: [{ foo: true }],
+    conflcitScalarArrayReverse: [1],
+    nested: {
+      foo: true,
+      conflict: 1,
+      nested: {
+        foo: true,
+        conflict: 1,
+        extraExtra: true,
+      },
+    },
+    nestedArray: [
+      {
+        foo: true,
+        conflict: 1,
+        extra: true,
+        nested: { foo: true, conflict: 1, extraExtraExtra: true },
+      },
+    ],
+  },
+]
+
+describe(`merges explicit and inferred type definitions`, () => {
+  beforeAll(() => {
+    store.dispatch({ type: `DELETE_CACHE` })
+    nodes.forEach(node =>
+      store.dispatch({ type: `CREATE_NODE`, payload: node })
+    )
+  })
+
+  const buildTestSchema = async ({
+    infer = true,
+    addDefaultResolvers = true,
+  }) => {
+    const inferDirective = infer ? `@infer` : `@dontInfer`
+    const shouldAddDefaultResolvers = addDefaultResolvers ? `true` : `false`
+    const typeDefs = [
+      `
+      type NestedNested {
+        bar: Boolean!
+        conflict: String!
+        notExtra: Boolean
+      }
+
+      type Nested {
+        bar: Boolean!
+        conflict: String!
+        nested: NestedNested
+      }
+
+      type Test implements Node ${inferDirective}(addDefaultResolvers: ${shouldAddDefaultResolvers}) {
+        bar: Boolean!
+        nested: Nested!
+        nestedArray: [Nested!]!
+        conflictType: String!
+        conflictArray: Int!
+        conflictArrayReverse: [Int!]!
+        conflictArrayType: [String!]!
+        conflictScalar: Int!
+        conflictScalarReverse: Nested!
+        conflictScalarArray: [Int!]!
+        conflcitScalarArrayReverse: [Nested!]!
+      }`,
+    ]
+
+    typeDefs.forEach(def =>
+      store.dispatch({ type: `CREATE_TYPES`, payload: def })
+    )
+
+    await build({})
+    return store.getState().schema
+  }
+
+  it(`with default strategy`, async () => {
+    const schema = await buildTestSchema({})
+    const fields = schema.getType(`Test`).getFields()
+    const nestedFields = schema.getType(`Nested`).getFields()
+    const nestedNestedFields = schema.getType(`NestedNested`).getFields()
+
+    // Non-conflicting top-level fields added
+    expect(fields.foo.type.toString()).toBe(`Boolean`)
+    expect(fields.bar.type.toString()).toBe(`Boolean!`)
+
+    // Non-conflicting fields added on nested type
+    expect(fields.nested.type.toString()).toBe(`Nested!`)
+    expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
+    expect(nestedFields.foo.type.toString()).toBe(`Boolean`)
+    expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
+    expect(nestedNestedFields.foo.type.toString()).toBe(`Boolean`)
+    expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
+
+    // When type is referenced more than once on typeDefs, all non-conflicting
+    // fields are added
+    expect(nestedFields.extra.type.toString()).toBe(`Boolean`)
+    expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
+    expect(nestedNestedFields.extraExtra.type.toString()).toBe(`Boolean`)
+    expect(nestedNestedFields.extraExtraExtra.type.toString()).toBe(`Boolean`)
+
+    // Explicit typeDefs have proprity in case of type conflict
+    expect(fields.conflictType.type.toString()).toBe(`String!`)
+    expect(fields.conflictArray.type.toString()).toBe(`Int!`)
+    expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
+    expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
+    expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
+    expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
+    expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
+    expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(`[Nested!]!`)
+
+    // Explicit typeDefs have priority on nested types as well
+    expect(nestedFields.conflict.type.toString()).toBe(`String!`)
+    expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
+  })
+
+  it.todo(`with @infer directive`)
+
+  it.todo(`with @dontInfer directive`)
+
+  it.todo(`with addDefaultResolvers: false`)
+
+  // FIXME: Currently we don't do that
+  it.todo(`warns in case of user-defined Node interface`)
+})

--- a/packages/gatsby/src/schema/infer/__tests__/merge-types.js
+++ b/packages/gatsby/src/schema/infer/__tests__/merge-types.js
@@ -48,7 +48,7 @@ describe(`merges explicit and inferred type definitions`, () => {
     addDefaultResolvers = true,
   }) => {
     const inferDirective = infer ? `@infer` : `@dontInfer`
-    const shouldAddDefaultResolvers = addDefaultResolvers ? `true` : `false`
+    const noDefaultResolvers = addDefaultResolvers ? `false` : `true`
     const typeDefs = [
       `
       type NestedNested {
@@ -63,7 +63,7 @@ describe(`merges explicit and inferred type definitions`, () => {
         nested: NestedNested
       }
 
-      type Test implements Node ${inferDirective}(addDefaultResolvers: ${shouldAddDefaultResolvers}) {
+      type Test implements Node ${inferDirective}(noDefaultResolvers: ${noDefaultResolvers}) {
         bar: Boolean!
         nested: Nested!
         nestedArray: [Nested!]!
@@ -126,11 +126,11 @@ describe(`merges explicit and inferred type definitions`, () => {
     expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
   })
 
-  it.todo(`with @infer directive`)
-
   it.todo(`with @dontInfer directive`)
 
-  it.todo(`with addDefaultResolvers: false`)
+  it.todo(`with noDefaultResolvers: true`)
+
+  it.todo(`with both @dontInfer and noDefaultResolvers: true`)
 
   // FIXME: Currently we don't do that
   it.todo(`warns in case of user-defined Node interface`)

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -258,7 +258,7 @@ const getFieldConfigFromFieldNameConvention = (
     type = linkedTypes[0]
   }
 
-  return { type, resolve: link({ by: foreignKey || `id`, from: key }) }
+  return { type, resolve: link({ by: foreignKey || `id` }) }
 }
 
 const getSimpleFieldConfig = (
@@ -300,7 +300,10 @@ const getSimpleFieldConfig = (
         // because we don't yet know if this type should end up in
         // the schema. It might be for a possibleField that will be
         // disregarded later.
-        const typeComposer = schemaComposer.TypeComposer.createTemp(
+        // const typeComposer = schemaComposer.TypeComposer.createTemp(
+        //   createTypeName(selector)
+        // )
+        const typeComposer = schemaComposer.getOrCreateTC(
           createTypeName(selector)
         )
         return {

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -215,7 +215,7 @@ const getFieldConfig = ({
 
 const resolveMultipleFields = possibleFields => {
   const nodeField = possibleFields.find(field =>
-    field.unsanitizedKey.endsWith(`___NODE`)
+    field.unsanitizedKey.includes(`___NODE`)
   )
   if (nodeField) {
     return nodeField

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -1,5 +1,10 @@
 const _ = require(`lodash`)
-const { defaultFieldResolver, getNamedType } = require(`graphql`)
+const {
+  defaultFieldResolver,
+  getNamedType,
+  GraphQLObjectType,
+  GraphQLList,
+} = require(`graphql`)
 const invariant = require(`invariant`)
 const report = require(`gatsby-cli/lib/reporter`)
 
@@ -24,7 +29,7 @@ const addInferredFields = ({
       nodeStore,
       exampleObject: exampleValue,
       prefix: typeComposer.getTypeName(),
-      typeMapping: typeMapping,
+      typeMapping,
       addDefaultResolvers: inferConfig ? inferConfig.addDefaultResolvers : true,
     })
   }
@@ -49,6 +54,7 @@ const addInferredFieldsImpl = ({
     fields.push(
       getFieldConfig({
         schemaComposer,
+        typeComposer,
         nodeStore,
         prefix,
         exampleValue,
@@ -82,24 +88,51 @@ const addInferredFieldsImpl = ({
     }
 
     if (typeComposer.hasField(key)) {
-      let field = typeComposer.getField(key)
-      let fieldType = typeComposer.getFieldType(key)
-      if (
-        addDefaultResolvers &&
-        getNamedType(fieldType).name === fieldConfig.type
-      ) {
-        if (!field.type) {
-          field = {
-            type: field,
+      const fieldType = typeComposer.getFieldType(key)
+
+      let lists = 0
+      let namedFieldType = fieldType
+      while (namedFieldType.ofType) {
+        namedFieldType = namedFieldType.ofType
+        if (namedFieldType instanceof GraphQLList) {
+          lists++
+        }
+      }
+
+      let arrays = 0
+      let namedInferredType = fieldConfig.type
+      while (Array.isArray(namedInferredType)) {
+        namedInferredType = namedInferredType[0]
+        arrays++
+      }
+
+      if (arrays === lists) {
+        if (
+          namedFieldType instanceof GraphQLObjectType &&
+          typeof namedInferredType !== `string` &&
+          namedFieldType.name === namedInferredType.getTypeName()
+        ) {
+          const fieldTypeComposer = typeComposer.getFieldTC(key)
+          const inferredFields = namedInferredType.getFields()
+          fieldTypeComposer.addFields(inferredFields)
+        } else if (
+          addDefaultResolvers &&
+          namedFieldType.name === namedInferredType
+        ) {
+          let field = typeComposer.getField(key)
+          if (!field.type) {
+            field = {
+              type: field,
+            }
           }
+          if (_.isEmpty(field.args) && fieldConfig.args) {
+            field.args = fieldConfig.args
+          }
+          if (!field.resolve && fieldConfig.resolve) {
+            field.resolve = fieldConfig.resolve
+          }
+          typeComposer.setField(key, field)
         }
-        if (_.isEmpty(field.args) && fieldConfig.args) {
-          field.args = fieldConfig.args
-        }
-        if (!field.resolve && fieldConfig.resolve) {
-          field.resolve = fieldConfig.resolve
-        }
-        typeComposer.setField(key, field)
       }
     } else {
       typeComposer.setField(key, fieldConfig)
@@ -111,6 +144,7 @@ const addInferredFieldsImpl = ({
 
 const getFieldConfig = ({
   schemaComposer,
+  typeComposer,
   nodeStore,
   prefix,
   exampleValue,
@@ -132,24 +166,26 @@ const getFieldConfig = ({
   if (hasMapping(typeMapping, selector)) {
     // TODO: Use `prefix` instead of `selector` in hasMapping and getFromMapping?
     // i.e. does the config contain sanitized field names?
-    fieldConfig = getFieldConfigFromMapping(typeMapping, selector)
+    fieldConfig = getFieldConfigFromMapping({ typeMapping, selector })
   } else if (key.includes(`___NODE`)) {
-    fieldConfig = getFieldConfigFromFieldNameConvention(
+    fieldConfig = getFieldConfigFromFieldNameConvention({
       schemaComposer,
       nodeStore,
-      exampleValue,
-      unsanitizedKey
-    )
+      value: exampleValue,
+      key: unsanitizedKey,
+    })
     key = key.split(`___NODE`)[0]
   } else {
-    fieldConfig = getSimpleFieldConfig(
+    fieldConfig = getSimpleFieldConfig({
       schemaComposer,
+      typeComposer,
       nodeStore,
+      key,
       value,
       selector,
       typeMapping,
-      addDefaultResolvers
-    )
+      addDefaultResolvers,
+    })
   }
 
   // Proxy resolver to unsanitized fieldName in case it contained invalid characters
@@ -202,18 +238,18 @@ const resolveMultipleFields = possibleFields => {
 const hasMapping = (mapping, selector) =>
   mapping && Object.keys(mapping).includes(selector)
 
-const getFieldConfigFromMapping = (mapping, selector) => {
-  const [type, ...path] = mapping[selector].split(`.`)
+const getFieldConfigFromMapping = ({ typeMapping, selector }) => {
+  const [type, ...path] = typeMapping[selector].split(`.`)
   return { type, resolve: link({ by: path.join(`.`) || `id` }) }
 }
 
 // probably should be in example value
-const getFieldConfigFromFieldNameConvention = (
+const getFieldConfigFromFieldNameConvention = ({
   schemaComposer,
   nodeStore,
   value,
-  key
-) => {
+  key,
+}) => {
   const path = key.split(`___NODE___`)[1]
   // Allow linking by nested fields, e.g. `author___NODE___contact___email`
   const foreignKey = path && path.replace(/___/g, `.`)
@@ -261,14 +297,16 @@ const getFieldConfigFromFieldNameConvention = (
   return { type, resolve: link({ by: foreignKey || `id` }) }
 }
 
-const getSimpleFieldConfig = (
+const getSimpleFieldConfig = ({
   schemaComposer,
+  typeComposer,
   nodeStore,
+  key,
   value,
   selector,
   typeMapping,
-  addDefaultResolvers
-) => {
+  addDefaultResolvers,
+}) => {
   switch (typeof value) {
     case `boolean`:
       return { type: `Boolean` }
@@ -296,25 +334,36 @@ const getSimpleFieldConfig = (
         return { type: `String` }
       }
       if (value /* && depth < MAX_DEPTH*/) {
-        // We only create a temporary TypeComposer on nested fields,
-        // because we don't yet know if this type should end up in
-        // the schema. It might be for a possibleField that will be
-        // disregarded later.
-        // const typeComposer = schemaComposer.TypeComposer.createTemp(
-        //   createTypeName(selector)
-        // )
-        const typeComposer = schemaComposer.getOrCreateTC(
-          createTypeName(selector)
-        )
+        // We only create a temporary TypeComposer on nested fields
+        // (either a clone of an existing field type, or a temporary new one),
+        // because we don't yet know if this type should end up in the schema.
+        // It might be for a possibleField that will be disregarded later,
+        // so we cannot mutate the original.
+        let fieldTypeComposer
+        if (
+          typeComposer.hasField(key) &&
+          getNamedType(typeComposer.getFieldType(key)) instanceof
+            GraphQLObjectType
+        ) {
+          const originalFieldTypeComposer = typeComposer.getFieldTC(key)
+          fieldTypeComposer = originalFieldTypeComposer.clone(
+            originalFieldTypeComposer.getTypeName()
+          )
+        } else {
+          fieldTypeComposer = schemaComposer.TypeComposer.createTemp(
+            createTypeName(selector)
+          )
+        }
+
         return {
           type: addInferredFieldsImpl({
             schemaComposer,
-            typeComposer,
+            typeComposer: fieldTypeComposer,
             nodeStore,
             exampleObject: value,
             typeMapping,
             prefix: selector,
-            addDefaultResolvers: addDefaultResolvers,
+            addDefaultResolvers,
           }),
         }
       }

--- a/packages/gatsby/src/schema/infer/get-infer-config.js
+++ b/packages/gatsby/src/schema/infer/get-infer-config.js
@@ -17,7 +17,7 @@ const getInferConfig: (
   typeComposer: TypeComposer
 ) => InferConfig = typeComposer => {
   const type = typeComposer.getType()
-  const inferConfig = DEFAULT_INFER_CONFIG
+  const inferConfig = { ...DEFAULT_INFER_CONFIG }
   if (type.astNode && type.astNode.directives) {
     type.astNode.directives.forEach(directive => {
       if (directive.name.value === `infer`) {

--- a/packages/gatsby/src/schema/infer/get-infer-config.js
+++ b/packages/gatsby/src/schema/infer/get-infer-config.js
@@ -40,8 +40,8 @@ const getNoDefaultResolvers = directive => {
     ({ name }) => name.value === `noDefaultResolvers`
   )
   if (noDefaultResolvers) {
-    if (noDefaultResolvers.value.kind === Kind.BOOLEAN_NODE) {
-      return noDefaultResolvers.value.value
+    if (noDefaultResolvers.value.kind === Kind.BOOLEAN) {
+      return !noDefaultResolvers.value.value
     }
   }
 

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -66,7 +66,7 @@ const group = (source, args, context, info) => {
     }, [])
 }
 
-const paginate = (results, { skip = 0, limit }) => {
+const paginate = (results = [], { skip = 0, limit }) => {
   const count = results.length
   const items = results.slice(skip, limit && skip + limit)
 

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -33,7 +33,9 @@ const distinct = (source, args, context, info) => {
   const { edges } = source
   const values = edges.reduce((acc, { node }) => {
     const value = getValueAtSelector(node, field)
-    return value != null ? acc.concat(value) : acc
+    return value != null
+      ? acc.concat(value instanceof Date ? value.toISOString() : value)
+      : acc
   }, [])
   return Array.from(new Set(values)).sort()
 }
@@ -46,7 +48,10 @@ const group = (source, args, context, info) => {
     const values = Array.isArray(value) ? value : [value]
     values
       .filter(value => value != null)
-      .forEach(v => (acc[v] = (acc[v] || []).concat(node)))
+      .forEach(value => {
+        const key = value instanceof Date ? value.toISOString() : value
+        acc[key] = (acc[key] || []).concat(node)
+      })
     return acc
   }, {})
   return Object.keys(groupedResults)

--- a/packages/gatsby/src/schema/schema-composer.js
+++ b/packages/gatsby/src/schema/schema-composer.js
@@ -1,9 +1,11 @@
 const { SchemaComposer } = require(`graphql-compose`)
+const { getNodeInterface } = require(`./types/node-interface`)
 const { GraphQLDate } = require(`./types/date`)
 const { InferDirective, DontInferDirective } = require(`./types/directives`)
 
 const createSchemaComposer = () => {
   const schemaComposer = new SchemaComposer()
+  getNodeInterface({ schemaComposer })
   schemaComposer.add(GraphQLDate)
   schemaComposer.addDirective(InferDirective)
   schemaComposer.addDirective(DontInferDirective)

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1,5 +1,10 @@
 const _ = require(`lodash`)
-const { isSpecifiedScalarType, isIntrospectionType } = require(`graphql`)
+const {
+  isSpecifiedScalarType,
+  isIntrospectionType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+} = require(`graphql`)
 const apiRunner = require(`../utils/api-runner-node`)
 const report = require(`gatsby-cli/lib/reporter`)
 const { addNodeInterfaceFields } = require(`./types/node-interface`)
@@ -125,7 +130,6 @@ const addTypes = ({ schemaComposer, types, parentSpan }) => {
     if (typeof typeOrTypeDef === `string`) {
       const addedTypes = schemaComposer.addTypeDefs(typeOrTypeDef)
       addedTypes.forEach(type => {
-        const { GraphQLInterfaceType, GraphQLUnionType } = require(`graphql`)
         let typeComposer
         if (type instanceof GraphQLInterfaceType) {
           typeComposer = schemaComposer.getOrCreateIFTC(type.name)
@@ -178,10 +182,10 @@ const addThirdPartySchemas = ({
   parentSpan,
 }) => {
   thirdPartySchemas.forEach(schema => {
-    const QueryTC = schemaComposer.TypeComposer.createTemp(
+    const queryTC = schemaComposer.TypeComposer.createTemp(
       schema.getQueryType()
     )
-    const fields = QueryTC.getFields()
+    const fields = queryTC.getFields()
     schemaComposer.Query.addFields(fields)
 
     // Explicitly add the third-party schema's types, so they can be targeted

--- a/packages/gatsby/src/schema/types/filter.js
+++ b/packages/gatsby/src/schema/types/filter.js
@@ -32,7 +32,7 @@ const convert = ({ schemaComposer, inputTypeComposer }) => {
     if (type instanceof GraphQLInputObjectType) {
       const itc = new schemaComposer.InputTypeComposer(type)
 
-      const OperatorsInputTC = convert({
+      const operatorsInputTC = convert({
         schemaComposer,
         inputTypeComposer: itc,
       })
@@ -46,9 +46,9 @@ const convert = ({ schemaComposer, inputTypeComposer }) => {
         ? getQueryOperatorListInput({
             schemaComposer,
             type: type,
-            inputTypeComposer: OperatorsInputTC,
+            inputTypeComposer: operatorsInputTC,
           })
-        : OperatorsInputTC
+        : operatorsInputTC
     } else {
       // GraphQLScalarType || GraphQLEnumType
       const operatorFields = getQueryOperatorInput({ schemaComposer, type })
@@ -92,7 +92,7 @@ const removeEmptyFields = (
 
 const getFilterInput = ({ schemaComposer, typeComposer }) => {
   const inputTypeComposer = typeComposer.getInputTypeComposer()
-  const FilterInputTC = convert({
+  const filterInputTC = convert({
     schemaComposer,
     inputTypeComposer,
   })
@@ -103,7 +103,7 @@ const getFilterInput = ({ schemaComposer, typeComposer }) => {
   // to handle circular definitions, e.g. like in `NodeInput`.
   // NOTE: We can remove this if we can guarantee that every type has query
   // operators.
-  return removeEmptyFields({ schemaComposer, inputTypeComposer: FilterInputTC })
+  return removeEmptyFields({ schemaComposer, inputTypeComposer: filterInputTC })
 }
 
 module.exports = { getFilterInput }

--- a/packages/gatsby/src/schema/types/pagination.js
+++ b/packages/gatsby/src/schema/types/pagination.js
@@ -56,7 +56,7 @@ const getGroup = ({ schemaComposer, typeComposer }) => {
 const getPagination = ({ schemaComposer, typeComposer }) => {
   const inputTypeComposer = typeComposer.getInputTypeComposer()
   const typeName = typeComposer.getTypeName() + `Connection`
-  const FieldsEnumTC = getFieldsEnum({
+  const fieldsEnumTC = getFieldsEnum({
     schemaComposer,
     typeComposer,
     inputTypeComposer,
@@ -65,7 +65,7 @@ const getPagination = ({ schemaComposer, typeComposer }) => {
     distinct: {
       type: [`String!`],
       args: {
-        field: FieldsEnumTC.getTypeNonNull(),
+        field: fieldsEnumTC.getTypeNonNull(),
       },
       resolve: distinct,
     },
@@ -74,7 +74,7 @@ const getPagination = ({ schemaComposer, typeComposer }) => {
       args: {
         skip: `Int`,
         limit: `Int`,
-        field: FieldsEnumTC.getTypeNonNull(),
+        field: fieldsEnumTC.getTypeNonNull(),
       },
       resolve: group,
     },

--- a/packages/gatsby/src/schema/types/sort.js
+++ b/packages/gatsby/src/schema/types/sort.js
@@ -17,16 +17,18 @@ const getSortOrderEnum = ({ schemaComposer }) =>
 
 const getFieldsEnum = ({ schemaComposer, typeComposer, inputTypeComposer }) => {
   const typeName = typeComposer.getTypeName()
-  return schemaComposer.getOrCreateETC(`${typeName}FieldsEnum`, etc => {
-    const fields = convert(inputTypeComposer.getFields())
-    etc.addFields(fields)
-  })
+  const fieldsEnumTypeComposer = schemaComposer.getOrCreateETC(
+    `${typeName}FieldsEnum`
+  )
+  const fields = convert(inputTypeComposer.getFields())
+  fieldsEnumTypeComposer.setFields(fields)
+  return fieldsEnumTypeComposer
 }
 
 const getSortInput = ({ schemaComposer, typeComposer }) => {
   const inputTypeComposer = typeComposer.getInputTypeComposer()
-  const SortOrderEnumTC = getSortOrderEnum({ schemaComposer })
-  const FieldsEnumTC = getFieldsEnum({
+  const sortOrderEnumTC = getSortOrderEnum({ schemaComposer })
+  const fieldsEnumTC = getFieldsEnum({
     schemaComposer,
     typeComposer,
     inputTypeComposer,
@@ -35,8 +37,8 @@ const getSortInput = ({ schemaComposer, typeComposer }) => {
 
   return schemaComposer.getOrCreateITC(`${typeName}SortInput`, itc => {
     itc.addFields({
-      fields: [FieldsEnumTC],
-      order: { type: [SortOrderEnumTC], defaultValue: [`ASC`] },
+      fields: [fieldsEnumTC],
+      order: { type: [sortOrderEnumTC], defaultValue: [`ASC`] },
     })
   })
 }

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -195,35 +195,69 @@ exports.onCreatePage = true
 exports.setFieldsOnGraphQLNodeType = true
 
 /**
- * Adds custom resolvers to the GraphQLSchema after all schema processing happened.
- * *
+ * Add custom field resolvers to the GraphQL schema.
+ *
+ * Allows adding new fields to types by providing field configs, or adding resolver
+ * functions to existing fields.
+ *
+ * Things to note:
+ * * Overriding field types is disallowed, instead use the `createTypes`
+ *   action. In case of types added from third-party schemas, where this is not
+ *   possible, overriding field types is allowed.
+ * * New fields will not be available on `filter` and `sort` input types. Extend
+ *   types defined with `createTypes` if you need this.
+ * * In field configs, types can be referenced as strings.
+ * * When extending a field with an existing field resolver, thr original
+ *   resolver function is available from `info.originalResolver`.
+ * * The `createResolvers` API is called as the last step in schema generation.
+ *   Thus, an intermediate schema is made available on the `schema` argument.
+ *   In resolver functions themselves, it is recommended to access the final
+ *   built schema from `info.schema`.
+ * * Gatsby's model layer, including all internal query capabilities, is
+ *   exposed on `context.nodeModel`. The node store can be queried directly
+ *   with `getAllNodes`, `getNodeById` and `getNodesByIds`, while more advanced
+ *   queries can be composed with `runQuery`. Note that `runQuery` will call
+ *   field resolvers before querying, so e.g. foreign-key fields will be
+ *   expanded to full nodes. The other methods on  `nodeModel` don't do this.
+ * * It is possible to add fields to the root `Query` type.
+ * * When using the first resolver argument (`source` in the example below,
+ *   often also called `parent` or `root`), take care of the fact that field
+ *   resolvers can be called more than once in a query, e.g. when the field is
+ *   present both in the input filter and in the selection set. This means that
+ *   foreign-key fields on `source` can be either resolved or not-resolved.
+ *
+ * For fuller examples, see [`using-type-definitions`](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-type-definitions).
+ *
  * @param {object} $0
- * @param {GraphQLSchema}: $0.schema Current GraphQL schema
- * @param {function} $0.addResolvers Add custom resolvers to GraphQL field configs
+ * @param {GraphQLSchema} $0.schema Current GraphQL schema
+ * @param {function} $0.createResolvers Add custom resolvers to GraphQL field configs
  * @param {object} $1
- * @param {string} resolvers Resolvers from plugin options in `gatsby-config.js`.
+ * @param {object} $1.resolvers Resolvers from plugin options in `gatsby-config.js`.
  * @example
- * ```js
  * exports.createResolvers = ({ createResolvers }) => {
  *   const resolvers = {
  *     Author: {
  *       fullName: {
  *         resolve: (source, args, context, info) => {
- *           // const { findById } = context.resolvers
  *           return source.firstName + source.lastName
  *         }
  *       },
- *       helloWorld: {
- *         type: `String`,
+ *     },
+ *     Query: {
+ *       allRecentPosts: {
+ *         type: [`BlogPost`]
  *         resolve: (source, args, context, info) => {
- *           return `Hello World`
+ *           const posts = context.nodeModel.getAllNodes({ type: `BlogPost` })
+ *           const recentPosts = posts.filter(
+ *             post => post.publishedAt > Date.UTC(2018, 0 , 1)
+ *           )
+ *           return recentPosts
  *         }
  *       }
  *     }
  *   }
  *   createResolvers(resolvers)
  * }
- * ```
  */
 exports.createResolvers = true
 

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -207,13 +207,13 @@ exports.setFieldsOnGraphQLNodeType = true
  * * New fields will not be available on `filter` and `sort` input types. Extend
  *   types defined with `createTypes` if you need this.
  * * In field configs, types can be referenced as strings.
- * * When extending a field with an existing field resolver, thr original
+ * * When extending a field with an existing field resolver, the original
  *   resolver function is available from `info.originalResolver`.
  * * The `createResolvers` API is called as the last step in schema generation.
- *   Thus, an intermediate schema is made available on the `schema` argument.
+ *   Thus, an intermediate schema is made available on the `schema` property.
  *   In resolver functions themselves, it is recommended to access the final
  *   built schema from `info.schema`.
- * * Gatsby's model layer, including all internal query capabilities, is
+ * * Gatsby's data layer, including all internal query capabilities, is
  *   exposed on `context.nodeModel`. The node store can be queried directly
  *   with `getAllNodes`, `getNodeById` and `getNodesByIds`, while more advanced
  *   queries can be composed with `runQuery`. Note that `runQuery` will call


### PR DESCRIPTION
This is for #11480 

Adds:
* more query tests
* test for merging inferred field types
* some test todos
* added JSdoc

Fixes:
* ensure schema composer has Node interface
* make `noDefaultResolvers: true` mean `addDefaultResolvers: false`
* rebuild with `SitePage` `context` now works correctly. A more general solution for on-demand schema rebuild would still require a bit more work.
* merging nested types in inference: because we now guarantee priority when we have conflicting field names, we have to deal with temporary TypeComposers on nested fields. Also ensure that we honor array depth; and get the nested TC's name from an existing TC, not from createSelector.
* make sorting work (lowercase sort order enum) -- this has triggered another Loki mismatch (it is the same issue with `null` values on indexed fields: the kitchen sink query sorts DESC on `likes`, which sorts `nulls` to the front, and those screw things up. It is good that we know this, and we should find a solution, but it's an edge case. The easiest "fix" for now would be to adjust sort order in kitchen sink query from DESC to ASC and update the snapshot. EDIT: I now did just that.