### PR TITLE
Put gatsbyjs.org on a diet

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -120,7 +120,6 @@ module.exports = {
     `gatsby-plugin-sharp`,
     `gatsby-plugin-catch-links`,
     `gatsby-plugin-layout`,
-    `gatsby-plugin-lodash`,
     {
       resolve: `gatsby-plugin-manifest`,
       options: {

--- a/www/package.json
+++ b/www/package.json
@@ -23,7 +23,6 @@
     "gatsby-plugin-google-tagmanager": "^2.0.5",
     "gatsby-plugin-guess-js": "^1.0.0",
     "gatsby-plugin-layout": "^1.0.10",
-    "gatsby-plugin-lodash": "^3.0.1",
     "gatsby-plugin-mailchimp": "^2.2.3",
     "gatsby-plugin-manifest": "^2.0.2",
     "gatsby-plugin-netlify": "^2.0.0",

--- a/www/package.json
+++ b/www/package.json
@@ -57,7 +57,7 @@
     "graphql-request": "1.6.0",
     "gray-percentage": "^2.0.0",
     "hex2rgba": "^0.0.1",
-    "lodash": "^4.17.10",
+    "lodash-es": "^4.17.11",
     "mitt": "^1.1.3",
     "mousetrap": "^1.6.1",
     "parse-filepath": "^1.0.2",

--- a/www/src/components/debounce-input.js
+++ b/www/src/components/debounce-input.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import debounce from "lodash/debounce"
+import { debounce } from "lodash-es"
 import PropTypes from "prop-types"
 
 class DebounceInput extends Component {

--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -13,8 +13,7 @@ import { Link } from "gatsby"
 import DownloadArrow from "react-icons/lib/md/file-download"
 import AlgoliaLogo from "../assets/algolia.svg"
 import GatsbyIcon from "../monogram.svg"
-import debounce from "lodash/debounce"
-import unescape from "lodash/unescape"
+import { debounce, unescape } from "lodash-es"
 
 import {
   space,

--- a/www/src/components/tags-section.js
+++ b/www/src/components/tags-section.js
@@ -5,7 +5,7 @@ import TagsIcon from "react-icons/lib/ti/tags"
 import Button from "./button"
 import { rhythm } from "../utils/typography"
 import { space, fontSizes } from "../utils/presets"
-const _ = require(`lodash`)
+const { kebabCase } = require(`lodash-es`)
 
 const TagsSection = ({ tags }) => {
   if (!tags) return null
@@ -13,7 +13,7 @@ const TagsSection = ({ tags }) => {
     const divider = i < tags.length - 1 && <span>{`, `}</span>
     return (
       <span key={tag}>
-        <Link to={`/blog/tags/${_.kebabCase(tag.toLowerCase())}`}>{tag}</Link>
+        <Link to={`/blog/tags/${kebabCase(tag.toLowerCase())}`}>{tag}</Link>
         {divider}
       </span>
     )

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -1,8 +1,17 @@
-import React from "react"
-import PluginLibraryWrapper from "../components/layout/plugin-library-wrapper"
+import React, { useState } from "react"
 
+let PluginLibraryWrapper
 export default props => {
-  if (props.pageContext.layout === `plugins`) {
+  const [loaded, setLoaded] = useState(false)
+
+  const promise = import(`../components/layout/plugin-library-wrapper`)
+  if (props.pageContext.layout === `plugins` && !loaded) {
+    promise.then(pl => {
+      PluginLibraryWrapper = pl.default
+      setLoaded(true)
+    })
+    return null
+  } else if (props.pageContext.layout === `plugins` && loaded) {
     return (
       <PluginLibraryWrapper location={props.location}>
         {props.children}

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -2,7 +2,7 @@ import React from "react"
 import { Helmet } from "react-helmet"
 import PropTypes from "prop-types"
 import { graphql, Link } from "gatsby"
-import kebabCase from "lodash/kebabCase"
+import { kebabCase } from "lodash-es"
 
 import Layout from "../../components/layout"
 import Container from "../../components/container"

--- a/www/src/pages/docs/actions.js
+++ b/www/src/pages/docs/actions.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { Helmet } from "react-helmet"
-import sortBy from "lodash/sortBy"
+import { sortBy } from "lodash-es"
 
 import APIReference from "../../components/api-reference"
 import { space } from "../../utils/presets"

--- a/www/src/pages/docs/browser-apis.js
+++ b/www/src/pages/docs/browser-apis.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { Helmet } from "react-helmet"
-import sortBy from "lodash/sortBy"
+import { sortBy } from "lodash-es"
 
 import APIReference from "../../components/api-reference"
 import { space } from "../../utils/presets"

--- a/www/src/pages/docs/node-api-helpers.js
+++ b/www/src/pages/docs/node-api-helpers.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql, Link } from "gatsby"
 import Helmet from "react-helmet"
-import sortBy from "lodash/sortBy"
+import { sortBy } from "lodash-es"
 
 import APIReference from "../../components/api-reference"
 import { space } from "../../utils/presets"

--- a/www/src/pages/docs/node-apis.js
+++ b/www/src/pages/docs/node-apis.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql, Link } from "gatsby"
 import { Helmet } from "react-helmet"
-import sortBy from "lodash/sortBy"
+import { sortBy } from "lodash-es"
 
 import APIReference from "../../components/api-reference"
 import { space } from "../../utils/presets"

--- a/www/src/pages/docs/node-model.js
+++ b/www/src/pages/docs/node-model.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { Helmet } from "react-helmet"
-import sortBy from "lodash/sortBy"
+import { sortBy } from "lodash-es"
 
 import APIReference from "../../components/api-reference"
 import { rhythm } from "../../utils/typography"

--- a/www/src/pages/docs/ssr-apis.js
+++ b/www/src/pages/docs/ssr-apis.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { Helmet } from "react-helmet"
-import sortBy from "lodash/sortBy"
+import { sortBy } from "lodash-es"
 
 import APIReference from "../../components/api-reference"
 import { space } from "../../utils/presets"

--- a/www/src/templates/template-docs-local-packages.js
+++ b/www/src/templates/template-docs-local-packages.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import _ from "lodash"
+import { pick } from "lodash-es"
 
 import PackageReadme from "../components/package-readme"
 import Unbird from "../components/unbird"
@@ -30,7 +30,7 @@ class DocsLocalPackagesTemplate extends React.Component {
     return (
       <>
         <PackageReadme
-          page={markdownRemark ? _.pick(markdownRemark, `parent`) : false}
+          page={markdownRemark ? pick(markdownRemark, `parent`) : false}
           packageName={
             markdownRemark
               ? markdownRemark.fields.title

--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -8,7 +8,7 @@ import styles from "../shared/styles"
 import ThumbnailLink from "../shared/thumbnail"
 import EmptyGridItems from "../shared/empty-grid-items"
 import V2Icon from "../../assets/v2icon.svg"
-import get from "lodash/get"
+import { get } from "lodash"
 
 const StartersList = ({ urlState, starters, count, sortRecent }) => {
   if (!starters.length) {


### PR DESCRIPTION
This drops gatsbyjs.org's app bundle from 664kb to 222kb 😱 

### Switch from lodash to lodash-es

I noticed a number of components were pulling in the full lodash. I
removed that in favor of lodash-es which supports tree-shaking and
swapped out all lodash imports

### Lazy load Algolia's terrible React components

They're huge (~250kb) and kinda annoying and we got to get rid of them
someday but in the meantime, let's not load them unless we actually need
them.