### PR TITLE
Use schema metadata

### DIFF
--- a/packages/gatsby/src/redux/reducers/schema-customization.js
+++ b/packages/gatsby/src/redux/reducers/schema-customization.js
@@ -21,9 +21,20 @@ module.exports = (
     case `CREATE_TYPES`: {
       let types
       if (_.isArray(action.payload)) {
-        types = [...state.types, ...action.payload]
+        types = [
+          ...state.types,
+          ...action.payload.map(typeOrTypeDef => {
+            return {
+              typeOrTypeDef,
+              plugin: action.plugin,
+            }
+          }),
+        ]
       } else {
-        types = [...state.types, action.payload]
+        types = [
+          ...state.types,
+          { typeOrTypeDef: action.payload, plugin: action.plugin },
+        ]
       }
       return {
         ...state,

--- a/packages/gatsby/src/schema/infer/__tests__/merge-types.js
+++ b/packages/gatsby/src/schema/infer/__tests__/merge-types.js
@@ -1,3 +1,4 @@
+const { buildObjectType } = require(`../../types/type-builders`)
 const { store } = require(`../../../redux`)
 const { build } = require(`../..`)
 require(`../../../db/__tests__/fixtures/ensure-loki`)()
@@ -56,7 +57,7 @@ describe(`merges explicit and inferred type definitions`, () => {
     )
   })
 
-  const buildTestSchema = async ({
+  const buildTestSchemaWithSdl = async ({
     infer = true,
     addDefaultResolvers = true,
   }) => {
@@ -100,192 +101,266 @@ describe(`merges explicit and inferred type definitions`, () => {
     return store.getState().schema
   }
 
-  it(`with default strategy`, async () => {
-    const schema = await buildTestSchema({})
-    const fields = schema.getType(`Test`).getFields()
-    const nestedFields = schema.getType(`Nested`).getFields()
-    const nestedNestedFields = schema.getType(`NestedNested`).getFields()
+  const buildTestSchemaWithTypeBuilders = async ({
+    infer = true,
+    addDefaultResolvers = true,
+  }) => {
+    const typeDefs = [
+      buildObjectType({
+        name: `NestedNested`,
+        fields: {
+          bar: `Boolean!`,
+          conflict: `String!`,
+          notExtra: `Boolean`,
+        },
+      }),
+      buildObjectType({
+        name: `Nested`,
+        fields: {
+          bar: `Boolean!`,
+          conflict: `String!`,
+          nested: `NestedNested`,
+        },
+      }),
+      buildObjectType({
+        name: `Test`,
+        interfaces: [`Node`],
+        extensions: {
+          inferConfig: {
+            infer,
+            addDefaultResolvers,
+          },
+        },
+        fields: {
+          explicitDate: `Date`,
+          bar: `Boolean!`,
+          nested: `Nested!`,
+          nestedArray: `[Nested!]!`,
+          conflictType: `String!`,
+          conflictArray: `Int!`,
+          conflictArrayReverse: `[Int!]!`,
+          conflictArrayType: `[String!]!`,
+          conflictScalar: `Int!`,
+          conflictScalarReverse: `Nested!`,
+          conflictScalarArray: `[Int!]!`,
+          conflcitScalarArrayReverse: `[Nested!]!`,
+        },
+      }),
+    ]
 
-    // Non-conflicting top-level fields added
-    expect(fields.foo.type.toString()).toBe(`Boolean`)
-    expect(fields.bar.type.toString()).toBe(`Boolean!`)
+    typeDefs.forEach(def =>
+      store.dispatch({ type: `CREATE_TYPES`, payload: def })
+    )
 
-    // Non-conflicting fields added on nested type
-    expect(fields.nested.type.toString()).toBe(`Nested!`)
-    expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
-    expect(nestedFields.foo.type.toString()).toBe(`Boolean`)
-    expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
-    expect(nestedNestedFields.foo.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
+    await build({})
+    return store.getState().schema
+  }
 
-    // When type is referenced more than once on typeDefs, all non-conflicting
-    // fields are added
-    expect(nestedFields.extra.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.extraExtra.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.extraExtraExtra.type.toString()).toBe(`Boolean`)
+  ;[
+    [`sdl`, buildTestSchemaWithSdl],
+    [`typeBuilders`, buildTestSchemaWithTypeBuilders],
+  ].forEach(([name, buildTestSchema]) => {
+    describe(`with ${name}`, () => {
+      it(`with default strategy`, async () => {
+        const schema = await buildTestSchema({})
+        const fields = schema.getType(`Test`).getFields()
+        const nestedFields = schema.getType(`Nested`).getFields()
+        const nestedNestedFields = schema.getType(`NestedNested`).getFields()
 
-    // Explicit typeDefs have proprity in case of type conflict
-    expect(fields.conflictType.type.toString()).toBe(`String!`)
-    expect(fields.conflictArray.type.toString()).toBe(`Int!`)
-    expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
-    expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
-    expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
-    expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(`[Nested!]!`)
+        // Non-conflicting top-level fields added
+        expect(fields.foo.type.toString()).toBe(`Boolean`)
+        expect(fields.bar.type.toString()).toBe(`Boolean!`)
 
-    // Explicit typeDefs have priority on nested types as well
-    expect(nestedFields.conflict.type.toString()).toBe(`String!`)
-    expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
+        // Non-conflicting fields added on nested type
+        expect(fields.nested.type.toString()).toBe(`Nested!`)
+        expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
+        expect(nestedFields.foo.type.toString()).toBe(`Boolean`)
+        expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
+        expect(nestedNestedFields.foo.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
 
-    // Date resolvers
-    expect(fields.explicitDate.resolve).toBeDefined()
-    expect(fields.inferDate.resolve).toBeDefined()
-  })
+        // When type is referenced more than once on typeDefs, all non-conflicting
+        // fields are added
+        expect(nestedFields.extra.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.extraExtra.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.extraExtraExtra.type.toString()).toBe(
+          `Boolean`
+        )
 
-  it(`with @dontInfer directive`, async () => {
-    const schema = await buildTestSchema({
-      infer: false,
+        // Explicit typeDefs have proprity in case of type conflict
+        expect(fields.conflictType.type.toString()).toBe(`String!`)
+        expect(fields.conflictArray.type.toString()).toBe(`Int!`)
+        expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
+        expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
+        expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
+        expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(
+          `[Nested!]!`
+        )
+
+        // Explicit typeDefs have priority on nested types as well
+        expect(nestedFields.conflict.type.toString()).toBe(`String!`)
+        expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
+
+        // Date resolvers
+        expect(fields.explicitDate.resolve).toBeDefined()
+        expect(fields.inferDate.resolve).toBeDefined()
+      })
+
+      it(`with @dontInfer directive`, async () => {
+        const schema = await buildTestSchema({
+          infer: false,
+        })
+        const fields = schema.getType(`Test`).getFields()
+        const nestedFields = schema.getType(`Nested`).getFields()
+        const nestedNestedFields = schema.getType(`NestedNested`).getFields()
+
+        // Non-conflicting top-level fields added
+        expect(fields.bar.type.toString()).toBe(`Boolean!`)
+
+        // Not adding inferred fields
+        expect(fields.foo).toBeUndefined()
+        expect(nestedFields.foo).toBeUndefined()
+        expect(nestedNestedFields.foo).toBeUndefined()
+        expect(nestedFields.extra).toBeUndefined()
+        expect(nestedNestedFields.extraExtra).toBeUndefined()
+        expect(nestedNestedFields.extraExtraExtra).toBeUndefined()
+        expect(fields.inferDate).toBeUndefined()
+
+        // Non-conflicting fields added on nested type
+        expect(fields.nested.type.toString()).toBe(`Nested!`)
+        expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
+        expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
+        expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
+
+        // When type is referenced more than once on typeDefs, all non-conflicting
+        // fields are added
+        expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
+
+        // Explicit typeDefs have proprity in case of type conflict
+        expect(fields.conflictType.type.toString()).toBe(`String!`)
+        expect(fields.conflictArray.type.toString()).toBe(`Int!`)
+        expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
+        expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
+        expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
+        expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(
+          `[Nested!]!`
+        )
+
+        // Explicit typeDefs have priority on nested types as well
+        expect(nestedFields.conflict.type.toString()).toBe(`String!`)
+        expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
+
+        // Date resolvers
+        expect(fields.explicitDate.resolve).toBeDefined()
+      })
+
+      it(`with noDefaultResolvers: true`, async () => {
+        const schema = await buildTestSchema({
+          addDefaultResolvers: false,
+        })
+        const fields = schema.getType(`Test`).getFields()
+        const nestedFields = schema.getType(`Nested`).getFields()
+        const nestedNestedFields = schema.getType(`NestedNested`).getFields()
+
+        // Non-conflicting top-level fields added
+        expect(fields.foo.type.toString()).toBe(`Boolean`)
+        expect(fields.bar.type.toString()).toBe(`Boolean!`)
+
+        // Non-conflicting fields added on nested type
+        expect(fields.nested.type.toString()).toBe(`Nested!`)
+        expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
+        expect(nestedFields.foo.type.toString()).toBe(`Boolean`)
+        expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
+        expect(nestedNestedFields.foo.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
+
+        // When type is referenced more than once on typeDefs, all non-conflicting
+        // fields are added
+        expect(nestedFields.extra.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.extraExtra.type.toString()).toBe(`Boolean`)
+        expect(nestedNestedFields.extraExtraExtra.type.toString()).toBe(
+          `Boolean`
+        )
+
+        // Explicit typeDefs have proprity in case of type conflict
+        expect(fields.conflictType.type.toString()).toBe(`String!`)
+        expect(fields.conflictArray.type.toString()).toBe(`Int!`)
+        expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
+        expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
+        expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
+        expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(
+          `[Nested!]!`
+        )
+
+        // Explicit typeDefs have priority on nested types as well
+        expect(nestedFields.conflict.type.toString()).toBe(`String!`)
+        expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
+
+        // Date resolvers
+        expect(fields.explicitDate.resolve).toBeUndefined()
+        expect(fields.inferDate.resolve).toBeDefined()
+      })
+
+      it(`with both @dontInfer and noDefaultResolvers: true`, async () => {
+        const schema = await buildTestSchema({
+          addDefaultResolvers: false,
+          infer: false,
+        })
+
+        const fields = schema.getType(`Test`).getFields()
+        const nestedFields = schema.getType(`Nested`).getFields()
+        const nestedNestedFields = schema.getType(`NestedNested`).getFields()
+
+        // Non-conflicting top-level fields added
+        expect(fields.bar.type.toString()).toBe(`Boolean!`)
+
+        // Not adding inferred fields
+        expect(fields.foo).toBeUndefined()
+        expect(nestedFields.foo).toBeUndefined()
+        expect(nestedNestedFields.foo).toBeUndefined()
+        expect(nestedFields.extra).toBeUndefined()
+        expect(nestedNestedFields.extraExtra).toBeUndefined()
+        expect(nestedNestedFields.extraExtraExtra).toBeUndefined()
+        expect(fields.inferDate).toBeUndefined()
+
+        // Non-conflicting fields added on nested type
+        expect(fields.nested.type.toString()).toBe(`Nested!`)
+        expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
+        expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
+        expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
+
+        // When type is referenced more than once on typeDefs, all non-conflicting
+        // fields are added
+        expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
+
+        // Explicit typeDefs have proprity in case of type conflict
+        expect(fields.conflictType.type.toString()).toBe(`String!`)
+        expect(fields.conflictArray.type.toString()).toBe(`Int!`)
+        expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
+        expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
+        expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
+        expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
+        expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(
+          `[Nested!]!`
+        )
+
+        // Explicit typeDefs have priority on nested types as well
+        expect(nestedFields.conflict.type.toString()).toBe(`String!`)
+        expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
+
+        // Date resolvers
+        expect(fields.explicitDate.resolve).toBeUndefined()
+      })
     })
-    const fields = schema.getType(`Test`).getFields()
-    const nestedFields = schema.getType(`Nested`).getFields()
-    const nestedNestedFields = schema.getType(`NestedNested`).getFields()
-
-    // Non-conflicting top-level fields added
-    expect(fields.bar.type.toString()).toBe(`Boolean!`)
-
-    // Not adding inferred fields
-    expect(fields.foo).toBeUndefined()
-    expect(nestedFields.foo).toBeUndefined()
-    expect(nestedNestedFields.foo).toBeUndefined()
-    expect(nestedFields.extra).toBeUndefined()
-    expect(nestedNestedFields.extraExtra).toBeUndefined()
-    expect(nestedNestedFields.extraExtraExtra).toBeUndefined()
-    expect(fields.inferDate).toBeUndefined()
-
-    // Non-conflicting fields added on nested type
-    expect(fields.nested.type.toString()).toBe(`Nested!`)
-    expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
-    expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
-    expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
-
-    // When type is referenced more than once on typeDefs, all non-conflicting
-    // fields are added
-    expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
-
-    // Explicit typeDefs have proprity in case of type conflict
-    expect(fields.conflictType.type.toString()).toBe(`String!`)
-    expect(fields.conflictArray.type.toString()).toBe(`Int!`)
-    expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
-    expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
-    expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
-    expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(`[Nested!]!`)
-
-    // Explicit typeDefs have priority on nested types as well
-    expect(nestedFields.conflict.type.toString()).toBe(`String!`)
-    expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
-
-    // Date resolvers
-    expect(fields.explicitDate.resolve).toBeDefined()
-  })
-
-  it(`with noDefaultResolvers: true`, async () => {
-    const schema = await buildTestSchema({
-      addDefaultResolvers: false,
-    })
-    const fields = schema.getType(`Test`).getFields()
-    const nestedFields = schema.getType(`Nested`).getFields()
-    const nestedNestedFields = schema.getType(`NestedNested`).getFields()
-
-    // Non-conflicting top-level fields added
-    expect(fields.foo.type.toString()).toBe(`Boolean`)
-    expect(fields.bar.type.toString()).toBe(`Boolean!`)
-
-    // Non-conflicting fields added on nested type
-    expect(fields.nested.type.toString()).toBe(`Nested!`)
-    expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
-    expect(nestedFields.foo.type.toString()).toBe(`Boolean`)
-    expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
-    expect(nestedNestedFields.foo.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
-
-    // When type is referenced more than once on typeDefs, all non-conflicting
-    // fields are added
-    expect(nestedFields.extra.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.extraExtra.type.toString()).toBe(`Boolean`)
-    expect(nestedNestedFields.extraExtraExtra.type.toString()).toBe(`Boolean`)
-
-    // Explicit typeDefs have proprity in case of type conflict
-    expect(fields.conflictType.type.toString()).toBe(`String!`)
-    expect(fields.conflictArray.type.toString()).toBe(`Int!`)
-    expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
-    expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
-    expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
-    expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(`[Nested!]!`)
-
-    // Explicit typeDefs have priority on nested types as well
-    expect(nestedFields.conflict.type.toString()).toBe(`String!`)
-    expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
-
-    // Date resolvers
-    expect(fields.explicitDate.resolve).toBeUndefined()
-    expect(fields.inferDate.resolve).toBeDefined()
-  })
-
-  it(`with both @dontInfer and noDefaultResolvers: true`, async () => {
-    const schema = await buildTestSchema({
-      addDefaultResolvers: false,
-      infer: false,
-    })
-
-    const fields = schema.getType(`Test`).getFields()
-    const nestedFields = schema.getType(`Nested`).getFields()
-    const nestedNestedFields = schema.getType(`NestedNested`).getFields()
-
-    // Non-conflicting top-level fields added
-    expect(fields.bar.type.toString()).toBe(`Boolean!`)
-
-    // Not adding inferred fields
-    expect(fields.foo).toBeUndefined()
-    expect(nestedFields.foo).toBeUndefined()
-    expect(nestedNestedFields.foo).toBeUndefined()
-    expect(nestedFields.extra).toBeUndefined()
-    expect(nestedNestedFields.extraExtra).toBeUndefined()
-    expect(nestedNestedFields.extraExtraExtra).toBeUndefined()
-    expect(fields.inferDate).toBeUndefined()
-
-    // Non-conflicting fields added on nested type
-    expect(fields.nested.type.toString()).toBe(`Nested!`)
-    expect(fields.nestedArray.type.toString()).toBe(`[Nested!]!`)
-    expect(nestedFields.bar.type.toString()).toBe(`Boolean!`)
-    expect(nestedNestedFields.bar.type.toString()).toBe(`Boolean!`)
-
-    // When type is referenced more than once on typeDefs, all non-conflicting
-    // fields are added
-    expect(nestedNestedFields.notExtra.type.toString()).toBe(`Boolean`)
-
-    // Explicit typeDefs have proprity in case of type conflict
-    expect(fields.conflictType.type.toString()).toBe(`String!`)
-    expect(fields.conflictArray.type.toString()).toBe(`Int!`)
-    expect(fields.conflictArrayReverse.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflictArrayType.type.toString()).toBe(`[String!]!`)
-    expect(fields.conflictScalar.type.toString()).toBe(`Int!`)
-    expect(fields.conflictScalarReverse.type.toString()).toBe(`Nested!`)
-    expect(fields.conflictScalarArray.type.toString()).toBe(`[Int!]!`)
-    expect(fields.conflcitScalarArrayReverse.type.toString()).toBe(`[Nested!]!`)
-
-    // Explicit typeDefs have priority on nested types as well
-    expect(nestedFields.conflict.type.toString()).toBe(`String!`)
-    expect(nestedNestedFields.conflict.type.toString()).toBe(`String!`)
-
-    // Date resolvers
-    expect(fields.explicitDate.resolve).toBeUndefined()
   })
 
   it(`honors array depth when merging types`, async () => {

--- a/packages/gatsby/src/schema/infer/__tests__/merge-types.js
+++ b/packages/gatsby/src/schema/infer/__tests__/merge-types.js
@@ -126,10 +126,8 @@ describe(`merges explicit and inferred type definitions`, () => {
         name: `Test`,
         interfaces: [`Node`],
         extensions: {
-          inferConfig: {
-            infer,
-            addDefaultResolvers,
-          },
+          infer,
+          addDefaultResolvers,
         },
         fields: {
           explicitDate: `Date`,

--- a/packages/gatsby/src/schema/infer/get-infer-config.js
+++ b/packages/gatsby/src/schema/infer/get-infer-config.js
@@ -1,7 +1,5 @@
 // @flow
 
-const { Kind } = require(`graphql`)
-
 export interface InferConfig {
   infer: boolean;
   addDefaultResolvers: boolean;
@@ -16,34 +14,10 @@ const DEFAULT_INFER_CONFIG: InferConfig = {
 const getInferConfig: (
   typeComposer: TypeComposer
 ) => InferConfig = typeComposer => {
-  const type = typeComposer.getType()
-  const inferConfig = { ...DEFAULT_INFER_CONFIG }
-  if (type.astNode && type.astNode.directives) {
-    type.astNode.directives.forEach(directive => {
-      if (directive.name.value === `infer`) {
-        inferConfig.infer = true
-        inferConfig.addDefaultResolvers = getNoDefaultResolvers(directive)
-      } else if (directive.name.value === `dontInfer`) {
-        inferConfig.infer = false
-        inferConfig.addDefaultResolvers = getNoDefaultResolvers(directive)
-      }
-    })
+  return {
+    ...DEFAULT_INFER_CONFIG,
+    ...(typeComposer.getExtension(`inferConfig`) || {}),
   }
-
-  return inferConfig
 }
 
 module.exports = getInferConfig
-
-const getNoDefaultResolvers = directive => {
-  const noDefaultResolvers = directive.arguments.find(
-    ({ name }) => name.value === `noDefaultResolvers`
-  )
-  if (noDefaultResolvers) {
-    if (noDefaultResolvers.value.kind === Kind.BOOLEAN) {
-      return !noDefaultResolvers.value.value
-    }
-  }
-
-  return DEFAULT_INFER_CONFIG.addDefaultResolvers
-}

--- a/packages/gatsby/src/schema/infer/get-infer-config.js
+++ b/packages/gatsby/src/schema/infer/get-infer-config.js
@@ -15,8 +15,12 @@ const getInferConfig: (
   typeComposer: TypeComposer
 ) => InferConfig = typeComposer => {
   return {
-    ...DEFAULT_INFER_CONFIG,
-    ...(typeComposer.getExtension(`inferConfig`) || {}),
+    infer: typeComposer.hasExtension(`infer`)
+      ? typeComposer.getExtension(`infer`)
+      : DEFAULT_INFER_CONFIG.infer,
+    addDefaultResolvers: typeComposer.hasExtension(`addDefaultResolvers`)
+      ? typeComposer.getExtension(`addDefaultResolvers`)
+      : DEFAULT_INFER_CONFIG.addDefaultResolvers,
   }
 }
 

--- a/packages/gatsby/src/schema/infer/index.js
+++ b/packages/gatsby/src/schema/infer/index.js
@@ -16,8 +16,17 @@ const addInferredType = ({
   parentSpan,
 }) => {
   const typeName = typeComposer.getTypeName()
+  const nodes = nodeStore.getNodesByType(typeName)
+  if (
+    !typeComposer.hasExtension(`plugin`) &&
+    typeComposer.getExtension(`createdFrom`) === `infer`
+  ) {
+    typeComposer.setExtension(`plugin`, {
+      name: nodes[0].internal.owner,
+    })
+  }
   const exampleValue = getExampleValue({
-    nodes: nodeStore.getNodesByType(typeName),
+    nodes,
     typeName,
     typeConflictReporter,
     ignoreFields: [
@@ -63,6 +72,7 @@ const addInferredTypes = ({
       }
     } else {
       typeComposer = schemaComposer.createObjectTC(typeName)
+      typeComposer.setExtension(`createdFrom`, `infer`)
       addNodeInterface({ schemaComposer, typeComposer })
     }
   })

--- a/packages/gatsby/src/schema/infer/index.js
+++ b/packages/gatsby/src/schema/infer/index.js
@@ -21,9 +21,7 @@ const addInferredType = ({
     !typeComposer.hasExtension(`plugin`) &&
     typeComposer.getExtension(`createdFrom`) === `infer`
   ) {
-    typeComposer.setExtension(`plugin`, {
-      name: nodes[0].internal.owner,
-    })
+    typeComposer.setExtension(`plugin`, nodes[0].internal.owner)
   }
   const exampleValue = getExampleValue({
     nodes,

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -202,21 +202,23 @@ const processAddedType = ({
   schemaComposer.addSchemaMustHaveType(typeComposer)
 
   typeComposer.setExtension(`createdFrom`, createdFrom)
-  typeComposer.setExtension(`plugin`, plugin)
+  typeComposer.setExtension(`plugin`, plugin ? plugin.name : null)
 
   if (createdFrom === `sdl`) {
     if (type.astNode && type.astNode.directives) {
       type.astNode.directives.forEach(directive => {
         if (directive.name.value === `infer`) {
-          typeComposer.setExtension(`inferConfig`, {
-            infer: true,
-            addDefaultResolvers: getNoDefaultResolvers(directive),
-          })
+          typeComposer.setExtension(`infer`, true)
+          typeComposer.setExtension(
+            `addDefaultResolvers`,
+            getNoDefaultResolvers(directive)
+          )
         } else if (directive.name.value === `dontInfer`) {
-          typeComposer.setExtension(`inferConfig`, {
-            infer: false,
-            addDefaultResolvers: getNoDefaultResolvers(directive),
-          })
+          typeComposer.setExtension(`infer`, false)
+          typeComposer.setExtension(
+            `addDefaultResolvers`,
+            getNoDefaultResolvers(directive)
+          )
         }
       })
     }

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -6,6 +6,7 @@ const {
   defaultFieldResolver,
   assertValidName,
   getNamedType,
+  Kind,
 } = require(`graphql`)
 const {
   ObjectTypeComposer,
@@ -135,7 +136,7 @@ const processTypeComposer = async ({
 }
 
 const addTypes = ({ schemaComposer, types, parentSpan }) => {
-  types.forEach(typeOrTypeDef => {
+  types.forEach(({ typeOrTypeDef, plugin }) => {
     if (typeof typeOrTypeDef === `string`) {
       let addedTypes
       try {
@@ -143,25 +144,50 @@ const addTypes = ({ schemaComposer, types, parentSpan }) => {
       } catch (error) {
         reportParsingError(error)
       }
-      addedTypes.forEach(type =>
-        processAddedType({ schemaComposer, type, parentSpan })
-      )
+      addedTypes.forEach(type => {
+        processAddedType({
+          schemaComposer,
+          type,
+          parentSpan,
+          createdFrom: `sdl`,
+          plugin,
+        })
+      })
     } else if (isGatsbyType(typeOrTypeDef)) {
       const type = createTypeComposerFromGatsbyType({
         schemaComposer,
         type: typeOrTypeDef,
         parentSpan,
       })
+
       if (type) {
-        processAddedType({ schemaComposer, type, parentSpan })
+        processAddedType({
+          schemaComposer,
+          type,
+          parentSpan,
+          createdFrom: `typeBuilder`,
+          plugin,
+        })
       }
     } else {
-      processAddedType({ schemaComposer, type: typeOrTypeDef, parentSpan })
+      processAddedType({
+        schemaComposer,
+        type: typeOrTypeDef,
+        parentSpan,
+        createdFrom: `graphql-js`,
+        plugin,
+      })
     }
   })
 }
 
-const processAddedType = ({ schemaComposer, type, parentSpan }) => {
+const processAddedType = ({
+  schemaComposer,
+  type,
+  parentSpan,
+  createdFrom,
+  plugin,
+}) => {
   const typeName = schemaComposer.addAsComposer(type)
   checkIsAllowedTypeName(typeName)
   const typeComposer = schemaComposer.get(typeName)
@@ -174,6 +200,42 @@ const processAddedType = ({ schemaComposer, type, parentSpan }) => {
     }
   }
   schemaComposer.addSchemaMustHaveType(typeComposer)
+
+  typeComposer.setExtension(`createdFrom`, createdFrom)
+  typeComposer.setExtension(`plugin`, plugin)
+
+  if (createdFrom === `sdl`) {
+    if (type.astNode && type.astNode.directives) {
+      type.astNode.directives.forEach(directive => {
+        if (directive.name.value === `infer`) {
+          typeComposer.setExtension(`inferConfig`, {
+            infer: true,
+            addDefaultResolvers: getNoDefaultResolvers(directive),
+          })
+        } else if (directive.name.value === `dontInfer`) {
+          typeComposer.setExtension(`inferConfig`, {
+            infer: false,
+            addDefaultResolvers: getNoDefaultResolvers(directive),
+          })
+        }
+      })
+    }
+  }
+
+  return typeComposer
+}
+
+const getNoDefaultResolvers = directive => {
+  const noDefaultResolvers = directive.arguments.find(
+    ({ name }) => name.value === `noDefaultResolvers`
+  )
+  if (noDefaultResolvers) {
+    if (noDefaultResolvers.value.kind === Kind.BOOLEAN) {
+      return !noDefaultResolvers.value.value
+    }
+  }
+
+  return null
 }
 
 const checkIsAllowedTypeName = name => {

--- a/packages/gatsby/src/schema/types/directives.js
+++ b/packages/gatsby/src/schema/types/directives.js
@@ -14,6 +14,7 @@ const InferDirective = new GraphQLDirective({
       type: new GraphQLNonNull(GraphQLBoolean),
       default: false,
       description: `Don't add default resolvers to defined fields.`,
+      deprecationReason: `noDefaultResolvers is deprecated, annotate individual fields.`,
     },
   },
 })
@@ -27,6 +28,7 @@ const DontInferDirective = new GraphQLDirective({
       type: new GraphQLNonNull(GraphQLBoolean),
       default: false,
       description: `Don't add default resolvers to defined fields.`,
+      deprecationReason: `noDefaultResolvers is deprecated, annotate individual fields.`,
     },
   },
 })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Store info about infer config in schema metadata. This allows specifying infer config for builder types too.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
