### PR TITLE
fix(gatsby-remark-copy-linked-files): Support MDX by visiting JSX nodes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
   notify: true,
   verbose: true,
   roots: pkgs,
+  transformIgnorePatterns: [`node_modules/(?!remark-mdx)`],
   modulePathIgnorePatterns: ignoreDirs,
   coveragePathIgnorePatterns: ignoreDirs,
   testPathIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,6 @@ module.exports = {
   notify: true,
   verbose: true,
   roots: pkgs,
-  transformIgnorePatterns: [`node_modules/(?!remark-mdx)`],
   modulePathIgnorePatterns: ignoreDirs,
   coveragePathIgnorePatterns: ignoreDirs,
   testPathIgnorePatterns: [

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -22,7 +22,8 @@
     "babel-preset-gatsby-package": "^0.1.4",
     "cross-env": "^5.1.4",
     "remark": "^10.0.1",
-    "remark-mdx": "^1.0.14"
+    "remark-mdx": "^1.0.14",
+    "semver": "^6.0.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files#readme",
   "keywords": [

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -20,7 +20,9 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.4",
-    "cross-env": "^5.1.4"
+    "cross-env": "^5.1.4",
+    "remark": "^10.0.1",
+    "remark-mdx": "^1.0.14"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files#readme",
   "keywords": [

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -7,6 +7,7 @@ jest.mock(`fs-extra`, () => {
 })
 const Remark = require(`remark`)
 const fsExtra = require(`fs-extra`)
+const mdx = require(`remark-mdx`)
 const path = require(`path`)
 
 const plugin = require(`../`)
@@ -116,6 +117,18 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     const path = `images/sample-image.gif`
 
     const markdownAST = remark.parse(`<img src="${path}">`)
+
+    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).toHaveBeenCalled()
+  })
+
+  it(`can copy JSX images`, async () => {
+    const path = `images/sample-image.gif`
+
+    const markdownAST = remark()
+      .use(mdx)
+      .parse(`<img src="${path}" />`)
 
     await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
 

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -9,6 +9,7 @@ const Remark = require(`remark`)
 const fsExtra = require(`fs-extra`)
 const mdx = require(`remark-mdx`)
 const path = require(`path`)
+const semver = require(`semver`)
 
 const plugin = require(`../`)
 
@@ -19,6 +20,15 @@ const remark = new Remark().data(`settings`, {
 })
 
 const imageURL = markdownAST => markdownAST.children[0].children[0].url
+
+const testInNode8OrHigher = (title, ...args) => {
+  const isNode8OrHigher = semver.satisfies(process.version, `>=8`)
+  if (isNode8OrHigher) {
+    it(title, ...args)
+  } else {
+    it.skip(`skipped on Node 7 or lower: ${title}`, ...args)
+  }
+}
 
 describe(`gatsby-remark-copy-linked-files`, () => {
   afterEach(() => {
@@ -123,14 +133,19 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalled()
   })
 
-  it(`can copy JSX images`, async () => {
+  testInNode8OrHigher(`can copy JSX images`, async () => {
     const path = `images/sample-image.gif`
 
     const markdownAST = remark()
       .use(mdx)
       .parse(`<img src="${path}" />`)
 
-    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+    await plugin({
+      files: getFiles(path),
+      markdownAST,
+      markdownNode,
+      getNode,
+    })
 
     expect(fsExtra.copy).toHaveBeenCalled()
   })

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -20,6 +20,15 @@ const remark = new Remark().data(`settings`, {
 
 const imageURL = markdownAST => markdownAST.children[0].children[0].url
 
+const testInNode8OrHigher = (title, ...args) => {
+  const isNode8OrHigher = semver.satisfies(process.version, `>=8`)
+  if (isNode8OrHigher) {
+    it(title, ...args)
+  } else {
+    it.skip(`skipped on Node 7 or lower: ${title}`, ...args)
+  }
+}
+
 describe(`gatsby-remark-copy-linked-files`, () => {
   afterEach(() => {
     fsExtra.copy.mockReset()
@@ -123,28 +132,23 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalled()
   })
 
-  const canCopyJSXTitle = `can copy JSX images`
-  if (semver.satisfies(process.version, `>=8`)) {
+  testInNode8OrHigher(`can copy JSX images`, async () => {
     const mdx = require(`remark-mdx`)
-    it(canCopyJSXTitle, async () => {
-      const path = `images/sample-image.gif`
+    const path = `images/sample-image.gif`
 
-      const markdownAST = remark()
-        .use(mdx)
-        .parse(`<img src="${path}" />`)
+    const markdownAST = remark()
+      .use(mdx)
+      .parse(`<img src="${path}" />`)
 
-      await plugin({
-        files: getFiles(path),
-        markdownAST,
-        markdownNode,
-        getNode,
-      })
-
-      expect(fsExtra.copy).toHaveBeenCalled()
+    await plugin({
+      files: getFiles(path),
+      markdownAST,
+      markdownNode,
+      getNode,
     })
-  } else {
-    it.skip(canCopyJSXTitle, () => {})
-  }
+
+    expect(fsExtra.copy).toHaveBeenCalled()
+  })
 
   it(`can copy HTML multiple images`, async () => {
     const path1 = `images/sample-image.gif`

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -203,7 +203,7 @@ module.exports = (
   })
 
   // For each HTML Node
-  visit(markdownAST, `html`, node => {
+  visit(markdownAST, [`html`, `jsx`], node => {
     const $ = cheerio.load(node.value)
 
     function processUrl({ url }) {


### PR DESCRIPTION
## Description

This PR addresses an issue where files referenced in `<img>` tags were ignored if the file was being parsed as MDX, since those nodes are of the `jsx` type, instead of the expected `html`. To address this, I changed the `test` argument passed to `visit` from the string `'html'` to an array: `['html', 'jsx']`

The `test` argument expects some input that is compatible with [`is`](https://github.com/syntax-tree/unist-util-is#istest-node-index-parent-context), which includes an array of strings as used in this PR. Here's some API reference for the `test` arg as it pertains to the `visit` function: https://github.com/syntax-tree/unist-util-visit-parents#visittree-test-visitor-reverse

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/12621
