### PR TITLE
fix(gatsby-plugin-canonical-urls): fix typo in "How to use" section (http -> https)

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/README.md
+++ b/packages/gatsby-plugin-canonical-urls/README.md
@@ -28,5 +28,5 @@ With the above configuration, the plugin will add to the head of every HTML page
 a `rel=canonical` e.g.
 
 ```html
-<link rel="canonical" href="http://www.example.com/about-us/" />
+<link rel="canonical" href="https://www.example.com/about-us/" />
 ```


### PR DESCRIPTION
https://www.gatsbyjs.org/packages/gatsby-plugin-canonical-urls/

## Description

`siteUrl` includes `https` but the sample generated tag has `http` … looks like a minor typo

## Related Issues

(none)