### PR TITLE
chore(gatsby-remark-prismjs): Correct the line numbering import filename

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -137,10 +137,10 @@ CSS along your PrismJS theme and the styles for `.gatsby-highlight-code-line`:
 
 If you want to add line numbering alongside your code, you need to
 import the corresponding CSS file from PrismJS, right after importing your
-colorscheme in `src/components/layout.js`:
+colorscheme in `gatsby-browser.js`:
 
 ```javascript
-// src/components/layout.js
+// gatsby-browser.js
 require("prismjs/plugins/line-numbers/prism-line-numbers.css")
 ```
 


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The previous filename is incorrect, as the colorscheme was just imported in gatsby-browser.js, and that is where the line numbering css needs to be imported as well.

This change updates the docs to fix that.
