### PR TITLE
fix(www): Normalize spaced and hyphenated blog tags

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -414,16 +414,26 @@ exports.createPages = ({ graphql, actions, reporter }) => {
         })
       })
 
-      const tagLists = releasedBlogPosts
-        .filter(post => _.get(post, `node.frontmatter.tags`))
-        .map(post => _.get(post, `node.frontmatter.tags`))
+      const makeSlugTag = tag => _.kebabCase(tag.toLowerCase())
 
-      _.uniq(_.flatten(tagLists)).forEach(tag => {
+      // Collect all tags and group them by their kebab-case so that
+      // hyphenated and spaced tags are treated the same. e.g
+      // `case-study` -> [`case-study`, `case study`]. The hyphenated
+      // version will be used for the slug, and the spaced version
+      // will be used for human readability (see templates/tags)
+      const tagGroups = _(releasedBlogPosts)
+        .map(post => _.get(post, `node.frontmatter.tags`))
+        .filter()
+        .flatten()
+        .uniq()
+        .groupBy(makeSlugTag)
+
+      tagGroups.forEach((tags, tagSlug) => {
         createPage({
-          path: `/blog/tags/${_.kebabCase(tag.toLowerCase())}/`,
+          path: `/blog/tags/${tagSlug}/`,
           component: tagTemplate,
           context: {
-            tag,
+            tags,
           },
         })
       })

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -57,6 +57,12 @@ class TagsPage extends React.Component {
         lookup[key] = Object.assign(tag, {
           slug: `/blog/tags/${key}`,
         })
+      } else {
+        lookup[key].totalCount += tag.totalCount
+      }
+      // Prefer spaced tag names (instead of hyphenated) for display
+      if (tag.fieldValue.includes(` `)) {
+        lookup[key].fieldValue = tag.fieldValue
       }
       return lookup
     }, {})

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -8,12 +8,24 @@ import Container from "../components/container"
 import Layout from "../components/layout"
 import { rhythm } from "../utils/typography"
 
+// Select first tag with whitespace instead of hyphens for
+// readability. But if none present, just use the first tag in the
+// collection
+const preferSpacedTag = tags => {
+  for (const tag of tags) {
+    if (!tag.includes(` `)) {
+      return tag
+    }
+  }
+  return tags[0]
+}
+
 const Tags = ({ pageContext, data, location }) => {
-  const { tag } = pageContext
+  const { tags } = pageContext
   const { edges, totalCount } = data.allMarkdownRemark
   const tagHeader = `${totalCount} post${
     totalCount === 1 ? `` : `s`
-  } tagged with "${tag}"`
+  } tagged with "${preferSpacedTag(tags)}"`
 
   return (
     <Layout location={location}>
@@ -37,12 +49,12 @@ const Tags = ({ pageContext, data, location }) => {
 export default Tags
 
 export const pageQuery = graphql`
-  query($tag: String) {
+  query($tags: [String]) {
     allMarkdownRemark(
       limit: 2000
       sort: { fields: [frontmatter___date, fields___slug], order: DESC }
       filter: {
-        frontmatter: { tags: { in: [$tag] } }
+        frontmatter: { tags: { in: $tags } }
         fileAbsolutePath: { regex: "/docs.blog/" }
         fields: { released: { eq: true } }
       }


### PR DESCRIPTION
## Description

Blog markdown frontmatter tags can contain hyphens or spaces. E.g [case-study](https://github.com/gatsbyjs/gatsby/blob/master/docs/blog/2019-01-28-building-a-large-ecommerce-website-with-gatsby-at-daniel-wellington/index.md) or [case study](https://github.com/gatsbyjs/gatsby/blob/master/docs/blog/2018-09-27-sendgrid-knowledge-center-cuts-page-load-times-in-half-with-gatsby/index.md). Gatsby creates slug URLs for the tags page by kebab casing, so both the above should be viewable at https://www.gatsbyjs.org/blog/tags/case-study. But only the hyphenated variant is present.

The issue is that the tags template query searches `frontmatter.tags` using `context.tag`. But the context tag is converted to kebab case during page creation, so it will only ever find hyphenated tags. As a result, even though the tags aggregation page (https://www.gatsbyjs.org/blog/tags) shows 6 results for "case-study", only 1 is present when you click through. There are actually 7 results, but the "case study" tag is ignored.

This fix groups spaced and hyphenated tags together into `context.tags` so that they can all be queried by the hyphenated version. An alternative would be to enforce that tags must be hyphenated, which would certainly clean up the code.
