### PR TITLE
Update/fix to "Creating Tags Pages" documentation

### DIFF
--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -54,8 +54,7 @@ Try running the following query in Graph<em>i</em>QL (`localhost:8000/___graphql
   ) {
     edges {
       node {
-        fields
-        {
+        fields {
           slug
         }
         frontmatter {
@@ -127,7 +126,7 @@ Tags.propTypes = {
             }),
             fields: PropTypes.shape({
               slug: PropTypes.string.isRequired,
-            })
+            }),
           }),
         }).isRequired
       ),
@@ -184,8 +183,7 @@ exports.createPages = ({ actions, graphql }) => {
       ) {
         edges {
           node {
-            fields
-            {
+            fields {
               slug
             }
             frontmatter {
@@ -307,9 +305,7 @@ export const pageQuery = graphql`
         title
       }
     }
-    allMarkdownRemark(
-      limit: 2000
-    ) {
+    allMarkdownRemark(limit: 2000) {
       group(field: frontmatter___tags) {
         fieldValue
         totalCount


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This updates the markup provided in this documentation (and one minor text tweak to clarify markup change) so that it is not dependent on a GraphQL query to frontmatter.path. This query fails, and @jlengstorf mentioned that this was a bug. I was working through this problem from the gatsby-starter-blog codebase.

Replaced calls to `path` with `slug` and updated the code examples provided (having worked through relevant issues and have tags & categories pages working at https://github.com/shinytoyrobots/shinytoyrobots-dotcom/pull/5).

In addition removed line `filter: { frontmatter: { published: { ne: false } } }` from GraphQL query in tutorial section on creating a Tags index page. This only threw errors and compile failure for me, and this specific documentation page does not appear to be dependent on any other previous tutorial which has required a `published` field, so it seemed unnecessary that it be there.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
