### PR TITLE
feat(performance): change data.json to trie

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/find-page.js
+++ b/packages/gatsby/cache-dir/__tests__/find-page.js
@@ -1,10 +1,11 @@
 const pageFinderFactory = require(`../find-page`).default
+const { createPathsFromArray } = require(`../path-matcher`)
 
 let findPage
 
 describe(`find-page`, () => {
   beforeEach(() => {
-    const newPages = [
+    const newPages = createPathsFromArray([
       {
         path: `/about/`,
         componentChunkName: `page-component---src-pages-test-js`,
@@ -26,7 +27,7 @@ describe(`find-page`, () => {
         componentChunkName: `page-component---src-pages-app-js`,
         jsonName: `app.json`,
       },
-    ]
+    ])
     findPage = pageFinderFactory(newPages)
   })
 
@@ -54,13 +55,13 @@ describe(`find-page`, () => {
   })
 
   it(`handles finding prefixed links`, () => {
-    const newPages = [
+    const newPages = createPathsFromArray([
       {
         path: `/about/`,
         componentChunkName: `page-component---src-pages-test-js`,
         jsonName: `about.json`,
       },
-    ]
+    ])
     const findPage2 = pageFinderFactory(newPages, `/my-test-prefix`)
     expect(findPage2(`/my-test-prefix/about/`).path).toBe(`/about/`)
   })

--- a/packages/gatsby/cache-dir/__tests__/path-matcher.js
+++ b/packages/gatsby/cache-dir/__tests__/path-matcher.js
@@ -1,0 +1,105 @@
+const {
+  matchPathFactory,
+  addPathFactory,
+  createPathsFromArray,
+} = require(`../path-matcher`)
+
+fdescribe(`Path Matcher`, () => {
+  describe(`create`, () => {
+    it(`should add paths from an array of paths`, () => {
+      const routes = [
+        { path: `/app`, matchPath: `/game/test/*` },
+        { path: `/app/nice` },
+        { path: `/new` },
+      ]
+
+      expect(createPathsFromArray(routes)).toEqual({
+        c: {
+          app: {
+            v: { path: `/app`, matchPath: `/game/test/*` },
+            c: {
+              nice: {
+                v: { path: `/app/nice` },
+              },
+            },
+          },
+          new: {
+            v: { path: `/new` },
+          },
+          game: {
+            c: {
+              test: {
+                c: {
+                  "*": {
+                    v: { path: `/app`, matchPath: `/game/test/*` },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+
+    it(`should add a path to an already existing path`, () => {
+      const root = {
+        c: {
+          app: {
+            v: { path: `/app` },
+          },
+        },
+      }
+
+      addPathFactory(root)(`/app/test`, { path: `/app/test` })
+
+      expect(root).toEqual({
+        c: {
+          app: {
+            v: {
+              path: `/app`,
+            },
+            c: {
+              test: {
+                v: { path: `/app/test` },
+              },
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe(`match`, () => {
+    let match
+
+    beforeEach(() => {
+      const routes = [
+        { path: `/so-deep`, matchPath: `/deeply/nested/route/*` },
+        { path: `/deeply/nested/route/that/is/not/so/deep` },
+        { path: `/deeply/nested` },
+      ]
+
+      match = matchPathFactory(createPathsFromArray(routes))
+    })
+
+    it(`should match nested routes`, () => {
+      expect(match(`/deeply/nested`).path).toBe(`/deeply/nested`)
+      expect(match(`/deeply/nested/route/that/is/not/so/deep`).path).toBe(
+        `/deeply/nested/route/that/is/not/so/deep`
+      )
+    })
+
+    it(`should try and match the entire route before falling back to matchPath`, () => {
+      expect(match(`/deeply/nested/route/that/is/not/so/deep`).path).toBe(
+        `/deeply/nested/route/that/is/not/so/deep`
+      )
+      expect(
+        match(`/deeply/nested/route/that/is/not/so/deep/too-far`).path
+      ).toBe(`/so-deep`)
+    })
+
+    it(`should not care about trailing slashes`, () => {
+      expect(match(`/so-deep/`).path).toBe(`/so-deep`)
+    })
+  })
+})

--- a/packages/gatsby/cache-dir/__tests__/static-entry.js
+++ b/packages/gatsby/cache-dir/__tests__/static-entry.js
@@ -31,13 +31,17 @@ jest.mock(
           [`about.json`]: `/400/about`,
         },
       ],
-      pages: [
-        {
-          path: `/about/`,
-          componentChunkName: `page-component---src-pages-test-js`,
-          jsonName: `about.json`,
+      pages: {
+        c: {
+          about: {
+            v: {
+              path: `/about/`,
+              componentChunkName: `page-component---src-pages-test-js`,
+              jsonName: `about.json`,
+            },
+          },
         },
-      ],
+      },
     }
   },
   {

--- a/packages/gatsby/cache-dir/path-matcher.js
+++ b/packages/gatsby/cache-dir/path-matcher.js
@@ -1,0 +1,97 @@
+const reRemoveSlash = /(^\/+|\/+$)/g
+const segmentize = uri =>
+  uri
+    .replace(reRemoveSlash, ``)
+    .split(`/`)
+    .filter(x => !!x)
+
+const addPathFactory = root => (path, value) => {
+  const segments = segmentize(path)
+
+  let reference = root
+  for (let segment of segments) {
+    if (!reference.c) {
+      reference.c = {}
+    }
+
+    if (!reference.c[segment]) {
+      reference.c[segment] = {}
+    }
+
+    reference = reference.c[segment]
+  }
+
+  reference.v = value
+}
+
+const createPathsFromArray = pages => {
+  const root = {}
+  const addPath = addPathFactory(root)
+  for (let page of pages) {
+    if (page.path) {
+      addPath(page.path, page)
+    }
+
+    if (page.matchPath) {
+      addPath(page.matchPath, page)
+    }
+  }
+  return root
+}
+
+const createArrayFromAllPaths = root => {
+  const paths = []
+
+  const traverse = parent => {
+    if (parent.v) {
+      paths.push(parent.v)
+    }
+
+    if (parent.c) {
+      Object.keys(parent.c).forEach(key => traverse(parent.c[key]))
+    }
+  }
+
+  traverse(root)
+
+  return paths
+}
+
+const matchPathFactory = root => path => {
+  const segments = segmentize(path)
+
+  let reference = root
+  let splat
+  for (let segment of segments) {
+    const children = reference.c || {}
+
+    // If the current segment has a catch-all,
+    // set the splat. If not, keep using the old
+    // or undefined one
+    splat = children[`*`] || splat
+
+    // Get the next reference based on the path segment
+    const nextReference = children[segment]
+
+    // If a component for the next segment doesn't exist
+    // fall back to the splat or return undefined
+    if (!nextReference) {
+      if (splat) {
+        reference = splat
+        break
+      } else {
+        return undefined
+      }
+    }
+
+    reference = nextReference
+  }
+  return reference.v
+}
+
+module.exports = {
+  createArrayFromAllPaths,
+  matchPathFactory,
+  createPathsFromArray,
+  addPathFactory,
+}

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -15,12 +15,13 @@ import PageRenderer from "./page-renderer"
 import asyncRequires from "./async-requires"
 import loader, { setApiRunnerForLoader, postInitialRenderWork } from "./loader"
 import EnsureResources from "./ensure-resources"
+import { createPathsFromArray } from "./path-matcher"
 
 window.asyncRequires = asyncRequires
 window.___emitter = emitter
 window.___loader = loader
 
-loader.addPagesArray([window.page])
+loader.addPagesArray(createPathsFromArray([window.page]))
 loader.addDataPaths({ [window.page.jsonName]: window.dataPath })
 loader.addProdRequires(asyncRequires)
 setApiRunnerForLoader(apiRunner)

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -1,7 +1,6 @@
 import React, { createElement } from "react"
 import { Router } from "@reach/router"
 import { ScrollContext } from "gatsby-react-router-scroll"
-
 import {
   shouldUpdateScroll,
   init as navigationInit,
@@ -9,12 +8,13 @@ import {
 } from "./navigation"
 import { apiRunner } from "./api-runner-browser"
 import syncRequires from "./sync-requires"
-import pages from "./pages.json"
+import pageData from "./pages.json"
 import loader from "./loader"
 import JSONStore from "./json-store"
 import EnsureResources from "./ensure-resources"
 
 import { reportError, clearError } from "./error-overlay-handler"
+import { matchPathFactory, createArrayFromAllPaths } from "./path-matcher"
 
 if (window.__webpack_hot_middleware_reporter__ !== undefined) {
   const overlayErrorID = `webpack`
@@ -34,6 +34,8 @@ if (window.__webpack_hot_middleware_reporter__ !== undefined) {
 }
 
 navigationInit()
+
+const pages = createArrayFromAllPaths(pageData)
 
 class RouteHandler extends React.Component {
   render() {
@@ -63,7 +65,7 @@ class RouteHandler extends React.Component {
         </EnsureResources>
       )
     } else {
-      const dev404Page = pages.find(p => /^\/dev-404-page\/?$/.test(p.path))
+      const dev404Page = matchPathFactory(pageData)(`/dev-404-page`)
       const Dev404Page = syncRequires.components[dev404Page.componentChunkName]
 
       if (!loader.getPage(`/404.html`)) {

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -9,10 +9,7 @@ const apiRunner = require(`./api-runner-ssr`)
 const syncRequires = require(`./sync-requires`)
 const { dataPaths, pages } = require(`./data.json`)
 const { version: gatsbyVersion } = require(`gatsby/package.json`)
-
-// Speed up looking up pages.
-const pagesObjectMap = new Map()
-pages.forEach(p => pagesObjectMap.set(p.path, p))
+const { matchPathFactory } = require(`./path-matcher`)
 
 const stats = JSON.parse(
   fs.readFileSync(`${process.cwd()}/public/webpack.stats.json`, `utf-8`)
@@ -45,7 +42,7 @@ try {
 
 Html = Html && Html.__esModule ? Html.default : Html
 
-const getPage = path => pagesObjectMap.get(path)
+const getPage = matchPathFactory(pages)
 
 const createElement = React.createElement
 

--- a/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
+++ b/packages/gatsby/src/internal-plugins/query-runner/pages-writer.js
@@ -4,6 +4,8 @@ const crypto = require(`crypto`)
 
 const { store, emitter } = require(`../../redux/`)
 
+const { createPathsFromArray } = require(`../../../cache-dir/path-matcher`)
+
 import { joinPath } from "../../utils/path"
 
 let lastHash = null
@@ -12,42 +14,30 @@ let lastHash = null
 const writePages = async () => {
   bootstrapFinished = true
   let { program, jsonDataPaths, pages } = store.getState()
-  pages = [...pages.values()]
 
   const pagesComponentDependencies = {}
 
-  // Write out pages.json
-  let pagesData = []
-  pages.forEach(({ path, matchPath, componentChunkName, jsonName }) => {
-    const pageComponentsChunkNames = {
-      componentChunkName,
-    }
+  pages = Array.from(pages.values())
 
-    if (program._[0] === `develop`) {
-      pagesComponentDependencies[path] = pageComponentsChunkNames
-    }
+  const pagesData = createPathsFromArray(
+    pages.map(({ path, matchPath, componentChunkName, jsonName }) => {
+      const pageComponentsChunkNames = {
+        componentChunkName,
+      }
 
-    pagesData.push({
-      ...pageComponentsChunkNames,
-      jsonName,
-      path,
-      matchPath,
+      if (program._[0] === `develop`) {
+        pagesComponentDependencies[path] = pageComponentsChunkNames
+      }
+
+      return {
+        ...pageComponentsChunkNames,
+        jsonName,
+        path,
+        matchPath,
+      }
     })
-  })
+  )
 
-  pagesData = _(pagesData)
-    // Ensure pages keep the same sorting through builds.
-    // Pages without matchPath come first, then pages with matchPath,
-    // where more specific patterns come before less specific patterns.
-    // This ensures explicit routes will match before general.
-    // Specificity is inferred from number of path segments.
-    .sortBy(
-      p =>
-        `${p.matchPath ? 9999 - p.matchPath.split(`/`).length : `0000`}${
-          p.path
-        }`
-    )
-    .value()
   const newHash = crypto
     .createHash(`md5`)
     .update(JSON.stringify(pagesComponentDependencies))


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Gatsby sites that have a lot of pages (50k - 60k) spend a lot of time during run time in the `findPage` method when prefetching links. This is due to the method looping through all members of the `page-manifest.json` file to search for matching paths. 

To fix this, I've changed the `page-manifests.json` file to use a trie-based data structure. This allows for near-constant time lookups and path matching, rather than the O(n) complexity of an array search.

This could also be used in the future for lazy loading chunked `page-manifest.json` files for particular path segments, and also optimising the dev 404 page to a tree-view as it struggles to load when trying to render large quantities of pages.

One concern that I have regarding this change is that it removes the `@reach/router` match function. While the trie version does support splats (`*`) for `matchPath`, it doesn't support more complex routes such as route parameters (which are not currently used by Gatsby). 

You can see the benefits of the change by using the `gatsby-dev-cli` with the [gatsby-intense-benchmark](https://github.com/bennetthardwick/gatsby-intense-benchmark). 

Our company has been working on a Gatsby site which has 30k pages at the moment, with the intention to scale to 100k+. We believe improvements to runtime performance are crucial to meet this goal.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
