### PR TITLE
docs: update tutorial to useStaticQuery

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -292,7 +292,7 @@ Page queries live outside of the component definition -- by convention at the en
 ### Use a StaticQuery
 
 [StaticQuery](/docs/static-query/) is a new API introduced in Gatsby v2 that allows non-page components (like our `layout.js` component), to retrieve data via GraphQL queries.
-
+Let's use its newly introduced hook version — [`useStaticQuery`](/docs/use-static-query/)
 Go ahead and make some changes to your `src/components/layout.js` file to use the `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
 
 ```jsx:title=src/components/layout.js
@@ -303,8 +303,8 @@ import { useStaticQuery, Link, graphql } from "gatsby"
 
 import { rhythm } from "../utils/typography"
 
-// highlight-start
 export default ({ children }) => {
+// highlight-start
   const data = useStaticQuery(
     graphql`
       query {
@@ -316,8 +316,8 @@ export default ({ children }) => {
       }
     `
   )
+  // highlight-end
   return (
-    // highlight-end
     <div
       css={css`
         margin: 0 auto;
@@ -347,10 +347,8 @@ export default ({ children }) => {
       </Link>
       {children}
     </div>
-    // highlight-start
   )
 }
-// highlight-end
 ```
 
 Another success! 🎉

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -293,16 +293,7 @@ Page queries live outside of the component definition -- by convention at the en
 
 [StaticQuery](/docs/static-query/) is a new API introduced in Gatsby v2 that allows non-page components (like our `layout.js` component), to retrieve data via GraphQL queries.
 
-There are two ways to use StaticQuery:-
-
-1. The [StaticQuery component](/docs/static-query/)
-2. The newer [useStaticQuery hook](/docs/use-static-query/)
-
-In this tutorial you'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
-
-You need to include hooks within the body of your function component. To facilitate this you change the `export` line to include `{` rather than `(`. Also, within the function you'll use `return()`. When you use `(` on your export line you're effectively using a shortcut to writing `return(` each time. But because you now need to run the hook before you return the component you will need to define it.
-
-Go ahead and make some changes to your `src/components/layout.js` file to run a `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
+Go ahead and make some changes to your `src/components/layout.js` file to use the `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
 
 ```jsx:title=src/components/layout.js
 import React from "react"
@@ -362,6 +353,8 @@ export default ({ children }) => {
 }
 {/* highlight-end */}
 ```
+
+You've now added the query before you return the component by changing your function to use `{}` instead of `()` and wrapping what was there before with `return()`.
 
 Another success! 🎉
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -300,7 +300,7 @@ There are two ways to use StaticQuery:-
 
 You'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
 
-With React, Hooks need to be within the body of the function component. Notice the change of the `export` line to `{` rather than `(` and the introduction of `return()`. This includes what was previously the only thing in our function. This allows you to do additional work before you render your component, in this case that means running our static query.
+You need to include hooks within the body of your function component. To facilitate this you change the `export` line to include `{` rather than `(`. Also, within the function you'll use `return()`. When you use `(` on your export line you're effectively using a shortcut to writing `return(` each time. But because you now need to run the hook before you return the component you will need to write it longhand this time.
 
 Go ahead and make some changes to your `src/components/layout.js` file to run a `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -298,7 +298,7 @@ There are two ways to use StaticQuery:-
 1. The [StaticQuery component](/docs/static-query/)
 2. The newer [useStaticQuery hook](/docs/use-static-query/)
 
-You'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
+In this tutorial you'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
 
 You need to include hooks within the body of your function component. To facilitate this you change the `export` line to include `{` rather than `(`. Also, within the function you'll use `return()`. When you use `(` on your export line you're effectively using a shortcut to writing `return(` each time. But because you now need to run the hook before you return the component you will need to write it longhand this time.
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -354,8 +354,6 @@ export default ({ children }) => {
 {/* highlight-end */}
 ```
 
-You've now added the query before you return the component by changing your function to use `{}` instead of `()` and wrapping what was there before with `return()`.
-
 Another success! 🎉
 
 ![Page title and layout title both pulling from siteMetadata](site-metadata-two-titles.png)

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -300,7 +300,7 @@ There are two ways to use StaticQuery:-
 
 In this tutorial you'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
 
-You need to include hooks within the body of your function component. To facilitate this you change the `export` line to include `{` rather than `(`. Also, within the function you'll use `return()`. When you use `(` on your export line you're effectively using a shortcut to writing `return(` each time. But because you now need to run the hook before you return the component you will need to write it longhand this time.
+You need to include hooks within the body of your function component. To facilitate this you change the `export` line to include `{` rather than `(`. Also, within the function you'll use `return()`. When you use `(` on your export line you're effectively using a shortcut to writing `return(` each time. But because you now need to run the hook before you return the component you will need to define it.
 
 Go ahead and make some changes to your `src/components/layout.js` file to run a `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -293,20 +293,29 @@ Page queries live outside of the component definition -- by convention at the en
 
 [StaticQuery](/docs/static-query/) is a new API introduced in Gatsby v2 that allows non-page components (like our `layout.js` component), to retrieve data via GraphQL queries.
 
-Go ahead and add a `<StaticQuery />` to your `src/components/layout.js` file and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
+There are two ways to use StaticQuery:-
+
+1. The [StaticQuery component](/docs/static-query/)
+2. The newer [useStaticQuery hook](/docs/use-static-query/)
+
+We'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
+
+With React, Hooks need to be within the body of the function component. So you will notice we change the `export` line to `{` rather than `(` and introduce `return()` which includes what was previously the only thing in our function. This allows us to do additional work before we render our component, in our case that means running our static query.
+
+Go ahead and make some changes to your `src/components/layout.js` file to run a `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
 
 ```jsx:title=src/components/layout.js
 import React from "react"
 import { css } from "@emotion/core"
 // highlight-next-line
-import { StaticQuery, Link, graphql } from "gatsby"
+import { useStaticQuery, Link, graphql } from "gatsby"
 
 import { rhythm } from "../utils/typography"
 
-export default ({ children }) => (
-  {/* highlight-start */}
-  <StaticQuery
-    query={graphql`
+{/* highlight-start */}
+export default ({ children }) => {
+  const data = useStaticQuery(
+    graphql`
       query {
         site {
           siteMetadata {
@@ -314,43 +323,44 @@ export default ({ children }) => (
           }
         }
       }
-    `}
-    render={data => (
-      {/* highlight-end */}
-      <div
-        css={css`
-          margin: 0 auto;
-          max-width: 700px;
-          padding: ${rhythm(2)};
-          padding-top: ${rhythm(1.5)};
-        `}
-      >
-        <Link to={`/`}>
-          <h3
-            css={css`
-              margin-bottom: ${rhythm(2)};
-              display: inline-block;
-              font-style: normal;
-            `}
-          >
-            {data.site.siteMetadata.title}{/* highlight-line */}
-          </h3>
-        </Link>
-        <Link
-          to={`/about/`}
+    `
+  )
+  
+  return(
+  {/* highlight-end */}
+    <div
+      css={css`
+        margin: 0 auto;
+        max-width: 700px;
+        padding: ${rhythm(2)};
+        padding-top: ${rhythm(1.5)};
+      `}
+    >
+      <Link to={`/`}>
+        <h3
           css={css`
-            float: right;
+            margin-bottom: ${rhythm(2)};
+            display: inline-block;
+            font-style: normal;
           `}
         >
-          About
-        </Link>
-        {children}
-      </div>
-      {/* highlight-start */}
-    )}
-  />
-  {/* highlight-end */}
-)
+          {data.site.siteMetadata.title}{/* highlight-line */}
+        </h3>
+      </Link>
+      <Link
+        to={`/about/`}
+        css={css`
+          float: right;
+        `}
+      >
+        About
+      </Link>
+      {children}
+    </div>
+  {/* highlight-start */}
+  )
+}
+{/* highlight-end */}
 ```
 
 Another success! 🎉

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -298,9 +298,9 @@ There are two ways to use StaticQuery:-
 1. The [StaticQuery component](/docs/static-query/)
 2. The newer [useStaticQuery hook](/docs/use-static-query/)
 
-We'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
+You'll be using the newer hook method which is cleaner and more succinct, but you may wish to learn about the component version too.
 
-With React, Hooks need to be within the body of the function component. So you will notice we change the `export` line to `{` rather than `(` and introduce `return()` which includes what was previously the only thing in our function. This allows us to do additional work before we render our component, in our case that means running our static query.
+With React, Hooks need to be within the body of the function component. Notice the change of the `export` line to `{` rather than `(` and the introduction of `return()`. This includes what was previously the only thing in our function. This allows you to do additional work before you render your component, in this case that means running our static query.
 
 Go ahead and make some changes to your `src/components/layout.js` file to run a `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done your file looks like this:
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -325,7 +325,7 @@ export default ({ children }) => {
       }
     `
   )
-  
+
   return(
   {/* highlight-end */}
     <div

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -304,7 +304,7 @@ import { useStaticQuery, Link, graphql } from "gatsby"
 import { rhythm } from "../utils/typography"
 
 export default ({ children }) => {
-// highlight-start
+  // highlight-start
   const data = useStaticQuery(
     graphql`
       query {

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -303,7 +303,7 @@ import { useStaticQuery, Link, graphql } from "gatsby"
 
 import { rhythm } from "../utils/typography"
 
-{/* highlight-start */}
+// highlight-start
 export default ({ children }) => {
   const data = useStaticQuery(
     graphql`
@@ -316,9 +316,8 @@ export default ({ children }) => {
       }
     `
   )
-
-  return(
-  {/* highlight-end */}
+  return (
+    // highlight-end
     <div
       css={css`
         margin: 0 auto;
@@ -335,7 +334,7 @@ export default ({ children }) => {
             font-style: normal;
           `}
         >
-          {data.site.siteMetadata.title}{/* highlight-line */}
+          {data.site.siteMetadata.title} {/* highlight-line */}
         </h3>
       </Link>
       <Link
@@ -348,10 +347,10 @@ export default ({ children }) => {
       </Link>
       {children}
     </div>
-  {/* highlight-start */}
+    // highlight-start
   )
 }
-{/* highlight-end */}
+// highlight-end
 ```
 
 Another success! 🎉


### PR DESCRIPTION
## Description
A colleague of mine came across this page when learning Gatsby and mentioned that the code looked very messy and a bit hacky.

I introduced him to the useStaticQuery hook which clicked a lot more for him. When I first started learning Gatsby I also found the current code sample using the component inelegant and I wonder how many people drop out of the tutorial at this point because of the perceived code-smell.

I don't know if it's the core team's intention for people to be using useStaticQuery over the original component but if they are, might I suggest we update the tutorial as this pull request suggests? I think it'd be more accessible and also introduces the idea of using hooks in a hopefully easy to understand way into the tutorial which I think is a useful addition.