### PR TITLE
chore(*): remove all githead from package.json

### DIFF
--- a/packages/gatsby-codemods/package.json
+++ b/packages/gatsby-codemods/package.json
@@ -31,6 +31,5 @@
     "babel-preset-gatsby-package": "^0.1.4",
     "cross-env": "^5.0.5",
     "jscodeshift": "^0.5.1"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -36,6 +36,5 @@
     "prepare": "cross-env NODE_ENV=production npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "babel -w src --out-dir dist"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -42,6 +42,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -42,6 +42,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-plugin-react-css-modules/package.json
+++ b/packages/gatsby-plugin-react-css-modules/package.json
@@ -39,6 +39,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -47,6 +47,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -39,6 +39,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -40,6 +40,5 @@
     "build": "babel --out-dir . --ignore **/__tests__ src",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "788133e56dd005663f353fff90ffa37ce2fd87b9"
+  }
 }

--- a/packages/gatsby-remark-graphviz/package.json
+++ b/packages/gatsby-remark-graphviz/package.json
@@ -40,6 +40,5 @@
     "build": "babel --out-dir . src",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -32,6 +32,5 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^2.0.0"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -44,6 +44,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -37,6 +37,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -41,6 +41,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "afc22bfad9e23be36b73d469f7abbb8eb5fb1e18"
+  }
 }

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -34,6 +34,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "afc22bfad9e23be36b73d469f7abbb8eb5fb1e18"
+  }
 }

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -43,6 +43,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "afc22bfad9e23be36b73d469f7abbb8eb5fb1e18"
+  }
 }

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -36,6 +36,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -32,6 +32,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -38,6 +38,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-source-medium/package.json
+++ b/packages/gatsby-source-medium/package.json
@@ -31,6 +31,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -34,6 +34,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -37,6 +37,5 @@
     "lodash": "^4.17.4",
     "p-iteration": "^1.1.7",
     "prettyjson": "^1.2.1"
-  },
-  "gitHead": "afc22bfad9e23be36b73d469f7abbb8eb5fb1e18"
+  }
 }

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -42,6 +42,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "afc22bfad9e23be36b73d469f7abbb8eb5fb1e18"
+  }
 }

--- a/packages/gatsby-transformer-excel/package.json
+++ b/packages/gatsby-transformer-excel/package.json
@@ -32,6 +32,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-transformer-json/package.json
+++ b/packages/gatsby-transformer-json/package.json
@@ -31,6 +31,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -38,6 +38,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -44,6 +44,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -33,6 +33,5 @@
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }


### PR DESCRIPTION
These were/are temporary lerna artifacts that shouldn't be committed. They
[should not appear in package.json](https://github.com/lerna/lerna/issues/1880#issuecomment-456160357).

The _why_ of this PR is that I was publishing a minor release, and it
led to a publish failing because it was updating gitHead and trying to
commit the change. May as well remove this so we're isolated from that going forward.

This will cause a re-release of a _bunch_ of packages upon merging, but
that's probably OK.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
