### PR TITLE
fix(docs): Fix setup code for Gatsby theme starter

### DIFF
--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -9,7 +9,7 @@ title: Building Themes
 There's a Gatsby Theme Starter which you can use to get up and running quickly:
 
 ```sh
-npx gatsby new https://github.com/ChristopherBiscardi/gatsby-starter-theme
+npx gatsby new my-theme https://github.com/ChristopherBiscardi/gatsby-starter-theme
 ```
 
 This starter will set you up with a yarn workspace and example site which you can


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The current code block is missing the name of the new Gatsby project and
thus will create an error when you run this code. This commit fixes and
adds a name for the Gatsby starter theme to get started.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
I couldn't find any.