### PR TITLE
chore(sites): Add mixkit.co to Website Showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4708,3 +4708,17 @@
   built_by: Kirankumar Ambati
   built_by_url: https://github.com/kirankumarambati
   featured: false
+- title: Mixkit by Envato
+  url: https://mixkit.co
+  main_url: https://mixkit.co
+  description: >
+    Extraordinary free HD videos
+  categories:
+    - Video
+    - Art
+    - Design
+    - Gallery
+    - Video
+  built_by: Envato
+  built_by_url: https://github.com/envato
+  featured: false


### PR DESCRIPTION
Over at Envato we just built <a href="https://mixkit.co">mixkit.co</a> using Gatsby + GraphQL + Airtable

It showcases a wide variety of free HD videos that can be used in any project.

![image](https://user-images.githubusercontent.com/543073/53848663-f2407900-4000-11e9-82dc-64c1e2cf9206.png)

(Producthunt product of the month) 

Everyone congratulates gatsby on how fast the website loads. Good job! 