### PR TITLE
fix: pageInfo.totalCount should be total number of results

### DIFF
--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -596,7 +596,7 @@ describe(`Query schema`, () => {
               },
             ],
           },
-          skiplimit: { totalCount: 1, edges: [{ node: { id: `md2` } }] },
+          skiplimit: { totalCount: 2, edges: [{ node: { id: `md2` } }] },
         }
         expect(results.errors).toBeUndefined()
         expect(results.data).toEqual(expected)
@@ -646,7 +646,7 @@ Object {
         const results = await runQuery(query)
         const expected = {
           allMarkdown: {
-            totalCount: 1,
+            totalCount: 2,
             nodes: [{ id: `md2` }],
           },
         }

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -78,7 +78,7 @@ const paginate = (results = [], { skip = 0, limit }) => {
   const hasNextPage = skip + limit < count
 
   return {
-    totalCount: items.length,
+    totalCount: count,
     edges: items.map((item, i, arr) => {
       return {
         node: item,


### PR DESCRIPTION
`pageInfo.totalCount` was showing number of query results with `limit` applied, should be total number of results.

Fixes #13342