### PR TITLE
chore(docs): Unstub js-search page

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -213,7 +213,7 @@
               link: /docs/adding-search-with-algolia/
             - title: Adding Search with elasticlunr*
               link: /docs/adding-search-with-elasticlunr/
-            - title: Adding Search with js-search*
+            - title: Adding Search with js-search
               link: /docs/adding-search-with-js-search/
         - title: Adding Analytics
           link: /docs/adding-analytics/


### PR DESCRIPTION
## Description

the "Adding search with js-search" page is filled in so I am removing the stub in the sidebar