### PR TITLE
feat(gatsby-plugin-google-tagmanager): Add plugin option for custom dataLayer name

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -23,6 +23,7 @@ plugins: [
       // Specify optional GTM environment details.
       gtmAuth: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_AUTH_STRING",
       gtmPreview: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_PREVIEW_NAME",
+      dataLayerName: "YOUR_DATA_LAYER_NAME",
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -41,11 +41,8 @@ exports.onRenderBody = (
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
-            })(window,document,'script','${
-              pluginOptions.dataLayerName
-                ? pluginOptions.dataLayerName
-                : `dataLayer`
-            }', '${pluginOptions.id}');`,
+            })(window,document,'script','${pluginOptions.dataLayerName ||
+              `datalayer`}', '${pluginOptions.id}');`,
         }}
       />,
     ])

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -19,20 +19,6 @@ exports.onRenderBody = (
         : ``
 
     setHeadComponents([
-      ...(pluginOptions.dataLayerName
-        ? [
-            <script
-              key="plugin-google-tagmanager-dataLayerName"
-              dangerouslySetInnerHTML={{
-                __html: stripIndent`
-                  // pre-populate the GTM dataLayer
-                  var dataLayer = dataLayer || [];
-                  // set the dataLayerName to the existing dataLayer
-                  var ${[pluginOptions.dataLayerName]} = dataLayer;`,
-              }}
-            />,
-          ]
-        : []),
       <script
         key="plugin-google-tagmanager"
         dangerouslySetInnerHTML={{

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -19,6 +19,20 @@ exports.onRenderBody = (
         : ``
 
     setHeadComponents([
+      ...(pluginOptions.dataLayerName
+        ? [
+            <script
+              key="plugin-google-tagmanager-dataLayerName"
+              dangerouslySetInnerHTML={{
+                __html: stripIndent`
+                  // pre-populate the GTM dataLayer
+                  var dataLayer = dataLayer || [];
+                  // set the dataLayerName to the existing dataLayer
+                  var ${[pluginOptions.dataLayerName]} = dataLayer;`,
+              }}
+            />,
+          ]
+        : []),
       <script
         key="plugin-google-tagmanager"
         dangerouslySetInnerHTML={{
@@ -27,7 +41,11 @@ exports.onRenderBody = (
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer', '${pluginOptions.id}');`,
+            })(window,document,'script','${
+              pluginOptions.dataLayerName
+                ? pluginOptions.dataLayerName
+                : `dataLayer`
+            }', '${pluginOptions.id}');`,
         }}
       />,
     ])


### PR DESCRIPTION
## Description

This pull request provides a plugin option that will make data in a renamed dataLayer accessible (see #12782 for details).  The value assigned to "dataLayerName" is simply the renamed dataLayer (e.g. "bzDataLayer").  Then, any data pushed to a renamed dataLayer (e.g. "bzDataLayer") will also be pushed to dataLayer, thereby making it accessible through a standard GTM configuration.  

## Related Issues

Addresses #12782 
