### PR TITLE
docs(www): Wording improvement

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -290,7 +290,7 @@ You'll often want to link between pages -- Let's look at routing in a Gatsby sit
 
 ### ✋ Using the `<Link />` component
 
-1.  Open the index page component (`src/pages/index.js`). Import the `<Link />` component from Gatsby. Add a `<Link />` component below the header, and give it a `to` property, with the value of `"/contact/"` for the pathname:
+1.  Open the index page component (`src/pages/index.js`). Import the `<Link />` component from Gatsby. Add a `<Link />` component above the header, and give it a `to` property, with the value of `"/contact/"` for the pathname:
 
 ```jsx:title=src/pages/index.js
 import React from "react"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In the code example, the Link component is placed "above" the Header component. The current instructions say to place the Link component "below" the Header component.

I changed the word "below" to "above".

## Related Issues

<!--

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.

  https://github.com/gatsbyjs/gatsby/blob/master/docs/tutorial/part-one/index.md

-->
