### PR TITLE
chore(gatsby-remark-prismjs): add warnings when language not found

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
@@ -56,11 +56,42 @@ export default Counter
   })
 
   describe(`with language-text`, () => {
-    it(`escapes &, <, " elements #4597`, () => {
+    it(`escapes &, <, " elements #4597 and warns`, () => {
+      spyOn(console, `warn`)
+
       const highlightCode = require(`../highlight-code`)
       const language = `text`
       const code = `<button />`
       expect(highlightCode(language, code)).toMatch(`&lt;button /&gt;`)
+      expect(console.warn).toHaveBeenCalledWith(
+        `unable to find prism language 'text' for highlighting.`,
+        `applying generic code block`
+      )
+    })
+
+    it(`warns once per language`, () => {
+      spyOn(console, `warn`)
+
+      const highlightCode = require(`../highlight-code`)
+      const language1 = `text`
+      const language2 = `raw`
+      const code1 = `<button />`
+      const code2 = `<form />`
+      const code3 = `<input />`
+      highlightCode(language1, code1)
+      highlightCode(language1, code2)
+      highlightCode(language2, code3)
+      expect(console.warn).toHaveBeenCalledTimes(2)
+      expect(console.warn).toHaveBeenNthCalledWith(
+        1,
+        `unable to find prism language 'text' for highlighting.`,
+        `applying generic code block`
+      )
+      expect(console.warn).toHaveBeenNthCalledWith(
+        2,
+        `unable to find prism language 'raw' for highlighting.`,
+        `applying generic code block`
+      )
     })
   })
 

--- a/packages/gatsby-remark-prismjs/src/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/highlight-code.js
@@ -3,7 +3,7 @@ const _ = require(`lodash`)
 
 const loadPrismLanguage = require(`./load-prism-language`)
 const handleDirectives = require(`./directives`)
-const notSupportedLanguages = []
+const unsupportedLanguages = new Set()
 
 module.exports = (language, code, lineNumbersHighlight = []) => {
   // (Try to) load languages on demand.
@@ -15,12 +15,12 @@ module.exports = (language, code, lineNumbersHighlight = []) => {
       if (language === `none`) {
         return code // Don't escape if set to none.
       } else {
-        if (!notSupportedLanguages.includes(language)) {
+        if (!unsupportedLanguages.has(language)) {
           console.warn(
             `unable to find prism language '${language}' for highlighting.`,
             `applying generic code block`
           )
-          notSupportedLanguages.push(language)
+          unsupportedLanguages.add(language)
         }
         return _.escape(code)
       }

--- a/packages/gatsby-remark-prismjs/src/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/highlight-code.js
@@ -3,6 +3,7 @@ const _ = require(`lodash`)
 
 const loadPrismLanguage = require(`./load-prism-language`)
 const handleDirectives = require(`./directives`)
+const notSupportedLanguages = []
 
 module.exports = (language, code, lineNumbersHighlight = []) => {
   // (Try to) load languages on demand.
@@ -14,6 +15,13 @@ module.exports = (language, code, lineNumbersHighlight = []) => {
       if (language === `none`) {
         return code // Don't escape if set to none.
       } else {
+        if (!notSupportedLanguages.includes(language)) {
+          console.warn(
+            `unable to find prism language '${language}' for highlighting.`,
+            `applying generic code block`
+          )
+          notSupportedLanguages.push(language)
+        }
         return _.escape(code)
       }
     }

--- a/packages/gatsby-remark-prismjs/src/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/highlight-code.js
@@ -15,12 +15,13 @@ module.exports = (language, code, lineNumbersHighlight = []) => {
       if (language === `none`) {
         return code // Don't escape if set to none.
       } else {
-        if (!unsupportedLanguages.has(language)) {
+        const lang = language.toLowerCase()
+        if (!unsupportedLanguages.has(lang)) {
           console.warn(
-            `unable to find prism language '${language}' for highlighting.`,
+            `unable to find prism language '${lang}' for highlighting.`,
             `applying generic code block`
           )
-          unsupportedLanguages.add(language)
+          unsupportedLanguages.add(lang)
         }
         return _.escape(code)
       }


### PR DESCRIPTION
## Description

Adding a warning to the `gatsby-remark-prismjs` plugin when language is not found. The warn pops up only once per language to avoid spamming messages as @pieh commented in the issue #11667.

## Related Issues

Fixes: #11667 