### PR TITLE
chore(gatsby): Get rid of "DeprecationWarning: asynchronous function without callback"

### DIFF
--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -1,6 +1,8 @@
 /* @flow */
 const webpack = require(`webpack`)
 const fs = require(`fs`)
+const { promisify } = require(`util`)
+const promisifiedUnlink = promisify(fs.unlink)
 
 const webpackConfig = require(`../utils/webpack.config`)
 const { createErrorFromString } = require(`gatsby-cli/lib/reporter/errors`)
@@ -44,8 +46,8 @@ const buildRenderer = async (program, stage) => {
 
 const deleteRenderer = async rendererPath => {
   try {
-    await fs.unlink(rendererPath)
-    await fs.unlink(`${rendererPath}.map`)
+    await promisifiedUnlink(rendererPath)
+    await promisifiedUnlink(`${rendererPath}.map`)
   } catch (e) {
     // This function will fail on Windows with no further consequences.
   }

--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -1,8 +1,6 @@
 /* @flow */
 const webpack = require(`webpack`)
-const fs = require(`fs`)
-const { promisify } = require(`util`)
-const promisifiedUnlink = promisify(fs.unlink)
+const fs = require(`fs-extra`)
 
 const webpackConfig = require(`../utils/webpack.config`)
 const { createErrorFromString } = require(`gatsby-cli/lib/reporter/errors`)
@@ -46,8 +44,8 @@ const buildRenderer = async (program, stage) => {
 
 const deleteRenderer = async rendererPath => {
   try {
-    await promisifiedUnlink(rendererPath)
-    await promisifiedUnlink(`${rendererPath}.map`)
+    await fs.remove(rendererPath)
+    await fs.remove(`${rendererPath}.map`)
   } catch (e) {
     // This function will fail on Windows with no further consequences.
   }


### PR DESCRIPTION
Before:
![Screenshot 2019-04-08 16 05 50](https://user-images.githubusercontent.com/7701981/55718235-e3425180-5a18-11e9-968e-695c5881075b.png)

After:
![Screenshot 2019-04-08 16 11 17](https://user-images.githubusercontent.com/7701981/55718256-f2290400-5a18-11e9-831a-12a23826ac6d.png)

Fixes https://github.com/gatsbyjs/gatsby/issues/13188