### PR TITLE
fix(gatsby-plugin-manifest): fix regression with sharp failing to load

### DIFF
--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "sharp": "^0.22.0"
+    "sharp": "^0.21.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
## Description

Fairly annoying and confusing bug here--updating sharp in #12757 (which would seem totally reasonable) actually causes the require sharp statement to silently fail in `gatsby-node.js`. I'll open an issue to address the latter part of this statement, but the _why_ of why this happens is helpful.

Other plugins (e.g. gatsby-transformer-sharp, gatsby-plugin-sharp, etc. require `sharp`@`0.21.3`. The change to `0.22.0` caused a tree like:

```
➜ yarn why sharp
yarn why v1.15.2
[1/4] 🤔  Why do we have the module "sharp"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "sharp@0.21.3"
info Has been hoisted to "sharp"
info Reasons this module exists
   - Hoisted from "gatsby-plugin-sharp#sharp"
   - Hoisted from "gatsby-transformer-sharp#sharp"
info Disk size without dependencies: "23.27MB"
info Disk size with unique dependencies: "24.35MB"
info Disk size with transitive dependencies: "26.69MB"
info Number of shared dependencies: 46
=> Found "gatsby-plugin-manifest#sharp@0.22.0"
info This module exists because "gatsby-plugin-manifest" depends on it.
info Disk size without dependencies: "34.67MB"
info Disk size with unique dependencies: "35.75MB"
info Disk size with transitive dependencies: "38.09MB"
info Number of shared dependencies: 46
```

The `require('sharp')` statement in gatsby-node.js would silently fail with:

```
⠁ Error: dlopen(/Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/gatsby-plugin-manifest/node_modules/sharp/build/Release/sharp.node, 1): Library not loaded: @rpath/libglib-2.0.dylib
  Referenced from: /Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/gatsby-plugin-manifest/node_modules/sharp/build/Release/sharp.node
  Reason: Incompatible library version: sharp.node requires version 6001.0.0 or later, but libglib-2.0.dylib provides version 5801.0.0
    at Object.Module._extensions..node (internal/modules/cjs/loader.js:846:18)
    at Module.load (internal/modules/cjs/loader.js:672:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:612:12)
    at Function.Module._load (internal/modules/cjs/loader.js:604:3)
    at Module.require (internal/modules/cjs/loader.js:711:19)
    at require (/Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at bindings (/Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/bindings/bindings.js:112:48)
    at Object.<anonymous> (/Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/gatsby-plugin-manifest/node_modules/sharp/lib/constructor.js:10:34)
    at Module._compile (/Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/v8-compile-cache/v8-compile-cache.js:178:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:816:10)
    at Module.load (internal/modules/cjs/loader.js:672:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:612:12)
    at Function.Module._load (internal/modules/cjs/loader.js:604:3)
    at Module.require (internal/modules/cjs/loader.js:711:19)
    at require (/Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous> (/Users/dschau/Code/Work/gatsby/test/manifest-issue/node_modules/gatsby-plugin-manifest/node_modules/sharp/lib/index.js:3:15)
```

So there are really two issues here:

- Sharp not handling multiple versions (this is probably not something easily fixed)
- Plugin errors being silenced--at least in this specific case

## Related Issues

Fixes #13264