### PR TITLE
chore(www): remove failing sites

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -760,14 +760,6 @@
   featured: false
   categories:
     - Web Development
-- title: Nortcast
-  main_url: "https://nortcast.com/"
-  url: "https://nortcast.com/"
-  featured: false
-  categories:
-    - Technology
-    - Entertainment
-    - Podcast
 - title: Open FDA
   description: >
     Provides APIs and raw download access to a number of high-value, high
@@ -2853,22 +2845,6 @@
     - Web Development
   built_by: Maxence Poutord
   built_by_url: https://www.maxpou.fr
-- title: "Dante Calderón"
-  description: >
-    Personal Website and Blog of Dante Calderón
-  main_url: https://dantecalderon.com/
-  url: https://dantecalderon.com/
-  source_url: https://github.com/dantehemerson/dantecalderon.com
-  featured: false
-  categories:
-    - Blog
-    - Portfolio
-    - Web Development
-    - Open Source
-    - Technology
-    - Education
-  built_by: Dante Calderón
-  built_by_url: https://github.com/dantehemerson
 - title: "The Noted Project"
   url: https://thenotedproject.org
   main_url: https://thenotedproject.org

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1445,7 +1445,7 @@
     - ESLint with Airbnb's config
     - Prettier integrated into ESLint
     - A few example components and pages with stories and simple site structure
-- url: https://devchico.com/gatsby-starter-cv/
+- url: https://santosfrancisco.github.io/gatsby-starter-cv/
   repo: https://github.com/santosfrancisco/gatsby-starter-cv
   description: A simple starter to get up and developing your digital curriculum with GatsbyJS'
   tags:


### PR DESCRIPTION
## Description

Quick fix to fix breaking build 😩 Longer term--will want to follow a similar approach in creating a placeholder/placeholder fields (or use Schema Customization API?).

```
2019-04-15T21:21:18.41202802Z [Gatsby] (forked gatsby build stderr) error Building static HTML failed for path "/starters/santosfrancisco/gatsby-starter-cv/"

See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html
 +364186ms","level":"error"}
2019-04-15T21:21:18.475176397Z [Gatsby] (forked gatsby build stdout) 

  WebpackError: TypeError: Cannot read property 'screenshotFile' of null
  
  
  - bootstrap:24 c
    lib/webpack/bootstrap:24:1
  
  - bootstrap:25 Sa
    lib/webpack/bootstrap:25:1
  
  - bootstrap:30 a.render
    lib/webpack/bootstrap:30:1
  
  - bootstrap:30 a.read
    lib/webpack/bootstrap:30:1
  
  - bootstrap:42 renderToString
    lib/webpack/bootstrap:42:1
  
  - static-entry.js:207 Module../.cache/static-entry.js.__webpack_exports__.defa    ult
    lib/.cache/static-entry.js:207:17

```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
