### PR TITLE
Revert "chore(*): Use new createContentDigest helper (#8992)"

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.15"
+    "gatsby": "^2.0.0"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem",
   "scripts": {

--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -5,7 +5,7 @@ const mime = require(`mime`)
 const prettyBytes = require(`pretty-bytes`)
 
 const md5File = require(`bluebird`).promisify(require(`md5-file`))
-const { createContentDigest } = require(`gatsby/utils`)
+const crypto = require(`crypto`)
 
 exports.createFileNode = async (
   pathToFile,
@@ -27,10 +27,12 @@ exports.createFileNode = async (
   const stats = await fs.stat(slashedFile.absolutePath)
   let internal
   if (stats.isDirectory()) {
-    const contentDigest = createContentDigest({
-      stats: stats,
-      absolutePath: slashedFile.absolutePath,
-    })
+    const contentDigest = crypto
+      .createHash(`md5`)
+      .update(
+        JSON.stringify({ stats: stats, absolutePath: slashedFile.absolutePath })
+      )
+      .digest(`hex`)
     internal = {
       contentDigest,
       type: `Directory`,

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -1,6 +1,6 @@
 const fs = require(`fs-extra`)
 const got = require(`got`)
-const { createContentDigest } = require(`gatsby/utils`)
+const crypto = require(`crypto`)
 const path = require(`path`)
 const { isWebUri } = require(`valid-url`)
 const Queue = require(`better-queue`)
@@ -52,6 +52,24 @@ const bar = new ProgressBar(
  * @param  {Function} options.createNode
  * @param  {Auth} [options.auth]
  */
+
+/*********
+ * utils *
+ *********/
+
+/**
+ * createHash
+ * --
+ *
+ * Create an md5 hash of the given str
+ * @param  {Stringq} str
+ * @return {String}
+ */
+const createHash = str =>
+  crypto
+    .createHash(`md5`)
+    .update(str)
+    .digest(`hex`)
 
 const CACHE_DIR = `.cache`
 const FS_PLUGIN_DIR = `gatsby-source-filesystem`
@@ -197,7 +215,7 @@ async function processRemoteNode({
   }
 
   // Create the temp and permanent file names for the url.
-  const digest = createContentDigest(url)
+  const digest = createHash(url)
   if (!name) {
     name = getRemoteFileName(url)
   }

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -1,7 +1,6 @@
 const { graphql } = require(`gatsby/graphql`)
 const { onCreateNode } = require(`../gatsby-node`)
 const extendNodeType = require(`../extend-node-type`)
-const { createContentDigest } = require(`gatsby/utils`)
 
 // given a set of nodes and a query, return the result of the query
 async function queryResult(
@@ -105,7 +104,6 @@ const bootstrapTest = (
         loadNodeContent,
         actions,
         createNodeId,
-        createContentDigest,
       },
       { ...additionalParameters, ...pluginOptions }
     )

--- a/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
@@ -3,8 +3,6 @@ const _ = require(`lodash`)
 const onCreateNode = require(`../on-node-create`)
 const { graphql } = require(`gatsby/graphql`)
 
-const { createContentDigest } = require(`gatsby/utils`)
-
 let node
 let actions
 let createNodeId
@@ -40,7 +38,6 @@ Where oh where is my little pony?
         loadNodeContent,
         actions,
         createNodeId,
-        createContentDigest,
       }).then(() => {
         expect(actions.createNode.mock.calls).toMatchSnapshot()
         expect(
@@ -78,7 +75,6 @@ Sed bibendum sem iaculis, pellentesque leo sed, imperdiet ante. Sed consequat ma
           loadNodeContent,
           actions,
           createNodeId,
-          createContentDigest,
         },
         { excerpt_separator: `<!-- end -->` }
       ).then(() => {
@@ -110,7 +106,6 @@ yadda yadda
         actions,
         createNodeId,
         loadNodeContent,
-        createContentDigest,
       })
 
       expect(parsed.frontmatter.date).toEqual(new Date(date).toJSON())
@@ -212,7 +207,6 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
           loadNodeContent,
           actions,
           createNodeId,
-          createContentDigest,
         },
         { excerpt_separator: `<!-- end -->` }
       )
@@ -267,7 +261,6 @@ Sed bibendum sem iaculis, pellentesque leo sed, imperdiet ante. Sed consequat ma
         loadNodeContent,
         actions,
         createNodeId,
-        createContentDigest,
       })
     })
   })

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,15 +1,9 @@
 const grayMatter = require(`gray-matter`)
+const crypto = require(`crypto`)
 const _ = require(`lodash`)
 
 module.exports = async function onCreateNode(
-  {
-    node,
-    loadNodeContent,
-    actions,
-    createNodeId,
-    reporter,
-    createContentDigest,
-  },
+  { node, loadNodeContent, actions, createNodeId, reporter },
   pluginOptions
 ) {
   const { createNode, createParentChildLink } = actions
@@ -59,7 +53,10 @@ module.exports = async function onCreateNode(
       markdownNode.fileAbsolutePath = node.absolutePath
     }
 
-    markdownNode.internal.contentDigest = createContentDigest(markdownNode)
+    markdownNode.internal.contentDigest = crypto
+      .createHash(`md5`)
+      .update(JSON.stringify(markdownNode))
+      .digest(`hex`)
 
     createNode(markdownNode)
     createParentChildLink({ parent: node, child: markdownNode })

--- a/packages/gatsby/utils.js
+++ b/packages/gatsby/utils.js
@@ -1,1 +1,0 @@
-exports.createContentDigest = require(`./dist/utils/create-content-digest`)


### PR DESCRIPTION
This reverts commit c91d110807d900bc6b8aeb629ff319fb8e5b9a49 and PR https://github.com/gatsbyjs/gatsby/pull/8992

We can't introduce a new file to the core gatsby package and then also update packages to use it without having a fallback as people often update/install packages without updating core.


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->


<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->