### PR TITLE
fix(www): Disable subfont as it's currently breaking the build of gatsbyjs.org

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -227,6 +227,6 @@ module.exports = {
         nodeTypes: [`StartersYaml`],
       },
     },
-    `gatsby-plugin-subfont`,
+    // `gatsby-plugin-subfont`,
   ].concat(dynamicPlugins),
 }

--- a/www/package.json
+++ b/www/package.json
@@ -32,7 +32,6 @@
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.5",
     "gatsby-plugin-sitemap": "^2.0.1",
-    "gatsby-plugin-subfont": "^1.0.1",
     "gatsby-plugin-twitter": "^2.0.5",
     "gatsby-plugin-typography": "^2.2.0",
     "gatsby-remark-autolink-headers": "^2.0.10",


### PR DESCRIPTION
```
⚠ WARN: ENOENT: no such file or directory, open 'public/workbox-v3.6.3/packages/workbox-sw/browser.mjs'
         Including assets:
             public/workbox-v3.6.3/workbox-sw.js.map

error Plugin gatsby-plugin-subfont returned an error
```

Looks like the same error as https://github.com/gatsbyjs/gatsby/issues/9357

Not sure why it started occurring right now.


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->


<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->