### PR TITLE
fix(docs): Correct link to Source plugin tutorial

### DIFF
--- a/docs/docs/sourcing-from-private-apis.md
+++ b/docs/docs/sourcing-from-private-apis.md
@@ -10,7 +10,7 @@ There are 3 approaches that you can use to source data from your private API:
 
 1. If your private API is a GraphQL API, you can use [`gatsby-source-graphql`](/packages/gatsby-source-graphql/).
 2. If your private API is not a GraphQL API and you are new to GraphQL, treat the data as unstructured data and fetch it during build time, as described by the guide "[Using Gatsby without GraphQL](/docs/using-gatsby-without-graphql/)". However, as highlighted in the guide, this approach comes with some tradeoffs.
-3. Create a source plugin, as described in the tutorial "[Source plugin tutorial](/docs/source-plugin-tutorial/)".
+3. Create a source plugin, as described in the tutorial "[Source plugin tutorial](/docs/pixabay-source-plugin-tutorial/)".
 
 ### Other considerations
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Corrects the url to Source plugin tutorial

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
