### PR TITLE
chore(monorepo): remove unused eslint-plugin-flow-var from devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "eslint-config-google": "^0.10.0",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-filenames": "^1.3.2",
-    "eslint-plugin-flow-vars": "^0.5.0",
     "eslint-plugin-flowtype": "^2.50.3",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8405,11 +8405,6 @@ eslint-plugin-filenames@^1.3.2:
     lodash.snakecase "4.1.1"
     lodash.upperfirst "4.3.1"
 
-eslint-plugin-flow-vars@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flow-vars/-/eslint-plugin-flow-vars-0.5.0.tgz#a7fb78fd873c86e0e5839df3b3c90d47bc68c6d2"
-  integrity sha1-p/t4/Yc8huDlg53zs8kNR7xoxtI=
-
 eslint-plugin-flowtype@^2.46.1:
   version "2.50.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.0.tgz#953e262fa9b5d0fa76e178604892cf60dfb916da"


### PR DESCRIPTION
## Description

This PR removes `eslint-plugin-flow-var` from the `package.json` and `yarn.lock` files. The new package `eslint-plugin-flow-var` was already included in the existing repository files. 

## Related Issues
The second part of #13387 is a little more complicated. It appears `coffee-script` is required by `gray-matter@2.1.1`, which is the dependency. According to the developers [github repository](https://github.com/jonschlinkert/gray-matter/blob/master/CHANGELOG.md):
```
4.0.0 - 2018-04-01
Breaking changes
Now requires node v4 or higher.

3.0.0 - 2017-06-30
Breaking changes
`toml`, `coffee` and `cson` are no longer supported by default. Please see options.engines and the examples to learn how to add engines.
```

