### PR TITLE
fix(gatsby): quick check if string looks like a date

### DIFF
--- a/packages/gatsby/src/schema/types/date.js
+++ b/packages/gatsby/src/schema/types/date.js
@@ -99,8 +99,13 @@ const GraphQLDate = new GraphQLScalarType({
 // Check if this is a date.
 // All the allowed ISO 8601 date-time formats used.
 function isDate(value) {
+  // quick check if value does not look like a date
+  if (typeof value === `number` || !/^\d{4}/.test(value)) {
+    return false
+  }
+
   const momentDate = moment.utc(value, ISO_8601_FORMAT, true)
-  return momentDate.isValid() && typeof value !== `number`
+  return momentDate.isValid()
 }
 
 const formatDate = ({


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Checks if strings start with 4 numbers as all ISO 8601 date-time are using YYYY syntax

## Related Issues
#12692