### PR TITLE
docs: Replace npm run develop with gatsby develop

### DIFF
--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -77,7 +77,7 @@ collections:
       - { name: body, label: Body, widget: markdown }
 ```
 
-Then in your terminal run `npm run build` to build the site then `npm run develop` to start the
+Then in your terminal run `gatsby develop` to start the
 Gatsby development server. Once the server is running, it will print the address to open for
 viewing. It's typically `localhost:8000`. Open that in a browser and you should see the text
 "Hello World" in the top left corner. Now navigate to `/admin/` - so if your site is at

--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -77,11 +77,11 @@ collections:
       - { name: body, label: Body, widget: markdown }
 ```
 
-Then in your terminal run `npm run develop` to start the Gatsby development server. Once the server
-is running, it will print the address to open for viewing. It's typically `localhost:8000`. Open that
-in a browser and you should see the text "Hello World" in the top left corner. Now navigate to
-`/admin/` - so if your site is at `localhost:8000`, go to `localhost:8000/admin/`. **The trailing
-slash is required!**
+Then in your terminal run `npm run build` to build the site then `npm run develop` to start the
+Gatsby development server. Once the server is running, it will print the address to open for
+viewing. It's typically `localhost:8000`. Open that in a browser and you should see the text
+"Hello World" in the top left corner. Now navigate to `/admin/` - so if your site is at
+`localhost:8000`, go to `localhost:8000/admin/`. **The trailing slash is required!**
 
 You should now be viewing your Netlify CMS instance. You defined a "blog" collection in the
 configuration above, so you can create new blogs, but Netlify CMS will only store them in memory -


### PR DESCRIPTION
This is necessary for Netlify to run locally.
See: https://github.com/netlify-templates/gatsby-starter-netlify-cms#access-locally

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
