### PR TITLE
fix(www): ensure rotator is ssr-friendly

### DIFF
--- a/www/src/components/rotator.js
+++ b/www/src/components/rotator.js
@@ -31,6 +31,7 @@ const controlButtonStyles = {
 
 class Rotator extends Component {
   state = {
+    shouldAnimate: false,
     item: 0,
     size: {},
   }
@@ -67,10 +68,11 @@ class Rotator extends Component {
   }
 
   componentDidMount() {
-    if (this.shouldAnimate()) {
+    const shouldAnimate = this.shouldAnimate()
+    if (shouldAnimate) {
       requestAnimationFrame(() => {
         this.intervalId = setInterval(this.incrementItem, 5000)
-        this.setState({ size: this.getDimensions() })
+        this.setState({ shouldAnimate, size: this.getDimensions() })
       })
     }
   }
@@ -80,7 +82,7 @@ class Rotator extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.shouldAnimate() && prevState.item !== this.state.item) {
+    if (prevState.shouldAnimate && prevState.item !== this.state.item) {
       requestAnimationFrame(() => {
         this.setState({ size: this.getDimensions() })
       })
@@ -104,8 +106,9 @@ class Rotator extends Component {
   }
 
   render() {
+    const { shouldAnimate } = this.state
     const { text, pluginName } = this.props.items[this.state.item]
-    const enableSlider = this.shouldAnimate() && this.intervalId
+    const enableSlider = shouldAnimate && this.intervalId
 
     return (
       <div


### PR DESCRIPTION
## Description

Fixes a tiny regression re: SSR rendering introduced in #12530

Validated this by:

1. Ensuring rotater animates (by default!) in built version
1. Ensuring rotater _does not_ animate when reduced motion is enabled in System Preferences - Accessibility
1. Ensuring site can build with `gatsby build` & `gatsby serve`

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
