### PR TITLE
fix(gatsby-source-contentful): Add gatsby-source-filesystem as dependency

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -15,6 +15,7 @@
     "deep-map": "^1.5.0",
     "fs-extra": "^4.0.2",
     "gatsby-plugin-sharp": "^2.0.29",
+    "gatsby-source-filesystem": "^2.0.27",
     "is-online": "^7.0.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.10",


### PR DESCRIPTION
## Description

gatsby-source-contentful@2.0.39 introduces localDownload, using gatsby-source-filesystem. This should be added as dependency.