### PR TITLE
chore(docs): migrate to global in styled-components doc

### DIFF
--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -34,7 +34,7 @@ module.exports = {
 }
 ```
 
-Then in your terminal run `npm run develop` to start the Gatsby development server.
+Then in your terminal run `gatsby develop` to start the Gatsby development server.
 
 Now let's create a sample Styled Components page at `src/pages/index.js`:
 


### PR DESCRIPTION
Changed `npm run develop` to `gatsby develop`

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
