### PR TITLE
fix(gatsby-plugin-sharp): don't write to same temporary time multiple times at a same time

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/trace-svg.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/trace-svg.js
@@ -1,0 +1,217 @@
+jest.mock(`sharp`, () => {
+  const sharp = path => {
+    const pipeline = {
+      rotate: () => pipeline,
+      resize: () => pipeline,
+      png: () => pipeline,
+      jpeg: () => pipeline,
+      toFile: (_, cb) => cb(),
+    }
+    return pipeline
+  }
+
+  sharp.simd = () => {}
+
+  return sharp
+})
+
+jest.mock(`potrace`, () => {
+  return {
+    trace: (_, _2, cb) => cb(null, ``),
+    Potrace: {
+      TURNPOLICY_MAJORITY: `wat`,
+    },
+  }
+})
+
+const path = require(`path`)
+
+const traceSVGHelpers = require(`../trace-svg`)
+
+const notMemoizedtraceSVG = jest.spyOn(traceSVGHelpers, `notMemoizedtraceSVG`)
+const notMemoizedPrepareTraceSVGInputFile = jest.spyOn(
+  traceSVGHelpers,
+  `notMemoizedPrepareTraceSVGInputFile`
+)
+// note that we started spying on not memoized functions first
+// now we recreate memoized functions that will use function we just started
+// spying on
+traceSVGHelpers.createMemoizedFunctions()
+const memoizedTraceSVG = jest.spyOn(traceSVGHelpers, `memoizedTraceSVG`)
+const memoizedPrepareTraceSVGInputFile = jest.spyOn(
+  traceSVGHelpers,
+  `memoizedPrepareTraceSVGInputFile`
+)
+
+const { traceSVG } = require(`../`)
+
+function getFileObject(absolutePath, name = path.parse(absolutePath).name) {
+  return {
+    id: `${absolutePath} absPath of file`,
+    name: name,
+    absolutePath,
+    extension: `png`,
+    internal: {
+      contentDigest: `1234`,
+    },
+  }
+}
+
+describe(`traceSVG memoization`, () => {
+  const file = getFileObject(path.join(__dirname, `images/test.png`))
+  const copyOfFile = getFileObject(path.join(__dirname, `images/test-copy.png`))
+  const differentFile = getFileObject(
+    path.join(__dirname, `images/different.png`)
+  )
+  differentFile.internal.contentDigest = `4321`
+
+  beforeEach(() => {
+    traceSVGHelpers.clearMemoizeCaches()
+    memoizedTraceSVG.mockClear()
+    notMemoizedtraceSVG.mockClear()
+    memoizedPrepareTraceSVGInputFile.mockClear()
+    notMemoizedPrepareTraceSVGInputFile.mockClear()
+  })
+
+  it(`Baseline`, async () => {
+    await traceSVG({
+      file,
+    })
+
+    expect(memoizedTraceSVG).toBeCalledTimes(1)
+    expect(notMemoizedtraceSVG).toBeCalledTimes(1)
+    expect(memoizedPrepareTraceSVGInputFile).toBeCalledTimes(1)
+    expect(notMemoizedPrepareTraceSVGInputFile).toBeCalledTimes(1)
+  })
+
+  it(`Is memoizing results for same args`, async () => {
+    await traceSVG({
+      file,
+    })
+
+    await traceSVG({
+      file,
+    })
+
+    expect(memoizedTraceSVG).toBeCalledTimes(2)
+    expect(notMemoizedtraceSVG).toBeCalledTimes(1)
+    expect(memoizedPrepareTraceSVGInputFile).toBeCalledTimes(1)
+    expect(notMemoizedPrepareTraceSVGInputFile).toBeCalledTimes(1)
+  })
+
+  it(`Is calling functions with same input file when params change`, async () => {
+    await traceSVG({
+      file,
+      args: {
+        color: `red`,
+      },
+      fileArgs: {
+        width: 400,
+      },
+    })
+    await traceSVG({
+      file,
+      args: {
+        color: `blue`,
+      },
+      fileArgs: {
+        width: 400,
+      },
+    })
+    await traceSVG({
+      file,
+      args: {
+        color: `red`,
+      },
+      fileArgs: {
+        width: 200,
+      },
+    })
+    await traceSVG({
+      file,
+      args: {
+        color: `blue`,
+      },
+      fileArgs: {
+        width: 200,
+      },
+    })
+    await traceSVG({
+      file: differentFile,
+      args: {
+        color: `red`,
+      },
+      fileArgs: {
+        width: 400,
+      },
+    })
+
+    expect(memoizedTraceSVG).toBeCalledTimes(5)
+    expect(notMemoizedtraceSVG).toBeCalledTimes(5)
+    expect(memoizedPrepareTraceSVGInputFile).toBeCalledTimes(5)
+    // trace svg should be actually created just 3 times
+    // because it's affected just by `fileArgs`, and not `args`
+    // this makes sure we don't try to write to same input file multiple times
+    expect(notMemoizedPrepareTraceSVGInputFile).toBeCalledTimes(3)
+    expect(notMemoizedPrepareTraceSVGInputFile).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        file,
+        options: expect.objectContaining({
+          width: 400,
+        }),
+      })
+    )
+    expect(notMemoizedPrepareTraceSVGInputFile).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        file,
+        options: expect.objectContaining({
+          width: 200,
+        }),
+      })
+    )
+    expect(notMemoizedPrepareTraceSVGInputFile).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        file: differentFile,
+        options: expect.objectContaining({
+          width: 400,
+        }),
+      })
+    )
+
+    const usedTmpFilePaths = notMemoizedPrepareTraceSVGInputFile.mock.calls.map(
+      args => args[0].tmpFilePath
+    )
+
+    // tmpFilePath was always unique
+    expect(usedTmpFilePaths.length).toBe(new Set(usedTmpFilePaths).size)
+  })
+
+  it(`Use memoized results for file copies`, async () => {
+    await traceSVG({
+      file,
+      args: {
+        color: `red`,
+      },
+      fileArgs: {
+        width: 400,
+      },
+    })
+    await traceSVG({
+      file: copyOfFile,
+      args: {
+        color: `red`,
+      },
+      fileArgs: {
+        width: 400,
+      },
+    })
+
+    expect(memoizedTraceSVG).toBeCalledTimes(2)
+    expect(notMemoizedtraceSVG).toBeCalledTimes(1)
+    expect(memoizedPrepareTraceSVGInputFile).toBeCalledTimes(1)
+    expect(notMemoizedPrepareTraceSVGInputFile).toBeCalledTimes(1)
+  })
+})

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,9 +1,11 @@
 const {
   setBoundActionCreators,
-  setPluginOptions,
   // queue: jobQueue,
   // reportError,
 } = require(`./index`)
+
+const { setPluginOptions } = require(`./plugin-options`)
+
 // const { scheduleJob } = require(`./scheduler`)
 // let normalizedOptions = {}
 

--- a/packages/gatsby-plugin-sharp/src/plugin-options.js
+++ b/packages/gatsby-plugin-sharp/src/plugin-options.js
@@ -1,0 +1,80 @@
+const _ = require(`lodash`)
+
+/// Plugin options are loaded onPreBootstrap in gatsby-node
+const pluginDefaults = {
+  forceBase64Format: false,
+  useMozJpeg: process.env.GATSBY_JPEG_ENCODER === `MOZJPEG`,
+  stripMetadata: true,
+  lazyImageGeneration: true,
+  defaultQuality: 50,
+}
+
+const generalArgs = {
+  quality: 50,
+  jpegProgressive: true,
+  pngCompressionLevel: 9,
+  // default is 4 (https://github.com/kornelski/pngquant/blob/4219956d5e080be7905b5581314d913d20896934/rust/bin.rs#L61)
+  pngCompressionSpeed: 4,
+  base64: true,
+  grayscale: false,
+  duotone: false,
+  pathPrefix: ``,
+  toFormat: ``,
+  toFormatBase64: ``,
+  sizeByPixelDensity: false,
+}
+
+let pluginOptions = Object.assign({}, pluginDefaults)
+exports.setPluginOptions = opts => {
+  pluginOptions = Object.assign({}, pluginOptions, opts)
+  generalArgs.quality = pluginOptions.defaultQuality
+
+  return pluginOptions
+}
+
+exports.getPluginOptions = () => pluginOptions
+
+const healOptions = (
+  { defaultQuality: quality },
+  args,
+  fileExtension,
+  defaultArgs = {}
+) => {
+  let options = _.defaults({}, args, { quality }, defaultArgs, generalArgs)
+  options.quality = parseInt(options.quality, 10)
+  options.pngCompressionLevel = parseInt(options.pngCompressionLevel, 10)
+  options.pngCompressionSpeed = parseInt(options.pngCompressionSpeed, 10)
+  options.toFormat = options.toFormat.toLowerCase()
+  options.toFormatBase64 = options.toFormatBase64.toLowerCase()
+
+  // when toFormat is not set we set it based on fileExtension
+  if (options.toFormat === ``) {
+    options.toFormat = fileExtension.toLowerCase()
+
+    if (fileExtension === `jpeg`) {
+      options.toFormat = `jpg`
+    }
+  }
+
+  // only set width to 400 if neither width nor height is passed
+  if (options.width === undefined && options.height === undefined) {
+    options.width = 400
+  } else if (options.width !== undefined) {
+    options.width = parseInt(options.width, 10)
+  } else if (options.height !== undefined) {
+    options.height = parseInt(options.height, 10)
+  }
+
+  // only set maxWidth to 800 if neither maxWidth nor maxHeight is passed
+  if (options.maxWidth === undefined && options.maxHeight === undefined) {
+    options.maxWidth = 800
+  } else if (options.maxWidth !== undefined) {
+    options.maxWidth = parseInt(options.maxWidth, 10)
+  } else if (options.maxHeight !== undefined) {
+    options.maxHeight = parseInt(options.maxHeight, 10)
+  }
+
+  return options
+}
+
+exports.healOptions = healOptions

--- a/packages/gatsby-plugin-sharp/src/report-error.js
+++ b/packages/gatsby-plugin-sharp/src/report-error.js
@@ -1,0 +1,12 @@
+const reportError = (message, err, reporter) => {
+  if (reporter) {
+    reporter.error(message, err)
+  } else {
+    console.error(message, err)
+  }
+
+  if (process.env.gatsby_executing_command === `build`) {
+    process.exit(1)
+  }
+}
+exports.reportError = reportError

--- a/packages/gatsby-plugin-sharp/src/trace-svg.js
+++ b/packages/gatsby-plugin-sharp/src/trace-svg.js
@@ -1,0 +1,136 @@
+const { promisify } = require(`bluebird`)
+const crypto = require(`crypto`)
+const _ = require(`lodash`)
+const tmpDir = require(`os`).tmpdir()
+const sharp = require(`sharp`)
+
+const duotone = require(`./duotone`)
+const { getPluginOptions, healOptions } = require(`./plugin-options`)
+const { reportError } = require(`./report-error`)
+
+exports.notMemoizedPrepareTraceSVGInputFile = async ({
+  file,
+  options,
+  tmpFilePath,
+  reporter,
+}) => {
+  let pipeline
+  try {
+    pipeline = sharp(file.absolutePath).rotate()
+  } catch (err) {
+    reportError(`Failed to process image ${file.absolutePath}`, err, reporter)
+    return
+  }
+
+  pipeline
+    .resize(options.width, options.height, {
+      position: options.cropFocus,
+    })
+    .png({
+      compressionLevel: options.pngCompressionLevel,
+      adaptiveFiltering: false,
+      force: options.toFormat === `png`,
+    })
+    .jpeg({
+      quality: options.quality,
+      progressive: options.jpegProgressive,
+      force: options.toFormat === `jpg`,
+    })
+
+  // grayscale
+  if (options.grayscale) {
+    pipeline = pipeline.grayscale()
+  }
+
+  // rotate
+  if (options.rotate && options.rotate !== 0) {
+    pipeline = pipeline.rotate(options.rotate)
+  }
+
+  // duotone
+  if (options.duotone) {
+    pipeline = await duotone(options.duotone, options.toFormat, pipeline)
+  }
+
+  await new Promise((resolve, reject) =>
+    pipeline.toFile(tmpFilePath, err => {
+      if (err) {
+        return reject(err)
+      }
+      return resolve()
+    })
+  )
+}
+
+const optimize = svg => {
+  const SVGO = require(`svgo`)
+  const svgo = new SVGO({ multipass: true, floatPrecision: 0 })
+  return svgo.optimize(svg).then(({ data }) => data)
+}
+
+exports.notMemoizedtraceSVG = async ({ file, args, fileArgs, reporter }) => {
+  const options = healOptions(getPluginOptions(), fileArgs, file.extension)
+
+  const tmpFilePath = `${tmpDir}/${file.internal.contentDigest}-${
+    file.name
+  }-${crypto
+    .createHash(`md5`)
+    .update(JSON.stringify(options))
+    .digest(`hex`)}.${file.extension}`
+
+  try {
+    await exports.memoizedPrepareTraceSVGInputFile({
+      tmpFilePath,
+      file,
+      options,
+      reporter,
+    })
+
+    const svgToMiniDataURI = require(`mini-svg-data-uri`)
+    const potrace = require(`potrace`)
+    const trace = promisify(potrace.trace)
+
+    const defaultArgs = {
+      color: `lightgray`,
+      optTolerance: 0.4,
+      turdSize: 100,
+      turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
+    }
+
+    const optionsSVG = _.defaults(args, defaultArgs)
+
+    return trace(tmpFilePath, optionsSVG)
+      .then(optimize)
+      .then(svgToMiniDataURI)
+  } catch (e) {
+    throw e
+  }
+}
+
+let memoizedPrepareTraceSVGInputFile, memoizedTraceSVG
+const createMemoizedFunctions = () => {
+  exports.memoizedPrepareTraceSVGInputFile = memoizedPrepareTraceSVGInputFile = _.memoize(
+    exports.notMemoizedPrepareTraceSVGInputFile,
+    ({ tmpFilePath }) => tmpFilePath
+  )
+
+  exports.memoizedTraceSVG = memoizedTraceSVG = _.memoize(
+    exports.notMemoizedtraceSVG,
+    ({ file, args, fileArgs }) =>
+      `${file.internal.contentDigest}${JSON.stringify(args)}${JSON.stringify(
+        fileArgs
+      )}`
+  )
+}
+
+// This is very hacky, but memozied function are pretty tricky to spy on
+// in tests ;(
+createMemoizedFunctions()
+exports.createMemoizedFunctions = () => {
+  createMemoizedFunctions()
+}
+
+exports.clearMemoizeCaches = () => {
+  memoizedTraceSVG.cache.clear()
+  memoizedPrepareTraceSVGInputFile.cache.clear()
+}


### PR DESCRIPTION
Memoization key for tracedSVG was not entirely correct and we were trying to write to temporary file multiple times. This was causing those temporary files to become corrupted in dependencies of `potrace` were crashing while trying to read those corrupted input files (there was a lot of concurrency, so that's why those crashes were very random - sometimes timing was bad and we would end up . This _should_ fix memoization key and avoid writing to same file more than once - there is also extra memoization layer just for that, so if general memoization key for `traceSVG` function fails, there is another memoization that checks just temporary file location.

This was happening most likely when there were copies of same image in multiple places (as memoization key was using `absolutePath` before).

I've moved some code around (mostly because I needed to export some trace SVG related functions for added tests). I'll try to mark places in removed code that did change.

related issue #8301