### PR TITLE
feat(gatsby): add anonymous telemetry instrumentation to gatsby

### DIFF
--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -34,8 +34,8 @@ Specifically, we collect the following information for _all_ telemetry events:
 
 - Timestamp of the occurrence
 - Command invoked (e.g. `build` or `develop`)
-- Unique and unidentifiable machine ID
-- Unique and unidentifiable session ID
+- Gatsby machine ID. This is generated with UUID and stored in global gatsby config at ~/.config/gatsby/config.json.
+- Unique session ID. This is generated on each run with UUID.
 - One-way hash of the current working directory or a hash of the git remote
 - General OS level information (operating system, version, CPU architecture, and whether the command is run inside a CI)
 - Current Gatsby version
@@ -44,6 +44,6 @@ The access to the raw data is highly controlled, and we cannot identify individu
 
 ## What about sensitive data? (e.g. secrets)
 
-We perform additional steps to ensure that secure data (e.g. environment variables used to store secrets for the build process) **do not** make their way into our analytics. We strip logs, error messages, etc. of this sensitive data to ensure we _never_ gain access to this sensitive data.
+We perform additional steps to ensure that secure data (e.g. environment variables used to store secrets for the build process) **do not** make their way into our analytics. [We strip logs, error messages, etc.](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/sanitize-error.js) of this sensitive data to ensure we _never_ gain access to this sensitive data.
 
 You can view all the information that is sent by Gatsby’s telemetry by setting the environment variable `GATSBY_TELEMETRY_DEBUG`to `1` to print the telemetry data instead of sending it over.

--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -17,7 +17,7 @@ Users may always opt-out from the telemetry with `gatsby telemetry --disable` or
 Since much of Gatsby’s function revolves around community plugins and starters, we want to collect information on usage
 and reliability so that we can ensure a high-quality ecosystem.
 
-This raises a question. How will we use this telemetry data to improve the ecosystem? Some examples are helpful:
+This raises a question: how will we use this telemetry data to improve the ecosystem? Some examples are helpful:
 
 - We will be able to understand which plugins are typically used together. This will enable us to surface this information in our public plugin library and build more relevant starters and tutorials based on this data.
 - We will be able to surface popularity of different starters in the starter showcase.

--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -1,0 +1,49 @@
+---
+title: Telemetry
+---
+
+Gatsby contains a telemetry feature that collects anonymous usage information that is used to help improve Gatsby for all users.
+The Gatsby user base is growing very rapidly. It's important that our small team and the greater community will better understand the usage patterns, so we can best decide how to design future features and prioritize current work.
+
+You will be notified when installing Gatsby and when running it for the first time.
+
+## How to opt-out
+
+Users may always opt-out from the telemetry with `gatsby telemetry --disable` or setting the environment variable `GATSBY_TELEMETRY_DISABLED` to `1`
+
+## Why?
+
+**Anonymous** aggregate user analytics allow us to prioritize fixes and features based on how and when people use Gatsby.
+Since much of Gatsby’s function revolves around community plugins and starters, we want to collect information on usage
+and reliability so that we can ensure a high-quality ecosystem.
+
+This raises a question. How will we use this telemetry data to improve the ecosystem? Some examples are helpful:
+
+- We will be able to understand which plugins are typically used together. This will enable us to surface this information in our public plugin library and build more relevant starters and tutorials based on this data.
+- We will be able to surface popularity of different starters in the starter showcase.
+- We will be able to get more detail on the types of errors users are running into in _every_ build stage (e.g. development, build, etc.). This will let us improve the quality of our tool and better focus our time on solving more common, frustrating issues.
+- We will be able to surface reliability of different plugins and starters, and detect which of these tend to error more frequently. We can use this data to surface quality metrics and improve the quality of our plugins and starters.
+- We will be able to see timings for different build stages to guide us in where we should focus optimization work.
+
+## What do we track?
+
+We track general usage details, including command invocation, build process status updates, performance measurements, and errors.
+We use these metrics to better understand the usage patterns. These metrics will directly allow us to better decide how to design future features and prioritize current work.
+
+Specifically, we collect the following information for _all_ telemetry events:
+
+- Timestamp of the occurrence
+- Command invoked (e.g. `build` or `develop`)
+- Unique and unidentifiable machine ID
+- Unique and unidentifiable session ID
+- One-way hash of the current working directory or a hash of the git remote
+- General OS level information (operating system, version, CPU architecture, and whether the command is run inside a CI)
+- Current Gatsby version
+
+The access to the raw data is highly controlled, and we cannot identify individual users from the dataset. It is anonymized and untraceable back to the user.
+
+## What about sensitive data? (e.g. secrets)
+
+We perform additional steps to ensure that secure data (e.g. environment variables used to store secrets for the build process) **do not** make their way into our analytics. We strip logs, error messages, etc. of this sensitive data to ensure we _never_ gain access to this sensitive data.
+
+You can view all the information that is sent by Gatsby’s telemetry by setting the environment variable `GATSBY_TELEMETRY_DEBUG`to `1` to print the telemetry data instead of sending it over.

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -17,12 +17,14 @@
     "convert-hrtime": "^2.0.0",
     "core-js": "^2.5.0",
     "envinfo": "^5.8.1",
+    "gatsby-telemetry": "^0.0.1",
     "execa": "^0.8.0",
     "fs-exists-cached": "^1.0.0",
     "fs-extra": "^4.0.1",
     "hosted-git-info": "^2.6.0",
     "lodash": "^4.17.10",
     "meant": "^1.0.1",
+    "node-fetch": "2.3.0",
     "opentracing": "^0.14.3",
     "pretty-error": "^2.1.1",
     "resolve-cwd": "^2.0.0",
@@ -30,6 +32,7 @@
     "stack-trace": "^0.0.10",
     "update-notifier": "^2.3.0",
     "yargs": "^12.0.5",
+    "uuid": "3.3.2",
     "yurnalist": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -355,9 +355,11 @@ module.exports = argv => {
             description: `Disable telemetry`,
           }),
 
-      handler: handlerP(({ enable, disable }) =>
-        setTelemetryEnabled(enable || !disable)
-      ),
+      handler: handlerP(({ enable, disable }) => {
+        const enabled = enable || !disable
+        setTelemetryEnabled(enabled)
+        report.log(`Telemetry collection ${enabled ? `enabled` : `disabled`}`)
+      }),
     })
     .wrap(cli.terminalWidth())
     .demandCommand(1, `Pass --help to see all available commands and options.`)

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -5,6 +5,11 @@ const report = require(`./reporter`)
 const didYouMean = require(`./did-you-mean`)
 const envinfo = require(`envinfo`)
 const existsSync = require(`fs-exists-cached`).sync
+const {
+  trackCli,
+  setDefaultTags,
+  setTelemetryEnabled,
+} = require(`gatsby-telemetry`)
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(
@@ -40,6 +45,11 @@ function buildLocalCommands(cli, isLocalSite) {
         `gatsby`,
         `package.json`
       ))
+      try {
+        setDefaultTags({ installedGatsbyVersion: packageInfo.version })
+      } catch (e) {
+        // ignore
+      }
       majorVersion = parseInt(packageInfo.version.split(`.`)[0], 10)
     } catch (err) {
       /* ignore */
@@ -311,6 +321,15 @@ module.exports = argv => {
 
   buildLocalCommands(cli, isLocalSite)
 
+  try {
+    const { version } = require(`../package.json`)
+    setDefaultTags({ gatsbyCliVersion: version })
+  } catch (e) {
+    // ignore
+  }
+
+  trackCli(argv)
+
   return cli
     .command({
       command: `new [rootPath] [starter]`,
@@ -320,6 +339,24 @@ module.exports = argv => {
           const initStarter = require(`./init-starter`)
           return initStarter(starter, { rootPath })
         }
+      ),
+    })
+    .command({
+      command: `telemetry`,
+      desc: `Enable or disable Gatsby anonymous analytics collection.`,
+      builder: yargs =>
+        yargs
+          .option(`enable`, {
+            type: `boolean`,
+            description: `Enable telemetry (default)`,
+          })
+          .option(`disable`, {
+            type: `boolean`,
+            description: `Disable telemetry`,
+          }),
+
+      handler: handlerP(({ enable, disable }) =>
+        setTelemetryEnabled(enable || !disable)
       ),
     })
     .wrap(cli.terminalWidth())

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -5,6 +5,7 @@ const { stripIndent } = require(`common-tags`)
 const convertHrtime = require(`convert-hrtime`)
 const tracer = require(`opentracing`).globalTracer()
 const { getErrorFormatter } = require(`./errors`)
+const { trackError } = require(`gatsby-telemetry`)
 
 const VERBOSE = process.env.gatsby_log_level === `verbose`
 
@@ -47,11 +48,13 @@ module.exports = Object.assign(reporter, {
    */
   panic(...args) {
     this.error(...args)
+    trackError(`GENERAL_PANIC`, { error: args })
     process.exit(1)
   },
 
   panicOnBuild(...args) {
     this.error(...args)
+    trackError(`BUILD_PANIC`, { error: args })
     if (process.env.gatsby_executing_command === `build`) {
       process.exit(1)
     }

--- a/packages/gatsby-telemetry/.babelrc
+++ b/packages/gatsby-telemetry/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    ["babel-preset-gatsby-package"]
+  ]
+}

--- a/packages/gatsby-telemetry/.gitignore
+++ b/packages/gatsby-telemetry/.gitignore
@@ -1,0 +1,2 @@
+/lib
+/node_modules

--- a/packages/gatsby-telemetry/CHANGELOG.md
+++ b/packages/gatsby-telemetry/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/gatsby-telemetry/README.md
+++ b/packages/gatsby-telemetry/README.md
@@ -1,35 +1,33 @@
 # gatsby-telemetry
 
-Gatsby contains a telemetry feature that collects anonymous usage information that helps improve Gatsby for all users.
-You will be notified when installing Gatsby and when running it for the first time.
+Check out: [gatsby.dev/telemetry](https://gatsby.dev/telemetry)
 
-## How to opt-out
+## API
 
-Users may always opt-out from the telemetry with `gatsby telemetry --disable` or setting the environment variable `GATSBY_TELEMETRY_DISABLED` to `1`
+### trackCli(type, tags)
 
-## Why?
+Capture an event of type `type` and decorate the generated event with these tags (note: allowed tags are filtered on server side)
 
-Anonymous aggregate user analytics allow us to prioritise fixes and features based on how, and when people use Gatsby.
-Since much of Gatsby’s function revolves around community plugins and starters, we want to collect information on usage,
-and, importantly, reliability, so that we can ensure a high-quality plugin (and soon, theme) ecosystem.
+### trackError(type, tags)
 
-For example:
+Capture an error of type `type`. The exception maybe passed in tags and it will be sanitize to anonymize the contents.
 
-- We will be able to understand which plugins are used together, surface that information in the public plugin library, and, for example, build more relevant starters and tutorials.
-- We will be able to surface popularity of different starters in the starter showcase.
-- We will be able to surface error rates in each build stage, and focusing on driving these down over time. We want the experience to remain error free.
-- We will be able to surface reliability of different plugins and starters, and detect the ones which seen buggy to then improve these.
-- We will be able to see timings for different build stages to guide us in where we should focus optimization work.
+### trackBuildError(type, tags)
 
-## We collect the following data for all events
+Capture an build error of type `type`. The exception maybe passed in tags and it will be sanitize to anonymize the contents.
 
-- Timestamp of the occurrence
-- Command invoked (e.g. `build` or `develop`)
-- Unique and unidentifiable machine ID
-- Unique and unidentifiable session ID
-- One-way hashed current working directory
-- General OS level information (operating system, version, CPU architecture, and whether the command is run inside a CI)
-- Used Gatsby version
-- Errors with PII (e.g., paths) sanitized.
+### setDefaultTags(tags)
 
-In addition to these events, we may collect additional performance affecting measurements, such as how many pages / queries etc. the build involved.
+Set additional tags to be included in all future events.
+
+### decorateEvent(type, tags)
+
+Attach additional tags to the next event generated of type `type`.
+
+### setTelemetryEnabled(enabled)
+
+Enable or disable the telemetry collection.
+
+### expressMiddleware(type)
+
+Returns a debounced events tracker for collecting general activity information for incoming requests.

--- a/packages/gatsby-telemetry/README.md
+++ b/packages/gatsby-telemetry/README.md
@@ -1,0 +1,35 @@
+# gatsby-telemetry
+
+Gatsby contains a telemetry feature that collects anonymous usage information that helps improve Gatsby for all users.
+You will be notified when installing Gatsby and when running it for the first time.
+
+## How to opt-out
+
+Users may always opt-out from the telemetry with `gatsby telemetry --disable` or setting the environment variable `GATSBY_TELEMETRY_DISABLED` to `1`
+
+## Why?
+
+Anonymous aggregate user analytics allow us to prioritise fixes and features based on how, and when people use Gatsby.
+Since much of Gatsby’s function revolves around community plugins and starters, we want to collect information on usage,
+and, importantly, reliability, so that we can ensure a high-quality plugin (and soon, theme) ecosystem.
+
+For example:
+
+- We will be able to understand which plugins are used together, surface that information in the public plugin library, and, for example, build more relevant starters and tutorials.
+- We will be able to surface popularity of different starters in the starter showcase.
+- We will be able to surface error rates in each build stage, and focusing on driving these down over time. We want the experience to remain error free.
+- We will be able to surface reliability of different plugins and starters, and detect the ones which seen buggy to then improve these.
+- We will be able to see timings for different build stages to guide us in where we should focus optimization work.
+
+## We collect the following data for all events
+
+- Timestamp of the occurrence
+- Command invoked (e.g. `build` or `develop`)
+- Unique and unidentifiable machine ID
+- Unique and unidentifiable session ID
+- One-way hashed current working directory
+- General OS level information (operating system, version, CPU architecture, and whether the command is run inside a CI)
+- Used Gatsby version
+- Errors with PII (e.g., paths) sanitized.
+
+In addition to these events, we may collect additional performance affecting measurements, such as how many pages / queries etc. the build involved.

--- a/packages/gatsby-telemetry/README.md
+++ b/packages/gatsby-telemetry/README.md
@@ -34,5 +34,5 @@ Returns a debounced events tracker for collecting general activity information f
 
 ## ENV Variables
 
-- Set `GATSBY_TELEMETRY_DEBUG`to `1` to print the telemetry data instead of sending it over
-- Set `GATSBY_TELEMETRY_DISABLED` `1` to opt out of all telemetry
+- Set `GATSBY_TELEMETRY_DEBUG` to `1` to print the telemetry data instead of sending it over
+- Set `GATSBY_TELEMETRY_DISABLED` to `1` to opt out of all telemetry

--- a/packages/gatsby-telemetry/README.md
+++ b/packages/gatsby-telemetry/README.md
@@ -31,3 +31,7 @@ Enable or disable the telemetry collection.
 ### expressMiddleware(type)
 
 Returns a debounced events tracker for collecting general activity information for incoming requests.
+
+## Debugging
+
+You can view all the information that is sent by Gatsby’s telemetry by setting the environment variable `GATSBY_TELEMETRY_DEBUG`to `1` to print the telemetry data instead of sending it over.

--- a/packages/gatsby-telemetry/README.md
+++ b/packages/gatsby-telemetry/README.md
@@ -32,6 +32,7 @@ Enable or disable the telemetry collection.
 
 Returns a debounced events tracker for collecting general activity information for incoming requests.
 
-## Debugging
+## ENV Variables
 
-You can view all the information that is sent by Gatsby’s telemetry by setting the environment variable `GATSBY_TELEMETRY_DEBUG`to `1` to print the telemetry data instead of sending it over.
+- Set `GATSBY_TELEMETRY_DEBUG`to `1` to print the telemetry data instead of sending it over
+- Set `GATSBY_TELEMETRY_DISABLED` `1` to opt out of all telemetry

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "gatsby-telemetry",
+  "description": "Gatsby Telemetry",
+  "version": "0.0.1",
+  "author": "Jarmo Isotalo <jarmo@isotalo.fi>",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "dependencies": {
+    "@babel/code-frame": "^7.0.0",
+    "@babel/runtime": "^7.0.0",
+    "bluebird": "^3.5.0",
+    "ci-info": "2.0.0",
+    "configstore": "4.0.0",
+    "envinfo": "^5.8.1",
+    "node-fetch": "2.3.0",
+    "resolve-cwd": "^2.0.0",
+    "source-map": "^0.5.7",
+    "stack-trace": "^0.0.10",
+    "stack-utils": "1.0.2",
+    "uuid": "3.3.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "babel-jest": "^24.0.0",
+    "babel-preset-gatsby-package": "^0.1.3",
+    "cross-env": "^5.1.4",
+    "jest": "^24.0.0",
+    "jest-cli": "^24.0.0",
+    "jest-junit": "^6.1.0"
+  },
+  "files": [
+    "lib",
+    "src/postinstall.js"
+  ],
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry#readme",
+  "keywords": [
+    "telemetry"
+  ],
+  "license": "MIT",
+  "main": "lib/index.js",
+  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry",
+  "scripts": {
+    "build": "babel src --out-dir lib --ignore **/__tests__",
+    "prepare": "cross-env NODE_ENV=production npm run build",
+    "jest": "jest",
+    "postinstall": "node src/postinstall.js",
+    "watch": "babel -w src --out-dir lib --ignore **/__tests__"
+  },
+  "yargs": {
+    "boolean-negation": false
+  },
+  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+}

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -50,6 +50,5 @@
   },
   "yargs": {
     "boolean-negation": false
-  },
-  "gitHead": "5bd5aebe066b9875354a81a4b9ed98722731c465"
+  }
 }

--- a/packages/gatsby-telemetry/src/__tests__/is-truthy.js
+++ b/packages/gatsby-telemetry/src/__tests__/is-truthy.js
@@ -1,0 +1,22 @@
+const isTruthy = require(`../is-truthy`)
+
+describe(`isTruthy`, () => {
+  it(`handles Booleans`, () => {
+    expect(isTruthy(true)).toBe(true)
+    expect(isTruthy(false)).toBe(false)
+  })
+  it(`handles true or false strings `, () => {
+    expect(isTruthy(`true`)).toBe(true)
+    expect(isTruthy(`false`)).toBe(false)
+    expect(isTruthy(`TRUE`)).toBe(true)
+    expect(isTruthy(`FALSE`)).toBe(false)
+  })
+  it(`handles numbers`, () => {
+    expect(isTruthy(`1`)).toBe(true)
+    expect(isTruthy(`0`)).toBe(false)
+    expect(isTruthy(`-1`)).toBe(false)
+  })
+  it(`defaults to false`, () => {
+    expect(isTruthy(`blah`)).toBe(false)
+  })
+})

--- a/packages/gatsby-telemetry/src/__tests__/sanitize-error.js
+++ b/packages/gatsby-telemetry/src/__tests__/sanitize-error.js
@@ -1,0 +1,60 @@
+const sanitize = require(`../sanitize-error`)
+
+describe(`sanitize errors`, () => {
+  it(`Removes env, output and converts buffers to strings from execa output`, () => {
+    const tags = {
+      error: [
+        {
+          error: null,
+          cmd: `git commit -m"test"`,
+          file: `/bin/sh`,
+          args: [`/bin/sh`, `-c`, `git commit -m"test`],
+          options: {
+            cwd: `here`,
+            shell: true,
+            envPairs: [`VERSION=1.2.3`],
+            stdio: [{}, {}, {}], // pipes
+          },
+          envPairs: [`VERSION=1.2.3`],
+
+          stderr: Buffer.from(`this is a test`),
+          stdout: Buffer.from(`this is a test`),
+        },
+      ],
+    }
+
+    const error = tags.error[0]
+    expect(error).toBeDefined()
+    expect(error.envPairs).toBeDefined()
+    expect(error.options).toBeDefined()
+
+    expect(typeof error.stdout).toEqual(`object`)
+
+    sanitize(tags)
+    expect(typeof error.stdout).toEqual(`string`)
+
+    expect(error).toBeDefined()
+    expect(error.envPairs).toBeUndefined()
+    expect(error.options).toBeUndefined()
+  })
+
+  it(`Sanitizes current path from error stracktraces`, () => {
+    const errormessage = `this is a test`
+    let e
+    try {
+      throw new Error(errormessage)
+    } catch (error) {
+      e = error
+    }
+    expect(e).toBeDefined()
+    expect(e.message).toEqual(errormessage)
+    expect(e.stack).toBeDefined()
+    const localPathRegex = new RegExp(process.cwd())
+    expect(localPathRegex.test(e.stack)).toBeTruthy()
+    const tags = { error: [e] }
+
+    sanitize(tags)
+
+    expect(localPathRegex.test(e.stack)).toBeFalsy()
+  })
+})

--- a/packages/gatsby-telemetry/src/__tests__/sanitize-error.js
+++ b/packages/gatsby-telemetry/src/__tests__/sanitize-error.js
@@ -49,7 +49,9 @@ describe(`sanitize errors`, () => {
     expect(e).toBeDefined()
     expect(e.message).toEqual(errormessage)
     expect(e.stack).toBeDefined()
-    const localPathRegex = new RegExp(process.cwd())
+    const localPathRegex = new RegExp(
+      process.cwd().replace(/[-[/{}()*+?.\\^$|]/g, `\\$&`)
+    )
     expect(localPathRegex.test(e.stack)).toBeTruthy()
     const tags = { error: [e] }
 

--- a/packages/gatsby-telemetry/src/__tests__/telemetry.js
+++ b/packages/gatsby-telemetry/src/__tests__/telemetry.js
@@ -1,0 +1,17 @@
+jest.mock(`../event-storage`)
+const eventStore = require(`../event-storage`)
+const Telemetry = require(`../telemetry`)
+
+let telemetry
+beforeEach(() => {
+  eventStore.mockReset()
+  telemetry = new Telemetry()
+})
+
+describe(`Telemetry`, () => {
+  it(`Adds event to store`, () => {
+    telemetry.buildAndStoreEvent(`demo`, {})
+    expect(eventStore).toHaveBeenCalledTimes(1)
+    expect(eventStore.mock.instances[0].addEvent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -42,9 +42,6 @@ module.exports = class EventStorage {
         headers: { "content-type": `application/json` },
         body: JSON.stringify(events),
       })
-      if (res.ok) {
-        return true
-      }
       return res.ok
     } catch (e) {
       return false

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -58,7 +58,7 @@ module.exports = class EventStorage {
     return this.store.getConfig()
   }
 
-  updateConfig(conf) {
-    return this.store.updateConfig(conf)
+  updateConfig(...conf) {
+    return this.store.updateConfig(...conf)
   }
 }

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -1,0 +1,64 @@
+const Store = require(`./store`)
+const fetch = require(`node-fetch`)
+
+/* The events data collection is a spooled process that
+ * buffers events to a local fs based buffer
+ * which then is asynchronously flushed to the server.
+ * This both increases the fault tolerancy and allows collection
+ * to continue even when working offline.
+ */
+module.exports = class EventStorage {
+  store = new Store()
+  debugEvents = !!process.env.GATSBY_TELEMETRY_DEBUG
+  disabled = !!process.env.GATSBY_TELEMETRY_OPTOUT
+
+  addEvent(event) {
+    if (this.disabled) {
+      return
+    }
+
+    if (this.debugEvents) {
+      console.error(`Captured event:`, JSON.stringify(event))
+    } else {
+      this.store.appendToBuffer(JSON.stringify(event) + `\n`)
+    }
+  }
+
+  async sendEvents() {
+    return this.store.startFlushEvents(async eventsData => {
+      const events = eventsData
+        .split(`\n`)
+        .filter(e => e && e.length > 2) // drop empty lines
+        .map(e => JSON.parse(e))
+
+      return this.submitEvents(events)
+    })
+  }
+
+  async submitEvents(events) {
+    try {
+      const res = await fetch(`https://analytics.gatsbyjs.com/events`, {
+        method: `POST`,
+        headers: { "content-type": `application/json` },
+        body: JSON.stringify(events),
+      })
+      if (res.ok) {
+        return true
+      }
+      return res.ok
+    } catch (e) {
+      return false
+    }
+  }
+
+  getConfig(key) {
+    if (key) {
+      return this.store.getConfig(key)
+    }
+    return this.store.getConfig()
+  }
+
+  updateConfig(conf) {
+    return this.store.updateConfig(conf)
+  }
+}

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -1,6 +1,17 @@
 const Store = require(`./store`)
 const fetch = require(`node-fetch`)
 
+const isEnvVariableTruthy = envVar => {
+  const number = parseInt(envVar, 10)
+
+  // NaN, return false
+  if (isNaN(number)) return false
+  // Greater than 0, return true
+  if (number > 0) return true
+  // Default to false
+  return false
+}
+
 /* The events data collection is a spooled process that
  * buffers events to a local fs based buffer
  * which then is asynchronously flushed to the server.
@@ -9,8 +20,8 @@ const fetch = require(`node-fetch`)
  */
 module.exports = class EventStorage {
   store = new Store()
-  debugEvents = !!process.env.GATSBY_TELEMETRY_DEBUG
-  disabled = !!process.env.GATSBY_TELEMETRY_DISABLED
+  debugEvents = isEnvVariableTruthy(process.env.GATSBY_TELEMETRY_DEBUG)
+  disabled = isEnvVariableTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
 
   addEvent(event) {
     if (this.disabled) {

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -1,16 +1,7 @@
 const Store = require(`./store`)
 const fetch = require(`node-fetch`)
 
-const isEnvVariableTruthy = envVar => {
-  const number = parseInt(envVar, 10)
-
-  // NaN, return false
-  if (isNaN(number)) return false
-  // Greater than 0, return true
-  if (number > 0) return true
-  // Default to false
-  return false
-}
+const isTruthy = require(`./is-truthy`)
 
 /* The events data collection is a spooled process that
  * buffers events to a local fs based buffer
@@ -20,8 +11,8 @@ const isEnvVariableTruthy = envVar => {
  */
 module.exports = class EventStorage {
   store = new Store()
-  debugEvents = isEnvVariableTruthy(process.env.GATSBY_TELEMETRY_DEBUG)
-  disabled = isEnvVariableTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
+  debugEvents = isTruthy(process.env.GATSBY_TELEMETRY_DEBUG)
+  disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
 
   addEvent(event) {
     if (this.disabled) {

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -10,7 +10,7 @@ const fetch = require(`node-fetch`)
 module.exports = class EventStorage {
   store = new Store()
   debugEvents = !!process.env.GATSBY_TELEMETRY_DEBUG
-  disabled = !!process.env.GATSBY_TELEMETRY_OPTOUT
+  disabled = !!process.env.GATSBY_TELEMETRY_DISABLED
 
   addEvent(event) {
     if (this.disabled) {

--- a/packages/gatsby-telemetry/src/flush.js
+++ b/packages/gatsby-telemetry/src/flush.js
@@ -1,0 +1,12 @@
+const { join } = require(`path`)
+const { fork } = require(`child_process`)
+
+module.exports = async () => {
+  // Submit events on background w/o blocking the main process
+  // nor relying on it's lifecycle
+  const forked = fork(join(__dirname, `send.js`), {
+    detached: true,
+    stdio: `ignore`,
+  })
+  forked.unref()
+}

--- a/packages/gatsby-telemetry/src/index.js
+++ b/packages/gatsby-telemetry/src/index.js
@@ -1,0 +1,34 @@
+const Telemetry = require(`./telemetry`)
+const flush = require(`./flush`)
+
+const instance = new Telemetry()
+
+process.on(`exit`, flush)
+
+// For longrunning commands we want to occasinally flush the data
+// The data is also sent on exit.
+const interval = 10 * 60 * 1000 // 10 min
+const tick = _ => {
+  flush()
+    .catch(console.error)
+    .then(_ => setTimeout(tick, interval))
+}
+setTimeout(tick, interval)
+
+module.exports = {
+  trackCli: (input, tags) => instance.captureEvent(input, tags),
+  trackError: (input, tags) => instance.captureError(input, tags),
+  trackBuildError: (input, tags) => instance.captureBuildError(input, tags),
+  setDefaultTags: tags => instance.decorateAll(tags),
+  decorateEvent: (event, tags) => instance.decorateNextEvent(event, tags),
+  setTelemetryEnabled: enabled => instance.setTelemetryEnabled(enabled),
+
+  expressMiddleware: source => (req, res, next) => {
+    try {
+      instance.trackActivity(`${source}_ACTIVE`)
+    } catch (e) {
+      // ignore
+    }
+    next()
+  },
+}

--- a/packages/gatsby-telemetry/src/is-truthy.js
+++ b/packages/gatsby-telemetry/src/is-truthy.js
@@ -1,0 +1,23 @@
+// Returns true for `true`, true, positive numbers
+// Returns false for `false`, false, 0, negative integers and anything else
+const isTruthy = value => {
+  // Return if Boolean
+  if (typeof value === `boolean`) return value
+
+  // Return false if null or undefined
+  if (value === undefined || value === null) return false
+
+  // If the String is true or false
+  if (value.toLowerCase() === `true`) return true
+  if (value.toLowerCase() === `false`) return false
+
+  // Now check if it's a number
+  const number = parseInt(value, 10)
+  if (isNaN(number)) return false
+  if (number > 0) return true
+
+  // Default to false
+  return false
+}
+
+module.exports = isTruthy

--- a/packages/gatsby-telemetry/src/postinstall.js
+++ b/packages/gatsby-telemetry/src/postinstall.js
@@ -1,5 +1,16 @@
-console.log(
-  `Gatsby has started collecting anonymous usage analytics to help improve Gatsby for all users.\n` +
-    `If you'd like to opt-out, you can use \`gatsby analytics --disable\`\n` +
-    `To learn more, checkout http://gatsby.dev/analytics`
-)
+let enabled = false
+try {
+  const Configstore = require(`configstore`)
+  const config = new Configstore(`gatsby`, {}, { globalConfigPath: true })
+  enabled = config.get(`telemetry.enabled`)
+  if (enabled === undefined) {
+    console.log(
+      `Gatsby has started collecting anonymous usage analytics to help improve Gatsby for all users.\n` +
+        `If you'd like to opt-out, you can use \`gatsby telemetry --disable\`\n` +
+        `To learn more, checkout http://gatsby.dev/telemetry`
+    )
+    enabled = config.set(`telemetry.enabled`, true)
+  }
+} catch (e) {
+  // ignore
+}

--- a/packages/gatsby-telemetry/src/postinstall.js
+++ b/packages/gatsby-telemetry/src/postinstall.js
@@ -1,0 +1,5 @@
+console.log(
+  `Gatsby has started collecting anonymous usage analytics to help improve Gatsby for all users.\n` +
+    `If you'd like to opt-out, you can use \`gatsby analytics --disable\`\n` +
+    `To learn more, checkout http://gatsby.dev/analytics`
+)

--- a/packages/gatsby-telemetry/src/sanitize-error.js
+++ b/packages/gatsby-telemetry/src/sanitize-error.js
@@ -1,0 +1,28 @@
+const StackUtils = require(`stack-utils`)
+
+module.exports = tags => {
+  if (!tags) return
+  const { error } = tags
+  if (error) {
+    try {
+      ;[].concat(error).forEach(e => {
+        ;[`envPairs`, `options`, `output`].forEach(f => delete e[f])
+        // These may be buffers
+        if (e.stderr) e.stderr = String(e.stderr)
+        if (e.stdout) e.stdout = String(e.stdout)
+        let { stack } = e
+        if (stack) {
+          const stackUtils = new StackUtils({
+            cwd: process.cwd(),
+            internals: StackUtils.nodeInternals(),
+          })
+          stack = stackUtils.clean(stack)
+          e.stack = stack
+        }
+        return e
+      })
+    } catch (err) {
+      // ignore
+    }
+  }
+}

--- a/packages/gatsby-telemetry/src/send.js
+++ b/packages/gatsby-telemetry/src/send.js
@@ -2,14 +2,9 @@ const Telemetry = require(`./telemetry`)
 const instance = new Telemetry()
 
 const flush = _ => {
-  instance
-    .sendEvents()
-    .then(e => {
-      // ignore
-    })
-    .catch(e => {
-      // ignore
-    })
+  instance.sendEvents().catch(e => {
+    // ignore
+  })
 }
 
 flush()

--- a/packages/gatsby-telemetry/src/send.js
+++ b/packages/gatsby-telemetry/src/send.js
@@ -1,0 +1,15 @@
+const Telemetry = require(`./telemetry`)
+const instance = new Telemetry()
+
+const flush = _ => {
+  instance
+    .sendEvents()
+    .then(e => {
+      // ignore
+    })
+    .catch(e => {
+      // ignore
+    })
+}
+
+flush()

--- a/packages/gatsby-telemetry/src/store.js
+++ b/packages/gatsby-telemetry/src/store.js
@@ -22,8 +22,8 @@ module.exports = class Store {
     return this.config.all
   }
 
-  updateConfig(fields) {
-    this.config.set(fields)
+  updateConfig(...fields) {
+    this.config.set(...fields)
   }
 
   appendToBuffer(event) {

--- a/packages/gatsby-telemetry/src/store.js
+++ b/packages/gatsby-telemetry/src/store.js
@@ -58,7 +58,7 @@ module.exports = class Store {
     }
     const contents = readFileSync(newPath, `utf8`)
 
-    // There is still a chance process dies while sending data and some events is lost
+    // There is still a chance process dies while sending data and some events are lost
     // This will be ok for now, however
     unlinkSync(newPath)
     let success = false

--- a/packages/gatsby-telemetry/src/store.js
+++ b/packages/gatsby-telemetry/src/store.js
@@ -1,0 +1,76 @@
+const { homedir } = require(`os`)
+const path = require(`path`)
+const {
+  appendFileSync,
+  readFileSync,
+  renameSync,
+  existsSync,
+  unlinkSync,
+} = require(`fs`)
+const { ensureDirSync } = require(`fs-extra`)
+const Configstore = require(`configstore`)
+
+module.exports = class Store {
+  config = new Configstore(`gatsby`, {}, { globalConfigPath: true })
+
+  constructor() {}
+
+  getConfig(key) {
+    if (key) {
+      return this.config.get(key)
+    }
+    return this.config.all
+  }
+
+  updateConfig(fields) {
+    this.config.set(fields)
+  }
+
+  appendToBuffer(event) {
+    const bufferPath = this.getBufferFilePath()
+    appendFileSync(bufferPath, event, `utf8`)
+  }
+
+  getConfigPath() {
+    const configPath = path.join(homedir(), `.config/gatsby`)
+    ensureDirSync(configPath)
+    return configPath
+  }
+
+  getBufferFilePath() {
+    const configPath = this.getConfigPath()
+    return path.join(configPath, `events.json`)
+  }
+
+  async startFlushEvents(flushOperation) {
+    const now = Date.now()
+    const filePath = this.getBufferFilePath()
+    if (!existsSync(filePath)) {
+      return
+    }
+    const newPath = `${filePath}-${now}`
+
+    try {
+      renameSync(filePath, newPath)
+    } catch (e) {
+      // ignore
+      return
+    }
+    const contents = readFileSync(newPath, `utf8`)
+
+    // There is still a chance process dies while sending data and some events is lost
+    // This will be ok for now, however
+    unlinkSync(newPath)
+    let success = false
+    try {
+      success = await flushOperation(contents)
+    } catch (e) {
+      // ignore
+    } finally {
+      // if sending fails, we write the data back to the log
+      if (!success) {
+        this.appendToBuffer(contents)
+      }
+    }
+  }
+}

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -15,9 +15,8 @@ module.exports = class AnalyticsTracker {
   osInfo // lazy
   trackingEnabled // lazy
   componentVersion
-  sessionId
+  sessionId = uuid()
   constructor() {
-    this.sessionId = uuid()
     try {
       this.componentVersion = require(`../package.json`).version
     } catch (e) {
@@ -190,7 +189,7 @@ module.exports = class AnalyticsTracker {
 
   async sendEvents() {
     if (!this.isTrackingEnabled()) {
-      return async _ => {} // so that then/await won't fail
+      return Promise.resolve()
     }
     return this.store.sendEvents()
   }

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -111,8 +111,8 @@ module.exports = class AnalyticsTracker {
     if (telemetry === undefined || telemetry === null) {
       console.log(
         `Gatsby has started collecting anonymous usage analytics to help improve Gatsby for all users.\n` +
-          `If you'd like to opt-out, you can use \`gatsby analytics --disable\`\n` +
-          `To learn more, checkout http://gatsby.dev/analytics`
+          `If you'd like to opt-out, you can use \`gatsby telemetry --disable\`\n` +
+          `To learn more, checkout http://gatsby.dev/telemetry`
       )
       telemetry = true
       this.store.updateConfig({ telemetry })

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -93,10 +93,10 @@ module.exports = class AnalyticsTracker {
     if (this.machineId) {
       return this.machineId
     }
-    let machineId = this.store.getConfig(`machineId`)
+    let machineId = this.store.getConfig(`telemetry.machineId`)
     if (!machineId) {
       machineId = uuid()
-      this.store.updateConfig({ machineId })
+      this.store.updateConfig(`telemetry.machineId`, machineId)
     }
     this.machineId = machineId
     return machineId
@@ -107,18 +107,18 @@ module.exports = class AnalyticsTracker {
     if (this.trackingEnabled !== undefined) {
       return this.trackingEnabled
     }
-    let telemetry = this.store.getConfig(`telemetry`)
-    if (telemetry === undefined || telemetry === null) {
+    let enabled = this.store.getConfig(`telemetry.enabled`)
+    if (enabled === undefined || enabled === null) {
       console.log(
         `Gatsby has started collecting anonymous usage analytics to help improve Gatsby for all users.\n` +
           `If you'd like to opt-out, you can use \`gatsby telemetry --disable\`\n` +
           `To learn more, checkout http://gatsby.dev/telemetry`
       )
-      telemetry = true
-      this.store.updateConfig({ telemetry })
+      enabled = true
+      this.store.updateConfig(`telemetry.enabled`, enabled)
     }
-    this.trackingEnabled = telemetry
-    return telemetry
+    this.trackingEnabled = enabled
+    return enabled
   }
 
   getRepoId() {
@@ -182,9 +182,9 @@ module.exports = class AnalyticsTracker {
     this.defaultTags = Object.assign(this.defaultTags, tags)
   }
 
-  setAnalyticsEnabled(enabled) {
+  setTelemetryEnabled(enabled) {
     this.trackingEnabled = enabled
-    this.store.updateConfig({ telemetry: enabled })
+    this.store.updateConfig(`telemetry.enabled`, enabled)
   }
 
   async sendEvents() {

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -184,7 +184,6 @@ module.exports = class AnalyticsTracker {
   setTelemetryEnabled(enabled) {
     this.trackingEnabled = enabled
     this.store.updateConfig(`telemetry.enabled`, enabled)
-    console.log(`Telemetry collection`, enabled ? `enabled` : `disabled`)
   }
 
   async sendEvents() {

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -185,6 +185,7 @@ module.exports = class AnalyticsTracker {
   setTelemetryEnabled(enabled) {
     this.trackingEnabled = enabled
     this.store.updateConfig(`telemetry.enabled`, enabled)
+    console.log(`Telemetry collection`, enabled ? `enabled` : `disabled`)
   }
 
   async sendEvents() {

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -1,0 +1,196 @@
+const { createHash } = require(`crypto`)
+const uuid = require(`uuid/v1`)
+const EventStorage = require(`./event-storage`)
+const sanitizeError = require(`./sanitize-error`)
+const ci = require(`ci-info`)
+const os = require(`os`)
+const { basename } = require(`path`)
+const { execSync } = require(`child_process`)
+
+module.exports = class AnalyticsTracker {
+  store = new EventStorage()
+  debouncer = {}
+  metadataCache = {}
+  defaultTags = {}
+  osInfo // lazy
+  trackingEnabled // lazy
+  componentVersion
+  sessionId
+  constructor() {
+    this.sessionId = uuid()
+    try {
+      this.componentVersion = require(`../package.json`).version
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  captureEvent(type = ``, tags = {}) {
+    if (!this.isTrackingEnabled()) {
+      return
+    }
+    if (Array.isArray(type) && type.length > 2) {
+      type = type[2].toUpperCase()
+    }
+    const decoration = this.metadataCache[type]
+    delete this.metadataCache[type]
+    const eventType = `CLI_COMMAND_${type}`
+    this.buildAndStoreEvent(eventType, Object.assign(tags, decoration))
+  }
+
+  captureError(type, tags = {}) {
+    if (!this.isTrackingEnabled()) {
+      return
+    }
+    const decoration = this.metadataCache[type]
+    delete this.metadataCache[type]
+    const eventType = `CLI_ERROR_${type}`
+    sanitizeError(tags)
+
+    // JSON.stringify won't work for Errors w/o some trickery:
+    let { error } = tags
+    if (error) {
+      error = error.map(e =>
+        JSON.parse(JSON.stringify(e, Object.getOwnPropertyNames(e)))
+      )
+    }
+    tags.error = JSON.stringify(error)
+
+    this.buildAndStoreEvent(eventType, Object.assign(tags, decoration))
+  }
+
+  captureBuildError(type, tags = {}) {
+    if (!this.isTrackingEnabled()) {
+      return
+    }
+    const decoration = this.metadataCache[type]
+    delete this.metadataCache[type]
+    const eventType = `BUILD_ERROR_${type}`
+    sanitizeError(tags)
+    tags.error = JSON.stringify(tags.error)
+
+    this.buildAndStoreEvent(eventType, Object.assign(tags, decoration))
+  }
+
+  buildAndStoreEvent(eventType, tags) {
+    const event = {
+      ...this.defaultTags,
+      ...tags, // The schema must include these
+      eventType,
+      sessionId: this.sessionId,
+      time: new Date(),
+      machineId: this.getMachineId(),
+      repositoryId: this.getRepoId(),
+      componentId: `gatsby-cli`,
+      osInformation: this.getOsInfo(),
+      componentVersion: this.componentVersion,
+    }
+    this.store.addEvent(event)
+  }
+
+  getMachineId() {
+    // Cache the result
+    if (this.machineId) {
+      return this.machineId
+    }
+    let machineId = this.store.getConfig(`machineId`)
+    if (!machineId) {
+      machineId = uuid()
+      this.store.updateConfig({ machineId })
+    }
+    this.machineId = machineId
+    return machineId
+  }
+
+  isTrackingEnabled() {
+    // Cache the result
+    if (this.trackingEnabled !== undefined) {
+      return this.trackingEnabled
+    }
+    let telemetry = this.store.getConfig(`telemetry`)
+    if (telemetry === undefined || telemetry === null) {
+      console.log(
+        `Gatsby has started collecting anonymous usage analytics to help improve Gatsby for all users.\n` +
+          `If you'd like to opt-out, you can use \`gatsby analytics --disable\`\n` +
+          `To learn more, checkout http://gatsby.dev/analytics`
+      )
+      telemetry = true
+      this.store.updateConfig({ telemetry })
+    }
+    this.trackingEnabled = telemetry
+    return telemetry
+  }
+
+  getRepoId() {
+    // we may live multiple levels in git repo
+    let prefix = `pwd:`
+    let repo = basename(process.cwd())
+    try {
+      const originBuffer = execSync(
+        `git config --local --get remote.origin.url`,
+        { timeout: 1000 }
+      )
+      repo = String(originBuffer).trim()
+      prefix = `git:`
+    } catch (e) {
+      // ignore
+    }
+    const hash = createHash(`sha256`)
+    hash.update(repo)
+    return prefix + hash.digest(`hex`)
+  }
+
+  getOsInfo() {
+    if (this.osInfo) {
+      return this.osInfo
+    }
+    const cpus = os.cpus()
+    const osInfo = {
+      nodeVersion: process.version,
+      platform: os.platform(),
+      release: os.release(),
+      cpus: cpus && cpus.length > 0 && cpus[0].model,
+      arch: os.arch(),
+      ci: ci.isCI,
+      ciName: (ci.isCI && ci.name) || undefined,
+    }
+    this.osInfo = osInfo
+    return osInfo
+  }
+
+  trackActivity(source) {
+    if (!this.isTrackingEnabled()) {
+      return
+    }
+    // debounce by sending only the first event whithin a rolling window
+    const now = Date.now()
+    const last = this.debouncer[source] || 0
+    const debounceTime = 5 * 1000 // 5 sec
+
+    if (now - last > debounceTime) {
+      this.captureEvent(source)
+    }
+    this.debouncer[source] = now
+  }
+
+  decorateNextEvent(event, obj) {
+    const cached = this.metadataCache[event] || {}
+    this.metadataCache[event] = Object.assign(cached, obj)
+  }
+
+  decorateAll(tags) {
+    this.defaultTags = Object.assign(this.defaultTags, tags)
+  }
+
+  setAnalyticsEnabled(enabled) {
+    this.trackingEnabled = enabled
+    this.store.updateConfig({ telemetry: enabled })
+  }
+
+  async sendEvents() {
+    if (!this.isTrackingEnabled()) {
+      return async _ => {} // so that then/await won't fail
+    }
+    return this.store.sendEvents()
+  }
+}

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -127,7 +127,7 @@ module.exports = class AnalyticsTracker {
     try {
       const originBuffer = execSync(
         `git config --local --get remote.origin.url`,
-        { timeout: 1000 }
+        { timeout: 1000, stdio: `pipe` }
       )
       repo = String(originBuffer).trim()
       prefix = `git:`

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -68,6 +68,7 @@
     "gatsby-link": "^2.0.16",
     "gatsby-plugin-page-creator": "^2.0.11",
     "gatsby-react-router-scroll": "^2.0.6",
+    "gatsby-telemetry": "^0.0.1",
     "glob": "^7.1.1",
     "graphql": "^14.1.1",
     "graphql-compose": "^6.0.3",

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -9,6 +9,7 @@ const del = require(`del`)
 const path = require(`path`)
 const convertHrtime = require(`convert-hrtime`)
 const Promise = require(`bluebird`)
+const telemetry = require(`gatsby-telemetry`)
 
 const apiRunnerNode = require(`../utils/api-runner-node`)
 const getBrowserslist = require(`../utils/browserslist`)
@@ -111,6 +112,10 @@ module.exports = async (args: BootstrapArgs) => {
   activity.start()
   const flattenedPlugins = await loadPlugins(config, program.directory)
   activity.end()
+
+  telemetry.decorateEvent(`BUILD_END`, {
+    plugins: flattenedPlugins.map(p => `${p.name}@${p.version}`),
+  })
 
   // onPreInit
   activity = report.activityTimer(`onPreInit`, {

--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -7,6 +7,7 @@ const webpackConfig = require(`../utils/webpack.config`)
 const { store } = require(`../redux`)
 const { createErrorFromString } = require(`gatsby-cli/lib/reporter/errors`)
 const renderHTMLQueue = require(`../utils/html-renderer-queue`)
+const telemetry = require(`gatsby-telemetry`)
 
 module.exports = async (program: any, activity: any) => {
   const { directory } = program
@@ -14,6 +15,9 @@ module.exports = async (program: any, activity: any) => {
   debug(`generating static HTML`)
   // Reduce pages objects to an array of paths.
   const pages = Array.from(store.getState().pages.values(), page => page.path)
+  telemetry.decorateEvent(`BUILD_END`, {
+    siteMeasurements: { pagesCount: pages.length },
+  })
 
   // Static site generation.
   const compilerConfig = await webpackConfig(

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -31,6 +31,7 @@ const getSslCert = require(`../utils/get-ssl-cert`)
 const slash = require(`slash`)
 const { initTracer } = require(`../utils/tracer`)
 const apiRunnerNode = require(`../utils/api-runner-node`)
+const telemetry = require(`gatsby-telemetry`)
 
 // const isInteractive = process.stdout.isTTY
 
@@ -48,6 +49,7 @@ const rlInterface = rl.createInterface({
 
 // Quit immediately on hearing ctrl-c
 rlInterface.on(`SIGINT`, () => {
+  telemetry.trackCli(`DEVELOP_STOP`)
   process.exit()
 })
 
@@ -88,6 +90,7 @@ async function startServer(program) {
    * Set up the express app.
    **/
   const app = express()
+  app.use(telemetry.expressMiddleware(`DEVELOP`))
   app.use(
     require(`webpack-hot-middleware`)(compiler, {
       log: false,
@@ -254,6 +257,7 @@ async function startServer(program) {
 
 module.exports = async (program: any) => {
   initTracer(program.openTracingConfigFile)
+  telemetry.trackCli(`DEVELOP_START`)
 
   const detect = require(`detect-port`)
   const port =

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -17,6 +17,7 @@ const {
 } = require(`../schema/types/type-builders`)
 const { emitter } = require(`../redux`)
 const { getNonGatsbyCodeFrame } = require(`./stack-trace-utils`)
+const { trackBuildError, decorateEvent } = require(`gatsby-telemetry`)
 
 // Bind action creators per plugin so we can auto-add
 // metadata to actions they create.
@@ -188,7 +189,16 @@ const runAPI = (plugin, api, args) => {
           callback(err, val)
           apiFinished = true
         }
-        gatsbyNode[api](...apiCallArgs, cb)
+
+        try {
+          gatsbyNode[api](...apiCallArgs, cb)
+        } catch (e) {
+          trackBuildError(api, {
+            error: e,
+            pluginName: `${plugin.name}@${plugin.version}`,
+          })
+          throw e
+        }
       })
     } else {
       const result = gatsbyNode[api](...apiCallArgs)
@@ -326,6 +336,9 @@ module.exports = async (api, args = {}, pluginSource) =>
       return new Promise(resolve => {
         resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }))
       }).catch(err => {
+        decorateEvent(`BUILD_PANIC`, {
+          pluginName: `${plugin.name}@${plugin.version}`,
+        })
         reporter.panicOnBuild(`${pluginName} returned an error`, err)
         return null
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5085,13 +5085,14 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
-ci-info@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.5.1.tgz#17e8eb5de6f8b2b6038f0cbb714d410bfa9f3030"
-
-ci-info@^2.0.0:
+ci-info@2.0.0, ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -5502,6 +5503,18 @@ config-chain@^1.1.11:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
+
+configstore@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-4.0.0.tgz#5933311e95d3687efb592c528b922d9262d227e7"
+  integrity sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 configstore@^3.0.0, configstore@^3.1.0:
   version "3.1.2"
@@ -12754,6 +12767,11 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
+node-fetch@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
 node-fetch@^1.0.1, node-fetch@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -16536,6 +16554,11 @@ stack-trace@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
 
+stack-utils@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
+  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
@@ -18007,7 +18030,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 


### PR DESCRIPTION
This PR adds anonymous telemetry instrumentation as outlined in the [telemetry RFC](https://github.com/gatsbyjs/rfcs/pull/33)

This implementation buffers all telemetry events to a local buffer file, from which events are then sent asynchronously on in a background process.
