### PR TITLE
chore(starters): add gatsby-mongodb-starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2082,3 +2082,11 @@
   features:
     - Showcase of portfolio items
     - About me page
+- url: https://gatsby-mongodb-starter.netlify.com/
+  repo: https://github.com/charlzzdev/gatsby-mongodb-starter
+  description: Gatsby starter with MongoDB
+  tags:
+    - MongoDB
+    - Barebones
+  features:
+    - Ability to fetch data from a MongoDB database


### PR DESCRIPTION
## Description

I created a starter with MongoDB because I noticed that there weren't any MongoDB starters in the [Starter Library](https://www.gatsbyjs.org/starters/?s=mongodb&v=2).