### PR TITLE
fix(gatsby-telemetry): Set enabled to false in isTrackingEnabled if GATSBY_TELEMETRY_DISABLED

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -153,6 +153,12 @@ module.exports = class AnalyticsTracker {
       enabled = true
       this.store.updateConfig(`telemetry.enabled`, enabled)
     }
+
+    // `GATSBY_TELEMETRY_DISABLED` overrides config value
+    if (this.store.disabled) {
+      enabled = false
+    }
+
     this.trackingEnabled = enabled
     return enabled
   }


### PR DESCRIPTION
Currently, when `GATSBY_TELEMETRY_DISABLED` is set to something truthy (for example, `1`, `true`), we disable telemetry in `src/event-storage.js`

This PR adds an escape hatch _earlier_ in `src/telemetry.js`, a happy side effect of which is a fix for https://github.com/gatsbyjs/gatsby/issues/13714