### PR TITLE
docs: fix OpenTracing name usage inconstistencies

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -65,11 +65,11 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 
 #### Options
 
-|            Option            | Description                                                                                                |
-| :--------------------------: | ---------------------------------------------------------------------------------------------------------- |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    |
-| `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
+|            Option            | Description                                                                                               |
+| :--------------------------: | --------------------------------------------------------------------------------------------------------- |
+|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                       |
+|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                   |
+| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
 
 ### `serve`
 

--- a/docs/docs/performance-tracing.md
+++ b/docs/docs/performance-tracing.md
@@ -35,7 +35,7 @@ The above configuration file can be passed to Gatsby with the `--open-tracing-co
 
 ## Tracing backend examples
 
-There are many open tracing compatible backends available. Below is an example of how to hook Zipkin into Gatsby.
+There are many OpenTracing compatible backends available. Below is an example of how to hook Zipkin into Gatsby.
 
 ### local Jaeger with Docker
 
@@ -102,7 +102,7 @@ There are many open tracing compatible backends available. Below is an example o
 
 The default tracing that comes with Gatsby can give you a good idea of which plugins or stages of the build are slowing down your site. But sometimes, you'll want to trace the internals of your site. Or if you're a plugin author, you might want to trace long operations.
 
-To provide custom tracing, you can use the `tracing` object, which is present in the args passed to API implementers. This tracing object contains a function called `startSpan`. This simply wraps [open tracing startSpan](https://github.com/opentracing/opentracing-javascript/blob/master/src/tracer.ts#L79), but provides the default `childOf: parentSpan` span args. `startSpan` returns a span object that you must explicitly end by calling its `.finish()` method. For example:
+To provide custom tracing, you can use the `tracing` object, which is present in the args passed to API implementers. This tracing object contains a function called `startSpan`. This simply wraps [OpenTracing startSpan](https://github.com/opentracing/opentracing-javascript/blob/master/src/tracer.ts#L79), but provides the default `childOf: parentSpan` span args. `startSpan` returns a span object that you must explicitly end by calling its `.finish()` method. For example:
 
 ```javascript:title=gatsby-node.js
 exports.sourceNodes = async ({ actions, tracing }) => {

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -59,11 +59,11 @@ At the root of a Gatsby app run `gatsby build` to do a production build of a sit
 
 #### Options
 
-|            Option            | Description                                                                                                 | Default |
-| :--------------------------: | ----------------------------------------------------------------------------------------------------------- | :-----: |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                         | `false` |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                     | `false` |
-| `--open-tracing-config-file` | Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |         |
+|            Option            | Description                                                                                                | Default |
+| :--------------------------: | ---------------------------------------------------------------------------------------------------------- | :-----: |
+|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        | `false` |
+|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    | `false` |
+| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |         |
 
 ### `serve`
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -59,11 +59,11 @@ At the root of a Gatsby app run `gatsby build` to do a production build of a sit
 
 #### Options
 
-|            Option            | Description                                                                                                | Default |
-| :--------------------------: | ---------------------------------------------------------------------------------------------------------- | :-----: |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        | `false` |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    | `false` |
-| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |         |
+|            Option            | Description                                                                       | Default |
+| :--------------------------: | --------------------------------------------------------------------------------- | :-----: |
+|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)               | `false` |
+|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                           | `false` |
+| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See http://gatsby.dev/tracing |         |
 
 ### `serve`
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -59,11 +59,11 @@ At the root of a Gatsby app run `gatsby build` to do a production build of a sit
 
 #### Options
 
-|            Option            | Description                                                                       | Default |
-| :--------------------------: | --------------------------------------------------------------------------------- | :-----: |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)               | `false` |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                           | `false` |
-| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See http://gatsby.dev/tracing |         |
+|            Option            | Description                                                                                                | Default |
+| :--------------------------: | ---------------------------------------------------------------------------------------------------------- | :-----: |
+|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        | `false` |
+|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    | `false` |
+| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |         |
 
 ### `serve`
 

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -148,7 +148,7 @@ function buildLocalCommands(cli, isLocalSite) {
         })
         .option(`open-tracing-config-file`, {
           type: `string`,
-          describe: `Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/`,
+          describe: `Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/`,
         }),
     handler: handlerP(
       getCommandHandler(`develop`, (args, cmd) => {
@@ -178,7 +178,7 @@ function buildLocalCommands(cli, isLocalSite) {
         })
         .option(`open-tracing-config-file`, {
           type: `string`,
-          describe: `Tracer configuration file (open tracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/`,
+          describe: `Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/`,
         }),
     handler: handlerP(
       getCommandHandler(`build`, (args, cmd) => {

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -148,7 +148,7 @@ function buildLocalCommands(cli, isLocalSite) {
         })
         .option(`open-tracing-config-file`, {
           type: `string`,
-          describe: `Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/`,
+          describe: `Tracer configuration file (OpenTracing compatible). See http://gatsby.dev/tracing`,
         }),
     handler: handlerP(
       getCommandHandler(`develop`, (args, cmd) => {
@@ -178,7 +178,7 @@ function buildLocalCommands(cli, isLocalSite) {
         })
         .option(`open-tracing-config-file`, {
           type: `string`,
-          describe: `Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/`,
+          describe: `Tracer configuration file (OpenTracing compatible). See http://gatsby.dev/tracing`,
         }),
     handler: handlerP(
       getCommandHandler(`build`, (args, cmd) => {

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -148,7 +148,7 @@ function buildLocalCommands(cli, isLocalSite) {
         })
         .option(`open-tracing-config-file`, {
           type: `string`,
-          describe: `Tracer configuration file (OpenTracing compatible). See http://gatsby.dev/tracing`,
+          describe: `Tracer configuration file (OpenTracing compatible). See https://gatsby.dev/tracing`,
         }),
     handler: handlerP(
       getCommandHandler(`develop`, (args, cmd) => {
@@ -178,7 +178,7 @@ function buildLocalCommands(cli, isLocalSite) {
         })
         .option(`open-tracing-config-file`, {
           type: `string`,
-          describe: `Tracer configuration file (OpenTracing compatible). See http://gatsby.dev/tracing`,
+          describe: `Tracer configuration file (OpenTracing compatible). See https://gatsby.dev/tracing`,
         }),
     handler: handlerP(
       getCommandHandler(`build`, (args, cmd) => {


### PR DESCRIPTION
thanks @fk for spotting inconsistencies

Also adjusting cli help to use shortened link