### PR TITLE
feat(gatsby-plugin-feed): add feedUrl plugin option

### DIFF
--- a/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
@@ -50,7 +50,7 @@ describe(`assetPrefix`, () => {
     })
     it(`keeps RSS feedUrl intact`, () => {
       cy.get(`head link[type="application/rss+xml"]:last`)
-        .should(`have.attr`, `href`)
+        .should(`have.attr`, `href`, `http://localhost:9000/rss-2.xml`)
         .and(`not.matches`, assetPrefixExpression)
     })
   })

--- a/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
@@ -46,7 +46,12 @@ describe(`assetPrefix`, () => {
 
   describe(`gatsby-plugin-feed`, () => {
     it(`prefixes RSS feed`, () => {
-      assetPrefixMatcher(cy.get(`head link[type="application/rss+xml"]`))
+      assetPrefixMatcher(cy.get(`head link[type="application/rss+xml"]:first`))
+    })
+    it(`keeps RSS feedUrl intact`, () => {
+      cy.get(`head link[type="application/rss+xml"]:last`)
+        .should(`have.attr`, `href`)
+        .and(`not.matches`, assetPrefixExpression)
     })
   })
 })

--- a/e2e-tests/path-prefix/gatsby-config.js
+++ b/e2e-tests/path-prefix/gatsby-config.js
@@ -58,6 +58,29 @@ module.exports = {
             title: `assetPrefix + pathPrefix RSS Feed`,
             output: `rss.xml`,
           },
+          {
+            query: `
+              {
+                pages: allSitePage {
+                  nodes {
+                    path
+                  }
+                }
+              }
+            `,
+            serialize({ query: { site, pages } }) {
+              return pages.nodes.map(node => {
+                return {
+                  description: `A sample page hello world suh dude`,
+                  date: `10-08-1990`,
+                  url: `${site.siteMetadata.siteUrl}${pathPrefix}${node.path}`,
+                }
+              })
+            },
+            title: `feedUrl RSS Feed`,
+            feedUrl: `http://localhost:9000/rss-2.xml`,
+            output: `rss-2.xml`,
+          },
         ],
       },
     },

--- a/packages/gatsby-plugin-feed/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-feed/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Adds <Link> for feed to head creates Link href with feedUrl, ignoring __PATH_PREFIX__ 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        <link
+          href="https://example.org/gryffindor/feed.xml"
+          rel="alternate"
+          type="application/rss+xml"
+        />,
+        <link
+          href="https://example.org/ravenclaw/feed.xml"
+          rel="alternate"
+          type="application/rss+xml"
+        />,
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`Adds <Link> for feed to head creates Link href with path prefix when __PATH_PREFIX__ sets 1`] = `
 [MockFunction] {
   "calls": Array [

--- a/packages/gatsby-plugin-feed/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-feed/src/__tests__/gatsby-ssr.js
@@ -79,7 +79,33 @@ describe(`Adds <Link> for feed to head`, () => {
     expect(setHeadComponents).toMatchSnapshot()
     expect(setHeadComponents).toHaveBeenCalledTimes(1)
   })
+  it(`creates Link href with feedUrl, ignoring __PATH_PREFIX__`, async () => {
+    global.__PATH_PREFIX__ = `/hogwarts`
 
+    const pluginOptions = {
+      feeds: [
+        {
+          output: `/gryffindor/feed.xml`,
+          feedUrl: `https://example.org/gryffindor/feed.xml`,
+        },
+        {
+          output: `/ravenclaw/feed.xml`,
+          feedUrl: `https://example.org/ravenclaw/feed.xml`,
+        },
+      ],
+    }
+    const setHeadComponents = jest.fn()
+
+    await onRenderBody(
+      {
+        setHeadComponents,
+      },
+      pluginOptions
+    )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(1)
+  })
   it(`creates Link with a title if it does exist`, async () => {
     const pluginOptions = {
       feeds: [

--- a/packages/gatsby-plugin-feed/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-ssr.js
@@ -11,7 +11,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     ...pluginOptions,
   }
 
-  const links = feeds.map(({ output, title }, i) => {
+  const links = feeds.map(({ feedUrl, output, title }, i) => {
     if (output.charAt(0) !== `/`) {
       output = `/` + output
     }
@@ -22,7 +22,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
         rel="alternate"
         type="application/rss+xml"
         title={title}
-        href={withPrefix(output)}
+        href={feedUrl || withPrefix(output)}
       />
     )
   })

--- a/packages/gatsby-plugin-feed/src/plugin-options.js
+++ b/packages/gatsby-plugin-feed/src/plugin-options.js
@@ -3,6 +3,7 @@ import Joi from "joi"
 // TODO: make serialize required in next major version bump
 const feed = Joi.object({
   output: Joi.string().required(),
+  feedUrl: Joi.string(),
   query: Joi.string().required(),
   title: Joi.string(),
   serialize: Joi.func(),


### PR DESCRIPTION
Thanks so much for the work on the [`asset-prefix` PR](https://github.com/gatsbyjs/gatsby/pull/12128)! :tada:

I just found a small setback, this PR solves that.

## Description

**use case**:
My project uses a different url for each build (via the just-released `--path-prefix` option), but the feedUrl should be kept stable, as it's user visible.

The built urls are behind a reverse-proxy, and only appear for stable/hashed resourced. For feed readers, the url must continue the same.

## Related Issues

Related to #12128