### PR TITLE
fix(gatsby-source-graphql): Destructure createContentDigest from first parameter

### DIFF
--- a/packages/gatsby-source-graphql/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-source-graphql/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validation throws on missing fieldName 1`] = `"gatsby-source-graphql requires option \`fieldName\` to be specified"`;
+
+exports[`validation throws on missing typename 1`] = `"gatsby-source-graphql requires option \`typeName\` to be specified"`;
+
+exports[`validation throws on missing url 1`] = `"gatsby-source-graphql requires either option \`url\` or \`createLink\` callback"`;

--- a/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
@@ -1,0 +1,69 @@
+jest.mock(`graphql-tools`, () => {
+  return {
+    makeRemoteExecutableSchema: jest.fn(),
+    transformSchema: jest.fn(),
+    introspectSchema: jest.fn(),
+    RenameTypes: jest.fn(),
+  }
+})
+jest.mock(`graphql`, () => {
+  const graphql = jest.requireActual(`graphql`)
+  return {
+    ...graphql,
+    buildSchema: jest.fn(),
+    printSchema: jest.fn(),
+  }
+})
+const { sourceNodes } = require(`../gatsby-node`)
+
+const getInternalGatsbyAPI = () => {
+  const actions = {
+    addThirdPartySchema: jest.fn(),
+    createPageDependency: jest.fn(),
+    createNode: jest.fn(),
+  }
+
+  return {
+    actions,
+    cache: {
+      get: jest.fn(),
+      set: jest.fn(),
+    },
+    createContentDigest: jest.fn(),
+    createNodeId: jest.fn(),
+  }
+}
+
+describe(`validation`, () => {
+  ;[
+    [
+      `throws on missing typename`,
+      { fieldName: `github`, url: `https://github.com` },
+    ],
+    [
+      `throws on missing fieldName`,
+      { typeName: `Github`, url: `https://github.com` },
+    ],
+    [`throws on missing url`, { typeName: `Github`, fieldName: `github` }],
+  ].forEach(([testName, pluginOptions]) => {
+    it(testName, () => {
+      expect(
+        sourceNodes(getInternalGatsbyAPI(), pluginOptions)
+      ).rejects.toThrowErrorMatchingSnapshot()
+    })
+  })
+})
+
+describe(`createSchemaNode`, () => {
+  it(`invokes createContentDigest`, async () => {
+    const api = getInternalGatsbyAPI()
+    await sourceNodes(api, {
+      typeName: `Github`,
+      fieldName: `github`,
+      url: `https://github.com`,
+    })
+
+    expect(api.createContentDigest).toHaveBeenCalledWith(expect.any(String))
+    expect(api.createContentDigest).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -9,13 +9,14 @@ const {
 const { createHttpLink } = require(`apollo-link-http`)
 const fetch = require(`node-fetch`)
 const invariant = require(`invariant`)
+
 const {
   NamespaceUnderFieldTransform,
   StripNonQueryTransform,
 } = require(`./transforms`)
 
 exports.sourceNodes = async (
-  { actions, createNodeId, cache, store, createContentDigest },
+  { actions, createNodeId, cache, createContentDigest },
   options
 ) => {
   const { addThirdPartySchema, createPageDependency, createNode } = actions

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -15,13 +15,7 @@ const {
 } = require(`./transforms`)
 
 exports.sourceNodes = async (
-  { 
-    actions, 
-    createNodeId, 
-    cache, 
-    store, 
-    createContentDigest, 
-  },
+  { actions, createNodeId, cache, store, createContentDigest },
   options
 ) => {
   const { addThirdPartySchema, createPageDependency, createNode } = actions

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -15,7 +15,13 @@ const {
 } = require(`./transforms`)
 
 exports.sourceNodes = async (
-  { actions, createNodeId, cache, store },
+  { 
+    actions, 
+    createNodeId, 
+    cache, 
+    store, 
+    createContentDigest, 
+  },
   options
 ) => {
   const { addThirdPartySchema, createPageDependency, createNode } = actions
@@ -28,7 +34,6 @@ exports.sourceNodes = async (
     createLink,
     createSchema,
     refetchInterval,
-    createContentDigest,
   } = options
 
   invariant(


### PR DESCRIPTION
## Description

It fixes a wrong import of createContentDigest that breaks gatsby-source-graphql since 2.0.16

## Related Issues

Mistake made in a refactoring (#13000)
