### PR TITLE
Fix broken link in blog

### DIFF
--- a/docs/blog/2019-03-11-dot-org-prototypes/index.md
+++ b/docs/blog/2019-03-11-dot-org-prototypes/index.md
@@ -7,7 +7,7 @@ tags: ["ux", "design"]
 
 Our current [gatsbyjs.org](/) homepage is getting a bit long in the tooth -- our incredible designer @fk built it out a year and a half ago, but a lot's changed and we're getting ready to update it.
 
-We sent out a [messaging survey](blog/2019-03-05-dot-org-messaging-survey/) a few weeks ago to hear how the community was thinking about Gatsby. We put together some [lo-fi prototypes](https://www.figma.com/proto/UH2Qb3IeF8Hvg6csIW3mcqFc/Gatsbyjs.org-mobile-homepage-prototype?node-id=22%3A329&viewport=-227%2C349%2C0.39312&scaling=scale-down).
+We sent out a [messaging survey](/blog/2019-03-05-dot-org-messaging-survey/) a few weeks ago to hear how the community was thinking about Gatsby. We put together some [lo-fi prototypes](https://www.figma.com/proto/UH2Qb3IeF8Hvg6csIW3mcqFc/Gatsbyjs.org-mobile-homepage-prototype?node-id=22%3A329&viewport=-227%2C349%2C0.39312&scaling=scale-down).
 
 Now, it was time to move to the next phase: user testing.
 


### PR DESCRIPTION
## Description

I found broken link in [latest blog](https://www.gatsbyjs.org/blog/2019-03-11-dot-org-prototypes/)
I fixed it.