### PR TITLE
chore(docs): fix broken gatsby style guide link

### DIFF
--- a/docs/docs/adding-page-transitions-with-plugin-page-transitions.md
+++ b/docs/docs/adding-page-transitions-with-plugin-page-transitions.md
@@ -8,5 +8,5 @@ This guide will cover the setup and the various ways you can utilize this plugin
 
 This is a stub. Help our community expand it.
 
-Please use the [Gatsby Style Guide](/docs/gatsby-style-guide/) to ensure your
+Please use the [Gatsby Style Guide](/contributing/gatsby-style-guide/) to ensure your
 pull request gets accepted.


### PR DESCRIPTION
# Description
This fixes a broken `Gatsby Style Guide` link

## In
The ["Adding Page Transitions with gatsby-plugin-page-transitions"](https://www.gatsbyjs.org/docs/adding-page-transitions-with-plugin-page-transitions/) page

`docs/docs/adding-page-transitions-with-plugin-page-transitions.md`