### PR TITLE
chore(docs): migrate to global in examples doc

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ Complex/complete websites are for studying how to build more complex websites.
 
 1.  Enter one of the sites (e.g. `cd gatsbygram`)
 2.  Install the dependencies for the site `npm install`
-3.  Run the Gatsby development server `npm run develop`
+3.  Run the Gatsby development server `gatsby develop`
 
 ## Checklist for building an example website
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

changes `npm run develop` to `gatsby develop`

## Related Issues


