### PR TITLE
fix(gatsby): fix infinite calls with circular nodes

### DIFF
--- a/packages/gatsby/src/schema/infer/example-value.js
+++ b/packages/gatsby/src/schema/infer/example-value.js
@@ -106,6 +106,7 @@ const getExampleObject = ({
         nodes: objects,
         prefix: selector,
         typeConflictReporter,
+        ignoreFields,
       })
       if (!Object.keys(exampleObject).length) return acc
       exampleFieldValue = exampleObject


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This should be a mistake, causing issues with nodes have `parent` field.

## Related Issues

#13259

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
