### PR TITLE
Expose LOCAL_URL as gatsby-link method

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -297,17 +297,13 @@ following may be a good starting point:
 
 ```jsx
 import { Link as GatsbyLink } from "gatsby"
+import { isInternalLink } from "gatsby-link"
 
 // Since DOM elements <a> cannot receive activeClassName,
 // destructure the prop here and pass it only to GatsbyLink
 const Link = ({ children, to, activeClassName, ...other }) => {
-  // Tailor the following test to your environment.
-  // This example assumes that any internal link (intended for Gatsby)
-  // will start with exactly one slash, and that anything else is external.
-  const internal = /^\/(?!\/)/.test(to)
-
   // Use Gatsby Link for internal links, and <a> for others
-  if (internal) {
+  if (isInternalLink(to)) {
     return (
       <GatsbyLink to={to} activeClassName={activeClassName} {...other}>
         {children}

--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -17,6 +17,7 @@ export default class GatsbyLink<TState> extends React.Component<
 > {}
 export const navigate: NavigateFn
 export const withPrefix: (path: string) => string
+export const isInternalLink: (to: string) => boolean
 
 // TODO: Remove navigateTo, push & replace for Gatsby v3
 export const push: (to: string) => void

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -21,6 +21,8 @@ const NavLinkPropTypes = {
   partiallyActive: PropTypes.bool,
 }
 
+const LOCAL_URL = /^\/(?!\/)/
+
 // Set up IntersectionObserver
 const handleIntersection = (el, cb) => {
   const io = new window.IntersectionObserver(entries => {
@@ -113,8 +115,7 @@ class GatsbyLink extends React.Component {
       ...rest
     } = this.props
 
-    const LOCAL_URL = /^\/(?!\/)/
-    if (process.env.NODE_ENV !== `production` && !LOCAL_URL.test(to)) {
+    if (process.env.NODE_ENV !== `production` && !isInternalLink(to)) {
       console.warn(
         `External link ${to} was detected in a Link component. Use the Link component only for internal links. See: https://gatsby.dev/internal-links`
       )
@@ -199,3 +200,5 @@ export const navigateTo = to => {
   )
   return push(to)
 }
+
+export const isInternalLink = to => LOCAL_URL.test(to)


### PR DESCRIPTION
Reading [gatsby-link](https://www.gatsbyjs.org/docs/gatsby-link/#reminder-use-link-only-for-internal-links) documentation, it says you need to validate links you pass to `GatsbyLink` should be just internal links:

```js
import { Link as GatsbyLink } from "gatsby"

// Since DOM elements <a> cannot receive activeClassName,
// destructure the prop here and pass it only to GatsbyLink
const Link = ({ children, to, activeClassName, ...other }) => {
  // Tailor the following test to your environment.
  // This example assumes that any internal link (intended for Gatsby)
  // will start with exactly one slash, and that anything else is external.
  const internal = /^\/(?!\/)/.test(to)
```

This is done using a regex; however, instead of re-declare the regex, I expose it from the internal module, being the same and exposed as function:

```js
import { Link as GatsbyLink } from "gatsby"
import { isInternalLink } from "gatsby-link"

// Since DOM elements <a> cannot receive activeClassName,
// destructure the prop here and pass it only to GatsbyLink
const Link = ({ children, to, activeClassName, ...other }) => {
  // Tailor the following test to your environment.
  // This example assumes that any internal link (intended for Gatsby)
  // will start with exactly one slash, and that anything else is external.
  const internal = /^\/(?!\/)/.test(to)
  // Use Gatsby Link for internal links, and <a> for others
  if (isInternalLink(to)) {
```