### PR TITLE
docs(gatsby-plugin-layout): add missing parentheses in documentation

### DIFF
--- a/packages/gatsby-plugin-layout/README.md
+++ b/packages/gatsby-plugin-layout/README.md
@@ -192,7 +192,7 @@ In `gatsby-node.js`:
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage } = actions
 
-  if(page.path.match(/special-page/) {
+  if (page.path.match(/special-page/)) {
     page.context.layout = 'special'
     createPage(page)
   }

--- a/packages/gatsby-plugin-layout/README.md
+++ b/packages/gatsby-plugin-layout/README.md
@@ -193,7 +193,7 @@ exports.onCreatePage = ({ page, actions }) => {
   const { createPage } = actions
 
   if (page.path.match(/special-page/)) {
-    page.context.layout = 'special'
+    page.context.layout = "special"
     createPage(page)
   }
 }


### PR DESCRIPTION
## Description

if statement checking for page match was missing the closing `)`,
