### PR TITLE
`spacebar` is not the right key to adress the spacebar

### DIFF
--- a/examples/gatsbygram/src/components/modal.js
+++ b/examples/gatsbygram/src/components/modal.js
@@ -23,13 +23,13 @@ class GatsbyGramModal extends React.Component {
   componentDidMount() {
     mousetrap.bind(`left`, () => this.previous())
     mousetrap.bind(`right`, () => this.next())
-    mousetrap.bind(`spacebar`, () => this.next())
+    mousetrap.bind(`space`, () => this.next())
   }
 
   componentWillUnmount() {
     mousetrap.unbind(`left`)
     mousetrap.unbind(`right`)
-    mousetrap.unbind(`spacebar`)
+    mousetrap.unbind(`space`)
   }
 
   findCurrentIndex() {


### PR DESCRIPTION
## Description

From the API documentation of `mousetrap` https://craig.is/killing/mice/#keys you will see, the right key is `space`, not `spacebar`.

## Related Issues

No related issues.