### PR TITLE
docs: updated CSS links in tutorial part 2

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -309,7 +309,7 @@ CSS-in-JS is a component-oriented styling approach. Most generally, it is a patt
 
 #### Using CSS-in-JS with Gatsby
 
-There are many different CSS-in-JS libraries and many of them have Gatsby plugins already. We won't cover an example of CSS-in-JS in this initial tutorial, but we encourage you to [explore](/docs/styling/) what the ecosystem has to offer. There are mini-tutorials for two libraries in particular, [Glamor](/docs/glamor/) and [Styled Components](/docs/styled-components/).
+There are many different CSS-in-JS libraries and many of them have Gatsby plugins already. We won't cover an example of CSS-in-JS in this initial tutorial, but we encourage you to [explore](/docs/styling/) what the ecosystem has to offer. There are mini-tutorials for two libraries in particular, [Emotion](/docs/emotion/) and [Styled Components](/docs/styled-components/).
 
 #### Suggested reading on CSS-in-JS
 
@@ -321,9 +321,9 @@ Gatsby supports almost every possible styling option (if there isn't a plugin ye
 
 - [Typography.js](/packages/gatsby-plugin-typography/)
 - [Sass](/packages/gatsby-plugin-sass/)
-- [Emotion](/packages/gatsby-plugin-emotion/)
 - [JSS](/packages/gatsby-plugin-jss/)
 - [Stylus](/packages/gatsby-plugin-stylus/)
+- [PostCSS](/packages/gatsby-plugin-postcss/)
 
 and more!
 


### PR DESCRIPTION



<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

docs: updated CSS links in tutorial part 2.

- steer users toward new Emotion instead of old Glamor
- add PostCSS plugin link

The [Gatsby Glamor tutorial](https://www.gatsbyjs.org/docs/glamor/) says Glamor is not supported and the (former) maintainer recommends Emotion. Seems prudent to steer new users to the Emotion tutorial instead.

PostCSS is popular and there's a plugin and a tutorial for it, so I added it to the "other options" list.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
