### PR TITLE
only check for update when not on CI

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -21,6 +21,7 @@
     "fs-exists-cached": "^1.0.0",
     "fs-extra": "^4.0.1",
     "hosted-git-info": "^2.6.0",
+    "is-ci": "^2.0.0",
     "lodash": "^4.17.10",
     "meant": "^1.0.1",
     "opentracing": "^0.14.3",

--- a/packages/gatsby-cli/src/index.js
+++ b/packages/gatsby-cli/src/index.js
@@ -4,18 +4,21 @@
 // use require() with backtick strings so use the es6 syntax
 import "@babel/polyfill"
 
+const isCI = require(`is-ci`)
 const createCli = require(`./create-cli`)
 const report = require(`./reporter`)
 
 global.Promise = require(`bluebird`)
 
+if (!icCI) {
+  const pkg = require(`../package.json`)
+  const updateNotifier = require(`update-notifier`)
+  // Check if update is available
+  updateNotifier({ pkg }).notify()
+}
+
 const version = process.version
 const verDigit = Number(version.match(/\d+/)[0])
-
-const pkg = require(`../package.json`)
-const updateNotifier = require(`update-notifier`)
-// Check if update is available
-updateNotifier({ pkg }).notify()
 
 if (verDigit < 6) {
   report.panic(

--- a/packages/gatsby-cli/src/index.js
+++ b/packages/gatsby-cli/src/index.js
@@ -10,7 +10,7 @@ const report = require(`./reporter`)
 
 global.Promise = require(`bluebird`)
 
-if (!icCI) {
+if (!isCI) {
   const pkg = require(`../package.json`)
   const updateNotifier = require(`update-notifier`)
   // Check if update is available


### PR DESCRIPTION
## Description

When running Gatsby on a CI, the prompt to update it is annoying. Moreover, if it fails (because CI env are weird sometimes), the entire command with:

```
error There was a problem loading the local build command. Gatsby may not be installed. Perhaps you need to run "npm install"?

┌────────────────────────────────────────────────────────────────┐
│ gatsby-cli update check failed │
│ Try running with sudo or get access │
│ to the local update config store via │
│ sudo chown -R $USER:$(id -gn $USER) /home/sbx_user1051/.config │
└────────────────────────────────────────────────────────────────┘
```

which is a really weird error message, especially considering the beginning of it.

This PR makes sure that the check for updates is skipped on CIs