### PR TITLE
feat(gatsby-remark-prismjs): load languages when referred to by an alias

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/load-prism-language.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/load-prism-language.js
@@ -41,4 +41,32 @@ describe(`load prism language`, () => {
     expect(Prism.languages).toHaveProperty(requiredLanguage)
     expect(languagesAfterLoaded.length).toBe(languagesBeforeLoaded.length + 2)
   })
+
+  it(`loads languages when referred by their aliases (set as a String in components)`, () => {
+    const language = `python`
+    const languageAlias = `py`
+    const Prism = require(`prismjs`)
+
+    expect(Prism.languages).not.toHaveProperty(language)
+    expect(Prism.languages).not.toHaveProperty(languageAlias)
+
+    loadPrismLanguage(languageAlias)
+
+    expect(Prism.languages).toHaveProperty(language)
+    expect(Prism.languages).toHaveProperty(languageAlias)
+  })
+
+  it(`loads languages when referred by their aliases (set as as Array in components)`, () => {
+    const language = `lisp`
+    const languageAlias = `emacs-lisp`
+    const Prism = require(`prismjs`)
+
+    expect(Prism.languages).not.toHaveProperty(language)
+    expect(Prism.languages).not.toHaveProperty(languageAlias)
+
+    loadPrismLanguage(languageAlias)
+
+    expect(Prism.languages).toHaveProperty(language)
+    expect(Prism.languages).toHaveProperty(languageAlias)
+  })
 })

--- a/packages/gatsby-remark-prismjs/src/__tests__/load-prism-language.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/load-prism-language.js
@@ -1,5 +1,7 @@
 const loadPrismLanguage = require(`../load-prism-language`)
 
+const { getBaseLanguageName } = loadPrismLanguage
+
 describe(`load prism language`, () => {
   afterEach(() => {
     jest.resetModules()
@@ -42,31 +44,57 @@ describe(`load prism language`, () => {
     expect(languagesAfterLoaded.length).toBe(languagesBeforeLoaded.length + 2)
   })
 
-  it(`loads languages when referred by their aliases (set as a String in components)`, () => {
-    const language = `python`
-    const languageAlias = `py`
-    const Prism = require(`prismjs`)
+  describe(`aliasing`, () => {
+    it(`returns undefined if language does not exist`, () => {
+      const baseLanguage = getBaseLanguageName(`suhdude`, {
+        languages: {
+          python: {},
+        },
+      })
 
-    expect(Prism.languages).not.toHaveProperty(language)
-    expect(Prism.languages).not.toHaveProperty(languageAlias)
+      expect(baseLanguage).toBe(undefined)
+    })
 
-    loadPrismLanguage(languageAlias)
+    it(`defaults to language, if exists in lookup`, () => {
+      const language = `python`
 
-    expect(Prism.languages).toHaveProperty(language)
-    expect(Prism.languages).toHaveProperty(languageAlias)
-  })
+      const baseLanguage = getBaseLanguageName(language, {
+        languages: {
+          [language]: {},
+        },
+      })
 
-  it(`loads languages when referred by their aliases (set as as Array in components)`, () => {
-    const language = `lisp`
-    const languageAlias = `emacs-lisp`
-    const Prism = require(`prismjs`)
+      expect(baseLanguage).toBe(language)
+    })
 
-    expect(Prism.languages).not.toHaveProperty(language)
-    expect(Prism.languages).not.toHaveProperty(languageAlias)
+    it(`loads language that has a single alias`, () => {
+      const language = `python`
+      const alias = `py`
 
-    loadPrismLanguage(languageAlias)
+      const baseLanguage = getBaseLanguageName(alias, {
+        languages: {
+          [language]: {
+            alias,
+          },
+        },
+      })
 
-    expect(Prism.languages).toHaveProperty(language)
-    expect(Prism.languages).toHaveProperty(languageAlias)
+      expect(baseLanguage).toBe(language)
+    })
+
+    it(`loads language that has an array of aliases`, () => {
+      const language = `lisp`
+      const alias = `emacs-lisp`
+
+      const baseLanguage = getBaseLanguageName(alias, {
+        languages: {
+          [language]: {
+            alias: [alias],
+          },
+        },
+      })
+
+      expect(baseLanguage).toBe(language)
+    })
   })
 })

--- a/packages/gatsby-remark-prismjs/src/load-prism-language.js
+++ b/packages/gatsby-remark-prismjs/src/load-prism-language.js
@@ -1,16 +1,35 @@
 const Prism = require(`prismjs`)
 const components = require(`prismjs/components`)
 
+// Get the real name of a language given it or an alias
+const getBaseLanguageName = nameOrAlias => {
+  if (components.languages[nameOrAlias]) {
+    return nameOrAlias
+  }
+  return Object.keys(components.languages).find(language => {
+    const { alias } = components.languages[language]
+    if (!alias) return false
+    if (Array.isArray(alias)) {
+      return alias.includes(nameOrAlias)
+    } else {
+      return alias === nameOrAlias
+    }
+  })
+}
+
 module.exports = function loadPrismLanguage(language) {
-  if (Prism.languages[language]) {
+  const baseLanguage = getBaseLanguageName(language)
+
+  if (!baseLanguage) {
+    throw new Error(`Prism doesn't support language '${language}'.`)
+  }
+
+  if (Prism.languages[baseLanguage]) {
     // Don't load already loaded language
     return
   }
 
-  const languageData = components.languages[language]
-  if (!languageData) {
-    throw new Error(`Prism doesn't support language '${language}'.`)
-  }
+  const languageData = components.languages[baseLanguage]
 
   if (languageData.option === `default`) {
     // Default language has already been loaded by Prism
@@ -26,5 +45,5 @@ module.exports = function loadPrismLanguage(language) {
     }
   }
 
-  require(`prismjs/components/prism-${language}.js`)
+  require(`prismjs/components/prism-${baseLanguage}.js`)
 }

--- a/packages/gatsby-remark-prismjs/src/load-prism-language.js
+++ b/packages/gatsby-remark-prismjs/src/load-prism-language.js
@@ -1,8 +1,8 @@
 const Prism = require(`prismjs`)
-const components = require(`prismjs/components`)
+const prismComponents = require(`prismjs/components`)
 
 // Get the real name of a language given it or an alias
-const getBaseLanguageName = nameOrAlias => {
+const getBaseLanguageName = (nameOrAlias, components = prismComponents) => {
   if (components.languages[nameOrAlias]) {
     return nameOrAlias
   }
@@ -29,7 +29,7 @@ module.exports = function loadPrismLanguage(language) {
     return
   }
 
-  const languageData = components.languages[baseLanguage]
+  const languageData = prismComponents.languages[baseLanguage]
 
   if (languageData.option === `default`) {
     // Default language has already been loaded by Prism
@@ -47,3 +47,6 @@ module.exports = function loadPrismLanguage(language) {
 
   require(`prismjs/components/prism-${baseLanguage}.js`)
 }
+
+/* Exposed for unit testing */
+module.exports.getBaseLanguageName = getBaseLanguageName


### PR DESCRIPTION
Currently, referring to a language by an alias (defined in https://github.com/PrismJS/prism/tree/master/components) doesn't work unless the language is already loaded. 

This PR adds first class support for aliases so that languages are loaded when they are referred to by their aliases as well. 

Fixes https://github.com/gatsbyjs/gatsby/issues/13119