### PR TITLE
chore(docs): Adding stub to Maintaining a Plugin page

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -178,7 +178,7 @@
                   link: /docs/pixabay-source-plugin-tutorial/
                 - title: Remark Plugin Tutorial
                   link: /docs/remark-plugin-tutorial/
-                - title: Maintaining a Plugin
+                - title: Maintaining a Plugin*
                   link: /docs/maintaining-a-plugin/
         - title: Starters
           link: /docs/starters/


### PR DESCRIPTION
## Description

[Maintaining A Plugin](https://www.gatsbyjs.org/docs/maintaining-a-plugin/) is a Stub but it wasn't classified as such in the doc-links.yaml file. This fixes such issue.