### PR TITLE
fix(schema): Remove accidental capitalization of lowercase typenames.

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -337,6 +337,32 @@ describe(`Build schema`, () => {
         })
       )
     })
+
+    it(`allows modifying nested types`, async () => {
+      createTypes(`
+        type PostFrontmatter {
+          published: Boolean!
+          newField: String
+        }
+
+        type Post implements Node {
+          frontmatter: PostFrontmatter
+        }
+      `)
+
+      const schema = await buildSchema()
+
+      const type = schema.getType(`Post`)
+      const fields = type.getFields()
+      expect(fields[`frontmatter`].type.toString()).toEqual(`PostFrontmatter`)
+      const nestedType = schema.getType(`PostFrontmatter`)
+      const nestedFields = nestedType.getFields()
+      expect(nestedFields[`authors`].type.toString()).toEqual(`[String]`)
+      expect(nestedFields[`reviewers`].type.toString()).toEqual(`[String]`)
+      expect(nestedFields[`published`].type.toString()).toEqual(`Boolean!`)
+      expect(nestedFields[`date`].type.toString()).toEqual(`Date`)
+      expect(nestedFields[`newField`].type.toString()).toEqual(`String`)
+    })
   })
 
   describe(`createResolvers`, () => {

--- a/packages/gatsby/src/schema/infer/__tests__/__snapshots__/infer.js.snap
+++ b/packages/gatsby/src/schema/infer/__tests__/__snapshots__/infer.js.snap
@@ -253,6 +253,27 @@ Object {
 }
 `;
 
+exports[`GraphQL type inference handles lowercase type names 1`] = `
+Object {
+  "data": Object {
+    "allWordpressPage": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "__typename": "wordpress__PAGE",
+            "acfFields": Object {
+              "__typename": "wordpress__PAGEAcfFields",
+              "fooz": "bar",
+            },
+            "id": "1",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`GraphQL type inference type conflicts catches conflicts and removes field 1`] = `
 Array [
   TypeConflictEntry {

--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -408,6 +408,50 @@ describe(`GraphQL type inference`, () => {
     expect(result).toMatchSnapshot()
   })
 
+  it(`handles lowercase type names`, async () => {
+    const nodes = [
+      {
+        id: `1`,
+        internal: { type: `wordpress__PAGE` },
+        acfFields: {
+          fooz: `bar`,
+        },
+      },
+    ]
+    const schema = await buildTestSchema(nodes)
+    store.dispatch({ type: `SET_SCHEMA`, payload: schema })
+    const result = await graphql(
+      schema,
+      `
+        query {
+          allWordpressPage {
+            edges {
+              node {
+                __typename
+                id
+                acfFields {
+                  fooz
+                  __typename
+                }
+              }
+            }
+          }
+        }
+      `,
+      undefined,
+      {
+        path: `/`,
+        nodeModel: new LocalNodeModel({
+          schema,
+          nodeStore,
+          createPageDependency,
+        }),
+      }
+    )
+
+    expect(result).toMatchSnapshot()
+  })
+
   describe(`Handles dates`, () => {
     it(`Handles integer with valid date format`, async () => {
       const nodes = [

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -78,7 +78,7 @@ const addInferredFieldsImpl = ({
         .map(field => `\`${field.unsanitizedKey}\``)
         .join(`, `)
       report.warn(
-        `Multiple node fields resolve to the same GraphQL field \`${
+        `Multiple node fields resolve to the same GraphQL field \`${prefix}.${
           field.key
         }\` - [${possibleFieldsNames}]. Gatsby will use \`${
           field.unsanitizedKey
@@ -361,15 +361,10 @@ const getSimpleFieldConfig = ({
             originalFieldTypeComposer.getTypeName()
           )
         } else {
-          const typeName = createTypeName(selector)
-          if (schemaComposer.has(typeName)) {
-            fieldTypeComposer = schemaComposer.getOTC(typeName)
-          } else {
-            fieldTypeComposer = ObjectTypeComposer.createTemp(
-              createTypeName(selector),
-              schemaComposer
-            )
-          }
+          fieldTypeComposer = ObjectTypeComposer.createTemp(
+            createTypeName(selector),
+            schemaComposer
+          )
         }
 
         return {
@@ -390,12 +385,12 @@ const getSimpleFieldConfig = ({
 }
 
 const createTypeName = selector => {
-  const key = selector
-    .split(`.`)
+  const keys = selector.split(`.`)
+  const suffix = keys
+    .slice(1)
     .map(_.upperFirst)
     .join(``)
-
-  return key
+  return `${keys[0]}${suffix}`
 }
 
 const NON_ALPHA_NUMERIC_EXPR = new RegExp(`[^a-zA-Z0-9_]`, `g`)

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -361,10 +361,15 @@ const getSimpleFieldConfig = ({
             originalFieldTypeComposer.getTypeName()
           )
         } else {
-          fieldTypeComposer = ObjectTypeComposer.createTemp(
-            createTypeName(selector),
-            schemaComposer
-          )
+          const typeName = createTypeName(selector)
+          if (schemaComposer.has(typeName)) {
+            fieldTypeComposer = schemaComposer.getOTC(typeName)
+          } else {
+            fieldTypeComposer = ObjectTypeComposer.createTemp(
+              createTypeName(selector),
+              schemaComposer
+            )
+          }
         }
 
         return {

--- a/packages/gatsby/src/schema/infer/index.js
+++ b/packages/gatsby/src/schema/infer/index.js
@@ -68,7 +68,7 @@ const addInferredTypes = ({
   })
 
   // XXX(freiksenet): We iterate twice to pre-create all types
-  const typeComposers = typeNames.map(typeName => {
+  const typeComposers = typeNames.map(typeName =>
     addInferredType({
       schemaComposer,
       nodeStore,
@@ -77,7 +77,7 @@ const addInferredTypes = ({
       typeMapping,
       parentSpan,
     })
-  })
+  )
 
   if (noNodeInterfaceTypes.length > 0) {
     noNodeInterfaceTypes.forEach(type => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

We accidentally uppercased typenamse when making inline types, causing very weird errors. This reverts to old behaviour. 

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
