### PR TITLE
fix(gatsby): move db.startAutosave after bootstrap in `gatsby develop`

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -89,6 +89,7 @@ async function startServer(program) {
   // Start bootstrap process.
   await bootstrap(program)
 
+  db.startAutosave()
   queryWatcher.startWatchDeletePage()
 
   await createIndexHtml()
@@ -300,8 +301,6 @@ module.exports = async (program: any) => {
   }
 
   program.port = await detectPortInUseAndPrompt(port, rlInterface)
-
-  db.startAutosave()
 
   const [compiler] = await startServer(program)
 


### PR DESCRIPTION
## Description

In `gatsby develop`, we should start db autosaving **after** bootstrap.
