### PR TITLE
Websocket manager use page data

### DIFF
--- a/packages/gatsby/src/utils/page-data.js
+++ b/packages/gatsby/src/utils/page-data.js
@@ -6,6 +6,12 @@ const getFilePath = ({ publicDir }, pagePath) => {
   return path.join(publicDir, `page-data`, fixedPagePath, `page-data.json`)
 }
 
+const read = async ({ publicDir }, pagePath) => {
+  const filePath = getFilePath({ publicDir }, pagePath)
+  const rawPageData = await fs.readFile(filePath, `utf-8`)
+  return JSON.parse(rawPageData)
+}
+
 const write = async ({ publicDir }, page, result) => {
   const filePath = getFilePath({ publicDir }, page.path)
   const body = {
@@ -17,5 +23,6 @@ const write = async ({ publicDir }, page, result) => {
 }
 
 module.exports = {
+  read,
   write,
 }


### PR DESCRIPTION
**Note: merges to `per-page-manifest`, not master. See https://github.com/gatsbyjs/gatsby/pull/13004 for more info**

## Description

Now that we're saving `page-data.json` per page, we can update the websocket manager to serve data from it instead of `static/d/...` (which will eventually go away).

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004
- builds on https://github.com/gatsbyjs/gatsby/pull/13139