### PR TITLE
fix(docs): Update custom Link component by adding `partiallyActive`

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -298,9 +298,9 @@ following may be a good starting point:
 ```jsx
 import { Link as GatsbyLink } from "gatsby"
 
-// Since DOM elements <a> cannot receive activeClassName,
+// Since DOM elements <a> cannot receive activeClassName and partiallyActive,
 // destructure the prop here and pass it only to GatsbyLink
-const Link = ({ children, to, activeClassName, ...other }) => {
+const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
   // Tailor the following test to your environment.
   // This example assumes that any internal link (intended for Gatsby)
   // will start with exactly one slash, and that anything else is external.
@@ -309,7 +309,7 @@ const Link = ({ children, to, activeClassName, ...other }) => {
   // Use Gatsby Link for internal links, and <a> for others
   if (internal) {
     return (
-      <GatsbyLink to={to} activeClassName={activeClassName} {...other}>
+      <GatsbyLink to={to} activeClassName={activeClassName} partiallyActive={partiallyActive} {...other}>
         {children}
       </GatsbyLink>
     )

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -298,8 +298,9 @@ following may be a good starting point:
 ```jsx
 import { Link as GatsbyLink } from "gatsby"
 
-// Since DOM elements <a> cannot receive activeClassName and partiallyActive,
-// destructure the prop here and pass it only to GatsbyLink
+// Since DOM elements <a> cannot receive activeClassName
+// and partiallyActive, destructure the prop here and 
+// pass it only to GatsbyLink
 const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
   // Tailor the following test to your environment.
   // This example assumes that any internal link (intended for Gatsby)

--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -299,7 +299,7 @@ following may be a good starting point:
 import { Link as GatsbyLink } from "gatsby"
 
 // Since DOM elements <a> cannot receive activeClassName
-// and partiallyActive, destructure the prop here and 
+// and partiallyActive, destructure the prop here and
 // pass it only to GatsbyLink
 const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
   // Tailor the following test to your environment.
@@ -310,7 +310,12 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
   // Use Gatsby Link for internal links, and <a> for others
   if (internal) {
     return (
-      <GatsbyLink to={to} activeClassName={activeClassName} partiallyActive={partiallyActive} {...other}>
+      <GatsbyLink
+        to={to}
+        activeClassName={activeClassName}
+        partiallyActive={partiallyActive}
+        {...other}
+      >
         {children}
       </GatsbyLink>
     )


### PR DESCRIPTION
## Description

Updated Custom Link component in gatsby-link page by adding `partiallyActive` option.
