### PR TITLE
fix(gatsby): workaround webpack terser plugin hanging on WSL

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -79,6 +79,7 @@
     "invariant": "^2.2.4",
     "is-relative": "^1.0.0",
     "is-relative-url": "^2.0.0",
+    "is-wsl": "^1.1.0",
     "jest-worker": "^23.2.0",
     "joi": "12.x.x",
     "json-loader": "^0.5.7",

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -445,6 +445,8 @@ module.exports = async ({
   plugins.minifyJs = ({ terserOptions, ...options } = {}) =>
     new TerserPlugin({
       cache: true,
+      // We can't use parallel in WSL because of https://github.com/gatsbyjs/gatsby/issues/6540
+      // This issue was fixed in https://github.com/gatsbyjs/gatsby/pull/12636
       parallel: !isWsl,
       exclude: /\.min\.js/,
       sourceMap: true,

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -5,7 +5,7 @@ const flexbugs = require(`postcss-flexbugs-fixes`)
 const TerserPlugin = require(`terser-webpack-plugin`)
 const MiniCssExtractPlugin = require(`mini-css-extract-plugin`)
 const OptimizeCssAssetsPlugin = require(`optimize-css-assets-webpack-plugin`)
-const os = require(`os`)
+const isWsl = require(`is-wsl`)
 
 const GatsbyWebpackStatsExtractor = require(`./gatsby-webpack-stats-extractor`)
 
@@ -445,7 +445,7 @@ module.exports = async ({
   plugins.minifyJs = ({ terserOptions, ...options } = {}) =>
     new TerserPlugin({
       cache: true,
-      parallel: !os.release().includes(`Microsoft`),
+      parallel: !isWsl,
       exclude: /\.min\.js/,
       sourceMap: true,
       terserOptions: {

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -5,6 +5,7 @@ const flexbugs = require(`postcss-flexbugs-fixes`)
 const TerserPlugin = require(`terser-webpack-plugin`)
 const MiniCssExtractPlugin = require(`mini-css-extract-plugin`)
 const OptimizeCssAssetsPlugin = require(`optimize-css-assets-webpack-plugin`)
+const os = require(`os`)
 
 const GatsbyWebpackStatsExtractor = require(`./gatsby-webpack-stats-extractor`)
 
@@ -444,7 +445,7 @@ module.exports = async ({
   plugins.minifyJs = ({ terserOptions, ...options } = {}) =>
     new TerserPlugin({
       cache: true,
-      parallel: true,
+      parallel: !os.release().includes(`Microsoft`),
       exclude: /\.min\.js/,
       sourceMap: true,
       terserOptions: {


### PR DESCRIPTION
## Description

### What is the issue?
I am running Gatsby on WSL and I have this problem #6540.
[Right here](https://github.com/gatsbyjs/gatsby/issues/6540#issuecomment-438524817) someone said that if you change `parallel:true` to `parallel:false` in node_modules/gatsby/dist/utils/webpack-utils.js that solves the problem.

### Why do I submit this pull request?
I decided to make a pull request so that this issue is resolved permanently for everyone using WSL (Windows Subsystem for Linux).

### How did I test it?
I followed [this guide](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) and tested it locally and I can confirm that it works.
After that I ran `yarn test` to make sure that I didn't break anything in the repository.

### Why do I want it merged?
I hope this gets merged so all of us using WSL can stop editing node_modules/gatsby/dist/utils/webpack-utils.js every time we do `npm install` or `yarn install`

## Related Issues

If this pull request gets merged it will solve #6540 and #7013


