### PR TITLE
Add warning message for missing siteURL

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -34,6 +34,10 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
       r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(
         r.data.site.siteMetadata.siteUrl
       )
+    } else {
+      console.warn(
+        `No siteURL defined. Please define a siteURL for gatsby-plugin-sitemap to work properly.`
+      )
     }
 
     return r.data


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR adds a descriptive warning message for a website that is missing a siteURL. 

## Related Issues
Fixes #12912
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
