### PR TITLE
chore(docs): add starter library to docs sidebar under starters

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -157,6 +157,8 @@
     - title: Starters
       link: /docs/starters/
       items:
+        - title: Starter Library
+          link: /starters/
         - title: Create a Starter*
           link: /contributing/create-a-starter/
     - title: Styling Your Site

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -154,6 +154,8 @@
           link: /docs/creating-a-source-plugin/
         - title: Source Plugin Tutorial
           link: /docs/source-plugin-tutorial/
+        - title: Plugin Library
+          link: /plugins/
     - title: Starters
       link: /docs/starters/
       items:


### PR DESCRIPTION
 40% of people visiting the starters page go here next, so we should probably add this:

![image](https://user-images.githubusercontent.com/4388699/55285012-58d26180-5337-11e9-9259-68e81b4894ad.png)
