### PR TITLE
feat(gatsby-source-shopify): Add support for Shopify Pages

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -103,7 +103,6 @@ The following data types are available:
 | **ProductVariant** | Represents a different version of a product, such as differing sizes or differing colors.                             |
 | **ProductType**    | Represents a category of products.                                                                                    |
 | **ShopPolicy**     | Policy that a merchant has configured for their store, such as their refund or privacy policy.                        |
-| **Page**           | Pages that hold static HTML content. Each Page object represents a custom page on the online store.                   |
 
 For each data type listed above, `shopify${typeName}` and
 `allShopify${typeName}` is made available. Nodes that are closely related, such
@@ -319,6 +318,26 @@ like the following:
         body
         title
         type
+      }
+    }
+  }
+}
+```
+
+### Query pages
+
+Shopify merchants can create pages to hold static HTML content.
+
+```graphql
+{
+  allShopifyPage {
+    edges {
+      node {
+        id
+        handle
+        title
+        body
+        bodySummary
       }
     }
   }

--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -103,6 +103,7 @@ The following data types are available:
 | **ProductVariant** | Represents a different version of a product, such as differing sizes or differing colors.                             |
 | **ProductType**    | Represents a category of products.                                                                                    |
 | **ShopPolicy**     | Policy that a merchant has configured for their store, such as their refund or privacy policy.                        |
+| **Page**           | Pages that hold static HTML content. Each Page object represents a custom page on the online store.                   |
 
 For each data type listed above, `shopify${typeName}` and
 `allShopify${typeName}` is made available. Nodes that are closely related, such

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -12,6 +12,7 @@ import {
   ProductVariantNode,
   ShopPolicyNode,
   ProductTypeNode,
+  PageNode,
 } from "./nodes"
 import {
   ARTICLES_QUERY,
@@ -20,6 +21,7 @@ import {
   PRODUCTS_QUERY,
   SHOP_POLICIES_QUERY,
   PRODUCT_TYPES_QUERY,
+  PAGES_QUERY,
 } from "./queries"
 
 export const sourceNodes = async (
@@ -62,6 +64,7 @@ export const sourceNodes = async (
       createNodes(`blogs`, BLOGS_QUERY, BlogNode, args),
       createNodes(`collections`, COLLECTIONS_QUERY, CollectionNode, args),
       createNodes(`productTypes`, PRODUCT_TYPES_QUERY, ProductTypeNode, args),
+      createNodes(`pages`, PAGES_QUERY, PageNode, args),
       createNodes(`products`, PRODUCTS_QUERY, ProductNode, args, async x => {
         if (x.variants)
           await forEach(x.variants.edges, async edge =>

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -16,7 +16,7 @@ const PRODUCT_OPTION = `ProductOption`
 const PRODUCT_VARIANT = `ProductVariant`
 const SHOP_POLICY = `ShopPolicy`
 const PRODUCT_TYPE = `ProductType`
-const PAGE = `PAGE`
+const PAGE = `Page`
 const { createNodeFactory, generateNodeId } = createNodeHelpers({
   typePrefix: TYPE_PREFIX,
 })

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -16,6 +16,7 @@ const PRODUCT_OPTION = `ProductOption`
 const PRODUCT_VARIANT = `ProductVariant`
 const SHOP_POLICY = `ShopPolicy`
 const PRODUCT_TYPE = `ProductType`
+const PAGE = `PAGE`
 const { createNodeFactory, generateNodeId } = createNodeHelpers({
   typePrefix: TYPE_PREFIX,
 })
@@ -144,3 +145,5 @@ export const ProductVariantNode = imageArgs =>
   })
 
 export const ShopPolicyNode = createNodeFactory(SHOP_POLICY)
+
+export const PagesNode = createNodeFactory(PAGE)

--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -226,8 +226,11 @@ export const PRODUCT_TYPES_QUERY = `
 `
 
 export const PAGES_QUERY = `
-  query GetPages($first: Int!) {
-    pages(first: 10) {
+  query GetPages($first: Int!, $after: String) {
+    pages(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+      }
       edges {
         node {
           id

--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -224,3 +224,21 @@ export const PRODUCT_TYPES_QUERY = `
     }
   }
 `
+
+export const PAGES_QUERY = `
+  query GetPages($first: Int!) {
+    pages(first: 10) {
+      edges {
+        node {
+          id
+          handle
+          title
+          body
+          bodySummary
+          updatedAt
+          url
+        }
+      }
+    }
+  }
+`

--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -232,6 +232,7 @@ export const PAGES_QUERY = `
         hasNextPage
       }
       edges {
+        cursor
         node {
           id
           handle


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

- Add `Pages` support to `gatsby-source-shopify`.
- See https://help.shopify.com/en/api/custom-storefronts/storefront-api/reference/queryroot

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
