### PR TITLE
Improve docs for Cypress / start-server-and-test

### DIFF
--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -32,7 +32,7 @@ Last but not least you add additional scripts to your `package.json` to run Cypr
 
 Run `test:e2e` in your command line and see Cypress running for the first time. A folder named `cypress` will be created at the root of your project and a new application window will pop up. [Cypress' getting started guide](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html#) is a good start to learn how to write tests!
 
-Important note: If you are running Gatsby with the `--https` flag, whether using your own or automatically generated certificates, you will also need to tell `start-server-and-test` to disable HTTPS certificate checks (otherwise it will wait forever and never actually launch cypress. You do this using by passing in an environmental variable: `START_SERVER_AND_TEST_INSECURE=1`. ([docs](https://github.com/bahmutov/start-server-and-test#disable-https-certificate-checks)). 
+*Important note*: If you are running Gatsby with the `--https` flag, whether using your own or automatically generated certificates, you will also need to tell `start-server-and-test` to disable HTTPS certificate checks (otherwise it will wait forever and never actually launch cypress. You do this using by passing in an environmental variable: `START_SERVER_AND_TEST_INSECURE=1`. [docs](https://github.com/bahmutov/start-server-and-test#disable-https-certificate-checks). 
 
 This means your `test:e2e` script would look like this:
 ```bash

--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -32,11 +32,12 @@ Last but not least you add additional scripts to your `package.json` to run Cypr
 
 Run `test:e2e` in your command line and see Cypress running for the first time. A folder named `cypress` will be created at the root of your project and a new application window will pop up. [Cypress' getting started guide](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html#) is a good start to learn how to write tests!
 
-*Important note*: If you are running Gatsby with the `--https` flag, whether using your own or automatically generated certificates, you will also need to tell `start-server-and-test` to disable HTTPS certificate checks (otherwise it will wait forever and never actually launch cypress. You do this using by passing in an environmental variable: `START_SERVER_AND_TEST_INSECURE=1`. [docs](https://github.com/bahmutov/start-server-and-test#disable-https-certificate-checks). 
+_Important note_: If you are running Gatsby with the `--https` flag, whether using your own or automatically generated certificates, you will also need to tell `start-server-and-test` to disable HTTPS certificate checks (otherwise it will wait forever and never actually launch Cypress. You do this by passing in an environmental variable: `START_SERVER_AND_TEST_INSECURE=1`. [start-server-and-test docs](https://github.com/bahmutov/start-server-and-test#disable-https-certificate-checks). 
 
 This means your `test:e2e` script would look like this:
-```bash
-START_SERVER_AND_TEST_INSECURE=1 start-server-and-test develop http://localhost:8000 cy:open
+
+```json:title=package.json
+"test:e2e": "START_SERVER_AND_TEST_INSECURE=1 start-server-and-test develop http://localhost:8000 cy:open"
 ```
 
 ### Continuous Integration

--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -32,7 +32,7 @@ Last but not least you add additional scripts to your `package.json` to run Cypr
 
 Run `test:e2e` in your command line and see Cypress running for the first time. A folder named `cypress` will be created at the root of your project and a new application window will pop up. [Cypress' getting started guide](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html#) is a good start to learn how to write tests!
 
-_Important note_: If you are running Gatsby with the `--https` flag, whether using your own or automatically generated certificates, you will also need to tell `start-server-and-test` to disable HTTPS certificate checks (otherwise it will wait forever and never actually launch Cypress. You do this by passing in an environmental variable: `START_SERVER_AND_TEST_INSECURE=1`. [start-server-and-test docs](https://github.com/bahmutov/start-server-and-test#disable-https-certificate-checks). 
+_Important note_: If you are running Gatsby with the `--https` flag, whether using your own or automatically generated certificates, you will also need to tell `start-server-and-test` to disable HTTPS certificate checks (otherwise it will wait forever and never actually launch Cypress. You do this by passing in an environmental variable: `START_SERVER_AND_TEST_INSECURE=1`. [start-server-and-test docs](https://github.com/bahmutov/start-server-and-test#disable-https-certificate-checks).
 
 This means your `test:e2e` script would look like this:
 

--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -32,6 +32,13 @@ Last but not least you add additional scripts to your `package.json` to run Cypr
 
 Run `test:e2e` in your command line and see Cypress running for the first time. A folder named `cypress` will be created at the root of your project and a new application window will pop up. [Cypress' getting started guide](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html#) is a good start to learn how to write tests!
 
+Important note: If you are running Gatsby with the `--https` flag, whether using your own or automatically generated certificates, you will also need to tell `start-server-and-test` to disable HTTPS certificate checks (otherwise it will wait forever and never actually launch cypress. You do this using by passing in an environmental variable: `START_SERVER_AND_TEST_INSECURE=1`. ([docs](https://github.com/bahmutov/start-server-and-test#disable-https-certificate-checks)). 
+
+This means your `test:e2e` script would look like this:
+```bash
+START_SERVER_AND_TEST_INSECURE=1 start-server-and-test develop http://localhost:8000 cy:open
+```
+
 ### Continuous Integration
 
 If you want to run Cypress in Continuous Integration (CI) you have to use `cypress run` instead of `cypress open`:


### PR DESCRIPTION
## Description

`start-server-and-test` needs additional config if running Gatsby with the `--https` flag. This PR adds information about that config.
