### PR TITLE
chore(docs): Setting Up a Gatsby Site Without Gatsby New

### DIFF
--- a/docs/docs/preparing-your-environment.md
+++ b/docs/docs/preparing-your-environment.md
@@ -1,5 +1,5 @@
 ---
-title: Preparing your environment
+title: Preparing your Environment
 overview: true
 ---
 

--- a/docs/docs/preparing-your-environment.md
+++ b/docs/docs/preparing-your-environment.md
@@ -11,4 +11,9 @@ To get started with Gatsby, you'll need to make sure you have the following soft
 
 For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](/tutorial/part-zero/).
 
+The [Quick Start](/docs/quick-start/) is also available for intermediate to advanced developers.
+
+>**Note:** If you work for an Enterprise-level company where you are unable to pull from public GitHub repositories, you can [still set up Gatsby](/docs/setting-up-gatsby-without-gatsby-new/).
+
+
 [[guidelist]]

--- a/docs/docs/preparing-your-environment.md
+++ b/docs/docs/preparing-your-environment.md
@@ -13,7 +13,6 @@ For step-by-step installation instructions and detailed explanations of the requ
 
 The [Quick Start](/docs/quick-start/) is also available for intermediate to advanced developers.
 
->**Note:** If you work for an Enterprise-level company where you are unable to pull from public GitHub repositories, you can [still set up Gatsby](/docs/setting-up-gatsby-without-gatsby-new/).
-
+> **Note:** If you work for an Enterprise-level company where you are unable to pull from public GitHub repositories, you can [still set up Gatsby](/docs/setting-up-gatsby-without-gatsby-new/).
 
 [[guidelist]]

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -5,9 +5,10 @@ There are many Enterprise level companies that maintain an internal clone of the
 ## Preparing your environment
 To get started with Gatsby, you’ll need to make sure you have the following software tools installed:
 
-1.[Node.js](https://www.gatsbyjs.org/tutorial/part-zero/#install-nodejs)
-1.[npm CLI](https://www.gatsbyjs.org/tutorial/part-zero/#familiarize-with-npm)
-1.[Gatsby CLI](https://www.gatsbyjs.org/tutorial/part-zero/#install-the-gatsby-cli)
+1. [Node.js](https://www.gatsbyjs.org/tutorial/part-zero/#install-nodejs)
+1. [npm CLI](https://www.gatsbyjs.org/tutorial/part-zero/#familiarize-with-npm)
+1. [Gatsby CLI](https://www.gatsbyjs.org/tutorial/part-zero/#install-the-gatsby-cli)
+
 For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/).
 
 After your developer environment is set up, you'll want to set up a new project folder.

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -2,7 +2,15 @@
 
 There are many Enterprise level companies that maintain an internal clone of the NPM registry for security purposes. If you work for such a company, you may find that you are able to successfully run `npm install -g gatsby-cli` but cannot run the `gatsby new <project-source>` as the `gatsby new` command clones a repo from a public GitHub repository. Many companies block public GitHub, which will cause the `gatsby new` command to fail. Not to worry, though, you can set up a new Gatsby site without the `gatsby new` command with a few quick steps.
 
-First, you'll want to set up a new project folder.
+## Preparing your environment
+To get started with Gatsby, you’ll need to make sure you have the following software tools installed:
+
+1.[Node.js](https://www.gatsbyjs.org/tutorial/part-zero/#install-nodejs)
+1.[npm CLI](https://www.gatsbyjs.org/tutorial/part-zero/#familiarize-with-npm)
+1.[Gatsby CLI](https://www.gatsbyjs.org/tutorial/part-zero/#install-the-gatsby-cli)
+For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/).
+
+After your developer environment is set up, you'll want to set up a new project folder.
 ```shell
 mkdir my-new-gatsby-site
 cd my-new-gatsby-site

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -63,4 +63,4 @@ cd ../../
 gatsby develop
 ```
 
-And that's it! You should now have your initial page running on `localhost:8000` with a GraphiQL IDE running on `localhost:8000/___graphql`. From here, you can follow the rest of the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/#set-up-a-code-editor) starting with setting up a code editor to get the full experience of what Gatsby can offer.  
+And that's it! You should now have your initial page running on `localhost:8000` with a GraphiQL IDE running on `localhost:8000/___graphql`. From here, you can follow the rest of the [Gatsby tutorial](/tutorial/part-zero/#set-up-a-code-editor) starting with setting up a code editor to get the full experience of what Gatsby can offer.  

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -5,7 +5,7 @@ There are many Enterprise level companies that maintain an internal clone of the
 ## Preparing your environment
 To get started with Gatsby, you’ll need to make sure you have the following software tools installed:
 
-1. [Node.js](https://www.gatsbyjs.org/tutorial/part-zero/#install-nodejs)
+1. [Node.js](/tutorial/part-zero/#install-nodejs)
 1. [npm CLI](https://www.gatsbyjs.org/tutorial/part-zero/#familiarize-with-npm)
 1. [Gatsby CLI](https://www.gatsbyjs.org/tutorial/part-zero/#install-the-gatsby-cli)
 

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -26,7 +26,7 @@ Fill out the prompts for the package.json file that is generated. If you'd like 
 
 Now, you'll need to install the neccessary packages that Gatsby relies on to work its magic.
 ```shell
-npm i gatsby react react-dom
+npm install --save gatsby react react-dom
 ```
 
 Once your packages have installed, you'll likely want to add some of the Gatsby specific files at the root of your project.

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -6,7 +6,7 @@ There are many Enterprise level companies that maintain an internal clone of the
 To get started with Gatsby, you’ll need to make sure you have the following software tools installed:
 
 1. [Node.js](/tutorial/part-zero/#install-nodejs)
-1. [npm CLI](https://www.gatsbyjs.org/tutorial/part-zero/#familiarize-with-npm)
+1. [npm CLI](/tutorial/part-zero/#familiarize-with-npm)
 1. [Gatsby CLI](https://www.gatsbyjs.org/tutorial/part-zero/#install-the-gatsby-cli)
 
 For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/).

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -29,12 +29,6 @@ Now, you'll need to install the neccessary packages that Gatsby relies on to wor
 npm install --save gatsby react react-dom
 ```
 
-Once your packages have installed, you'll likely want to add some of the Gatsby specific files at the root of your project.
-```shell
-touch gatsby-config.js
-touch gatsby-browser.js
-```
-
 Next, you'll add a `src` directory and a `pages` directory inside your project.
 ```shell
 mkdir src

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -1,0 +1,57 @@
+## Setting Up a Gatsby Site Without Gatsby New
+
+There are many Enterprise level companies that maintain an internal clone of the NPM registry for security purposes. If you work for such a company, you may find that you are able to successfully run `npm install -g gatsby-cli` but cannot run the `gatsby new <project-source>` as the `gatsby new` command clones a repo from a public GitHub repository. Many companies block public GitHub, which will cause the `gatsby new` command to fail. Not to worry, though, you can set up a new Gatsby site without the `gatsby new` command with a few quick steps.
+
+First, you'll want to set up a new project folder.
+```shell
+mkdir my-new-gatsby-site
+cd my-new-gatsby-site
+```
+
+Next, you'll need to set up NPM within your project.
+```shell
+npm init
+```
+
+Fill out the prompts for the package.json file that is generated. If you'd like to skip that, you can run `npm init -y` and a pre-filled package.json will be generated for you.
+
+Now, you'll need to install the neccessary packages that Gatsby relies on to work its magic.
+```shell
+npm i gatsby react react-dom
+```
+
+Once your packages have installed, you'll likely want to add some of the Gatsby specific files at the root of your project.
+```shell
+touch gatsby-config.js
+touch gatsby-browser.js
+```
+
+Next, you'll add a `src` directory and a `pages` directory inside of that. 
+```shell
+mkdir src
+cd src
+mkdir pages
+```
+
+Inside the pages directory, you'll make an `index.js` file that exports a React component.
+```shell
+cd pages
+touch index.js
+```
+
+Now, add some React code to your `index.js` file as a starting point for your project.
+```jsx:title=src/pages/index.js
+import React from 'react';
+
+export default () => (
+  <h1>Hello Gatsby!</h1>
+);
+```
+
+Finally, go back to the root of your project and run the `gatsby develop` command to start a development server and begin coding.
+```shell
+cd ../../ 
+gatsby develop
+```
+
+And that's it! You should now have your initial page running on `localhost:8000` with a GraphiQL IDE running on `localhost:8000/___graphql`. From here, you can follow the rest of the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/#set-up-a-code-editor) starting with setting up a code editor to get the full experience of what Gatsby can offer.  

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -9,7 +9,7 @@ To get started with Gatsby, you’ll need to make sure you have the following so
 1. [npm CLI](/tutorial/part-zero/#familiarize-with-npm)
 1. [Gatsby CLI](/tutorial/part-zero/#install-the-gatsby-cli)
 
-For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/).
+For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](/tutorial/part-zero/).
 
 After your developer environment is set up, you'll want to set up a new project folder.
 ```shell

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -35,7 +35,7 @@ touch gatsby-config.js
 touch gatsby-browser.js
 ```
 
-Next, you'll add a `src` directory and a `pages` directory inside of that. 
+Next, you'll add a `src` directory and a `pages` directory inside your project.
 ```shell
 mkdir src
 cd src

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -7,7 +7,7 @@ To get started with Gatsby, you’ll need to make sure you have the following so
 
 1. [Node.js](/tutorial/part-zero/#install-nodejs)
 1. [npm CLI](/tutorial/part-zero/#familiarize-with-npm)
-1. [Gatsby CLI](https://www.gatsbyjs.org/tutorial/part-zero/#install-the-gatsby-cli)
+1. [Gatsby CLI](/tutorial/part-zero/#install-the-gatsby-cli)
 
 For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/).
 

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -1,4 +1,6 @@
-## Setting Up a Gatsby Site Without `gatsby new`
+---
+title: Setting Up a Gatsby Site without the `gatsby new` Command
+---
 
 There are many Enterprise level companies that maintain an internal clone of the NPM registry for security purposes. If you work for such a company, you may find that you are able to successfully run `npm install -g gatsby-cli` but cannot run the `gatsby new <project-source>` as the `gatsby new` command clones a repo from a public GitHub repository. Many companies block public GitHub, which will cause the `gatsby new` command to fail. Not to worry, though, you can set up a new Gatsby site without the `gatsby new` command with a few quick steps.
 

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -1,4 +1,4 @@
-## Setting Up a Gatsby Site Without Gatsby New
+## Setting Up a Gatsby Site Without `gatsby new`
 
 There are many Enterprise level companies that maintain an internal clone of the NPM registry for security purposes. If you work for such a company, you may find that you are able to successfully run `npm install -g gatsby-cli` but cannot run the `gatsby new <project-source>` as the `gatsby new` command clones a repo from a public GitHub repository. Many companies block public GitHub, which will cause the `gatsby new` command to fail. Not to worry, though, you can set up a new Gatsby site without the `gatsby new` command with a few quick steps.
 

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -3,6 +3,7 @@
 There are many Enterprise level companies that maintain an internal clone of the NPM registry for security purposes. If you work for such a company, you may find that you are able to successfully run `npm install -g gatsby-cli` but cannot run the `gatsby new <project-source>` as the `gatsby new` command clones a repo from a public GitHub repository. Many companies block public GitHub, which will cause the `gatsby new` command to fail. Not to worry, though, you can set up a new Gatsby site without the `gatsby new` command with a few quick steps.
 
 ## Preparing your environment
+
 To get started with Gatsby, you’ll need to make sure you have the following software tools installed:
 
 1. [Node.js](/tutorial/part-zero/#install-nodejs)
@@ -12,12 +13,14 @@ To get started with Gatsby, you’ll need to make sure you have the following so
 For step-by-step installation instructions and detailed explanations of the required software, head on over to the [Gatsby tutorial](/tutorial/part-zero/).
 
 After your developer environment is set up, you'll want to set up a new project folder.
+
 ```shell
 mkdir my-new-gatsby-site
 cd my-new-gatsby-site
 ```
 
 Next, you'll need to set up NPM within your project.
+
 ```shell
 npm init
 ```
@@ -25,11 +28,13 @@ npm init
 Fill out the prompts for the package.json file that is generated. If you'd like to skip that, you can run `npm init -y` and a pre-filled package.json will be generated for you.
 
 Now, you'll need to install the neccessary packages that Gatsby relies on to work its magic.
+
 ```shell
 npm install --save gatsby react react-dom
 ```
 
 Next, you'll add a `src` directory and a `pages` directory inside your project.
+
 ```shell
 mkdir src
 cd src
@@ -37,24 +42,25 @@ mkdir pages
 ```
 
 Inside the pages directory, you'll make an `index.js` file that exports a React component.
+
 ```shell
 cd pages
 touch index.js
 ```
 
 Now, add some React code to your `index.js` file as a starting point for your project.
-```jsx:title=src/pages/index.js
-import React from 'react';
 
-export default () => (
-  <h1>Hello Gatsby!</h1>
-);
+```jsx:title=src/pages/index.js
+import React from "react"
+
+export default () => <h1>Hello Gatsby!</h1>
 ```
 
 Finally, go back to the root of your project and run the `gatsby develop` command to start a development server and begin coding.
+
 ```shell
-cd ../../ 
+cd ../../
 gatsby develop
 ```
 
-And that's it! You should now have your initial page running on `localhost:8000` with a GraphiQL IDE running on `localhost:8000/___graphql`. From here, you can follow the rest of the [Gatsby tutorial](/tutorial/part-zero/#set-up-a-code-editor) starting with setting up a code editor to get the full experience of what Gatsby can offer.  
+And that's it! You should now have your initial page running on `localhost:8000` with a GraphiQL IDE running on `localhost:8000/___graphql`. From here, you can follow the rest of the [Gatsby tutorial](/tutorial/part-zero/#set-up-a-code-editor) starting with setting up a code editor to get the full experience of what Gatsby can offer.

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -27,7 +27,7 @@ npm init
 
 Fill out the prompts for the `package.json` file that is generated. If you'd like to skip that, you can run `npm init -y` and a pre-filled `package.json` will be generated for you.
 
-Now, you'll need to install the neccessary packages that Gatsby relies on to work its magic.
+Now, you'll need to install the necessary packages that Gatsby relies on to work its magic.
 
 ```shell
 npm install --save gatsby react react-dom

--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -25,7 +25,7 @@ Next, you'll need to set up NPM within your project.
 npm init
 ```
 
-Fill out the prompts for the package.json file that is generated. If you'd like to skip that, you can run `npm init -y` and a pre-filled package.json will be generated for you.
+Fill out the prompts for the `package.json` file that is generated. If you'd like to skip that, you can run `npm init -y` and a pre-filled `package.json` will be generated for you.
 
 Now, you'll need to install the neccessary packages that Gatsby relies on to work its magic.
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -460,6 +460,8 @@
           link: /docs/convincing-others/
         - title: Your First Professional Project
           link: /docs/first-professional-project/
+        - title: Setting Up Gatsby Without Gatsby New
+          link: /docs/setting-up-gatsby-without-gatsby-new
         - title: Winning Over Different Stakeholders
           link: /docs/winning-over-stakeholders/
           items:


### PR DESCRIPTION
The purpose of this is to provide documentation for developers in jobs that have a private NPM clone, but do not have access to public Github repos.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Adding documentation to set up a new Gatsby project without the `gatsby new` command.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
