### PR TITLE
fix(gatsby-cypress): use correct links in package json

### DIFF
--- a/packages/gatsby-cypress/package.json
+++ b/packages/gatsby-cypress/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.7",
   "description": "Cypress tools for Gatsby projects",
   "main": "index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands#readme",
+  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress#readme",
   "author": "David Bailey <david.j.b@vivaldi.net>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
## Description

repository field was linking to an old page which now resolves to a 404. Fixed that and also added a homepage field.

## Related Issues

This may tackle a portion of #13457 but I will leave the issue open as we will likely want to check when the site and the plugin library is rebuilt before closing the issue
