### PR TITLE
Removed unregistering of service workers on reload

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -22,22 +22,6 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     })
   }
 
-  /**
-   * Service Workers are persistent by nature. They stick around,
-   * serving a cached version of the site if they aren't removed.
-   * This is especially frustrating when you need to test the
-   * production build on your local machine.
-   *
-   * Let's unregister the service workers in development, and tidy up a few errors.
-   */
-  if (supportsServiceWorkers(location, navigator)) {
-    navigator.serviceWorker.getRegistrations().then(registrations => {
-      for (let registration of registrations) {
-        registration.unregister()
-      }
-    })
-  }
-
   const rootElement = document.getElementById(`___gatsby`)
 
   const renderer = apiRunner(
@@ -60,10 +44,3 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     })
   })
 })
-
-function supportsServiceWorkers(location, navigator) {
-  if (location.hostname === `localhost` || location.protocol === `https:`) {
-    return `serviceWorker` in navigator
-  }
-  return false
-}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixed issue https://github.com/gatsbyjs/gatsby/issues/9770
