### PR TITLE
docs(gatsby-plugin-feed): fix examples link

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -74,7 +74,7 @@ Each feed must include `output`, `query`, and `title`. Additionally, it is stron
 
 All additional options are passed through to the [`rss`][rss] utillity. For more info on those additional options, [explore the `itemOptions` section of the `rss` package](https://www.npmjs.com/package/rss#itemoptions).
 
-Check out an example of [how you could implement](/docs/docs/adding-an-rss-feed/) to your own site, with a custom `serialize` function, and additional functionality.
+Check out an example of [how you could implement](https://www.gatsbyjs.org/docs/adding-an-rss-feed/) to your own site, with a custom `serialize` function, and additional functionality.
 
 _NOTE: This plugin only generates the `xml` file(s) when run in `production` mode! To test your feed, run: `gatsby build && gatsby serve`._
 

--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -74,7 +74,7 @@ Each feed must include `output`, `query`, and `title`. Additionally, it is stron
 
 All additional options are passed through to the [`rss`][rss] utillity. For more info on those additional options, [explore the `itemOptions` section of the `rss` package](https://www.npmjs.com/package/rss#itemoptions).
 
-Check out an example of [how you could implement](/docs/adding-an-rss-feed/) to your own site, with a custom `serialize` function, and additional functionality.
+Check out an example of [how you could implement](/docs/docs/adding-an-rss-feed/) to your own site, with a custom `serialize` function, and additional functionality.
 
 _NOTE: This plugin only generates the `xml` file(s) when run in `production` mode! To test your feed, run: `gatsby build && gatsby serve`._
 


### PR DESCRIPTION
Or should it link to https://www.gatsbyjs.org/docs/adding-an-rss-feed/ ?

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
