### PR TITLE
chore(www): fix redundant boolean condition

### DIFF
--- a/www/src/utils/sidebar/create-link.js
+++ b/www/src/utils/sidebar/create-link.js
@@ -49,7 +49,7 @@ const createLink = ({
           isDraft && styles.draft,
           isActive && styles.activeLink,
           isParentOfActiveItem && styles.parentOfActiveLink,
-          customCSS && customCSS,
+          customCSS,
           { paddingLeft: indent },
           {
             "&:before, &:after": {


### PR DESCRIPTION
Passing identical, or seemingly identical, operands to an operator such as subtraction or conjunction may indicate a typo; even if it is intentional, it makes the code hard to read.

Many arithmetic or logical operators yield a trivial result when applied to identical operands: for instance, x-x yields zero if x is a number, and yields NaN otherwise; x&&x is always equal to x. Code like this is often the result of a typo, such as misspelling a variable name. Even if it is intentional (relying, for instance, on side effects), such code is hard to read and understand and should be avoided.

