### PR TITLE
chore(www): Simplify code highlighting things

### DIFF
--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -73,7 +73,6 @@ const _options = {
       // gatsby-remark-prismjs styles
       ".gatsby-highlight": {
         background: colors.code.bg,
-        borderRadius: `${radii[1]}px`,
         position: `relative`,
         WebkitOverflowScrolling: `touch`,
       },
@@ -189,7 +188,6 @@ const _options = {
       },
       ".gatsby-highlight pre::-webkit-scrollbar-track": {
         background: colors.code.border,
-        borderRadius: `0 0 ${radii[2]}px ${radii[2]}px`,
       },
       // Target image captions.
       // This is kind of a fragile selector...
@@ -261,17 +259,17 @@ const _options = {
         padding: `${rhythm(space[5])} ${rhythm(space[6])} ${rhythm(space[4])}`,
         fontSize: `74%`,
       },
-      "@media (max-width:634px)": {
-        ".gatsby-highlight, .gatsby-code-title, .gatsby-resp-image-link": {
-          borderRadius: 0,
-          borderLeft: 0,
-          borderRight: 0,
-        },
-      },
-      [`${mediaQueries.md} and (max-width:980px)`]: {
-        ".gatsby-highlight, .gatsby-code-title": {
+      [mediaQueries.md]: {
+        ".gatsby-highlight, .gatsby-resp-image-link, .gatsby-code-title": {
           marginLeft: 0,
           marginRight: 0,
+          borderRadius: `${radii[2]}px`,
+        },
+        ".gatsby-code-title": {
+          borderRadius: `${radii[2]}px ${radii[2]}px 0 0`,
+        },
+        ".gatsby-code-title + .gatsby-highlight": {
+          borderRadius: `0 0 ${radii[2]}px ${radii[2]}px`,
         },
       },
       video: {
@@ -288,7 +286,6 @@ const _options = {
         ".gatsby-highlight, .post-body .gatsby-resp-image-link, .gatsby-code-title": {
           marginLeft: rhythm(-space[6]),
           marginRight: rhythm(-space[6]),
-          borderRadius: `${radii[2]}px`,
         },
         ".gatsby-highlight pre": {
           padding: `${rhythm(space[6])} 0`,

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -287,17 +287,6 @@ const _options = {
           marginLeft: rhythm(-space[6]),
           marginRight: rhythm(-space[6]),
         },
-        ".gatsby-highlight pre": {
-          padding: `${rhythm(space[6])} 0`,
-          marginBottom: rhythm(space[6]),
-        },
-        ".gatsby-highlight pre code, .gatsby-code-title": {
-          paddingLeft: rhythm(space[6]),
-          paddingRight: rhythm(space[6]),
-        },
-        ".gatsby-highlight pre[class*='language-']::before": {
-          right: rhythm(space[6]),
-        },
       },
       [mediaQueries.xxl]: {
         html: {

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -258,7 +258,7 @@ const _options = {
         background: colors.code.bg,
         borderBottom: `1px solid ${colors.code.border}`,
         color: colors.code.text,
-        padding: `${rhythm(space[6])} ${rhythm(space[6])} ${rhythm(space[3])}`,
+        padding: `${rhythm(space[5])} ${rhythm(space[6])} ${rhythm(space[4])}`,
         fontSize: `74%`,
       },
       "@media (max-width:634px)": {
@@ -286,32 +286,20 @@ const _options = {
       },
       [mediaQueries.lg]: {
         ".gatsby-highlight, .post-body .gatsby-resp-image-link, .gatsby-code-title": {
-          marginLeft: rhythm(-space[7]),
-          marginRight: rhythm(-space[7]),
+          marginLeft: rhythm(-space[6]),
+          marginRight: rhythm(-space[6]),
+          borderRadius: `${radii[2]}px`,
         },
         ".gatsby-highlight pre": {
-          padding: `${rhythm(space[7])} 0`,
-          marginBottom: rhythm(space[7]),
+          padding: `${rhythm(space[6])} 0`,
+          marginBottom: rhythm(space[6]),
         },
-        ".gatsby-highlight pre code": {
-          padding: `0 ${rhythm(space[7])}`,
-        },
-        ".gatsby-highlight-code-line": {
-          marginRight: rhythm(-space[7]),
-          marginLeft: rhythm(-space[7]),
-          paddingRight: rhythm(space[7]),
+        ".gatsby-highlight pre code, .gatsby-code-title": {
           paddingLeft: rhythm(space[6]),
-          borderLeftWidth: rhythm(space[2]),
-        },
-        ".gatsby-code-title": {
-          marginRight: rhythm(-space[7]),
-          marginLeft: rhythm(-space[7]),
-          padding: `${rhythm(space[6])} ${rhythm(space[7])} ${rhythm(
-            space[3]
-          )}`,
+          paddingRight: rhythm(space[6]),
         },
         ".gatsby-highlight pre[class*='language-']::before": {
-          right: rhythm(space[7]),
+          right: rhythm(space[6]),
         },
       },
       [mediaQueries.xxl]: {

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -257,7 +257,7 @@ const _options = {
         borderBottom: `1px solid ${colors.code.border}`,
         color: colors.code.text,
         padding: `${rhythm(space[5])} ${rhythm(space[6])} ${rhythm(space[4])}`,
-        fontSize: `74%`,
+        fontSize: fontSizes[0],
       },
       [mediaQueries.md]: {
         ".gatsby-highlight, .gatsby-resp-image-link, .gatsby-code-title": {


### PR DESCRIPTION
- unify negative margin for `.gatsby-highlight`, etc. for small and large screens — no need to complicate things for mediaQueries.lg by increasing the negative margin
- unify padding-top/-bottom of `.gatsby-code-title`
- fix border-radius for `.gatsby-highlight`, `.gatsby-code-title`, and `.gatsby-higlight + .gatsby-code-title`
- use `presets.fontSizes` instead of a percent value for `.gatsby-code-title`