### PR TITLE
Improvements to plugin authoring docs based on interview

### DIFF
--- a/docs/docs/creating-a-transformer-plugin.md
+++ b/docs/docs/creating-a-transformer-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: Create a Transformer Plugin
+title: Creating a Transformer Plugin
 ---
 
 There are two types of plugins that work within Gatsby's data system, "source"
@@ -12,8 +12,8 @@ and "transformer" plugins.
 
 The purpose of this doc is to:
 
-1. Define what a Gatsby transformer plugin is, and
-2. Walk through a simplified reimplementation of an existing plugin, to demonstrate how to create a transformer plugin.
+1.  Define what a Gatsby transformer plugin is, and
+2.  Walk through a simplified reimplementation of an existing plugin, to demonstrate how to create a transformer plugin.
 
 ## What do transformer plugins do?
 

--- a/docs/docs/how-plugins-work.md
+++ b/docs/docs/how-plugins-work.md
@@ -1,5 +1,5 @@
 ---
-title: Plugin authoring
+title: How Plugins Work
 ---
 
 You may be looking to build a plugin that doesn't exist yet, or you may just be curious to know more about the anatomy of a Gatsby plugin. We'll review:

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -213,6 +213,24 @@ exports.createPages = ({ graphql, actions, reporter }) => {
     isPermanent: true,
   })
 
+  createRedirect({
+    fromPath: `/docs/create-source-plugin/`,
+    toPath: `/docs/creating-a-source-plugin/`,
+    isPermanent: true,
+  })
+
+  createRedirect({
+    fromPath: `/docs/create-transformer-plugin/`,
+    toPath: `/docs/creating-a-transformer-plugin/`,
+    isPermanent: true,
+  })
+
+  createRedirect({
+    fromPath: `/docs/plugin-authoring/`,
+    toPath: `/docs/how-plugins-work/`,
+    isPermanent: true,
+  })
+
   Object.entries(startersRedirects).forEach(([fromSlug, toSlug]) => {
     createRedirect({
       fromPath: `/starters${fromSlug}`,

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -137,12 +137,12 @@
     - title: Plugins
       link: /docs/plugins/
       items:
-        - title: Plugin Authoring
-          link: /docs/plugin-authoring/
-        - title: Create a Transformer Plugin
-          link: /docs/create-transformer-plugin/
-        - title: Create a Source Plugin
-          link: /docs/create-source-plugin/
+        - title: How Plugins Work
+          link: /docs/how-plugins-work/
+        - title: Creating a Transformer Plugin
+          link: /docs/creating-a-transformer-plugin/
+        - title: Creating a Source Plugin
+          link: /docs/creating-a-source-plugin/
         - title: Source Plugin Tutorial
           link: /docs/source-plugin-tutorial/
     - title: Starters


### PR DESCRIPTION
## Description

Hey @marcysutton @kyleamathews @jlengstorf here are some improvements I thought might make the plugin docs slightly easier to scan, since we've seen thru interviews that people aren't finding the gems in these docs. I think the new titles and the ToC in creating a source plugin doc could still be improved. The ToC kind of reveals that maybe the whole structure and purpose of that doc could be refined--what do ya'll think?

## Related Issues

See issue #12230 for more complete list of proposed changes. This is a small subset
