### PR TITLE
feat(gatsby-transformer-sharp): add inside and outside fit options

### DIFF
--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -158,6 +158,14 @@ const fixedNodeType = ({
         type: GraphQLInt,
         defaultValue: 0,
       },
+      fit: {
+        type: ImageFitType,
+        defaultValue: sharp.fit.cover,
+      },
+      background: {
+        type: GraphQLString,
+        defaultValue: `rgba(0,0,0,1)`,
+      },
     },
     resolve: (image, fieldArgs, context) => {
       const file = getNodeAndSavePathDependency(image.parent, context.path)
@@ -474,6 +482,14 @@ module.exports = ({
         rotate: {
           type: GraphQLInt,
           defaultValue: 0,
+        },
+        fit: {
+          type: ImageFitType,
+          defaultValue: sharp.fit.cover,
+        },
+        background: {
+          type: GraphQLString,
+          defaultValue: `rgba(0,0,0,1)`,
         },
       },
       resolve: (image, fieldArgs, context) => {

--- a/packages/gatsby-transformer-sharp/src/types.js
+++ b/packages/gatsby-transformer-sharp/src/types.js
@@ -25,6 +25,8 @@ const ImageFitType = new GraphQLEnumType({
     COVER: { value: sharp.fit.cover },
     CONTAIN: { value: sharp.fit.contain },
     FILL: { value: sharp.fit.fill },
+    INSIDE: { value: sharp.fit.inside },
+    OUTSIDE: { value: sharp.fit.outside },
   },
 })
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add `inside` and `outside` options
## Related Issues
Addresses #12972 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
