### PR TITLE
fix(gatsby-remark-prismjs): Update warnings to handle missing language

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -355,7 +355,7 @@ Object {
             },
           },
           "type": "html",
-          "value": "<code class=\\"custom-inline-text\\">foo bar</code>",
+          "value": "<code class=\\"custom-text\\">foo bar</code>",
         },
       ],
       "position": Position {
@@ -465,7 +465,7 @@ Object {
             },
           },
           "type": "html",
-          "value": "<code class=\\"language-inline-text\\">foo bar</code>",
+          "value": "<code class=\\"language-text\\">foo bar</code>",
         },
       ],
       "position": Position {

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -355,7 +355,7 @@ Object {
             },
           },
           "type": "html",
-          "value": "<code class=\\"custom-text\\">foo bar</code>",
+          "value": "<code class=\\"custom-inline-text\\">foo bar</code>",
         },
       ],
       "position": Position {
@@ -465,7 +465,7 @@ Object {
             },
           },
           "type": "html",
-          "value": "<code class=\\"language-text\\">foo bar</code>",
+          "value": "<code class=\\"language-inline-text\\">foo bar</code>",
         },
       ],
       "position": Position {

--- a/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
@@ -62,9 +62,24 @@ export default Counter
       const highlightCode = require(`../highlight-code`)
       const language = `text`
       const code = `<button />`
-      expect(highlightCode(language, code)).toMatch(`&lt;button /&gt;`)
+      expect(highlightCode(language, code, [], true)).toMatch(
+        `&lt;button /&gt;`
+      )
       expect(console.warn).toHaveBeenCalledWith(
         `code block language not specified in markdown.`,
+        `applying generic code block`
+      )
+    })
+
+    it(`can warn about languages missing from inline code`, () => {
+      spyOn(console, `warn`)
+
+      const highlightCode = require(`../highlight-code`)
+      const language = `text`
+      const code = `<button />`
+      expect(highlightCode(language, code)).toMatch(`&lt;button /&gt;`)
+      expect(console.warn).toHaveBeenCalledWith(
+        `code block or inline code language not specified in markdown.`,
         `applying generic code block`
       )
     })
@@ -84,27 +99,12 @@ export default Counter
       expect(console.warn).toHaveBeenCalledTimes(2)
       expect(console.warn).toHaveBeenNthCalledWith(
         1,
-        `code block language not specified in markdown.`,
+        `code block or inline code language not specified in markdown.`,
         `applying generic code block`
       )
       expect(console.warn).toHaveBeenNthCalledWith(
         2,
         `unable to find prism language 'raw' for highlighting.`,
-        `applying generic code block`
-      )
-    })
-  })
-
-  describe(`with language-inline-text`, () => {
-    it(`escapes &, <, " elements and warns`, () => {
-      spyOn(console, `warn`)
-
-      const highlightCode = require(`../highlight-code`)
-      const language = `inline-text`
-      const code = `<button />`
-      expect(highlightCode(language, code)).toMatch(`&lt;button /&gt;`)
-      expect(console.warn).toHaveBeenCalledWith(
-        `inline code language not specified in markdown.`,
         `applying generic code block`
       )
     })

--- a/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/highlight-code.js
@@ -56,7 +56,7 @@ export default Counter
   })
 
   describe(`with language-text`, () => {
-    it(`escapes &, <, " elements #4597 and warns`, () => {
+    it(`escapes &, <, " elements and warns`, () => {
       spyOn(console, `warn`)
 
       const highlightCode = require(`../highlight-code`)
@@ -64,7 +64,7 @@ export default Counter
       const code = `<button />`
       expect(highlightCode(language, code)).toMatch(`&lt;button /&gt;`)
       expect(console.warn).toHaveBeenCalledWith(
-        `unable to find prism language 'text' for highlighting.`,
+        `code block language not specified in markdown.`,
         `applying generic code block`
       )
     })
@@ -84,12 +84,27 @@ export default Counter
       expect(console.warn).toHaveBeenCalledTimes(2)
       expect(console.warn).toHaveBeenNthCalledWith(
         1,
-        `unable to find prism language 'text' for highlighting.`,
+        `code block language not specified in markdown.`,
         `applying generic code block`
       )
       expect(console.warn).toHaveBeenNthCalledWith(
         2,
         `unable to find prism language 'raw' for highlighting.`,
+        `applying generic code block`
+      )
+    })
+  })
+
+  describe(`with language-inline-text`, () => {
+    it(`escapes &, <, " elements and warns`, () => {
+      spyOn(console, `warn`)
+
+      const highlightCode = require(`../highlight-code`)
+      const language = `inline-text`
+      const code = `<button />`
+      expect(highlightCode(language, code)).toMatch(`&lt;button /&gt;`)
+      expect(console.warn).toHaveBeenCalledWith(
+        `inline code language not specified in markdown.`,
         `applying generic code block`
       )
     })

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -1,7 +1,12 @@
 const remark = require(`remark`)
-const plugin = require(`../index`)
+let plugin
 
 describe(`remark prism plugin`, () => {
+  beforeEach(() => {
+    jest.resetModules()
+    plugin = require(`../index`)
+  })
+
   describe(`generates a <pre> tag`, () => {
     it(`with class="language-*" prefix by default`, () => {
       const code = `\`\`\`js\n// Fake\n\`\`\``
@@ -99,6 +104,30 @@ describe(`remark prism plugin`, () => {
       const markdownAST = remark.parse(code)
       plugin({ markdownAST })
       expect(markdownAST).toMatchSnapshot()
+    })
+  })
+
+  describe(`warnings`, () => {
+    it(`warns if the language is not specified for a code block`, () => {
+      spyOn(console, `warn`)
+      const code = `\`\`\`\n// Fake\n\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST }, { noInlineHighlight: true })
+      expect(console.warn).toHaveBeenCalledWith(
+        `code block language not specified in markdown.`,
+        `applying generic code block`
+      )
+    })
+
+    it(`gives a different warning if inline code can be highlighted`, () => {
+      spyOn(console, `warn`)
+      const code = `\`foo bar\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST })
+      expect(console.warn).toHaveBeenCalledWith(
+        `code block or inline code language not specified in markdown.`,
+        `applying generic code block`
+      )
     })
   })
 })

--- a/packages/gatsby-remark-prismjs/src/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/highlight-code.js
@@ -9,7 +9,7 @@ module.exports = (
   language,
   code,
   lineNumbersHighlight = [],
-  notInline = false
+  noInlineHighlight = false
 ) => {
   // (Try to) load languages on demand.
   if (!Prism.languages[language]) {
@@ -22,7 +22,7 @@ module.exports = (
         case `none`:
           return code // Don't escape if set to none.
         case `text`:
-          message = notInline
+          message = noInlineHighlight
             ? `code block language not specified in markdown.`
             : `code block or inline code language not specified in markdown.`
           break

--- a/packages/gatsby-remark-prismjs/src/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/highlight-code.js
@@ -5,7 +5,12 @@ const loadPrismLanguage = require(`./load-prism-language`)
 const handleDirectives = require(`./directives`)
 const unsupportedLanguages = new Set()
 
-module.exports = (language, code, lineNumbersHighlight = []) => {
+module.exports = (
+  language,
+  code,
+  lineNumbersHighlight = [],
+  notInline = false
+) => {
   // (Try to) load languages on demand.
   if (!Prism.languages[language]) {
     try {
@@ -17,10 +22,9 @@ module.exports = (language, code, lineNumbersHighlight = []) => {
         case `none`:
           return code // Don't escape if set to none.
         case `text`:
-          message = `code block language not specified in markdown.`
-          break
-        case `inline-text`:
-          message = `inline code language not specified in markdown.`
+          message = notInline
+            ? `code block language not specified in markdown.`
+            : `code block or inline code language not specified in markdown.`
           break
         default:
           message = `unable to find prism language '${language}' for highlighting.`

--- a/packages/gatsby-remark-prismjs/src/highlight-code.js
+++ b/packages/gatsby-remark-prismjs/src/highlight-code.js
@@ -12,19 +12,26 @@ module.exports = (language, code, lineNumbersHighlight = []) => {
       loadPrismLanguage(language)
     } catch (e) {
       // Language wasn't loaded so let's bail.
-      if (language === `none`) {
-        return code // Don't escape if set to none.
-      } else {
-        const lang = language.toLowerCase()
-        if (!unsupportedLanguages.has(lang)) {
-          console.warn(
-            `unable to find prism language '${lang}' for highlighting.`,
-            `applying generic code block`
-          )
-          unsupportedLanguages.add(lang)
-        }
-        return _.escape(code)
+      let message = null
+      switch (language) {
+        case `none`:
+          return code // Don't escape if set to none.
+        case `text`:
+          message = `code block language not specified in markdown.`
+          break
+        case `inline-text`:
+          message = `inline code language not specified in markdown.`
+          break
+        default:
+          message = `unable to find prism language '${language}' for highlighting.`
       }
+
+      const lang = language.toLowerCase()
+      if (!unsupportedLanguages.has(lang)) {
+        console.warn(message, `applying generic code block`)
+        unsupportedLanguages.add(lang)
+      }
+      return _.escape(code)
     }
   }
 

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -79,7 +79,7 @@ module.exports = (
 
   if (!noInlineHighlight) {
     visit(markdownAST, `inlineCode`, node => {
-      let languageName = `text`
+      let languageName = `inline-text`
 
       if (inlineCodeMarker) {
         let [language, restOfValue] = node.value.split(`${inlineCodeMarker}`, 2)

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -70,7 +70,7 @@ module.exports = (
     + `<div class="${highlightClassName}" data-language="${languageName}">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`
     +     `<code class="${className}">`
-    +       `${highlightCode(languageName, node.value, highlightLines)}`
+    +       `${highlightCode(languageName, node.value, highlightLines, noInlineHighlight)}`
     +     `</code>`
     +     `${numLinesNumber}`
     +   `</pre>`
@@ -79,7 +79,7 @@ module.exports = (
 
   if (!noInlineHighlight) {
     visit(markdownAST, `inlineCode`, node => {
-      let languageName = `inline-text`
+      let languageName = `text`
 
       if (inlineCodeMarker) {
         let [language, restOfValue] = node.value.split(`${inlineCodeMarker}`, 2)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Motivation

<!-- Write a brief description of the changes introduced by this PR -->
At the moment, the plugin will correctly warn users if they try to use a language that is not supported by PrismJS.  However, the same type of message appears if no language has been supplied.

If their markdown contains either
>\`some code`

or

>\```
  some code block
\```

They get the warning `unable to find prism language 'text' for highlighting.`.  This is potentially confusing since it's unclear, from the outside, why the language `text` was being looked for.  This is particularly true for inline code as that's not often highlighted (at least in my experience).  The appearance of the above message can be seen in [this project](https://github.com/ojeytonwilliams/gatsby-remark-prismjs-bug) at `/shell/`.

## Description

This PR adds distinct error messages for when the user does not specify a language.  It uses the class postfix `-inline-text` to differentiate inline code from code blocks and generate the correct messages.

I did consider suppressing the messages for inline text, since it's pretty common to not try and highlight them. However, I wasn't 100% sure what the best approach was and I erred on the side of more warnings!  If anything seems off, let me know.