### PR TITLE
feat(gatsby-plugin-feed): add match plugin option

### DIFF
--- a/docs/docs/adding-an-rss-feed.md
+++ b/docs/docs/adding-an-rss-feed.md
@@ -130,6 +130,8 @@ This snippet contains a custom `gatsby-plugin-feed` setup in `gatsby-config.js` 
 
 The `output` field in your feed object allows you to customize the filename for your RSS feed, and `title` for the name of your site's RSS feed.
 
+By default, feed is referenced in every page. You can customize this behavior by providing an extra field `match` of type `string`. This string will be used to build a `RegExp`, and this regular expression will be used to test the `pathname` of current page. Only pages that satisfied the regular expression will have feed reference included.
+
 To see your feed in action, run `gatsby build && gatsby serve` and you can then inspect the content and URLs in your RSS file at `http://localhost:9000/rss.xml`.
 
 > NOTE: if your blog has custom permalinks, such as links with or without dates in them, you may need to [customize `gatsby-node.js`](https://github.com/gatsbyjs/gatsby-starter-blog/blob/master/gatsby-node.js#L57) to output the correct URLs in your RSS feed. [Get in touch with us](/contributing/how-to-contribute/) if you need any help!

--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -61,6 +61,11 @@ module.exports = {
             `,
             output: "/rss.xml",
             title: "Your Site's RSS Feed",
+            // optional configuration to insert feed reference in pages:
+            // if `string` is used, it will be used to create RegExp and then test if pathname of
+            // current page satisfied this regular expression;
+            // if not provided or `undefined`, all pages will have feed reference inserted
+            match: "^/blog/",
           },
         ],
       },
@@ -70,6 +75,8 @@ module.exports = {
 ```
 
 Each feed must include `output`, `query`, and `title`. Additionally, it is strongly recommended to pass a custom `serialize` function, otherwise an internal serialize function will be used which may not exactly match your particular use case.
+
+`match` is an optional configuration, indicating which pages will have feed reference included. The accepted types of `match` are `string` or `undefined`. By default, when `match` is not configured, all pages will have feed reference inserted. If `string` is provided, it will be used to build a RegExp and then to test whether `pathname` of current page satisifed this regular expression. Only pages that satisifed this rule will have feed reference included.
 
 All additional options are passed through to the [`rss`][rss] utillity. For more info on those additional options, [explore the `itemOptions` section of the `rss` package](https://www.npmjs.com/package/rss#itemoptions).
 

--- a/packages/gatsby-plugin-feed/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-feed/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -49,6 +49,29 @@ exports[`Adds <Link> for feed to head creates Link if feeds does exist 1`] = `
 }
 `;
 
+exports[`Adds <Link> for feed to head creates Link only if pathname satisfied match 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        <link
+          href="/gryffindor/feed.xml"
+          rel="alternate"
+          title="Gryffindor's RSS Feed"
+          type="application/rss+xml"
+        />,
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`Adds <Link> for feed to head creates Link with a title if it does exist 1`] = `
 [MockFunction] {
   "calls": Array [

--- a/packages/gatsby-plugin-feed/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-feed/src/__tests__/gatsby-ssr.js
@@ -105,4 +105,33 @@ describe(`Adds <Link> for feed to head`, () => {
     expect(setHeadComponents).toMatchSnapshot()
     expect(setHeadComponents).toHaveBeenCalledTimes(1)
   })
+
+  it(`creates Link only if pathname satisfied match`, async () => {
+    const pluginOptions = {
+      feeds: [
+        {
+          output: `gryffindor/feed.xml`,
+          title: `Gryffindor's RSS Feed`,
+          match: `^/gryffindor/`,
+        },
+        {
+          output: `ravenclaw/feed.xml`,
+          title: `Ravenclaw's RSS Feed`,
+          match: `^/ravenclaw/`,
+        },
+      ],
+    }
+    const setHeadComponents = jest.fn()
+
+    await onRenderBody(
+      {
+        setHeadComponents,
+        pathname: `/gryffindor/welcome`,
+      },
+      pluginOptions
+    )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/gatsby-plugin-feed/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-ssr.js
@@ -5,27 +5,32 @@ import { defaultOptions } from "./internals"
 // TODO: remove for v3
 const withPrefix = withAssetPrefix || fallbackWithPrefix
 
-exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
+exports.onRenderBody = ({ setHeadComponents, pathname }, pluginOptions) => {
   const { feeds } = {
     ...defaultOptions,
     ...pluginOptions,
   }
 
-  const links = feeds.map(({ output, title }, i) => {
-    if (output.charAt(0) !== `/`) {
-      output = `/` + output
-    }
+  const links = feeds
+    .filter(({ match }) => {
+      if (typeof match === `string`) return new RegExp(match).exec(pathname)
+      return true
+    })
+    .map(({ output, title }, i) => {
+      if (output.charAt(0) !== `/`) {
+        output = `/` + output
+      }
 
-    return (
-      <link
-        key={`gatsby-plugin-feed-${i}`}
-        rel="alternate"
-        type="application/rss+xml"
-        title={title}
-        href={withPrefix(output)}
-      />
-    )
-  })
+      return (
+        <link
+          key={`gatsby-plugin-feed-${i}`}
+          rel="alternate"
+          type="application/rss+xml"
+          title={title}
+          href={withPrefix(output)}
+        />
+      )
+    })
 
   setHeadComponents(links)
 }

--- a/packages/gatsby-plugin-feed/src/plugin-options.js
+++ b/packages/gatsby-plugin-feed/src/plugin-options.js
@@ -6,6 +6,7 @@ const feed = Joi.object({
   query: Joi.string().required(),
   title: Joi.string(),
   serialize: Joi.func(),
+  match: Joi.string(),
 }).unknown(true)
 
 // TODO: make feeds required in next major version bump


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR is to propose a way to only include RSS feed in part of website, not all pages of it. `gatsby-plugin-feed` allows to customize the generated feed to only include part of the contents. However, the generated feed will be included in all pages by default, which might not be necessary in some cases.

It will be useful when for example blog is only part of the website, and there are many other pages which are not related to blog posts; or when there are different RSS feeds in website and each belongs to different part.

Adding an extra field `match` in feed array provides the ability to control where feed should be inserted when generating SSR result.

## Related Issues

No issue related
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
