### PR TITLE
chore: Update gatsby dependency in example site

### DIFF
--- a/examples/using-type-definitions/package.json
+++ b/examples/using-type-definitions/package.json
@@ -4,7 +4,7 @@
   "description": "An example site using createTypes action and createResolvers API",
   "version": "0.1.0",
   "dependencies": {
-    "gatsby": "schema-customization",
+    "gatsby": "^2.2.0",
     "gatsby-image": "^2.0.20",
     "gatsby-plugin-sharp": "^2.0.14",
     "gatsby-source-filesystem": "^2.0.13",


### PR DESCRIPTION
I don't think we're still updating the dist tag?