### PR TITLE
chore(gatsby-cli): remove bluebird promise from global namespace

### DIFF
--- a/packages/gatsby-cli/src/index.js
+++ b/packages/gatsby-cli/src/index.js
@@ -7,8 +7,6 @@ import "@babel/polyfill"
 const createCli = require(`./create-cli`)
 const report = require(`./reporter`)
 
-global.Promise = require(`bluebird`)
-
 const version = process.version
 const verDigit = Number(version.match(/\d+/)[0])
 
@@ -23,11 +21,6 @@ if (verDigit < 6) {
       `Upgrade node to the latest stable release.`
   )
 }
-
-Promise.onPossiblyUnhandledRejection(error => {
-  report.error(error)
-  throw error
-})
 
 process.on(`unhandledRejection`, error => {
   // This will exit the process in newer Node anyway so lets be consistent


### PR DESCRIPTION
We currently set `global.Promise` to `bluebird`. I'm not entirely clear why we do this, but it does add quite a bit of noise to stack traces.