### PR TITLE
fix(gatsby-starter-blog): Return null in then in gatsby-node

### DIFF
--- a/starters/blog/gatsby-node.js
+++ b/starters/blog/gatsby-node.js
@@ -47,6 +47,8 @@ exports.createPages = ({ graphql, actions }) => {
         },
       })
     })
+
+    return null
   })
 }
 


### PR DESCRIPTION
Fixes a warning from Bluebird about a promise being created and not returned 