### PR TITLE
fix(link): URI encode the to field

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -118,6 +118,12 @@ describe(`<Link />`, () => {
       setup({ linkProps: { to } })
       expect(console.warn).toBeCalled()
     })
+
+    it(`supports non-encoded URIs`, () => {
+      const location = `/some bad url`
+      const { link } = setup({ linkProps: { to: location } })
+      expect(link.getAttribute(`href`)).toEqual(`${encodeURI(location)}`)
+    })
   })
 
   it(`push is called with correct args`, () => {

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -120,7 +120,7 @@ class GatsbyLink extends React.Component {
       )
     }
 
-    const prefixedTo = withPrefix(to)
+    const prefixedTo = withPrefix(encodeURI(to))
 
     return (
       <Link


### PR DESCRIPTION
## Description

Currently if you use a Link tag pointing at a non-URI encoded URL, it won't show as active on the page. This fixes it by URI encoding the 'to' passed into the Link.
