### PR TITLE
chore(starters): add gatsby-react-bootstrap-starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2406,3 +2406,14 @@
     - Sass stylesheets to manage your CSS (SCSS flavored)
     - Simple, minimal base setup to get started
     - No baked in configurations or assumptions
+- url: https://billyjacoby.github.io/gatsby-react-bootstrap-starter/
+  repo: https://github.com/billyjacoby/gatsby-react-bootstrap-starter
+  description: GatsbyJS starter with react-bootstrap and react-icons
+  tags:
+    - Bootstrap
+    - SASS
+    - react-bootstrap
+  features:
+    - SASS stylesheets to make styling components easy.
+    - Sample navbar that sticks to the top of the page on scroll.
+    - Includes react-icons to make adding icons to your app super simple.

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2414,6 +2414,6 @@
     - SASS
     - react-bootstrap
   features:
-    - SASS stylesheets to make styling components easy.
-    - Sample navbar that sticks to the top of the page on scroll.
-    - Includes react-icons to make adding icons to your app super simple.
+    - SASS stylesheets to make styling components easy
+    - Sample navbar that sticks to the top of the page on scroll
+    - Includes react-icons to make adding icons to your app super simple


### PR DESCRIPTION
added a react-bootstrap/react-icons starter

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Added a new starter that includes react0bootstrap and react-icons

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
