### PR TITLE
feat(gatsby-plugin-netlify-cms): support multiple cms module paths

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -39,7 +39,7 @@ docs](https://www.gatsbyjs.org/docs/plugins/#how-to-use-gatsby-plugins).
 
 ### `modulePath`
 
-(_optional_, default: `undefined`)
+(_optional_, type: `string | Array<string>`, default: `undefined`)
 
 If you need to customize Netlify CMS, e.g. registering [custom
 widgets](https://www.netlifycms.org/docs/custom-widgets/#registerwidget) or
@@ -100,7 +100,7 @@ CMS.registerWidget(`image-gallery`, ImageGalleryWidget, ImageGalleryPreview)
 
 ### `manualInit`
 
-(_optional_, default: `false`)
+(_optional_, type: `boolean`, default: `false`)
 
 Set this to `true` If you need to [manually initialize](https://www.netlifycms.org/docs/beta-features/#manual-initialization) Netlify CMS. The plugin will take care of setting `window.CMS_MANUAL_INIT` to `true`:
 
@@ -135,7 +135,7 @@ init({
 
 ### `enableIdentityWidget`
 
-(_optional_, default: `true`)
+(_optional_, type: `boolean`, default: `true`)
 
 `enableIdentityWidget` is `true` by default, allowing [Netlify
 Identity](https://www.netlify.com/docs/identity/) to be used without
@@ -156,13 +156,13 @@ plugins: [
 
 ### `publicPath`
 
-(_optional_, default: `"admin"`)
+(_optional_, type: `string`, default: `"admin"`)
 
 Customize the path to Netlify CMS on your Gatsby site.
 
 ### `htmlTitle`
 
-(_optional_, default: `Content Manager`)
+(_optional_, type: `string`, default: `Content Manager`)
 
 Customize the value of the `title` tag in your CMS HTML (shows in the browser
 bar).

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -1,6 +1,6 @@
 import CMS from "netlify-cms"
 
 /**
- * The stylesheet output from the module at `modulePath` will be at `cms.css`.
+ * The stylesheet output from the modules at `modulePath` will be at `cms.css`.
  */
 CMS.registerPreviewStyle(`cms.css`)

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -52,9 +52,10 @@ exports.onCreateWebpackConfig = (
         cms: [
           manualInit && `${__dirname}/cms-manual-init.js`,
           `${__dirname}/cms.js`,
-          modulePath,
           enableIdentityWidget && `${__dirname}/cms-identity.js`,
-        ].filter(p => p),
+        ]
+          .concat(modulePath)
+          .filter(p => p),
       },
       output: {
         path: path.join(program.directory, `public`, publicPathClean),


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This change allows for multiple cms module paths to be imported
and compiled into the netlify cms applicationm generated by this plugin.

It's generally not necessary to need more than one cms module entry in
a simple gatsby-site, but it's convenient to support it in combination with
`gatsby themes`. This makes it possible to create a custom theme that e.g.
sets up the cms and provides it's own custom cms module, while also allowing
theme-consumers to provide their own cms modules with additional config.

Note that the previous config option `modulePath` has been renamed to `modulePaths`, while the plugin is still backwards compatible.
This is maybe a little weird, and personally I would prefer to bump the major version of the plugin and remove the reference to the old `modulePath` config option instead.
I haven't done that since I'm not sure whether this is a wanted feature or not, but would be happy to do so (or any other feedback regarding this feature/API change).

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
