### PR TITLE
feat(gatsby-source-wordpress) : Adding unique multi-site node id's

### DIFF
--- a/packages/gatsby-source-wordpress/src/__tests__/normalize.js
+++ b/packages/gatsby-source-wordpress/src/__tests__/normalize.js
@@ -25,7 +25,7 @@ describe(`Process WordPress data`, () => {
   it(`creates Gatsby IDs for each entity`, () => {
     const createNodeId = jest.fn()
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
-    entities = normalize.createGatsbyIds(createNodeId, entities)
+    entities = normalize.createGatsbyIds(createNodeId, entities, `http://dev-gatbsyjswp.pantheonsite.io`)
     expect(entities).toMatchSnapshot()
   })
   it(`Creates map of types`, () => {

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -93,7 +93,7 @@ exports.sourceNodes = async (
   entities = normalize.excludeUnknownEntities(entities)
 
   // Creates Gatsby IDs for each entity
-  entities = normalize.createGatsbyIds(createNodeId, entities)
+  entities = normalize.createGatsbyIds(createNodeId, entities, _siteURL)
 
   // Creates links between authors and user entities
   entities = normalize.mapAuthorsToUsers(entities)

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -172,12 +172,12 @@ exports.excludeUnknownEntities = entities =>
 // Create node ID from known entities
 // excludeUnknownEntities whitelisted types don't contain a wordpress_id
 // we create the node ID based upon type if the wordpress_id doesn't exist
-exports.createGatsbyIds = (createNodeId, entities) =>
+exports.createGatsbyIds = (createNodeId, entities, _siteURL) =>
   entities.map(e => {
     if (e.wordpress_id) {
-      e.id = createNodeId(`${e.__type}-${e.wordpress_id.toString()}`)
+      e.id = createNodeId(`${e.__type}-${e.wordpress_id.toString()}-${_siteURL}`)
     } else {
-      e.id = createNodeId(e.__type)
+      e.id = createNodeId(`${e.__type}-${_siteURL}`)
     }
     return e
   })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

There was a little bug where in a multi-site config of the gatsby-source-wordpress plugin, the id's of the graphQL nodes were not always unique. Since the node id's were mainly being generated by the node.__type, in the case of two post types had the same type and id (even though they were from different data sources), resulted in only 1 graphQL node being created. This PR adds the __siteUrl to the id generation to resolve this issue. 

## Related Issues

The changes in this PR will resolve this issue where [multi-site WordPress config looses data](https://github.com/gatsbyjs/gatsby/issues/12608)
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
