### PR TITLE
Fixing Browser & SSR API docs to have all examples use CommonJS syntax

### DIFF
--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -152,10 +152,10 @@ exports.onPreRenderHTML = true
  * @param {pluginOptions} pluginOptions
  * @returns {ReactNode} Wrapped element
  * @example
- * import React from "react"
- * import Layout from "./src/components/layout"
+ * const React = require("react")
+ * const Layout = require("./src/components/layout")
  *
- * export const wrapPageElement = ({ element, props }) => {
+ * exports.wrapPageElement = ({ element, props }) => {
  *   // props provide same data to Layout as Page element will get
  *   // including location, data, etc - you don't need to pass it
  *   return <Layout {...props}>{element}</Layout>
@@ -175,13 +175,13 @@ exports.wrapPageElement = true
  * @param {pluginOptions} pluginOptions
  * @returns {ReactNode} Wrapped element
  * @example
- * import React from "react"
- * import { Provider } from "react-redux"
+ * const React = require("react")
+ * const { Provider } = require("react-redux")
  *
- * import createStore from "./src/state/createStore"
+ * const createStore = require("./src/state/createStore")
  * const store = createStore()
  *
- * export const wrapRootElement = ({ element }) => {
+ * exports.wrapRootElement = ({ element }) => {
  *   return (
  *     <Provider store={store}>
  *       {element}

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -145,10 +145,10 @@ exports.replaceComponentRenderer = true
  * @param {pluginOptions} pluginOptions
  * @returns {ReactNode} Wrapped element
  * @example
- * import React from "react"
- * import Layout from "./src/components/layout"
+ * const React = require("react")
+ * const Layout = require("./src/components/layout")
  *
- * export const wrapPageElement = ({ element, props }) => {
+ * exports.wrapPageElement = ({ element, props }) => {
  *   // props provide same data to Layout as Page element will get
  *   // including location, data, etc - you don't need to pass it
  *   return <Layout {...props}>{element}</Layout>
@@ -168,13 +168,13 @@ exports.wrapPageElement = true
  * @param {pluginOptions} pluginOptions
  * @returns {ReactNode} Wrapped element
  * @example
- * import React from "react"
- * import { Provider } from "react-redux"
+ * const React = require("react")
+ * const { Provider } = require("react-redux")
  *
- * import createStore from "./src/state/createStore"
+ * const createStore = require("./src/state/createStore")
  * const store = createStore()
  *
- * export const wrapRootElement = ({ element }) => {
+ * exports.wrapRootElement = ({ element }) => {
  *   return (
  *     <Provider store={store}>
  *       {element}


### PR DESCRIPTION
## Description

There was a inconsistent usage between CommonJS and ES Module Syntaxes in the gatsby-browser and gatsby-ssr API docs pages. I have converted everything over to CommonJS.

## Related Issues

Fixes #13248
