### PR TITLE
Add microsecond support for ISO 8601 datetime formats

### DIFF
--- a/packages/gatsby/src/schema/types/type-date.js
+++ b/packages/gatsby/src/schema/types/type-date.js
@@ -22,6 +22,8 @@ const ISO_8601_FORMAT = [
   `YYYY-MM-DDTHHmmss`,
   `YYYY-MM-DDTHH:mm:ss.SSS`,
   `YYYY-MM-DDTHHmmss.SSS`,
+  `YYYY-MM-DDTHH:mm:ss.SSSSSSS`,
+  `YYYY-MM-DDTHHmmss.SSSSSSS`,
 
   // Coordinated Universal Time (UTC)
   `YYYY-MM-DDTHHZ`,
@@ -31,6 +33,8 @@ const ISO_8601_FORMAT = [
   `YYYY-MM-DDTHHmmssZ`,
   `YYYY-MM-DDTHH:mm:ss.SSSZ`,
   `YYYY-MM-DDTHHmmss.SSSZ`,
+  `YYYY-MM-DDTHH:mm:ss.SSSSSSZ`,
+  `YYYY-MM-DDTHHmmss.SSSSSSZ`,
 
   `YYYY-[W]WW`,
   `YYYY[W]WW`,


### PR DESCRIPTION
## Description
When attempting to use `formatString` to format dates in GraphQL, we get "Invalid date", which I believe is due to the precision format of seconds.

From what I've seen in other issues/PRs, it seems to be related to the list of formats in type-date.js file. It seems to only have ISO formats with millisecond precision (`YYYY-MM-DDTHHmmss.SSS`). We're using a python backend api for page generation and their default precision is in microseconds (`YYYY-MM-DDTHHmmss.SSSSSS`).

(ref: https://docs.python.org/3.7/library/datetime.html)

The proposed fix is to add microseconds support for UTC and local time.

## Related Issues

Related to #4813

