### PR TITLE
fix(schema): fix `types` for buildUnionType config object

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -244,6 +244,7 @@ describe(`Build schema`, () => {
       expect(interfaceType).toBeInstanceOf(GraphQLInterfaceType)
       const unionType = schema.getType(`UFooBar`)
       expect(unionType).toBeInstanceOf(GraphQLUnionType)
+      expect(unionType.getTypes().length).toBe(3)
       ;[(`Foo`, `Bar`, `Author`)].forEach(typeName => {
         const type = schema.getType(typeName)
         const typeSample = { internal: { type: typeName } }

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -229,8 +229,13 @@ const createTypeComposerFromGatsbyType = ({
         {
           ...type.config,
           types: () => {
-            if (type.types) {
-              return type.types.map(typeName =>
+            if (type.config.types) {
+              // handle thunk
+              const types = _.isFunction(type.config.types)
+                ? type.config.types()
+                : type.config.types
+
+              return types.map(typeName =>
                 schemaComposer.getOTC(typeName).getType()
               )
             } else {

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -230,12 +230,7 @@ const createTypeComposerFromGatsbyType = ({
           ...type.config,
           types: () => {
             if (type.config.types) {
-              // handle thunk
-              const types = _.isFunction(type.config.types)
-                ? type.config.types()
-                : type.config.types
-
-              return types.map(typeName =>
+              return type.config.types.map(typeName =>
                 schemaComposer.getOTC(typeName).getType()
               )
             } else {


### PR DESCRIPTION
using `schema.buildUnionType` results in

```
Error: Union type <type_name} must define one or more member types.
```

This should fix it (TM)

I've also added thunk handling (not sure if needed). This was something I hit when I tried to debug initial error I saw without doing debugging first ;)