### PR TITLE
fix(gatsby-telemetry): add the missing fs-extra dependency

### DIFF
--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -13,6 +13,7 @@
     "ci-info": "2.0.0",
     "configstore": "4.0.0",
     "envinfo": "^5.8.1",
+    "fs-extra": "^7.0.1",
     "node-fetch": "2.3.0",
     "resolve-cwd": "^2.0.0",
     "source-map": "^0.5.7",


### PR DESCRIPTION
## Description

The new `gatsby-telemetry` package [uses `fs-extra`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/store.js#L10) but doesn't list it in the `package.json` field.

You should use Plug'n'Play 😛 
