### PR TITLE
fix: File type inference on array fields

### DIFF
--- a/packages/gatsby/src/schema/infer/is-file.js
+++ b/packages/gatsby/src/schema/infer/is-file.js
@@ -1,9 +1,9 @@
-const _ = require(`lodash`)
 const path = require(`path`)
 const slash = require(`slash`)
 const mime = require(`mime`)
 const isRelative = require(`is-relative`)
 const isRelativeUrl = require(`is-relative-url`)
+const { getValueAt } = require(`../utils/get-value-at`)
 
 const isFile = (nodeStore, field, relativePath) => {
   const filePath = getFilePath(nodeStore, field, relativePath)
@@ -19,7 +19,7 @@ module.exports = {
 }
 
 const getFirstValueAt = (node, selector) => {
-  let value = _.get(node, selector)
+  let value = getValueAt(node, selector)
   while (Array.isArray(value)) {
     value = value[0]
   }

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -2,6 +2,7 @@ const systemPath = require(`path`)
 const normalize = require(`normalize-path`)
 const _ = require(`lodash`)
 const { GraphQLList, getNullableType, getNamedType } = require(`graphql`)
+const { getValueAt } = require(`./utils/get-value-at`)
 
 const findMany = typeName => ({ args, context, info }) =>
   context.nodeModel.runQuery(
@@ -32,7 +33,7 @@ const distinct = (source, args, context, info) => {
   const { field } = args
   const { edges } = source
   const values = edges.reduce((acc, { node }) => {
-    const value = getValueAtSelector(node, field)
+    const value = getValueAt(node, field)
     return value != null
       ? acc.concat(value instanceof Date ? value.toISOString() : value)
       : acc
@@ -44,7 +45,7 @@ const group = (source, args, context, info) => {
   const { field } = args
   const { edges } = source
   const groupedResults = edges.reduce((acc, { node }) => {
-    const value = getValueAtSelector(node, field)
+    const value = getValueAt(node, field)
     const values = Array.isArray(value) ? value : [value]
     values
       .filter(value => value != null)
@@ -90,19 +91,6 @@ const paginate = (results = [], { skip = 0, limit }) => {
       hasNextPage,
     },
   }
-}
-
-const getValueAtSelector = (obj, selector) => {
-  const selectors = Array.isArray(selector) ? selector : selector.split(`.`)
-  return selectors.reduce((acc, key) => {
-    if (acc && typeof acc === `object`) {
-      if (Array.isArray(acc)) {
-        return acc.map(a => a[key]).filter(a => a !== undefined)
-      }
-      return acc[key]
-    }
-    return undefined
-  }, obj)
 }
 
 const link = ({ by, from }) => async (source, args, context, info) => {

--- a/packages/gatsby/src/schema/utils/get-value-at.js
+++ b/packages/gatsby/src/schema/utils/get-value-at.js
@@ -1,0 +1,14 @@
+const getValueAt = (obj, selector) => {
+  const selectors = Array.isArray(selector) ? selector : selector.split(`.`)
+  return selectors.reduce((acc, key) => {
+    if (acc && typeof acc === `object`) {
+      if (Array.isArray(acc)) {
+        return acc.map(a => a[key]).filter(a => a !== undefined)
+      }
+      return acc[key]
+    }
+    return undefined
+  }, obj)
+}
+
+module.exports = { getValueAt }


### PR DESCRIPTION
Don't use lodash.get to get values for arrays of objects. This should fix #12696