### PR TITLE
chore(gatsby-plugin-react-helmet): ignore __mocks__ when building package

### DIFF
--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -40,8 +40,8 @@
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet",
   "scripts": {
-    "build": "babel src --out-dir . --ignore **/__tests__",
+    "build": "babel src --out-dir . --ignore **/__tests__,**/__mocks__",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+    "watch": "babel -w src --out-dir . --ignore **/__tests__,**/__mocks__"
   }
 }


### PR DESCRIPTION
recently `__mocks__` were added to `gatsby-plugin-react-helmet` but babel does compile those and result is not gitignored, so it's easy to stage and commit this file by mistake (like in https://github.com/gatsbyjs/gatsby/pull/12604/commits/31c0897cd2d5c8ef23a019dfdbe9e16a0058b67a#diff-634ad4cd28b951f32c8fcaafe4842128 )

Let's ignore __mocks__ when running babel