### PR TITLE
fix(www): Fix urlToSearch to correctly decode the query string

### DIFF
--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -464,7 +464,10 @@ class PluginSearchBar extends Component {
   urlToSearch = () => {
     if (this.props.location.search) {
       // ignore this automatically added query parameter
-      return this.props.location.search.replace(`no-cache=1`, ``).slice(2)
+      const search = this.props.location.search
+        .replace(`no-cache=1`, ``)
+        .slice(2)
+      return decodeURIComponent(search)
     }
     return ``
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes urlToSearch to decode the query string correctly.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #13696