### PR TITLE
fix(gatsby): warn if trying to create a page with similar path for trailing/non-trailing

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -351,6 +351,18 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
   const contextModified =
     !!oldPage && !_.isEqual(oldPage.context, internalPage.context)
 
+  const alternateSlashPath = page.path.endsWith(`/`)
+    ? page.path.slice(0, -1)
+    : page.path + `/`
+
+  if (store.getState().pages.has(alternateSlashPath)) {
+    report.warn(
+      `Attempting to create page "${
+        page.path
+      }", but page "${alternateSlashPath}" already exists. This could lead to non-deterministic routing behavior`
+    )
+  }
+
   return {
     ...actionOptions,
     type: `CREATE_PAGE`,


### PR DESCRIPTION
## Description

Warn if trying to create a page whose path is the same as an existing page, but with or without a trailing slash. See https://github.com/gatsbyjs/gatsby/issues/13464

## Related Issues

- addresses https://github.com/gatsbyjs/gatsby/issues/13464
