### PR TITLE
feat(gatsby-source-drupal): Add ability to use JSON API filters when querying

### DIFF
--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -34,6 +34,46 @@ module.exports = {
 }
 ```
 
+### Filters
+
+You can use the `filters` option to limit the data that is retrieved from Drupal. Filters are applied per JSON API collection. You can use any [valid JSON API filter query](https://www.drupal.org/docs/8/modules/jsonapi/filtering). For large data sets this can reduce the build time of your application by allowing Gatsby to skip content you'll never use.
+
+As an example, if your JSON API endpoint (https://live-contentacms.pantheonsite.io/api) returns the following collections list, then `articles` and `recipes` are both collections that can have a filters applied:
+
+```json
+{
+  ...
+  links: {
+    articles: "https://live-contentacms.pantheonsite.io/api/articles",
+    recipes: "https://live-contentacms.pantheonsite.io/api/recipes",
+    ...
+  }
+}
+```
+
+To retrieve only recipes with a specific tag you could do something like the following where the key (recipe) is the collection from above, and the value is the filter you want to apply.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-drupal`,
+      options: {
+        baseUrl: `https://live-contentacms.pantheonsite.io/`,
+        apiBase: `api`,
+        filters: {
+          // collection : filter
+          recipe: "filter[tags.name][value]=British",
+        },
+      },
+    },
+  ],
+}
+```
+
+Which would result in Gatsby using the filtered collection https://live-contentacms.pantheonsite.io/api/recipes?filter[tags.name][value]=British to retrieve data.
+
 ### Basic Auth
 
 You can use `basicAuth` option if your site is protected by basicauth.

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -14,7 +14,7 @@ const createContentDigest = obj =>
 
 exports.sourceNodes = async (
   { actions, getNode, hasNodeChanged, store, cache, createNodeId },
-  { baseUrl, apiBase, basicAuth }
+  { baseUrl, apiBase, basicAuth, filters }
 ) => {
   const { createNode } = actions
 
@@ -50,6 +50,15 @@ exports.sourceNodes = async (
         if (typeof url === `object`) {
           // url can be string or object containing href field
           url = url.href
+
+          // Apply any filters configured in gatsby-config.js. Filters
+          // can be any valid JSON API filter query string.
+          // See https://www.drupal.org/docs/8/modules/jsonapi/filtering
+          if (typeof filters === `object`) {
+            if (filters.hasOwnProperty(type)) {
+              url = url + `?${filters[type]}`
+            }
+          }
         }
 
         let d


### PR DESCRIPTION
## Description

Adds the ability to use JSON API filters when querying Drupal. This can be configured per JSON API collection in your gatsby-config.js file. This allows a developer to selectively reduce the amount of data that needs to be pulled from Drupal. It potentially reduces build time for large data sets. And allows developers to ignore data they don't need.

Example configuration:

```javascript
module.exports = {
  plugins: [
    {
      resolve: `gatsby-source-drupal`,
      options: {
        baseUrl: `https://live-contentacms.pantheonsite.io/`,
        apiBase: `api`,
        filters: {
          // collection : filter
          recipe: "filter[tags.name][value]=British",
        },
      },
    },
  ],
}
```

Would result in the "recipe" collection being queried like so `https://live-contentacms.pantheonsite.io/api/recipes?filter[tags.name][value]=British` while leaving all other collections unfiltered.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/11696 based on suggestions made by @apmsooner.
