### PR TITLE
chore(showcase): Add Assortment to site showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5147,3 +5147,14 @@
   built_by: William Neill
   built_by_url: https://twitter.com/williamneill
   featured: false
+- title: Assortment
+  main_url: https://assortment.io
+  url: https://assortment.io
+  description: >
+    Assortment aims to provide detailed tutorials (and more) for developers of all skill levels within the Web Development Industry. Attempting to cut out the fluff and arm you with the facts. 
+  categories:
+    - Blog
+    - Web Development
+  built_by: Luke Whitehouse
+  built_by_url: https://twitter.com/_lukewh
+  featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5151,7 +5151,7 @@
   main_url: https://assortment.io
   url: https://assortment.io
   description: >
-    Assortment aims to provide detailed tutorials (and more) for developers of all skill levels within the Web Development Industry. Attempting to cut out the fluff and arm you with the facts. 
+    Assortment aims to provide detailed tutorials (and more) for developers of all skill levels within the Web Development Industry. Attempting to cut out the fluff and arm you with the facts.
   categories:
     - Blog
     - Web Development


### PR DESCRIPTION
## Description

Adding [assortment.io](https://assortment.io) to site showcase. Assortment is my Web Development blog that I've recently updated to Gatsby, Netlify, Netlify CMS and Emotion. It'd be cool to see it on the showcase 😃