### PR TITLE
Fix #13202 - Remove render-page.js and render-page.js.map from ./public

### DIFF
--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -44,8 +44,8 @@ const buildRenderer = async (program, stage) => {
 
 const deleteRenderer = async rendererPath => {
   try {
-    await fs.unlink(rendererPath)
-    await fs.unlink(`${rendererPath}.map`)
+    fs.unlinkSync(rendererPath)
+    fs.unlinkSync(`${rendererPath}.map`)
   } catch (e) {
     // This function will fail on Windows with no further consequences.
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
I created #13202 asking why after version 2.3.11 render-page.js and render-page.js.map are added to ./public. After looking at [this commit](https://github.com/gatsbyjs/gatsby/commit/1534fe529a170d1e4f0ae6013e97ce5255c0c4d0#diff-87b9cc88fc16a731c1acb2ac60723f0aL52) I realized that
```
fs.unlinkSync(outputFile)
fs.unlinkSync(`${outputFile}.map`)
```
Got changed into:
```
await fs.unlink(rendererPath)
await fs.unlink(`${rendererPath}.map`)
```

So this is what prevented the files from being deleted after the build process has finished. To confirm this I console logged the error in the catch block [right here](https://github.com/gatsbyjs/gatsby/blob/1534fe529a170d1e4f0ae6013e97ce5255c0c4d0/packages/gatsby/src/commands/build-html.js#L49-L51) and this is the result.

![gatsby-error](https://user-images.githubusercontent.com/5230079/55713808-1c1efe00-59fa-11e9-91a2-0087450a86d0.jpg)

After that I reverted it back to `fs.unlinkSync(rendererPath)` without await and it got fixed.


## Related Issues and commits
#13202 and [1534fe52](https://github.com/gatsbyjs/gatsby/commit/1534fe529a170d1e4f0ae6013e97ce5255c0c4d0#diff-87b9cc88fc16a731c1acb2ac60723f0aL52)
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
