### PR TITLE
fix(gatsby-dev-cli): Persist verdaccio stuff in os.tmpdir

### DIFF
--- a/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio.js
@@ -2,6 +2,7 @@ const startVerdaccio = require(`verdaccio`).default
 const path = require(`path`)
 const fs = require(`fs-extra`)
 const _ = require(`lodash`)
+const os = require(`os`)
 
 const {
   getMonorepoPackageJsonPath,
@@ -12,7 +13,7 @@ const { registerCleanupTask } = require(`./cleanup-tasks`)
 let VerdaccioInitPromise = null
 
 const verdaccioConfig = {
-  storage: path.join(__dirname, `..`, `..`, `verdaccio`, `storage`),
+  storage: path.join(os.tmpdir(), `verdaccio`, `storage`),
   port: 4873, // default
   web: {
     enable: true,


### PR DESCRIPTION
It currently persists in a dir two steps back (where gatsby-dev is) and sometimes that isn't writable because of an operation previously run with `sudo` like in https://circleci.com/gh/gatsbyjs/gatsby/104049?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Note: `require('os').tmpdir()` is good in Node.js 4 and up. So we're fine. 