### PR TITLE
Fix possible typo in Themes docs

### DIFF
--- a/docs/docs/themes/converting-a-starter.md
+++ b/docs/docs/themes/converting-a-starter.md
@@ -2,7 +2,7 @@
 title: Converting a Starter to a Theme
 ---
 
-Gatsby themes are designed to be easy to create from an existing starter. Here we will walk you through the main steps of converting your theme to a starter.
+Gatsby themes are designed to be easy to create from an existing starter. Here we will walk you through the main steps of converting your starter to a theme.
 
 ## Prepare Your `package.json`
 


### PR DESCRIPTION
## Description

This PR fixes a (possible) typo  _"converting your theme to a starter"_ into the opposite, to match the page title [Converting a Starter to a Theme](https://www.gatsbyjs.org/docs/themes/converting-a-starter/).