### PR TITLE
fix: darken link color on homepage diagram

### DIFF
--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -176,7 +176,16 @@ const ItemDescription = ({ children }) => (
 )
 
 const ItemDescriptionLink = ({ to, children }) => (
-  <Link to={to}>{children}</Link>
+  <Link
+    css={{
+      "&&": {
+        color: colors.gatsbyDark,
+      },
+    }}
+    to={to}
+  >
+    {children}
+  </Link>
 )
 
 const Gatsby = () => (


### PR DESCRIPTION
@fk I think some of the recent homepage changes resulted in insufficient contrast on the links in the diagram.

I've darkened it a shade for sufficient contrast.