### PR TITLE
fix(gatsby): return graphqlRunner from bootstrap

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -494,7 +494,7 @@ module.exports = async (args: BootstrapArgs) => {
       emitter.off(`END_JOB`, onEndJob)
 
       await finishBootstrap(bootstrapSpan)
-      resolve(graphqlRunner)
+      resolve({ graphqlRunner })
     }
   }, 100)
 


### PR DESCRIPTION
Return `graphqlRunner` which is [expected in `onPostBuild`](https://github.com/gatsbyjs/gatsby/blob/9381fd0348514289984ef060e6ed907a4c86bffe/packages/gatsby/src/commands/build.js#L32)

Should fix #12475