### PR TITLE
Update fetch.js to fix WordPress.com integration

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -5,7 +5,7 @@ const minimatch = require(`minimatch`)
 const colorized = require(`./output-color`)
 const httpExceptionHandler = require(`./http-exception-handler`)
 const requestInQueue = require(`./request-in-queue`)
-const URL = require("url").URL
+const URL = require(`url`).URL
 /**
  * Check auth object to see if we should fetch JWT access token
  */


### PR DESCRIPTION
Related to https://github.com/gatsbyjs/gatsby/pull/10624

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

When running gatsby develop, the terminal showed that all my fetch requests were pointing to 'https://public-api.wordpress.com' instead of the individual wordpress.com pages. By referencing #10624 and a few minor tweaks, I was able to get this to work correctly.

## Related Issues

#10624
#10427


