### PR TITLE
fix(docs): Fix `bound-action-creators` links that weren't redirecting.

### DIFF
--- a/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
+++ b/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
@@ -93,7 +93,7 @@ plus there is a
 [tutorial](/tutorial/part-four/#data-in-gatsby), which
 gives examples. In sum, I created a `gatsby-node.js` file which exports
 `createPages` method using the `createPage` action from
-[`boundActionCreators`](/docs/bound-action-creators/).
+[`boundActionCreators`](/docs/actions/).
 
 This might sound way more complicated than what it is:
 

--- a/docs/blog/2018-01-22-getting-started-gatsby-and-wordpress/index.md
+++ b/docs/blog/2018-01-22-getting-started-gatsby-and-wordpress/index.md
@@ -112,7 +112,7 @@ _.each(result.data.allWordpressPost.edges, edge => {
 })
 ```
 
-The [docs define a Gatsby page](/docs/api-specification/#concepts) as "a site page with a pathname, a template component, and optional graphql query and layout component." See the docs on the [createPage bound action creator](/docs/bound-action-creators/#createPage) and [guide on creating and modifying pages for more detail](/docs/creating-and-modifying-pages/).
+The [docs define a Gatsby page](/docs/api-specification/#concepts) as "a site page with a pathname, a template component, and optional graphql query and layout component." See the docs on the [createPage bound action creator](/docs/actions/#createPage) and [guide on creating and modifying pages for more detail](/docs/creating-and-modifying-pages/).
 
 ##... Take a step back to "templates"
 

--- a/docs/docs/create-source-plugin.md
+++ b/docs/docs/create-source-plugin.md
@@ -77,7 +77,7 @@ exports.sourceNodes = async ({ actions }) => {
 ```
 
 Peruse the [`sourceNodes`](/docs/node-apis/#sourceNodes) and
-[`createNode`](/docs/bound-action-creators/#createNode) docs for detailed
+[`createNode`](/docs/actions/#createNode) docs for detailed
 documentation on implementing those APIs.
 
 But at a high-level, these are the jobs of a source plugin:
@@ -85,7 +85,7 @@ But at a high-level, these are the jobs of a source plugin:
 - Ensure local data is synced with its source and 100% accurate. If your source
   allows you to add an `updatedSince` query (or something similar) you can store
   the last time you fetched data using
-  [`setPluginStatus`](/docs/bound-action-creators/#setPluginStatus).
+  [`setPluginStatus`](/docs/actions/#setPluginStatus).
 - Create nodes with accurate media types, human meaningful types, and accurate
   contentDigests.
 - "Link" nodes types you create as appropriate (see

--- a/docs/docs/sourcing-from-wordpress.md
+++ b/docs/docs/sourcing-from-wordpress.md
@@ -92,7 +92,7 @@ _.each(result.data.allWordpressPost.edges, edge => {
 })
 ```
 
-The [docs define a Gatsby page](/docs/api-specification/#concepts) as "a site page with a pathname, a template component, and optional graphql query and layout component." See the docs on the [createPage bound action creator](/docs/bound-action-creators/#createPage) and [guide on creating and modifying pages for more detail](/docs/creating-and-modifying-pages/).
+The [docs define a Gatsby page](/docs/api-specification/#concepts) as "a site page with a pathname, a template component, and optional graphql query and layout component." See the docs on the [createPage bound action creator](/docs/actions/#createPage) and [guide on creating and modifying pages for more detail](/docs/creating-and-modifying-pages/).
 
 ## Wrapping Up
 

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -112,7 +112,7 @@ powerful, as any data you add to nodes is available to query later with GraphQL.
 So it'll be easy to get the slug when it comes time to create the pages.
 
 To do so, you'll use a function passed to our API implementation called
-[`createNodeField`](/docs/bound-action-creators/#createNodeField). This function
+[`createNodeField`](/docs/actions/#createNodeField). This function
 allows you to create additional fields on nodes created by other plugins. Only
 the original creator of a node can directly modify the node—all other plugins
 (including your `gatsby-node.js`) must use this function to create additional


### PR DESCRIPTION
### What does this PR do?

I'm finally getting around to updating my [`gatsby-source-s3-image`] plugin to
support Gatsby V2, I stumbled across a couple dead links pointing to the legacy
V1 docs pages, i.e., links pointing to `/docs/bound-actions-creators/*` rather
than `/docs/actions/*`. While I was at it, I `grep`'d the rest of the docs
folder and found a few more. A couple were in old blog posts; I'm not super keen
on retroactively updating others' prose (especially when they're coming mirrored
from personal blogs, etc.), but IMO it's the lesser evil compared to having the
page 404?

##### (sidebar)
I think this raises a larger question regarding keeping potentially
out-of-date information / links on the site (particularly in the blog), when the
docs themselves aren't versioned. Not a huge deal — the Gatsby V1 =\> V2
migration was obviously exceptional as far as breaking changes go — but may be
worth considering if it comes up again. (I know some projects host legacy
versions of their docs, and indicate when the information you're viewing is
either pre-release or legacy; [`react-native-firebase`] comes to mind, for
example. (see images below)

### Related Issues

That aside, I noticed two other things that could help prevent this kind of
thing as Gatsby continues to grow and mature:

1.  The brute force approach would be to automate checking for dead links as part of the build process; 
    this has in fact been discussed previously in issue #1727. I don't have the
    cycles at the moment to further dig into this, but I'd def be interested in
    taking a stab at it if my schedule frees up. 🙃 Would def be nice to delegate
    the task of checking for dead links to CI haha.

2.  There actually _are_ [redirects defined] to map e.g.
    `bound-actions-creators` routes to `actions` routes, but they only take effect
    on refresh, so you still get the 404 when navigating SPA-style. There's a
    `redirectInBrowser` param in the `createRedirect` action — would this do the
    trick? (Haven't tested myself, but I didn't see the param used in any of the
    other redirects... `¯\_(ツ)_/¯`)

[`gatsby-source-s3-image`]: https://github.com/jessestuart/gatsby-source-s3-image
[`react-native-firebase`]: https://rnfirebase.io/docs/
[redirects defined]: https://github.com/gatsbyjs/gatsby/blob/891e7f47b465107bd6230eb1f221463eb76c5e8e/www/gatsby-node.js#L186-L196

-----------------

![rnfirebase io_docs_v4 3 x_getting-started_with_selector](https://user-images.githubusercontent.com/583147/53600507-bc6e4100-3b77-11e9-9e03-139560879c4e.png)
^ versioned docs... worth the benefits of "immutable" documentation, esp. as Gatsby Inc takes on larger clients that may want to trail a few versions behind, stick to LTS releases, etc? Or too much work to maintain? Just a thought 🙃 