### PR TITLE
feat(gatsby-source-filesystem): add an environment variable to control concurrent queue size

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -62,6 +62,8 @@ They will be added to the following default list:
 ../**/dist/**
 ```
 
+To prevent concurrent requests overload of `processRemoteNode`, you can adjust the `200` default concurrent downloads, with `GATSBY_CONCURRENT_DOWNLOAD` environment variable.
+
 ## How to query
 
 You can query file nodes like the following:

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -81,7 +81,7 @@ const createFilePath = (directory, filename, ext) =>
 const queue = new Queue(pushToQueue, {
   id: `url`,
   merge: (old, _, cb) => cb(old),
-  concurrent: 200,
+  concurrent: process.env.GATSBY_CONCURRENT_DOWNLOAD || 200,
 })
 
 /**


### PR DESCRIPTION
related to #13073
