### PR TITLE
feat(docs): Stub List page

### DIFF
--- a/docs/contributing/how-to-write-a-stub.md
+++ b/docs/contributing/how-to-write-a-stub.md
@@ -29,3 +29,5 @@ If you create a stub or see an existing one on the Gatsby.js site and feel inter
 
 To change a stub into a living-breathing document, remove the `issue` entry from a stub's frontmatter (a fancy name for Markdown metadata) and replace the boilerplate content with
 your wonderful prose and code. Save the file, commit to GitHub, open a PR, get feedback. Learn more in our page on [docs contributions](/contributing/docs-contributions/).
+
+If you wish to see any of the available stubs, head over to the current [Stub List](/contributing/stub-list/).

--- a/www/src/data/sidebars/contributing-links.yaml
+++ b/www/src/data/sidebars/contributing-links.yaml
@@ -37,6 +37,8 @@
               link: /contributing/docs-templates/
             - title: How to Write a Stub
               link: /contributing/how-to-write-a-stub/
+            - title: Stub List
+              link: /contributing/stub-list/
         - title: Blog & Website Contributions
           link: /contributing/blog-and-website-contributions/
         - title: Code Contributions

--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -14,7 +14,7 @@ function findStubs(pages) {
   let stubs = []
 
   pages.forEach(page => {
-    if (page.link === undefined && page.items !== undefined) {
+    if (page.items !== undefined) {
       // Recurse downwards
       stubs.push(...findStubs(page.items))
     }
@@ -44,11 +44,22 @@ class StubListRoute extends React.Component {
             <h1 id="stublist" css={{ marginTop: 0 }}>
               Stub List
             </h1>
-            <p>Do the thing</p>
+            <p>
+              There are a variety of pages that are currently stubbed out but do
+              not contain any content yet. If you are interested in helping
+              write any of these pages, head to any of them or head over to{` `}
+              <Link to="/contributing/how-to-write-a-stub/">
+                How to Write a Stub
+              </Link>
+              {` `}
+              to learn more.
+            </p>
             <ul>
               {stubs.map(stub => (
                 <li key={stub.title}>
-                  <Link to={stub.link}>{stub.title}</Link>
+                  <Link to={stub.link}>
+                    {stub.title.slice(0, stub.title.length - 1)}
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -57,9 +57,7 @@ class StubListRoute extends React.Component {
             <ul>
               {stubs.map(stub => (
                 <li key={stub.title}>
-                  <Link to={stub.link}>
-                    {stub.title.slice(0, -1)}
-                  </Link>
+                  <Link to={stub.link}>{stub.title.slice(0, -1)}</Link>
                 </li>
               ))}
             </ul>

--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -58,7 +58,7 @@ class StubListRoute extends React.Component {
               {stubs.map(stub => (
                 <li key={stub.title}>
                   <Link to={stub.link}>
-                    {stub.title.slice(0, stub.title.length - 1)}
+                    {stub.title.slice(0, -1)}
                   </Link>
                 </li>
               ))}

--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -1,0 +1,62 @@
+import React from "react"
+import { Link } from "gatsby"
+import { Helmet } from "react-helmet"
+
+import Layout from "../../components/layout"
+import {
+  itemListContributing,
+  itemListDocs,
+} from "../../utils/sidebar/item-list"
+import Container from "../../components/container"
+import DocsearchContent from "../../components/docsearch-content"
+
+function findStubs(pages) {
+  let stubs = []
+
+  pages.forEach(page => {
+    if (page.link === undefined && page.items !== undefined) {
+      // Recurse downwards
+      stubs.push(...findStubs(page.items))
+    }
+
+    if (page.link !== undefined && page.title.indexOf(`*`) !== -1) {
+      // found a page which is a stub
+      stubs.push(page)
+    }
+  })
+
+  return stubs
+}
+
+class StubListRoute extends React.Component {
+  render() {
+    let allPages = [...itemListContributing, ...itemListDocs]
+
+    let stubs = findStubs(allPages)
+
+    return (
+      <Layout location={this.props.location} itemList={itemListContributing}>
+        <DocsearchContent>
+          <Container>
+            <Helmet>
+              <title>Stub List</title>
+            </Helmet>
+            <h1 id="stublist" css={{ marginTop: 0 }}>
+              Stub List
+            </h1>
+            <p>Do the thing</p>
+            <ul>
+              {stubs.map(stub => (
+                <li key={stub.title}>
+                  <Link to={stub.link}>{stub.title}</Link>
+                </li>
+              ))}
+            </ul>
+          </Container>
+        </DocsearchContent>
+      </Layout>
+    )
+  }
+}
+
+export default StubListRoute


### PR DESCRIPTION
## Description

I implemented a new page in the contributing section of the docs to aggregate all of the stubbed files in a single location so people can see any available articles that yet have to be written at a quick glance.

![screenshot_2019-03-08 stub list gatsbyjs](https://user-images.githubusercontent.com/3685876/54048091-c0691700-41a6-11e9-8d92-689a258b5e3d.png)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Closes #12362