### PR TITLE
fix(themes): Restrict the paths that count as shadowable for an issuer

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
@@ -1,0 +1,57 @@
+import ShadowingPlugin from "../"
+
+describe(`Component Shadowing`, () => {
+  it(`gets matching themes`, () => {
+    const plugin = new ShadowingPlugin({
+      themes: [`a-theme`, `theme-b`, `gatsby-theme-c`].map(name => {
+        return {
+          themeName: name,
+          themeDir: `/some/place/${name}`,
+        }
+      }),
+    })
+    expect(
+      // simple request path to a theme's component
+      plugin.getMatchingThemesForPath(
+        `/some/place/a-theme/src/components/a-component`
+      )
+    ).toEqual([`a-theme`])
+
+    expect(
+      // request to a shadowed component in theme b
+      // component-path is expected to be `a-theme/components/a-component`
+      plugin.getMatchingThemesForPath(
+        `/some/place/theme-b/src/a-theme/components/a-component`
+      )
+    ).toEqual([`theme-b`])
+  })
+
+  it(`can determine if the request path is in the shadow chain for the issuer`, () => {
+    const plugin = new ShadowingPlugin({
+      themes: [`a-theme`, `theme-b`, `gatsby-theme-c`].map(name => {
+        return {
+          themeName: name,
+          themeDir: `/some/place/${name}`,
+        }
+      }),
+    })
+    expect(
+      plugin.requestPathIsIssuerShadowPath({
+        // issuer is in `theme-b`
+        issuerPath: `/some/place/theme-b/src/a-theme/components/a-component`,
+        // require'ing a file it is a "shadow child" of in a-theme
+        requestPath: `/some/place/a-theme/src/components/a-component`,
+      })
+    ).toEqual(true)
+
+    expect(
+      plugin.requestPathIsIssuerShadowPath({
+        // issuer is in `theme-b`
+        issuerPath: `/some/place/theme-b/src/a-theme/components/a-component`,
+        // require'ing a file it is NOT a "shadow child" of, also in theme-b
+        // the `component-path` here would be "components/a-component"
+        requestPath: `/some/place/theme-b/src/components/a-component`,
+      })
+    ).toEqual(false)
+  })
+})

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
@@ -1,3 +1,4 @@
+import path from "path"
 import ShadowingPlugin from "../"
 
 describe(`Component Shadowing`, () => {
@@ -6,14 +7,22 @@ describe(`Component Shadowing`, () => {
       themes: [`a-theme`, `theme-b`, `gatsby-theme-c`].map(name => {
         return {
           themeName: name,
-          themeDir: `/some/place/${name}`,
+          themeDir: path.join(path.sep, `some`, `place`, name),
         }
       }),
     })
     expect(
       // simple request path to a theme's component
       plugin.getMatchingThemesForPath(
-        `/some/place/a-theme/src/components/a-component`
+        path.join(
+          path.sep,
+          `some`,
+          `place`,
+          `a-theme`,
+          `src`,
+          `components`,
+          `a-component`
+        )
       )
     ).toEqual([`a-theme`])
 
@@ -21,7 +30,16 @@ describe(`Component Shadowing`, () => {
       // request to a shadowed component in theme b
       // component-path is expected to be `a-theme/components/a-component`
       plugin.getMatchingThemesForPath(
-        `/some/place/theme-b/src/a-theme/components/a-component`
+        path.join(
+          path.sep,
+          `some`,
+          `place`,
+          `theme-b`,
+          `src`,
+          `a-theme`,
+          `components`,
+          `a-component`
+        )
       )
     ).toEqual([`theme-b`])
   })
@@ -31,26 +49,60 @@ describe(`Component Shadowing`, () => {
       themes: [`a-theme`, `theme-b`, `gatsby-theme-c`].map(name => {
         return {
           themeName: name,
-          themeDir: `/some/place/${name}`,
+          themeDir: path.join(path.sep, `some`, `place`, name),
         }
       }),
     })
     expect(
       plugin.requestPathIsIssuerShadowPath({
         // issuer is in `theme-b`
-        issuerPath: `/some/place/theme-b/src/a-theme/components/a-component`,
+        issuerPath: path.join(
+          path.sep,
+          `some`,
+          `place`,
+          `theme-b`,
+          `src`,
+          `a-theme`,
+          `components`,
+          `a-component`
+        ),
         // require'ing a file it is a "shadow child" of in a-theme
-        requestPath: `/some/place/a-theme/src/components/a-component`,
+        requestPath: path.join(
+          path.sep,
+          `some`,
+          `place`,
+          `a-theme`,
+          `src`,
+          `components`,
+          `a-component`
+        ),
       })
     ).toEqual(true)
 
     expect(
       plugin.requestPathIsIssuerShadowPath({
         // issuer is in `theme-b`
-        issuerPath: `/some/place/theme-b/src/a-theme/components/a-component`,
+        issuerPath: path.join(
+          path.sep,
+          `some`,
+          `place`,
+          `theme-b`,
+          `src`,
+          `a-theme`,
+          `components`,
+          `a-component`
+        ),
         // require'ing a file it is NOT a "shadow child" of, also in theme-b
         // the `component-path` here would be "components/a-component"
-        requestPath: `/some/place/theme-b/src/components/a-component`,
+        requestPath: path.join(
+          path.sep,
+          `some`,
+          `place`,
+          `theme-b`,
+          `src`,
+          `components`,
+          `a-component`
+        ),
       })
     ).toEqual(false)
   })

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/gatsby-node.js
@@ -11,7 +11,7 @@ exports.onCreateWebpackConfig = (
       resolve: {
         plugins: [
           new GatsbyThemeComponentShadowingResolverPlugin({
-            themes: themes.themes.map(({ themeName }) => themeName),
+            themes: themes.themes,
             projectRoot: program.directory,
           }),
         ],


### PR DESCRIPTION
This is an attempt to fix https://github.com/gatsbyjs/gatsby/issues/12813 by:

1. Creating a list of possible shadowing paths
2. Checking if the requested component path matches
3. Skipping the shadowing behavior

**NOTE: Right now this _does not_ work.**

I know I’m doing something wrong with the comparison, but I’m not exactly sure _what_ I’m doing wrong. 