### PR TITLE
Use SPDY for local development

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -200,7 +200,13 @@ async function startServer(program) {
 
   // If a SSL cert exists in program, use it with `createServer`.
   if (program.ssl) {
-    server = require(`https`).createServer(program.ssl, app)
+    server = require(`spdy`).createServer(
+      {
+        key: program.ssl.key,
+        cert: program.ssl.cert,
+      },
+      app
+    )
   }
   websocketManager.init({ server, directory: program.directory })
   const socket = websocketManager.getSocket()


### PR DESCRIPTION
## Description

This PR switches local development to use `SPDY` as opposed to HTTPs. This removes the connection limitations imposed by HTTP/1 and allows more than 5 simultaneous tabs open with hot module reloading.

## Related Issues

Fixes: https://github.com/gatsbyjs/gatsby/issues/12225