### PR TITLE
fix(gatsby-telemetry): Ensure we capture cli version even with older gatsby-cli

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -4,7 +4,7 @@ const EventStorage = require(`./event-storage`)
 const sanitizeError = require(`./sanitize-error`)
 const ci = require(`ci-info`)
 const os = require(`os`)
-const { basename, join } = require(`path`)
+const { basename, join, sep } = require(`path`)
 const { execSync } = require(`child_process`)
 
 module.exports = class AnalyticsTracker {
@@ -43,7 +43,15 @@ module.exports = class AnalyticsTracker {
 
   getGatsbyCliVersion() {
     try {
-      const { version } = require(`../package.json`)
+      const jsonfile = join(
+        require
+          .resolve(`gatsby-cli`) // Resolve where current gatsby-cli would be loaded from.
+          .split(sep)
+          .slice(0, -2) // drop lib/index.js
+          .join(sep),
+        `package.json`
+      )
+      const { version } = require(jsonfile).version
       return version
     } catch (e) {
       // ignore

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -4,7 +4,7 @@ const EventStorage = require(`./event-storage`)
 const sanitizeError = require(`./sanitize-error`)
 const ci = require(`ci-info`)
 const os = require(`os`)
-const { basename } = require(`path`)
+const { basename, join } = require(`path`)
 const { execSync } = require(`child_process`)
 
 module.exports = class AnalyticsTracker {
@@ -19,11 +19,37 @@ module.exports = class AnalyticsTracker {
   constructor() {
     try {
       this.componentVersion = require(`../package.json`).version
+      this.installedGatsbyVersion = this.getGatsbyVersion()
+      this.gatsbyCliVersion = this.getGatsbyCliVersion()
     } catch (e) {
       // ignore
     }
   }
 
+  getGatsbyVersion() {
+    const packageInfo = require(join(
+      process.cwd(),
+      `node_modules`,
+      `gatsby`,
+      `package.json`
+    ))
+    try {
+      return packageInfo.version
+    } catch (e) {
+      // ignore
+    }
+    return undefined
+  }
+
+  getGatsbyCliVersion() {
+    try {
+      const { version } = require(`../package.json`)
+      return version
+    } catch (e) {
+      // ignore
+    }
+    return undefined
+  }
   captureEvent(type = ``, tags = {}) {
     if (!this.isTrackingEnabled()) {
       return
@@ -73,6 +99,8 @@ module.exports = class AnalyticsTracker {
 
   buildAndStoreEvent(eventType, tags) {
     const event = {
+      installedGatsbyVersion: this.installedGatsbyVersion,
+      gatsbyCliVersion: this.gatsbyCliVersion,
       ...this.defaultTags,
       ...tags, // The schema must include these
       eventType,


### PR DESCRIPTION
This copies over the version metadata collection from `gatsby-cli/src/createCli.js`