### PR TITLE
chore(docs): tweak unit testing to remove invalid props from Link

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -132,12 +132,14 @@ const gatsby = jest.requireActual("gatsby")
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
-  Link: jest.fn().mockImplementation(({ activeClassName, activeStyle, to, ...rest }) =>
-    React.createElement("a", {
-      ...rest,
-      href: to,
-    })
-  ),
+  Link: jest
+    .fn()
+    .mockImplementation(({ activeClassName, activeStyle, to, ...rest }) =>
+      React.createElement("a", {
+        ...rest,
+        href: to,
+      })
+    ),
   StaticQuery: jest.fn(),
 }
 ```

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -132,7 +132,7 @@ const gatsby = jest.requireActual("gatsby")
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
-  Link: jest.fn().mockImplementation(({ to, ...rest }) =>
+  Link: jest.fn().mockImplementation(({ activeClassName, activeStyle, to, ...rest }) =>
     React.createElement("a", {
       ...rest,
       href: to,

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -133,22 +133,22 @@ module.exports = {
   ...gatsby,
   graphql: jest.fn(),
   Link: jest.fn().mockImplementation(
-      // these props are invalid for an `a` tag
-      ({
-        activeClassName,
-        activeStyle,
-        getProps,
-        innerRef,
-        ref,
-        replace,
-        to,
-        ...rest
-      }) =>
-        React.createElement("a", {
-          ...rest,
-          href: to,
-        })
-    ),
+    // these props are invalid for an `a` tag
+    ({
+      activeClassName,
+      activeStyle,
+      getProps,
+      innerRef,
+      ref,
+      replace,
+      to,
+      ...rest,
+    }) =>
+      React.createElement("a", {
+        ...rest,
+        href: to,
+      })
+  ),
   StaticQuery: jest.fn(),
 }
 ```

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -132,9 +132,7 @@ const gatsby = jest.requireActual("gatsby")
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
-  Link: jest
-    .fn()
-    .mockImplementation(
+  Link: jest.fn().mockImplementation(
       // these props are invalid for an `a` tag
       ({
         activeClassName,

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -136,6 +136,7 @@ module.exports = {
     .fn()
     .mockImplementation(
       ({
+        // these props are invalid for an `a` tag
         activeClassName,
         activeStyle,
         getProps,

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -142,7 +142,7 @@ module.exports = {
       ref,
       replace,
       to,
-      ...rest,
+      ...rest
     }) =>
       React.createElement("a", {
         ...rest,

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -134,11 +134,21 @@ module.exports = {
   graphql: jest.fn(),
   Link: jest
     .fn()
-    .mockImplementation(({ activeClassName, activeStyle, to, ...rest }) =>
-      React.createElement("a", {
-        ...rest,
-        href: to,
-      })
+    .mockImplementation(
+      ({
+        activeClassName,
+        activeStyle,
+        getProps,
+        innerRef,
+        ref,
+        replace,
+        to,
+        ...rest
+      }) =>
+        React.createElement("a", {
+          ...rest,
+          href: to,
+        })
     ),
   StaticQuery: jest.fn(),
 }

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -135,8 +135,8 @@ module.exports = {
   Link: jest
     .fn()
     .mockImplementation(
+      // these props are invalid for an `a` tag
       ({
-        // these props are invalid for an `a` tag
         activeClassName,
         activeStyle,
         getProps,


### PR DESCRIPTION
## Description
I followed the Unit-Testing docs to set up jest with Gatsby, and I ran into the following error related to Gatsby's `Link` component:
```
React does not recognize the `activeStyle` prop on a DOM element.
```

## Changes
Removing the `activeStyle` prop from the `Link` mock fixed the issue for me. Seems like this should be the default setup. I was unable to find any discussion of this issue on the internet, sorry if there's something I'm missing.
