### PR TITLE
Add mongodb source connection url

### DIFF
--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -9,21 +9,27 @@ exports.sourceNodes = (
 ) => {
   const { createNode } = actions
 
-  let serverOptions = pluginOptions.server || {
-    address: `localhost`,
-    port: 27017,
-  }
-  let dbName = pluginOptions.dbName || `local`,
-    authUrlPart = ``
-  if (pluginOptions.auth)
-    authUrlPart = `${pluginOptions.auth.user}:${pluginOptions.auth.password}@`
+a  let connectionURL = pluginOptions.connectionURL
 
-  let connectionExtraParams = getConnectionExtraParams(
-    pluginOptions.extraParams
-  )
-  const connectionURL = `mongodb://${authUrlPart}${serverOptions.address}:${
-    serverOptions.port
-  }/${dbName}${connectionExtraParams}`
+  const dbName = pluginOptions.dbName || `local`
+  if (!connectionURL) {
+    const serverOptions = pluginOptions.server || {
+      address: `localhost`,
+      port: 27017,
+    }
+
+    const authUrlPart = pluginOptions.auth
+      ? `${pluginOptions.auth.user}:${pluginOptions.auth.password}@`
+      : ""
+
+    const connectionExtraParams = getConnectionExtraParams(
+      pluginOptions.extraParams
+    )
+
+    connectionURL = `mongodb://${authUrlPart}${serverOptions.address}:${
+      serverOptions.port
+    }/${dbName}${connectionExtraParams}`
+  }
 
   return MongoClient.connect(connectionURL)
     .then(db => {

--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -9,7 +9,7 @@ exports.sourceNodes = (
 ) => {
   const { createNode } = actions
 
-a  let connectionURL = pluginOptions.connectionURL
+  let connectionURL = pluginOptions.connectionURL
 
   const dbName = pluginOptions.dbName || `local`
   if (!connectionURL) {
@@ -20,7 +20,7 @@ a  let connectionURL = pluginOptions.connectionURL
 
     const authUrlPart = pluginOptions.auth
       ? `${pluginOptions.auth.user}:${pluginOptions.auth.password}@`
-      : ""
+      : ``
 
     const connectionExtraParams = getConnectionExtraParams(
       pluginOptions.extraParams

--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -8,7 +8,6 @@ exports.sourceNodes = (
   pluginOptions
 ) => {
   const { createNode } = actions
-
   let connectionURL = pluginOptions.connectionURL
 
   const dbName = pluginOptions.dbName || `local`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR adds the `connectionURL` property to the mongodb source plugin options. When creating a mongodb atlas you are given a clean connection URL to use. Instead of having the user break that url up and provide them as separate options it is much easier to just copy and paste that url in directly. 

This PR does not take away any functionality of using separate options but adds the simplicity of 1 option.

**Old Format**
```js
{
      resolve: `gatsby-source-mongodb`,
      options: { 
         dbName: `local`, 
         collection: `xxxxx`,
         server: {
           address: config.mongodb.address,
           port: config.mongodb.port
         },
        auth: {
          user: config.mongodb.user,
          password: config.mongodb.password
        },
        extraParams: config.mongodb.extraParams
      },
    },
```


**New Format**
```js
{
      resolve: `gatsby-source-mongodb`,
      options: {
        dbName: "local",
        collection: `xxxxxx`,
        connectionURL: config.mongoDBLogin,
      },
    },
```
