### PR TITLE
feat(docs): Update "Writing documentation with Docz"

### DIFF
--- a/docs/docs/writing-documentation-with-docz.md
+++ b/docs/docs/writing-documentation-with-docz.md
@@ -4,9 +4,9 @@ title: "Writing documentation with Docz"
 
 Writing good documentation is important for your project maintainers (and for your future self!). A very nice documentation generator is [Docz](https://www.docz.site). It allows you to easily write interactive docs for your React components.
 
-Docz leverages `mdx` files -- short for Markdown with JSX-- which brings **React components** to Markdown files. From your PropTypes, or Flow types or TypeScript types, it can generate **property tables** to document properly how to use your components. In addition, you can provide a **coding playground** for your components, so that anyone can see them in action, modify the code and see the changes live, or copy the snippet to use it somewhere else.
+Docz leverages `mdx` files – short for Markdown with JSX – which brings **React components** to Markdown files. From your PropTypes, or Flow types or TypeScript types, it can generate **property tables** to document properly how to use your components. In addition, you can provide a **coding playground** for your components, so that anyone can see them in action, modify the code and see the changes live, or copy the snippet to use it somewhere else.
 
-If you're starting your Gatsby project from scratch and would like to have great documentation, with Docz support out of the box, you can use the starter mentioned in [Other Resources](#other-resources) below.
+If you're starting your Gatsby project from scratch and would like to have great documentation, with Docz support out of the box, you can use [`gatsby-starter-docz`](https://github.com/pedronauck/gatsby-starter-docz). You can also find more information at the end of this guide in the [Other resources](#other-resources) section.
 
 Alternatively, the following guide should help you to get Docz working within an existing Gatsby project.
 
@@ -22,152 +22,159 @@ To set up Docz you need to install dependencies and do some custom configuration
 
 ```shell
 cd my-gatsby-site-with-docz
-gatsby develop
 ```
 
-and test that your Gatsby site is running by going to http://localhost:8000.
-
-Going back to your terminal, install the necessary dev dependencies to get a Docz site up and running.
+And install the following packages:
 
 ```shell
-# run this from my-gatsby-site-with-docz/
-npm install --save-dev docz docz-theme-default docz-plugin-css @babel/plugin-syntax-dynamic-import webpack-merge
+npm install --save gatsby-theme-docz docz docz-theme-default
 ```
 
-Add the following scripts to your `package.json` file:
+Define `docz-theme-default` as a theme inside the `__experimentalThemes` of `gatsby-config.js`:
 
-```json:title=package.json
-{
-    ...
-    "scripts": {
-        ...
-        "docz:dev": "docz dev",
-        "docz:build": "docz build",
-        ...
-    }
-    ...
+```js:title=gatsby-config.js
+module.exports = {
+  //highlight-next-line
+  __experimentalThemes: [`gatsby-theme-docz`],
+  plugins: [`// your plugins go here`],
 }
 ```
-
-Create these two files:
-
-- `doczrc.js` to configure Docz,
-- `docz/wrapper.js` to inject some JavaScript in Docz pages, to ensure compatibility with Gatsby.
-
-Create a new folder `docz`, and inside that folder, a new file `wrapper.js`. Add the following code to `wrapper.js`:
-
-```js:title=docz/wrapper.js
-import * as React from "react"
-
-// Gatsby's Link overrides:
-// Gatsby internal mocking to prevent unnecessary error in docz: __PATH_PREFIX__ is not defined
-global.__PATH_PREFIX__ = ""
-
-export default ({ children }) => children
-```
-
-> You are essentially creating a dummy wrapper that does nothing else than making sure that `global.__PATH_PREFIX__` is defined on every page.
-
-Create a new file called `doczrc.js` in the root directory of your Gatsby project, and add the following content:
-
-```js:title=doczrc.js
-import merge from "webpack-merge"
-import { css } from "docz-plugin-css"
-
-export default {
-  title: "Docz with Gatsby",
-  // Add CSS support in case you use them in your Gatsby project
-  plugins: [css()],
-  // highlight-next-line
-  // Wrapper used to inject some global variable mocks
-  wrapper: "docz/wrapper.js",
-  modifyBundlerConfig: config => {
-    const gatsbyNecessaryConfig = {
-      module: {
-        rules: [
-          {
-            // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
-            // Ignore .json files because they fail to be parsed
-            exclude: [/node_modules\/(?!(gatsby)\/)/, /\.json$/],
-            use: [
-              {
-                // use installed babel-loader which is v8.0-beta (which is meant to work with @babel/core@7)
-                loader: "babel-loader",
-                options: {
-                  // use @babel/preset-react for JSX and env (instead of staged presets)
-                  presets: ["@babel/preset-react", "@babel/preset-env"],
-                  plugins: [
-                    // use @babel/plugin-proposal-class-properties for class arrow functions
-                    "@babel/plugin-proposal-class-properties",
-                    // use @babel/plugin-syntax-dynamic-import for dynamic import support
-                    "@babel/plugin-syntax-dynamic-import",
-                  ],
-                },
-              },
-            ],
-          },
-        ],
-      },
-    }
-
-    return merge(gatsbyNecessaryConfig, config)
-  },
-}
-```
-
-Once you have this configured you should run Docz to ensure it can start up properly. You should see by default a _Page Not Found_ page, this is fine as you haven't created any `mdx` files yet. To run Docz:
-
-```shell
-npm run docz:dev
-```
-
-If Docz builds successfully you should be able to navigate to `http://localhost:3000` and see the default _Page Not Found_ page.
 
 ## Writing documentation
 
-Docz searches your directory for `mdx` files and renders them. Let's add your first documentation page by creating a file `index.mdx` in the root directory of your Gatsby project.
+Docz searches your directories for `mdx` files and renders them. Create a `docs` folder at the root of your project. Place an `index.mdx` file inside this directory with the following content:
 
-```mdx:title=index.mdx
+```md:title=docs/index.mdx
 ---
-name: Getting started
+name: Getting Started
 route: /
 ---
 
 # Getting Started
 
-This is the start of an amazing Docz site
+## Hello world
+
+Type here the most beautyiful getting started that you ever saw!
 ```
 
-This is a very simple documentation page without much going on, but let's spice things up by adding and rendering a Gatsby component. Assuming you have a header component in your components folder which does not rely on `StaticQuery` or `graphql`, you can add:
+Run the development server with `gatsby develop` and you should be greeted with the default Docz layout and a "Getting Started" heading. Stop the development server after verifying that everything works.
 
-```mdx:title=index.mdx
----
-name: Getting started
-route: /
----
+Let's spice things up by adding and rendering a React component. For the sake of simplicity you can create the following button component in the same `docs` directory.
 
-//highlight-next-line
-import Header from './src/components/header'
+```jsx:title=docs/button.jsx
+import React from "react"
+import PropTypes from "prop-types"
 
-# Getting Started
+const scales = {
+  small: {
+    fontSize: "16px",
+  },
+  normal: {
+    fontSize: "18px",
+  },
+  big: {
+    fontSize: "22px",
+  },
+}
 
-This is the start of an amazing Docz site
+export const Button = ({ children, scale }) => (
+  <button style={scales[scale]}>{children}</button>
+)
 
-//highlight-next-line
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  scale: PropTypes.oneOf(["small", "normal", "big"]),
+}
 
-<Header siteTitle="Hello from Gatsby" />
+Button.defaultProps = {
+  scale: "normal",
+}
 ```
 
-Restart the Docz server and voilà!
+The button will display its text by default with a `font-size` of `18px` however you can also pass in `small` & `big` as a size. These properties will later be displayed by Docz.
 
-> Note: If your component relies on `StaticQuery` or `graphql`, consider splitting it into two smaller components:
+> **Note:** If your component relies on `StaticQuery` or `graphql`, consider splitting it into two smaller components:
 >
 > - one React component dealing only with the **UI layer**, and
 > - another dealing with the **data layer**.
 >
 > You could showcase the UI layer React component in your `mdx` files and your data layer component could use it to render the data it fetched thanks to `StaticQuery` and `graphql`.
 
+Create a new file in the `docs` directory to document your newly created button component. Call the file `button.mdx`:
+
+```md:title=docs/button.mdx
+---
+name: Button
+menu: Components
+---
+
+# Button
+
+Buttons make common actions more obvious and help users more easily perform them. Buttons use labels and sometimes icons to communicate the action that will occur when the user touches them.
+```
+
+Docz offers some internal components you can use to display the component and its properties. Import both these and your component itself into the document and use them:
+
+```md:title=docs/button.mdx
+---
+name: Button
+menu: Components
+---
+
+// highlight-start
+import { Playground, Props } from "docz"
+import { Button } from "./button"
+// highlight-end
+
+# Button
+
+Buttons make common actions more obvious and help users more easily perform them. Buttons use labels and sometimes icons to communicate the action that will occur when the user touches them.
+
+// highlight-start
+
+## Properties
+
+<Props of={Button} />
+
+## Basic usage
+
+<Playground>
+  <Button>Click me</Button>
+</Playground>
+
+## With different sizes
+
+<Playground>
+  <Button scale="small">Click me</Button>
+  <Button scale="normal">Click me</Button>
+  <Button scale="big">Click me</Button>
+</Playground>
+// highlight-end
+```
+
+Start the development server again and you should see the properties (children and scale), one playground displaying the normal button, and one playground showing the button in its three sizes.
+
+## Configuration
+
+You can usually set your config using a `doczrc.js` file ([see all available options](https://www.docz.site/docs/project-configuration)) or if you want to set some default options for your theme, you can set `options` in the theme definition.
+
+```js:title=gatsby-config.js
+module.exports = {
+  __experimentalThemes: [
+    {
+      resolve: `gatsby-theme-docz`,
+      options: {
+        // Your options here
+      },
+    },
+  ],
+  plugins: [`// your plugins go here`],
+}
+```
+
+> We highly recommend that you set your configuration using `doczrc.js`! Live reloading will only work with the configuration file, not the settings inside the theme definition.
+
 ## Other resources
 
-- For more information on Docz visit [the Docz site](https://docz.site/)
-- Get started with a [Docz starter](https://github.com/RobinCsl/gatsby-starter-docz)
+- For more information on Docz visit [the Docz site](https://docz.site/) and in particular the [Gatsby theme documentation](https://www.docz.site/docs/gatsby-theme)
+- Check out the official [Docz starter](https://github.com/pedronauck/gatsby-starter-docz)


### PR DESCRIPTION
Closes #13315

Intentionally left out the [Getting data](https://www.docz.site/docs/gatsby-theme) part.

---

<details>
  <summary>Preview</summary>
  <p><img src="https://user-images.githubusercontent.com/16143594/56286786-e0cbb000-611a-11e9-972b-ad3a20a5bf53.png" /></p>
</details>
