### PR TITLE
Fix spelling. GitHub not Github.  JavaScript not Javascript. TypeScript not Typescript.  GitLab not Gitlab.

### DIFF
--- a/docs/accessibility-statement.md
+++ b/docs/accessibility-statement.md
@@ -18,7 +18,7 @@ Gatsbyjs.com is the business website for Gatsby, Inc. the startup building Gatsb
 
 We strive to make these websites and the Gatsby framework itself as accessible as possible. Our goal is to meet [WCAG 2.0 AA](https://www.w3.org/TR/WCAG20/), with which we are partially compliant. We’ll be the first to admit the Gatsby ecosystem is a work in progress, and we are open to all feedback to make things better.
 
-To contact the core team with your accessibility feedback or challenges, please [file an issue on Github](https://github.com/gatsbyjs/gatsby/issues/new/choose).
+To contact the core team with your accessibility feedback or challenges, please [file an issue on GitHub](https://github.com/gatsbyjs/gatsby/issues/new/choose).
 
 Alternatively, we welcome you to reach out directly to Marcy Sutton, Head of Learning at Gatsby: [marcy@gatsbyjs.com](mailto:marcy@gatsbyjs.com)
 

--- a/docs/blog/2018-10-16-why-mobile-performance-is-crucial/index.md
+++ b/docs/blog/2018-10-16-why-mobile-performance-is-crucial/index.md
@@ -109,7 +109,7 @@ CDNs are globally available, so they’ll be closer to your customer than your s
 
 Payload optimization and delivery optimization are complementary approaches. That’s both good news -- you _can_ do both -- and bad news -- you often _need_ to do both.
 
-For example, if you use a CDN to serve 3MB Javascript bundles, your site is still going to be slow, especially on medium- and low-end mobile devices.
+For example, if you use a CDN to serve 3MB JavaScript bundles, your site is still going to be slow, especially on medium- and low-end mobile devices.
 
 <figure>
   <img alt="" src="./network-requests-adobe-com.png" />

--- a/docs/blog/2018-10-18-vscode-gatsby-development/index.md
+++ b/docs/blog/2018-10-18-vscode-gatsby-development/index.md
@@ -11,7 +11,7 @@ VS Code is a truly great choice for your code editing needs. In this article, I'
 
 ![Lots of Available Options](./images/color-wall.jpeg)
 
-I know that there are as many choices for IDE editors and personal preferences as there are JS frameworks in existence (hint LOTS). I am not going to debate those here, this article will focus on [VS Code](https://code.visualstudio.com/). It's the editor I use and find it amazing for the Javascript and web development ecosystem. I was a long time holdout using Sublime Text, but once I gave VS Code a try I switched over within a day and haven't looked back.
+I know that there are as many choices for IDE editors and personal preferences as there are JS frameworks in existence (hint LOTS). I am not going to debate those here, this article will focus on [VS Code](https://code.visualstudio.com/). It's the editor I use and find it amazing for the JavaScript and web development ecosystem. I was a long time holdout using Sublime Text, but once I gave VS Code a try I switched over within a day and haven't looked back.
 
 ## Enough Talk, Let's get Started
 

--- a/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
+++ b/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
@@ -47,7 +47,7 @@ rows.forEach(row => {
   const date = new Date(row.created * 1000);
 ```
 
-The interesting thing here is the initial query, and this is based on a Drupal 7 database. A Drupal 8 or Drupal 6 database could be different, so check your schema. Next, load the tags on a simple Javascript array. Each post can have more than one tag, so you can take advantage of better-sqlite's _.pluck()_ function, which retrieves only the first column of a database query, and the _.all()_ function, which retrieves all rows in a single array:
+The interesting thing here is the initial query, and this is based on a Drupal 7 database. A Drupal 8 or Drupal 6 database could be different, so check your schema. Next, load the tags on a simple JavaScript array. Each post can have more than one tag, so you can take advantage of better-sqlite's _.pluck()_ function, which retrieves only the first column of a database query, and the _.all()_ function, which retrieves all rows in a single array:
 
 ```javascript
 const tags = db
@@ -75,7 +75,7 @@ if (image) {
 }
 ```
 
-And now that you have all the data you need, it is just a matter of creating a file with the metadata in yaml format and the body of the text in Markdown format. Luckily, a Drupal blog can also use Markdown or you can also look for an HTML to Markdown Javascript library like [turndown](https://github.com/domchristie/turndown).
+And now that you have all the data you need, it is just a matter of creating a file with the metadata in yaml format and the body of the text in Markdown format. Luckily, a Drupal blog can also use Markdown or you can also look for an HTML to Markdown JavaScript library like [turndown](https://github.com/domchristie/turndown).
 
 ```javascript
   fs.mkdir(path, (err) => { });

--- a/docs/blog/2018-12-04-gatsby-analogy/index.md
+++ b/docs/blog/2018-12-04-gatsby-analogy/index.md
@@ -18,7 +18,7 @@ In this post, I'll aim for the latter -- an approachable explanation of what Gat
 
 ## 1. Start off with a pre-configured development environment and build process
 
-Gatsby uses [React](https://reactjs.org/) for its UI layer. It can be notoriously difficult for newcomers to get started with React, or even for experienced React devs to configure a new React project from the ground up every time. (See: [Javascript Fatigue](https://medium.com/@ericclemmons/javascript-fatigue-48d4011b6fc4)).
+Gatsby uses [React](https://reactjs.org/) for its UI layer. It can be notoriously difficult for newcomers to get started with React, or even for experienced React devs to configure a new React project from the ground up every time. (See: [JavaScript Fatigue](https://medium.com/@ericclemmons/javascript-fatigue-48d4011b6fc4)).
 
 Is it possible to learn every fine-grained detail to optimize a development environment and build process for React? Sure. Is it necessary to get up and going on a project? No, not anymore.
 

--- a/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
+++ b/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
@@ -20,7 +20,7 @@ Today I'd like to show you how you can incrementally add functionality to a Gats
 
 Why would you use something like Gatsby over Jekyll or Hugo or one of the [hundreds of Static Site Generators](https://www.staticgen.com/) out there? [There are many reasons](/blog/2018-2-27-why-i-upgraded-my-website-to-gatsbyjs-from-jekyll/), but one of the unique selling points is how Gatsby helps you build ["Static Progressive Web Apps"](/docs/progressive-web-app/#progressive-web-app) with React.
 
-[Gatsby's ability to rehydrate](/docs/production-app/#dom-hydration) (what a delicious word!) the DOM means you can do incredibly dynamic things with Javascript and React that would be much harder with legacy SSG's.
+[Gatsby's ability to rehydrate](/docs/production-app/#dom-hydration) (what a delicious word!) the DOM means you can do incredibly dynamic things with JavaScript and React that would be much harder with legacy SSG's.
 
 Let's say you have a typical static Gatsby site, like [gatsby-starter-default](/starters/gatsby-starter-default). You can `npm run build` it, and it spits out a bunch of HTML files. Great! I can host that for free!
 
@@ -57,7 +57,7 @@ Let's walk through the steps:
   },
 ```
 
-3. **Configure your Netlify build**: When serving your site on Netlify, `netlify-lambda` will now build each Javascript/Typescript file in your `src/lambda` folder as a standalone Netlify function (with a path corresponding to the filename). Make sure you have a Functions path in a `netlify.toml` file at root of your repository:
+3. **Configure your Netlify build**: When serving your site on Netlify, `netlify-lambda` will now build each JavaScript/TypeScript file in your `src/lambda` folder as a standalone Netlify function (with a path corresponding to the filename). Make sure you have a Functions path in a `netlify.toml` file at root of your repository:
 
 ```toml
 [build]

--- a/docs/blog/2019-02-14-behind-the-scenes-q-and-a/index.md
+++ b/docs/blog/2019-02-14-behind-the-scenes-q-and-a/index.md
@@ -40,7 +40,7 @@ To watch the full recorded webinar, [register here](https://www.gatsbyjs.com/beh
 **Question:** Gatsby transformers support Markdown and asciidoc. Possible support for Sphinx reStructuredText?
 **Answer:** Certainly! Gatsby is super pluggable, so whatever content you want to bring to Gatsby, just write a plugin! [https://www.gatsbyjs.org/docs/source-plugin-tutorial/](/docs/source-plugin-tutorial/ "Gatsby plugins")
 
-**Question:** How did you implement the Github PR test for lighthouse scoring?
+**Question:** How did you implement the GitHub PR test for lighthouse scoring?
 **Answer:** All available in this repo. I run Lighthouse from a CI container, and then parse the response: [https://github.com/dschau/gatsby-perf-audit](https://github.com/dschau/gatsby-perf-audit "https://github.com/dschau/gatsby-perf-audit")
 
 **Question:** Is it possible to dictate code splitting manually, e.g. component level code splitting?

--- a/docs/blog/2019-03-11-dot-org-prototypes/index.md
+++ b/docs/blog/2019-03-11-dot-org-prototypes/index.md
@@ -27,7 +27,7 @@ Back in November, we watched 8 people who had never heard of Gatsby before as th
 
 Two problems became clear as a result:
 
-- The first impression people have about Gatsby from above-the-fold and just below the fold on homepage is not accurate. Sources of more accurate understanding were the Github README file and the diagram on homepage
+- The first impression people have about Gatsby from above-the-fold and just below the fold on homepage is not accurate. Sources of more accurate understanding were the GitHub README file and the diagram on homepage
 - We had not written down the following key facts about the .org site and therefore sometimes struggled to stay aligned in our answers to these questions:
   - Who is the audience for .org?
   - What are our value propositions for that audience?

--- a/docs/blog/2019-04-19-gatsby-why-we-write/index.md
+++ b/docs/blog/2019-04-19-gatsby-why-we-write/index.md
@@ -30,7 +30,7 @@ The answer:
 
 ## Principle 2: content acts as a guide unlocking the power of Gatsby.
 
-Gatsby is so powerful, because of its core _and the ecosystem_ — not just plugins and themes, but React, Webpack and Babel, the entire npm ecosystem, and modern Javascript in general.
+Gatsby is so powerful, because of its core _and the ecosystem_ — not just plugins and themes, but React, Webpack and Babel, the entire npm ecosystem, and modern JavaScript in general.
 
 You can do almost anything you want with Gatsby, you just have to:
 

--- a/docs/contributing/community-contributions.md
+++ b/docs/contributing/community-contributions.md
@@ -12,7 +12,7 @@ We welcome all contributions from you in the community, and would be thrilled to
 - Blog posts and case studies
 - Talk and lecture videos
 - Workshop materials
-- Github issues and pull requests
+- GitHub issues and pull requests
 
 ...and anything else you can think of. Our showcase and library contribution docs are a great place to start:
 

--- a/docs/docs/adding-page-transitions-with-plugin-transition-link.md
+++ b/docs/docs/adding-page-transitions-with-plugin-transition-link.md
@@ -69,7 +69,7 @@ You have two main methods of creating page transitions:
 1. Use the `trigger` function defined in your `exit`/`entry` prop. More details in the '[Using the `trigger` function](#using-the-trigger-function)' subsection.
 2. Use the props passed by `TransitionLink` to define your transitions. More details in the '[Using passed props](#using-passed-props)' subsection.
 
-Additionally, you can specify a number of props and options on the `TransitionLink` component, like `length`, `delay`, and more. For more options and details, see [the documentation of TransitionLink](https://transitionlink.tylerbarnes.ca/docs/transitionlink/). For further examples of usage, visit the [plugin's Github repository.](https://github.com/TylerBarnes/gatsby-plugin-transition-link)
+Additionally, you can specify a number of props and options on the `TransitionLink` component, like `length`, `delay`, and more. For more options and details, see [the documentation of TransitionLink](https://transitionlink.tylerbarnes.ca/docs/transitionlink/). For further examples of usage, visit the [plugin's GitHub repository.](https://github.com/TylerBarnes/gatsby-plugin-transition-link)
 
 #### Using the trigger function
 

--- a/docs/docs/creating-a-starter.md
+++ b/docs/docs/creating-a-starter.md
@@ -27,7 +27,7 @@ Let's expand upon these items to prepare you for creating a winning starter.
 
 ## Open source and available from a stable URL
 
-The Gatsby CLI allows users to install a new site with a starter using the command `gatsby new <starter-url>`. For this to work, your starter needs to be available to download. The easiest way to accomplish this is to host your starter on GitHub or Gitlab and use the publicly available repo URL, such as:
+The Gatsby CLI allows users to install a new site with a starter using the command `gatsby new <starter-url>`. For this to work, your starter needs to be available to download. The easiest way to accomplish this is to host your starter on GitHub or GitLab and use the publicly available repo URL, such as:
 
 `gatsby new https://github.com/gatsbyjs/gatsby-starter-blog`
 

--- a/docs/docs/debugging-cache-issues.md
+++ b/docs/docs/debugging-cache-issues.md
@@ -31,6 +31,6 @@ First make sure the version of `gatsby` specified in your `package.json` depende
 
 Now when issues arise that seem to be related to caching, you can use `npm run clean` to wipe out the cache and start from a fresh slate.
 
-_Note: If you find yourself using this command regularly, consider helping us out and [responding to our Github Issue][github-issue] with clear reproduction steps._
+_Note: If you find yourself using this command regularly, consider helping us out and [responding to our GitHub Issue][github-issue] with clear reproduction steps._
 
 [github-issue]: https://github.com/gatsbyjs/gatsby/issues/11747

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -144,7 +144,7 @@ You can trigger this endpoint locally for example on Unix-based operating system
 As noted above `NODE_ENV` is a reserved environment variable in Gatsby as it is needed by the build system to make key optimizations when compiling React and other modules. For this reason it is necessary to make use of a secondary environment variable for additional environment support, and manually make the environment variables available to the client-side code.
 
 You can define your own OS Env Var to track the active environment, and then to locate the relevant Project Env Vars to load. Gatsby itself will not do anything with that OS Env Var, but you can use it in `gatsby-config.js`.
-Specifically, you can use `dotenv` and your individual OS Env Var to locate the `.env.myCustomEnvironment` file, and then use module.exports to store those Project Env Vars somewhere that the client-side Javascript can access the values (via GraphQL queries).
+Specifically, you can use `dotenv` and your individual OS Env Var to locate the `.env.myCustomEnvironment` file, and then use module.exports to store those Project Env Vars somewhere that the client-side JavaScript can access the values (via GraphQL queries).
 
 For instance: if you would like to add a `staging` environment with a custom Google Analytics Tracking ID, and a dedicated `apiUrl`. You can add `.env.staging` at the root of your project with the following modification to your `gatsby-config.js`
 

--- a/docs/docs/gatsby-vendor-partnership.md
+++ b/docs/docs/gatsby-vendor-partnership.md
@@ -48,7 +48,7 @@ If you haven’t yet integrated with Gatsby, [developer documentation](https://w
 
 In addition, you’ll probably want to create an "example" application. We call this a “starter”.
 
-However development is most convenient, when you publish these, they should be in separate code repositories on Github.
+However development is most convenient, when you publish these, they should be in separate code repositories on GitHub.
 
 Current partners have reported development timelines of 2-3 days when the content schema is fully defined by their platform, around up to 2 weeks when their platforms allowing the user to completely define the content schema, for a team of 1-2 developers.
 
@@ -56,7 +56,7 @@ If you have a GraphQL-based API, you **may not need to build an integration at a
 
 If you have questions while building your Gatsby integrations, try reading other supporting documentation such as the [general plugin authoring guide](https://www.gatsbyjs.org/docs/plugin-authoring/) and [source plugin tutorial](https://www.gatsbyjs.org/docs/source-plugin-tutorial/).
 
-If you still have questions, please[ raise an issue on Github](https://github.com/gatsbyjs/gatsby/issues), ask a question in [Discord chat](https://discord.gg/0ZcbPKXt5bVoxkfV), or reach out to our Head of Developer Relations [Jason Lengstorf](https://www.gatsbyjs.org/contributors/jason-lengstorf/) at developer-relations@gatsbyjs.com.
+If you still have questions, please [raise an issue on GitHub](https://github.com/gatsbyjs/gatsby/issues), ask a question in [Discord chat](https://discord.gg/0ZcbPKXt5bVoxkfV), or reach out to our Head of Developer Relations [Jason Lengstorf](https://www.gatsbyjs.org/contributors/jason-lengstorf/) at developer-relations@gatsbyjs.com.
 
 ### Step Two: Launching Your Gatsby Integration
 

--- a/docs/docs/localization-i18n.md
+++ b/docs/docs/localization-i18n.md
@@ -24,7 +24,7 @@ File - src/pages/about.**en**.js
 
 URL - /**en**/about
 
-[gatsby-plugin-i18n on Github](https://github.com/angeloocana/gatsby-plugin-i18n)
+[gatsby-plugin-i18n on GitHub](https://github.com/angeloocana/gatsby-plugin-i18n)
 
 ### react-intl
 

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -3830,7 +3830,7 @@
 - title: Logicwind
   main_url: "https://logicwind.com"
   url: "https://logicwind.com"
-  description: Website of Logicwind - Javascript experts, Technology development agency & consulting.
+  description: Website of Logicwind - JavaScript experts, Technology development agency & consulting.
   featured: false
   categories:
     - Portfolio
@@ -4628,7 +4628,7 @@
   url: https://www.szewczyk.cz/
   main_url: https://www.szewczyk.cz/
   description: >
-    Patrik Szewczyk – Javascript, Typescript, React, Node.js developer, Redux, Reason
+    Patrik Szewczyk – JavaScript, TypeScript, React, Node.js developer, Redux, Reason
   categories:
     - Portfolio
   built_by: Patrik Szewczyk
@@ -4900,7 +4900,7 @@
   main_url: https://www.agynamix.de/
   source_url: https://github.com/tuhlmann/agynamix.de
   description: >
-    Full Stack Java, Scala, Clojure, Typescript, React Developer in Thalheim, Germany
+    Full Stack Java, Scala, Clojure, TypeScript, React Developer in Thalheim, Germany
   categories:
     - Freelance
     - Web Development

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -952,7 +952,7 @@
     - Social sharing (Twitter, Facebook, Google, LinkedIn)
 - url: https://gatsby-starter-typescript-sass.netlify.com
   repo: https://github.com/tdharmon/gatsby-starter-typescript-sass
-  description: A basic starter with Typescript and Sass built in
+  description: A basic starter with TypeScript and Sass built in
   tags:
     - TypeScript
     - Styling:SCSS
@@ -994,7 +994,7 @@
     - Uses the Cosmic JS Gatsby source plugin
 - url: https://www.gatsby-typescript-template.com/
   repo: https://github.com/ikeryo1182/gatsby-typescript-template
-  description: This is a standard starter with Typescript, TSLint, Prettier, Lint-Staged(Husky) and Sass
+  description: This is a standard starter with TypeScript, TSLint, Prettier, Lint-Staged(Husky) and Sass
   tags:
     - TypeScript
     - Linting
@@ -1020,7 +1020,7 @@
     - Styling:CSS-in-JS
   features:
     - Emotion CSS-in-JS
-    - Typescript
+    - TypeScript
     - Author and tag pages
     - RSS
 - url: https://gatsby-universal.netlify.com
@@ -1166,7 +1166,7 @@
     - Netlify optimization
 - url: https://gatsby-starter-typescript-power-blog.majidhajian.com/
   repo: https://github.com/mhadaily/gatsby-starter-typescript-power-blog
-  description: Minimal Personal Blog with Gatsby and Typescript
+  description: Minimal Personal Blog with Gatsby and TypeScript
   tags:
     - PWA
     - Blog
@@ -1645,7 +1645,7 @@
     - Netlify integration ready to deploy
     - Material UI
     - styled-components
-    - Github markdown css support
+    - GitHub markdown css support
 - url: https://create-ueno-app.netlify.com
   repo: https://github.com/ueno-llc/ueno-gatsby-starter
   description: Opinionated Gatsby starter by Ueno.

--- a/examples/using-typescript/README.md
+++ b/examples/using-typescript/README.md
@@ -2,4 +2,4 @@
 
 https://using-typescript.gatsbyjs.org
 
-Demonstrates using Typescript to build Gatsby sites.
+Demonstrates using TypeScript to build Gatsby sites.

--- a/examples/using-typescript/src/pages/index.tsx
+++ b/examples/using-typescript/src/pages/index.tsx
@@ -30,7 +30,7 @@ export default class IndexPage extends React.Component<IndexPageProps, {}> {
     const { siteName } = this.props.data.site.siteMetadata
     return (
       <Layout>
-        <h1>{this.hello} Typescript world!</h1>
+        <h1>{this.hello} TypeScript world!</h1>
         <p>
           This site is named <strong>{siteName}</strong>
         </p>

--- a/packages/gatsby/CHANGELOG.md
+++ b/packages/gatsby/CHANGELOG.md
@@ -2337,7 +2337,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Enhance API for multiple feeds #1548 @nicholaswyoung
 - Add new plugin to handle csv files #1496 @ssonal
 - Adds showcase segment for starters/websites built with Gatsby. #1535 @Vagr9K
-- Fancy Javascript Example #1492 @jbolda
+- Fancy JavaScript Example #1492 @jbolda
 - Add sitemap plugin to www #1541 @nicholaswyoung
 
 ### Fixed
@@ -2466,7 +2466,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Support NavLink in gatsby-link #1302 @abi
 - Add an example for using the sass plugin #1312 @danielfarrell
 - Add CSS Modules example site #1314 @kyleamathews
-- Add Typescript example #1319 @kyleamathews
+- Add TypeScript example #1319 @kyleamathews
 - Support using browserslist for setting per-site browser targeting for JS/CSS
   transformations #1336 @kyleamathews
 - Add gatsby-plugin-canonical-url #1337 @kyleamathews


### PR DESCRIPTION
Fix single markdown link syntax.