### PR TITLE
Add section to gatsby-remark-smartypants docs about gatsby-mdx

### DIFF
--- a/packages/gatsby-remark-smartypants/README.md
+++ b/packages/gatsby-remark-smartypants/README.md
@@ -45,3 +45,26 @@ plugins: [
   },
 ]
 ```
+
+### Use and Options with `gatsby-mdx`
+
+The configuration is slightly different when you use it with `gatsby-mdx`. Here is an example like above with the same `oldschool` options, but notice that you write `gatsbyRemarkPlugins` in place of `plugins` and you have to use the longer resolve form even if you don't have any options.
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: "gatsby-mdx",
+    options: {
+      gatsbyRemarkPlugins: [
+        {
+          resolve: `gatsby-remark-smartypants`,
+          options: {
+            dashes: `oldschool`
+          }
+        }
+      ]
+    }
+  },
+]
+```


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The differences in setup with `gatsby-mdx` are not currently mentioned in the docs. This would save a a some effort in tracking down the differences in setup. This might be especially important with the big push I've noticed that you are doing to get more thorough mdx docs available on the Gatsby site. I attempted to _briefly_ address the two main differences, namely the use of `gatsbyRemarkPlugins` in place of `plugins` and the need to use the longer syntax even if you aren't setting any options.

It's your project, but obviously feel free to modify this PR however best suits your needs, or go about it an a completely different way, but I do think it would be helpful for the information to be along with the plugin since it is used with both remark and mdx. Thanks!

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
