### PR TITLE
[www] Show no sidebar on top-level markdown pages

### DIFF
--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -56,7 +56,7 @@ const getDocsData = location => {
     tutorial: itemListTutorial,
   }
 
-  return [urlSegment, itemListLookup[urlSegment] || itemListTutorial]
+  return [urlSegment, itemListLookup[urlSegment]]
 }
 
 function DocsTemplate({ data, location }) {


### PR DESCRIPTION
## Description

The Accessibility Statement makes sense to be top level, so I added the Markdown file to the base `/docs` directory. It was showing the tutorial sidebar due to some code in the docs-markdown template: https://github.com/gatsbyjs/gatsby/blob/master/www/src/templates/template-docs-markdown.js#L59

This PR simply removes the fallback array entry with the Tutorial sidebar. I wasn't sure if there were some tests I should update as well (that would make sense!). It seemed to work fine locally.
