### PR TITLE
fix(gatsby-transformer-remark): always include the root node of AST

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -22,13 +22,21 @@ Object {
   "excerptAst": Object {
     "children": Array [
       Object {
-        "type": "text",
-        "value": "Where oh where is my little pony?",
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony?",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
       },
     ],
-    "properties": Object {},
-    "tagName": "p",
-    "type": "element",
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
   },
   "frontmatter": Object {
     "title": "my little pony",
@@ -42,13 +50,21 @@ Object {
   "excerptAst": Object {
     "children": Array [
       Object {
-        "type": "text",
-        "value": "Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla…",
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla…",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
       },
     ],
-    "properties": Object {},
-    "tagName": "p",
-    "type": "element",
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
   },
   "frontmatter": Object {
     "title": "my little pony",
@@ -62,13 +78,21 @@ Object {
   "excerptAst": Object {
     "children": Array [
       Object {
-        "type": "text",
-        "value": "Where oh where is my little pony? Lorem ipsum…",
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony? Lorem ipsum…",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
       },
     ],
-    "properties": Object {},
-    "tagName": "p",
-    "type": "element",
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
   },
   "frontmatter": Object {
     "title": "my little pony",
@@ -82,13 +106,21 @@ Object {
   "excerptAst": Object {
     "children": Array [
       Object {
-        "type": "text",
-        "value": "Where oh where is my little pony? Lorem ipsum dol…",
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony? Lorem ipsum dol…",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
       },
     ],
-    "properties": Object {},
-    "tagName": "p",
-    "type": "element",
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
   },
   "frontmatter": Object {
     "title": "my little pony",
@@ -136,72 +168,80 @@ Object {
   "excerptAst": Object {
     "children": Array [
       Object {
-        "type": "text",
-        "value": "Where oh ",
-      },
-      Object {
         "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh ",
+          },
           Object {
             "children": Array [
               Object {
-                "type": "text",
-                "value": "where",
+                "children": Array [
+                  Object {
+                    "type": "text",
+                    "value": "where",
+                  },
+                ],
+                "properties": Object {},
+                "tagName": "em",
+                "type": "element",
               },
             ],
-            "properties": Object {},
-            "tagName": "em",
+            "properties": Object {
+              "href": "nick.com",
+            },
+            "tagName": "a",
             "type": "element",
           },
-        ],
-        "properties": Object {
-          "href": "nick.com",
-        },
-        "tagName": "a",
-        "type": "element",
-      },
-      Object {
-        "type": "text",
-        "value": " ",
-      },
-      Object {
-        "children": Array [
+          Object {
+            "type": "text",
+            "value": " ",
+          },
           Object {
             "children": Array [
               Object {
-                "type": "text",
-                "value": "is",
+                "children": Array [
+                  Object {
+                    "type": "text",
+                    "value": "is",
+                  },
+                ],
+                "properties": Object {},
+                "tagName": "em",
+                "type": "element",
               },
             ],
             "properties": Object {},
-            "tagName": "em",
+            "tagName": "strong",
             "type": "element",
+          },
+          Object {
+            "type": "text",
+            "value": " ",
+          },
+          Object {
+            "children": Array [],
+            "properties": Object {
+              "alt": "that pony",
+              "src": "pony.png",
+            },
+            "tagName": "img",
+            "type": "element",
+          },
+          Object {
+            "type": "text",
+            "value": "?",
           },
         ],
         "properties": Object {},
-        "tagName": "strong",
+        "tagName": "p",
         "type": "element",
-      },
-      Object {
-        "type": "text",
-        "value": " ",
-      },
-      Object {
-        "children": Array [],
-        "properties": Object {
-          "alt": "that pony",
-          "src": "pony.png",
-        },
-        "tagName": "img",
-        "type": "element",
-      },
-      Object {
-        "type": "text",
-        "value": "?",
       },
     ],
-    "properties": Object {},
-    "tagName": "p",
-    "type": "element",
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
   },
   "frontmatter": Object {
     "title": "my little pony",
@@ -215,13 +255,21 @@ Object {
   "excerptAst": Object {
     "children": Array [
       Object {
-        "type": "text",
-        "value": "Where oh where is that pony? Is he in the stable…",
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is that pony? Is he in the stable…",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
       },
     ],
-    "properties": Object {},
-    "tagName": "p",
-    "type": "element",
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
   },
   "frontmatter": Object {
     "title": "my little pony",
@@ -284,28 +332,36 @@ Object {
   "excerptAst": Object {
     "children": Array [
       Object {
-        "type": "text",
-        "value": "Where is my ",
-      },
-      Object {
         "children": Array [
           Object {
             "type": "text",
-            "value": "pony",
+            "value": "Where is my ",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "pony",
+              },
+            ],
+            "properties": Object {},
+            "tagName": "code",
+            "type": "element",
+          },
+          Object {
+            "type": "text",
+            "value": " named leo?",
           },
         ],
         "properties": Object {},
-        "tagName": "code",
+        "tagName": "p",
         "type": "element",
       },
-      Object {
-        "type": "text",
-        "value": " named leo?",
-      },
     ],
-    "properties": Object {},
-    "tagName": "p",
-    "type": "element",
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
   },
   "frontmatter": Object {
     "title": "my little pony",

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -149,13 +149,19 @@ Where oh where is my little pony?`,
       expect(node.excerptAst).toMatchObject({
         children: [
           {
-            type: `text`,
-            value: `Where oh where is my little pony?`,
+            children: [
+              {
+                type: `text`,
+                value: `Where oh where is my little pony?`,
+              },
+            ],
+            properties: {},
+            tagName: `p`,
+            type: `element`,
           },
         ],
-        properties: {},
-        tagName: `p`,
-        type: `element`,
+        data: { quirksMode: false },
+        type: `root`,
       })
     }
   )
@@ -177,9 +183,7 @@ date: "2017-09-18T23:19:51.246Z"
       expect(node.excerpt).toMatch(``)
       expect(node.excerptAst).toMatchObject({
         children: [],
-        data: {
-          quirksMode: false,
-        },
+        data: { quirksMode: false },
         type: `root`,
       })
     }
@@ -224,9 +228,7 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
             value: `\n`,
           },
         ],
-        data: {
-          quirksMode: false,
-        },
+        data: { quirksMode: false },
         type: `root`,
       })
     },
@@ -254,7 +256,8 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
       expect(node).toMatchSnapshot()
       expect(node.excerpt.length).toBe(139)
       expect(node.excerptAst.children.length).toBe(1)
-      expect(node.excerptAst.children[0].value.length).toBe(139)
+      expect(node.excerptAst.children[0].children.length).toBe(1)
+      expect(node.excerptAst.children[0].children[0].value.length).toBe(139)
     }
   )
 
@@ -271,7 +274,8 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
       expect(node).toMatchSnapshot()
       expect(node.excerpt.length).toBe(46)
       expect(node.excerptAst.children.length).toBe(1)
-      expect(node.excerptAst.children[0].value.length).toBe(46)
+      expect(node.excerptAst.children[0].children.length).toBe(1)
+      expect(node.excerptAst.children[0].children[0].value.length).toBe(46)
     }
   )
 
@@ -288,7 +292,8 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
       expect(node).toMatchSnapshot()
       expect(node.excerpt.length).toBe(50)
       expect(node.excerptAst.children.length).toBe(1)
-      expect(node.excerptAst.children[0].value.length).toBe(50)
+      expect(node.excerptAst.children[0].children.length).toBe(1)
+      expect(node.excerptAst.children[0].children[0].value.length).toBe(50)
     }
   )
 
@@ -314,72 +319,78 @@ Where oh [*where*](nick.com) **_is_** ![that pony](pony.png)?`,
       expect(node.excerptAst).toMatchObject({
         children: [
           {
-            type: `text`,
-            value: `Where oh `,
-          },
-          {
             children: [
+              {
+                type: `text`,
+                value: `Where oh `,
+              },
               {
                 children: [
                   {
-                    type: `text`,
-                    value: `where`,
+                    children: [
+                      {
+                        type: `text`,
+                        value: `where`,
+                      },
+                    ],
+                    properties: {},
+                    tagName: `em`,
+                    type: `element`,
                   },
                 ],
-                properties: {},
-                tagName: `em`,
+                properties: {
+                  href: `nick.com`,
+                },
+                tagName: `a`,
                 type: `element`,
               },
-            ],
-            properties: {
-              href: `nick.com`,
-            },
-            tagName: `a`,
-            type: `element`,
-          },
-          {
-            type: `text`,
-            value: ` `,
-          },
-          {
-            children: [
+              {
+                type: `text`,
+                value: ` `,
+              },
               {
                 children: [
                   {
-                    type: `text`,
-                    value: `is`,
+                    children: [
+                      {
+                        type: `text`,
+                        value: `is`,
+                      },
+                    ],
+                    properties: {},
+                    tagName: `em`,
+                    type: `element`,
                   },
                 ],
                 properties: {},
-                tagName: `em`,
+                tagName: `strong`,
                 type: `element`,
+              },
+              {
+                type: `text`,
+                value: ` `,
+              },
+              {
+                children: [],
+                properties: {
+                  alt: `that pony`,
+                  src: `pony.png`,
+                },
+                tagName: `img`,
+                type: `element`,
+              },
+              {
+                type: `text`,
+                value: `?`,
               },
             ],
             properties: {},
-            tagName: `strong`,
+            tagName: `p`,
             type: `element`,
-          },
-          {
-            type: `text`,
-            value: ` `,
-          },
-          {
-            children: [],
-            properties: {
-              alt: `that pony`,
-              src: `pony.png`,
-            },
-            tagName: `img`,
-            type: `element`,
-          },
-          {
-            type: `text`,
-            value: `?`,
           },
         ],
-        properties: {},
-        tagName: `p`,
-        type: `element`,
+        data: { quirksMode: false },
+        type: `root`,
       })
     }
   )
@@ -406,28 +417,34 @@ Where is my <code>pony</code> named leo?`,
       expect(node.excerptAst).toMatchObject({
         children: [
           {
-            type: `text`,
-            value: `Where is my `,
-          },
-          {
             children: [
               {
                 type: `text`,
-                value: `pony`,
+                value: `Where is my `,
+              },
+              {
+                children: [
+                  {
+                    type: `text`,
+                    value: `pony`,
+                  },
+                ],
+                properties: {},
+                tagName: `code`,
+                type: `element`,
+              },
+              {
+                type: `text`,
+                value: ` named leo?`,
               },
             ],
             properties: {},
-            tagName: `code`,
+            tagName: `p`,
             type: `element`,
           },
-          {
-            type: `text`,
-            value: ` named leo?`,
-          },
         ],
-        properties: {},
-        tagName: `p`,
-        type: `element`,
+        data: { quirksMode: false },
+        type: `root`,
       })
     },
     { pluginOptions: { excerpt_separator: `<!-- end -->` } }
@@ -455,13 +472,19 @@ Where oh where is that pony? Is he in the stable or down by the stream?`,
       expect(node.excerptAst).toMatchObject({
         children: [
           {
-            type: `text`,
-            value: `Where oh where is that pony? Is he in the stable…`,
+            children: [
+              {
+                type: `text`,
+                value: `Where oh where is that pony? Is he in the stable…`,
+              },
+            ],
+            properties: {},
+            tagName: `p`,
+            type: `element`,
           },
         ],
-        properties: {},
-        tagName: `p`,
-        type: `element`,
+        data: { quirksMode: false },
+        type: `root`,
       })
     }
   )
@@ -522,9 +545,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet v
             value: `\n`,
           },
         ],
-        data: {
-          quirksMode: false,
-        },
+        data: { quirksMode: false },
         type: `root`,
       })
     },

--- a/packages/gatsby-transformer-remark/src/hast-processing.js
+++ b/packages/gatsby-transformer-remark/src/hast-processing.js
@@ -45,6 +45,7 @@ function cloneTreeUntil(root, endCondition) {
         clonedRoot = newNode
         preOrderTraversal(child)
       })
+      clonedRoot = newNode
     }
   }
   preOrderTraversal(root)


### PR DESCRIPTION
## Description

Fixes a bug in `cloneTreeUntil` function in `gatsby-transformer-remark`, where it only returns the last child node. This function is expected to clone a `root` node, but the current implementation forgets to revert the variable back to the `root` node. Reassigning `clonedRoot = newNode` (originally this is the argument `root`) should fix this. By resolving this bug, it appears to correctly returns the entire root node of AST in `excerptAst` of the markdown node, instead of returning the partial result.

## Related Issues

Related to #11237