### PR TITLE
fix(gatsby-plugin-netlify): Add Referrer-Policy to security headers

### DIFF
--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -21,6 +21,7 @@ export const SECURITY_HEADERS = {
     `X-Frame-Options: DENY`,
     `X-XSS-Protection: 1; mode=block`,
     `X-Content-Type-Options: nosniff`,
+    `Referrer-Policy: same-origin`,
   ],
 }
 


### PR DESCRIPTION
## Description

Add 'Referrer-Policy: same-origin' to SECURITY_HEADERS.

This is one of the headers checked by securityheaders.com and currently [it's not included by Gatsby by default](https://securityheaders.com/?q=gatsbyjs.org&followRedirects=on). I was adding it to a few of my projects, but I realised it could probably be added upstream, so here it is.

Looking around, it seems that 'same-origin' is a good default, but I don't feel strongly about it. Would this be welcome?

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
