### PR TITLE
feat(www): Calmer border-color for the docsearch dropdown

### DIFF
--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -82,8 +82,8 @@ const algoliaStyles = css`
 
   /* Caret */
   .algolia-autocomplete .ds-dropdown-menu::before {
-    border-top-color: ${colors.ui.bright} !important;
-    border-right-color: ${colors.ui.bright} !important;
+    border-top-color: ${colors.gray.border} !important;
+    border-right-color: ${colors.gray.border} !important;
   }
 
   .algolia-autocomplete .ds-dropdown-menu [class^="ds-dataset-"] {
@@ -91,7 +91,7 @@ const algoliaStyles = css`
       100vh - ${sizes.headerHeight} - ${sizes.bannerHeight}
     ) !important;
     padding: 0 !important;
-    border-color: ${colors.ui.bright} !important;
+    border-color: ${colors.gray.border} !important;
   }
 
   .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
@@ -160,7 +160,7 @@ const algoliaStyles = css`
     padding: ${space[1]} ${space[3]} !important;
     margin-top: 0 !important;
     font-size: ${fontSizes[1]} !important;
-    border-color: ${colors.ui.light} !important;
+    border-color: ${colors.gray.border} !important;
     color: ${colors.gatsby} !important;
     font-weight: bold !important;
   }
@@ -181,7 +181,7 @@ const algoliaStyles = css`
     width: 100% !important;
     height: 30px !important;
     margin-top: 0 !important;
-    border-top: 1px solid ${colors.ui.light} !important;
+    border-top: 1px solid ${colors.gray.border} !important;
   }
 
   .algolia-autocomplete .algolia-docsearch-footer--logo {


### PR DESCRIPTION
Before/after:

![image](https://user-images.githubusercontent.com/21834/57066913-d807dc00-6ccd-11e9-923a-3a6e6a2bd824.png)

![image](https://user-images.githubusercontent.com/21834/57066896-cc1c1a00-6ccd-11e9-9bc9-20c59e3e328b.png)
