### PR TITLE
fix(docs): expand guidelist on partnering with gatsby page

### DIFF
--- a/docs/docs/partnering-with-gatsby.md
+++ b/docs/docs/partnering-with-gatsby.md
@@ -1,5 +1,6 @@
 ---
 title: Partnering with Gatsby
+overview: true
 ---
 
 If you're an organization in the website space -- whether a vendor or an agency -- we'd love to work together with you.


### PR DESCRIPTION
Following up on #12970. Current https://www.gatsbyjs.org/docs/partnering-with-gatsby/:

![image](https://user-images.githubusercontent.com/21834/55404445-2f445080-5558-11e9-84d8-f75db8dd7297.png)
