### PR TITLE
docs(www): Change CommonJS examples to ES6 modules

### DIFF
--- a/docs/docs/add-offline-support-with-a-service-worker.md
+++ b/docs/docs/add-offline-support-with-a-service-worker.md
@@ -48,7 +48,7 @@ Note: Service worker registers only in production builds (`gatsby build`).
 To display a custom message once your service worker finds an update, you can use the [`onServiceWorkerUpdateReady`](/docs/browser-apis/#onServiceWorkerUpdateReady) browser API in your `gatsby-browser.js` file. The following code will display a confirm prompt asking the user whether they would like to refresh the page when an update is found:
 
 ```javascript:title=gatsby-browser.js
-exports const onServiceWorkerUpdateReady = () => {
+export const onServiceWorkerUpdateReady = () => {
   const answer = window.confirm(
     `This application has been updated. ` +
       `Reload to display the latest version?`
@@ -69,7 +69,7 @@ Add a file called `sw.js` in the `static` folder.
 Use the [`registerServiceWorker`](/docs/browser-apis/#registerServiceWorker) browser API in your `gatsby-browser.js` file.
 
 ```javascript:title=gatsby-browser.js
-exports const registerServiceWorker = () => true
+export const registerServiceWorker = () => true
 ```
 
 That's all! Gatsby will register your custom service worker.

--- a/docs/docs/add-offline-support-with-a-service-worker.md
+++ b/docs/docs/add-offline-support-with-a-service-worker.md
@@ -48,7 +48,7 @@ Note: Service worker registers only in production builds (`gatsby build`).
 To display a custom message once your service worker finds an update, you can use the [`onServiceWorkerUpdateReady`](/docs/browser-apis/#onServiceWorkerUpdateReady) browser API in your `gatsby-browser.js` file. The following code will display a confirm prompt asking the user whether they would like to refresh the page when an update is found:
 
 ```javascript:title=gatsby-browser.js
-exports.onServiceWorkerUpdateReady = () => {
+exports const onServiceWorkerUpdateReady = () => {
   const answer = window.confirm(
     `This application has been updated. ` +
       `Reload to display the latest version?`
@@ -69,7 +69,7 @@ Add a file called `sw.js` in the `static` folder.
 Use the [`registerServiceWorker`](/docs/browser-apis/#registerServiceWorker) browser API in your `gatsby-browser.js` file.
 
 ```javascript:title=gatsby-browser.js
-exports.registerServiceWorker = () => true
+exports const registerServiceWorker = () => true
 ```
 
 That's all! Gatsby will register your custom service worker.


### PR DESCRIPTION
## Description

When I tried to follow the guide and add service worker to my project, I got this error:

![image](https://user-images.githubusercontent.com/5833391/54295694-e94e3980-45f6-11e9-848a-d574580399ba.png)

The reason is already listed on your [migration guide from v1 to v2](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#convert-to-either-pure-commonjs-or-pure-es6).
Though the error message and the migration guide are already awesome, I think this can still be improved.

Why I think this will make document more helpful is almost all of the examples or starter are using ES6 modules in `gatsby-browser.js`, changing that could make development more smoothly.
