### PR TITLE
docs(www): Fix Internal links in Debugging page

### DIFF
--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -6,8 +6,8 @@ Gatsby's `build` and `develop` steps run as a Node.js application which you can 
 
 In this guide you will learn how to debug some code using:
 
-- [VS Code debugger (Auto-Config)](<#vs-code-debugger-auto-config>)
-- [VS Code debugger (Manual-Config)](<#vs-code-debugger-manual-config>)
+- [VS Code debugger (Auto-Config)](#vs-code-debugger-auto-config)
+- [VS Code debugger (Manual-Config)](#vs-code-debugger-manual-config)
 - [Chrome DevTools for Node](#chrome-devtools-for-node)
 
 As an example let's use the following code snippet in a `gatsby-node.js` file:

--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -7,7 +7,7 @@ Gatsby's `build` and `develop` steps run as a Node.js application which you can 
 In this guide you will learn how to debug some code using:
 
 - [VS Code debugger (Auto-Config)](<#vs-code-debugger-auto-config>)
-- [VS Code debugger](<#vs-code-debugger-manual-config>) (Manual-Config)
+- [VS Code debugger (Manual-Config)](<#vs-code-debugger-manual-config>)
 - [Chrome DevTools for Node](#chrome-devtools-for-node)
 
 As an example let's use the following code snippet in a `gatsby-node.js` file:

--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -6,7 +6,7 @@ Gatsby's `build` and `develop` steps run as a Node.js application which you can 
 
 In this guide you will learn how to debug some code using:
 
-- [VS Code debugger](<#vs-code-debugger-auto-config>) (Auto-Config)
+- [VS Code debugger (Auto-Config)](<#vs-code-debugger-auto-config>)
 - [VS Code debugger](<#vs-code-debugger-manual-config>) (Manual-Config)
 - [Chrome DevTools for Node](#chrome-devtools-for-node)
 

--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -6,8 +6,8 @@ Gatsby's `build` and `develop` steps run as a Node.js application which you can 
 
 In this guide you will learn how to debug some code using:
 
-- [VS Code debugger](<#vs-code-debugger-(auto-config)>) (Auto-Config)
-- [VS Code debugger](<#vs-code-debugger-(manual-config)>) (Manual-Config)
+- [VS Code debugger](<#vs-code-debugger-auto-config>) (Auto-Config)
+- [VS Code debugger](<#vs-code-debugger-manual-config>) (Manual-Config)
 - [Chrome DevTools for Node](#chrome-devtools-for-node)
 
 As an example let's use the following code snippet in a `gatsby-node.js` file:


### PR DESCRIPTION
## Description

Fix for this page: 
When you click the first two internal links (Auto-Config, Manual-Config) they don't work. 
https://www.gatsbyjs.org/docs/debugging-the-build-process/#vs-code-debugger-manual-config

Removing the parentheses fixes the internal target. 

## Related Issues
None
