### PR TITLE
feat(docs): fix eslint warnings

### DIFF
--- a/www/src/pages/contributing/index.js
+++ b/www/src/pages/contributing/index.js
@@ -21,11 +21,11 @@ class IndexRoute extends React.Component {
               Contributing to Gatsby.js
             </h1>
             <p>
-              Thanks for being interested in contributing! We're so glad you
+              Thanks for for your interest in contributing! We&apos;re glad you
               want to help!
             </p>
             <p>
-              Below you'll find guides on the Gatsby.js community, code of
+              Below you&apos;ll find guides on the Gatsby.js community, code of
               conduct, and how to get started contributing:
             </p>
             <ul>


### PR DESCRIPTION
## Description

PR #12960 introduced two apostrophes, violating rule
`react/no-unescaped-entities`.  A basic `yarn test` reveals:

```
  24:63  warning  HTML entities must be escaped  react/no-unescaped-entities
```

This PR replaces the bare apostrophes with `&apos;`