### PR TITLE
chore(docs): removed language header from inline code block.

### DIFF
--- a/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
+++ b/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
@@ -250,7 +250,9 @@ export default ({ children }) => (
 
 To import your styled components, go to _index.js_
 
-`packages/theme/index.js`
+```js:title=packages/theme/index.js
+packages/theme/index.js
+```
 
 You will then export your component.
 

--- a/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
+++ b/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
@@ -251,7 +251,7 @@ export default ({ children }) => (
 To import your styled components, go to _index.js_
 
 ```js:title=packages/theme/index.js
-packages/theme/index.js
+packages / theme / index.js
 ```
 
 You will then export your component.

--- a/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
+++ b/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
@@ -250,7 +250,7 @@ export default ({ children }) => (
 
 To import your styled components, go to _index.js_
 
-`javascript:title=packages/theme/index.js`
+`packages/theme/index.js`
 
 You will then export your component.
 


### PR DESCRIPTION
## Description

This PR cleanup an inline code block which included the javascript language, normally displayed in the header. It originally displayed as:

`javascript:title=packages/theme/index.js`

This PR changes the inline code to display correctly:

`packages/theme/index.js`

