### PR TITLE
fix(gatsby-image): ensure that currentSrc exists

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -224,7 +224,7 @@ class Image extends React.Component {
         this.setState({ isVisible: true }, () =>
           this.setState({
             imgLoaded: imageInCache,
-            imgCached: this.imageRef.current.currentSrc && this.imageRef.current.currentSrc.length > 0,
+            imgCached: !!this.imageRef.current.currentSrc,
           })
         )
       })

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -224,7 +224,7 @@ class Image extends React.Component {
         this.setState({ isVisible: true }, () =>
           this.setState({
             imgLoaded: imageInCache,
-            imgCached: this.imageRef.current.currentSrc.length > 0,
+            imgCached: this.imageRef.current.currentSrc && this.imageRef.current.currentSrc.length > 0,
           })
         )
       })


### PR DESCRIPTION
Trying to read `currentSrc` before it has been set throws an `Unable to get property 'length' of undefined or null reference` error.
It should be an empty string, but IE11 can return `undefined`.

The issue was introduced by #12468 - it's simply missing an extra guard to ensure the value is defined.