### PR TITLE
fix(gatsby-transformer-documentationjs): handle free floating jsdocs

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -6,7 +6,7 @@ Object {
     Object {
       "name": "ObjectType",
       "type": "NameExpression",
-      "typeDef___NODE": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"}]",
+      "typeDef___NODE": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"}] line 12",
     },
     Object {
       "name": "Object",
@@ -21,11 +21,11 @@ Object {
 exports[`transformer-react-doc-gen: onCreateNode Complex example should handle typedefs should handle type applications 1`] = `
 Object {
   "children": Array [
-    "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"},{\\"fieldName\\":\\"properties\\",\\"fieldIndex\\":0}]--DocumentationJSComponentDescription--comment.description",
+    "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"},{\\"fieldName\\":\\"properties\\",\\"fieldIndex\\":0}] line 3--DocumentationJSComponentDescription--comment.description",
   ],
   "commentNumber": null,
-  "description___NODE": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"},{\\"fieldName\\":\\"properties\\",\\"fieldIndex\\":0}]--DocumentationJSComponentDescription--comment.description",
-  "id": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"},{\\"fieldName\\":\\"properties\\",\\"fieldIndex\\":0}]",
+  "description___NODE": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"},{\\"fieldName\\":\\"properties\\",\\"fieldIndex\\":0}] line 3--DocumentationJSComponentDescription--comment.description",
+  "id": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"},{\\"fieldName\\":\\"properties\\",\\"fieldIndex\\":0}] line 3",
   "internal": Object {
     "contentDigest": "content-digest",
     "type": "DocumentationJs",
@@ -33,7 +33,7 @@ Object {
   "level": 1,
   "name": "ready",
   "optional": false,
-  "parent": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"}]",
+  "parent": "documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"}] line 12",
   "type": Object {
     "applications": Array [
       Object {

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/code.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/code.js
@@ -8,39 +8,3 @@
 exports.apple = paramName => {
   console.log(`hi`)
 }
-
-/**
- * Description of callback type
- * @callback CallbackType
- * @param {string} message A message to split
- * @returns {string[]} Splitted message
- */
-
-/**
- * More complex example
- */
-exports.complex = {
-  /**
-   * Description of object type
-   * @typedef {Object} ObjectType
-   * @property {Promise<any>} ready Returns promise that resolves when instance is ready to use
-   * @property {Object} nested This is nested object
-   * @property {string} nested.foo This is field in nested object
-   * @property {number} [nested.optional] This is optional field in nested object
-   * @property {CallbackType} nested.callback This is function in nested object
-   */
-
-  /**
-   * Description of function
-   * @type {(ObjectType|Object)}
-   */
-  object: {
-    ready: new Promise(),
-    nested: {
-      foo: `bar`,
-      callback: message => { 
-        return message.split(`,`)
-      }
-    }
-  }
-}

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/complex-example.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/complex-example.js
@@ -1,0 +1,35 @@
+/**
+ * Description of callback type
+ * @callback CallbackType
+ * @param {string} message A message to split
+ * @returns {string[]} Splitted message
+ */
+
+/**
+ * More complex example
+ */
+exports.complex = {
+  /**
+   * Description of object type
+   * @typedef {Object} ObjectType
+   * @property {Promise<any>} ready Returns promise that resolves when instance is ready to use
+   * @property {Object} nested This is nested object
+   * @property {string} nested.foo This is field in nested object
+   * @property {number} [nested.optional] This is optional field in nested object
+   * @property {CallbackType} nested.callback This is function in nested object
+   */
+
+  /**
+   * Description of function
+   * @type {(ObjectType|Object)}
+   */
+  object: {
+    ready: new Promise(),
+    nested: {
+      foo: `bar`,
+      callback: message => { 
+        return message.split(`,`)
+      }
+    }
+  }
+}

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/free-floating.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/free-floating.js
@@ -1,0 +1,8 @@
+/**
+ * This is a free-floating comment
+ */
+
+/**
+ * This is a function
+ */
+const fn = () => {}

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
@@ -117,8 +117,9 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
     })
 
     it(`doesn't create multiple nodes with same id`, () => {
-      Object.values(groupBy(createdNodes, `id`)).forEach(nodes =>
-        expect(nodes.length).toBe(1)
+      const groupedById = groupBy(createdNodes, `id`)
+      Object.keys(groupedById).forEach(id =>
+        expect(groupedById[id].length).toBe(1)
       )
     })
   })
@@ -246,8 +247,9 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
     })
 
     it(`doesn't create multiple nodes with same id`, () => {
-      Object.values(groupBy(createdNodes, `id`)).forEach(nodes =>
-        expect(nodes.length).toBe(1)
+      const groupedById = groupBy(createdNodes, `id`)
+      Object.keys(groupedById).forEach(id =>
+        expect(groupedById[id].length).toBe(1)
       )
     })
   })
@@ -258,8 +260,9 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
     })
 
     it(`doesn't create multiple nodes with same id`, () => {
-      Object.values(groupBy(createdNodes, `id`)).forEach(nodes =>
-        expect(nodes.length).toBe(1)
+      const groupedById = groupBy(createdNodes, `id`)
+      Object.keys(groupedById).forEach(id =>
+        expect(groupedById[id].length).toBe(1)
       )
     })
   })

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
@@ -7,14 +7,16 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
   const createNodeId = jest.fn(id => id)
   const createContentDigest = jest.fn().mockReturnValue(`content-digest`)
 
-  const node = {
-    id: `node_1`,
-    children: [],
-    absolutePath: path.join(__dirname, `fixtures`, `code.js`),
-    internal: {
-      mediaType: `application/javascript`,
-      type: `File`,
-    },
+  const getFileNode = fixture => {
+    return {
+      id: `node_1`,
+      children: [],
+      absolutePath: path.join(__dirname, `fixtures`, fixture),
+      internal: {
+        mediaType: `application/javascript`,
+        type: `File`,
+      },
+    }
   }
 
   const actions = {
@@ -44,11 +46,11 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
     )
   }
 
-  beforeAll(async () => {
-    await run(node)
-  })
-
   describe(`Simple example`, () => {
+    beforeAll(async () => {
+      await run(getFileNode(`code.js`))
+    })
+
     it(`creates doc json apple node`, () => {
       const appleNode = createdNodes.find(node => node.name === `apple`)
       expect(appleNode).toBeDefined()
@@ -113,9 +115,19 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
         })
       )
     })
+
+    it(`doesn't create multiple nodes with same id`, () => {
+      Object.values(groupBy(createdNodes, `id`)).forEach(nodes =>
+        expect(nodes.length).toBe(1)
+      )
+    })
   })
 
   describe(`Complex example`, () => {
+    beforeAll(async () => {
+      await run(getFileNode(`complex-example.js`))
+    })
+
     let callbackNode, typedefNode
 
     it(`should create top-level node for callback`, () => {
@@ -232,6 +244,24 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
         expect(typeElement.typeDef___NODE).toBe(typedefNode.id)
       })
     })
+
+    it(`doesn't create multiple nodes with same id`, () => {
+      Object.values(groupBy(createdNodes, `id`)).forEach(nodes =>
+        expect(nodes.length).toBe(1)
+      )
+    })
+  })
+
+  describe(`Free floating comments`, () => {
+    beforeAll(async () => {
+      await run(getFileNode(`free-floating.js`))
+    })
+
+    it(`doesn't create multiple nodes with same id`, () => {
+      Object.values(groupBy(createdNodes, `id`)).forEach(nodes =>
+        expect(nodes.length).toBe(1)
+      )
+    })
   })
 
   describe(`Sanity checks`, () => {
@@ -262,7 +292,7 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
       await run({ internal: { mediaType: `application/javascript` } })
       expect(createdNodes.length).toBe(0)
 
-      await run(node)
+      await run(getFileNode(`code.js`))
       expect(createdNodes.length).toBeGreaterThan(0)
     })
   })

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -11,8 +11,16 @@ const stringifyMarkdownAST = (node = ``) => {
   }
 }
 
-const docId = (parentId, docsJson) =>
-  `documentationJS ${parentId} path #${JSON.stringify(docsJson.path)}`
+const docId = (parentId, docsJson) => {
+  const lineNumber = docsJson.loc
+    ? docsJson.loc.start.line
+    : docsJson.lineNumber
+
+  return `documentationJS ${parentId} path #${JSON.stringify(
+    docsJson.path
+  )} line ${lineNumber}`
+}
+
 const descriptionId = (parentId, name) =>
   `${parentId}--DocumentationJSComponentDescription--${name}`
 


### PR DESCRIPTION
This is not great fix, but it is fix for issue described in #13052 . This is happening because `documention` package creates 2 jsdocs for same object. I'm not sure if "free floating" jsdoc is valid or not (in scenarios other than defining type definition / callback), but because this is problematic quick fix is to not create multiple nodes with same `id`


Fixes #13052