### PR TITLE
feat(gatsby-dev-cli): Handle websocket upgrades

### DIFF
--- a/docs/docs/api-proxy.md
+++ b/docs/docs/api-proxy.md
@@ -86,12 +86,12 @@ If you need to proxy websocket connections.
 var proxy = require("http-proxy-middleware")
 module.exports = {
   developMiddleware: (app, server) => {
-    const proxy = proxyMiddleware('/api', {
-      target: 'http://localhost:9000',
+    const proxy = proxyMiddleware("/api", {
+      target: "http://localhost:9000",
       ws: true,
     })
     app.use(proxy)
-    server.on('upgrade', proxy.upgrade)
+    server.on("upgrade", proxy.upgrade)
   },
 }
 ```

--- a/docs/docs/api-proxy.md
+++ b/docs/docs/api-proxy.md
@@ -77,3 +77,23 @@ module.exports = {
   },
 }
 ```
+
+### Websockets
+
+If you need to proxy websocket connections.
+
+```javascript:title=gatsby-config.js
+var proxy = require("http-proxy-middleware")
+module.exports = {
+  developMiddleware: (app, server) => {
+    const proxy = proxyMiddleware('/api', {
+      target: 'http://localhost:9000',
+      ws: true,
+    })
+    app.use(proxy)
+    server.on('upgrade', proxy.upgrade)
+  },
+}
+```
+
+Keep in mind that middleware only has effect in development (with `gatsby develop`).

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -195,13 +195,6 @@ async function startServer(program) {
     })
   )
 
-  // Expose access to app for advanced use cases
-  const { developMiddleware } = store.getState().config
-
-  if (developMiddleware) {
-    developMiddleware(app)
-  }
-
   // Set up API proxy.
   const { proxy } = store.getState().config
   if (proxy) {
@@ -245,6 +238,13 @@ async function startServer(program) {
   }
   websocketManager.init({ server, directory: program.directory })
   const socket = websocketManager.getSocket()
+
+  // Expose access to app for advanced use cases
+  const { developMiddleware } = store.getState().config
+
+  if (developMiddleware) {
+    developMiddleware(app, server)
+  }
 
   const listener = server.listen(program.port, program.host, err => {
     if (err) {


### PR DESCRIPTION
## Description

This PR opens up for websocket proxying of the development server. Currently there is only access to the express app, but for websockets to be proxied one needs to be able to register a websocket upgrade handler with the HTTP server itself. With this PR the following will be possible:

```
// gatsby-config.js
const proxyMiddleware = require('http-proxy-middleware')

module.export = {
  developmentMiddleware: (app, server) => {
    const proxy = proxyMiddleware('/api', {
      target: 'http://localhost:8080',
      ws: true,
    });
    app.use(proxy);
    server.on('upgrade', proxy.upgrade);
  }
}
```

This PR is supposed to (and should) be backwards compatible.
