### PR TITLE
fix(docs): Two missing lines in "Adding pagination"

### DIFF
--- a/docs/docs/adding-pagination.md
+++ b/docs/docs/adding-pagination.md
@@ -103,7 +103,7 @@ exports.createPages = ({ graphql, actions }) => {
               limit: postsPerPage,
               skip: i * postsPerPage,
               numPages,
-              currentPage: i + 1
+              currentPage: i + 1,
             },
           })
         })

--- a/docs/docs/adding-pagination.md
+++ b/docs/docs/adding-pagination.md
@@ -102,6 +102,8 @@ exports.createPages = ({ graphql, actions }) => {
             context: {
               limit: postsPerPage,
               skip: i * postsPerPage,
+              numPages,
+              currentPage: i + 1
             },
           })
         })


### PR DESCRIPTION
## Description

After reviewing the [Add Pagination](https://www.gatsbyjs.org/docs/adding-pagination/) docs, I noticed two lines missing from the blog-list Array, when compared to the [Example Github repository](https://www.gatsbyjs.org/docs/adding-pagination/), linked at the bottom of the page. 

This PR aligns the docs with the example.  

