### PR TITLE
fix(www): prevent filter accordions from disappearing on collapse

### DIFF
--- a/www/src/views/showcase/collapsible-filter-list.js
+++ b/www/src/views/showcase/collapsible-filter-list.js
@@ -14,7 +14,7 @@ const CollapsibleFilterList = ({
   setFilters,
   heading,
 }) => (
-  <Collapsible heading={heading}>
+  <Collapsible heading={heading} fixed={300}>
     {categoryKeys.map(c => (
       <button
         key={c}

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -134,6 +134,7 @@ export default class FilteredStarterLibrary extends Component {
               setFilters={setFiltersVersion}
             />
             <LHSFilter
+              fixed={150}
               heading="Categories"
               data={Array.from(
                 count(starters.map(({ node: starter }) => starter.tags))
@@ -143,6 +144,7 @@ export default class FilteredStarterLibrary extends Component {
               sortRecent={urlState.sort === `recent`}
             />
             <LHSFilter
+              fixed={150}
               heading="Gatsby Dependencies"
               data={Array.from(
                 count(


### PR DESCRIPTION
## Description

The following filters on the Gatsby website were disappearing from view on collapsing them:
1. **Categories** in Starters
2. **Gatsby Dependencies** in Starters
3. **Categories** in Showcase

All three of these filter accordions use the `Collapsible` component, which takes in a prop called `fixed` to set the `minHeight` and `maxHeight` of the component. If these heights are set, then the filter accordions correctly do not disappear from view.

This PR hence introduces the following changes:

1. Adds the prop `fixed={150}` for **Categories** in Starters
2. Adds the prop `fixed={150}` for **Gatsby Dependencies** in Starters
3. Adds the prop `fixed={300}` for **Categories** in Showcase

Notes: 
- The **Gatsby Version** category in Starters uses `fixed={150}` already, so I have used the same value for the other two categories in Starters. 
- `Categories` in Showcase is the only filter, so I chose a bigger value for it.

Please let me know if any other changes have to be made! Thanks 😄 

## Related Issues

Fixes #12517.