### PR TITLE
Move diagram above card and change explanatory text

### DIFF
--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -250,25 +250,30 @@ const Diagram = () => (
           borderRadius: presets.radiusLg,
           fontFamily: options.headerFontFamily.join(`,`),
           padding: vP,
-          marginTop: rhythm(1),
           textAlign: `center`,
           borderTopLeftRadius: 0,
           borderTopRightRadius: 0,
           flex: `1 1 100%`,
           borderTop: `1px solid ${colors.ui.light}`,
-          [presets.Tablet]: {
-            marginTop: 0,
-          },
         }}
       >
-        <h1 css={{ marginBottom: rhythm(1.5), ...scale(0.9) }}>
+        <h1
+          css={{
+            marginTop: rhythm(1 / 4),
+            marginBottom: rhythm(3 / 4),
+            ...scale(0.9),
+            [presets.Tablet]: {
+              marginTop: rhythm(1),
+              marginBottom: rhythm(1.5),
+            },
+          }}
+        >
           How Gatsby works
         </h1>
         <div css={{ maxWidth: rhythm(20), margin: `0 auto ${rhythm(2)}` }}>
           <FuturaParagraph>
-            Gatsby lets you build blazing fast sites with <em>your data</em>,
-            whatever the source. Liberate your sites from legacy CMSs and fly
-            into the future.
+            Gatsby is a free and open source framework based on React for
+            building blazing fast websites and apps
           </FuturaParagraph>
         </div>
 

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -13,7 +13,7 @@ const MastheadContent = () => (
     css={{
       display: `flex`,
       padding: vP,
-      paddingTop: rhythm(5),
+      paddingTop: rhythm(4),
       paddingBottom: rhythm(1),
       flexGrow: `0`,
       flexShrink: `1`,

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -127,6 +127,7 @@ class IndexRoute extends React.Component {
                 }}
               >
                 <Cards>
+                  <Diagram />
                   <Card>
                     <CardHeadline>
                       Modern web tech without the headache
@@ -199,7 +200,6 @@ class IndexRoute extends React.Component {
                       delivered instantly to your users wherever they are.
                     </FuturaParagraph>
                   </Card>
-                  <Diagram />
                   <div css={{ flex: `1 1 100%` }}>
                     <Container hasSideBar={false}>
                       <div


### PR DESCRIPTION
We couldn't fit the newly written text at the top pending a redesign of
the masthead but since we also wanted to move the diagram to the top, we
replaced its subheader with our new one.

<img width="399" alt="screenshot 2019-03-01 18 16 36" src="https://user-images.githubusercontent.com/71047/53675763-98316380-3c4e-11e9-9c0e-68dde48be58f.png">
