### PR TITLE
feat(gatsby-plugin-google-tagmanager): Allow to place the GTM script …

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -24,6 +24,11 @@ plugins: [
       gtmAuth: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_AUTH_STRING",
       gtmPreview: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_PREVIEW_NAME",
       dataLayerName: "YOUR_DATA_LAYER_NAME",
+
+      // Whether to put the GTM script into the <head> (as suggested by Google)
+      // or append it to the <body> (making it non-blocking).
+      // If you activate Google Optimize through Google Tag Manager leave it untouched.
+      placeInHead: true,
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -27,8 +27,8 @@ plugins: [
 
       // Whether to put the GTM script into the <head> (as suggested by Google)
       // or append it to the <body> (making it non-blocking).
-      // If you activate Google Optimize through Google Tag Manager leave it untouched.
-      placeInHead: true,
+      // Defaults to false meaning GTM will be added in the <head> (again, as suggested by Google).
+      addTagInBody: false,
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-google-tagmanager",
   "description": "Gatsby plugin to add google tagmanager onto a site",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "author": "Thijs Koerselman <thijs@vauxlab.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -1,8 +1,8 @@
-import React from "react"
-import { oneLine, stripIndent } from "common-tags"
+import { oneLine, stripIndent } from "common-tags";
+import React from "react";
 
 exports.onRenderBody = (
-  { setHeadComponents, setPreBodyComponents },
+  { setHeadComponents, setPreBodyComponents, setPostBodyComponents },
   pluginOptions
 ) => {
   if (
@@ -18,7 +18,8 @@ exports.onRenderBody = (
     `
         : ``
 
-    setHeadComponents([
+    const setComponents = pluginOptions.placeInHead === false ? setPostBodyComponents : setHeadComponents;
+    setComponents([
       <script
         key="plugin-google-tagmanager"
         dangerouslySetInnerHTML={{

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -1,5 +1,5 @@
-import { oneLine, stripIndent } from "common-tags";
-import React from "react";
+import { oneLine, stripIndent } from "common-tags"
+import React from "react"
 
 exports.onRenderBody = (
   { setHeadComponents, setPreBodyComponents, setPostBodyComponents },
@@ -18,7 +18,10 @@ exports.onRenderBody = (
     `
         : ``
 
-    const setComponents = pluginOptions.placeInHead === false ? setPostBodyComponents : setHeadComponents;
+    const setComponents =
+      pluginOptions.placeInHead === false
+        ? setPostBodyComponents
+        : setHeadComponents
     setComponents([
       <script
         key="plugin-google-tagmanager"

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -18,10 +18,9 @@ exports.onRenderBody = (
     `
         : ``
 
-    const setComponents =
-      pluginOptions.placeInHead === false
-        ? setPostBodyComponents
-        : setHeadComponents
+    const setComponents = pluginOptions.addTagInBody
+      ? setPostBodyComponents
+      : setHeadComponents
     setComponents([
       <script
         key="plugin-google-tagmanager"


### PR DESCRIPTION
…at the end of the <body> tag

## Description

I added one more option to the `gatsby-plugin-google-tagmanager` plugin to allow adding the GTM script in the head (by default, as it is now) or append it to the body (to make it non-blocking).