### PR TITLE
test(gatsby-plugin-nprogress): add tests for nprogress plugin

### DIFF
--- a/packages/gatsby-plugin-nprogress/src/__tests__/__snapshots__/gatsby-browser.js.snap
+++ b/packages/gatsby-plugin-nprogress/src/__tests__/__snapshots__/gatsby-browser.js.snap
@@ -1,18 +1,25 @@
-import NProgress from "nprogress"
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-const defaultOptions = { color: `#29d` }
+exports[`gatsby-plugin-nprogress onClientEntry calls NProgress.configure with the correct styles 1`] = `
+Array [
+  Array [
+    Object {
+      "color": "#29d",
+      "showSpinner": false,
+    },
+  ],
+]
+`;
 
-export const onClientEntry = (a, pluginOptions = {}) => {
-  // Merge default options with user defined options in `gatsby-config.js`
-  const options = { ...defaultOptions, ...pluginOptions }
-
-  // Inject styles.
-  const styles = `
+exports[`gatsby-plugin-nprogress onClientEntry calls NProgress.configure with the correct styles 2`] = `
+Object {
+  "id": "nprogress-styles",
+  "innerHTML": "
     #nprogress {
      pointer-events: none;
     }
     #nprogress .bar {
-      background: ${options.color};
+      background: #29d;
       position: fixed;
       z-index: 1031;
       top: 0;
@@ -26,7 +33,7 @@ export const onClientEntry = (a, pluginOptions = {}) => {
       right: 0px;
       width: 100px;
       height: 100%;
-      box-shadow: 0 0 10px ${options.color}, 0 0 5px ${options.color};
+      box-shadow: 0 0 10px #29d, 0 0 5px #29d;
       opacity: 1.0;
       -webkit-transform: rotate(3deg) translate(0px, -4px);
       -ms-transform: rotate(3deg) translate(0px, -4px);
@@ -44,8 +51,8 @@ export const onClientEntry = (a, pluginOptions = {}) => {
       height: 18px;
       box-sizing: border-box;
       border: solid 2px transparent;
-      border-top-color: ${options.color};
-      border-left-color: ${options.color};
+      border-top-color: #29d;
+      border-left-color: #29d;
       border-radius: 50%;
       -webkit-animation: nprogress-spinner 400ms linear infinite;
       animation: nprogress-spinner 400ms linear infinite;
@@ -74,20 +81,6 @@ export const onClientEntry = (a, pluginOptions = {}) => {
         transform: rotate(360deg);
       }
     }
-  `
-
-  const node = document.createElement(`style`)
-  node.id = `nprogress-styles`
-  node.innerHTML = styles
-  document.head.appendChild(node)
-
-  NProgress.configure(options)
+  ",
 }
-
-export const onRouteUpdateDelayed = () => {
-  NProgress.start()
-}
-
-export const onRouteUpdate = () => {
-  NProgress.done()
-}
+`;

--- a/packages/gatsby-plugin-nprogress/src/__tests__/__snapshots__/gatsby-browser.js.snap
+++ b/packages/gatsby-plugin-nprogress/src/__tests__/__snapshots__/gatsby-browser.js.snap
@@ -1,20 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`gatsby-plugin-nprogress onClientEntry calls NProgress.configure with the correct styles 1`] = `
-Array [
-  Array [
-    Object {
-      "color": "#29d",
-      "showSpinner": false,
-    },
-  ],
-]
-`;
-
-exports[`gatsby-plugin-nprogress onClientEntry calls NProgress.configure with the correct styles 2`] = `
-Object {
-  "id": "nprogress-styles",
-  "innerHTML": "
+"
     #nprogress {
      pointer-events: none;
     }
@@ -81,6 +68,5 @@ Object {
         transform: rotate(360deg);
       }
     }
-  ",
-}
+  "
 `;

--- a/packages/gatsby-plugin-nprogress/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-nprogress/src/__tests__/gatsby-browser.js
@@ -1,11 +1,11 @@
+jest.mock(`nprogress`)
+
 import NProgress from "nprogress"
 import {
   onClientEntry,
   onRouteUpdateDelayed,
   onRouteUpdate,
 } from "../gatsby-browser"
-
-jest.mock(`nprogress`)
 
 describe(`gatsby-plugin-nprogress`, () => {
   describe(`onClientEntry`, () => {
@@ -16,16 +16,24 @@ describe(`gatsby-plugin-nprogress`, () => {
       createElement.mockReturnValue(element)
       appendChild.mockReturnValue(true)
       NProgress.configure = jest.fn()
+
       onClientEntry(null, { showSpinner: false })
-      expect(NProgress.configure.mock.calls).toMatchSnapshot()
-      expect(element).toMatchSnapshot()
+
+      expect(element.id).toEqual(`nprogress-styles`)
+      expect(element.innerHTML).toMatchSnapshot()
+      expect(NProgress.configure).toHaveBeenCalledWith({
+        color: `#29d`,
+        showSpinner: false,
+      })
     })
   })
 
   describe(`onRouteUpdateDelayed`, () => {
     it(`calls NProgress.start`, () => {
       NProgress.start = jest.fn()
+
       onRouteUpdateDelayed()
+
       expect(NProgress.start).toHaveBeenCalledTimes(1)
     })
   })
@@ -33,7 +41,9 @@ describe(`gatsby-plugin-nprogress`, () => {
   describe(`onRouteUpdate`, () => {
     it(`calls NProgress.done`, () => {
       NProgress.done = jest.fn()
+
       onRouteUpdate()
+
       expect(NProgress.done).toHaveBeenCalledTimes(1)
     })
   })

--- a/packages/gatsby-plugin-nprogress/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-nprogress/src/__tests__/gatsby-browser.js
@@ -1,0 +1,40 @@
+import NProgress from "nprogress"
+import {
+  onClientEntry,
+  onRouteUpdateDelayed,
+  onRouteUpdate,
+} from "../gatsby-browser"
+
+jest.mock(`nprogress`)
+
+describe(`gatsby-plugin-nprogress`, () => {
+  describe(`onClientEntry`, () => {
+    it(`calls NProgress.configure with the correct styles`, () => {
+      const element = {}
+      const createElement = jest.spyOn(document, `createElement`)
+      const appendChild = jest.spyOn(document.head, `appendChild`)
+      createElement.mockReturnValue(element)
+      appendChild.mockReturnValue(true)
+      NProgress.configure = jest.fn()
+      onClientEntry(null, { showSpinner: false })
+      expect(NProgress.configure.mock.calls).toMatchSnapshot()
+      expect(element).toMatchSnapshot()
+    })
+  })
+
+  describe(`onRouteUpdateDelayed`, () => {
+    it(`calls NProgress.start`, () => {
+      NProgress.start = jest.fn()
+      onRouteUpdateDelayed()
+      expect(NProgress.start).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe(`onRouteUpdate`, () => {
+    it(`calls NProgress.done`, () => {
+      NProgress.done = jest.fn()
+      onRouteUpdate()
+      expect(NProgress.done).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
## Description
Adding tests for `gatsby-plugin-nprogress`. 

#### Summary of changes
- Verifies that onClientEntry calls NProgress.configure with the correct styles
- Verifies that onRouteUpdateDelayed calls NProgress.start
- Verifies that onRouteUpdate calls NProgress.done
- Minor refactor, `export const` instead of `exports.` to keep this consistent throughout the package 