### PR TITLE
refactor(gatsby): Refactor query calc query ids

### DIFF
--- a/packages/gatsby/src/query/page-query-runner.js
+++ b/packages/gatsby/src/query/page-query-runner.js
@@ -64,8 +64,8 @@ const findIdsWithoutDataDependencies = state => {
   return notTrackedIds
 }
 
-const findDirtyIds = actions => {
-  const state = store.getState()
+const popNodeQueries = state => {
+  const actions = _.uniq(queuedDirtyActions, a => a.payload.id)
   const uniqDirties = _.uniq(
     actions.reduce((dirtyIds, action) => {
       const node = action.payload
@@ -83,18 +83,19 @@ const findDirtyIds = actions => {
       return _.compact(dirtyIds)
     }, [])
   )
+  queuedDirtyActions = []
   return uniqDirties
 }
 
 const calcQueries = (initial = false) => {
+  const state = store.getState()
+
   // Find paths dependent on dirty nodes
-  queuedDirtyActions = _.uniq(queuedDirtyActions, a => a.payload.id)
-  const dirtyIds = findDirtyIds(queuedDirtyActions)
-  queuedDirtyActions = []
+  const dirtyIds = popNodeQueries(state)
 
   // Find ids without data dependencies (i.e. no queries have been run for
   // them before) and run them.
-  const cleanIds = findIdsWithoutDataDependencies(store.getState())
+  const cleanIds = findIdsWithoutDataDependencies(state)
 
   // Construct paths for all queries to run
   let pathnamesToRun = _.uniq([...dirtyIds, ...cleanIds])

--- a/packages/gatsby/src/query/page-query-runner.js
+++ b/packages/gatsby/src/query/page-query-runner.js
@@ -9,9 +9,9 @@ const queryQueue = require(`./queue`)
 
 let queuedDirtyActions = []
 
-const runQueriesForPathnamesQueue = new Set()
-const queueQueryForPathname = pathname => {
-  runQueriesForPathnamesQueue.add(pathname)
+const extractedQueryIds = new Set()
+const enqueueExtractedQueryId = pathname => {
+  extractedQueryIds.add(pathname)
 }
 
 const calcQueries = (initial = false) => {
@@ -27,25 +27,22 @@ const calcQueries = (initial = false) => {
   // Construct paths for all queries to run
   let pathnamesToRun = _.uniq([...dirtyIds, ...cleanIds])
 
-  // If this is the initial run, remove pathnames from `runQueriesForPathnamesQueue`
+  // If this is the initial run, remove pathnames from `extractedQueryIds`
   // if they're also not in the dirtyIds or cleanIds.
   //
   // We do this because the page component reducer/machine always
-  // adds pages to runQueriesForPathnamesQueue but during bootstrap
+  // adds pages to extractedQueryIds but during bootstrap
   // we may not want to run those page queries if their data hasn't
   // changed since the last time we ran Gatsby.
-  let diffedPathnames = [...runQueriesForPathnamesQueue]
+  let diffedPathnames = [...extractedQueryIds]
   if (initial) {
-    diffedPathnames = _.intersection(
-      [...runQueriesForPathnamesQueue],
-      pathnamesToRun
-    )
+    diffedPathnames = _.intersection([...extractedQueryIds], pathnamesToRun)
   }
 
   // Combine.
   pathnamesToRun = _.union(diffedPathnames, pathnamesToRun)
 
-  runQueriesForPathnamesQueue.clear()
+  extractedQueryIds.clear()
 
   return pathnamesToRun
 }
@@ -228,5 +225,5 @@ module.exports = {
   runInitialQueries,
   startListening,
   runQueuedQueries,
-  queueQueryForPathname,
+  enqueueExtractedQueryId,
 }

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -18,7 +18,7 @@ const { boundActionCreators } = require(`../redux/actions`)
 const queryCompiler = require(`./query-compiler`).default
 const report = require(`gatsby-cli/lib/reporter`)
 const {
-  queueQueryForPathname,
+  enqueueExtractedQueryId,
   runQueuedQueries,
 } = require(`./page-query-runner`)
 const debug = require(`debug`)(`gatsby:query-watcher`)
@@ -89,7 +89,7 @@ const handleQuery = (
       )
 
       boundActionCreators.deleteComponentsDependencies([query.jsonName])
-      queueQueryForPathname(query.jsonName)
+      enqueueExtractedQueryId(query.jsonName)
     }
     return true
   }
@@ -210,12 +210,12 @@ const queueQueriesForPageComponent = componentPath => {
   boundActionCreators.deleteComponentsDependencies(
     pages.map(p => p.path || p.id)
   )
-  pages.forEach(page => queueQueryForPathname(page.path))
+  pages.forEach(page => enqueueExtractedQueryId(page.path))
   runQueuedQueries()
 }
 
 const runQueryForPage = path => {
-  queueQueryForPathname(path)
+  enqueueExtractedQueryId(path)
   runQueuedQueries()
 }
 


### PR DESCRIPTION
## Description

A purely cosmetic refactor. I found the logic in `page-query-runner/runQueries` difficult to get my head around. Hopefully it's a little better now but I'm sure it can still be improved.

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004
- builds on https://github.com/gatsbyjs/gatsby/pull/13061