### PR TITLE
fix: raise Unexpected Errors in resolve-module-exports

### DIFF
--- a/packages/gatsby/src/bootstrap/__mocks__/require/module-error.js
+++ b/packages/gatsby/src/bootstrap/__mocks__/require/module-error.js
@@ -1,0 +1,3 @@
+// this will cause errors when importing it - that's fine - that's the point opf this mock
+// eslint-disable-next-line
+wat()

--- a/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
@@ -226,4 +226,21 @@ describe(`Resolve module exports`, () => {
     })
     expect(result).toEqual([`foo`])
   })
+
+  it(`Resolves exports when using require mode - returns empty array when module doesn't exist`, () => {
+    const result = resolveModuleExports(`require/not-existing-module`, {
+      mode: `require`,
+    })
+    expect(result).toEqual([])
+  })
+
+  it(`Resolves exports when using require mode - panic on errors`, () => {
+    jest.mock(`require/module-error`)
+
+    resolveModuleExports(`require/module-error`, {
+      mode: `require`,
+    })
+
+    expect(reporter.panic).toBeCalled()
+  })
 })

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -134,15 +134,15 @@ module.exports = (
         exportName => exportName !== `__esModule`
       )
     } catch (e) {
-      if (testRequireError(modulePath, e)) {
-        // if we can't find gatsby-node.js, that's OK. Some plugins
-        // don't implement it.
-        return []
+      if (!testRequireError(modulePath, e)) {
+        // if module exists, but requiring it cause errors,
+        // show the error to the user and terminate build
+        report.panic(`Error in "${absPath}":`, e)
       }
-      // Otherwise report the error so it raises to the user
-      report.panic(`Error in "${absPath}":`, e)
     }
   } else {
     return staticallyAnalyzeExports(modulePath, resolver)
   }
+
+  return []
 }

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -126,7 +126,18 @@ module.exports = (modulePath, { mode = `analysis`, resolver } = {}) => {
       return Object.keys(require(modulePath)).filter(
         exportName => exportName !== `__esModule`
       )
-    } catch {
+    } catch (e) {
+      if (
+        e.toString().startsWith(`Error: Cannot find module`) &&
+        e.toString().includes(modulePath)
+      ) {
+        // if we can't find gatsby-node.js, that's OK. Some plugins
+        // don't implement it.
+        return []
+      }
+      // Otherwise report the error so it raises to the user
+      report.error(e)
+      // return [] so that the build continues anyway
       return []
     }
   } else {


### PR DESCRIPTION
On stream today I ran into an issue in the mdx-js repo when trying to upgrade
gatsby-plugin-mdx to 1.0. The issue was that the mdx-js repo happened to have an
example with a package name of `webpack` and `gatsby-plugin-mdx` requires
`webpack` in it's `gatsby-node.js`. As a result, we get a "can not find module
webpack" error, but it gets swallowed by resolve-module-exports when trying to
find and require `gatsby-node`.

This PR checks for "Can not find module `modulePath`" and if the error or module
aren't what we expect, we forward the error to the user.