### PR TITLE
docs: fix ts-jest testRegex

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -231,7 +231,7 @@ module.exports = {
     "^.+\\.tsx?$": "ts-jest",
     "^.+\\.jsx?$": "<rootDir>/jest-preprocess.js",
   },
-  testRegex: "(/__tests__/.*\\.([tj]sx?)|(\\.|/)(test|spec))\\.([tj]sx?)$",
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.([tj]sx?)$",
   moduleNameMapper: {
     ".+\\.(css|styl|less|sass|scss)$": "identity-obj-proxy",
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":


### PR DESCRIPTION
## Description

The previously used testRegex for TS tests with Jest did not work as (I assume) was intended: files inside a `__tests__` folder would only be recognized if they had double file extensions, such as `__tests__/file.ts.ts`.

In some preliminary tests, the new regex in this change should work as intended, catching all ts(x)/js(x) files inside a `__tests__` folder (or any subfolders of it), and all files with extensions of .spec/test.ts(x)/js(x).

For easier validation, I've put this into a little playground where you can edit the Regex and add more test cases on the fly: https://codesandbox.io/embed/3v2z573qrm

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
