### PR TITLE
chore: mv codeowners to @gatsby/themes-core team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,8 +26,8 @@ appveyor.yml                                    @gatsbyjs/core
 
 # Themes 
 
-/docs/docs/themes/                              @gatsbyjs/themes
-/themes/                                        @gatsbyjs/themes
-/packages/gatsby/src/bootstrap/load-themes      @gatsbyjs/themes
-/packages/gatsby/src/bootstrap/index.js         @gatsbyjs/themes
-/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/   @gatsbyjs/themes
+/docs/docs/themes/                              @gatsbyjs/themes-core
+/themes/                                        @gatsbyjs/themes-core
+/packages/gatsby/src/bootstrap/load-themes      @gatsbyjs/themes-core
+/packages/gatsby/src/bootstrap/index.js         @gatsbyjs/themes-core
+/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/   @gatsbyjs/themes-core


### PR DESCRIPTION
I moved the reviewing themes team to @gatsbyjs/themes-core so that @gatsbyjs/themes can be used for more community oriented discussions and onboarding into themes and themes related projects. This commit changes the `CODEOWNERS` accordingly.