### PR TITLE
Include a boolean flag to telemetry data whether gatsby is running in docker or not.

### DIFF
--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -14,6 +14,7 @@
     "configstore": "4.0.0",
     "envinfo": "^5.8.1",
     "fs-extra": "^7.0.1",
+    "is-docker": "1.1.0",
     "node-fetch": "2.3.0",
     "resolve-cwd": "^2.0.0",
     "source-map": "^0.5.7",

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -6,6 +6,7 @@ const ci = require(`ci-info`)
 const os = require(`os`)
 const { basename } = require(`path`)
 const { execSync } = require(`child_process`)
+const isDocker = require(`is-docker`)
 
 module.exports = class AnalyticsTracker {
   store = new EventStorage()
@@ -155,6 +156,7 @@ module.exports = class AnalyticsTracker {
       arch: os.arch(),
       ci: ci.isCI,
       ciName: (ci.isCI && ci.name) || undefined,
+      docker: isDocker(),
     }
     this.osInfo = osInfo
     return osInfo

--- a/yarn.lock
+++ b/yarn.lock
@@ -11496,6 +11496,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-1.1.0.tgz#f04374d4eee5310e9a8e113bf1495411e46176a1"
+  integrity sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"


### PR DESCRIPTION
Inspired from: https://github.com/orgs/gatsbyjs/teams/maintainers/discussions/57?from_comment=1#discussion-57-comment-1