### PR TITLE
fix(gatsby-telemetry): Ensure quickly running commands exit freely

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -10,7 +10,6 @@ const {
   setDefaultTags,
   setTelemetryEnabled,
 } = require(`gatsby-telemetry`)
-console.log(require.resolve(`gatsby-telemetry`))
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -10,6 +10,7 @@ const {
   setDefaultTags,
   setTelemetryEnabled,
 } = require(`gatsby-telemetry`)
+console.log(require.resolve(`gatsby-telemetry`))
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(

--- a/packages/gatsby-telemetry/src/index.js
+++ b/packages/gatsby-telemetry/src/index.js
@@ -8,12 +8,12 @@ process.on(`exit`, flush)
 // For longrunning commands we want to occasinally flush the data
 // The data is also sent on exit.
 const interval = 10 * 60 * 1000 // 10 min
+
 const tick = _ => {
   flush()
     .catch(console.error)
     .then(_ => setTimeout(tick, interval))
 }
-setTimeout(tick, interval)
 
 module.exports = {
   trackCli: (input, tags) => instance.captureEvent(input, tags),
@@ -22,6 +22,9 @@ module.exports = {
   setDefaultTags: tags => instance.decorateAll(tags),
   decorateEvent: (event, tags) => instance.decorateNextEvent(event, tags),
   setTelemetryEnabled: enabled => instance.setTelemetryEnabled(enabled),
+  startBackgroudUptate: _ => {
+    setTimeout(tick, interval)
+  },
 
   expressMiddleware: source => (req, res, next) => {
     try {

--- a/packages/gatsby-telemetry/src/index.js
+++ b/packages/gatsby-telemetry/src/index.js
@@ -22,7 +22,7 @@ module.exports = {
   setDefaultTags: tags => instance.decorateAll(tags),
   decorateEvent: (event, tags) => instance.decorateNextEvent(event, tags),
   setTelemetryEnabled: enabled => instance.setTelemetryEnabled(enabled),
-  startBackgroudUptate: _ => {
+  startBackgroundUpdate: _ => {
     setTimeout(tick, interval)
   },
 

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -258,6 +258,7 @@ async function startServer(program) {
 module.exports = async (program: any) => {
   initTracer(program.openTracingConfigFile)
   telemetry.trackCli(`DEVELOP_START`)
+  telemetry.startBackgroudUptate()
 
   const detect = require(`detect-port`)
   const port =

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -258,7 +258,7 @@ async function startServer(program) {
 module.exports = async (program: any) => {
   initTracer(program.openTracingConfigFile)
   telemetry.trackCli(`DEVELOP_START`)
-  telemetry.startBackgroudUptate()
+  telemetry.startBackgroundUpdate()
 
   const detect = require(`detect-port`)
   const port =

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -44,6 +44,7 @@ const clientOnlyPathsRouter = (pages, options) => {
 
 module.exports = async program => {
   telemetry.trackCli(`SERVE_START`)
+  telemetry.startBackgroundUpdate()
   let { prefixPaths, port, open, host } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 


### PR DESCRIPTION
It turns out the events timer caused `gatsby clean` in particular to never exit - unlike other fairly quickly running commands such as help, telemetry and build...

This should fix it