### PR TITLE
test(gatsby-plugin-fullstory): add tests for fullstory plugin

### DIFF
--- a/packages/gatsby-plugin-fullstory/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-fullstory/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,31 +1,32 @@
-import React from "react"
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-export const onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-  if (process.env.NODE_ENV === `production`) {
-    return setHeadComponents([
+exports[`gatsby-plugin-fullstory onRenderBody in production mode sets the correct head components 1`] = `
+Array [
+  Array [
+    Array [
       <script
-        key={`gatsby-plugin-fullstory`}
-        dangerouslySetInnerHTML={{
-          __html: `
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "
 window['_fs_debug'] = false;
 window['_fs_host'] = 'fullstory.com';
-window['_fs_org'] = '${pluginOptions.fs_org}';
+window['_fs_org'] = 'test-org';
 window['_fs_namespace'] = 'FS';
 (function(m,n,e,t,l,o,g,y){
-    if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+    if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window[\\"_fs_namespace\\"].');} return;}
     g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
     o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js';
     y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
     g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
-    y="rec";g.shutdown=function(i,v){g(y,!1)};g.restart=function(i,v){g(y,!0)};
+    y=\\"rec\\";g.shutdown=function(i,v){g(y,!1)};g.restart=function(i,v){g(y,!0)};
     g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
     g.clearUserCookie=function(){};
 })(window,document,window['_fs_namespace'],'script','user');
-      `,
-        }}
+      ",
+          }
+        }
       />,
-    ])
-  }
-
-  return null
-}
+    ],
+  ],
+]
+`;

--- a/packages/gatsby-plugin-fullstory/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-fullstory/src/__tests__/gatsby-ssr.js
@@ -1,0 +1,37 @@
+import { onRenderBody } from "../gatsby-ssr"
+
+describe(`gatsby-plugin-fullstory`, () => {
+  describe(`onRenderBody`, () => {
+    describe(`in development mode`, () => {
+      it(`does not set any head components`, () => {
+        const setHeadComponents = jest.fn()
+
+        onRenderBody({ setHeadComponents }, {})
+
+        expect(setHeadComponents).not.toHaveBeenCalled()
+      })
+    })
+
+    describe(`in production mode`, () => {
+      let env
+
+      beforeAll(() => {
+        env = process.env.NODE_ENV
+        process.env.NODE_ENV = `production`
+      })
+
+      afterAll(() => {
+        process.env.NODE_ENV = env
+      })
+
+      it(`sets the correct head components`, () => {
+        const setHeadComponents = jest.fn()
+        const pluginOptions = { fs_org: `test-org` }
+
+        onRenderBody({ setHeadComponents }, pluginOptions)
+
+        expect(setHeadComponents.mock.calls).toMatchSnapshot()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description
Adding tests for `gatsby-plugin-fullstory`. 

#### Summary of changes
- Adding tests to verify that the correct head components are set in production.
- Minor refactor: use `export const` instead of `exports.`.