### PR TITLE
fix(gatsby-plugin-google-tagmanager): update dataLayer to be camelCased

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -28,7 +28,7 @@ exports.onRenderBody = (
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
             })(window,document,'script','${pluginOptions.dataLayerName ||
-              `datalayer`}', '${pluginOptions.id}');`,
+              `dataLayer`}', '${pluginOptions.id}');`,
         }}
       />,
     ])


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
For the `gatsby-plugin-google-tagmanager` this PR/release: https://github.com/gatsbyjs/gatsby/pull/12783, has introduced a bug where by default the `'dataLayer'` is being set to `'datalayer'` (all lower case). Which means that by default this will not work with GTM. This PR just updates to use the correct form, `dataLayer` as the default. It is possibly the smallest PR I've ever made, but it will prevent a lot of people from being confused why they can't push to the dataLayer... 

## Related Issues
issue i filed for this: 
https://github.com/gatsbyjs/gatsby/issues/12921