### PR TITLE
test(gatsby-plugin-emotion): add tests for emotion plugin

### DIFF
--- a/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
@@ -1,0 +1,65 @@
+import { onCreateBabelConfig } from "../gatsby-node"
+
+describe(`gatsby-plugin-emotion`, () => {
+  describe(`onCreateBabelConfig`, () => {
+    it(`sets the correct babel preset`, () => {
+      const actions = { setBabelPreset: jest.fn() }
+
+      onCreateBabelConfig({ actions }, null)
+
+      expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
+      expect(actions.setBabelPreset).toHaveBeenCalledWith({
+        name: `@emotion/babel-preset-css-prop`,
+        options: {
+          sourceMap: true,
+          autoLabel: true,
+        },
+      })
+    })
+
+    it(`passes additional options on to the preset`, () => {
+      const actions = { setBabelPreset: jest.fn() }
+      const pluginOptions = { useBuiltIns: true }
+
+      onCreateBabelConfig({ actions }, pluginOptions)
+
+      expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
+      expect(actions.setBabelPreset).toHaveBeenCalledWith({
+        name: `@emotion/babel-preset-css-prop`,
+        options: {
+          sourceMap: true,
+          autoLabel: true,
+          useBuiltIns: true,
+        },
+      })
+    })
+
+    describe(`in production mode`, () => {
+      let env
+
+      beforeAll(() => {
+        env = process.env.NODE_ENV
+        process.env.NODE_ENV = `production`
+      })
+
+      afterAll(() => {
+        process.env.NODE_ENV = env
+      })
+
+      it(`sets the correct babel preset`, () => {
+        const actions = { setBabelPreset: jest.fn() }
+
+        onCreateBabelConfig({ actions }, null)
+
+        expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
+        expect(actions.setBabelPreset).toHaveBeenCalledWith({
+          name: `@emotion/babel-preset-css-prop`,
+          options: {
+            sourceMap: false,
+            autoLabel: false,
+          },
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description
Adding tests for `gatsby-plugin-emotion`. 

#### Summary of changes
- Adding test cases verifying that onCreateBabelConfig sets the correct babel preset.