### PR TITLE
Make the content field docs clearer for the createNode action

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -456,9 +456,19 @@ const typeOwners = {}
  * node as the type is used in forming GraphQL types so users will query
  * for nodes based on the type choosen here. Nodes of a given type can
  * only be created by one plugin.
- * @param {string} node.internal.content An optional field. The raw content
- * of the node. Can be excluded if it'd require a lot of memory to load in
- * which case you must define a `loadNodeContent` function for this node.
+ * @param {string} node.internal.content An optional field. This is rarely
+ * used. It is used when a source plugin sources data it doesn't know how
+ * to transform e.g. a markdown string pulled from an API. The source plugin
+ * can defer the transformation to a specialized transformer plugin like
+ * gatsby-transformer-remark. This `content` field holds the raw content
+ * (so for the markdown case, the markdown string).
+ *
+ * Data that's already structured should be part of the node and not added
+ * here. You should not stringify the node content here.
+ *
+ * If the content is very large and can be lazy-loaded, e.g. a file on disk,
+ * you can define a `loadNodeContent` function for this node and the node
+ * content will be lazy loaded when it's needed.
  * @param {string} node.internal.contentDigest the digest for the content
  * of this node. Helps Gatsby avoid doing extra work on data that hasn't
  * changed.

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -463,8 +463,9 @@ const typeOwners = {}
  * gatsby-transformer-remark. This `content` field holds the raw content
  * (so for the markdown case, the markdown string).
  *
- * Data that's already structured should be part of the node and not added
- * here. You should not stringify the node content here.
+ * Data that's already structured should be added to the top-level of the node
+ * object and _not_ added here. You should not `JSON.stringify` your node's
+ * data here.
  *
  * If the content is very large and can be lazy-loaded, e.g. a file on disk,
  * you can define a `loadNodeContent` function for this node and the node


### PR DESCRIPTION
Make very clear it should only be used in rare cases e.g. when pulling markdown strings from an API.

Also that you _shouldn't_ `JSON.stringify` your node's content here — a pattern which leaked into the wild and keeps coming up.
