### PR TITLE
feat(docs): Add contributing/organize-a-gatsby-event/

### DIFF
--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -1,0 +1,35 @@
+---
+title: Organize a Gatsby Event
+---
+
+Interested in organizing a Gatsby event? We want to help build the Gatsby community in your area. If your event meets a few basic requirements listed below, you’ll be eligible to receive support from Gatsby such as Gatsby swag, \$300 for food, learning resources, and more. Get started by requesting event support below.
+
+[Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
+
+## What constitutes a Gatsby event?
+
+A community organized Gatsby event can be a local meetup, a small conference, a _lunch and learn_ with coworkers, or a larger event. It’s up to you how many people you want to invite and how casual the environment. You can organize an event at your workplace or for the local community.
+
+## What support does Gatsby provide?
+
+There are several ways Gatsby may support your event:
+
+- Promote event on the Gatsbyjs.org events page
+- Promote event via Gatsby’s Twitter handle
+- \$300 off food related expenses
+- Free Gatsby stickers from the [Gatsby Swag Store](https://store.gatsbyjs.org/)
+- 20% off swag in the [Gatsby Swag Store](https://store.gatsbyjs.org/) for your attendees
+- Gatsby team member speaker (when available)
+
+## Requirements
+
+- The event must have at least half of the content focused on Gatsby or a Gatsby-related topic (such as JAMstack)
+- Both US and international events qualify for support
+- If you’re requesting the \$300 food credit, then you must submit a receipt for the expense
+- The event must be in harmony with the [Gatsby Code of Conduct](/contributing/code-of-conduct/) and follow the [Gatsby brand guidelines](https://mutability.netlify.com/logo/)
+
+## How do you qualify for Gatsby support?
+
+To request support and submit your event to the Gatsby events page, apply at the link below.
+
+[Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)

--- a/www/src/data/sidebars/contributing-links.yaml
+++ b/www/src/data/sidebars/contributing-links.yaml
@@ -14,6 +14,8 @@
           link: /contributing/pair-programming/
         - title: Where to Participate in the Community
           link: /contributing/where-to-participate/
+        - title: Organize a Gatsby Event
+          link: /contributing/organize-a-gatsby-event/
         - title: How to Run a Gatsby Workshop
           link: /contributing/how-to-run-a-gatsby-workshop/
         - title: How to Pitch Gatsby


### PR DESCRIPTION
This adds a new page at `/contributing/organize-a-gatsby-event/`:

![screencapture-localhost-8000-contributing-organize-a-gatsby-event-2019-04-25-00_07_12](https://user-images.githubusercontent.com/21834/56697105-232e5780-66ee-11e9-8291-27300f2090f4.png)

I'm not sure where to place it in the sidebar menu's hierarchy.

/cc @lindaleebumblebee @marisamorby @marcysutton 