### PR TITLE
fix(gatsby): fixes react-hot-reloader for new react features

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -156,6 +156,7 @@ module.exports = async (
       case `develop`:
         return {
           commons: [
+            `react-hot-loader/patch`,
             `event-source-polyfill`,
             `${require.resolve(
               `webpack-hot-middleware/client`

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -156,7 +156,6 @@ module.exports = async (
       case `develop`:
         return {
           commons: [
-            `react-hot-loader/patch`,
             `event-source-polyfill`,
             `${require.resolve(
               `webpack-hot-middleware/client`
@@ -275,6 +274,16 @@ module.exports = async (
             oneOf: [rules.cssModules(), rules.css()],
           },
         ])
+
+        // RHL will patch React, replace React-DOM by React-🔥-DOM and work with fiber directly
+        // It's necessary to remove the warning in console (https://github.com/gatsbyjs/gatsby/issues/11934)
+        configRules.push({
+          include: /node_modules/,
+          test: /\.jsx?$/,
+          use: {
+            loader: `react-hot-loader/webpack`,
+          },
+        })
 
         break
       }


### PR DESCRIPTION

## Description
Fixes HMR for hooks & suspense features with react-🔥-dom. It uses the webpack loader to patch react-dom as react-dom is a peer dependency we can't force users to install `@hot-loader/react-dom` as mentioned in the [README of react-hot-loader](https://github.com/gaearon/react-hot-loader#react--dom).

After:
![image](https://user-images.githubusercontent.com/1120926/56688067-02f39e00-66d8-11e9-916e-37023ccd3328.png)

Before:
![image](https://user-images.githubusercontent.com/1120926/56687872-85c82900-66d7-11e9-92fd-7b56083a108d.png)

It also actually fixes HMR for components using hooks 😛 not just remove the message.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
#11934
