### PR TITLE
feat(docs): Grouping stubs on Stub List

### DIFF
--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -10,6 +10,7 @@ import {
 import Container from "../../components/container"
 import DocsearchContent from "../../components/docsearch-content"
 import FooterLinks from "../../components/shared/footer-links"
+import { fontSizes, space } from "../../utils/presets"
 
 const findStubs = pages =>
   pages.filter(
@@ -28,25 +29,27 @@ class StubListRoute extends React.Component {
       flatten([...itemListContributing.items, ...itemListDocs.items])
     )
 
-    let groupedStubs = {
-      Other: [],
-    }
+    let groupedStubs = {}
 
     stubs.forEach(stub => {
-      if (stub.parentTitle === undefined) {
-        groupedStubs[`Other`].push(stub)
-        return
-      }
+      let categoryTitle = stub.parentTitle || `Top Level Documentation Pages`
 
-      if (groupedStubs[stub.parentTitle] === undefined) {
-        groupedStubs[stub.parentTitle] = []
+      if (groupedStubs[categoryTitle] === undefined) {
+        groupedStubs[categoryTitle] = []
       }
-      groupedStubs[stub.parentTitle].push(stub)
+      groupedStubs[categoryTitle].push(stub)
     })
 
     let sortedCategories = Object.keys(groupedStubs).sort((a, b) =>
       a.localeCompare(b)
     )
+
+    // Put top level at the front of the array
+    sortedCategories.splice(
+      sortedCategories.indexOf(`Top Level Documentation Pages`),
+      1
+    )
+    sortedCategories = [`Top Level Documentation Pages`, ...sortedCategories]
 
     return (
       <Layout location={this.props.location} itemList={itemListContributing}>
@@ -74,7 +77,11 @@ class StubListRoute extends React.Component {
                   category.slice(-1) === `*` ? category.slice(0, -1) : category
                 return (
                   <React.Fragment key={category}>
-                    <h2>{categoryTitle}</h2>
+                    <h2
+                      css={{ fontSize: fontSizes[4], marginBottom: space[3] }}
+                    >
+                      {categoryTitle}
+                    </h2>
                     <ul>
                       {groupedStubs[category].map(stub => (
                         <li key={stub.title}>

--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -28,6 +28,26 @@ class StubListRoute extends React.Component {
       flatten([...itemListContributing.items, ...itemListDocs.items])
     )
 
+    let groupedStubs = {
+      Other: [],
+    }
+
+    stubs.forEach(stub => {
+      if (stub.parentTitle === undefined) {
+        groupedStubs[`Other`].push(stub)
+        return
+      }
+
+      if (groupedStubs[stub.parentTitle] === undefined) {
+        groupedStubs[stub.parentTitle] = []
+      }
+      groupedStubs[stub.parentTitle].push(stub)
+    })
+
+    let sortedCategories = Object.keys(groupedStubs).sort((a, b) =>
+      a.localeCompare(b)
+    )
+
     return (
       <Layout location={this.props.location} itemList={itemListContributing}>
         <DocsearchContent>
@@ -48,13 +68,24 @@ class StubListRoute extends React.Component {
               {` `}
               to learn more.
             </p>
-            <ul data-testid="list-of-stubs">
-              {stubs.map(stub => (
-                <li key={stub.title}>
-                  <Link to={stub.link}>{stub.title.slice(0, -1)}</Link>
-                </li>
-              ))}
-            </ul>
+            <section data-testid="list-of-stubs">
+              {sortedCategories.map(category => {
+                let categoryTitle =
+                  category.slice(-1) === `*` ? category.slice(0, -1) : category
+                return (
+                  <React.Fragment key={category}>
+                    <h2>{categoryTitle}</h2>
+                    <ul>
+                      {groupedStubs[category].map(stub => (
+                        <li key={stub.title}>
+                          <Link to={stub.link}>{stub.title.slice(0, -1)}</Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </React.Fragment>
+                )
+              })}
+            </section>
             <FooterLinks />
           </Container>
         </DocsearchContent>


### PR DESCRIPTION
## Description

![Screenshot_2019-04-19 Stub List GatsbyJS(2)](https://user-images.githubusercontent.com/3685876/56448563-094fd780-62de-11e9-8a83-a97bc0e6a34c.png)

Rather than having a strict list full of links, I am chunking them based upon the `parentTitle` field in each stub. If said field is undefined, it will go into a group titled "Other"

## Related Issues

Closes #13474