### PR TITLE
chore(showcase): add AWS Amplify Community Site

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5705,3 +5705,17 @@
     - Food
   built_by: Connerra
   featured: false
+- title: AWS Amplify Community
+  url: https://amplify.aws/community/
+  main_url: https://amplify.aws/community/
+  source_url: https://github.com/aws-amplify/community
+  description: >
+    Amplify Community is a hub for developers building fullstack serverless applications with Amplify to easily access content (such as events, blog posts, videos, sample projects, and tutorials) created by other members of the Amplify community.
+  categories:
+    - Blog
+    - Directory
+    - Education
+    - Technology
+  built_by: Nikhil Swaminathan
+  built_by_url: https://github.com/swaminator
+  featured: false


### PR DESCRIPTION
## Description

There's an awesome new site by @swaminator for AWS Amplify Community built on top of Gatsby.js.

Let's get it featured.

→ [Amplify.aws/community](https://amplify.aws/community/)

[![img](https://on.ahmda.ws/ea6a44/url)](https://amplify.aws/community/)