### PR TITLE
chore(docs): add link on gatsby-link documentation

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -69,7 +69,7 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 | :--------------------------: | ----------------------------------------------------------------------------------- |
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                 |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                             |
-| `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See /docs/performance-tracing/ |
+| `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
 
 ### `serve`
 

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -65,10 +65,10 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 
 #### Options
 
-|            Option            | Description                                                                         |
-| :--------------------------: | ----------------------------------------------------------------------------------- |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                 |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                             |
+|            Option            | Description                                                                                                |
+| :--------------------------: | ---------------------------------------------------------------------------------------------------------- |
+|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        |
+|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    |
 | `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
 
 ### `serve`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

enable clickable link in documentation

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
