### PR TITLE
docs(gatsby-plugin-netlify): remove comment that states to put it last

### DIFF
--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -20,7 +20,7 @@ config.
 ```javascript
 // In your gatsby-config.js
 plugins: [
-  `gatsby-plugin-netlify`, // make sure to put last in the array
+  `gatsby-plugin-netlify`,
 ]
 ```
 

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -19,9 +19,7 @@ config.
 
 ```javascript
 // In your gatsby-config.js
-plugins: [
-  `gatsby-plugin-netlify`,
-]
+plugins: [`gatsby-plugin-netlify`]
 ```
 
 ## Configuration
@@ -32,7 +30,6 @@ transform the given headers, you can use the following configuration options.
 
 ```javascript
 plugins: [
-  // make sure to put last in the array
   {
     resolve: `gatsby-plugin-netlify`,
     options: {


### PR DESCRIPTION
## Description

Removes a comment stating to put netlify plugin as last item on the array of plugins
Depends on: https://github.com/gatsbyjs/gatsby/pull/13750