### PR TITLE
feat(www): Add Contributing Introduction to the sidebar

### DIFF
--- a/www/src/data/sidebars/contributing-links.yaml
+++ b/www/src/data/sidebars/contributing-links.yaml
@@ -1,5 +1,7 @@
 - title: Contributing
   items:
+    - title: Introduction
+      link: /contributing/
     - title: Community
       link: /contributing/community/
       items:


### PR DESCRIPTION
This adds an "Introduction" item to the sidebar of https://www.gatsbyjs.org/contributing/, similar to what we do for https://www.gatsbyjs.org/tutorial/ and https://www.gatsbyjs.org/docs/.

Currently, the only way to bring up the "Contributing" "landing page" is by clicking "Contributing" in the main navigationg in the header, which might be a bit confusing.

From a Slack conversation with @marcysutton. 👋 