### PR TITLE
fix(gatsby-source-filesystem): createRemoteFileNode rejects promise instead resolving on failure

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -123,7 +123,6 @@ async function pushToQueue(task, cb) {
     const node = await processRemoteNode(task)
     return cb(null, node)
   } catch (e) {
-    console.warn(`Failed to process remote content ${task.url}`)
     return cb(e)
   }
 }
@@ -282,8 +281,8 @@ const pushTask = task =>
       .on(`finish`, task => {
         resolve(task)
       })
-      .on(`failed`, () => {
-        resolve()
+      .on(`failed`, err => {
+        reject(`failed to process ${task.url}\n${err}`)
       })
   })
 
@@ -341,9 +340,7 @@ module.exports = ({
   }
 
   if (!url || isWebUri(url) === undefined) {
-    // should we resolve here, or reject?
-    // Technically, it's invalid input
-    return Promise.resolve()
+    return Promise.reject(`wrong url: ${url}`)
   }
 
   totalJobs += 1


### PR DESCRIPTION
## Description

When `createRemoteFileNode` fails to download a remote file (e.g. 404), it returns a rejected Promise, with the error containing the failing URL and the error message, instead of resolving with `undefined` and outputting the error using `console.log`.
Additionally, it also returns a rejected Promise if the requested URL is invalid, instead of resolving with `undefined`.

This is a breaking change: we should inform users that they should catch possible rejections.

## Related Issues

This PR fixes #12280