### PR TITLE
fix(babel-preset-gatsby): set corejs version in babel-preset-env config

### DIFF
--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -49,6 +49,7 @@ module.exports = function preset(_, options = {}) {
           modules: stage === `test` ? `commonjs` : false,
           useBuiltIns: `usage`,
           targets,
+          corejs: 2,
         },
       ],
       [


### PR DESCRIPTION
## Description

Set corejs version in babel-preset-env config

## Related Issues

Related to #12744
