### PR TITLE
chore(www): bump gatsby version

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -13,7 +13,7 @@
     "dotenv": "^6.0.0",
     "email-validator": "^1.1.1",
     "fuse.js": "^3.2.0",
-    "gatsby": "^2.1.22",
+    "gatsby": "^2.2.0",
     "gatsby-image": "^2.0.5",
     "gatsby-plugin-canonical-urls": "^2.0.5",
     "gatsby-plugin-catch-links": "^2.0.2",


### PR DESCRIPTION
this is just to force build runner to reinstall dependencies
