### PR TITLE
docs(www): Fix incorrect casing in USing Babel

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -57,7 +57,7 @@
           items:
             - title: Customizing Babel.js Config
               link: /docs/babel/
-            - title: USing Babel Plugin Macros
+            - title: Using Babel Plugin Macros
               link: /docs/babel-plugin-macros/
             - title: Customizing Webpack Config
               link: /docs/add-custom-webpack-config/


### PR DESCRIPTION
## Description
The sidebar navigation had incorrect casing for "USing Babel Plugin Macros" should be "Using Babel Plugin Macros"