### PR TITLE
Theme blog core: changing the navigation from a post because of the posts order

### DIFF
--- a/themes/gatsby-theme-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-blog-core/gatsby-node.js
@@ -94,9 +94,9 @@ exports.createPages = ({ graphql, actions }) => {
         const posts = result.data.allMarkdownRemark.edges
 
         posts.forEach((post, index) => {
-          const previous =
+          const next =
             index === posts.length - 1 ? null : posts[index + 1].node
-          const next = index === 0 ? null : posts[index - 1].node
+          const previous = index === 0 ? null : posts[index - 1].node
 
           debug(`creating`, post.node.fields.slug)
           createPage({


### PR DESCRIPTION
## Description

**Problem** (small problem): the list of posts is in reverse order of date. However, the previous and next links from a post follow the order of date (not reverse). I think it's a little confusing. I'm not the only one who experimented the same thing.

**Solution** (small change): swapping the previous and next values. In this way, there will be the same order both in the main list and in a single post.