### PR TITLE
docs(www): Add quotes to Gryffindor string literal

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -151,7 +151,7 @@ exports.onCreatePage = ({ page, actions }) => {
   createPage({
     ...page,
     context: {
-      house: Gryffindor,
+      house: `Gryffindor`,
     },
   })
 }


### PR DESCRIPTION
I used backticks because that seems to be preferred in Gatsby's codebase

Related conversation here:
https://github.com/gatsbyjs/gatsby/commit/52cb18089aff6c78009f070089fa23834fe3c405#commitcomment-32669906