### PR TITLE
docs: Remove note about stringified options

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -78,8 +78,6 @@ module.exports = {
 }
 ```
 
-Note that plugin options will be stringified by Gatsby, so they cannot be functions.
-
 ## Loading plugins from your local plugins folder
 
 Gatsby can also load plugins from the your local website plugins folder which is a folder named `plugins` in the website's root directory.


### PR DESCRIPTION
I'm not entirely sure about this, I'm aware of the origin https://github.com/gatsbyjs/gatsby/pull/3987 yet this PR I made proofs the opposite https://github.com/gatsbyjs/gatsby/pull/12060 
Only thing I can think of right now that browser APIs get stringified, couldn't verify this so far, this https://github.com/gatsbyjs/gatsby/issues/3834 is suggesting they get stringified and it's the reason the note was added to the docs in the first place..

Couldn't just leave my confusion alone and thought doing it in a PR might be useful if it's actually not valid anymore so it can be merged directly, otherwise feel free to reject it of course 👍

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
