### PR TITLE
fix(www): Update minimum required Gatsby version to 2.3.33

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -13,7 +13,7 @@
     "dotenv": "^6.0.0",
     "email-validator": "^1.1.1",
     "fuse.js": "^3.2.0",
-    "gatsby": "^2.3.0",
+    "gatsby": "^2.3.33",
     "gatsby-image": "^2.0.5",
     "gatsby-plugin-canonical-urls": "^2.0.5",
     "gatsby-plugin-catch-links": "^2.0.2",


### PR DESCRIPTION

## Description

Sets a new minimum required version for the `www/` (docs) site, it looked appropriate since there is a bot which upgrades all the starters to use the latest Gatsby in https://github.com/gatsbyjs/gatsby/pull/13706 (I'm surprised it doesn't update this folder too).

I confirmed locally that this version does not run into the webassembly issue reported in #13641.

## Related Issues

- Ensures that people don't run into #13641, presently doing a clean yarn install led to reinstalling `2.3.31` on my device