### PR TITLE
feat(starters): enhance proptypes for SEO component

### DIFF
--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -85,12 +85,13 @@ SEO.defaultProps = {
   lang: `en`,
   meta: [],
   keywords: [],
+  description: ``,
 }
 
 SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
-  meta: PropTypes.array,
+  meta: PropTypes.arrayOf(PropTypes.object),
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
 }

--- a/starters/default/src/components/seo.js
+++ b/starters/default/src/components/seo.js
@@ -85,12 +85,13 @@ SEO.defaultProps = {
   lang: `en`,
   meta: [],
   keywords: [],
+  description: ``,
 }
 
 SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
-  meta: PropTypes.array,
+  meta: PropTypes.arrayOf(PropTypes.object),
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
 }


### PR DESCRIPTION
## Description
Fix the Gatsby `default` and `blog` starters `SEO` components prop-types.
Props:
* meta: propTypes
* description: defaultProps

## Related Issues
N/a