### PR TITLE
feat(www): Remove `iframe` borders

### DIFF
--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -45,6 +45,9 @@ const _options = {
       hr: {
         backgroundColor: colors.ui.light,
       },
+      iframe: {
+        border: 0,
+      },
       "tt, code, kbd, samp": {
         // reset line-height set by
         // https://github.com/KyleAMathews/typography.js/blob/3c99e905414d19cda124a7baabeb7a99295fec79/packages/typography/src/utils/createStyles.js#L198


### PR DESCRIPTION
Meh irt calling this a `feat` 😅 
This globally removes the border for `iframe`, making the GraphiQL embeds on https://www.gatsbyjs.org/docs/graphql-reference/ look a bit "nicer"; before/after:

![image](https://user-images.githubusercontent.com/21834/55998610-435a2180-5cbf-11e9-92bd-469bff03c926.png)

![image](https://user-images.githubusercontent.com/21834/55998635-6b498500-5cbf-11e9-922f-2723469bb5d1.png)
