### PR TITLE
docs: add clarity about package.json in playground docs

### DIFF
--- a/docs/docs/using-graphql-playground.md
+++ b/docs/docs/using-graphql-playground.md
@@ -12,7 +12,7 @@ The Playground is a way for you to interact with the data your sources and plugi
 
 ## Accessing the Playground
 
-As this is an experimental feature, you need to access it by adding an environmental variable, you need to add `GATSBY_GRAPHQL_IDE` to your `develop` script, like this:
+As this is an experimental feature, you need to access it by adding an environmental variable, you need to add `GATSBY_GRAPHQL_IDE` to your `develop` script in your `package.json`, like this:
 
 ```
 "develop": "GATSBY_GRAPHQL_IDE=playground gatsby develop",


### PR DESCRIPTION
## Description

Current version doesn't actually say where to put the change. A colleague asked "do you know where that playground command actually needs to go?" so I've added clarity about `package.json`