### PR TITLE
fix(gatsby): fix NODE_ENV & GATSBY_ACTIVE_ENV in webpack

### DIFF
--- a/packages/gatsby/src/utils/__tests__/webpack.config.js
+++ b/packages/gatsby/src/utils/__tests__/webpack.config.js
@@ -101,6 +101,10 @@ describe(`environment variables`, () => {
         expect.stringContaining(`.env.staging`),
         expect.anything()
       )
+      expect(DefinePlugin).toBeCalledTimes(1)
+      expect(DefinePlugin.mock.calls[0][0]).toMatchObject({
+        [`process.env.NODE_ENV`]: JSON.stringify(process.env.NODE_ENV),
+      })
     })
 
     it(`falls back to NODE_ENV`, async () => {


### PR DESCRIPTION
## Description
if GATSBY_ACTIVE_ENV is set, it's also used in webpack for NODE_ENV. This breaks our build because we rely on production or development mostly. This change will use `GATSBY_ACTIVE_ENV` to lookup the .env file but keep using NODE_ENV for webpack.

## Related Issues
fixes #13304
fixes #13273