### PR TITLE
chore(docs): add GatsbyGuides to sourcing from drupal doc

### DIFF
--- a/docs/docs/sourcing-from-drupal.md
+++ b/docs/docs/sourcing-from-drupal.md
@@ -84,3 +84,4 @@ Using Gatsby together with Drupal offers a powerful, full-featured, open-source,
 - Watch [Kyle Mathews’ presentation on Gatsby + Drupal](https://2017.badcamp.net/session/coding-development/beginner/headless-drupal-building-blazing-fast-websites-reactgatsbyjs)
 - Get started with Robert Ngo’s [Decoupling Drupal with Gatsby tutorial](https://evolvingweb.ca/blog/decoupling-drupal-gatsby) and watch his [Evolving Web 2018 Drupal conference presentation](https://www.youtube.com/watch?v=s5kUJRGDz6I)
 - Example site that demonstrates [how to build Gatsby sites that pull data from the Drupal CMS](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-drupal).
+- Take a [free course on building a Gatsby site with Drupal](https://gatsbyguides.com/).


### PR DESCRIPTION
## Description

[GatsbyGuides.com](https://gatsbyguides.com/) has a free 10-lesson course on building a site with Drupal as the back end. It would be a good resource to list here.