### PR TITLE
fix(gatsby): Improve handling of sparse arrays in example value creation

### DIFF
--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -232,7 +232,7 @@ describe(`GraphQL type inference`, () => {
     const nodes = [
       { sparse: [null, true], internal: { type: `Test` }, id: `1` },
       { sparse: [null], internal: { type: `Test` }, id: `2` },
-      { sparse: null, internal: { type: `Test` }, id: `2` },
+      { sparse: null, internal: { type: `Test` }, id: `3` },
     ]
     const result = await getQueryResult(
       nodes,
@@ -248,7 +248,7 @@ describe(`GraphQL type inference`, () => {
     const nodes = [
       { sparse: [null, { foo: true }], internal: { type: `Test` }, id: `1` },
       { sparse: [null], internal: { type: `Test` }, id: `2` },
-      { sparse: null, internal: { type: `Test` }, id: `2` },
+      { sparse: null, internal: { type: `Test` }, id: `3` },
     ]
     const result = await getQueryResult(
       nodes,

--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -228,6 +228,38 @@ describe(`GraphQL type inference`, () => {
     )
   })
 
+  it(`handles sparse arrays`, async () => {
+    const nodes = [
+      { sparse: [null, true], internal: { type: `Test` }, id: `1` },
+      { sparse: [null], internal: { type: `Test` }, id: `2` },
+      { sparse: null, internal: { type: `Test` }, id: `2` },
+    ]
+    const result = await getQueryResult(
+      nodes,
+      `
+      sparse
+      `
+    )
+    const { edges } = result.data.allTest
+    expect(edges[0].node.sparse).toEqual([null, true])
+  })
+
+  it(`handles sparse arrays of objects`, async () => {
+    const nodes = [
+      { sparse: [null, { foo: true }], internal: { type: `Test` }, id: `1` },
+      { sparse: [null], internal: { type: `Test` }, id: `2` },
+      { sparse: null, internal: { type: `Test` }, id: `2` },
+    ]
+    const result = await getQueryResult(
+      nodes,
+      `
+      sparse { foo }
+      `
+    )
+    const { edges } = result.data.allTest
+    expect(edges[0].node.sparse[1].foo).toBe(true)
+  })
+
   // NOTE: Honestly this test does not makes much sense now
   it.skip(`Removes specific root fields`, () => {
     const { addInferredFields } = require(`../infer`)

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -27,6 +27,7 @@ const getExampleObject = ({
   typeConflictReporter,
   ignoreFields = [],
 }) => {
+  debugger
   const nodes = rawNodes.filter(node => node != null)
   const allKeys = nodes.reduce(
     (acc, node) =>
@@ -94,14 +95,13 @@ const getExampleObject = ({
     ) {
       const objects = entries.reduce((acc, entry) => {
         let { value } = entry
-        if (!arrayWrappers) return acc.concat(value)
 
         let arrays = arrayWrappers - 1
         while (arrays > 0) {
           value = value.find(v => v != null)
           arrays--
         }
-        return acc.concat(value.filter(v => v != null))
+        return acc.concat(value)
       }, [])
       const exampleObject = getExampleObject({
         nodes: objects,

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -27,7 +27,6 @@ const getExampleObject = ({
   typeConflictReporter,
   ignoreFields = [],
 }) => {
-  debugger
   const nodes = rawNodes.filter(node => node != null)
   const allKeys = nodes.reduce(
     (acc, node) =>

--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -54,7 +54,7 @@ const getExampleObject = ({
     let { value, type } = entriesByType[0]
     let arrayWrappers = 0
     while (Array.isArray(value)) {
-      value = value[0]
+      value = value.find(v => v != null)
       arrayWrappers++
     }
 
@@ -94,12 +94,14 @@ const getExampleObject = ({
     ) {
       const objects = entries.reduce((acc, entry) => {
         let { value } = entry
+        if (!arrayWrappers) return acc.concat(value)
+
         let arrays = arrayWrappers - 1
         while (arrays > 0) {
-          value = value[0]
+          value = value.find(v => v != null)
           arrays--
         }
-        return acc.concat(value)
+        return acc.concat(value.filter(v => v != null))
       }, [])
       const exampleObject = getExampleObject({
         nodes: objects,


### PR DESCRIPTION
Should fix #12770

Follow-up to #12756