### PR TITLE
feat(gatsby-plugin-twitter): load widget for all Twitter embeds

### DIFF
--- a/packages/gatsby-plugin-twitter/README.md
+++ b/packages/gatsby-plugin-twitter/README.md
@@ -1,7 +1,7 @@
 # gatsby-plugin-twitter
 
-Loads the Twitter JavaScript for embedding tweets. Lets you add tweets to
-markdown and in other places.
+Loads the Twitter JavaScript for embedding tweets, timelines, share and follow
+buttons. Lets you add tweets to markdown and in other places.
 
 Note: when copying the embed code, just copy the blockquote section and not the
 script.

--- a/packages/gatsby-plugin-twitter/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/gatsby-browser.js
@@ -27,10 +27,12 @@ const injectTwitterScript = () => {
 
 let injectedTwitterScript = false
 
-const embedClasses = `.twitter-tweet,
-  .twitter-timeline,
-  .twitter-follow-button,
-  .twitter-share-button`
+const embedClasses = [
+  `.twitter-tweet`,
+  `.twitter-timeline`,
+  `.twitter-follow-button`,
+  `.twitter-share-button`
+].join(`,`)
 
 exports.onRouteUpdate = () => {
   // If there's an embedded element, lazy-load the twitter script (if it hasn't

--- a/packages/gatsby-plugin-twitter/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/gatsby-browser.js
@@ -27,10 +27,15 @@ const injectTwitterScript = () => {
 
 let injectedTwitterScript = false
 
+const embedClasses = `.twitter-tweet,
+  .twitter-timeline,
+  .twitter-follow-button,
+  .twitter-share-button`
+
 exports.onRouteUpdate = () => {
-  // If there's an embedded tweet, lazy-load the twitter script (if it hasn't
+  // If there's an embedded element, lazy-load the twitter script (if it hasn't
   // already been loaded), and then run the twitter load function.
-  if (document.querySelector(`.twitter-tweet`) !== null) {
+  if (document.querySelector(embedClasses) !== null) {
     if (!injectedTwitterScript) {
       injectTwitterScript()
       injectedTwitterScript = true

--- a/packages/gatsby-plugin-twitter/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-twitter/src/gatsby-browser.js
@@ -31,7 +31,7 @@ const embedClasses = [
   `.twitter-tweet`,
   `.twitter-timeline`,
   `.twitter-follow-button`,
-  `.twitter-share-button`
+  `.twitter-share-button`,
 ].join(`,`)
 
 exports.onRouteUpdate = () => {


### PR DESCRIPTION
Besides `.twitter-tweet`, there are other elements that Twitter widget renders: timelines, follow and share buttons - as mentioned in [Twitter developer docs](https://developer.twitter.com/en/docs/twitter-for-websites/overview.html).

This small change loads the widget script if _any_ of these elements is present on the page, not only `.twitter-tweet` elements.