### PR TITLE
fix(gatsby): Set fixed precision for "bootstrap finished" timer

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -528,7 +528,7 @@ const finishBootstrap = async bootstrapSpan => {
   activity.end()
 
   report.log(``)
-  report.info(`bootstrap finished - ${process.uptime()} s`)
+  report.info(`bootstrap finished - ${process.uptime().toFixed(3)} s`)
   report.log(``)
   emitter.emit(`BOOTSTRAP_FINISHED`)
   require(`../redux/actions`).boundActionCreators.setProgramStatus(


### PR DESCRIPTION
```shell
info bootstrap finished - 3.459334533 s
```
seems too precise.