### PR TITLE
chore(gatsby-remark-prismjs): bump prismjs to 1.16.0

### DIFF
--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -16,12 +16,12 @@
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.4",
     "cross-env": "^5.1.4",
-    "prismjs": "^1.15.0",
+    "prismjs": "^1.16.0",
     "remark": "^9.0.0"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0",
-    "prismjs": "^1.15.0"
+    "prismjs": "^1.16.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#readme",
   "keywords": [


### PR DESCRIPTION
See https://github.com/PrismJS/prism/releases/tag/v1.16.0