### PR TITLE
fix(gatsby): ignore __esModule export in gatsby-node exports

### DIFF
--- a/packages/gatsby/src/bootstrap/__mocks__/require/exports.js
+++ b/packages/gatsby/src/bootstrap/__mocks__/require/exports.js
@@ -1,2 +1,3 @@
 exports.foo = () => {}
 exports.bar = () => {}
+exports.__esModule = true

--- a/packages/gatsby/src/bootstrap/__mocks__/require/unusual-exports.js
+++ b/packages/gatsby/src/bootstrap/__mocks__/require/unusual-exports.js
@@ -4,3 +4,6 @@ Object.defineProperty(exports, `foo`, {
     return () => {}
   },
 })
+Object.defineProperty(exports, `__esModule`, {
+  value: true,
+})

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -123,7 +123,9 @@ https://gatsby.dev/no-mixed-modules
 module.exports = (modulePath, { mode = `analysis`, resolver } = {}) => {
   if (mode === `require`) {
     try {
-      return Object.keys(require(modulePath))
+      return Object.keys(require(modulePath)).filter(
+        exportName => exportName !== `__esModule`
+      )
     } catch {
       return []
     }


### PR DESCRIPTION
I introduced bug/regression in https://github.com/gatsbyjs/gatsby/pull/13053 by not removing `__esModule` export name from resolved export names - it break some plugins

Fixes: #13079