### PR TITLE
feat(gatsby-plugin-google-gtag): add TS types for OutboundLink

### DIFF
--- a/packages/gatsby-plugin-google-gtag/index.d.ts
+++ b/packages/gatsby-plugin-google-gtag/index.d.ts
@@ -1,0 +1,11 @@
+import * as React from "react"
+
+interface OutboundLinkProps {
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
+}
+
+export class OutboundLink extends React.Component<
+  OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>,
+  any
+> {}
+

--- a/packages/gatsby-plugin-google-gtag/src/index.js
+++ b/packages/gatsby-plugin-google-gtag/src/index.js
@@ -7,7 +7,7 @@ function OutboundLink(props) {
       {...props}
       onClick={e => {
         if (typeof props.onClick === `function`) {
-          props.onClick()
+          props.onClick(e)
         }
         let redirect = true
         if (


### PR DESCRIPTION
## Description

- gatsby-plugin-google-gtag's OutboundLink `props.onClick` now receives the original event. This mimics the behaviour of [gatsby-plugin-google-analytics OutboundLink](https://github.com/gatsbyjs/gatsby/blob/3834b2bce5edc60cd5386561498ca29f028c1d30/packages/gatsby-plugin-google-analytics/src/index.js#L10)
- Add types for gatsby-plugin-google-gtag. These are copied from [gatsby-plugin-google-analytics's types](https://github.com/gatsbyjs/gatsby/commits/master/packages/gatsby-plugin-google-analytics/index.d.ts) as the OutboundLink signatures are identical
