### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -44,6 +44,6 @@ The access to the raw data is highly controlled, and we cannot identify individu
 
 ## What about sensitive data? (e.g. secrets)
 
-We perform additional steps to ensure that secure data (e.g. environment variables used to store secrets for the build process) **do not** make their way into our analytics. [We strip logs, error messages, etc.](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/sanitize-error.js) of this sensitive data to ensure we _never_ gain access to this sensitive data.
+We perform additional steps to ensure that secure data (e.g. environment variables used to store secrets for the build process) **do not** make their way into our analytics. [We strip logs, error messages, etc.](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/error-helpers.js) of this sensitive data to ensure we _never_ gain access to this sensitive data.
 
 You can view all the information that is sent by Gatsby’s telemetry by setting the environment variable `GATSBY_TELEMETRY_DEBUG`to `1` to print the telemetry data instead of sending it over.


### PR DESCRIPTION
## Description
Looks like #12877 left a broken link in documentation. This PR is fixing the issue
