### PR TITLE
Adding repository field to gatsy-plugin-page-creator package.json

### DIFF
--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -17,6 +17,7 @@
     "Steven Natera <tektekpush@gmail.com> (https://twitter.com/stevennatera)"
   ],
   "license": "MIT",
+  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
## Description

Added repository field so when seen on the plugin library, it will have the Gatsby logo in the sidebar

## Related Issues

Closes #12317