### PR TITLE
feat(gatsby): Page data without compilation hash

### DIFF
--- a/packages/gatsby/src/utils/page-data.js
+++ b/packages/gatsby/src/utils/page-data.js
@@ -1,0 +1,21 @@
+const fs = require(`fs-extra`)
+const path = require(`path`)
+
+const getFilePath = ({ publicDir }, pagePath) => {
+  const fixedPagePath = pagePath === `/` ? `index` : pagePath
+  return path.join(publicDir, `page-data`, fixedPagePath, `page-data.json`)
+}
+
+const write = async ({ publicDir }, page, result) => {
+  const filePath = getFilePath({ publicDir }, page.path)
+  const body = {
+    componentChunkName: page.componentChunkName,
+    path: page.path,
+    result,
+  }
+  await fs.outputFile(filePath, JSON.stringify(body))
+}
+
+module.exports = {
+  write,
+}


### PR DESCRIPTION
**Note: merges to `per-page-manifest`, not master. See https://github.com/gatsbyjs/gatsby/pull/13004 for more info**

## Description

This PR saves the `page-data.json` during query running. In order to minimize the size of PRs, my strategy is to save the page-data.json along with the normal query results, and then gradually shift functionality over to use `page-data.json` instead of `data.json`. Once all those PRs are merged, we'll be able to go back and delete the static query results, jsonNames, dataPaths, data.json etc.

It does mean that we'll be storing double the amount of query results on disk. Hopefully that's ok in the interim.

Compilation-hash will be added in future PRs.

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004