### PR TITLE
fix(www): update documentation fragments to handle more complex types

### DIFF
--- a/www/src/components/api-reference/signature.js
+++ b/www/src/components/api-reference/signature.js
@@ -209,6 +209,14 @@ export const fragment = graphql`
       elements {
         name
         type
+        expression {
+          type
+          name
+        }
+        applications {
+          type
+          name
+        }
       }
       expression {
         type
@@ -217,6 +225,14 @@ export const fragment = graphql`
       applications {
         type
         name
+        expression {
+          type
+          name
+        }
+        applications {
+          type
+          name
+        }
       }
     }
   }


### PR DESCRIPTION
this should fix missing types in https://www.gatsbyjs.org/docs/actions/#createTypes