### PR TITLE
chore(starters): update gatsby-starter-default-intl

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2082,3 +2082,14 @@
   features:
     - Showcase of portfolio items
     - About me page
+- url: http://gatsby-starter-default-intl.netlify.com
+  repo: https://github.com/wiziple/gatsby-starter-default-intl
+  description: The default Gatsby starter with features of multi-language url routes and browser language detection.
+  tags:
+    - i18n
+    - intl
+  features:
+    - Localization (Multilanguage) provided by react-intl.
+    - Support automatic redirection based on user's preferred language in browser provided by browser-lang.
+    - Support multi-language url routes within a single page component. That means you don't have to create separate pages such as pages/en/index.js or pages/ko/index.js.
+    - Based on gatsby-starter-default with least modification.


### PR DESCRIPTION
Update metadata and link to [gatsby-starter-default-intl](https://github.com/wiziple/gatsby-starter-default-intl).

I made this starter last year and updated to v2 just yesterday 😓 