### PR TITLE
chore(gatsby-source-mongodb): Use new createContentDigest helper

### DIFF
--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.15"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb",
   "scripts": {

--- a/packages/gatsby-source-mongodb/src/__tests__/mapping.js
+++ b/packages/gatsby-source-mongodb/src/__tests__/mapping.js
@@ -19,6 +19,7 @@ const params = {
   key: `someKey`,
   text: `someText`,
   mediaType: `someMediaType`,
+  createContentDigest: jest.fn().mockReturnValue(`contentDigest`),
   createNode: jest.fn(),
 }
 
@@ -29,6 +30,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
+      params.createContentDigest,
       params.createNode
     )
   ).toHaveProperty(`id`)
@@ -38,6 +40,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
+      params.createContentDigest,
       params.createNode
     )
   ).toHaveProperty(`parent`)
@@ -47,6 +50,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
+      params.createContentDigest,
       params.createNode
     )
   ).toHaveProperty(`children`)
@@ -56,6 +60,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
+      params.createContentDigest,
       params.createNode
     )
   ).toHaveProperty(`internal`)
@@ -65,6 +70,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
+      params.createContentDigest,
       params.createNode
     )
   ).toHaveProperty(`someKey`)
@@ -89,6 +95,7 @@ test(`it returns a transformed object`, () => {
       params.key,
       params.text,
       params.mediaType,
+      params.createContentDigest,
       params.createNode
     )
   ).toMatchObject(desiredResult)

--- a/packages/gatsby-source-mongodb/src/mapping.js
+++ b/packages/gatsby-source-mongodb/src/mapping.js
@@ -1,8 +1,14 @@
 const camelCase = require(`lodash.camelcase`)
 const isString = require(`lodash.isstring`)
-const crypto = require(`crypto`)
 
-module.exports = function(node, key, text, mediaType, createNode) {
+module.exports = function(
+  node,
+  key,
+  text,
+  mediaType,
+  createContentDigest,
+  createNode
+) {
   const str = isString(text) ? text : ` `
   const id = `${node.id}${key}MappingNode`
   const mappingNode = {
@@ -14,10 +20,7 @@ module.exports = function(node, key, text, mediaType, createNode) {
       type: camelCase(`${node.internal.type} ${key} MappingNode`),
       mediaType: mediaType,
       content: str,
-      contentDigest: crypto
-        .createHash(`md5`)
-        .update(JSON.stringify(str))
-        .digest(`hex`),
+      contentDigest: createContentDigest(str),
     },
   }
 


### PR DESCRIPTION
This PR makes use of the new createContentDigest helper in gatsby-source-mongodb.

## Related Issues

Related to #8805 
