### PR TITLE
fix(gatsby-source-wordpress): fix local files being nulls after unpublishing and republishing posts

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -118,6 +118,7 @@ exports.sourceNodes = async (
     createNode,
     createNodeId,
     touchNode,
+    getNode,
     _auth,
   })
 

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -478,6 +478,7 @@ exports.downloadMediaFiles = async ({
   createNode,
   createNodeId,
   touchNode,
+  getNode,
   _auth,
 }) =>
   Promise.all(
@@ -490,8 +491,16 @@ exports.downloadMediaFiles = async ({
         // If we have cached media data and it wasn't modified, reuse
         // previously created file node to not try to redownload
         if (cacheMediaData && e.modified === cacheMediaData.modified) {
-          fileNodeID = cacheMediaData.fileNodeID
-          touchNode({ nodeId: cacheMediaData.fileNodeID })
+          const fileNode = getNode(cacheMediaData.fileNodeID)
+
+          // check if node still exists in cache
+          // it could be removed if image was made private
+          if (fileNode) {
+            fileNodeID = cacheMediaData.fileNodeID
+            touchNode({
+              nodeId: fileNodeID,
+            })
+          }
         }
 
         // If we don't have cached data, download the file


### PR DESCRIPTION
sometimes images are removed from responses (if they are tied to posts). This make it that previously cached id is used even if node don't really exist - this add extra check to make sure if node exists before trying to touch and reuse it

fixes #13104