### PR TITLE
Fix the post queries to match the query from the blog-starter #13795

### DIFF
--- a/themes/gatsby-theme-blog-core/src/pages/index.js
+++ b/themes/gatsby-theme-blog-core/src/pages/index.js
@@ -31,7 +31,7 @@ export default class Create extends React.Component {
 }
 export const query = graphql`
   query HomePage {
-    allMarkdownRemark {
+    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
       edges {
         node {
           id
@@ -40,8 +40,9 @@ export const query = graphql`
             slug
           }
           frontmatter {
-            title
             date(formatString: "MMMM DD, YYYY")
+            title
+            description
           }
         }
       }


### PR DESCRIPTION
## Description

fix the `allMarkdownRemary` query in the theme to match the starter per #13795. 
I did not remove `node.id` from the query in the theme, because it is referenced on line 23. 
