### PR TITLE
[schema] Ensure default by: id for link() resolver

### DIFF
--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -93,7 +93,7 @@ const paginate = (results = [], { skip = 0, limit }) => {
   }
 }
 
-const link = ({ by, from }) => async (source, args, context, info) => {
+const link = ({ by = `id`, from }) => async (source, args, context, info) => {
   const fieldValue = source && source[from || info.fieldName]
 
   if (fieldValue == null || _.isPlainObject(fieldValue)) return fieldValue


### PR DESCRIPTION
This is for #13028

Because `addResolver` directive is generic we don't have defaultValue for options. So better ensure we have default `by: id` arg for link resolver.