### PR TITLE
docs(www): Fix 'Plugin Authoring' link

### DIFF
--- a/docs/docs/using-gatsby-without-graphql.md
+++ b/docs/docs/using-gatsby-without-graphql.md
@@ -100,7 +100,7 @@ Another difficulty added when working with unstructured data is that your data f
 If you're building a small site, one efficient way to build it is to pull in unstructured data as outlined in this guide, using `createPages` API, and then if the site becomes more complex later on, you move on to building more complex sites, or you'd like to transform your data, follow these steps:
 
 1.  Check out the [Plugin Library](/plugins/) to see if the source plugins and/or transformer plugins you'd like to use already exist
-2.  If they don't exist, read the [Plugin Authoring](/docs/plugin-authoring/) guide and consider building your own!
+2.  If they don't exist, read the [Plugin Authoring](/docs/how-plugins-work/) guide and consider building your own!
 
 ## Further reading
 


### PR DESCRIPTION
## Description
Again, it looks like there is a redirect in place from `/docs/plugin-authoring/` to `/docs/how-plugins-work/`. This works for full page loads, but the link in this page still points to `/docs/plugin-authoring/` which results in a 404 via client side routing.

This change points the 'Plugin Authoring' link to `/docs/how-plugins-work/`