### PR TITLE
[gatsby-plugin-canonical-urls] Only append search parameters if required

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/CHANGELOG.md
+++ b/packages/gatsby-plugin-canonical-urls/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.12...gatsby-plugin-canonical-urls@2.0.13) (2019-03-13)
+
+- **gatsby-plugin-canonical-urls:** URL search params only included if `search` option is `true` 
+
 ## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.11...gatsby-plugin-canonical-urls@2.0.12) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls

--- a/packages/gatsby-plugin-canonical-urls/README.md
+++ b/packages/gatsby-plugin-canonical-urls/README.md
@@ -30,3 +30,23 @@ a `rel=canonical` e.g.
 ```html
 <link rel="canonical" href="https://www.example.com/about-us/" />
 ```
+
+### Adding search params
+
+URL search parameters are **not** included in the canonical url by default. This is to prevent search bots 
+penalizing a website for having duplicate content on pages when search tags are present. 
+
+To enable search parameters being added to the canonical url, set the `search` option to `true`:
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-canonical-urls`,
+    options: {
+      siteUrl: `https://www.example.com`,
+      search: true,
+    },
+  },
+]
+```

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-canonical-urls",
   "description": "Add canonical links to HTML pages Gatsby generates.",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,14 +1,21 @@
-exports.onRouteUpdate = ({ location }) => {
+exports.onRouteUpdate = (
+  { location },
+  pluginOptions
+) => {
   const domElem = document.querySelector(`link[rel='canonical']`)
   var existingValue = domElem.getAttribute(`href`)
   var baseProtocol = domElem.getAttribute(`data-baseProtocol`)
   var baseHost = domElem.getAttribute(`data-baseHost`)
   if (existingValue && baseProtocol && baseHost) {
+    var value = `${baseProtocol}//${baseHost}${location.pathname}`
+
+    if (pluginOptions.search === true) {
+      value += location.search
+    }
+
     domElem.setAttribute(
       `href`,
-      `${baseProtocol}//${baseHost}${location.pathname}${location.search}${
-        location.hash
-      }`
+      `${value}${location.hash}`
     )
   }
 }

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -6,15 +6,24 @@ exports.onRenderBody = (
   pluginOptions
 ) => {
   if (pluginOptions && pluginOptions.siteUrl) {
-    const parsedUrl = url.parse(pluginOptions.siteUrl)
-    const myUrl = `${pluginOptions.siteUrl}${pathname}`
+    const siteUrl = pluginOptions.siteUrl.replace(/\/$/, '')
+    const parsed = url.parse(`${siteUrl}${pathname}`)
+
+    let pageUrl = '';
+
+    if (pluginOptions.search === true) {
+      pageUrl = parsed.href;
+    } else {
+      pageUrl = `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+    }
+
     setHeadComponents([
       <link
         rel="canonical"
-        key={myUrl}
-        href={myUrl}
-        data-baseprotocol={parsedUrl.protocol}
-        data-basehost={parsedUrl.host}
+        key={pageUrl}
+        href={pageUrl}
+        data-baseprotocol={parsed.protocol}
+        data-basehost={parsed.host}
       />,
     ])
   }


### PR DESCRIPTION
[gatsby-plugin-canonical-urls]

cc @sidharthachatterjee @MarkSalabutin

## Description

This is a fairly opinionated PR. I can flip the logic if needed 👍 

Issue https://github.com/gatsbyjs/gatsby/issues/12709 makes a good point about the search params (e.g. `?tag=foobar`) being added to the canonical urls this plugin generates. From my limited SEO knowledge, the search params being included makes this plugin somewhat redundant. 

> A canonical tag (aka "rel canonical") is a way of telling search engines that a specific URL represents the master copy of a page. Using the canonical tag prevents problems caused by identical or "duplicate" content appearing on multiple URLs. Practically speaking, the canonical tag tells search engines which version of a URL you want to appear in search results. https://moz.com/learn/seo/canonicalization

Lets say I have the following page: `/blog`

If I add a tagging system, and have functionality for `/blog?tag=foobar`, search engines will still index this as a separate page, even with this plugin installed. The master reference is in-fact `/blog`.  This may not be the case all of the time, but I can't think of many cases, especially in Gatsby, where you'd want a "duplicate page" to be indexed when search params are different - it'd make more sense to create a totally different page/route.

These changes means search params won't be added by default, but gives the user the ability to set a flag adding them on. As mentioned above, I can flip this logic if you guys think it's too opinionated to do that 😄 

It would be good for someone else to test this, as breaking this functionality can have pretty serious consequences for websites SEO!

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/12709
