### PR TITLE
docs: Update eslint documentation

### DIFF
--- a/docs/docs/eslint.md
+++ b/docs/docs/eslint.md
@@ -34,7 +34,6 @@ Copy the snippet below to the newly created `.eslintrc.js` file. Then add additi
 ```js:title=.eslintrc.js
 module.exports = {
   globals: {
-    graphql: true,
     __PATH_PREFIX__: true,
   },
   extends: `react-app`,


### PR DESCRIPTION
## Description

Remove graphql from globals in eslint configuration because graphql should be now imported from gatsby package (since v2 right ?)

```
import {graphql} from 'gatsby'
```

Thanks for gatsby :+1:
