### PR TITLE
[schema] Ignore empty strings in example value creation

### DIFF
--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -39,6 +39,12 @@ const getExampleObject = ({
     const entries = nodes
       .map(node => {
         const value = node[key]
+
+        // Treat empty strings not as String type,
+        // but ignore them for type inference.
+        // TODO: Possibly revisit in Gatsby v3.
+        if (value === ``) return undefined
+
         const type = getType(value)
         return type && { value, type, parent: node }
       })

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -39,12 +39,6 @@ const getExampleObject = ({
     const entries = nodes
       .map(node => {
         const value = node[key]
-
-        // Treat empty strings not as String type,
-        // but ignore them for type inference.
-        // TODO: Possibly revisit in Gatsby v3.
-        if (value === ``) return undefined
-
         const type = getType(value)
         return type && { value, type, parent: node }
       })
@@ -67,7 +61,12 @@ const getExampleObject = ({
       if (
         // Maybe have a warning here too
         isMixOfDatesAndStrings(
-          entriesByType.map(entry => entry.type),
+          entriesByType
+            // Treat empty strings not as String type,
+            // but ignore them for type inference.
+            // TODO: Possibly revisit in Gatsby v3.
+            .filter(entry => entry.value !== ``)
+            .map(entry => entry.type),
           arrayWrappers
         )
       ) {

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -59,18 +59,28 @@ const getExampleObject = ({
 
     if (entriesByType.length > 1 || type.includes(`,`)) {
       if (
-        // Maybe have a warning here too
         isMixOfDatesAndStrings(
-          entriesByType
-            // Treat empty strings not as String type,
-            // but ignore them for type inference.
-            // TODO: Possibly revisit in Gatsby v3.
-            .filter(entry => entry.value !== ``)
-            .map(entry => entry.type),
+          entriesByType.map(entry => entry.type),
           arrayWrappers
         )
       ) {
-        value = `String`
+        // TODO: Possibly revisit this in Gatsby v3.
+        const allNonEmptyStringsAreDates = entries.every(entry => {
+          const values = Array.isArray(entry.value)
+            ? _.flatMap(entry.value)
+            : [entry.value]
+          if (
+            values.every(value => value === `` || getType(value) === `date`)
+          ) {
+            return true
+          }
+          return false
+        })
+        if (allNonEmptyStringsAreDates) {
+          value = `1978-09-26`
+        } else {
+          value = `string`
+        }
       } else {
         typeConflictReporter.addConflict(selector, entriesByType)
         return acc

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -69,12 +69,9 @@ const getExampleObject = ({
           const values = Array.isArray(entry.value)
             ? _.flatMap(entry.value)
             : [entry.value]
-          if (
-            values.every(value => value === `` || getType(value) === `date`)
-          ) {
-            return true
-          }
-          return false
+          return values.every(
+            value => value === `` || getType(value) === `date`
+          )
         })
         if (allNonEmptyStringsAreDates) {
           value = `1978-09-26`

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -79,7 +79,7 @@ const getExampleObject = ({
         if (allNonEmptyStringsAreDates) {
           value = `1978-09-26`
         } else {
-          value = `string`
+          value = `String`
         }
       } else {
         typeConflictReporter.addConflict(selector, entriesByType)


### PR DESCRIPTION
This is for #11480 

For compatibility with current master, don't treat empty strings as String type, but ignore them in example value creation. Possibly revisit this for Gatsby v3.