### PR TITLE
docs(gatsby-source-contentful): Add downloadLocal to configuration options

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -138,6 +138,10 @@ The base host for all the API requests, by default it's 'cdn.contentful.com', if
 
 The environment to pull the content from, for more info on environments check out this [Guide](https://www.contentful.com/developers/docs/concepts/multiple-environments/).
 
+**`downloadLocal`** [boolean][optional] [default: `false`]
+
+Downloads and caches `ContentfulAsset`'s to the local filesystem. Allows you to query a `ContentfulAsset`'s `localFile` field, which is not linked to Contentful's CDN. Useful for reducing data usage.
+
 You can pass in any other options available in the [contentful.js SDK](https://github.com/contentful/contentful.js#configuration).
 
 ## Notes on Contentful Content Models


### PR DESCRIPTION
The option was just missing from the consolidated "Configuration Options" section. It is documented already elsewhere on the page though.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
