### PR TITLE
fix(gatsby-plugin-netlify-cms): fix hardcoded admin path for localhost

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -33,11 +33,12 @@ function deepMap(obj, fn) {
   return obj
 }
 
-exports.onCreateDevServer = ({ app, store }) => {
+exports.onCreateDevServer = ({ app, store }, { publicPath = `admin` }) => {
   const { program } = store.getState()
-  app.get(`/admin`, function(req, res) {
+  const publicPathClean = trim(publicPath, `/`)
+  app.get(`/${publicPathClean}`, function(req, res) {
     res.sendFile(
-      path.join(program.directory, `public/admin/index.html`),
+      path.join(program.directory, `public`, publicPathClean, `index.html`),
       err => {
         if (err) {
           res.status(500).end(err.message)


### PR DESCRIPTION
## Description

There was a hardcoded path for the NetlifyCMS admin page for localhost dev server, so I made it dynamic by reading the `publicPath` from `pluginOptions`.

## Related Issues

Fixes #13291
