### PR TITLE
Document that you can use just the username and repo in `gatsby new` …

### DIFF
--- a/docs/docs/starters.md
+++ b/docs/docs/starters.md
@@ -6,15 +6,21 @@ The Gatsby CLI tool lets you install “starters”. These are boilerplate Gatsb
 
 `gatsby new` helps you start your project by cloning the boilerplate, installing dependencies, and clearing Git history.
 
-When creating a new site, you can optionally specify a starter to base your new site on e.g.
+When creating a new site, you can optionally specify a starter to base your new site on, eith er with the `[URL]` of the `[GIT_USER_NAME/REPO]` e.g.
 
 `gatsby new [SITE_DIRECTORY] [URL_OF_STARTER_GITHUB_REPO]`
+or
+`gatsby new [SITE_DIRECTORY] [GIT_USER_NAME/REPO]`
 
 For example, to quickly create a blog using Gatsby, you could install the Gatsby Starter Blog by running:
 
 `gatsby new blog https://github.com/gatsbyjs/gatsby-starter-blog`
 
 This downloads the files and initializes the site by running `npm install`
+
+Or, you can use the `[GIT_USER_NAME/REPO]`
+
+`gatsby new blog gatsbyjs/gatsby-starter-blog`
 
 If you don't specify a custom starter, your site will be created from the [default starter](https://github.com/gatsbyjs/gatsby-starter-default).
 

--- a/docs/docs/starters.md
+++ b/docs/docs/starters.md
@@ -6,7 +6,7 @@ The Gatsby CLI tool lets you install “starters”. These are boilerplate Gatsb
 
 `gatsby new` helps you start your project by cloning the boilerplate, installing dependencies, and clearing Git history.
 
-When creating a new site, you can optionally specify a starter to base your new site on, eith er with the `[URL]` of the `[GIT_USER_NAME/REPO]` e.g.
+When creating a new site, you can optionally specify a starter to base your new site on, either with the `[URL]` of the `[GIT_USER_NAME/REPO]` e.g.
 
 `gatsby new [SITE_DIRECTORY] [URL_OF_STARTER_GITHUB_REPO]`
 or


### PR DESCRIPTION
closes #13455

## Description

Updated and added the `gatsby new` alias to the Starters Docs page. If there are other areas on the site or documentation you want me to address, I am available. 

