### PR TITLE
docs: fix misplaced comma causing error

### DIFF
--- a/docs/blog/2019-03-11-dot-org-prototypes/index.md
+++ b/docs/blog/2019-03-11-dot-org-prototypes/index.md
@@ -2,7 +2,7 @@
 title: "How We Tested Prototypes For the New gatsbyjs.org Homepage"
 date: 2019-03-11
 author: Shannon Soper
-tags: ["ux," "design"]
+tags: ["ux", "design"]
 ---
 
 Our current [gatsbyjs.org](/) homepage is getting a bit long in the tooth -- our incredible designer @fk built it out a year and a half ago, but a lot's changed and we're getting ready to update it.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Running `develop` in www prints
```
error Error processing Markdown file gatsby/docs/blog/2019-03-11-dot-org-prototypes/index.md:

      missed comma between flow collection entries at line 5, column 14:
    tags: ["ux," "design"]
```

A comma just seems to be misplaced in `tags`. It should be like [this](https://github.com/gatsbyjs/gatsby/blob/master/docs/blog/2019-03-05-dot-org-messaging-survey/index.md) blog post.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
