### PR TITLE
fix(docs): Update MDX install instructions

### DIFF
--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -40,6 +40,8 @@ can follow these steps for configuring the [gatsby-mdx](/packages/gatsby-mdx/) p
    yarn add gatsby-mdx @mdx-js/mdx @mdx-js/react
    ```
 
+   If you're upgrading from v0, [check out the MDX migration guide](https://mdxjs.com/migrating/v1).
+
 1. **Update your `gatsby-config.js`** to use the `gatsby-mdx` plugin
 
    ```javascript:title=gatsby-config.js

--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -37,7 +37,7 @@ can follow these steps for configuring the [gatsby-mdx](/packages/gatsby-mdx/) p
 1. **Add `gatsby-mdx`** and MDX as dependencies
 
    ```sh
-   yarn add gatsby-mdx @mdx-js/mdx @mdx-js/tag
+   yarn add gatsby-mdx @mdx-js/mdx @mdx-js/react
    ```
 
 1. **Update your `gatsby-config.js`** to use the `gatsby-mdx` plugin


### PR DESCRIPTION
In MDX v1 the tag package has been replaced
with mdx-js/react. This updates the installation
instructions to reflect that.

---

Related: https://mdxjs.com/migrating/v1