### PR TITLE
fix(www): set item count to 0 when undefined in plugin searchbar

### DIFF
--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -232,6 +232,14 @@ class Search extends Component {
             <Configure analyticsTags={[`gatsby-plugins`]} />
             <RefinementList
               attributeName="keywords"
+              transformItems={items =>
+                items.map(({ count, ...item }) => {
+                  return {
+                    ...item,
+                    count: count || 0,
+                  }
+                })
+              }
               defaultRefinement={[`gatsby-component`, `gatsby-plugin`]}
             />
             <Toggle


### PR DESCRIPTION
## Description

This PR fixes a bug that originates from RefinementList component when item.count is undefined.

## Related Issues

 Fixes #12294 
