### PR TITLE
fix(gatsby-plugin-sitemap): add meaningful error when siteUrl is missing

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -21,6 +21,10 @@ plugins: [`gatsby-plugin-sitemap`]
 Above is the minimal configuration required to have it work. By default, the
 generated sitemap will include all of your site's pages, except the ones you exclude.
 
+## Note
+
+`siteUrl` is required with `gatsby-plugin-sitemap`.
+
 ## Options
 
 The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L34) can be overridden.

--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -21,10 +21,6 @@ plugins: [`gatsby-plugin-sitemap`]
 Above is the minimal configuration required to have it work. By default, the
 generated sitemap will include all of your site's pages, except the ones you exclude.
 
-## Note
-
-`siteUrl` is required with `gatsby-plugin-sitemap`.
-
 ## Options
 
 The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L34) can be overridden.

--- a/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
@@ -69,6 +69,20 @@ describe(`results using default settings`, () => {
 
       verifyUrlsExistInResults(urls, [`http://dummy.url${pathPrefix}/page-1`])
     })
+
+    it(`should fail when siteUrl is not set`, async () => {
+      const graphql = () =>
+        Promise.resolve(generateQueryResultsMock({ siteUrl: null }))
+      expect.assertions(1)
+
+      try {
+        await runQuery(graphql, ``, [], pathPrefix)
+      } catch (err) {
+        expect(err.message).toEqual(
+          expect.stringContaining(`SiteMetaData 'siteUrl' property is required`)
+        )
+      }
+    })
   }
 
   describe(`no path-prefix`, () => {

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -29,6 +29,10 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
       return page
     })
 
+    if (!r.data.site.siteMetadata.siteUrl) {
+      throw new Error(`SiteMetaData 'siteUrl' property is required`)
+    }
+
     if (r.data.site.siteMetadata.siteUrl) {
       // remove trailing slash of siteUrl
       r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -30,15 +30,15 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
     })
 
     if (!r.data.site.siteMetadata.siteUrl) {
-      throw new Error(`SiteMetaData 'siteUrl' property is required`)
-    }
-
-    if (r.data.site.siteMetadata.siteUrl) {
-      // remove trailing slash of siteUrl
-      r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(
-        r.data.site.siteMetadata.siteUrl
+      throw new Error(
+        `SiteMetaData 'siteUrl' property is required. (https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use)`
       )
     }
+
+    // remove trailing slash of siteUrl
+    r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(
+      r.data.site.siteMetadata.siteUrl
+    )
 
     return r.data
   })

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -31,7 +31,7 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
 
     if (!r.data.site.siteMetadata.siteUrl) {
       throw new Error(
-        `SiteMetaData 'siteUrl' property is required. (https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use)`
+        `SiteMetaData 'siteUrl' property is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
       )
     }
 


### PR DESCRIPTION
## Description
Throw a more descriptive error when users do not supply a `siteUrl` property when using `gatsby-plugin-sitemap`

## Related Issues
Fixes #12912 
