### PR TITLE
[schema] Add default page dependency path

### DIFF
--- a/examples/using-type-definitions/gatsby-node.js
+++ b/examples/using-type-definitions/gatsby-node.js
@@ -26,12 +26,9 @@ exports.createResolvers = ({ createResolvers }) => {
       allAuthorFullNames: {
         type: [`String!`],
         resolve(source, args, context, info) {
-          const authors = context.nodeModel.getAllNodes(
-            {
-              type: `AuthorJson`,
-            },
-            { path: context.path }
-          )
+          const authors = context.nodeModel.getAllNodes({
+            type: `AuthorJson`,
+          })
           return authors.map(author => `${author.name}, ${author.firstName}`)
         },
       },
@@ -39,14 +36,11 @@ exports.createResolvers = ({ createResolvers }) => {
       allPostsTaggedWithBaz: {
         type: [`BlogJson`],
         resolve(source, args, context, info) {
-          return context.nodeModel.runQuery(
-            {
-              query: { filter: { tags: { eq: `baz` } } },
-              type: `BlogJson`,
-              firstOnly: false,
-            },
-            { path: context.path }
-          )
+          return context.nodeModel.runQuery({
+            query: { filter: { tags: { eq: `baz` } } },
+            type: `BlogJson`,
+            firstOnly: false,
+          })
         },
       },
     },
@@ -60,12 +54,9 @@ exports.createResolvers = ({ createResolvers }) => {
           // We use an author's `email` as foreign key in `BlogJson.authors`
           const fieldValue = source.email
 
-          const posts = context.nodeModel.getAllNodes(
-            {
-              type: `BlogJson`,
-            },
-            { path: context.path }
-          )
+          const posts = context.nodeModel.getAllNodes({
+            type: `BlogJson`,
+          })
           return posts.filter(post =>
             (post.authors || []).some(author => author === fieldValue)
           )
@@ -79,12 +70,9 @@ exports.createResolvers = ({ createResolvers }) => {
           const emails = source[info.fieldName]
           if (emails == null) return null
 
-          const authors = context.nodeModel.getAllNodes(
-            {
-              type: `AuthorJson`,
-            },
-            { path: context.path }
-          )
+          const authors = context.nodeModel.getAllNodes({
+            type: `AuthorJson`,
+          })
           return authors.filter(author => emails.includes(author.email))
         },
       },

--- a/examples/using-type-definitions/package.json
+++ b/examples/using-type-definitions/package.json
@@ -10,7 +10,6 @@
     "gatsby-source-filesystem": "^2.0.13",
     "gatsby-transformer-json": "^2.1.7",
     "gatsby-transformer-sharp": "^2.1.8",
-    "graphql": "0.13.2",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",

--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -5,7 +5,7 @@ require(`../../db/__tests__/fixtures/ensure-loki`)()
 const nodes = require(`./fixtures/node-model`)
 
 describe(`Build schema`, () => {
-  let schema
+  // let schema
 
   beforeEach(async () => {
     store.dispatch({ type: `DELETE_CACHE` })
@@ -14,7 +14,7 @@ describe(`Build schema`, () => {
     )
 
     await build({})
-    schema = store.getState().schema
+    // schema = store.getState().schema
   })
 
   describe(`createTypes action`, () => {

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -130,7 +130,6 @@ describe(`Query schema`, () => {
       store.dispatch({ type: `CREATE_TYPES`, payload: def })
     )
 
-    debugger
     await build({})
     schema = store.getState().schema
   })

--- a/packages/gatsby/src/schema/context.js
+++ b/packages/gatsby/src/schema/context.js
@@ -6,7 +6,12 @@ const withResolverContext = (context, schema) => {
 
   return {
     ...context,
-    nodeModel: new LocalNodeModel({ nodeStore, schema, createPageDependency }),
+    nodeModel: new LocalNodeModel({
+      nodeStore,
+      schema,
+      createPageDependency,
+      path: context.path,
+    }),
   }
 }
 

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -31,10 +31,11 @@ export interface NodeModel {
 }
 
 class LocalNodeModel {
-  constructor({ schema, nodeStore, createPageDependency }) {
+  constructor({ schema, nodeStore, createPageDependency, path }) {
     this.schema = schema
     this.nodeStore = nodeStore
     this.createPageDependency = createPageDependency
+    this.path = path
   }
 
   getNodeById(args, pageDependencies) {
@@ -54,7 +55,7 @@ class LocalNodeModel {
 
     return trackPageDependencies(
       result,
-      pageDependencies,
+      { path: this.path, ...pageDependencies },
       this.createPageDependency
     )
   }
@@ -76,7 +77,7 @@ class LocalNodeModel {
 
     return trackPageDependencies(
       result,
-      pageDependencies,
+      { path: this.path, ...pageDependencies },
       this.createPageDependency
     )
   }
@@ -98,7 +99,7 @@ class LocalNodeModel {
 
     return trackPageDependencies(
       result,
-      pageDependencies,
+      { path: this.path, ...pageDependencies },
       this.createPageDependency
     )
   }
@@ -143,7 +144,7 @@ class LocalNodeModel {
 
     return trackPageDependencies(
       result,
-      pageDependencies,
+      { path: this.path, ...pageDependencies },
       this.createPageDependency
     )
   }
@@ -187,7 +188,7 @@ const trackPageDependencies = (
   pageDependencies,
   createPageDependency
 ) => {
-  const { path, connectionType } = pageDependencies || {}
+  const { path, connectionType } = pageDependencies
   if (path) {
     if (connectionType) {
       createPageDependency({ path, connection: connectionType })


### PR DESCRIPTION
Currently, users of `context.nodeModel` methods are required to provide page dependency information manually. This still works, but this PR adds `context.path` as the default path, so providing page dependency info becomes optional. (Luckily, we instantiate a new `LocalNodeModel` everytime a field resolver is called!) When field resolvers are called in the "prepare nodes for query" step, no path information is added.