### PR TITLE
test(gatsby-plugin-twitter): add tests for twitter plugin

### DIFF
--- a/packages/gatsby-plugin-twitter/src/__tests__/__snapshots__/gatsby-browser.js.snap
+++ b/packages/gatsby-plugin-twitter/src/__tests__/__snapshots__/gatsby-browser.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gatsby-plugin-twitter onRouteUpdate injects the twitter script if it hasn't already been injected 1`] = `
+Object {
+  "innerText": "
+    window.twttr = (function(d, s, id) {
+      var js,
+        fjs = d.getElementsByTagName(s)[0],
+        t = window.twttr || {}
+      if (d.getElementById(id)) return t
+      js = d.createElement(s)
+      js.id = id
+      js.src = \\"https://platform.twitter.com/widgets.js\\"
+      fjs.parentNode.insertBefore(js, fjs)
+      t._e = []
+      t.ready = function(f) {
+        t._e.push(f)
+      }
+      return t
+    })(document, \\"script\\", \\"twitter-wjs\\")
+  ",
+  "type": "text/javascript",
+}
+`;

--- a/packages/gatsby-plugin-twitter/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/__tests__/gatsby-browser.js
@@ -1,0 +1,28 @@
+const { onRouteUpdate } = require(`../gatsby-browser`)
+
+describe(`gatsby-plugin-twitter`, () => {
+  describe(`onRouteUpdate`, () => {
+    it(`injects the twitter script if it hasn't already been injected`, () => {
+      const querySelector = jest.spyOn(document, `querySelector`)
+      const createElement = jest.spyOn(document, `createElement`)
+      const getElementsByTagName = jest.spyOn(document, `getElementsByTagName`)
+      const element = {}
+      querySelector.mockReturnValue(true)
+      createElement.mockReturnValueOnce(element)
+      getElementsByTagName.mockReturnValue([{ appendChild: jest.fn() }])
+      global.twttr = { widgets: { load: jest.fn() } }
+      onRouteUpdate()
+      onRouteUpdate()
+      expect(element).toMatchSnapshot()
+      expect(createElement).toHaveBeenCalledTimes(1)
+      expect(global.twttr.widgets.load).toHaveBeenCalledTimes(2)
+    })
+    it(`only injects the twitter script if there is an embedded tweet`, () => {
+      const querySelector = jest.spyOn(document, `querySelector`)
+      querySelector.mockReturnValue(null)
+      global.twttr = { widgets: { load: jest.fn() } }
+      onRouteUpdate()
+      expect(global.twttr.widgets.load).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/gatsby-plugin-twitter/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/gatsby-browser.js
@@ -7,27 +7,27 @@ const injectTwitterScript = () => {
     document.getElementsByTagName(`head`)[0].appendChild(s)
   }
   addJS(`
-          window.twttr = (function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0],
-    t = window.twttr || {};
-  if (d.getElementById(id)) return t;
-  js = d.createElement(s);
-  js.id = id;
-  js.src = "https://platform.twitter.com/widgets.js";
-  fjs.parentNode.insertBefore(js, fjs);
-
-  t._e = [];
-  t.ready = function(f) {
-    t._e.push(f);
-  };
-
-  return t;
-}(document, "script", "twitter-wjs"));
-`)
+    window.twttr = (function(d, s, id) {
+      var js,
+        fjs = d.getElementsByTagName(s)[0],
+        t = window.twttr || {}
+      if (d.getElementById(id)) return t
+      js = d.createElement(s)
+      js.id = id
+      js.src = "https://platform.twitter.com/widgets.js"
+      fjs.parentNode.insertBefore(js, fjs)
+      t._e = []
+      t.ready = function(f) {
+        t._e.push(f)
+      }
+      return t
+    })(document, "script", "twitter-wjs")
+  `)
 }
 
 let injectedTwitterScript = false
-exports.onRouteUpdate = function({ location }) {
+
+exports.onRouteUpdate = () => {
   // If there's an embedded tweet, lazy-load the twitter script (if it hasn't
   // already been loaded), and then run the twitter load function.
   if (document.querySelector(`.twitter-tweet`) !== null) {


### PR DESCRIPTION
## Description
Adding tests for `gatsby-plugin-twitter`.

#### Summary of changes
- Adding test cases to verifiy that onRouteUpdate injects the twitter script when it's necessary.
- Minor refactor to make the injected script easier to read + deleting the unused `location` parameter.

