### PR TITLE
feat(docs): Adding AST and Remark to the glossary

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -8,7 +8,7 @@ When you're new to Gatsby there can be a lot of words that seem alien. This glos
 
 ### AST
 
-Abstract Syntax Tree: A tree representation of the source code that is found during a [compiliation](#compiler) step between two languages. For example, [gatsby-transformer-remark](/packages/gatsby-transformer-remark/) will create an AST from [Markdown](#markdown) to describe a Markdown document in a tree structure and then further generate [HTML](#html) using that tree using the [Remark](#remark) parser.
+Abstract Syntax Tree: A tree representation of the source code that is found during a [compilation](#compiler) step between two languages. For example, [gatsby-transformer-remark](/packages/gatsby-transformer-remark/) will create an AST from [Markdown](#markdown) to describe a Markdown document in a tree structure using the [Remark](#remark) parser.
 
 ### API
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -222,7 +222,7 @@ A code library (written with [JavaScript](#javascript)) for building user interf
 
 ### Remark
 
-A markdown parser to translate [Markdown](#markdown) to other formats like [HTML](#html) or [React](#react) code.
+A parser to translate [Markdown](#markdown) to other formats like [HTML](#html) or [React](#react) code.
 
 ### Routing
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -6,6 +6,10 @@ When you're new to Gatsby there can be a lot of words that seem alien. This glos
 
 ## A
 
+### AST
+
+Abstract Syntax Tree: A tree representation of the source code that is found during a [compiliation](#compiler) step between two languages. For example, [gatsby-transformer-remark](/packages/gatsby-transformer-remark/) will create an AST from [Markdown](#markdown) to describe a Markdown document in a tree structure and then further generate [HTML](#html) using that tree using the [Remark](#remark) parser.
+
 ### API
 
 Application Programming Interface: A method for one application to communicate with another. For example, a [source plugin](#source-plugin) will often use an API to get its data.
@@ -215,6 +219,10 @@ The process of requesting specific data from somewhere. With Gatsby you normally
 ### React
 
 A code library (written with [JavaScript](#javascript)) for building user interfaces. It’s the framework that [Gatsby](#gatsby) uses to build pages and structure content.
+
+### Remark
+
+A markdown parser to translate [Markdown](#markdown) to other formats like [HTML](#html) or [React](#react) code.
 
 ### Routing
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -526,7 +526,7 @@
       link: /docs/gatsby-cli/
     - title: Cheat Sheet
       link: /docs/cheat-sheet/
-    - title: Glossary*
+    - title: Glossary
       link: /docs/glossary/
     - title: Gatsby REPL*
       link: /docs/gatsby-repl/


### PR DESCRIPTION
## Description

Upon suggestion by @marcysutton in #13234, I went ahead and added `AST` as well as `Remark` to the Glossary page in the docs.

As well since the page is no longer a stub, I removed the asterisk from the yaml entry.