### PR TITLE
fix(gatsby): improve missing page component error message

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -192,7 +192,9 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
   // component paths.
   if (process.env.NODE_ENV !== `test`) {
     if (!fileExistsSync(page.component)) {
-      const message = `${name} created a page with a component that doesn't exist`
+      const message = `${name} created a page with a component that doesn't exist. Missing component is ${
+        page.component
+      }`
       console.log(``)
       console.log(chalk.bold.red(message))
       console.log(``)


### PR DESCRIPTION
## Description

Adds the component to the error message so when people `require.resolve` instead of `path.resolve` they have some information with which to debug the location of the missing component.

## Related Issues

Fixes #12447