### PR TITLE
fix(gatsby): bail early if pageResources are not available in public pageRenderer

### DIFF
--- a/packages/gatsby/cache-dir/public-page-renderer-prod.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-prod.js
@@ -6,6 +6,10 @@ import loader from "./loader"
 
 const ProdPageRenderer = ({ location }) => {
   const pageResources = loader.getResourcesForPathnameSync(location.pathname)
+  if (!pageResources) {
+    return null
+  }
+
   return React.createElement(InternalPageRenderer, {
     location,
     pageResources,

--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -76,7 +76,9 @@ class DefaultLayout extends React.Component {
     if (isModal && window.innerWidth > 750) {
       return (
         <>
-          <PageRenderer location={{ pathname: this.props.location.pathname }} />
+          <PageRenderer
+            location={{ pathname: this.props.modalBackgroundPath }}
+          />
           <Modal
             isOpen={true}
             style={{

--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -76,9 +76,7 @@ class DefaultLayout extends React.Component {
     if (isModal && window.innerWidth > 750) {
       return (
         <>
-          <PageRenderer
-            location={{ pathname: this.props.modalBackgroundPath }}
-          />
+          <PageRenderer location={{ pathname: this.props.location.pathname }} />
           <Modal
             isOpen={true}
             style={{


### PR DESCRIPTION
See https://github.com/gatsbyjs/gatsby/issues/12138

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
