### PR TITLE
document reserved words in React context

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -39,7 +39,11 @@ your sites development server at `HOST:PORT/___graphql` e.g.
 }
 ```
 
+The `context` property accepts an object, and we can pass in any data we want the page to be able to access.
+
 You can also query for any `context` data you or plugins added to pages.
+
+> **NOTE:** There are a few reserved names that _cannot_ be used in `context`. They are: `path`, `matchPath`, `component`, `componentChunkName`, `pluginCreator___NODE`, and `pluginCreatorId`.
 
 ## Creating pages in gatsby-node.js
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Documenting limitations with React context, as per the feedback/comments in #11787.

Closes https://github.com/gatsbyjs/gatsby/issues/12423