### PR TITLE
refactor(gatsby): expicitly call db saveState and autoSave

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -23,7 +23,6 @@ const tracer = require(`opentracing`).globalTracer()
 const preferDefault = require(`./prefer-default`)
 const nodeTracking = require(`../db/node-tracking`)
 const withResolverContext = require(`../schema/context`)
-require(`../db`).startAutosave()
 // Add `util.promisify` polyfill for old node versions
 require(`util.promisify/shim`)()
 

--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -7,6 +7,7 @@ const bootstrap = require(`../bootstrap`)
 const apiRunnerNode = require(`../utils/api-runner-node`)
 const { copyStaticDirs } = require(`../utils/get-static-dir`)
 const { initTracer, stopTracer } = require(`../utils/tracer`)
+const db = require(`../db`)
 const chalk = require(`chalk`)
 const tracer = require(`opentracing`).globalTracer()
 const signalExit = require(`signal-exit`)
@@ -41,6 +42,8 @@ module.exports = async function build(program: BuildArgs) {
     ...program,
     parentSpan: buildSpan,
   })
+
+  await db.saveState()
 
   await apiRunnerNode(`onPreBuild`, {
     graphql: graphqlRunner,

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -31,6 +31,7 @@ const getSslCert = require(`../utils/get-ssl-cert`)
 const slash = require(`slash`)
 const { initTracer } = require(`../utils/tracer`)
 const apiRunnerNode = require(`../utils/api-runner-node`)
+const db = require(`../db`)
 const telemetry = require(`gatsby-telemetry`)
 const detectPortInUseAndPrompt = require(`../utils/detect-port-in-use-and-prompt`)
 const onExit = require(`signal-exit`)
@@ -296,6 +297,8 @@ module.exports = async (program: any) => {
   }
 
   program.port = await detectPortInUseAndPrompt(port, rlInterface)
+
+  db.startAutosave()
 
   const [compiler] = await startServer(program)
 

--- a/packages/gatsby/src/db/index.js
+++ b/packages/gatsby/src/db/index.js
@@ -27,33 +27,14 @@ async function saveState() {
 const saveStateDebounced = _.debounce(saveState, 1000)
 
 /**
- * Sets up listeners so that once bootstrap has finished, all
- * databases save their state to disk. If we're in `develop` mode,
- * then any new event triggers a debounced save as well.
+ * Starts listening to redux actions and triggers a database save to
+ * disk upon any action (debounced to every 1 second)
  */
 function startAutosave() {
-  // During development, once bootstrap is finished, persist state on changes.
-  let bootstrapFinished = false
-  if (process.env.gatsby_executing_command === `develop`) {
-    emitter.on(`BOOTSTRAP_FINISHED`, () => {
-      bootstrapFinished = true
-      saveState()
-    })
-    emitter.on(`*`, () => {
-      if (bootstrapFinished) {
-        saveStateDebounced()
-      }
-    })
-  }
-
-  // During builds, persist state once bootstrap has finished.
-  if (process.env.gatsby_executing_command === `build`) {
-    emitter.on(`BOOTSTRAP_FINISHED`, () => {
-      saveState()
-    })
-  }
+  emitter.on(`*`, () => saveStateDebounced())
 }
 
 module.exports = {
   startAutosave,
+  saveState,
 }

--- a/packages/gatsby/src/db/index.js
+++ b/packages/gatsby/src/db/index.js
@@ -31,6 +31,7 @@ const saveStateDebounced = _.debounce(saveState, 1000)
  * disk upon any action (debounced to every 1 second)
  */
 function startAutosave() {
+  saveStateDebounced()
   emitter.on(`*`, () => saveStateDebounced())
 }
 


### PR DESCRIPTION
## Description

As part of my work on https://github.com/gatsbyjs/gatsby/pull/13004, I've been trying to remove reliance on global events such as `BOOTSTRAP_FINISHED`. There are definitely some good use cases for global events, but I feel in this case, the code is more clear by specifically invoking `db.saveState/autoSave`. Curious on other's thoughts.

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004