### PR TITLE
feat(gatsby-plugin-sitemap): sanitize siteUrl

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
@@ -1,0 +1,81 @@
+const {
+  runQuery,
+  defaultOptions: { serialize },
+} = require(`../internals`)
+
+describe(`results using default settings`, () => {
+  const generateQueryResultsMock = (
+    { siteUrl } = { siteUrl: `http://dummy.url` }
+  ) => {
+    return {
+      data: {
+        site: {
+          siteMetadata: {
+            siteUrl: siteUrl,
+          },
+        },
+        allSitePage: {
+          edges: [
+            {
+              node: {
+                path: `/page-1`,
+              },
+            },
+            {
+              node: {
+                path: `/page-2`,
+              },
+            },
+          ],
+        },
+      },
+    }
+  }
+
+  const verifyUrlsExistInResults = (results, urls) => {
+    expect(results.map(result => result.url)).toEqual(urls)
+  }
+
+  const runTests = (pathPrefix = ``) => {
+    it(`prepares all urls correctly`, async () => {
+      const graphql = () => Promise.resolve(generateQueryResultsMock())
+      const queryRecords = await runQuery(graphql, ``, [], pathPrefix)
+      const urls = serialize(queryRecords)
+
+      verifyUrlsExistInResults(urls, [
+        `http://dummy.url${pathPrefix}/page-1`,
+        `http://dummy.url${pathPrefix}/page-2`,
+      ])
+    })
+
+    it(`sanitize siteUrl`, async () => {
+      const graphql = () =>
+        Promise.resolve(
+          generateQueryResultsMock({ siteUrl: `http://dummy.url/` })
+        )
+      const queryRecords = await runQuery(graphql, ``, [], pathPrefix)
+      const urls = serialize(queryRecords)
+
+      verifyUrlsExistInResults(urls, [
+        `http://dummy.url${pathPrefix}/page-1`,
+        `http://dummy.url${pathPrefix}/page-2`,
+      ])
+    })
+
+    it(`excludes pages`, async () => {
+      const graphql = () => Promise.resolve(generateQueryResultsMock())
+      const queryRecords = await runQuery(graphql, ``, [`/page-2`], pathPrefix)
+      const urls = serialize(queryRecords)
+
+      verifyUrlsExistInResults(urls, [`http://dummy.url${pathPrefix}/page-1`])
+    })
+  }
+
+  describe(`no path-prefix`, () => {
+    runTests()
+  })
+
+  describe(`with path-prefix`, () => {
+    runTests(`/path-prefix`)
+  })
+})

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -29,6 +29,9 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
       return page
     })
 
+    // remove trailing slash of siteUrl
+    r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(r.data.site.siteMetadata.siteUrl)
+
     return r.data
   })
 

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -30,7 +30,9 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
     })
 
     // remove trailing slash of siteUrl
-    r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(r.data.site.siteMetadata.siteUrl)
+    r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(
+      r.data.site.siteMetadata.siteUrl
+    )
 
     return r.data
   })

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -29,10 +29,12 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
       return page
     })
 
-    // remove trailing slash of siteUrl
-    r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(
-      r.data.site.siteMetadata.siteUrl
-    )
+    if (r.data.site.siteMetadata.siteUrl) {
+      // remove trailing slash of siteUrl
+      r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(
+        r.data.site.siteMetadata.siteUrl
+      )
+    }
 
     return r.data
   })


### PR DESCRIPTION
## Description

For sitemap plugin
Add code to remove trailing slash of siteUrl.

## Related Issues

Fix https://github.com/gatsbyjs/gatsby/issues/12590