### PR TITLE
Fix styles to be sorted on static-entry.js

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -22,6 +22,16 @@ const chunkMapping = JSON.parse(
   fs.readFileSync(`${process.cwd()}/public/chunk-map.json`, `utf-8`)
 )
 
+// Compare styles by names
+const compareStyleNames = ({ name: nameA }, { name: nameB }) => {
+  const [numberA, numberB] = [nameA, nameB].map(name =>
+    Number(name.replace(/^(\d+).*/, `$1`))
+  )
+
+  // do not swap if names don't start with number
+  return numberA - numberB || 0
+}
+
 // const testRequireError = require("./test-require-error")
 // For some extremely mysterious reason, webpack adds the above module *after*
 // this module so that when this code runs, testRequireError is undefined.
@@ -254,9 +264,9 @@ export default (pagePath, callback) => {
   const scripts = scriptsAndStyles.filter(
     script => script.name && script.name.endsWith(`.js`)
   )
-  const styles = scriptsAndStyles.filter(
-    style => style.name && style.name.endsWith(`.css`)
-  )
+  const styles = scriptsAndStyles
+    .filter(style => style.name && style.name.endsWith(`.css`))
+    .sort(compareStyleNames)
 
   apiRunner(`onRenderBody`, {
     setHeadComponents,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

There was a problem when a user tries to refresh without cache. In this case, style tags in HTML are messed up. To solve it, I added some code to sort style files by name.

- FYI (without this PR)
  1. Refresh without cache
    ![스크린샷 2019-04-19 오후 3 59 15](https://user-images.githubusercontent.com/2003265/56411577-355a6100-62bc-11e9-9df7-0f81da150b9e.png)

  1. Refresh with cache
    ![image](https://user-images.githubusercontent.com/2003265/56411631-59b63d80-62bc-11e9-8ae6-a9d2b20eb3c8.png)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
