### PR TITLE
fix(www): Hubspot form UI

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -69,7 +69,6 @@
     "react-dom": "^16.4.1",
     "react-helmet": "^5.2.0",
     "react-highcharts": "^16.0.2",
-    "react-hubspot-form": "^1.3.5",
     "react-icons": "^2.2.7",
     "react-instantsearch": "^4.5.1",
     "react-modal": "^3.4.4",

--- a/www/src/components/hubspot-form.js
+++ b/www/src/components/hubspot-form.js
@@ -1,10 +1,9 @@
 import React, { Component } from "react"
-import HubspotForm from "react-hubspot-form"
+import HubspotForm from "./react-hubspot-form"
 import hex2rgba from "hex2rgba"
 
 import { colors, radii, space, scale } from "../utils/presets"
-import { formInput } from "../utils/styles"
-import { buttonStyles } from "../utils/styles"
+import { formInput, buttonStyles } from "../utils/styles"
 
 export default class GatsbyHubspotForm extends Component {
   render() {

--- a/www/src/components/react-hubspot-form.js
+++ b/www/src/components/react-hubspot-form.js
@@ -1,0 +1,108 @@
+// this is a copy of react-hubspot-form@1.3.7, patched
+// to work around a problem with emotion's `css` prop —
+// see the comment starting with "patch" in this file
+//
+// react-hubspot-form allows passing options to HubSpot
+// via props https://github.com/escaladesports/react-hubspot-form#options
+//
+// we want to set the `css` option to an empty string to bypass
+// loading HubSpot's default form CSS, see
+// https://developers.hubspot.com/docs/methods/forms/advanced_form_options
+//
+// to bypass emotion, we used to spread the prop
+// which used to work:
+// https://github.com/gatsbyjs/gatsby/blob/bb43fe0c926f2b5d06fb6e9fa3a057ad5d3a685d/www/src/components/hubspot-form.js#L64
+// … but now it doesn't anymore
+
+import React from "react"
+
+let globalId = 0
+
+class HubspotForm extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      loaded: false,
+    }
+    this.id = globalId++
+    this.createForm = this.createForm.bind(this)
+    this.findFormElement = this.findFormElement.bind(this)
+  }
+  createForm() {
+    if (window.hbspt) {
+      // protect against component unmounting before window.hbspt is available
+      if (this.el === null) {
+        return
+      }
+      let props = {
+        ...this.props,
+      }
+      delete props.loading
+      delete props.onSubmit
+      delete props.onReady
+      let options = {
+        ...props,
+        // patch: disable HubSpot's default CSS
+        css: ``,
+        target: `#${this.el.getAttribute(`id`)}`,
+        onFormSubmit: $form => {
+          // ref: https://developers.hubspot.com/docs/methods/forms/advanced_form_options
+          var formData = $form.serializeArray()
+          this.props.onSubmit(formData)
+        },
+      }
+      window.hbspt.forms.create(options)
+      return true
+    } else {
+      setTimeout(this.createForm, 1)
+    }
+  }
+  loadScript() {
+    let script = document.createElement(`script`)
+    script.defer = true
+    script.onload = () => {
+      this.createForm()
+      this.findFormElement()
+    }
+    script.src = `//js.hsforms.net/forms/v2.js`
+    document.head.appendChild(script)
+  }
+  findFormElement() {
+    // protect against component unmounting before form is added
+    if (this.el === null) {
+      return
+    }
+    let form = this.el.querySelector(`iframe`)
+    if (form) {
+      this.setState({ loaded: true })
+      if (this.props.onReady) {
+        this.props.onReady(form)
+      }
+    } else {
+      setTimeout(this.findFormElement, 1)
+    }
+  }
+  componentDidMount() {
+    if (!window.hbspt && !this.props.noScript) {
+      this.loadScript()
+    } else {
+      this.createForm()
+      this.findFormElement()
+    }
+  }
+  componentWillUnmount() {}
+  render() {
+    return (
+      <div>
+        <div
+          ref={el => (this.el = el)}
+          id={`reactHubspotForm${this.id}`}
+          style={{ display: this.state.loaded ? `block` : `none` }}
+        />
+        {!this.state.loaded && this.props.loading}
+      </div>
+    )
+  }
+}
+
+export default HubspotForm

--- a/www/src/components/react-hubspot-form.js
+++ b/www/src/components/react-hubspot-form.js
@@ -52,7 +52,7 @@ class HubspotForm extends React.Component {
         },
       }
       window.hbspt.forms.create(options)
-      return true
+      return
     } else {
       setTimeout(this.createForm, 1)
     }

--- a/www/src/utils/styles.js
+++ b/www/src/utils/styles.js
@@ -158,8 +158,8 @@ export const formInput = {
   border: `1px solid ${colors.ui.bright}`,
   borderRadius: radii[1],
   color: colors.brand,
-  fontFamily: fonts.header,
-  padding: space[3],
+  padding: space[2],
+  fontSize: scale[2],
   verticalAlign: `middle`,
   transition: `all ${transition.speed.default} ${transition.curve.default}`,
   "::placeholder": {


### PR DESCRIPTION
Currently the Hubspot form UI at https://www.gatsbyjs.org/blog/2018-08-01-partner-program/#partner-application-form looks quite a bit broken. This wasn't always the case.

Under the hood we are using https://github.com/escaladesports/react-hubspot-form. It allows passing options to HubSpot (https://github.com/escaladesports/react-hubspot-form#options) via component props, which we at some point successfully used to disable the default HubSpot CSS: https://github.com/gatsbyjs/gatsby/blob/bb43fe0c926f2b5d06fb6e9fa3a057ad5d3a685d/www/src/components/hubspot-form.js#L64

I understand we did t like this to bypass emotions `css` prop. I strongly suppose this doesn't work anymore; it looks like the styling issues are caused by us currently loading the HubSpot default CSS — please compare their default CSS documented at https://designers.hubspot.com/docs/cos/hubspot-form-markup#default-embedded-form-css to what I'm seeing on .org:

![image (3)](https://user-images.githubusercontent.com/21834/55486812-3c7f3f00-562d-11e9-8c5b-207cecc7b10b.png)

This PR works around the issue by pulling in the current version of `react-hubspot-form` locally, and setting the `css` option there. I don't know if there's a more elegant way to fix this. Happy to make adjustments!

---

Along the way, I adjusted the hubspot form input styles to match the reference "Homepage Newsletter" input; before/after:

![image](https://user-images.githubusercontent.com/21834/55487110-c4654900-562d-11e9-825f-76b6069a27f3.png)

![image](https://user-images.githubusercontent.com/21834/55487035-a3045d00-562d-11e9-963c-378f4180c257.png)
