### PR TITLE
chore(gatsby-plugin-google-analytics): export class to avoid `declare module` error

### DIFF
--- a/packages/gatsby-plugin-google-analytics/index.d.ts
+++ b/packages/gatsby-plugin-google-analytics/index.d.ts
@@ -4,8 +4,8 @@ interface OutboundLinkProps {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
-class OutboundLink extends React.Component<
+export class OutboundLink extends React.Component<
   OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>,
   any
 > {}
-export { OutboundLink }
+


### PR DESCRIPTION
## Description

Running `tsc` against a project using `gatsby-plugin-google-analytics` throws an error.

``` bash
node_modules/gatsby-plugin-google-analytics/index.d.ts:7:1 - error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.
```

Exporting the class or wrapping in a module would fix the issue.