### PR TITLE
fix(gatsby-plugin-subfont) file paths isn't escaped in execSync command

### DIFF
--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
+    "shell-escape": "^0.2.0",
     "subfont": "^3.6.1"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-subfont/src/gatsby-node.js
+++ b/packages/gatsby-plugin-subfont/src/gatsby-node.js
@@ -1,16 +1,15 @@
 const path = require(`path`)
 const { execSync } = require(`child_process`)
+const shellescape = require(`shell-escape`)
 
 exports.onPostBuild = ({ store }) => {
   const root = path.join(store.getState().program.directory, `public`)
   // TODO make this configurable
   const urlPaths = [`/`]
-  const filePaths = urlPaths.reduce(
-    (accumulator, currentPath) =>
-      `${accumulator} ${path.join(root, currentPath, `index.html`)}`,
-    ``
-  )
-
-  const command = `node_modules/.bin/subfont -i --no-recursive --inline-css --root file://${root}${filePaths}`
+  const baseArgs = [`node_modules/.bin/subfont`,`-i`,`--no-recursive`,`--inline-css`,`--root`,`file://${root}`];
+  const args = baseArgs.concat(urlPaths.map((currentPath) =>
+      path.join(root, currentPath, `index.html`)
+  ))
+  const command = shellescape(args);
   execSync(command)
 }


### PR DESCRIPTION
In the gatsby-plugin-subfont plugin, file paths aren't escaped in execSync command.
I've get the error locally, in development context, during the build, because the absolute path of my project root contains spaces

see issue #12702