### PR TITLE
chore(docs): add pullquote snippet for Forestry CMS

### DIFF
--- a/.forestry/snippets/pullquote.snippet
+++ b/.forestry/snippets/pullquote.snippet
@@ -1,0 +1,3 @@
+<pullquote citation="Some Person @ Company">
+This is a blockquote. Use them!
+</pullquote>


### PR DESCRIPTION
## Description

Per [these comments on the Forestry workflow](https://gist.github.com/DSchau/f2048038432b37e103a62d0ff1deb8d6#normalization), it is recommended to use the `pullquote` component instead of the standard Markdown blockquote syntax.

To aid editors in the usage of this component, this PR adds a `pullquote.snippet` file to the Forestry configuration which will add `pullquote` as an option to the WYSIWYG toolbar when content for this site is edited in Forestry.

## Related Issues

This PR was made in response to the following gist remarking on the workflow for using Forestry:

https://gist.github.com/DSchau/f2048038432b37e103a62d0ff1deb8d6

