### PR TITLE
fix(gatsby): don't delete /404.html during development

### DIFF
--- a/packages/gatsby/src/bootstrap/page-hot-reloader.js
+++ b/packages/gatsby/src/bootstrap/page-hot-reloader.js
@@ -62,7 +62,8 @@ const runCreatePages = async () => {
   Array.from(store.getState().pages.values()).forEach(page => {
     if (
       !_.includes(statefulPlugins, page.pluginCreatorId) &&
-      page.updatedAt < timestamp
+      page.updatedAt < timestamp &&
+      page.path !== `/404.html`
     ) {
       deleteComponentsDependencies([page.path])
       deletePage(page)


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby/issues/12249 — kinda. I was seeing the `/` page get deleted while working on .org but then I wasn't able to reproduce it 🤷‍♂️ 

I could reproduce this so let's fix this in the meantime :-D