### PR TITLE
fix(www): Edge case layout issue, consistent design for plugin detail header links

### DIFF
--- a/www/src/components/markdown-page-footer.js
+++ b/www/src/components/markdown-page-footer.js
@@ -2,8 +2,8 @@ import React from "react"
 import { graphql } from "gatsby"
 import EditIcon from "react-icons/lib/md/create"
 
-import { rhythm, scale } from "../utils/typography"
-import { colors } from "../utils/presets"
+import { rhythm } from "../utils/typography"
+import { linkStyles } from "../utils/styles"
 
 export default class MarkdownPageFooter extends React.Component {
   constructor() {
@@ -17,28 +17,14 @@ export default class MarkdownPageFooter extends React.Component {
 
         {this.props.page && (
           <a
-            css={{
-              "&&": {
-                display: `block`,
-                color: colors.gray.calm,
-                fontSize: scale(-1 / 5).fontSize,
-                fontWeight: `normal`,
-                border: `none`,
-                boxShadow: `none`,
-                padding: rhythm(1 / 2),
-                "&:hover": {
-                  background: `transparent`,
-                  color: colors.gatsby,
-                },
-              },
-            }}
+            css={{ ...linkStyles }}
             href={`https://github.com/gatsbyjs/gatsby/blob/master/${
               this.props.packagePage ? `packages` : `docs`
             }/${this.props.page ? this.props.page.parent.relativePath : ``}`}
           >
-            <EditIcon css={{ fontSize: 20, position: `relative`, top: -2 }} />
+            <EditIcon css={{ marginRight: `.5rem` }} />
             {` `}
-            edit this page on GitHub
+            Edit this page on GitHub
           </a>
         )}
       </>

--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -3,10 +3,10 @@ import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 
 import { Link } from "gatsby"
-import { colors } from "../utils/presets"
 import Container from "../components/container"
 import MarkdownPageFooter from "../components/markdown-page-footer"
 import GithubIcon from "react-icons/lib/go/mark-github"
+import { linkStyles } from "../utils/styles"
 
 const PackageReadMe = props => {
   const { page, packageName, excerpt, html, githubUrl, timeToRead } = props
@@ -23,54 +23,30 @@ const PackageReadMe = props => {
         <meta name="twitter.label1" content="Reading time" />
         <meta name="twitter:data1" content={`${timeToRead} min read`} />
       </Helmet>
-      <div css={{ display: `flex`, justifyContent: `space-between` }}>
+      <div
+        css={{
+          display: `flex`,
+          justifyContent: `space-between`,
+        }}
+      >
         <a
-          css={{
-            "&&": {
-              display: githubUrl ? `flex` : `none`,
-              fontWeight: `normal`,
-              border: 0,
-              color: colors.gray.calm,
-              boxShadow: `none`,
-              alignItems: `center`,
-              "&:hover": {
-                background: `none`,
-                color: colors.gatsby,
-              },
-            },
-          }}
+          css={{ ...linkStyles }}
           href={githubUrl}
           aria-labelledby="github-link-label"
         >
-          <GithubIcon
-            focusable="false"
-            style={{ verticalAlign: `text-top`, marginRight: 10 }}
-          />
-          <span
-            id="github-link-label"
-            css={{
-              "@media screen and (max-width: 385px)": {
-                display: `none`,
-              },
-            }}
-          >
-            View plugin on GitHub
-          </span>
+          <GithubIcon focusable="false" style={{ marginRight: `.5rem` }} />
+          <span id="github-link-label">View plugin on GitHub</span>
         </a>
         {githubUrl && (
-          <Link to={`/starters?d=${packageName}`}>
-            See starters that use this
+          <Link to={`/starters?d=${packageName}`} css={{ ...linkStyles }}>
+            See starters using this
           </Link>
         )}
       </div>
 
       <div
-        css={{
-          position: `relative`,
-        }}
-        dangerouslySetInnerHTML={{
-          __html: html,
-        }}
+        css={{ position: `relative` }}
+        dangerouslySetInnerHTML={{ __html: html }}
       />
       <MarkdownPageFooter page={page} packagePage />
     </Container>

--- a/www/src/utils/styles.js
+++ b/www/src/utils/styles.js
@@ -140,3 +140,20 @@ export const svgStyles = {
     },
   },
 }
+
+// This is an exceptionally bad name
+export const linkStyles = {
+  ...scale(-1 / 6),
+  "&&": {
+    alignItems: `center`,
+    border: 0,
+    boxShadow: `none`,
+    color: colors.gray.calm,
+    display: `flex`,
+    fontWeight: `normal`,
+    "&:hover": {
+      background: `none`,
+      color: colors.gatsby,
+    },
+  },
+}


### PR DESCRIPTION
Follows up on #12126.

Consolidates link styles for „Edit this page on GitHub“, „View plugin on GitHub“, and „See starters using this [plugin]“:

* add `linkStyles` to `src/utils/styles.js`, and use them for the aforementioned links (I really don’t want to do this, but instead create a component … let’s move incrementally and shiiiip ;-))
* reducing font-size and slightly updating the link copy from „See starters that use this“ removed the need for hiding „View plugin on GitHub“ on mobile (tested on 320px wide viewport/~iPhone 5)
* also resolves the edge case issue shown in https://github.com/gatsbyjs/gatsby/pull/12126#pullrequestreview-209893262

![image](https://user-images.githubusercontent.com/21834/53691073-0c672680-3d77-11e9-8bc1-4dd1c7d5a93e.png)