### PR TITLE
fix(www): Off-by-one Event Dates Bug

### DIFF
--- a/www/src/hooks/use-community-events.js
+++ b/www/src/hooks/use-community-events.js
@@ -31,11 +31,14 @@ const useCommunityEvents = () => {
       return {
         id: event.id,
         ...event.data,
-        date: new Date(event.data.date).toLocaleDateString(`en-US`, {
-          year: `numeric`,
-          month: `long`,
-          day: `numeric`,
-        }),
+        date: new Date(`${event.data.date} 00:00:00`).toLocaleDateString(
+          `en-US`,
+          {
+            year: `numeric`,
+            month: `long`,
+            day: `numeric`,
+          }
+        ),
       }
     })
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Event dates on the [community Gatsby events page](https://www.gatsbyjs.org/contributing/events/) are off by one due to `.toLocaleDateString` using a Timezone of wherever the site is running. Adding a timestamp of 00:00:00 will initialize the new Date to the correct day.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

(None that I can find)
