### PR TITLE
fix(www): change view id in analytyics for guess

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -4,7 +4,7 @@ require(`dotenv`).config({
 
 const GA = {
   identifier: `UA-93349937-5`,
-  viewId: `142357465`,
+  viewId: `176383508`,
 }
 
 const dynamicPlugins = []


### PR DESCRIPTION
## Description
It seems like I used the wrong view id in analytics. I used 
![image](https://user-images.githubusercontent.com/1120926/54590268-f7052400-4a27-11e9-8f5e-aca8f94056b8.png) without looking at the data 🤦‍♂️

I now use the correct one:
![image](https://user-images.githubusercontent.com/1120926/54590308-1bf99700-4a28-11e9-8426-3c46624f4e9d.png)

which contains the following: 
![image](https://user-images.githubusercontent.com/1120926/54590334-2e73d080-4a28-11e9-8540-bd3da8013ed0.png)


## Related Issues
#12651
