### PR TITLE
chore(starters): add gatsby-firebase-hosting-starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1,3 +1,18 @@
+- url: https://gatsby-firebase-hosting.firebaseapp.com/
+  repo: https://github.com/bijenkorf-james-wakefield/gatsby-firebase-hosting-starter
+  description: A starter with configuration for Firebase Hosting and Cloud Build deployment.
+  tags:
+    - Firebase
+    - Google Cloud
+    - Linting
+  features:
+    - Linting with ESLint
+    - Jest Unit testing configuration
+    - Lint-staged on precommit hook
+    - Commitizen for conventional commit messages
+    - Configuration for Firebase hosting
+    - Configuration for Cloud Build deployment
+    - Clear documentation to have your site deployed behind SSL in no time!
 - url: https://graphcms.github.io/gatsby-graphcms-tailwindcss-example/
   repo: https://github.com/GraphCMS/gatsby-graphcms-tailwindcss-example
   description: The default Gatsby starter blog with the addition of the gatsby-source-graphql and tailwind dependencies.

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1,18 +1,3 @@
-- url: https://gatsby-firebase-hosting.firebaseapp.com/
-  repo: https://github.com/bijenkorf-james-wakefield/gatsby-firebase-hosting-starter
-  description: A starter with configuration for Firebase Hosting and Cloud Build deployment.
-  tags:
-    - Firebase
-    - Google Cloud
-    - Linting
-  features:
-    - Linting with ESLint
-    - Jest Unit testing configuration
-    - Lint-staged on precommit hook
-    - Commitizen for conventional commit messages
-    - Configuration for Firebase hosting
-    - Configuration for Cloud Build deployment
-    - Clear documentation to have your site deployed behind SSL in no time!
 - url: https://graphcms.github.io/gatsby-graphcms-tailwindcss-example/
   repo: https://github.com/GraphCMS/gatsby-graphcms-tailwindcss-example
   description: The default Gatsby starter blog with the addition of the gatsby-source-graphql and tailwind dependencies.
@@ -2239,3 +2224,18 @@
   features:
     - TypeScript support
     - Easily work in GatsbyJS and Framer X at the same time
+- url: https://gatsby-firebase-hosting.firebaseapp.com/
+  repo: https://github.com/bijenkorf-james-wakefield/gatsby-firebase-hosting-starter
+  description: A starter with configuration for Firebase Hosting and Cloud Build deployment.
+  tags:
+    - Firebase
+    - Google Cloud
+    - Linting
+  features:
+    - Linting with ESLint
+    - Jest Unit testing configuration
+    - Lint-staged on precommit hook
+    - Commitizen for conventional commit messages
+    - Configuration for Firebase hosting
+    - Configuration for Cloud Build deployment
+    - Clear documentation to have your site deployed behind SSL in no time!

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2238,4 +2238,4 @@
     - Commitizen for conventional commit messages
     - Configuration for Firebase hosting
     - Configuration for Cloud Build deployment
-    - Clear documentation to have your site deployed behind SSL in no time!
+    - Clear documentation to have your site deployed on Firebase behind SSL in no time!


### PR DESCRIPTION
## Description

Offering a new starter for Gatsby with Firebase Hosting, Cloud Build deployment, ESlint, Commitizen and Jest Testing Framework
