### PR TITLE
docs(www): make .babelrc example valid JSON

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -30,16 +30,16 @@ npm install --save-dev babel-preset-gatsby
 
 ```json5:title=.babelrc
 {
-  presets: [
+  "presets": [
     [
       "babel-preset-gatsby",
       {
-        targets: {
-          browsers: [">0.25%", "not dead"],
-        },
-      },
-    ],
-  ],
+        "targets": {
+          "browsers": [">0.25%", "not dead"]
+        }
+      }
+    ]
+  ]
 }
 ```
 

--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -29,7 +29,7 @@ npm install --save-dev babel-preset-gatsby
 ```
 
 <!-- prettier-ignore-start -->
-```json5:title=.babelrc
+```json:title=.babelrc
 {
   "presets": [
     [

--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -36,7 +36,7 @@ npm install --save-dev babel-preset-gatsby
       "babel-preset-gatsby",
       {
         "targets": {
-          "browsers": [">0.25%", "not dead"],
+          "browsers": [">0.25%", "not dead"]
         }
       }
     ]

--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -30,16 +30,16 @@ npm install --save-dev babel-preset-gatsby
 
 ```json5:title=.babelrc
 {
-  "presets": [
+  presets: [
     [
       "babel-preset-gatsby",
       {
-        "targets": {
-          "browsers": [">0.25%", "not dead"]
-        }
-      }
-    ]
-  ]
+        targets: {
+          browsers: [">0.25%", "not dead"],
+        },
+      },
+    ],
+  ],
 }
 ```
 

--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -28,19 +28,21 @@ to add custom Babel presets or plugins, you can create your own `.babelrc` at th
 npm install --save-dev babel-preset-gatsby
 ```
 
+<!-- prettier-ignore-start -->
 ```json5:title=.babelrc
 {
-  presets: [
+  "presets": [
     [
       "babel-preset-gatsby",
       {
-        targets: {
-          browsers: [">0.25%", "not dead"],
-        },
-      },
-    ],
-  ],
+        "targets": {
+          "browsers": [">0.25%", "not dead"],
+        }
+      }
+    ]
+  ]
 }
 ```
+<!-- prettier-ignore-end -->
 
 For more advanced configurations, you can also copy the defaults from [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby) and customize them to suit your needs.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

JSON at [https://www.gatsbyjs.org/docs/babel/](https://www.gatsbyjs.org/docs/babel/) is invalid. PR fixes it. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
