### PR TITLE
fix: Handle already deleted nodes in deleteNode action

### DIFF
--- a/packages/gatsby/src/db/loki/nodes.js
+++ b/packages/gatsby/src/db/loki/nodes.js
@@ -311,7 +311,9 @@ function reducer(state = new Map(), action) {
       return null
 
     case `DELETE_NODE`: {
-      deleteNode(action.payload)
+      if (action.payload) {
+        deleteNode(action.payload)
+      }
       return null
     }
 

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -368,7 +368,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
  * deleteNode({node: node})
  */
 actions.deleteNode = (options: any, plugin: Plugin, args: any) => {
-  let node = _.get(options, `node`)
+  let id
 
   // Check if using old method signature. Warn about incorrect usage but get
   // node from nodeID anyway.
@@ -383,8 +383,14 @@ actions.deleteNode = (options: any, plugin: Plugin, args: any) => {
     }
     report.warn(msg)
 
-    node = getNode(options)
+    id = options
+  } else {
+    id = options.node && options.node.id
   }
+
+  // Always get node from the store, as the node we get as an arg
+  // might already have been deleted.
+  const node = getNode(id)
 
   const createDeleteAction = node => {
     return {

--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -385,7 +385,7 @@ actions.deleteNode = (options: any, plugin: Plugin, args: any) => {
 
     id = options
   } else {
-    id = options.node && options.node.id
+    id = options && options.node && options.node.id
   }
 
   // Always get node from the store, as the node we get as an arg

--- a/packages/gatsby/src/redux/reducers/nodes-by-type.js
+++ b/packages/gatsby/src/redux/reducers/nodes-by-type.js
@@ -28,6 +28,7 @@ module.exports = (state = new Map(), action) => {
 
     case `DELETE_NODE`: {
       const node = action.payload
+      if (!node) return state
       const nodesOfType = getNodesOfType(node, state)
       nodesOfType.delete(node.id)
       if (!nodesOfType.size) {

--- a/packages/gatsby/src/redux/reducers/nodes.js
+++ b/packages/gatsby/src/redux/reducers/nodes.js
@@ -13,7 +13,9 @@ module.exports = (state = new Map(), action) => {
       return state
 
     case `DELETE_NODE`: {
-      state.delete(action.payload.id)
+      if (action.payload) {
+        state.delete(action.payload.id)
+      }
       return state
     }
 


### PR DESCRIPTION
Handle already deleted nodes in `deleteNode` action. Better way would be to only conditionally dispatch in a thunk, but until then this should be fine.