### PR TITLE
fix(gatsby-transformer-toml): Fix createContentDigest usage

### DIFF
--- a/packages/gatsby-transformer-toml/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-toml/src/__tests__/gatsby-node.js
@@ -42,20 +42,20 @@ describe(`Process TOML nodes correctly`, () => {
     const actions = { createNode, createParentChildLink }
     const createNodeId = jest.fn()
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
-    const createDigestContent = jest.fn().mockReturnValue(`contentDigest`)
+    const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
 
     await onCreateNode({
       node,
       loadNodeContent,
       actions,
       createNodeId,
-      createDigestContent,
+      createContentDigest,
     }).then(() => {
       expect(createNode.mock.calls).toMatchSnapshot()
       expect(createParentChildLink.mock.calls).toMatchSnapshot()
       expect(createNode).toHaveBeenCalledTimes(1)
       expect(createParentChildLink).toHaveBeenCalledTimes(1)
-      expect(createDigestContent).toHaveBeenCalledTimes(1)
+      expect(createContentDigest).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/gatsby-transformer-toml/src/gatsby-node.js
+++ b/packages/gatsby-transformer-toml/src/gatsby-node.js
@@ -6,7 +6,7 @@ async function onCreateNode({
   actions,
   loadNodeContent,
   createNodeId,
-  createDigestContent,
+  createContentDigest,
 }) {
   const { createNode, createParentChildLink } = actions
   // Filter out non-toml content
@@ -23,7 +23,7 @@ async function onCreateNode({
   // This version suffers from:
   // 1) More TOML files -> more types
   // 2) Different files with the same name creating conflicts
-  const contentDigest = createDigestContent(parsedContent)
+  const contentDigest = createContentDigest(parsedContent)
 
   const newNode = {
     ...parsedContent,


### PR DESCRIPTION
## Description

This PR fixes the toml transformer package 2.1.8 that uses the wrong name for `createContentDigest`.

## Related Issues

Fixes #13112 