### PR TITLE
fix(gatsby-source-contentful): add missing "face" crop focus option

### DIFF
--- a/packages/gatsby-source-contentful/src/schemes.js
+++ b/packages/gatsby-source-contentful/src/schemes.js
@@ -51,6 +51,7 @@ const ImageCropFocusType = new GraphQLEnumType({
     BOTTOM_LEFT: { value: `bottom_right` },
     RIGHT: { value: `right` },
     LEFT: { value: `left` },
+    FACE: { value: `face` },
     FACES: { value: `faces` },
     CENTER: { value: `center` },
   },


### PR DESCRIPTION
## Description

There’s another crop focus option called `face` that isn’t in the plugin yet.

Reference:
https://www.contentful.com/developers/docs/references/images-api/#/reference/resizing-&-cropping/specify-focus-area