### PR TITLE
fix(gatsby-plugin-flow): add .babelrc to transpile to cjs

### DIFF
--- a/packages/gatsby-plugin-flow/.babelrc
+++ b/packages/gatsby-plugin-flow/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["babel-preset-gatsby-package"]]
+}

--- a/packages/gatsby-plugin-flow/package.json
+++ b/packages/gatsby-plugin-flow/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "babel-preset-gatsby-package": "^0.1.3",
     "cross-env": "^5.0.5"
   }
 }


### PR DESCRIPTION
fixes #12487