### PR TITLE
fix(blog): Updating "why we write" title to fix linting issues

### DIFF
--- a/docs/blog/2019-04-19-gatsby-why-we-write/index.md
+++ b/docs/blog/2019-04-19-gatsby-why-we-write/index.md
@@ -1,5 +1,5 @@
 ---
-title: Gatsby: Why We Write
+title: "Gatsby: Why We Write"
 date: 2019-04-19
 author: Sam Bhagwat
 excerpt: "Why does the Gatsby team and community write so much? Six principles that explain our love for writing."


### PR DESCRIPTION
## Description

On @ChristopherBiscardi's stream, we found the frontmatter was throwing an error due to the extra colon. I added quotes around the title to fix this.

![Image](https://user-images.githubusercontent.com/551247/56446711-14dcd780-62b9-11e9-9072-8a385731fb99.png)