### PR TITLE
fix(gatsby): Emit BOOTSTRAP_FINISHED when bootstrap finishes

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -496,6 +496,7 @@ module.exports = async (args: BootstrapArgs) => {
       report.log(``)
       report.info(`bootstrap finished - ${process.uptime()} s`)
       report.log(``)
+      emitter.emit(`BOOTSTRAP_FINISHED`)
 
       // onPostBootstrap
       activity = report.activityTimer(`onPostBootstrap`, {


### PR DESCRIPTION
Currently we are only emitting `BOOTSTRAP_FINISHED` when the job queue is empty when bootstrap finishes, but not in the Promise.

EDIT: Should be emitted before or after `onPostBootstrap` API?

Also: might be a "good first issue" to reduce code duplication in this part a bit?