### PR TITLE
fix(docs): Fix flatten to include current item (#13590)

### DIFF
--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -19,7 +19,8 @@ const findStubs = pages =>
 
 const flatten = pages =>
   pages.reduce(
-    (flat, item) => flat.concat(item.items ? flatten(item.items) : item),
+    (flat, item) =>
+      flat.concat(item.items ? flatten(item.items).concat(item) : item),
     []
   )
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixes `flatten` to also include the current item of the array

## Related Issues
Fixes  #13590 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
