### PR TITLE
fix(themes): check issuer for null

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -35,20 +35,32 @@ module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
       // get the location of the component relative to src/
       const [, component] = request.path.split(path.join(theme, `src`))
 
-      const issuerExtension = path.extname(request.context.issuer)
+      /**
+       * if someone adds
+       * ```
+       * modules: [path.resolve(__dirname, 'src'), 'node_modules'],
+       * ```
+       * to the webpack config, `issuer` is `null`, so we skip this check.
+       * note that it's probably a bad idea in general to set `modules`
+       * like this in a theme, but we also shouldn't artificially break
+       * people that do.
+       */
+      if (request.context.issuer) {
+        const issuerExtension = path.extname(request.context.issuer)
 
-      if (
-        request.context.issuer
-          .slice(0, -issuerExtension.length)
-          .endsWith(component)
-      ) {
-        return resolver.doResolve(
-          `describedRelative`,
-          request,
-          null,
-          {},
-          callback
-        )
+        if (
+          request.context.issuer
+            .slice(0, -issuerExtension.length)
+            .endsWith(component)
+        ) {
+          return resolver.doResolve(
+            `describedRelative`,
+            request,
+            null,
+            {},
+            callback
+          )
+        }
       }
       const builtComponentPath = this.resolveComponentPath({
         matchingTheme: theme,


### PR DESCRIPTION
If a theme author sets the following config in their theme
(specifically `modules` with `src`), then the issuer for some requests
will be null.

```js
exports.onCreateWebpackConfig = ({ actions }) => {
  actions.setWebpackConfig({
    resolve: {
      modules: [path.resolve(__dirname, 'src'), 'node_modules'],
      alias: {
        $components: path.resolve(__dirname, 'src/components'),
      },
    },
  })
}
```

If the issuer is null, it can't be a self-reference shadow, so skip
the check that enables shadowed components to import their
shadow-parents.


---

Overriding `modules` is not generally a good idea in themes (if this config is set in two themes then you can get the wrong module depending on the order of theme inclusion), but we can't stop people from doing it and we shouldn't break unnecessarily if they do.