### PR TITLE
docs: fix graphql query example

### DIFF
--- a/docs/docs/programmatically-create-pages-from-data.md
+++ b/docs/docs/programmatically-create-pages-from-data.md
@@ -24,15 +24,17 @@ which is at the core of programmatically creating a page.
 ```js:title=gatsby-node.js
 exports.createPages = async function({ actions, graphql }) {
   const { data } = await graphql(`
-    allMarkdownRemark {
-      edges {
-        node {
-          fields {
-            slug
+    query {
+      allMarkdownRemark {
+        edges {
+          node {
+            fields {
+              slug
+             }
            }
          }
        }
-     }
+    }
   `)
   // highlight-start
   data.allMarkdownRemark.edges.forEach(edge => {

--- a/docs/docs/programmatically-create-pages-from-data.md
+++ b/docs/docs/programmatically-create-pages-from-data.md
@@ -30,10 +30,10 @@ exports.createPages = async function({ actions, graphql }) {
           node {
             fields {
               slug
-             }
-           }
-         }
-       }
+            }
+          }
+        }
+      }
     }
   `)
   // highlight-start


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

When following the tutorial, I encountered an unexpected syntax AllMarkdownRemark. This is caused by not wrapping the query inside a `query{ }`.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
