### PR TITLE
feat(www): don't check for overview frontmatter

### DIFF
--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -32,10 +32,6 @@ const childItemsBySlug = (docsHierarchy, slug) => {
 }
 
 const getPageHTML = page => {
-  if (!page.frontmatter.overview) {
-    return page.html
-  }
-
   const subitemsForPage =
     childItemsBySlug(docsHierarchy, page.fields.slug) || []
   const subitemList = subitemsForPage


### PR DESCRIPTION
Fixes `[[guidelist]]` not being replaced in few pages (i.e. in https://www.gatsbyjs.org/docs/winning-over-stakeholders/ )

The code is handling cases when there are no children (tried building locally and it worked just fine).

Follow up to this would be to clear `.md` files that use `overview` and adjust page query. But this is just quick fix.