### PR TITLE
refactor(gatsby): explicitly watch delete page from gatsby develop

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -34,6 +34,7 @@ const apiRunnerNode = require(`../utils/api-runner-node`)
 const telemetry = require(`gatsby-telemetry`)
 const detectPortInUseAndPrompt = require(`../utils/detect-port-in-use-and-prompt`)
 const onExit = require(`signal-exit`)
+const queryWatcher = require(`../query/query-watcher`)
 
 // const isInteractive = process.stdout.isTTY
 
@@ -86,6 +87,8 @@ async function startServer(program) {
 
   // Start bootstrap process.
   await bootstrap(program)
+
+  queryWatcher.startWatchDeletePage()
 
   await createIndexHtml()
 

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -267,32 +267,24 @@ const watch = rootDir => {
   filesToWatch.forEach(filePath => watcher.add(filePath))
 }
 
-if (process.env.gatsby_executing_command === `develop`) {
-  let bootstrapFinished = false
-
-  emitter.on(`BOOTSTRAP_FINISHED`, () => {
-    bootstrapFinished = true
-  })
-
+exports.startWatchDeletePage = () => {
   emitter.on(`DELETE_PAGE`, action => {
-    if (bootstrapFinished) {
-      const componentPath = slash(action.payload.component)
-      const { pages } = store.getState()
-      let otherPageWithTemplateExists = false
-      for (let page of pages.values()) {
-        if (slash(page.component) === componentPath) {
-          otherPageWithTemplateExists = true
-          break
-        }
+    const componentPath = slash(action.payload.component)
+    const { pages } = store.getState()
+    let otherPageWithTemplateExists = false
+    for (let page of pages.values()) {
+      if (slash(page.component) === componentPath) {
+        otherPageWithTemplateExists = true
+        break
       }
-      if (!otherPageWithTemplateExists) {
-        store.dispatch({
-          type: `REMOVE_TEMPLATE_COMPONENT`,
-          payload: {
-            componentPath,
-          },
-        })
-      }
+    }
+    if (!otherPageWithTemplateExists) {
+      store.dispatch({
+        type: `REMOVE_TEMPLATE_COMPONENT`,
+        payload: {
+          componentPath,
+        },
+      })
     }
   })
 }


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/pull/13004, the idea of when bootstrap "finishes" is changing. To help with that, I'm trying to remove reliance on the `BOOTSTRAP_FINISHED` event. This PR is a small change to start watching for `DELETE_PAGE` events explicitly in `gatsby develop`, rather than rely on the global event.

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004
- builds on https://github.com/gatsbyjs/gatsby/pull/13016