### PR TITLE
[WIP]: feat(docs): add creating an example project to docs

### DIFF
--- a/docs/contributing/how-to-make-an-example-project.md
+++ b/docs/contributing/how-to-make-an-example-project.md
@@ -1,0 +1,23 @@
+---
+title: How to Make an Example Project
+---
+
+> Looking for how to create a reproduction for a Gatsby bug? Check out [How to Make a Reproducible Test Case][reproducible-test-case]
+
+## What is an example project?
+
+An example project is a project that can be used to validate that an issue exists or has been addressed with a fix or a new feature. For example, if a pull request is opened fixing an issue in a plugin, an example project would have been used to _validate_ that the issue both exists and also that it can be fixed with the proposed solution.
+
+## Why should you create an example project?
+
+An example project helps the maintainers of Gatsby establish context and similarly validate the changes in a PR in an isolated system. Oftentimes the burden of creating these example projects is put onto the maintainers, which can be a time-consuming and sometimes challenging process. Providing this example project **up front** in the pull request or issue lets us focus on quickly shipping and delivering features and fixes to as many users of Gatsby as possible.
+
+## Steps to create an example project
+
+- If connecting to some third party system (Wordpress, Drupal, etc.), the system should be configured to demonstrate the issue
+  - Necesary plugins and/or features are configured appropriately
+  - (If necessary) credentials provided to the Gatsby maintainer to access
+- If using a Gatsby project to connect to this project, consider checking out [How to Make a Reproducible Test Case][reproducible-test-case]
+  - For example, if fixing a bug in Contentful a Gatsby project would come pre-configured with access to Contentful
+
+[reproducible-test-case]: /contributing/how-to-make-a-reproduction/

--- a/www/src/data/sidebars/contributing-links.yaml
+++ b/www/src/data/sidebars/contributing-links.yaml
@@ -29,6 +29,8 @@
           link: /contributing/how-to-file-an-issue/
         - title: How to Make a Reproducible Test Case
           link: /contributing/how-to-make-a-reproducible-test-case/
+        - title: How to Make an Example Project
+          link: /contributing/how-to-make-an-example-project/
         - title: How to Label an Issue
           link: /contributing/how-to-label-an-issue/
         - title: Triaging GitHub Issues


### PR DESCRIPTION
## Description

This PR adds a doc for creating an "Example Project" that we can use for issues/PRs/etc. when an example is helpful. This is solving an issue with pull requests being opened that are very hard to validate (e.g. specific Wordpress setup causing issues), so it'd be nice to point to something to speed up the review process.

This is (and should be?) separate from [Creating a Reproducible Test Case](https://gatsby.dev/reproduction) but I'm happy to tweak this to be additional notes on the existing document, as well. Unsure which is clearer!

Few notes:

- Not convinced this should go in the sidebar (seems confusing?)
- Unsure of terminology: "Example Project" seems OK, but open to something else