### PR TITLE
tests: add node 12 to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
   unit_tests_node12:
     executor:
       name: node
-      image: "12"
+      image: "latest"
     <<: *test_template
 
   unit_tests_www:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,6 @@ jobs:
     executor:
       name: node
       image: "12"
-
     <<: *test_template
 
   unit_tests_www:
@@ -230,6 +229,10 @@ workflows:
           requires:
             - bootstrap
       - unit_tests_node10:
+          <<: *ignore_docs
+          requires:
+            - bootstrap
+      - unit_tests_node12:
           <<: *ignore_docs
           requires:
             - bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,13 @@ jobs:
     executor: node
     <<: *test_template
 
+  unit_tests_node12:
+    executor:
+      name: node
+      image: "12"
+
+    <<: *test_template
+
   unit_tests_www:
     executor: node
     steps:


### PR DESCRIPTION

## Description

Modified the Circle CI config in preparation for the release for Node 12 on April 23rd. 

As the next node LTS we should start testing against this version to support it. IMO this test not be required to test for now but can be enabled to give us info on what's passing and not.  At the latest, we can require these tests to pass on 2019-10-22 when it's made an active LTS. In the mean, time we can do any work needed to get it passing.

We'll need to wait to merge this till CircleCI also supports node 12. Hopefully it won't take them too long.

https://nodejs.org/en/about/releases/
