### PR TITLE
fix(www): improve accessibility for gatsbyjs.org

### DIFF
--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -7,7 +7,7 @@ import { colors, space, dimensions, fonts } from "../utils/presets"
 const horizontalPadding = space[6]
 const backgroundColor = colors.gatsby
 
-const BannerContainer = styled(`div`)`
+const BannerContainer = styled(`aside`)`
   background-color: ${backgroundColor};
   height: ${dimensions.bannerHeight};
   position: fixed;

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -17,7 +17,6 @@ const MastheadContent = () => (
   <div
     className="masthead-content"
     css={{
-      boxSizing: `border-box`,
       margin: `0 auto`,
       paddingBottom: space[9],
       paddingTop: space[9],

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -17,9 +17,12 @@ const MastheadContent = () => (
   <div
     className="masthead-content"
     css={{
-      margin: `0 ${space[8]}`,
+      boxSizing: `border-box`,
+      margin: `0 auto`,
       paddingBottom: space[9],
       paddingTop: space[9],
+      paddingLeft: space[8],
+      paddingRight: space[8],
       textAlign: `center`,
       [breakpoints.md]: {
         paddingBottom: rhythm(3),

--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -5,15 +5,16 @@ import { colors, breakpoints, dimensions } from "../utils/presets"
 
 const PageWithPluginSearchBar = ({ isPluginsIndex, location, children }) => (
   <Fragment>
-    <section
+    <nav
       css={{
         ...styles.sidebar,
         // mobile: hide PluginSearchBar when on gatsbyjs.org/packages/foo, aka package README page
         display: !isPluginsIndex ? `none` : false,
       }}
+      aria-label="Plugin navigation"
     >
       <PluginSearchBar location={location} />
-    </section>
+    </nav>
     <main
       id={`reach-skip-nav`}
       css={{

--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -332,6 +332,7 @@ const Result = ({ hit, pathname, query }) => {
   return (
     <Link
       to={`/packages/${hit.name}/?=${query}`}
+      aria-current={selected ? `true` : undefined}
       css={{
         "&&": {
           background: selected ? colors.ui.whisper : false,

--- a/www/src/components/rotator.js
+++ b/www/src/components/rotator.js
@@ -121,66 +121,71 @@ class Rotator extends Component {
           position: `relative`,
         }}
       >
-        <p
-          css={{
-            color: colors.gray.copy,
-            fontSize: scale[4],
-            fontFamily: options.headerFontFamily.join(`,`),
-            textAlign: `center`,
-            marginBottom: 0,
-          }}
+        <div
+          aria-live={this.intervalId ? `off` : `polite`}
+          aria-atomic="true"
+          aria-relevant="all"
         >
-          <span>Need&nbsp;</span>
-          <span
-            style={{
-              display: `inline-block`,
-              transition: `width 150ms linear`,
-              width: this.state.size.width || `auto`,
+          <p
+            css={{
+              color: colors.gray.copy,
+              fontSize: scale[4],
+              fontFamily: options.headerFontFamily.join(`,`),
+              textAlign: `center`,
+              marginBottom: 0,
             }}
           >
+            <span>Need&nbsp;</span>
             <span
-              css={{
-                fontWeight: 600,
-                whiteSpace: `nowrap`,
+              style={{
                 display: `inline-block`,
+                transition: shouldAnimate ? `width 150ms linear` : `none`,
+                width: this.state.size.width || `auto`,
               }}
-              id="headline-slider"
-              ref={this.sliderContainer}
-              aria-live={this.intervalId ? `off` : `polite`}
             >
-              {!enableSlider ? (
-                <>{text}</>
-              ) : (
-                <Slider items={[text]} color={`#000`} />
-              )}
+              <span
+                css={{
+                  fontWeight: 600,
+                  whiteSpace: `nowrap`,
+                  display: `inline-block`,
+                }}
+                id="headline-slider"
+                ref={this.sliderContainer}
+              >
+                {!enableSlider ? (
+                  <>{text}</>
+                ) : (
+                  <Slider items={[text]} color={`#000`} />
+                )}
+              </span>
             </span>
-          </span>
-        </p>
+          </p>
 
-        <p
-          css={{
-            color: colors.gray.calm,
-            margin: 0,
-            fontSize: scale[3],
-            textAlign: `center`,
-          }}
-        >
-          There’s{` `}
-          {pluginName ? (
-            <Link to={`/packages/` + pluginName}>a plugin</Link>
-          ) : (
-            `a plugin`
-          )}
-          {` `}
-          for that.
-        </p>
+          <p
+            css={{
+              color: colors.gray.calm,
+              margin: 0,
+              fontSize: scale[3],
+              textAlign: `center`,
+            }}
+          >
+            There’s{` `}
+            {pluginName ? (
+              <Link to={`/packages/` + pluginName}>a plugin</Link>
+            ) : (
+              `a plugin`
+            )}
+            {` `}
+            for that.
+          </p>
+        </div>
         <button
           css={{ ...controlButtonStyles }}
           onClick={this.decrementItem}
           aria-controls="headline-slider"
         >
           <MdNavigateBefore aria-hidden="true" />
-          <span css={srOnly}>Previous</span>
+          <span css={srOnly}>Previous plugin category</span>
         </button>
         <button
           css={{ ...controlButtonStyles, left: `auto`, right: 0 }}
@@ -188,7 +193,7 @@ class Rotator extends Component {
           aria-controls="headline-slider"
         >
           <MdNavigateNext aria-hidden="true" />
-          <span css={srOnly}>Next</span>
+          <span css={srOnly}>Next plugin category</span>
         </button>
       </div>
     )

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -141,6 +141,7 @@ const SplitButton = ({
     <button
       aria-controls={uid}
       aria-expanded={isExpanded}
+      aria-label={item.title + (isExpanded ? ` collapse` : ` expand`)}
       css={{
         ...styles.resetButton,
         marginLeft: `auto`,

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -42,43 +42,45 @@ class IndexRoute extends React.Component {
               <li>
                 Choose your own adventure and peruse the various sections of the
                 Gatsby docs:
+                <ul>
+                  <li>
+                    <Link to="/docs/guides/">Guides</Link>: Dive deeper into
+                    different topics around building with Gatsby, like sourcing
+                    data, deployment, and more.
+                  </li>
+                  <li>
+                    <Link to="/ecosystem/">Ecosystem</Link>: Check out libraries
+                    for Gatsby starters and plugins, as well as external
+                    community resources.
+                  </li>
+                  <li>
+                    <Link to="/docs/api-reference/">API Reference</Link>: Learn
+                    more about Gatsby APIs and configuration.
+                  </li>
+                  <li>
+                    <Link to="/docs/releases-and-migration/">
+                      Releases &amp; Migration
+                    </Link>
+                    : Find release notes and guides for migration between major
+                    versions.
+                  </li>
+                  <li>
+                    <Link to="/docs/conceptual-guide/">Conceptual Guide</Link>:
+                    Read high-level overviews of the Gatsby approach.
+                  </li>
+                  <li>
+                    <Link to="/docs/behind-the-scenes/">Behind the Scenes</Link>
+                    : Dig into how Gatsby works under the hood.
+                  </li>
+                  <li>
+                    <Link to="/docs/advanced-tutorials/">
+                      Advanced Tutorials
+                    </Link>
+                    : Learn about topics that are too large for a doc and
+                    warrant a tutorial.
+                  </li>
+                </ul>
               </li>
-              <ul>
-                <li>
-                  <Link to="/docs/guides/">Guides</Link>: Dive deeper into
-                  different topics around building with Gatsby, like sourcing
-                  data, deployment, and more.
-                </li>
-                <li>
-                  <Link to="/ecosystem/">Ecosystem</Link>: Check out libraries
-                  for Gatsby starters and plugins, as well as external community
-                  resources.
-                </li>
-                <li>
-                  <Link to="/docs/api-reference/">API Reference</Link>: Learn
-                  more about Gatsby APIs and configuration.
-                </li>
-                <li>
-                  <Link to="/docs/releases-and-migration/">
-                    Releases &amp; Migration
-                  </Link>
-                  : Find release notes and guides for migration between major
-                  versions.
-                </li>
-                <li>
-                  <Link to="/docs/conceptual-guide/">Conceptual Guide</Link>:
-                  Read high-level overviews of the Gatsby approach.
-                </li>
-                <li>
-                  <Link to="/docs/behind-the-scenes/">Behind the Scenes</Link>:
-                  Dig into how Gatsby works under the hood.
-                </li>
-                <li>
-                  <Link to="/docs/advanced-tutorials/">Advanced Tutorials</Link>
-                  : Learn about topics that are too large for a doc and warrant
-                  a tutorial.
-                </li>
-              </ul>
             </ol>
             <p>
               Visit the <Link to="/contributing">Contributing</Link> section to

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -90,7 +90,6 @@ class IndexRoute extends React.Component {
             content="Blazing fast modern site generator for React. Go beyond static sites: build blogs, ecommerce sites, full-blown apps, and more with Gatsby."
           />
         </Helmet>
-        <MastheadContent />
         <main
           id={`reach-skip-nav`}
           css={{
@@ -100,6 +99,7 @@ class IndexRoute extends React.Component {
             justifyContent: `space-between`,
           }}
         >
+          <MastheadContent />
           <div
             css={{
               padding: space[6],


### PR DESCRIPTION
## Description

Some various accessibility fixes I found on the .org site, including:
- Sidebar toggle buttons missing screen reader text
- Plugin rotator fixes
- Putting content in landmarks (homepage masthead and webinar banner)
- invalid HTML on the docs landing page

More to come later on, as there are still issues with color contrast, skip links/routing and heading order on the homepage (also a ton of h1s which doesn't create a great content hierarchy for assistive tech)

## Related Issues

Closes https://github.com/gatsbyjs/gatsby/issues/12739