### PR TITLE
chore(ci): revert "tests: add node 12 to tests (#13538)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,12 +130,6 @@ jobs:
     executor: node
     <<: *test_template
 
-  unit_tests_node12:
-    executor:
-      name: node
-      image: "12"
-    <<: *test_template
-
   unit_tests_www:
     executor: node
     steps:
@@ -225,10 +219,6 @@ workflows:
           requires:
             - bootstrap
       - unit_tests_node10:
-          <<: *ignore_docs
-          requires:
-            - bootstrap
-      - unit_tests_node12:
           <<: *ignore_docs
           requires:
             - bootstrap


### PR DESCRIPTION
## Description

I'm not really sure what the value is of a failing CI status check on _every_ PR (and tends to introduce undue confusion)--so let's get this fixed up.

We can re-add it later when we iron out the upstream Sharp issues and/or add checks to core to ensure we can safely bump all versions of Sharp in our plugins.

Also before anyone asks if I should just comment it out... https://twitter.com/markdalgleish/status/1118286402280546304 😆 

## Related Issues

Reverts #13702