### PR TITLE
fix(types): node APIs typings should be in GatsbyNode interface not in Node

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -103,7 +103,7 @@ export interface GatsbyConfig {
  *
  * @see https://www.gatsbyjs.org/docs/node-apis/
  */
-export interface Node {
+export interface GatsbyNode {
   /**
    * Tell plugins to add pages. This extension point is called only after the initial
    * sourcing and transformation of nodes plus creation of the GraphQL schema are


### PR DESCRIPTION
Fixes regression introduced in #13755 

Fixes #13798 (this also has most context around it)

/cc @wKovacs64 