### PR TITLE
fix(starters): update ueno starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1652,16 +1652,23 @@
     - Material UI
     - styled-components
     - Github markdown css support
-- url: https://ueno.co/
+- url: https://create-ueno-app.netlify.com
   repo: https://github.com/ueno-llc/ueno-gatsby-starter
-  description: Ueno's starter template for Gatsby
+  description: Opinionated Gatsby starter by Ueno.
   tags:
     - TypeScript
+    - Styling:SCSS
+    - Linting
+    - Transitions
   features:
     - GraphQL hybrid
     - SEO friendly
     - GSAP ready
-    - Nice devtools
+    - Nice Devtools
+    - GsapTools
+    - Ueno plugins
+    - SVG to React component
+    - Ueno's TSlint
     - Decorators
 - url: https://gatsby-sseon-starter.netlify.com/
   repo: https://github.com/SeonHyungJo/gatsby-sseon-starter


### PR DESCRIPTION
Update metadata and link to [ueno-gatsby-starter](https://github.com/ueno-llc/ueno-gatsby-starter).