### PR TITLE
feat(gatsby-plugin-sitemap): create sitemap index

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -63,3 +63,28 @@ plugins: [
   }
 ]
 ```
+
+## Sitemap Index
+
+We also support generating `sitemap index`.
+
+- [Split up your large sitemaps](https://support.google.com/webmasters/answer/75712?hl=en)
+- [Using Sitemap index files (to group multiple sitemap files)](https://www.sitemaps.org/protocol.html#index)
+
+```javascript
+// In your gatsby-config.js
+siteMetadata: {
+  siteUrl: `https://www.example.com`,
+},
+plugins: [
+  {
+    resolve: `gatsby-plugin-sitemap`,
+    options: {
+      sitemapSize: 5000
+    }
+  }
+]
+```
+
+Above is the minimal configuration to split large sitemap.
+When number of URL in sitemap is more than 5000 plugin will create sitemap (e.g. `sitemap-0.xml`, `sitemap-1.xml`) and index (e.g. `sitemap.xml`) files.

--- a/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -14,3 +14,11 @@ exports[`Test plugin sitemap default settings work properly 1`] = `
 <url> <loc>http://dummy.url/page-2</loc> <changefreq>daily</changefreq> <priority>0.7</priority> </url>
 </urlset>"
 `;
+
+exports[`Test plugin sitemap sitemap index set sitempa size and urls are less than it. 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:news=\\"http://www.google.com/schemas/sitemap-news/0.9\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\" xmlns:mobile=\\"http://www.google.com/schemas/sitemap-mobile/1.0\\" xmlns:image=\\"http://www.google.com/schemas/sitemap-image/1.1\\" xmlns:video=\\"http://www.google.com/schemas/sitemap-video/1.1\\">
+<url> <loc>http://dummy.url/page-1</loc> <changefreq>daily</changefreq> <priority>0.7</priority> </url>
+<url> <loc>http://dummy.url/page-2</loc> <changefreq>daily</changefreq> <priority>0.7</priority> </url>
+</urlset>"
+`;

--- a/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test plugin sitemap custom query runs 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:news=\\"http://www.google.com/schemas/sitemap-news/0.9\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\" xmlns:mobile=\\"http://www.google.com/schemas/sitemap-mobile/1.0\\" xmlns:image=\\"http://www.google.com/schemas/sitemap-image/1.1\\" xmlns:video=\\"http://www.google.com/schemas/sitemap-video/1.1\\">
+<url> <loc>http://dummy.url/post/page-1</loc> <changefreq>weekly</changefreq> <priority>0.8</priority> </url>
+</urlset>"
+`;
+
+exports[`Test plugin sitemap default settings work properly 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:news=\\"http://www.google.com/schemas/sitemap-news/0.9\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\" xmlns:mobile=\\"http://www.google.com/schemas/sitemap-mobile/1.0\\" xmlns:image=\\"http://www.google.com/schemas/sitemap-image/1.1\\" xmlns:video=\\"http://www.google.com/schemas/sitemap-video/1.1\\">
+<url> <loc>http://dummy.url/page-1</loc> <changefreq>daily</changefreq> <priority>0.7</priority> </url>
+<url> <loc>http://dummy.url/page-2</loc> <changefreq>daily</changefreq> <priority>0.7</priority> </url>
+</urlset>"
+`;

--- a/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Adds <Link> for site to head creates Link href with path prefix when __PATH_PREFIX__ sets 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        <link
+          href="/hogwarts/sitemap.xml"
+          rel="sitemap"
+          type="application/xml"
+        />,
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Adds <Link> for site to head creates Link if createLinkInHead is true 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        <link
+          href="/sitemap.xml"
+          rel="sitemap"
+          type="application/xml"
+        />,
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Adds <Link> for site to head does not create Link if createLinkInHead is false 1`] = `[MockFunction]`;

--- a/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
@@ -1,0 +1,101 @@
+const path = require(`path`)
+const { onPostBuild } = require(`../gatsby-node`)
+const internals = require(`../internals`)
+const pathPrefix = ``
+
+describe(`Test plugin sitemap`, async () => {
+  it(`default settings work properly`, async () => {
+    internals.writeFile = jest.fn()
+    internals.writeFile.mockResolvedValue(true)
+    const graphql = jest.fn()
+    graphql.mockResolvedValue({
+      data: {
+        site: {
+          siteMetadata: {
+            siteUrl: `http://dummy.url/`,
+          },
+        },
+        allSitePage: {
+          edges: [
+            {
+              node: {
+                path: `page-1`,
+              },
+            },
+            {
+              node: {
+                path: `page-2`,
+              },
+            },
+          ],
+        },
+      },
+    })
+    await onPostBuild({ graphql, pathPrefix }, {})
+    const [filePath, contents] = internals.writeFile.mock.calls[0]
+    expect(filePath).toEqual(path.join(`public`, `sitemap.xml`))
+    expect(contents).toMatchSnapshot()
+  })
+  it(`custom query runs`, async () => {
+    internals.writeFile = jest.fn()
+    internals.writeFile.mockResolvedValue(true)
+    const graphql = jest.fn()
+    graphql.mockResolvedValue({
+      data: {
+        site: {
+          siteMetadata: {
+            siteUrl: `http://dummy.url/`,
+          },
+        },
+        allSitePage: {
+          edges: [
+            {
+              node: {
+                path: `page-1`,
+              },
+            },
+            {
+              node: {
+                path: `/post/exclude-page`,
+              },
+            },
+          ],
+        },
+      },
+    })
+    const customQuery = `
+      {
+        site {
+          siteMetadata {
+            siteUrl
+          }
+        }
+
+        allSitePage {
+          edges {
+            node {
+              path
+            }
+          }
+        } 
+    }`
+    const options = {
+      output: `custom-sitemap.xml`,
+      serialize: ({ site, allSitePage }) =>
+        allSitePage.edges.map(edge => {
+          return {
+            url: site.siteMetadata.siteUrl + `post/` + edge.node.path,
+            changefreq: `weekly`,
+            priority: 0.8,
+          }
+        }),
+      exclude: [`/post/exclude-page`],
+      query: customQuery,
+    }
+    await onPostBuild({ graphql, pathPrefix }, options)
+    const [filePath, contents] = internals.writeFile.mock.calls[0]
+    expect(filePath).toEqual(path.join(`public`, `custom-sitemap.xml`))
+    expect(contents).toMatchSnapshot()
+    expect(graphql).toBeCalledWith(customQuery)
+  })
+})

--- a/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-ssr.js
@@ -1,0 +1,67 @@
+const { onRenderBody } = require(`../gatsby-ssr`)
+
+const defaultPathPrefix = global.__PATH_PREFIX__
+
+describe(`Adds <Link> for site to head`, () => {
+  beforeEach(() => {
+    global.__PATH_PREFIX__ = ``
+  })
+
+  afterEach(() => {
+    global.__PATH_PREFIX__ = defaultPathPrefix
+  })
+
+  it(`creates Link if createLinkInHead is true`, async () => {
+    const pluginOptions = {
+      createLinkInHead: true,
+      output: `sitemap.xml`,
+    }
+    const setHeadComponents = jest.fn()
+
+    await onRenderBody(
+      {
+        setHeadComponents,
+      },
+      pluginOptions
+    )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(1)
+  })
+  it(`does not create Link if createLinkInHead is false`, async () => {
+    const pluginOptions = {
+      createLinkInHead: false,
+      output: `sitemap.xml`,
+    }
+    const setHeadComponents = jest.fn()
+
+    await onRenderBody(
+      {
+        setHeadComponents,
+      },
+      pluginOptions
+    )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(0)
+  })
+  it(`creates Link href with path prefix when __PATH_PREFIX__ sets`, async () => {
+    global.__PATH_PREFIX__ = `/hogwarts`
+
+    const pluginOptions = {
+      createLinkInHead: true,
+      output: `sitemap.xml`,
+    }
+    const setHeadComponents = jest.fn()
+
+    await onRenderBody(
+      {
+        setHeadComponents,
+      },
+      pluginOptions
+    )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -42,10 +42,10 @@ exports.onPostBuild = async ({ graphql, pathPrefix }, pluginOptions) => {
   )
   const urls = serialize(queryRecords)
 
-  if (!(rest.sitemapSize && urls.length > rest.sitemapSize)) {
+  if (!rest.sitemapSize || urls.length <= rest.sitemapSize) {
     const map = sitemap.createSitemap(rest)
     serialize(queryRecords).forEach(u => map.add(u))
-    return await writeFile(saved, map.toString())
+    return writeFile(saved, map.toString())
   } else {
     const {
       site: {
@@ -60,12 +60,11 @@ exports.onPostBuild = async ({ graphql, pathPrefix }, pluginOptions) => {
       )
       const sitemapIndexOptions = {
         ...rest,
-        ...{
           hostname: hostname || withoutTrailingSlash(siteUrl),
           targetFolder: distDir,
           urls,
           callback: error => {
-            if (error) reject()
+            if (error) throw new Error(error)
             renameFile(indexFilePath, saved).then(resolve)
           },
         },

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -44,32 +44,31 @@ exports.onPostBuild = async ({ graphql, pathPrefix }, pluginOptions) => {
 
   if (!rest.sitemapSize || urls.length <= rest.sitemapSize) {
     const map = sitemap.createSitemap(rest)
-    serialize(queryRecords).forEach(u => map.add(u))
+    urls.forEach(u => map.add(u))
     return writeFile(saved, map.toString())
-  } else {
-    const {
-      site: {
-        siteMetadata: { siteUrl },
-      },
-    } = queryRecords
-    return new Promise((resolve, reject) => {
-      // sitemapv-index.xml is default file name. (https://git.io/fhNgG)
-      const indexFilePath = path.join(
-        distDir,
-        `${rest.sitemapName || `sitemap`}-index.xml`
-      )
-      const sitemapIndexOptions = {
-        ...rest,
-          hostname: hostname || withoutTrailingSlash(siteUrl),
-          targetFolder: distDir,
-          urls,
-          callback: error => {
-            if (error) throw new Error(error)
-            renameFile(indexFilePath, saved).then(resolve)
-          },
-        },
-      }
-      sitemap.createSitemapIndex(sitemapIndexOptions)
-    })
   }
+
+  const {
+    site: {
+      siteMetadata: { siteUrl },
+    },
+  } = queryRecords
+  return new Promise(resolve => {
+    // sitemapv-index.xml is default file name. (https://git.io/fhNgG)
+    const indexFilePath = path.join(
+      distDir,
+      `${rest.sitemapName || `sitemap`}-index.xml`
+    )
+    const sitemapIndexOptions = {
+      ...rest,
+      hostname: hostname || withoutTrailingSlash(siteUrl),
+      targetFolder: distDir,
+      urls,
+      callback: error => {
+        if (error) throw new Error(error)
+        renameFile(indexFilePath, saved).then(resolve)
+      },
+    }
+    sitemap.createSitemapIndex(sitemapIndexOptions)
+  })
 }

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -15,21 +15,12 @@ exports.onPostBuild = async ({ graphql, pathPrefix }, pluginOptions) => {
   delete options.plugins
   delete options.createLinkInHead
 
-  const {
-    query,
-    serialize,
-    output,
-    exclude,
-    hostname,
-    targetFolder,
-    ...rest
-  } = {
+  const { query, serialize, output, exclude, hostname, ...rest } = {
     ...defaultOptions,
     ...options,
   }
 
-  const distDir = targetFolder || publicPath
-  const saved = path.join(distDir, output)
+  const saved = path.join(publicPath, output)
 
   // Paths we're excluding...
   const excludeOptions = exclude.concat(defaultOptions.exclude)
@@ -56,13 +47,13 @@ exports.onPostBuild = async ({ graphql, pathPrefix }, pluginOptions) => {
   return new Promise(resolve => {
     // sitemapv-index.xml is default file name. (https://git.io/fhNgG)
     const indexFilePath = path.join(
-      distDir,
+      publicPath,
       `${rest.sitemapName || `sitemap`}-index.xml`
     )
     const sitemapIndexOptions = {
       ...rest,
       hostname: hostname || withoutTrailingSlash(siteUrl),
-      targetFolder: distDir,
+      targetFolder: publicPath,
       urls,
       callback: error => {
         if (error) throw new Error(error)

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -2,10 +2,11 @@ import fs from "fs"
 import pify from "pify"
 import minimatch from "minimatch"
 
-const withoutTrailingSlash = path =>
+export const withoutTrailingSlash = path =>
   path === `/` ? path : path.replace(/\/$/, ``)
 
 export const writeFile = pify(fs.writeFile)
+export const renameFile = pify(fs.rename)
 
 export const runQuery = (handler, query, excludes, pathPrefix) =>
   handler(query).then(r => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Now `gatsby-plugin-sitemap` can not create [sitemap index](https://github.com/ekalinin/sitemap.js#example-of-sitemap-index).
This PR allow us to create it by passing additional option to that plugin.

Also this plugin did not have any tests so I added them.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

#12100 

## Details

```javascript
// In your gatsby-config.js
siteMetadata: {
  siteUrl: `https://www.example.com`,
},
plugins: [
  {
    resolve: `gatsby-plugin-sitemap`,
    options: {
      sitemapSize: 5000
    }
  }
]
```

Above is the minimal configuration to split large sitemap.
When number of URL in sitemap is more than 5000 plugin will create sitemap (e.g. `sitemap-0.xml`, `sitemap-1.xml`) and index (e.g. `sitemap.xml`) files.
