### PR TITLE
feat(guess): add guess.js to gatsbyjs.org

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -40,6 +40,17 @@ GATSBY_FEEDBACK_KEY_STARTERLIB=ADD_KEY
 
 If there's a problem with the feedback widgets, please open an issue in the repo.
 
+### Enabling guess.js
+
+Guess.js is disabled by default and can be enabled by setting `ANALYTICS_SERVICE_ACCOUNT` and `ANALYTICS_SERVICE_ACCOUNT_KEY` env variables. These variables need to have access to the gatsbyjs.org analytics.
+
+If you have access to the keys, add them like so:
+
+```
+ANALYTICS_SERVICE_ACCOUNT="service account@email.com"
+ANALYTICS_SERVICE_ACCOUNT_KEY="PEM KEY VALUE"
+```
+
 ## Running slow build? (Screenshots placeholder)
 
 If you are not working on starter or site showcase, it might be beneficial to use a placeholder image instead of actual screenshots. It will skip downloading screenshots and generating responsive images for all screenshots and replace them with a placeholder image.

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -2,6 +2,32 @@ require(`dotenv`).config({
   path: `.env.${process.env.NODE_ENV}`,
 })
 
+const GA = {
+  identifier: `UA-93349937-5`,
+  viewId: `142357465`,
+}
+
+const dynamicPlugins = []
+if (process.env.ANALYTICS_SERVICE_ACCOUNT) {
+  // pick data from 3 months ago
+  const startDate = new Date()
+  startDate.setMonth(startDate.getMonth() - 3)
+  dynamicPlugins.push({
+    resolve: `gatsby-plugin-guess-js`,
+    options: {
+      GAViewID: GA.viewId,
+      jwt: {
+        client_email: process.env.ANALYTICS_SERVICE_ACCOUNT,
+        private_key: process.env.ANALYTICS_SERVICE_ACCOUNT_KEY,
+      },
+      period: {
+        startDate,
+        endDate: new Date(),
+      },
+    },
+  })
+}
+
 module.exports = {
   siteMetadata: {
     title: `GatsbyJS`,
@@ -114,7 +140,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        trackingId: `UA-93349937-5`,
+        trackingId: GA.identifier,
         anonymize: true,
       },
     },
@@ -196,16 +222,5 @@ module.exports = {
       },
     },
     `gatsby-plugin-subfont`,
-    // {
-    // resolve: `gatsby-plugin-guess-js`,
-    // options: {
-    // GAViewID: `142357465`,
-    // // The "period" for fetching analytic data.
-    // period: {
-    // startDate: new Date(`2018-1-1`),
-    // endDate: new Date(),
-    // },
-    // },
-    // },
-  ],
+  ].concat(dynamicPlugins),
 }


### PR DESCRIPTION
## Description
Enabling guess.js to gatsbyjs.org. It only works when you enable the service account env variable as you need special gatsby access to get to it so it's disabled by default.

When building the site we need to get the key.pem and service account from somewhere. Service account can be stored inside an env variable. The key file I'm not sure.

## Related Issues
#6591