### PR TITLE
feat(gatsby-remark-embed-snippet): Add rb support

### DIFF
--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -12,6 +12,7 @@ const FILE_EXTENSION_TO_LANGUAGE_MAP = {
   js: `jsx`,
   md: `markup`,
   sh: `bash`,
+  rb: `ruby`,
 }
 
 const getLanguage = file => {


### PR DESCRIPTION
This tiny change allows the gatsby-remark-embed-snippet plugin to correctly highlight ruby files.

The plugin allows embedding files like:

`embed:myfile.myext`

For many languages, the language name and the extension are the same e.g. .html or .js or .css.

However, for some languages, the extension does not match E.g. for ruby, the extension is `.rb` and the language is `ruby`. In the case where these do not map, the plugin relies on an internal map.

This adds the mapping from .rb to ruby, so that ruby files are highlighted correctly.

## Summary

- Affects only gatsby-remark-embed-snippet plugin
- Added a mapping from rb -> ruby files
- This means files called something.rb will be correctly highlighted as ruby

