### PR TITLE
chore(docs/unit-testing): remove invalid props from link mock

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -132,11 +132,22 @@ const gatsby = jest.requireActual("gatsby")
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
-  Link: jest.fn().mockImplementation(({ to, ...rest }) =>
-    React.createElement("a", {
-      ...rest,
-      href: to,
-    })
+  Link: jest.fn().mockImplementation(
+    // these props are invalid for an `a` tag
+    ({
+      activeClassName,
+      activeStyle,
+      getProps,
+      innerRef,
+      ref,
+      replace,
+      to,
+      ...rest
+    }) =>
+      React.createElement("a", {
+        ...rest,
+        href: to,
+      })
   ),
   StaticQuery: jest.fn(),
   useStaticQuery: jest.fn(),


### PR DESCRIPTION
## Description
I followed the Unit-Testing docs to set up jest with Gatsby, and I ran into the following error related to Gatsby's `Link` component:
```
React does not recognize the `activeStyle` prop on a DOM element.
```

## Changes
Removed the following props (which are invalid for an `a` tag) from the link mock:
- `activeClassName`
- `activeStyle`
- `getProps`
- `innerRef`
- `ref`
- `replace`

## Duplicate of #12445 (that PR was made through the GitHub editing interface and is failing for reasons that are unresolvable in that context)