### PR TITLE
fix(docs): Link to themes "accessible by default"

### DIFF
--- a/docs/docs/themes/introduction.md
+++ b/docs/docs/themes/introduction.md
@@ -39,7 +39,7 @@ Themes benefit starter authors since they can be shipped as libraries. This mean
 
 Theming in Gatsby means you can now avoid the boilerplate required when setting up a new project that’s commonplace in the community. That means we can arrive at a shared convention for something like a blog, and not be required to write GraphQL or configure a plugin unless you want to. No longer do you have to reinvent the wheel for each new Gatsby site you want to build.
 
-It provides a foundation to build upon, and since themes can inherit from other themes you can focus on building out new abstractions or functionality. And by including [accessibility](./docs/themes/building-themes#accessibile-by-default) in your theme, you can contribute back to create a more accessible web!
+It provides a foundation to build upon, and since themes can inherit from other themes you can focus on building out new abstractions or functionality. And by including [accessibility](./docs/themes/building-themes/#make-it-accessible-by-default) in your theme, you can contribute back to create a more accessible web!
 
 ## How Do You Customize a Theme?
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Fixed 404 Error as mentioned by @deadcoder0904 in #13480

<!-- Write a brief description of the changes introduced by this PR -->
Go to https://www.gatsbyjs.org/docs/themes/introduction/.

Under https://www.gatsbyjs.org/docs/themes/introduction/#why-does-this-matter, click on the accessibility link, it redirects to 404.

It should link to https://www.gatsbyjs.org/docs/themes/building-themes/#make-it-accessible-by-default
## Related Issues
https://github.com/gatsbyjs/gatsby/issues/13480
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
