### PR TITLE
test(gatsby-plugin-facebook-analytics): add tests for facebook-analyt…

### DIFF
--- a/packages/gatsby-plugin-facebook-analytics/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-facebook-analytics/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gatsby-plugin-facebook-analytics onRenderBody in production mode sets the correct post body components 1`] = `
+Array [
+  Array [
+    Array [
+      <script
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": Array [
+              "
+          window.fbAsyncInit = function() {
+            FB.init({
+              appId      : ",
+              ",
+              xfbml      : true,
+              version    : 'v2.12'
+            });
+
+            FB.AppEvents.logPageView();
+
+          };
+
+          (function(d, s, id){
+             var js, fjs = d.getElementsByTagName(s)[0];
+             if (d.getElementById(id)) {return;}
+             js = d.createElement(s); js.id = id;
+             js.src = \\"https://connect.facebook.net/",
+              "/sdk",
+              "\\";
+             fjs.parentNode.insertBefore(js, fjs);
+           }(document, 'script', 'facebook-jssdk'));",
+            ],
+          }
+        }
+      />,
+    ],
+  ],
+]
+`;
+
+exports[`gatsby-plugin-facebook-analytics onRenderBody in production mode sets the correct script src during debug 1`] = `
+Array [
+  Array [
+    Array [
+      <script
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": Array [
+              "
+          window.fbAsyncInit = function() {
+            FB.init({
+              appId      : ",
+              ",
+              xfbml      : true,
+              version    : 'v2.12'
+            });
+
+            FB.AppEvents.logPageView();
+
+          };
+
+          (function(d, s, id){
+             var js, fjs = d.getElementsByTagName(s)[0];
+             if (d.getElementById(id)) {return;}
+             js = d.createElement(s); js.id = id;
+             js.src = \\"https://connect.facebook.net/",
+              "/sdk",
+              "\\";
+             fjs.parentNode.insertBefore(js, fjs);
+           }(document, 'script', 'facebook-jssdk'));",
+            ],
+          }
+        }
+      />,
+    ],
+  ],
+]
+`;
+
+exports[`gatsby-plugin-facebook-analytics onRenderBody in production mode sets the correct script src for other languages than en_US 1`] = `
+Array [
+  Array [
+    Array [
+      <script
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": Array [
+              "
+          window.fbAsyncInit = function() {
+            FB.init({
+              appId      : ",
+              ",
+              xfbml      : true,
+              version    : 'v2.12'
+            });
+
+            FB.AppEvents.logPageView();
+
+          };
+
+          (function(d, s, id){
+             var js, fjs = d.getElementsByTagName(s)[0];
+             if (d.getElementById(id)) {return;}
+             js = d.createElement(s); js.id = id;
+             js.src = \\"https://connect.facebook.net/",
+              "/sdk",
+              "\\";
+             fjs.parentNode.insertBefore(js, fjs);
+           }(document, 'script', 'facebook-jssdk'));",
+            ],
+          }
+        }
+      />,
+    ],
+  ],
+]
+`;

--- a/packages/gatsby-plugin-facebook-analytics/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-facebook-analytics/src/__tests__/gatsby-browser.js
@@ -1,0 +1,40 @@
+import { onRouteUpdate } from "../gatsby-browser"
+
+describe(`gatsby-plugin-facebook-analytics`, () => {
+  describe(`onRouteUpdate`, () => {
+    describe(`in development mode`, () => {
+      it(`does not log page views`, () => {
+        const logPageView = jest.fn()
+        window.FB = function() {}
+        window.FB.AppEvents = { logPageView }
+
+        onRouteUpdate()
+
+        expect(logPageView).not.toHaveBeenCalled()
+      })
+    })
+
+    describe(`in production mode`, () => {
+      let env
+
+      beforeAll(() => {
+        env = process.env.NODE_ENV
+        process.env.NODE_ENV = `production`
+      })
+
+      afterAll(() => {
+        process.env.NODE_ENV = env
+      })
+
+      it(`logs page views`, () => {
+        const logPageView = jest.fn()
+        window.FB = function() {}
+        window.FB.AppEvents = { logPageView }
+
+        onRouteUpdate()
+
+        expect(logPageView).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})

--- a/packages/gatsby-plugin-facebook-analytics/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-facebook-analytics/src/__tests__/gatsby-ssr.js
@@ -1,0 +1,61 @@
+jest.mock(`common-tags`, () => {
+  return {
+    stripIndent: args => args,
+  }
+})
+
+import { onRenderBody } from "../gatsby-ssr"
+
+describe(`gatsby-plugin-facebook-analytics`, () => {
+  describe(`onRenderBody`, () => {
+    describe(`in development mode`, () => {
+      it(`does not set any post body components`, () => {
+        const setPostBodyComponents = jest.fn()
+
+        onRenderBody({ setPostBodyComponents }, {})
+
+        expect(setPostBodyComponents).not.toHaveBeenCalled()
+      })
+    })
+
+    describe(`in production mode`, () => {
+      let env
+
+      beforeAll(() => {
+        env = process.env.NODE_ENV
+        process.env.NODE_ENV = `production`
+      })
+
+      afterAll(() => {
+        process.env.NODE_ENV = env
+      })
+
+      it(`sets the correct post body components`, () => {
+        const setPostBodyComponents = jest.fn()
+        const pluginOptions = { appId: 1 }
+
+        onRenderBody({ setPostBodyComponents }, pluginOptions)
+
+        expect(setPostBodyComponents.mock.calls).toMatchSnapshot()
+      })
+
+      it(`sets the correct script src during debug`, () => {
+        const setPostBodyComponents = jest.fn()
+        const pluginOptions = { appId: 1, debug: true }
+
+        onRenderBody({ setPostBodyComponents }, pluginOptions)
+
+        expect(setPostBodyComponents.mock.calls).toMatchSnapshot()
+      })
+
+      it(`sets the correct script src for other languages than en_US`, () => {
+        const setPostBodyComponents = jest.fn()
+        const pluginOptions = { appId: 1, language: `sv` }
+
+        onRenderBody({ setPostBodyComponents }, pluginOptions)
+
+        expect(setPostBodyComponents.mock.calls).toMatchSnapshot()
+      })
+    })
+  })
+})

--- a/packages/gatsby-plugin-facebook-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-facebook-analytics/src/gatsby-browser.js
@@ -1,4 +1,4 @@
-exports.onRouteUpdate = function() {
+export const onRouteUpdate = () => {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production` && typeof FB === `function`) {
     window.FB.AppEvents.logPageView()

--- a/packages/gatsby-plugin-facebook-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-facebook-analytics/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { stripIndent } from "common-tags"
 
-exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
+export const onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
   const {
     appId,
     includeInDevelopment = false,


### PR DESCRIPTION
## Description
Adding tests for `gatsby-plugin-facebook-analytics`. 

#### Summary of changes
- Adding tests for `gatsby-browser.js` and `gatsby-ssr.js`
- Minor refactor: use `export const` instead of `exports.` and use arrow functions.