### PR TITLE
Revert "feat(gatsby-plugin-google-tagmanager): Allow to place the GTM script …"

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -24,11 +24,6 @@ plugins: [
       gtmAuth: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_AUTH_STRING",
       gtmPreview: "YOUR_GOOGLE_TAGMANAGER_ENVIROMENT_PREVIEW_NAME",
       dataLayerName: "YOUR_DATA_LAYER_NAME",
-
-      // Whether to put the GTM script into the <head> (as suggested by Google)
-      // or append it to the <body> (making it non-blocking).
-      // Defaults to false meaning GTM will be added in the <head> (again, as suggested by Google).
-      addTagInBody: false,
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-google-tagmanager",
   "description": "Gatsby plugin to add google tagmanager onto a site",
-  "version": "2.1.0",
+  "version": "2.0.13",
   "author": "Thijs Koerselman <thijs@vauxlab.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -1,8 +1,8 @@
-import { oneLine, stripIndent } from "common-tags"
 import React from "react"
+import { oneLine, stripIndent } from "common-tags"
 
 exports.onRenderBody = (
-  { setHeadComponents, setPreBodyComponents, setPostBodyComponents },
+  { setHeadComponents, setPreBodyComponents },
   pluginOptions
 ) => {
   if (
@@ -18,10 +18,7 @@ exports.onRenderBody = (
     `
         : ``
 
-    const setComponents = pluginOptions.addTagInBody
-      ? setPostBodyComponents
-      : setHeadComponents
-    setComponents([
+    setHeadComponents([
       <script
         key="plugin-google-tagmanager"
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
@NoriSte As correctly pointed out by @wardpeet it seems that the added script is always `async` so adding it in body doesn't really have any impact. 

We want to limit adding options that aren't useful to 
- keep things simple for everyone
- reduce the burden of maintaining them