### PR TITLE
feat(gatsby-link): adds support for partiallyActive=true to Link

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -80,28 +80,27 @@ const SiteNavigation = () => (
 
 ### Show active styles for partially matched and parent links
 
-<iframe title="Screencast on egghead of how to style partially matched links in Gatsby." class="egghead-video" width=600 height=348 src="https://egghead.io/lessons/egghead-customize-styles-for-partially-matched-urls-with-gatsby-s-link-component/embed" />
-
-Video hosted on [egghead.io][egghead].
-
-The `activeStyle` or `activeClassName` prop are only set on a `<Link>` component if the current URL matches its `to` prop _exactly_. Sometimes, we may want to style a `<Link>` as active even if it partially matches the current URL. For example:
+By default the `activeStyle` and `activeClassName` props will only be set on a `<Link>` component if the current URL matches its `to` prop _exactly_. Sometimes, we may want to style a `<Link>` as active even if it partially matches the current URL. For example:
 
 - We may want `/blog/hello-world` to match `<Link to="/blog">`
 - Or `/gatsby-link/#passing-state-through-link-and-navigate` to match `<Link to="/gatsby-link">`
 
-In instances like these, we can use [@reach/router's](https://reach.tech/router/api/Link) `getProps` API to set active styles as follows:
+In instances like these, just add the `partiallyActive` prop to your `<Link>` component and the style will also be applied even if the `to` prop only is a partial match:
 
 ```jsx
 import React from "react"
 import { Link } from "gatsby"
 
-const partiallyActive = className => ({ isPartiallyCurrent }) => ({
-  className: className + (isPartiallyCurrent ? ` active` : ``),
-})
-
-const PartiallyActiveLink = ({ className, ...rest }) => (
-  <Link getProps={partiallyActive(className)} {...rest} />
-)
+const Header = <>
+  <Link
+    to="/articles/"
+    activeStyle={{ color: "red" }}
+    {/* highlight-next-line */}
+    partiallyActive={true}
+  >
+    Articles
+  </Link>
+</>;
 ```
 
 ### Pass state as props to the linked page

--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -6,6 +6,8 @@ export interface GatsbyLinkProps<TState> extends LinkProps<TState> {
   activeStyle?: object
   innerRef?: Function
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
+  partiallyActive?: boolean
+  replace?: boolean
   to: string
 }
 

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@reach/router": "^1.1.1",
     "@types/reach__router": "^1.0.0",
     "prop-types": "^15.6.1"
   },
@@ -26,6 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
+    "@reach/router": "^1.1.1",
     "gatsby": "^2.0.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2"

--- a/packages/gatsby-link/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-link/src/__tests__/__snapshots__/index.js.snap
@@ -24,3 +24,15 @@ exports[`<Link /> matches basic snapshot 1`] = `
   </a>
 </div>
 `;
+
+exports[`<Link /> matches partially active snapshot 1`] = `
+<div>
+  <a
+    class="link"
+    href="/active/nested"
+    style="color: black;"
+  >
+    link
+  </a>
+</div>
+`;

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -74,6 +74,13 @@ describe(`<Link />`, () => {
     expect(container).toMatchSnapshot()
   })
 
+  it(`matches partially active snapshot`, () => {
+    const { container } = setup({
+      linkProps: { to: `/active/nested`, partiallyActive: true },
+    })
+    expect(container).toMatchSnapshot()
+  })
+
   it(`does not fail to initialize without --prefix-paths`, () => {
     expect(() => {
       getInstance({})

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -18,6 +18,7 @@ function normalizePath(path) {
 const NavLinkPropTypes = {
   activeClassName: PropTypes.string,
   activeStyle: PropTypes.object,
+  partiallyActive: PropTypes.bool,
 }
 
 // Set up IntersectionObserver
@@ -83,8 +84,8 @@ class GatsbyLink extends React.Component {
     }
   }
 
-  defaultGetProps = ({ isCurrent }) => {
-    if (isCurrent) {
+  defaultGetProps = ({ isPartiallyCurrent, isCurrent, ...x }) => {
+    if (this.props.partiallyActive ? isPartiallyCurrent : isCurrent) {
       return {
         className: [this.props.className, this.props.activeClassName]
           .filter(Boolean)
@@ -105,6 +106,7 @@ class GatsbyLink extends React.Component {
       activeClassName: $activeClassName,
       activeStyle: $activeStyle,
       innerRef: $innerRef,
+      partiallyActive,
       state,
       replace,
       /* eslint-enable no-unused-vars */

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -84,7 +84,7 @@ class GatsbyLink extends React.Component {
     }
   }
 
-  defaultGetProps = ({ isPartiallyCurrent, isCurrent, ...x }) => {
+  defaultGetProps = ({ isPartiallyCurrent, isCurrent }) => {
     if (this.props.partiallyActive ? isPartiallyCurrent : isCurrent) {
       return {
         className: [this.props.className, this.props.activeClassName]


### PR DESCRIPTION
## Description

Implements a new option in the `<Link/>` component: `partiallyActive={bool}`. If true, the route will activate its `activeStyle` and `activeClassName` parameter even if only partially active.

I've put the settings on the component rather than the route, as there might be places where you want this settings to be on and others where you want it to be off. Also it was simpler 🙂 

I've also moved `@reach/router` into the peerDependencies (from the regular dependencies) since it's a stateful package (due to the context ref) and you don't want to run the risk of having version conflicts. It shouldn't be a problem because the `gatsby` package already provides `@reach/router`.

## Related Issues

Fixes #7208