### PR TITLE
fix(types): update TypeScript declarations

### DIFF
--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -1,4 +1,4 @@
-import { GatsbyNode, Store, Cache } from "gatsby"
+import { Node, Store, Cache } from "gatsby"
 
 /**
  * @see https://www.gatsbyjs.org/packages/gatsby-source-filesystem/?=files#createfilepath
@@ -13,7 +13,7 @@ export function createRemoteFileNode(
 ): FileSystemNode
 
 export interface CreateFilePathArgs {
-  node: GatsbyNode
+  node: Node
   getNode: Function
   basePath?: string
   trailingSlash?: boolean
@@ -35,7 +35,7 @@ export interface CreateRemoteFileNodeArgs {
   name?: string
 }
 
-export interface FileSystemNode extends GatsbyNode {
+export interface FileSystemNode extends Node {
   absolutePath: string
   accessTime: string
   birthTime: Date

--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -1,4 +1,4 @@
-import { Node, Store, Cache } from "gatsby"
+import { GatsbyNode, Store, Cache } from "gatsby"
 
 /**
  * @see https://www.gatsbyjs.org/packages/gatsby-source-filesystem/?=files#createfilepath
@@ -13,7 +13,7 @@ export function createRemoteFileNode(
 ): FileSystemNode
 
 export interface CreateFilePathArgs {
-  node: Node
+  node: GatsbyNode
   getNode: Function
   basePath?: string
   trailingSlash?: boolean
@@ -35,7 +35,7 @@ export interface CreateRemoteFileNodeArgs {
   name?: string
 }
 
-export interface FileSystemNode extends Node {
+export interface FileSystemNode extends GatsbyNode {
   absolutePath: string
   accessTime: string
   birthTime: Date

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -70,7 +70,7 @@ export const graphql: (query: TemplateStringsArray) => void
  *
  * @see https://www.gatsbyjs.org/docs/gatsby-config/
  */
-export interface GatsbyConfig {
+export interface GatsbyConfigAPI {
   /** When you want to reuse common pieces of data across the site (for example, your site title), you can store that here. */
   siteMetadata?: Record<string, unknown>
   /** Plugins are Node.js packages that implement Gatsby APIs. The config file accepts an array of plugins. Some plugins may need only to be listed by name, while others may take options. */
@@ -103,7 +103,7 @@ export interface GatsbyConfig {
  *
  * @see https://www.gatsbyjs.org/docs/node-apis/
  */
-export interface GatsbyNode {
+export interface GatsbyNodeAPI {
   /**
    * Tell plugins to add pages. This extension point is called only after the initial
    * sourcing and transformation of nodes plus creation of the GraphQL schema are
@@ -377,7 +377,7 @@ export interface GatsbyNode {
  *
  * @see https://www.gatsbyjs.org/docs/browser-apis/
  */
-export interface GatsbyBrowser {
+export interface GatsbyBrowserAPI {
   disableCorePrefetching?(args: BrowserPluginArgs, options: PluginOptions): any
   onClientEntry?(args: BrowserPluginArgs, options: PluginOptions): any
   onInitialClientRender?(args: BrowserPluginArgs, options: PluginOptions): any
@@ -427,7 +427,7 @@ export interface GatsbyBrowser {
  *
  * @see https://www.gatsbyjs.org/docs/ssr-apis/
  */
-export interface GatsbySSR {
+export interface GatsbySSRAPI {
   /**
    * Called after every page Gatsby server renders while building HTML so you can
    * replace head components to be rendered in your `html.js`. This is useful if
@@ -619,7 +619,7 @@ export interface CreateDevServerArgs extends ParentSpanPluginArgs {
 }
 
 export interface CreateNodeArgs extends ParentSpanPluginArgs {
-  node: Node
+  node: GatsbyNode
   traceId: string
   traceTags: {
     nodeId: string
@@ -628,7 +628,7 @@ export interface CreateNodeArgs extends ParentSpanPluginArgs {
 }
 
 export interface CreatePageArgs extends ParentSpanPluginArgs {
-  page: Node
+  page: GatsbyNode
   traceId: string
 }
 
@@ -736,11 +736,11 @@ interface ActionPlugin {
 }
 
 interface DeleteNodeArgs {
-  node: Node
+  node: GatsbyNode
 }
 
 interface CreateNodeFieldArgs {
-  node: Node
+  node: GatsbyNode
   name: string
   value: string
 
@@ -776,7 +776,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#deletePage */
   deleteNode(
-    options: { node: Node },
+    options: { node: GatsbyNode },
     plugin?: ActionPlugin,
     option?: ActionOptions
   ): void
@@ -788,7 +788,11 @@ export interface Actions {
   deleteNodes(nodes: string[], plugin?: ActionPlugin): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createNode */
-  createNode(node: Node, plugin?: ActionPlugin, options?: ActionOptions): void
+  createNode(
+    node: GatsbyNode,
+    plugin?: ActionPlugin,
+    options?: ActionOptions
+  ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#touchNode */
   touchNode(node: { nodeId: string; plugin?: ActionPlugin }): void
@@ -796,7 +800,7 @@ export interface Actions {
   /** @see https://www.gatsbyjs.org/docs/actions/#createNodeField */
   createNodeField(
     args: {
-      node: Node
+      node: GatsbyNode
       fieldName?: string
       fieldValue?: string
       name?: string
@@ -1099,11 +1103,11 @@ export interface ServiceWorkerArgs extends BrowserPluginArgs {
   serviceWorker: ServiceWorkerRegistration
 }
 
-export interface Node {
+export interface GatsbyNode {
   path?: string
   id: string
   parent: string
-  children: Node[]
+  children: GatsbyNode[]
   fields?: Record<string, string>
   internal: {
     type: string

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1,6 +1,5 @@
 import * as React from "react"
 import { EventEmitter } from "events"
-import { Application } from "express"
 import { WindowLocation } from "@reach/router"
 
 export {
@@ -96,7 +95,7 @@ export interface GatsbyConfig {
     url: string
   }
   /** Sometimes you need more granular/flexible access to the development server. Gatsby exposes the Express.js development server to your site’s gatsby-config.js where you can add Express middleware as needed. */
-  developMiddleware?(app: Application): void
+  developMiddleware?(app: any): void
 }
 
 /**
@@ -616,7 +615,7 @@ export interface CreateBabelConfigArgs extends ParentSpanPluginArgs {
 }
 
 export interface CreateDevServerArgs extends ParentSpanPluginArgs {
-  app: Application
+  app: any
 }
 
 export interface CreateNodeArgs extends ParentSpanPluginArgs {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -70,7 +70,7 @@ export const graphql: (query: TemplateStringsArray) => void
  *
  * @see https://www.gatsbyjs.org/docs/gatsby-config/
  */
-export interface GatsbyConfigAPI {
+export interface GatsbyConfig {
   /** When you want to reuse common pieces of data across the site (for example, your site title), you can store that here. */
   siteMetadata?: Record<string, unknown>
   /** Plugins are Node.js packages that implement Gatsby APIs. The config file accepts an array of plugins. Some plugins may need only to be listed by name, while others may take options. */
@@ -103,7 +103,7 @@ export interface GatsbyConfigAPI {
  *
  * @see https://www.gatsbyjs.org/docs/node-apis/
  */
-export interface GatsbyNodeAPI {
+export interface Node {
   /**
    * Tell plugins to add pages. This extension point is called only after the initial
    * sourcing and transformation of nodes plus creation of the GraphQL schema are
@@ -377,7 +377,7 @@ export interface GatsbyNodeAPI {
  *
  * @see https://www.gatsbyjs.org/docs/browser-apis/
  */
-export interface GatsbyBrowserAPI {
+export interface GatsbyBrowser {
   disableCorePrefetching?(args: BrowserPluginArgs, options: PluginOptions): any
   onClientEntry?(args: BrowserPluginArgs, options: PluginOptions): any
   onInitialClientRender?(args: BrowserPluginArgs, options: PluginOptions): any
@@ -427,7 +427,7 @@ export interface GatsbyBrowserAPI {
  *
  * @see https://www.gatsbyjs.org/docs/ssr-apis/
  */
-export interface GatsbySSRAPI {
+export interface GatsbySSR {
   /**
    * Called after every page Gatsby server renders while building HTML so you can
    * replace head components to be rendered in your `html.js`. This is useful if
@@ -619,7 +619,7 @@ export interface CreateDevServerArgs extends ParentSpanPluginArgs {
 }
 
 export interface CreateNodeArgs extends ParentSpanPluginArgs {
-  node: GatsbyNode
+  node: Node
   traceId: string
   traceTags: {
     nodeId: string
@@ -628,7 +628,7 @@ export interface CreateNodeArgs extends ParentSpanPluginArgs {
 }
 
 export interface CreatePageArgs extends ParentSpanPluginArgs {
-  page: GatsbyNode
+  page: Node
   traceId: string
 }
 
@@ -736,11 +736,11 @@ interface ActionPlugin {
 }
 
 interface DeleteNodeArgs {
-  node: GatsbyNode
+  node: Node
 }
 
 interface CreateNodeFieldArgs {
-  node: GatsbyNode
+  node: Node
   name: string
   value: string
 
@@ -776,7 +776,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#deletePage */
   deleteNode(
-    options: { node: GatsbyNode },
+    options: { node: Node },
     plugin?: ActionPlugin,
     option?: ActionOptions
   ): void
@@ -788,11 +788,7 @@ export interface Actions {
   deleteNodes(nodes: string[], plugin?: ActionPlugin): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createNode */
-  createNode(
-    node: GatsbyNode,
-    plugin?: ActionPlugin,
-    options?: ActionOptions
-  ): void
+  createNode(node: Node, plugin?: ActionPlugin, options?: ActionOptions): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#touchNode */
   touchNode(node: { nodeId: string; plugin?: ActionPlugin }): void
@@ -800,7 +796,7 @@ export interface Actions {
   /** @see https://www.gatsbyjs.org/docs/actions/#createNodeField */
   createNodeField(
     args: {
-      node: GatsbyNode
+      node: Node
       fieldName?: string
       fieldValue?: string
       name?: string
@@ -812,7 +808,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createParentChildLink */
   createParentChildLink(
-    args: { parent: GatsbyNode; child: GatsbyNode },
+    args: { parent: Node; child: Node },
     plugin?: ActionPlugin
   ): void
 
@@ -1103,11 +1099,11 @@ export interface ServiceWorkerArgs extends BrowserPluginArgs {
   serviceWorker: ServiceWorkerRegistration
 }
 
-export interface GatsbyNode {
+export interface Node {
   path?: string
   id: string
   parent: string
-  children: GatsbyNode[]
+  children: Node[]
   fields?: Record<string, string>
   internal: {
     type: string

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -812,7 +812,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createParentChildLink */
   createParentChildLink(
-    { parent: Node, child: Node },
+    args: { parent: GatsbyNode; child: GatsbyNode },
     plugin?: ActionPlugin
   ): void
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -867,16 +867,16 @@ export interface Actions {
   /** @see https://www.gatsbyjs.org/docs/actions/#addThirdPartySchema */
   addThirdPartySchema(
     args: { schema: object },
-    plugin?: ActionPlugin,
-    traceId: string
-  )
+    plugin: ActionPlugin,
+    traceId?: string
+  ): void
 
   /** TODO create jsdoc on gatsbyjs.org */
   createTypes(
     types: string | object | Array<string | object>,
-    plugin?: ActionPlugin,
-    traceId: string
-  )
+    plugin: ActionPlugin,
+    traceId?: string
+  ): void
 }
 
 export interface Store {


### PR DESCRIPTION
## Description

- replace Express.js `Application` type import with `any` to avoid `@types/express` dependency
- update `addThirdPartySchema`, `createTypes`, and `createParentChildLink` signatures
- rename `Node` to `GatsbyNode` to avoid collisions with the [`dom` lib](https://github.com/Microsoft/TypeScript/blob/49d6f61298af7a1b470257d293e160694dcd1416/lib/lib.dom.d.ts#L10585)
  - rename `GatsbyNode` to `GatsbyNodeAPI` to allow the above
  - append the `API` suffix to all the other API interfaces for consistency

Plenty to bikeshed here if we want, but this fixes things for now.

## Related Issues

Fixes #13754
