### PR TITLE
Improve semantic and key value in menuLinks map()

### DIFF
--- a/docs/docs/centralizing-your-sites-navigation.md
+++ b/docs/docs/centralizing-your-sites-navigation.md
@@ -240,14 +240,16 @@ import React from 'react'
 import { Link } from 'gatsby'
 
 const Header = ({ siteTitle, menuLinks }) => (
-+  <nav style={{ display: 'flex', flex: 1 }}>
-+    {
-+      menuLinks.map(link =>
-+        <li key={link.name} style={{ 'listStyleType': 'none' }}>
-+          <Link to={link.link}>{link.name}</Link>
-+        </li>)
-+    }
-+  </nav>
++		<nav>
++			<ul style={{ display: 'flex', flex: 1, listStyle: 'none' }}>
++				{menuLinks.map(link =>
++					<li key={link.link}>
++						<Link to={link.link}>{link.name}</Link>
++					</li>
++				)}
++			</ul>
++		</nav>
++	)
 )
 ```
 


### PR DESCRIPTION
Error: Element li not allowed as child of element nav in this context. (Suppressing further errors from this subtree.)
https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element
http://w3c.github.io/html/sections.html#the-nav-element

In my opinion link(slug) more unique value)) and better value for key in map()

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
