### PR TITLE
fix(docs): fix Heroku Node.js buildpack name

### DIFF
--- a/docs/docs/deploying-to-heroku.md
+++ b/docs/docs/deploying-to-heroku.md
@@ -22,7 +22,7 @@ Set the `heroku/node.js` and `heroku-buildpack-static` buildpacks on your applic
 Sometimes specifying buildpacks via the `app.json` file doesn’t work. If this is your case, try to add them in the Heroku dashboard or via the CLI with the following commands:
 
 ```sh
-$ heroku buildpacks:set heroku/node
+$ heroku buildpacks:set heroku/nodejs
 $ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-static.git
 ```
 


### PR DESCRIPTION
Does what it says on the tin :)