### PR TITLE
fix(gatsby-link): provide fallback for __BASE_PATH__ being missing

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -96,7 +96,8 @@ describe(`<Link />`, () => {
 
   it(`does not fail with missing __BASE_PATH__`, () => {
     global.__PATH_PREFIX__ = ``
-    delete global.__BASE_PATH__
+    global.__BASE_PATH__ = undefined
+
     const source = createMemorySource(`/active`)
 
     expect(() =>
@@ -176,7 +177,7 @@ describe(`withPrefix`, () => {
     })
 
     it(`falls back to __PATH_PREFIX__ if __BASE_PATH__ is undefined`, () => {
-      delete global.__BASE_PATH__
+      global.__BASE_PATH__ = undefined
       global.__PATH_PREFIX__ = `/blog`
 
       const to = `/abc/`

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -8,10 +8,12 @@ import {
 } from "@reach/router"
 import Link, { navigate, push, replace, withPrefix, withAssetPrefix } from "../"
 
-afterEach(() => {
+beforeEach(() => {
   global.__BASE_PATH__ = ``
-  cleanup()
+  global.__PATH_PREFIX__ = ``
 })
+
+afterEach(cleanup)
 
 const getInstance = (props, pathPrefix = ``) => {
   getWithPrefix()(pathPrefix)
@@ -92,6 +94,28 @@ describe(`<Link />`, () => {
     }).not.toThrow()
   })
 
+  it(`does not fail with missing __BASE_PATH__`, () => {
+    global.__PATH_PREFIX__ = ``
+    delete global.__BASE_PATH__
+    const source = createMemorySource(`/active`)
+
+    expect(() =>
+      render(
+        <LocationProvider history={createHistory(source)}>
+          <Link
+            to="/"
+            className="link"
+            style={{ color: `black` }}
+            activeClassName="is-active"
+            activeStyle={{ textDecoration: `underline` }}
+          >
+            link
+          </Link>
+        </LocationProvider>
+      )
+    ).not.toThrow()
+  })
+
   describe(`the location to link to`, () => {
     global.___loader = {
       enqueue: jest.fn(),
@@ -149,6 +173,15 @@ describe(`withPrefix`, () => {
       const pathPrefix = `/blog`
       const root = getWithPrefix(pathPrefix)(to)
       expect(root).toEqual(`${pathPrefix}${to}`)
+    })
+
+    it(`falls back to __PATH_PREFIX__ if __BASE_PATH__ is undefined`, () => {
+      delete global.__BASE_PATH__
+      global.__PATH_PREFIX__ = `/blog`
+
+      const to = `/abc/`
+
+      expect(withPrefix(to)).toBe(`${global.__PATH_PREFIX__}${to}`)
     })
   })
 })

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -7,7 +7,12 @@ import { parsePath } from "./parse-path"
 export { parsePath }
 
 export function withPrefix(path) {
-  return normalizePath(`${__BASE_PATH__}/${path}`)
+  return normalizePath(
+    [
+      typeof __BASE_PATH__ !== `undefined` ? __BASE_PATH__ : __PATH_PREFIX__,
+      path,
+    ].join(`/`)
+  )
 }
 
 export function withAssetPrefix(path) {


### PR DESCRIPTION
## Description

This fixes a regression identified by the inimitable @m-allanson--specifically that `__BASE_PATH__` won't be defined in older versions of gatsby, and older versions of gatsby use a `^` for dependencies, therefore they'd be using this version.

This would have been remediated with a lockfile, but nice not to break anyone needlessly.

As such--this introduces a guard using `typeof` to detect the existence of `__BASE_PATH__`. If it's not defined, it'll fallback to the "legacy" `__PATH_PREFIX__`.

## Related Issues

Fixes #13836