### PR TITLE
feat(remark): Add frontmatter defaults

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -22,7 +22,14 @@ plugins: [
       pedantic: true,
       // GitHub Flavored Markdown mode (default: true)
       gfm: true,
-      // Plugins configs
+      // Supply default values for specific frontmatter fields (default: {})
+      frontmatterDefaults: {
+        // Supply default key-value pair for your frontmatters.
+        // The following example would set 'hidden' to false on any
+        // frontmatter that didn't already have a value for 'hidden'
+        hidden: false
+      },
+      // Plugin's configs
       plugins: [],
     },
   },

--- a/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
@@ -100,6 +100,60 @@ Sed bibendum sem iaculis, pellentesque leo sed, imperdiet ante. Sed consequat ma
     })
   })
 
+  describe(`frontmatter defaults`, () => {
+    const content = `---
+something: something
+---
+
+yadda yadda
+      `
+
+    it(`does nothing on default setting`, async () => {
+      node.content = content
+      const parsed = await onCreateNode({
+        node,
+        actions,
+        createNodeId,
+        loadNodeContent,
+      })
+      expect(parsed.frontmatter.something).toEqual(`something`)
+    })
+
+    it(`doesn't overwrite existing value`, async () => {
+      node.content = content
+      const parsed = await onCreateNode(
+        {
+          node,
+          actions,
+          createNodeId,
+          loadNodeContent,
+        },
+        { frontmatterDefaults: { something: `another-thing` } }
+      )
+      expect(parsed.frontmatter.something).toEqual(`something`)
+    })
+
+    it(`doesn't overwrite existing value`, async () => {
+      node.content = `---
+thing: 1
+---
+
+writing about something ...
+`
+      const parsed = await onCreateNode(
+        {
+          node,
+          actions,
+          createNodeId,
+          loadNodeContent,
+        },
+        { frontmatterDefaults: { something: `another-thing` } }
+      )
+      expect(parsed.frontmatter.something).toEqual(`another-thing`)
+      expect(parsed.frontmatter.thing).toEqual(1)
+    })
+  })
+
   describe(`date formatting`, () => {
     const getContent = date => `---
 date: ${date}

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -4,7 +4,7 @@ const _ = require(`lodash`)
 
 module.exports = async function onCreateNode(
   { node, loadNodeContent, actions, createNodeId, reporter },
-  pluginOptions
+  pluginOptions = {}
 ) {
   const { createNode, createParentChildLink } = actions
 
@@ -40,11 +40,23 @@ module.exports = async function onCreateNode(
       },
     }
 
-    markdownNode.frontmatter = {
+    const baseFrontmatter = {
       title: ``, // always include a title
       ...data.data,
     }
 
+    if (_.isUndefined(pluginOptions.frontmatterDefaults)) {
+      pluginOptions.frontmatterDefaults = {}
+    } else if (!_.isObject(pluginOptions.frontmatterDefaults)) {
+      reporter.warn(`frontmatterDefaults must be an object, defaulting to '{}'`)
+      pluginOptions.frontmatterDefaults = {}
+    }
+
+    // Assign any default values from the config
+    markdownNode.frontmatter = _.defaults(
+      baseFrontmatter,
+      pluginOptions.frontmatterDefaults
+    )
     markdownNode.excerpt = data.excerpt
     markdownNode.rawMarkdownBody = data.content
 


### PR DESCRIPTION
Allow users to configure defaults for frontmatter entries. Default
values will be set in the node's frontmatter.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Added new option to supply default values inside a markdown's frontmatter.

An example use case for this (and the reason I've made it) is to guard page creations for unfinished posts. I want to add an optional `hidden` field, and set it to true for hidden posts. I also don't want to put `hidden: false` in every other post. This solves that issue by allowing me to supply a default of false to that `hidden` field.

Obviously this could be done using the `onCreateNode` API, but I think that this would be useful for others. 
