### PR TITLE
fix(www): use a flatten to get all pages

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -455,7 +455,6 @@
       items:
         - title: As a Freelancer
           link: /docs/gatsby-for-freelancers/
-          items:
         - title: Inside an Agency
           link: /docs/gatsby-for-agencies/
           items:

--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -23,9 +23,7 @@ const flatten = pages =>
 
 class StubListRoute extends React.Component {
   render() {
-    const pages = flatten([...itemListContributing, ...itemListDocs])
-
-    let stubs = findStubs(pages)
+    const stubs = findStubs(flatten([...itemListContributing, ...itemListDocs]))
 
     return (
       <Layout location={this.props.location} itemList={itemListContributing}>

--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -10,29 +10,22 @@ import {
 import Container from "../../components/container"
 import DocsearchContent from "../../components/docsearch-content"
 
-function findStubs(pages) {
-  let stubs = []
+const findStubs = pages =>
+  pages.filter(
+    page => page.link !== undefined && page.title.indexOf(`*`) !== -1
+  )
 
-  pages.forEach(page => {
-    if (page.items !== undefined) {
-      // Recurse downwards
-      stubs.push(...findStubs(page.items))
-    }
-
-    if (page.link !== undefined && page.title.indexOf(`*`) !== -1) {
-      // found a page which is a stub
-      stubs.push(page)
-    }
-  })
-
-  return stubs
-}
+const flatten = pages =>
+  pages.reduce(
+    (flat, item) => flat.concat(item.items ? flatten(item.items) : item),
+    []
+  )
 
 class StubListRoute extends React.Component {
   render() {
-    let allPages = [...itemListContributing, ...itemListDocs]
+    const pages = flatten([...itemListContributing, ...itemListDocs])
 
-    let stubs = findStubs(allPages)
+    let stubs = findStubs(pages)
 
     return (
       <Layout location={this.props.location} itemList={itemListContributing}>


### PR DESCRIPTION
## Description

Due to [this line](https://github.com/gatsbyjs/gatsby/pull/12779/files#diff-355f19a97a68170ef2cd96a7e96c3398R449) we broke the build because the `page.items` compares against `undefined` instead of null.

```
success Building production JavaScript and CSS bundles — 101.484 s


  15 | 
  16 |   pages.forEach(page => {
> 17 |     if (page.items !== undefined) {
     |         ^
  18 |       // Recurse downwards
  19 |       stubs.push(...findStubs(page.items))
  20 |     }


  WebpackError: TypeError: Cannot read property 'forEach' of null
  
  - stub-list.js:17 findStubs
    lib/src/pages/contributing/stub-list.js:17:9
  
  - stub-list.js:20 
    lib/src/pages/contributing/stub-list.js:20:6
  
  
  - stub-list.js:17 findStubs
    lib/src/pages/contributing/stub-list.js:17:9
  
  - stub-list.js:20 
    lib/src/pages/contributing/stub-list.js:20:6
```

This fixes the sidebar issue, and introduces a flatten algorithm that is a little cleaner and should be more fault tolerant in the future.

