### PR TITLE
Refactoring benchmark apps

### DIFF
--- a/benchmarks/create-pages/gatsby-node.js
+++ b/benchmarks/create-pages/gatsby-node.js
@@ -1,12 +1,7 @@
-let NUM_PAGES = 5000
-
-if (process.env.NUM_PAGES) {
-  NUM_PAGES = process.env.NUM_PAGES
-}
+const NUM_PAGES = parseInt(process.env.NUM_PAGES || 5000, 10)
 
 exports.createPages = ({ actions: { createPage } }) => {
-  var step
-  for (step = 0; step < NUM_PAGES; step++) {
+  for (let step = 0; step < NUM_PAGES; step++) {
     createPage({
       path: `/path/${step}/`,
       component: require.resolve(`./src/templates/blank.js`),

--- a/benchmarks/markdown/README.md
+++ b/benchmarks/markdown/README.md
@@ -2,7 +2,7 @@
 
 Stress tests creating lots of pages rendered from Markdown.
 
-Defaults to building a site with 5k markdown pages. Set the `NUM_PAGES` environment variable to change that e.g. `NUM_PAGES=25000 gatsby build`
+Defaults to building a site with 5k markdown pages and 25 maximum rows per age. Set the `NUM_PAGES` and `MAX_NUM_ROWS` environment variables to change that e.g. `NUM_PAGES=25000 MAX_NUM_ROWS=100 gatsby build`
 
 # Running the benchmark
 

--- a/benchmarks/markdown/gatsby-node.js
+++ b/benchmarks/markdown/gatsby-node.js
@@ -3,8 +3,7 @@ const template = require(`./page-template`)
 
 exports.sourceNodes = ({ actions: { createNode } }) => {
   // Create markdown nodes
-  let step
-  for (step = 0; step < NUM_PAGES; step++) {
+  for (let step = 0; step < NUM_PAGES; step++) {
     createNode({
       id: step.toString(),
       parent: null,

--- a/benchmarks/markdown/page-template.js
+++ b/benchmarks/markdown/page-template.js
@@ -1,15 +1,15 @@
 const faker = require(`faker`)
 const matter = require(`gray-matter`)
 
-const NUM_ROWS = parseInt(process.env.NUM_ROWS || 25, 10)
+const MAX_NUM_ROWS = parseInt(process.env.MAX_NUM_ROWS || 25, 10)
 
 module.exports = index => `
 ${matter
-  .stringify(``, {
-    title: faker.lorem.sentence(),
-    slug: `/${faker.helpers.slugify(faker.lorem.sentence())}`,
-  })
-  .trim()}
+    .stringify(``, {
+      title: faker.lorem.sentence(),
+      slug: `/${faker.helpers.slugify(faker.lorem.sentence())}`,
+    })
+    .trim()}
 
 ## Page #${index}
 
@@ -17,14 +17,14 @@ ${matter
 
 |Name|Description|Required|
 |:--:|-----------|--------|
-${new Array(faker.random.number(NUM_ROWS))
-  .fill(undefined)
-  .map(() =>
-    `
+${new Array(faker.random.number(MAX_NUM_ROWS))
+    .fill(undefined)
+    .map(() =>
+      `
 |${faker.lorem.word()}|${faker.lorem.sentence()}|${faker.random.boolean()}|
 `.trim()
-  )
-  .join(`\n`)}
+    )
+    .join(`\n`)}
 
 ### More Detail
 

--- a/benchmarks/markdown/page-template.js
+++ b/benchmarks/markdown/page-template.js
@@ -5,11 +5,11 @@ const MAX_NUM_ROWS = parseInt(process.env.MAX_NUM_ROWS || 25, 10)
 
 module.exports = index => `
 ${matter
-    .stringify(``, {
-      title: faker.lorem.sentence(),
-      slug: `/${faker.helpers.slugify(faker.lorem.sentence())}`,
-    })
-    .trim()}
+  .stringify(``, {
+    title: faker.lorem.sentence(),
+    slug: `/${faker.helpers.slugify(faker.lorem.sentence())}`,
+  })
+  .trim()}
 
 ## Page #${index}
 
@@ -18,13 +18,13 @@ ${matter
 |Name|Description|Required|
 |:--:|-----------|--------|
 ${new Array(faker.random.number(MAX_NUM_ROWS))
-    .fill(undefined)
-    .map(() =>
-      `
+  .fill(undefined)
+  .map(() =>
+    `
 |${faker.lorem.word()}|${faker.lorem.sentence()}|${faker.random.boolean()}|
 `.trim()
-    )
-    .join(`\n`)}
+  )
+  .join(`\n`)}
 
 ### More Detail
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

- Add small refactoring to the benchmarks apps.
- Fix benchmark query app warning:
```
warning Action createPage was called outside of its expected asynchronous lifecycle createPages in default-site-plugin.
```

## Related Issues

