### PR TITLE
chore(docs): add useStaticQuery to docs for mocking Gatsby

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -139,6 +139,7 @@ module.exports = {
     })
   ),
   StaticQuery: jest.fn(),
+  useStaticQuery: jest.fn(),
 }
 ```
 


### PR DESCRIPTION
## Description

Adds `useStaticQuery` to the docs for mocking out Gatsby related to unit testing.
