### PR TITLE
Ensure a consistent schema for gatsby-plugin-documentationjs and add TypeScript support

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -66,7 +66,7 @@ exports.sourceNodes = ({ actions }) => {
       type: DoctrineType
       default: JSON
       augments: [DocumentationJs]
-      examples: [JSON]
+      examples: [DocumentationJsExample]
       implements: [DocumentationJs]
       params: [DocumentationJs]
       properties: [DocumentationJs]
@@ -75,6 +75,11 @@ exports.sourceNodes = ({ actions }) => {
       todos: [DocumentationJs]
       yields: [DocumentationJs]
       members: DocumentationJsMembers
+    }
+
+    type DocumentationJsExample {
+      caption: String
+      description: String
     }
 
     type DocumentationJsMembers {

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -42,6 +42,64 @@ function prepareDescriptionNode(node, markdownStr, name, helpers) {
   return descriptionNode
 }
 
+exports.sourceNodes = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type DocumentationJs implements Node {
+      name: String
+      kind: String
+      memberof: String
+      scope: String
+      access: String
+      readonly: Boolean
+      abstract: Boolean
+      generator: Boolean
+      async: Boolean
+      override: Boolean
+      hideconstructor: Boolean
+      alias: String
+      copyright: String
+      author: String
+      license: String
+      since: String
+      lends: String
+      type: DoctrineType
+      default: JSON
+      augments: [DocumentationJs]
+      examples: [JSON]
+      implements: [DocumentationJs]
+      params: [DocumentationJs]
+      properties: [DocumentationJs]
+      returns: [DocumentationJs]
+      throws: [DocumentationJs]
+      todos: [DocumentationJs]
+      yields: [DocumentationJs]
+      members: DocumentationJsMembers
+    }
+
+    type DocumentationJsMembers {
+      static: [DocumentationJs]
+      instance: [DocumentationJs]
+      events: [DocumentationJs]
+      global: [DocumentationJs]
+      inner: [DocumentationJs]
+    }
+
+    type DoctrineType {
+      type: String!
+      name: String
+      elements: [JSON]
+      expression: JSON
+      applications: [JSON]
+      params: [JSON]
+      fields: [JSON]
+      result: JSON
+      typeDef: DocumentationJs
+    }
+  `
+  createTypes(typeDefs)
+}
+
 /**
  * Implement the onCreateNode API to create documentation.js nodes
  * @param {Object} super this is a super param
@@ -51,8 +109,12 @@ exports.onCreateNode = async ({ node, actions, ...helpers }) => {
   const { createNode, createParentChildLink } = actions
 
   if (
-    node.internal.mediaType !== `application/javascript` ||
-    node.internal.type !== `File`
+    node.internal.type !== `File` ||
+    !(
+      node.internal.mediaType === `application/javascript` ||
+      node.extension === `tsx` ||
+      node.extension === `ts`
+    )
   ) {
     return null
   }
@@ -150,6 +212,20 @@ exports.onCreateNode = async ({ node, actions, ...helpers }) => {
         `scope`,
         `type`,
         `default`,
+        `readonly`,
+        `access`,
+        `abstract`,
+        `generator`,
+        `async`,
+        `override`,
+        `hideconstructor`,
+        `alias`,
+        `copyright`,
+        `author`,
+        `license`,
+        `since`,
+        `lends`,
+        `examples`,
       ])
 
       picked.optional = false
@@ -190,7 +266,16 @@ exports.onCreateNode = async ({ node, actions, ...helpers }) => {
         }
       })
 
-      const docsSubfields = [`params`, `properties`, `returns`]
+      const docsSubfields = [
+        `augments`,
+        `implements`,
+        `params`,
+        `properties`,
+        `returns`,
+        `throws`,
+        `todos`,
+        `yields`,
+      ]
       docsSubfields.forEach(fieldName => {
         if (docsJson[fieldName] && docsJson[fieldName].length > 0) {
           picked[`${fieldName}___NODE`] = docsJson[fieldName].map(


### PR DESCRIPTION
This adds a schema definition for gatsby-plugin-documentationjs to ensure that it is consistent no matter what files are actually processed. Currently, with gatsby's automatic schema generation, the schema can be missing fields if they are unused by the code that is being parsed and therefore the query would have to change as the code changes. This ensures that the schema will have all fields available no matter what.

Also, [TypeScript support](https://github.com/documentationjs/documentation/pull/1234) was recently added to documentationjs, so this enables `.ts` and `.tsx` files to be processed as well.