### PR TITLE
chore(docs): add "--save" flag to script

### DIFF
--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -40,7 +40,7 @@ With Gatsby, we can make images way way better.
 1. Install `gatsby-image` and other, necessary dependencies like `gatsby-plugin-sharp` and `gatsby-transformer-sharp`
 
 ```shell
-  npm i --save gatsby-image gatsby-transformer-sharp gatsby-plugin-sharp
+  npm install --save gatsby-image gatsby-transformer-sharp gatsby-plugin-sharp
 ```
 
 2. Add the newly installed plugins and transformer plugins to your `gatsby-config.js`

--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -40,7 +40,7 @@ With Gatsby, we can make images way way better.
 1. Install `gatsby-image` and other, necessary dependencies like `gatsby-plugin-sharp` and `gatsby-transformer-sharp`
 
 ```shell
-  npm i gatsby-image gatsby-transformer-sharp gatsby-plugin-sharp
+  npm i --save gatsby-image gatsby-transformer-sharp gatsby-plugin-sharp
 ```
 
 2. Add the newly installed plugins and transformer plugins to your `gatsby-config.js`


### PR DESCRIPTION
## Description

Adds a "--save" flag to script for installing modules.

New devs may not remember to include the --save flag when writing the script, or it may remain left out if copied/pasted directly from the docs.

## Related Issues

Couldn't find an existing issue for this.
