### PR TITLE
fix: Get parent not root File node in resolver

### DIFF
--- a/packages/gatsby/src/schema/__tests__/queries-file.js
+++ b/packages/gatsby/src/schema/__tests__/queries-file.js
@@ -48,6 +48,30 @@ const nodes = [
     absolutePath: filePath(`test.txt`),
   },
   {
+    id: `file4`,
+    parent: `file5`,
+    children: [`test2`],
+    internal: {
+      type: `File`,
+      contentDigest: `file4`,
+    },
+    name: `parent.txt`,
+    dir: basePath,
+    absolutePath: filePath(`parent.txt`),
+  },
+  {
+    id: `file5`,
+    parent: null,
+    children: [`file4`],
+    internal: {
+      type: `File`,
+      contentDigest: `file5`,
+    },
+    name: `root.txt`,
+    dir: `/`,
+    absolutePath: `/root.txt`,
+  },
+  {
     id: `test1`,
     parent: `file3`,
     children: [],
@@ -70,6 +94,15 @@ const nodes = [
         files: [`./2.png`],
       },
     ],
+  },
+  {
+    id: `test2`,
+    parent: `file4`,
+    children: [],
+    internal: {
+      type: `TestChild`,
+    },
+    file: `./1.png`,
   },
 ]
 
@@ -184,6 +217,24 @@ describe(`Query fields of type File`, () => {
             files: [{ name: `2.png` }],
           },
         ],
+      },
+    }
+    expect(results.errors).toBeUndefined()
+    expect(results.data).toEqual(expected)
+  })
+
+  it(`uses nearest File node ancestor to resolve relative paths`, async () => {
+    const query = `
+      {
+        testChild {
+          file { name }
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      testChild: {
+        file: { name: `1.png` },
       },
     }
     expect(results.errors).toBeUndefined()

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -170,7 +170,10 @@ const fileByPath = (source, args, context, info) => {
 
   // Find the File node for this node (we assume the node is something
   // like markdown which would be a child node of a File node).
-  const parentFileNode = context.nodeModel.findRootNodeAncestor(source)
+  const parentFileNode = context.nodeModel.findRootNodeAncestor(
+    source,
+    node => node.internal && node.internal.type === `File`
+  )
 
   // Find the linked File node(s)
   if (isArray) {


### PR DESCRIPTION
In the `fileByPath` resolver, we need a node's parent `File` node to resolve relative to absolute paths. For this we use `findRootNodeAncestor`, which will return a node's root node. This can be problematic for (unusual) scenarios like in #13267 where a node has more than one `File` node ancestor. We should just use the closest `File` parent.

Fixes #13267