### PR TITLE
fix(gatsby-telemetry): don't inherit args from main process

### DIFF
--- a/packages/gatsby-telemetry/src/flush.js
+++ b/packages/gatsby-telemetry/src/flush.js
@@ -7,6 +7,7 @@ module.exports = async () => {
   const forked = fork(join(__dirname, `send.js`), {
     detached: true,
     stdio: `ignore`,
+    execArgv: [],
   })
   forked.unref()
 }


### PR DESCRIPTION
Don't inherit args from main process. This is e.g. an issue when starting node with `--inspect-brk`, which would leave the forked process sitting on port 9229.