### PR TITLE
Allow custom resolveType

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -151,7 +151,9 @@ const processAddedType = ({ schemaComposer, type, parentSpan }) => {
     schemaComposer.addSchemaMustHaveType(typeComposer)
   }
   if (abstractTypeComposer) {
-    abstractTypeComposer.setResolveType(node => node.internal.type)
+    if (!abstractTypeComposer.getResolveType()) {
+      abstractTypeComposer.setResolveType(node => node.internal.type)
+    }
     schemaComposer.addSchemaMustHaveType(abstractTypeComposer)
   }
 }


### PR DESCRIPTION
This is for #11480 

Allow custom `resolveType` when abstract graphql-js types are added with `createTypes` action. This should also allow non-top-level abstract types.