### PR TITLE
fix(www): button style on the Features page

### DIFF
--- a/www/src/components/evaluation-table.js
+++ b/www/src/components/evaluation-table.js
@@ -64,7 +64,9 @@ class EvaluationTable extends Component {
             >
               <button
                 css={{
+                  background: `none`,
                   border: 0,
+                  cursor: `inherit`,
                   padding: 0,
                   textAlign: `left`,
                 }}


### PR DESCRIPTION
1. Fix the restyled `button` (for Chrome on Windows and Linux we always have to set `background` property, otherwise it shows a `default` grey background)

2. Unify `cursor` type

![Peek 2019-04-12 12-54](https://user-images.githubusercontent.com/32480082/56033004-d9279800-5d23-11e9-9e9c-2e40608a9a48.gif)

with fix 

![Peek 2019-04-12 12-55](https://user-images.githubusercontent.com/32480082/56033002-d9279800-5d23-11e9-9d09-c02e5821eea3.gif)

