### PR TITLE
feat(gatsby-cli): add alias with-prefix to prefix-paths

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -182,6 +182,10 @@ function buildLocalCommands(cli, isLocalSite) {
         default: false,
         describe: `Build site with link paths prefixed (set pathPrefix in your gatsby-config.js).`,
       })
+        .option(`with-prefix`, {
+          alias: `prefix-paths`,
+          default: false,
+        })
         .option(`no-uglify`, {
           type: `boolean`,
           default: false,


### PR DESCRIPTION
## Description

Add an command `with-prefix` that alias `prefix-paths`

## Related Issues

#13549