### PR TITLE
fix(schema): Preserve ___NODE resolvers when noDefaultResolvers: false

### DIFF
--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -102,25 +102,27 @@ const addInferredFieldsImpl = ({
       let lists = 0
       let namedFieldType = fieldType
       while (namedFieldType.ofType) {
-        namedFieldType = namedFieldType.ofType
         if (namedFieldType instanceof GraphQLList) {
           lists++
         }
+        namedFieldType = namedFieldType.ofType
       }
 
-      if (arrays === lists) {
+      const namedInferredTypeName =
+        typeof namedInferredType === `string`
+          ? namedInferredType
+          : namedInferredType.getTypeName()
+
+      if (arrays === lists && namedFieldType.name === namedInferredTypeName) {
         if (
           namedFieldType instanceof GraphQLObjectType &&
-          typeof namedInferredType !== `string` &&
-          namedFieldType.name === namedInferredType.getTypeName()
+          namedInferredType instanceof ObjectTypeComposer
         ) {
           const fieldTypeComposer = typeComposer.getFieldTC(key)
           const inferredFields = namedInferredType.getFields()
           fieldTypeComposer.addFields(inferredFields)
-        } else if (
-          addDefaultResolvers &&
-          namedFieldType.name === namedInferredType
-        ) {
+        }
+        if (addDefaultResolvers) {
           let field = typeComposer.getField(key)
           if (!field.type) {
             field = {


### PR DESCRIPTION
* when providing type definitions to fix indeterministic inference, users expect that foreign-key resolvers on fields following the ___NODE convention will be preserved. See for example #12787:
Here the `sections` field on `ContentfulPage` is really `sections___NODE`. When providing an explicit type definitions for `sections` the expectation is that the foreign-key link stays intact. (Note: I am not 100% sure of the correct behavior here: we should probably require more explicit declaration of foreign-key relations, but at the same time this might run counter to the intended usecase of `createTypes` to easily fix inference inconsistencies.)
* fix incorrect list counting

Should fix #12787