### PR TITLE
chore(gatsby-plugin-typography): cleanup tests

### DIFF
--- a/packages/gatsby-plugin-typography/package.json
+++ b/packages/gatsby-plugin-typography/package.json
@@ -14,6 +14,8 @@
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.4",
     "cross-env": "^5.1.4",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-typography": "^0.16.18",
     "typography": "^0.16.18"
   },
@@ -28,6 +30,8 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.0",
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2",
     "react-typography": "^0.16.1 || ^1.0.0-alpha.0",
     "typography": "^0.16.0 || ^1.0.0-alpha.0"
   },

--- a/packages/gatsby-plugin-typography/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-typography/src/__tests__/gatsby-ssr.js
@@ -1,3 +1,5 @@
+import { onPreRenderHTML, onRenderBody } from "../gatsby-ssr"
+
 jest.mock(
   `../.cache/typography`,
   () => {
@@ -5,8 +7,6 @@ jest.mock(
   },
   { virtual: true }
 )
-
-import { onPreRenderHTML, onRenderBody } from "../gatsby-ssr"
 
 const clone = arr => arr.reduce((merged, item) => merged.concat(item), [])
 

--- a/packages/gatsby-plugin-typography/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-browser.js
@@ -10,7 +10,7 @@ if (process.env.BUILD_STAGE === `develop`) {
   React = require(`react`)
   GoogleFont = require(`react-typography`).GoogleFont
   // typography links to the file set in "pathToConfigModule"
-  const typographyConfig = require(`./.cache/typography.js`)
+  const typographyConfig = require(`./.cache/typography`)
   typography = typographyConfig.default || typographyConfig
 
   exports.onClientEntry = (a, pluginOptions) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17216,6 +17216,16 @@ react-dom@^16.4.1:
     prop-types "^15.6.2"
     schedule "^0.4.0"
 
+react-dom@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
@@ -17262,6 +17272,16 @@ react@^16.4.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     schedule "^0.4.0"
+
+react@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 read-chunk@^1.0.1:
   version "1.0.1"
@@ -18454,6 +18474,14 @@ schedule@^0.4.0:
   dependencies:
     object-assign "^4.1.1"
 
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^0.4.0, schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
@@ -18729,11 +18757,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-
-shell-escape@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/shell-escape/-/shell-escape-0.2.0.tgz#68fd025eb0490b4f567a027f0bf22480b5f84133"
-  integrity sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM=
 
 shell-escape@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Description
It looks like lots of tests are failing because of the react addition in package.json. Seems like gatsby-plugin-typography was the biggest offender. We should add peer-deps to all our packages that have react & react-dom.

This pr fixes at least the flaky tests so the ink pr doesn't fail for no reason.

## Related Issues
#13089 