### PR TITLE
docs(gatsby-plugin-typography): New tutorial link

### DIFF
--- a/packages/gatsby-plugin-typography/README.md
+++ b/packages/gatsby-plugin-typography/README.md
@@ -2,7 +2,7 @@
 
 A Gatsby plugin for utilizing the [Typography](https://kyleamathews.github.io/typography.js/) library with minimal configuration.
 
-See it in action in the [Tutorial](https://www.gatsbyjs.org/tutorial/part-two/#typographyjs)
+See it in action in the [Tutorial](https://www.gatsbyjs.org/tutorial/part-three/)
 ([source](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography))
 
 ## Install


### PR DESCRIPTION
## Description

Typography.js is now in tutorial part 3, not part 2.

(The previous link was to an anchor within part 2, but this link is to the top of part 3. I chose not to link to [Using Plugins](https://www.gatsbyjs.org/tutorial/part-three/#using-plugins) because it's not explicitly a section about Typography.js, because it's not far into the document, and because I think the preamble provides useful context. But I could have gone either way.)