### PR TITLE
chore(docs): reword module name for building themes

### DIFF
--- a/docs/docs/themes/api-reference.md
+++ b/docs/docs/themes/api-reference.md
@@ -118,7 +118,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-compile-es6-packages",
       options: {
-        modules: ["gatsby-theme-developer"],
+        modules: ["NAME_OF_YOUR_THEME"],
       },
     },
   ],

--- a/docs/docs/themes/api-reference.md
+++ b/docs/docs/themes/api-reference.md
@@ -118,7 +118,9 @@ module.exports = {
     {
       resolve: "gatsby-plugin-compile-es6-packages",
       options: {
-        modules: ["NAME_OF_YOUR_THEME"],
+        // replace with the name of your theme
+        // highlight-next-line
+        modules: ["gatsby-theme-developer"],
       },
     },
   ],


### PR DESCRIPTION
I tripped over this line, while working with themes and I think making it clear, that the theme name goes here is important.