### PR TITLE
fix(gatsby): development proxy should proceed request headers and method

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -208,9 +208,10 @@ async function startServer(program) {
     const { prefix, url } = proxy
     app.use(`${prefix}/*`, (req, res) => {
       const proxiedUrl = url + req.originalUrl
+      const { headers, method } = req
       req
         .pipe(
-          got.stream(proxiedUrl).on(`error`, err => {
+          got.stream(proxiedUrl, { headers, method }).on(`error`, err => {
             const message = `Error when trying to proxy request "${
               req.originalUrl
             }" to "${proxiedUrl}"`


### PR DESCRIPTION
Fixes #13684