### PR TITLE
Fix spelling. TypeScript not Typescript.

### DIFF
--- a/examples/using-typescript/gatsby-config.js
+++ b/examples/using-typescript/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    siteName: `Using Typescript Example`,
+    siteName: `Using TypeScript Example`,
   },
   plugins: [
     `gatsby-plugin-typescript`,

--- a/examples/using-typescript/package.json
+++ b/examples/using-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "using-typescript",
   "version": "1.0.0",
-  "description": "Gatsby example site demonstrating how to use Typescript with Gatsby",
+  "description": "Gatsby example site demonstrating how to use TypeScript with Gatsby",
   "author": "fabien0102 <fabien0102@gmail.com>",
   "license": "MIT",
   "scripts": {

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -81,7 +81,7 @@ class Plugins extends Component {
                   pluginName: `gatsby-plugin-typography`,
                 },
                 {
-                  text: `Typescript?`,
+                  text: `TypeScript?`,
                   pluginName: `gatsby-plugin-typescript`,
                 },
                 {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixed some misspellings of TypeScript through the project :)

## Related Issues
No related issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Cheers