### PR TITLE
fix(gatsby-telemetry): Ensure all new installs will see the telemetry message at least once

### DIFF
--- a/packages/gatsby-telemetry/src/postinstall.js
+++ b/packages/gatsby-telemetry/src/postinstall.js
@@ -9,7 +9,6 @@ try {
         `If you'd like to opt-out, you can use \`gatsby telemetry --disable\`\n` +
         `To learn more, checkout http://gatsby.dev/telemetry`
     )
-    enabled = config.set(`telemetry.enabled`, true)
   }
 } catch (e) {
   // ignore


### PR DESCRIPTION
This way the cli will re-post the message
https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/telemetry.js#L110