### PR TITLE
Update Gatsby starters LICENSE files to current year

### DIFF
--- a/starters/blog/LICENSE
+++ b/starters/blog/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Gatsbyjs
+Copyright (c) 2019 Gatsbyjs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/starters/default/LICENSE
+++ b/starters/default/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 gatsbyjs
+Copyright (c) 2019 gatsbyjs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/starters/hello-world/LICENSE
+++ b/starters/hello-world/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 gatsbyjs
+Copyright (c) 2019 gatsbyjs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update LICENSE files for all default starters with the current year.

Given that many people still need to go in there and change the entity name anyway, maybe it's not the most important update in the world, but still I think it's better if we at least maintain the current year in the LICENSE file.