### PR TITLE
feat(docs): Link to main sections from `/docs/`

### DIFF
--- a/docs/docs/advanced-tutorials.md
+++ b/docs/docs/advanced-tutorials.md
@@ -1,0 +1,8 @@
+---
+title: Advanced Tutorials
+overview: true
+---
+
+Learn about topics that are too large for a doc and warrant a tutorial.
+
+[[guidelist]]

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -1,0 +1,8 @@
+---
+title: API Reference
+overview: true
+---
+
+Learn more about Gatsby APIs and configuration.
+
+[[guidelist]]

--- a/docs/docs/conceptual-guide.md
+++ b/docs/docs/conceptual-guide.md
@@ -1,0 +1,8 @@
+---
+title: Conceptual Guide
+overview: true
+---
+
+Read high-level overviews of the Gatsby approach.
+
+[[guidelist]]

--- a/docs/docs/guides.md
+++ b/docs/docs/guides.md
@@ -1,0 +1,8 @@
+---
+title: Guides
+overview: true
+---
+
+Dive deeper into different topics around building with Gatsby, like sourcing data, deployment, and more.
+
+[[guidelist]]

--- a/docs/docs/releases-and-migration.md
+++ b/docs/docs/releases-and-migration.md
@@ -1,0 +1,8 @@
+---
+title: "Releases & Migration"
+overview: true
+---
+
+Find release notes and guides for migration between major versions.
+
+[[guidelist]]

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -7,6 +7,7 @@
     - title: Recipes
       link: /docs/recipes/
 - title: Guides
+  link: /docs/guides/
   items:
     - title: Preparing Your Environment
       link: /docs/preparing-your-environment/
@@ -288,6 +289,7 @@
     - title: Awesome Gatsby Resources
       link: /docs/awesome-gatsby/
 - title: API Reference
+  link: /docs/api-reference/
   items:
     - title: Gatsby Link
       link: /docs/gatsby-link/
@@ -306,6 +308,7 @@
     - title: API Philosophy
       link: /docs/api-specification/
 - title: Releases & Migration
+  link: /docs/releases-and-migration/
   items:
     - title: v2 Release Notes
       link: /docs/v2-release-notes/
@@ -316,6 +319,7 @@
     - title: Migrating from v0 to v1
       link: /docs/migrating-from-v0-to-v1/
 - title: Conceptual Guide
+  link: /docs/conceptual-guide/
   items:
     - title: The Gatsby Core Philosophy*
       link: /docs/gatsby-core-philosophy/
@@ -386,6 +390,7 @@
     - title: Terminology
       link: /docs/behind-the-scenes-terminology/
 - title: Advanced Tutorials
+  link: /docs/advanced-tutorials/
   items:
     - title: Making a Site with User Authentication
       link: /docs/authentication-tutorial/

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -35,7 +35,7 @@ class IndexRoute extends React.Component {
                 to dig straight in.
               </li>
               <li>
-                <Link to="/docs/recipes">Recipes</Link>: A happy medium between
+                <Link to="/docs/recipes/">Recipes</Link>: A happy medium between
                 the tutorial and the quick start, find some quick answers for
                 how to accomplish some specific, common tasks with Gatsby.
               </li>
@@ -45,33 +45,38 @@ class IndexRoute extends React.Component {
               </li>
               <ul>
                 <li>
-                  <strong>Guides</strong>: Dive deeper into different topics
-                  around building with Gatsby, like sourcing data, deployment,
-                  and more.
+                  <Link to="/docs/guides/">Guides</Link>: Dive deeper into
+                  different topics around building with Gatsby, like sourcing
+                  data, deployment, and more.
                 </li>
                 <li>
-                  <strong>Ecosystem</strong>: Check out libraries for Gatsby
-                  starters and plugins, as well as external community resources.
+                  <Link to="/ecosystem/">Ecosystem</Link>: Check out libraries
+                  for Gatsby starters and plugins, as well as external community
+                  resources.
                 </li>
                 <li>
-                  <strong>API Reference</strong>: Learn more about Gatsby APIs
-                  and configuration.
+                  <Link to="/docs/api-reference/">API Reference</Link>: Learn
+                  more about Gatsby APIs and configuration.
                 </li>
                 <li>
-                  <strong>Releases &amp; Migration</strong>: Find release notes
-                  and guides for migration between major versions.
+                  <Link to="/docs/releases-and-migration/">
+                    Releases &amp; Migration
+                  </Link>
+                  : Find release notes and guides for migration between major
+                  versions.
                 </li>
                 <li>
-                  <strong>Conceptual Guide</strong>: Read high-level overviews
-                  of the Gatsby approach.
+                  <Link to="/docs/conceptual-guide/">Conceptual Guide</Link>:
+                  Read high-level overviews of the Gatsby approach.
                 </li>
                 <li>
-                  <strong>Behind the Scenes</strong>: Dig into how Gatsby works
-                  under the hood.
+                  <Link to="/docs/behind-the-scenes/">Behind the Scenes</Link>:
+                  Dig into how Gatsby works under the hood.
                 </li>
                 <li>
-                  <strong>Advanced Tutorials</strong>: Learn about topics that
-                  are too large for a doc and warrant a tutorial.
+                  <Link to="/docs/advanced-tutorials/">Advanced Tutorials</Link>
+                  : Learn about topics that are too large for a doc and warrant
+                  a tutorial.
                 </li>
               </ul>
             </ol>

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -15,12 +15,8 @@ import Container from "../components/container"
 
 import docsHierarchy from "../data/sidebars/doc-links.yaml"
 
-// I’m doing some gymnastics here that I can only hope you’ll forgive me for.
-// Find the guides in the sidebar YAML.
-const guides = docsHierarchy.find(group => group.title === `Guides`).items
-
-// Search through guides tree, which may be 2, 3 or more levels deep
-const childItemsBySlug = (guides, slug) => {
+// Search through tree, which may be 2, 3 or more levels deep
+const childItemsBySlug = (docsHierarchy, slug) => {
   let result
 
   const iter = a => {
@@ -31,7 +27,7 @@ const childItemsBySlug = (guides, slug) => {
     return Array.isArray(a.items) && a.items.some(iter)
   }
 
-  guides.some(iter)
+  docsHierarchy.some(iter)
   return result && result.items
 }
 
@@ -40,14 +36,15 @@ const getPageHTML = page => {
     return page.html
   }
 
-  const guidesForPage = childItemsBySlug(guides, page.fields.slug) || []
-  const guideList = guidesForPage
-    .map(guide => `<li><a href="${guide.link}">${guide.title}</a></li>`)
+  const subitemsForPage =
+    childItemsBySlug(docsHierarchy, page.fields.slug) || []
+  const subitemList = subitemsForPage
+    .map(subitem => `<li><a href="${subitem.link}">${subitem.title}</a></li>`)
     .join(``)
-  const toc = guideList
+  const toc = subitemList
     ? `
-    <h2>Guides in this section:</h2>
-    <ul>${guideList}</ul>
+    <h2>In this section:</h2>
+    <ul>${subitemList}</ul>
   `
     : ``
 


### PR DESCRIPTION
TL;DR: Link the pages on https://www.gatsbyjs.org/docs/ marked in the screenshot below, add the required landing pages, and also link the corresponding items in the "Docs" sidebar navigation:

![image](https://user-images.githubusercontent.com/21834/54238492-ef6de880-4518-11e9-957c-a9e539e138cf.png)

- add landing pages for
  - Guides
  - API Reference
  - Releases & Migration
  - Conceptual Guide
  - Advanced Tutorials
  to `docs/docs/`; their intro paragraph is taken from the copy at `www/src/pages/docs/index` / https://www.gatsbyjs.org/docs/
- link those in `www/src/data/doc-links.yaml` and `www/src/pages/docs/index`
  - `/docs/guides/`
  - `/docs/api-reference/`
  - `/docs/releases-and-migration/`
  - `/docs/conceptual-guide/`
  - `/docs/advanced-tutorials/`
- link „Ecosystem“ and „Advanced Tutorials“ in `www/src/pages/docs/index`

Slightly tweak `www/src/templates/template-docs-markdown`: Change „Guides in this section“ headline preceding the list of child articles to say „In this section“, thus making it work for non „Guides“ articles (e.g. the newly added landing pages):

![image](https://user-images.githubusercontent.com/21834/54238774-ad917200-4519-11e9-9519-c864b852a42d.png)

![image](https://user-images.githubusercontent.com/21834/54238761-a10d1980-4519-11e9-89a2-9ef1de266a61.png)

/cc @calcsam @marcysutton