### PR TITLE
[schema] Clarify type conflict warning message

### DIFF
--- a/packages/gatsby/src/redux/actions.js
+++ b/packages/gatsby/src/redux/actions.js
@@ -1274,7 +1274,7 @@ import type GatsbyGraphQLType from "../schema/types/type-builders"
  *     Author information
  *     """
  *     # Does not include automatically inferred fields
- *     type AuthorJson implements Node @dontInfer(noFieldResolvers: true) {
+ *     type AuthorJson implements Node @dontInfer(noDefaultResolvers: true) {
  *       name: String!
  *       birthday: Date! # no default resolvers for Date formatting added
  *     }

--- a/packages/gatsby/src/schema/infer/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/infer/type-conflict-reporter.js
@@ -134,7 +134,14 @@ class TypeConflictReporter {
   printConflicts() {
     if (this.entries.size > 0) {
       report.warn(
-        `There are conflicting field types in your data. GraphQL schema will omit those fields.`
+        `There are conflicting field types in your data.\n\n` +
+          `If you have explicitly defined a type for those fields, you can ` +
+          `safely ignore this warning message.\n` +
+          `Otherwise, Gatsby will omit those fields from the GraphQL schema.\n\n` +
+          `If you know all field types in advance, the best strategy is to ` +
+          `explicitly define them with the \`createTypes\` action, and skip ` +
+          `inference with the \`@dontInfer\` directive.\n` +
+          `See https://www.gatsbyjs.org/docs/actions/#createTypes`
       )
       this.entries.forEach(entry => entry.printEntry())
     }


### PR DESCRIPTION
We currently show a warning message in case of conflicting field types, even when the field type has been explicitly defined with `createTypes`, which is a bit confusing. This tries to give more context to the warning.

See https://github.com/gatsbyjs/gatsby/issues/12272#issuecomment-479227514 and https://github.com/gatsbyjs/gatsby/pull/13028#issuecomment-487342249