### PR TITLE
let shadowed components import parents

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -35,6 +35,21 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
       // get the location of the component relative to src/
       const [, component] = request.path.split(path.join(theme, `src`))
 
+      const issuerExtension = path.extname(request.context.issuer)
+
+      if (
+        request.context.issuer
+          .slice(0, -issuerExtension.length)
+          .endsWith(component)
+      ) {
+        return resolver.doResolve(
+          `describedRelative`,
+          request,
+          null,
+          {},
+          callback
+        )
+      }
       const builtComponentPath = this.resolveComponentPath({
         matchingTheme: theme,
         themes: this.themes,


### PR DESCRIPTION
## Description

If we have a theme file and a shadow of that file

    
    gatsby-theme-a/src/components/bio.js
    site/src/gatsby-theme-a/components/bio.js
    

the site's bio.js can not import the theme's bio.js. Now it can.