### PR TITLE
fix(gatsby): Allow setting nullability in createResolvers

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -444,6 +444,38 @@ describe(`Build schema`, () => {
       expect(fields[`name`].type).toEqual(GraphQLString)
     })
 
+    it(`allows setting field type nullability on field`, async () => {
+      createTypes(`
+        type Post implements Node {
+          tags: [String!]!
+          categories: [String]
+        }
+      `)
+      createCreateResolversMock({
+        Post: {
+          tags: {
+            type: `[String]`,
+            resolve() {
+              return [`All good`]
+            },
+          },
+          categories: {
+            type: `[String!]!`,
+            resolve() {
+              return [`Even better`]
+            },
+          },
+        },
+      })
+      const schema = await buildSchema()
+      const type = schema.getType(`Post`)
+      const fields = type.getFields()
+      expect(fields[`tags`].type.toString()).toBe(`[String]`)
+      expect(fields[`tags`].resolve).toBeDefined()
+      expect(fields[`categories`].type.toString()).toBe(`[String!]!`)
+      expect(fields[`categories`].resolve).toBeDefined()
+    })
+
     it(`allows overriding field type on field on third-party type`, async () => {
       addThirdPartySchema(`
         type ThirdPartyFoo {

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -245,7 +245,7 @@ const createTypeComposerFromGatsbyType = ({
       return InterfaceTypeComposer.createTemp(type.config, schemaComposer)
     }
     default: {
-      console.warn(`Illegal type definition: ${JSON.stringify(type.config)}`)
+      report.warn(`Illegal type definition: ${JSON.stringify(type.config)}`)
       return null
     }
   }
@@ -354,7 +354,8 @@ const addCustomResolveFunctions = async ({ schemaComposer, parentSpan }) => {
               fieldConfig.type && fieldConfig.type.toString()
             if (
               !fieldTypeName ||
-              tc.getFieldType(fieldName) === fieldConfig.type.toString() ||
+              fieldTypeName.replace(/!/g, ``) ===
+                originalTypeName.replace(/!/g, ``) ||
               tc.getType().isThirdPartyType
             ) {
               const newConfig = {}


### PR DESCRIPTION
Currently we don't allow overriding the field type in `createResolvers`. This PR loosens this restriction and allows setting nullability.