### PR TITLE
test(gatsby-plugin-flow): add tests for flow plugin

### DIFF
--- a/packages/gatsby-plugin-flow/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-flow/src/__tests__/gatsby-node.js
@@ -1,0 +1,16 @@
+import { onCreateBabelConfig } from "../gatsby-node"
+
+describe(`gatsby-plugin-flow`, () => {
+  describe(`onCreateBabelConfig`, () => {
+    it(`sets the correct babel preset`, () => {
+      const actions = { setBabelPreset: jest.fn() }
+
+      onCreateBabelConfig({ actions }, null)
+
+      expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
+      expect(actions.setBabelPreset).toHaveBeenCalledWith({
+        name: `@babel/preset-flow`,
+      })
+    })
+  })
+})

--- a/packages/gatsby-plugin-flow/src/gatsby-node.js
+++ b/packages/gatsby-plugin-flow/src/gatsby-node.js
@@ -1,7 +1,5 @@
-function onCreateBabelConfig({ actions }, pluginOptions) {
+export const onCreateBabelConfig = ({ actions }, pluginOptions) => {
   actions.setBabelPreset({
     name: `@babel/preset-flow`,
   })
 }
-
-exports.onCreateBabelConfig = onCreateBabelConfig


### PR DESCRIPTION
## Description
Adding tests for `gatsby-plugin-flow`. 

#### Summary of changes
- Adding a test case to verify that onCreateBabelConfig sets the correct babel preset.
- Minor refactor: use `export const` instead of `exports.` and use arrow functions.