### PR TITLE
fix(gatsby-plugin-twitter): add back semi-colons to injected script

### DIFF
--- a/packages/gatsby-plugin-twitter/src/__tests__/__snapshots__/gatsby-browser.js.snap
+++ b/packages/gatsby-plugin-twitter/src/__tests__/__snapshots__/gatsby-browser.js.snap
@@ -6,18 +6,18 @@ Object {
     window.twttr = (function(d, s, id) {
       var js,
         fjs = d.getElementsByTagName(s)[0],
-        t = window.twttr || {}
-      if (d.getElementById(id)) return t
-      js = d.createElement(s)
-      js.id = id
-      js.src = \\"https://platform.twitter.com/widgets.js\\"
-      fjs.parentNode.insertBefore(js, fjs)
-      t._e = []
+        t = window.twttr || {};
+      if (d.getElementById(id)) return t;
+      js = d.createElement(s);
+      js.id = id;
+      js.src = \\"https://platform.twitter.com/widgets.js\\";
+      fjs.parentNode.insertBefore(js, fjs);
+      t._e = [];
       t.ready = function(f) {
-        t._e.push(f)
-      }
-      return t
-    })(document, \\"script\\", \\"twitter-wjs\\")
+        t._e.push(f);
+      };
+      return t;
+    })(document, \\"script\\", \\"twitter-wjs\\");
   ",
   "type": "text/javascript",
 }

--- a/packages/gatsby-plugin-twitter/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/gatsby-browser.js
@@ -10,18 +10,18 @@ const injectTwitterScript = () => {
     window.twttr = (function(d, s, id) {
       var js,
         fjs = d.getElementsByTagName(s)[0],
-        t = window.twttr || {}
-      if (d.getElementById(id)) return t
-      js = d.createElement(s)
-      js.id = id
-      js.src = "https://platform.twitter.com/widgets.js"
-      fjs.parentNode.insertBefore(js, fjs)
-      t._e = []
+        t = window.twttr || {};
+      if (d.getElementById(id)) return t;
+      js = d.createElement(s);
+      js.id = id;
+      js.src = "https://platform.twitter.com/widgets.js";
+      fjs.parentNode.insertBefore(js, fjs);
+      t._e = [];
       t.ready = function(f) {
-        t._e.push(f)
-      }
-      return t
-    })(document, "script", "twitter-wjs")
+        t._e.push(f);
+      };
+      return t;
+    })(document, "script", "twitter-wjs");
   `)
 }
 


### PR DESCRIPTION
## Description
Adds back the semi-colors to the injected script that was removed in #12193. As described [here](https://github.com/gatsbyjs/gatsby/pull/12193#issuecomment-469418343) this was causing the twitter embeds not to render.
