### PR TITLE
feat(gatsby): add util.promisify polyfill for older node version

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -124,6 +124,7 @@
     "true-case-path": "^1.0.3",
     "type-of": "^2.0.1",
     "url-loader": "^1.0.1",
+    "util.promisify": "^1.0.0",
     "uuid": "^3.1.0",
     "v8-compile-cache": "^1.1.0",
     "webpack": "~4.28.4",

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -24,6 +24,8 @@ const preferDefault = require(`./prefer-default`)
 const nodeTracking = require(`../db/node-tracking`)
 const withResolverContext = require(`../schema/context`)
 require(`../db`).startAutosave()
+// Add `util.promisify` polyfill for old node versions
+require(`util.promisify/shim`)()
 
 // Show stack trace on unhandled promises.
 process.on(`unhandledRejection`, (reason, p) => {


### PR DESCRIPTION
## Description

`util.promisify` was introduced in node v8, but gatsby still supports node v6. It's a useful utility when calling other libraries. Bluebird already supports [Promise.promisify](http://bluebirdjs.com/docs/api/promise.promisify.html), but not everyone is aware of it, and newcomers to gatsby will likely reach for `util.promisify` instead, since it's in the official node documentation.

This PR adds a polyfill for `util.promisify`.

## Related Issues

- enables https://github.com/gatsbyjs/gatsby/pull/13006
