### PR TITLE
refactor(gatsby): move redirects-writer to bootstrap

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -38,9 +38,7 @@ const {
 } = require(`../internal-plugins/query-runner/page-query-runner`)
 const queryQueue = require(`../internal-plugins/query-runner/query-queue`)
 const { writePages } = require(`../internal-plugins/query-runner/pages-writer`)
-const {
-  writeRedirects,
-} = require(`../internal-plugins/query-runner/redirects-writer`)
+const { writeRedirects } = require(`./redirects-writer`)
 
 // Override console.log to add the source file + line number.
 // Useful for debugging if you lose a console.log somewhere.

--- a/packages/gatsby/src/bootstrap/redirects-writer.js
+++ b/packages/gatsby/src/bootstrap/redirects-writer.js
@@ -1,8 +1,8 @@
 import _ from "lodash"
 import crypto from "crypto"
 import fs from "fs-extra"
-import { store, emitter } from "../../redux/"
-import { joinPath } from "../../utils/path"
+import { store, emitter } from "../redux/"
+import { joinPath } from "../utils/path"
 
 let lastHash = null
 


### PR DESCRIPTION
## Description

In a future sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004, I'll be moving the `query-runner` from `src/internal-plugins/query-runner` to `src/query`. I was surprised to find that `redirects-writer` was part of `query-runner`. I think it makes more sense to be under `bootstrap` so have moved it.

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004