### PR TITLE
fix(docs): Not clear where to add typography.js config file

### DIFF
--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -69,7 +69,7 @@ The `gatsby-config.js` is another special file that Gatsby will automatically re
 
 > Check out the [doc on gatsby-config.js](/docs/gatsby-config/) to read more, if you wish.
 
-3. Typography.js needs a configuration file. Create a new folder called `utils` in the `src` folder. Then add a new file called `typography.js` to `utils`, and copy the following into the file:
+3. Typography.js needs a configuration file. Create a new directory called `utils` in the `src` directory. Then add a new file called `typography.js` to `utils`, and copy the following into the file:
 
 ```javascript:title=src/utils/typography.js
 import Typography from "typography"

--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -69,9 +69,7 @@ The `gatsby-config.js` is another special file that Gatsby will automatically re
 
 > Check out the [doc on gatsby-config.js](/docs/gatsby-config/) to read more, if you wish.
 
-3. Add `typography.js` configuration file
-
-Typography.js needs a configuration file. Add it now.
+3. Typography.js needs a configuration file. Create a new folder called `utils` in the `src` folder. Then add a new file called `typography.js` to `utils`, and copy the following into the file:
 
 ```javascript:title=src/utils/typography.js
 import Typography from "typography"


### PR DESCRIPTION
The flow of the tutorial suggests that typography.js config file should be added to the root of the project - or at least, it's not explicit about where it should be created.

Edited the third step to make it clearer for beginners on where this file should live (utils).

