### PR TITLE
chore(docs): fix typo in centralizing-your-sites-navigation

### DIFF
--- a/docs/docs/centralizing-your-sites-navigation.md
+++ b/docs/docs/centralizing-your-sites-navigation.md
@@ -231,7 +231,7 @@ const Header = ({ siteTitle, menuLinks }) => (
 )
 ```
 
-The `siteTitle` and `menuLinks` arguments are de-structered es6 syntax for quickly accessing an objects inner properties. It is functionally equivalent to writing `object.siteTitle` or `object.menuLinks`.
+The `siteTitle` and `menuLinks` arguments are de-structured es6 syntax for quickly accessing an objects inner properties. It is functionally equivalent to writing `object.siteTitle` or `object.menuLinks`.
 
 You can now access the header component's props and map the `menuLinks` array into elements that can be rendered in the document:
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

fix typo `de-structered` -> `de-structured`

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
