### PR TITLE
chore(gatsby-transformer-sqip): Improve documentation

### DIFF
--- a/packages/gatsby-transformer-sqip/.npmignore
+++ b/packages/gatsby-transformer-sqip/.npmignore
@@ -1,3 +1,6 @@
+demo.gif
+demo.mp4
+
 # Logs
 logs
 *.log

--- a/packages/gatsby-transformer-sqip/README.md
+++ b/packages/gatsby-transformer-sqip/README.md
@@ -47,7 +47,9 @@ With `gatsby-transformer-sharp`:
 
 ```graphql
 image {
-  sqip(numberOfPrimitives: 12, blur: 12, width: 256, height: 256),
+  sqip(numberOfPrimitives: 12, blur: 12, width: 256, height: 256) {
+    dataURI
+  },
   sizes(maxWidth: 400, maxHeight: 400) {
     ...GatsbyImageSharpSizes_noBase64
   }
@@ -58,7 +60,9 @@ With `gatsby-source-contentful`:
 
 ```graphql
 image {
-  sqip(numberOfPrimitives: 30, blur: 0),
+  sqip(numberOfPrimitives: 30, blur: 0) {
+    dataURI
+  },
   resolutions {
     ...GatsbyContentfulResolutions_withWebp_noBase64
   }
@@ -181,7 +185,7 @@ const Img = require(`gatsby-image`)
 <Img
   resolutions={{
     ...image.resolutions,
-    base64: image.sqip
+    base64: image.sqip.dataURI
   }}
 />
 
@@ -190,7 +194,7 @@ const Img = require(`gatsby-image`)
 <Img
   sizes={{
     ...image.sizes,
-    base64: image.sqip
+    base64: image.sqip.dataURI
   }}
 />
 ```

--- a/packages/gatsby-transformer-sqip/README.md
+++ b/packages/gatsby-transformer-sqip/README.md
@@ -141,7 +141,7 @@ See: https://www.contentful.com/developers/docs/references/images-api/#/referenc
 
 ```jsx
 <div className="image-wrapper">
-  <img src={image.dataURI} alt="" role="presentation" />
+  <img src={image.sqip.dataURI} alt="" role="presentation" />
   <img src={image.src} alt="Useful description" className="image" />
 </div>
 ```

--- a/packages/gatsby-transformer-sqip/README.md
+++ b/packages/gatsby-transformer-sqip/README.md
@@ -50,8 +50,8 @@ image {
   sqip(numberOfPrimitives: 12, blur: 12, width: 256, height: 256) {
     dataURI
   },
-  sizes(maxWidth: 400, maxHeight: 400) {
-    ...GatsbyImageSharpSizes_noBase64
+  fluid(maxWidth: 400, maxHeight: 400) {
+    ...GatsbyImageSharpFluid_noBase64
   }
 }
 ```
@@ -63,8 +63,8 @@ image {
   sqip(numberOfPrimitives: 30, blur: 0) {
     dataURI
   },
-  resolutions {
-    ...GatsbyContentfulResolutions_withWebp_noBase64
+  fixed {
+    ...GatsbyContentfulFixed_withWebp_noBase64
   }
 }
 ```
@@ -183,8 +183,8 @@ Just use it as usual with the exception that you overwrite the base64 value with
 const Img = require(`gatsby-image`)
 
 <Img
-  resolutions={{
-    ...image.resolutions,
+  fixed={{
+    ...image.fixed,
     base64: image.sqip.dataURI
   }}
 />
@@ -192,8 +192,8 @@ const Img = require(`gatsby-image`)
 // or
 
 <Img
-  sizes={{
-    ...image.sizes,
+  fluid={{
+    ...image.fluid,
     base64: image.sqip.dataURI
   }}
 />


### PR DESCRIPTION
Turned out the documentation was out of date. This update shows how to actually use the plugin.

Additionally decreases the npm bundle size by not bundling the demo videos.