### PR TITLE
fix(docs): Hide Top Level heading if no contents

### DIFF
--- a/www/src/pages/contributing/stub-list.js
+++ b/www/src/pages/contributing/stub-list.js
@@ -45,12 +45,15 @@ class StubListRoute extends React.Component {
       a.localeCompare(b)
     )
 
-    // Put top level at the front of the array
+    // Put top level at the front of the array if it isn't empty
     sortedCategories.splice(
       sortedCategories.indexOf(`Top Level Documentation Pages`),
       1
     )
-    sortedCategories = [`Top Level Documentation Pages`, ...sortedCategories]
+
+    if (groupedStubs[`Top Level Documentation Pages`]) {
+      sortedCategories = [`Top Level Documentation Pages`, ...sortedCategories]
+    }
 
     return (
       <Layout location={this.props.location} itemList={itemListContributing}>


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Hides the 'Top Level Documentation Pages' heading if there are no stubs in the category

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #13593

Cheers
