### PR TITLE
chore(starters): add gatsby-starter-blog-typescript

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2389,7 +2389,7 @@
   tags:
     - Blog
     - Typescript
-    - Styled Components
+    - Styling:CSS-in-JS
   features:
     - Includes all features that come with gatsby's official starter blog
     - Typescript for type-safety out of the box

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2383,3 +2383,16 @@
     - Uses MDX with Gatsby theme for quick and easy set up
     - Material-ui design with optional config passed into the theme options
     - Gradient background with sitemap, rss feed, and offline capabilities
+- url: https://github.com/gperl27/Gatsby-Starter-Blog-Typescript
+  repo: https://github.com/gperl27/Gatsby-Starter-Blog-Typescript
+  description: Gatsby starter blog with typescript
+  tags:
+    - Blog
+    - Typescript
+    - Styled Components
+  features:
+    - Includes all features that come with gatsby's official starter blog
+    - Typescript for type-safety out of the box
+    - Styled components in favor of inline styles
+    - Transition Link for nice page transitions
+    - Type definitions from grapql schema (with code generation)


### PR DESCRIPTION
## Description

Adds a starter that integrates typescript and styled components on top of the official gatsby starter blog