### PR TITLE
feat(gatsby-transformer-yaml): support typeName

### DIFF
--- a/packages/gatsby-transformer-yaml/README.md
+++ b/packages/gatsby-transformer-yaml/README.md
@@ -164,3 +164,85 @@ Which would return:
 ```
 
 Please do **note** that `allLettersYaml` **will not** show up if you do not have any `.yaml` files.
+
+## Configuration options
+
+**`typeName`** [string|function][optional]
+
+The default naming convention documented above can be changed with
+either a static string value (e.g. to be able to query all json with a
+simple query):
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-transformer-yaml`,
+      options: {
+        typeName: `Yaml`, // a fixed string
+      },
+    },
+  ],
+}
+```
+
+```graphql
+{
+  allYaml {
+    edges {
+      node {
+        value
+      }
+    }
+  }
+}
+```
+
+or a function that receives the following arguments:
+
+- `node`: the graphql node that is being processed, e.g. a File node with
+  json content
+- `object`: a single object (either an item from an array or the whole json content)
+- `isArray`: boolean, true if `object` is part of an array
+
+```json
+[
+  {
+    "level": "info",
+    "message": "hurray"
+  },
+  {
+    "level": "info",
+    "message": "it works"
+  },
+  {
+    "level": "warning",
+    "message": "look out"
+  }
+]
+```
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-transformer-yaml`,
+      options: {
+        typeName: ({ node, object, isArray }) => object.level,
+      },
+    },
+  ],
+}
+```
+
+```graphql
+{
+  allInfo {
+    edges {
+      node {
+        message
+      }
+    }
+  }
+}
+```

--- a/packages/gatsby-transformer-yaml/README.md
+++ b/packages/gatsby-transformer-yaml/README.md
@@ -170,7 +170,7 @@ Please do **note** that `allLettersYaml` **will not** show up if you do not have
 **`typeName`** [string|function][optional]
 
 The default naming convention documented above can be changed with
-either a static string value (e.g. to be able to query all json with a
+either a static string value (e.g. to be able to query all yaml with a
 simple query):
 
 ```javascript
@@ -201,25 +201,17 @@ module.exports = {
 or a function that receives the following arguments:
 
 - `node`: the graphql node that is being processed, e.g. a File node with
-  json content
-- `object`: a single object (either an item from an array or the whole json content)
+  yaml content
+- `object`: a single object (either an item from an array or the whole yaml content)
 - `isArray`: boolean, true if `object` is part of an array
 
-```json
-[
-  {
-    "level": "info",
-    "message": "hurray"
-  },
-  {
-    "level": "info",
-    "message": "it works"
-  },
-  {
-    "level": "warning",
-    "message": "look out"
-  }
-]
+```yaml
+- level: info
+  message: hurray
+- level: info
+  message: it works
+- level: warning
+  message: look out
 ```
 
 ```javascript

--- a/packages/gatsby-transformer-yaml/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml/src/__tests__/gatsby-node.js
@@ -69,4 +69,114 @@ describe(`Process YAML nodes correctly`, () => {
       expect(createParentChildLink).toHaveBeenCalledTimes(1)
     })
   })
+
+  it(`correctly sets node type for array of objects`, () =>
+    Promise.all(
+      [
+        {
+          typeName: null,
+          expectedNodeTypes: [`TestYaml`, `TestYaml`],
+        },
+        {
+          typeName: `fixed`,
+          expectedNodeTypes: [`fixed`, `fixed`],
+        },
+        {
+          typeName: ({ node, object }) => object.funny,
+          expectedNodeTypes: [`yup`, `nope`],
+        },
+      ].map(
+        async ({ typeName, expectedNodeTypes: [expectedOne, expectedTwo] }) => {
+          const data = [
+            { id: `foo`, blue: true, funny: `yup` },
+            { blue: false, funny: `nope` },
+          ]
+
+          node.content = yaml.safeDump(data)
+          node.dir = `${os.tmpdir()}/bar/`
+
+          const createNode = jest.fn()
+          const createParentChildLink = jest.fn()
+          const actions = { createNode, createParentChildLink }
+          const createNodeId = jest.fn()
+          createNodeId.mockReturnValue(`uuid-from-gatsby`)
+          const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
+
+          return onCreateNode(
+            {
+              node,
+              loadNodeContent,
+              actions,
+              createNodeId,
+              createContentDigest,
+            },
+            { typeName }
+          ).then(() => {
+            expect(createNode).toBeCalledWith(
+              expect.objectContaining({
+                internal: expect.objectContaining({
+                  type: expectedOne,
+                }),
+              })
+            )
+            expect(createNode).toBeCalledWith(
+              expect.objectContaining({
+                internal: expect.objectContaining({
+                  type: expectedTwo,
+                }),
+              })
+            )
+          })
+        }
+      )
+    ))
+
+  it(`correctly sets node type for single object`, () =>
+    Promise.all(
+      [
+        {
+          typeName: null,
+          expectedNodeType: `TestdirYaml`,
+        },
+        {
+          typeName: `fixed`,
+          expectedNodeType: `fixed`,
+        },
+        {
+          typeName: ({ node, object }) => object.funny,
+          expectedNodeType: `yup`,
+        },
+      ].map(async ({ typeName, expectedNodeType }) => {
+        const data = { id: `foo`, blue: true, funny: `yup` }
+
+        node.content = yaml.safeDump(data)
+        node.dir = `${os.tmpdir()}/testdir/`
+
+        const createNode = jest.fn()
+        const createParentChildLink = jest.fn()
+        const actions = { createNode, createParentChildLink }
+        const createNodeId = jest.fn()
+        createNodeId.mockReturnValue(`uuid-from-gatsby`)
+        const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
+
+        return onCreateNode(
+          {
+            node,
+            loadNodeContent,
+            actions,
+            createNodeId,
+            createContentDigest,
+          },
+          { typeName }
+        ).then(() => {
+          expect(createNode).toBeCalledWith(
+            expect.objectContaining({
+              internal: expect.objectContaining({
+                type: expectedNodeType,
+              }),
+            })
+          )
+        })
+      })
+    ))
 })


### PR DESCRIPTION
## Description

This PR adds support for the `typeName` option to `gatsby-transformer-yaml`, as is implemented in `gatsby-transformer-json`

## Related Issues

None