### PR TITLE
fix(showcase): remove source_url from seomonitor

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4920,7 +4920,6 @@
 - title: SEOmonitor
   main_url: "https://www.seomonitor.com"
   url: "https://www.seomonitor.com"
-  source_url:
   description: >
     SEOmonitor is a suite of SEO tools dedicated to agencies.
   categories:


### PR DESCRIPTION
Seems like showcases are failing because of a wrong entry