### PR TITLE
test(gatsby-plugin-cxs): add tests for cxs plugin

### DIFF
--- a/packages/gatsby-plugin-cxs/.gitignore
+++ b/packages/gatsby-plugin-cxs/.gitignore
@@ -1,3 +1,3 @@
 /*.js
 !index.js
-gatsby-ssr.js
+!src/**

--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -13,7 +13,8 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.3",
-    "cross-env": "^5.2.0"
+    "cross-env": "^5.2.0",
+    "cxs": "^6.2.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs#readme",
   "keywords": [

--- a/packages/gatsby-plugin-cxs/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-cxs/src/__tests__/gatsby-ssr.js
@@ -1,0 +1,25 @@
+jest.mock(`cxs`)
+
+import React from "react"
+import cxs from "cxs"
+import { onRenderBody } from "../gatsby-ssr"
+
+describe(`gatsby-plugin-cxs`, () => {
+  describe(`onRenderBody`, () => {
+    it(`sets the correct head components`, () => {
+      cxs.css = jest.fn(() => `cxs-css`)
+      const setHeadComponents = jest.fn()
+
+      onRenderBody({ setHeadComponents })
+
+      expect(setHeadComponents).toHaveBeenCalledTimes(1)
+      expect(setHeadComponents).toHaveBeenCalledWith([
+        <style
+          id="cxs-ids"
+          key="cxs-ids"
+          dangerouslySetInnerHTML={{ __html: `cxs-css` }}
+        />,
+      ])
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6084,6 +6084,11 @@ cwebp-bin@^5.0.0:
     bin-wrapper "^4.0.1"
     logalot "^2.1.0"
 
+cxs@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/cxs/-/cxs-6.2.0.tgz#f11ca3bdaef154b93bdadca5df70f2cb3e37ca24"
+  integrity sha512-RGatb1BUwVMBzV8DRo9Kapc55bdGfAxMcukVk+ZzE3Ts8xaTve0GVz730kBDxjhEBU2LK+RPuAcjZb00Q3O24w==
+
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"


### PR DESCRIPTION
## Description
Adding tests for `gatsby-plugin-cxs`. 

#### Summary of changes
- Adding test case verifying that onRenderBody sets the correct head components
- Adding cxs as dev-dependency (needed to run the tests)
- Update .gitignore (so that test files are tracked)