### PR TITLE
fix(gatsby-react-router-scroll): hide sessionStorage warnings in production

### DIFF
--- a/packages/gatsby-react-router-scroll/.babelrc
+++ b/packages/gatsby-react-router-scroll/.babelrc
@@ -1,6 +1,3 @@
 {
-  "presets": [
-    ["babel-preset-gatsby-package", { "browser": true }]
-  ],
-  "plugins": ["dev-expression"]
+  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
 }

--- a/packages/gatsby-react-router-scroll/.eslintrc.yaml
+++ b/packages/gatsby-react-router-scroll/.eslintrc.yaml
@@ -1,4 +1,2 @@
 env:
   browser: true
-globals:
-  __DEV__: false

--- a/packages/gatsby-react-router-scroll/src/ScrollContainer.js
+++ b/packages/gatsby-react-router-scroll/src/ScrollContainer.js
@@ -34,7 +34,7 @@ class ScrollContainer extends React.Component {
 
     // Only keep around the current DOM node in development, as this is only
     // for emitting the appropriate warning.
-    if (__DEV__) {
+    if (process.env.NODE_ENV === `production`) {
       this.domNode = ReactDOM.findDOMNode(this) // eslint-disable-line react/no-find-dom-node
     }
   }
@@ -44,7 +44,7 @@ class ScrollContainer extends React.Component {
       prevProps.scrollKey === this.props.scrollKey,
       `<ScrollContainer> does not support changing scrollKey.`
     )
-    if (__DEV__) {
+    if (process.env.NODE_ENV === `production`) {
       const prevDomNode = this.domNode
       this.domNode = ReactDOM.findDOMNode(this) // eslint-disable-line react/no-find-dom-node
 

--- a/packages/gatsby-react-router-scroll/src/ScrollContainer.js
+++ b/packages/gatsby-react-router-scroll/src/ScrollContainer.js
@@ -34,7 +34,7 @@ class ScrollContainer extends React.Component {
 
     // Only keep around the current DOM node in development, as this is only
     // for emitting the appropriate warning.
-    if (process.env.NODE_ENV === `production`) {
+    if (process.env.NODE_ENV !== `production`) {
       this.domNode = ReactDOM.findDOMNode(this) // eslint-disable-line react/no-find-dom-node
     }
   }
@@ -44,7 +44,7 @@ class ScrollContainer extends React.Component {
       prevProps.scrollKey === this.props.scrollKey,
       `<ScrollContainer> does not support changing scrollKey.`
     )
-    if (process.env.NODE_ENV === `production`) {
+    if (process.env.NODE_ENV !== `production`) {
       const prevDomNode = this.domNode
       this.domNode = ReactDOM.findDOMNode(this) // eslint-disable-line react/no-find-dom-node
 

--- a/packages/gatsby-react-router-scroll/src/StateStorage.js
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.js
@@ -9,7 +9,7 @@ export default class SessionStorage {
       const value = window.sessionStorage.getItem(stateKey)
       return JSON.parse(value)
     } catch (e) {
-      if (process.env.NODE_ENV === `production`) {
+      if (process.env.NODE_ENV !== `production`) {
         console.warn(
           `[gatsby-react-router-scroll] Unable to access sessionStorage; sessionStorage is not available.`
         )
@@ -41,7 +41,7 @@ export default class SessionStorage {
         window[GATSBY_ROUTER_SCROLL_STATE][stateKey] = JSON.parse(storedValue)
       }
 
-      if (process.env.NODE_ENV === `production`) {
+      if (process.env.NODE_ENV !== `production`) {
         console.warn(
           `[gatsby-react-router-scroll] Unable to save state in sessionStorage; sessionStorage is not available.`
         )

--- a/packages/gatsby-react-router-scroll/src/StateStorage.js
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.js
@@ -9,7 +9,7 @@ export default class SessionStorage {
       const value = window.sessionStorage.getItem(stateKey)
       return JSON.parse(value)
     } catch (e) {
-      if (__DEV__) {
+      if (process.env.NODE_ENV === `production`) {
         console.warn(
           `[gatsby-react-router-scroll] Unable to access sessionStorage; sessionStorage is not available.`
         )
@@ -41,7 +41,7 @@ export default class SessionStorage {
         window[GATSBY_ROUTER_SCROLL_STATE][stateKey] = JSON.parse(storedValue)
       }
 
-      if (__DEV__) {
+      if (process.env.NODE_ENV === `production`) {
         console.warn(
           `[gatsby-react-router-scroll] Unable to save state in sessionStorage; sessionStorage is not available.`
         )

--- a/packages/gatsby-react-router-scroll/src/StateStorage.js
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.js
@@ -9,9 +9,11 @@ export default class SessionStorage {
       const value = window.sessionStorage.getItem(stateKey)
       return JSON.parse(value)
     } catch (e) {
-      console.warn(
-        `[gatsby-react-router-scroll] Unable to access sessionStorage; sessionStorage is not available.`
-      )
+      if (__DEV__) {
+        console.warn(
+          `[gatsby-react-router-scroll] Unable to access sessionStorage; sessionStorage is not available.`
+        )
+      }
 
       if (
         window &&
@@ -39,9 +41,11 @@ export default class SessionStorage {
         window[GATSBY_ROUTER_SCROLL_STATE][stateKey] = JSON.parse(storedValue)
       }
 
-      console.warn(
-        `[gatsby-react-router-scroll] Unable to save state in sessionStorage; sessionStorage is not available.`
-      )
+      if (__DEV__) {
+        console.warn(
+          `[gatsby-react-router-scroll] Unable to save state in sessionStorage; sessionStorage is not available.`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Hide sessionStorage warnings in production

## Description

Concerns the plugin `gatsby-react-router-scroll`.

If cookies are disabled, the production version of the website would show console warnings when scrolling.

With this change, those warnings will only be visible in the development version.

## Related Issues

Fixes #12577