### PR TITLE
feat(gatsby-remark-embed-snippet): let gatsby-remark-prismjs do the heavy lifting

### DIFF
--- a/docs/docs/wordpress-source-plugin-tutorial.md
+++ b/docs/docs/wordpress-source-plugin-tutorial.md
@@ -18,7 +18,7 @@ The same authentication schemes supported by the WP-API are supported in wp-grap
 
 While each source plugin may operate differently from others, it’s worth going through this tutorial because you will almost definitely be using a source plugin in most Gatsby sites you build. This tutorial will walk you through the basics of connecting your Gatsby site to a CMS, pulling in data, and using React to render that data in beautiful ways on your site.
 
-If you’d like to look at the growing number source plugins available to you, search for “source” in the [Gatsby plugin library](/plugins/?=source).
+If you’d like to look at the growing number of source plugins available to you, search for “source” in the [Gatsby plugin library](/plugins/?=source).
 
 ### Creating a site with the `gatsby-source-wordpress` plugin
 

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5815,6 +5815,20 @@
   built_by: Victor Björklund
   built_by_url: https://victorbjorklund.com
   featured: false
+- title: Kyma
+  url: https://kyma-project.io
+  main_url: https://kyma-project.io
+  source_url: https://github.com/kyma-project/website
+  description: >
+    This website holds overview, blog and documentation for Kyma open source project that is a Kubernates based application extensibility framework.
+  categories:
+    - Documentation
+    - Blog
+    - Technology
+    - Open Source
+  built_by: Kyma developers
+  built_by_url: https://twitter.com/kymaproject
+  featured: false
 - title: Verso
   main_url: https://verso.digital
   url: https://verso.digital

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5815,6 +5815,19 @@
   built_by: Victor Björklund
   built_by_url: https://victorbjorklund.com
   featured: false
+- title: Verso
+  main_url: https://verso.digital
+  url: https://verso.digital
+  description: >
+    Verso is a creative technology studio based in Singapore. Site built with Gatsby and Netlify.
+  categories:
+    - Agency
+    - Consulting
+    - Design
+    - Technology
+  built_by: Verso
+  built_by_url: https://verso.digital
+  featured: false
 - title: Camilo Holguin
   url: https://camiloholguin.me
   main_url: https://camiloholguin.me

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -3863,10 +3863,10 @@
     - Blog
   built_by: Logicwind
   built_by_url: "https://www.logicwind.com"
-- title: npm.cardiv.de
-  url: https://npm.cardiv.de
-  main_url: https://npm.cardiv.de
-  source_url: https://github.com/cardiv/npm.cardiv.de
+- title: npm-bookmarks
+  url: https://npm-bookmarks.netlify.com
+  main_url: https://npm-bookmarks.netlify.com
+  source_url: https://github.com/crstnio/npm-bookmarks
   description: >
     A site to collect personal favorites of NPM packages – sorted by downloads count with a tags filter and search by title. Fork it and bookmark your favorite packages!
   categories:
@@ -3876,8 +3876,8 @@
     - Open Source
     - Programming
     - Web Development
-  built_by: cardiv
-  built_by_url: https://github.com/cardiv/
+  built_by: crstnio
+  built_by_url: https://github.com/crstnio/
   featured: false
 - title: Waterscapes
   main_url: "https://waterscap.es"

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5804,3 +5804,14 @@
     - Portfolio
   built_by: Matthew Miller
   featured: false
+- title: Årets Kontor
+  url: https://aretskontor.newst.se
+  main_url: https://aretskontor.newst.se
+  description: >
+    A swedish competition for "office of the year" in sweden with a focus on design. Built with MDBootstrap and Gatsby.
+  categories:
+    - Real Estate
+    - Marketing
+  built_by: Victor Björklund
+  built_by_url: https://victorbjorklund.com
+  featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5815,6 +5815,19 @@
   built_by: Victor Björklund
   built_by_url: https://victorbjorklund.com
   featured: false
+- title: Camilo Holguin
+  url: https://camiloholguin.me
+  main_url: https://camiloholguin.me
+  source_url: https://github.com/camiloholguin/gatsby-portfolio
+  description: >
+    Portfolio site using GatsbyJS and Wordpress REST API.
+  categories:
+    - WordPress
+    - Portfolio
+    - Web Development
+  built_by: Camilo Holguin
+  built_by_url: https://camiloholguin.me
+  featured: false
 - title: Bennett Hardwick
   url: https://bennetthardwick.com
   main_url: https://bennetthardwick.com

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5815,3 +5815,16 @@
   built_by: Victor Björklund
   built_by_url: https://victorbjorklund.com
   featured: false
+- title: Bennett Hardwick
+  url: https://bennetthardwick.com
+  main_url: https://bennetthardwick.com
+  description: >
+    The personal website and blog of Bennett Hardwick, an Australian software developer and human being.
+  categories:
+    - Blog
+    - Programming
+    - Technology
+  source_url: https://github.com/bennetthardwick/website
+  built_by: Bennett Hardwick
+  built_by_url: https://bennetthardwick.com
+  featured: false

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2448,3 +2448,17 @@
     - Styled Components
     - Gatsby Image
     - Better SEO component with appropriate OG image and appropriate fallback meta tags
+- url: https://pranshuchittora.github.io/gatsby-material-boilerplate
+  repo: https://github.com/pranshuchittora/gatsby-material-boilerplate
+  description: A simple starter to get up and developing quickly with Gatsby in material design
+  tags:
+    - Styling:Material
+  features:
+    - Material design
+    - Sass/SCSS
+    - Tags
+    - Categories
+    - Google Analytics
+    - Offline support
+    - Web App Manifest
+    - SEO

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -177,15 +177,6 @@ module.exports = {
           {
             resolve: "gatsby-remark-embed-snippet",
             options: {
-              // Class prefix for <pre> tags containing syntax highlighting;
-              // defaults to 'language-' (eg <pre class="language-js">).
-              // If your site loads Prism into the browser at runtime,
-              // (eg for use with libraries like react-live),
-              // you may use this to prevent Prism from re-processing syntax.
-              // This is an uncommon use-case though;
-              // If you're unsure, it's best to use the default value.
-              classPrefix: "language-",
-
               // Example code links are relative to this dir.
               // eg examples/path/to/file.js
               directory: `${__dirname}/examples/`,

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -167,7 +167,7 @@ function App() {
 **Important**: This module must appear before `gatsby-remark-prismjs` in your
 plugins array, or the markup will have already been transformed into a code
 block and this plugin will fail to detect it and inline the file.
-For further information about it's options, visit `gatsby-remark-prismjs`'s
+For further information about its options, visit `gatsby-remark-prismjs`'s
 [README](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/).
 
 ```js

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -164,7 +164,11 @@ function App() {
 
 ## How to use
 
-**Important**: This module must appear before `gatsby-remark-prismjs` in your plugins array, or the markup will have already been transformed into a code block and this plugin will fail to detect it and inline the file.
+**Important**: This module must appear before `gatsby-remark-prismjs` in your
+plugins array, or the markup will have already been transformed into a code
+block and this plugin will fail to detect it and inline the file.
+For further information about it's options, visit `gatsby-remark-prismjs`'s
+[README](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/).
 
 ```js
 // In your gatsby-config.js

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -193,6 +193,29 @@ module.exports = {
               // This is an uncommon use-case though;
               // If you're unsure, it's best to use the default value.
               classPrefix: "language-",
+              // This is used to allow setting a language for inline code
+              // (i.e. single backticks) by creating a separator.
+              // This separator is a string and will do no white-space
+              // stripping.
+              // A suggested value for English speakers is the non-ascii
+              // character '›'.
+              inlineCodeMarker: null,
+              // This lets you set up language aliases.  For example,
+              // setting this to '{ sh: "bash" }' will let you use
+              // the language "sh" which will highlight using the
+              // bash highlighter.
+              aliases: {},
+              // This toggles the display of line numbers globally alongside the code.
+              // To use it, add the following line in gatsby-browser.js
+              // right after importing the prism color scheme:
+              //  `require("prismjs/plugins/line-numbers/prism-line-numbers.css");`
+              // Defaults to false.
+              // If you wish to only show line numbers on certain code blocks,
+              // leave false and use the {numberLines: true} syntax.
+              showLineNumbers: false,
+              // If setting this to true, the parser won't handle and highlight inline
+              // code used in markdown i.e. single backtick code like `this`.
+              noInlineHighlight: false,
             },
           },
         ],

--- a/packages/gatsby-remark-embed-snippet/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-embed-snippet/src/__tests__/__snapshots__/index.js.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "css",
           "position": Position {
             "end": Object {
               "column": 24,
@@ -19,10 +20,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-css\\"><code><span class=\\"token selector\\">html</span> <span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">height</span><span class=\\"token punctuation\\">:</span> 100%<span class=\\"token punctuation\\">;</span> <span class=\\"token punctuation\\">}</span></code></pre>
-        </div>",
+          "type": "code",
+          "value": "html { height: 100%; }",
         },
       ],
       "position": Position {
@@ -63,6 +62,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "html",
           "position": Position {
             "end": Object {
               "column": 25,
@@ -76,10 +76,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-html\\"><code><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>html</span><span class=\\"token punctuation\\">></span></span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>html</span><span class=\\"token punctuation\\">></span></span></code></pre>
-        </div>",
+          "type": "code",
+          "value": "<html></html>",
         },
       ],
       "position": Position {
@@ -120,6 +118,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "jsx",
           "position": Position {
             "end": Object {
               "column": 23,
@@ -133,10 +132,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-jsx\\"><code><span class=\\"token keyword\\">const</span> foo <span class=\\"token operator\\">=</span> <span class=\\"token string\\">\\"bar\\"</span><span class=\\"token punctuation\\">;</span></code></pre>
-        </div>",
+          "type": "code",
+          "value": "const foo = \\"bar\\";",
         },
       ],
       "position": Position {
@@ -177,6 +174,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "markup",
           "position": Position {
             "end": Object {
               "column": 23,
@@ -190,10 +188,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-markup\\"><code># Hi</code></pre>
-        </div>",
+          "type": "code",
+          "value": "# Hi",
         },
       ],
       "position": Position {
@@ -234,6 +230,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "yaml",
           "position": Position {
             "end": Object {
               "column": 25,
@@ -247,10 +244,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-yaml\\"><code><span class=\\"token key atrule\\">name</span><span class=\\"token punctuation\\">:</span> Brian Vaughn</code></pre>
-        </div>",
+          "type": "code",
+          "value": "name: Brian Vaughn",
         },
       ],
       "position": Position {
@@ -291,6 +286,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "bash",
           "position": Position {
             "end": Object {
               "column": 23,
@@ -304,10 +300,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-bash\\"><code><span class=\\"token function\\">pwd</span></code></pre>
-        </div>",
+          "type": "code",
+          "value": "pwd",
         },
       ],
       "position": Position {
@@ -348,6 +342,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "none",
           "position": Position {
             "end": Object {
               "column": 20,
@@ -361,10 +356,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-none\\"><code>const foo = \\"bar\\";</code></pre>
-        </div>",
+          "type": "code",
+          "value": "const foo = \\"bar\\";",
         },
       ],
       "position": Position {
@@ -405,6 +398,7 @@ Object {
     Object {
       "children": Array [
         Object {
+          "lang": "jsx",
           "position": Position {
             "end": Object {
               "column": 23,
@@ -418,10 +412,8 @@ Object {
               "offset": 0,
             },
           },
-          "type": "html",
-          "value": "<div class=\\"gatsby-highlight\\">
-        <pre class=\\"language-jsx\\"><code><span class=\\"token keyword\\">const</span> foo <span class=\\"token operator\\">=</span> <span class=\\"token string\\">\\"bar\\"</span><span class=\\"token punctuation\\">;</span></code></pre>
-        </div>",
+          "type": "code",
+          "value": "const foo = \\"bar\\";",
         },
       ],
       "position": Position {

--- a/packages/gatsby-remark-embed-snippet/src/__tests__/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/__tests__/index.js
@@ -48,6 +48,16 @@ describe(`gatsby-remark-embed-snippet`, () => {
     )
   })
 
+  it(`should error if an invalid file path is specified`, () => {
+    fs.existsSync.mockImplementation(path => path !== `examples/hello-world.js`)
+
+    const markdownAST = remark.parse(`\`embed:hello-world.js\``)
+
+    expect(() => plugin({ markdownAST }, { directory: `examples` })).toThrow(
+      `Invalid snippet specified; no such file "examples/hello-world.js"`
+    )
+  })
+
   it(`should not modify non-embed inlineCode nodes`, () => {
     const markdownAST = remark.parse(`\`console.log("hi")\``)
     const transformed = plugin({ markdownAST }, { directory: `examples` })

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -33,10 +33,7 @@ const getLanguage = file => {
     : extension.toLowerCase()
 }
 
-module.exports = (
-  { markdownAST },
-  { classPrefix = `language-`, directory } = {}
-) => {
+module.exports = ({ markdownAST }, { directory } = {}) => {
   if (!directory) {
     throw Error(`Required option "directory" not specified`)
   } else if (!fs.existsSync(directory)) {

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -13,6 +13,12 @@ const FILE_EXTENSION_TO_LANGUAGE_MAP = {
   md: `markup`,
   sh: `bash`,
   rb: `ruby`,
+  py: `python`,
+  ps1: `powershell`,
+  psm1: `powershell`,
+  bat: `batch`,
+  h: `c`,
+  tex: `latex`,
 }
 
 const getLanguage = file => {

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -4,7 +4,7 @@ const fs = require(`fs`)
 const normalizePath = require(`normalize-path`)
 const visit = require(`unist-util-visit`)
 
-const highlightCode = require(`gatsby-remark-prismjs/highlight-code`)
+// const highlightCode = require(`gatsby-remark-prismjs/highlight-code`)
 
 // Language defaults to extension.toLowerCase();
 // This map tracks languages that don't match their extension.
@@ -13,12 +13,12 @@ const FILE_EXTENSION_TO_LANGUAGE_MAP = {
   md: `markup`,
   sh: `bash`,
   rb: `ruby`,
-  py: 'python',
-  ps1: 'powershell',
-  psm1: 'powershell',
-  bat: 'batch',
-  h: 'c',
-  tex: 'latex'
+  py: `python`,
+  ps1: `powershell`,
+  psm1: `powershell`,
+  bat: `batch`,
+  h: `c`,
+  tex: `latex`,
 }
 
 const getLanguage = file => {

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -62,14 +62,14 @@ module.exports = ({ markdownAST }, { directory } = {}) => {
       const language = getLanguage(file)
 
       // Change the node type to code, insert our file as value and set language.
-      try {
-        node.type = `code`
-        node.value = code
-        node.lang = language
-      } catch (e) {
-        // rethrow error pointing to a file
-        throw Error(`${e.message}\nFile: ${file}`)
-      }
+      // try {
+      node.type = `code`
+      node.value = code
+      node.lang = language
+      // } catch (e) {
+      //   // rethrow error pointing to a file
+      //   throw Error(`${e.message}\nFile: ${file}`)
+      // }
     }
   })
 

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -4,8 +4,6 @@ const fs = require(`fs`)
 const normalizePath = require(`normalize-path`)
 const visit = require(`unist-util-visit`)
 
-// const highlightCode = require(`gatsby-remark-prismjs/highlight-code`)
-
 // Language defaults to extension.toLowerCase();
 // This map tracks languages that don't match their extension.
 const FILE_EXTENSION_TO_LANGUAGE_MAP = {
@@ -52,26 +50,6 @@ module.exports = ({ markdownAST }, { directory } = {}) => {
       if (!fs.existsSync(path)) {
         throw Error(`Invalid snippet specified; no such file "${path}"`)
       }
-
-      const code = fs.readFileSync(path, `utf8`).trim()
-
-      // PrismJS's theme styles are targeting pre[class*="language-"]
-      // to apply its styles. We do the same here so that users
-      // can apply a PrismJS theme and get the expected, ready-to-use
-      // outcome without any additional CSS.
-      //
-      // @see https://github.com/PrismJS/prism/blob/1d5047df37aacc900f8270b1c6215028f6988eb1/themes/prism.css#L49-L54
-      const language = getLanguage(file)
-
-      // Allow users to specify a custom class prefix to avoid breaking
-      // line highlights if Prism is required by any other code.
-      // This supports custom user styling without causing Prism to
-      // re-process our already-highlighted markup.
-      // @see https://github.com/gatsbyjs/gatsby/issues/1486
-      // const className = language
-      //   .split(` `)
-      //   .map(token => `${classPrefix}${token}`)
-      //   .join(` `)
 
       // Change the node type to code, insert our file as value and set language.
       try {

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -51,6 +51,16 @@ module.exports = ({ markdownAST }, { directory } = {}) => {
         throw Error(`Invalid snippet specified; no such file "${path}"`)
       }
 
+      const code = fs.readFileSync(path, `utf8`).trim()
+
+      // PrismJS's theme styles are targeting pre[class*="language-"]
+      // to apply its styles. We do the same here so that users
+      // can apply a PrismJS theme and get the expected, ready-to-use
+      // outcome without any additional CSS.
+      //
+      // @see https://github.com/PrismJS/prism/blob/1d5047df37aacc900f8270b1c6215028f6988eb1/themes/prism.css#L49-L54
+      const language = getLanguage(file)
+
       // Change the node type to code, insert our file as value and set language.
       try {
         node.type = `code`

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -13,12 +13,12 @@ const FILE_EXTENSION_TO_LANGUAGE_MAP = {
   md: `markup`,
   sh: `bash`,
   rb: `ruby`,
-  py: `python`,
-  ps1: `powershell`,
-  psm1: `powershell`,
-  bat: `batch`,
-  h: `c`,
-  tex: `latex`,
+  py: 'python',
+  ps1: 'powershell',
+  psm1: 'powershell',
+  bat: 'batch',
+  h: 'c',
+  tex: 'latex'
 }
 
 const getLanguage = file => {
@@ -71,20 +71,16 @@ module.exports = (
       // This supports custom user styling without causing Prism to
       // re-process our already-highlighted markup.
       // @see https://github.com/gatsbyjs/gatsby/issues/1486
-      const className = language
-        .split(` `)
-        .map(token => `${classPrefix}${token}`)
-        .join(` `)
+      // const className = language
+      //   .split(` `)
+      //   .map(token => `${classPrefix}${token}`)
+      //   .join(` `)
 
-      // Replace the node with the markup we need to make 100% width highlighted code lines work
+      // Change the node type to code, insert our file as value and set language.
       try {
-        node.value = `<div class="gatsby-highlight">
-        <pre class="${className}"><code>${highlightCode(
-          language,
-          code
-        ).trim()}</code></pre>
-        </div>`
-        node.type = `html`
+        node.type = `code`
+        node.value = code
+        node.lang = language
       } catch (e) {
         // rethrow error pointing to a file
         throw Error(`${e.message}\nFile: ${file}`)

--- a/packages/gatsby-transformer-xml/README.md
+++ b/packages/gatsby-transformer-xml/README.md
@@ -44,10 +44,15 @@ So if your project has a `books.xml` with
 </catalog>
 ```
 
-Then the following 2 nodes will be created
+The plugin uses [xml-parser](https://www.npmjs.com/package/xml-parser) to convert it to json
 
 ```json
 {
+  "declaration": {
+    "attributes": {
+      "version": "1.0"
+    }
+  },
   "root": {
     "name": "catalog",
     "attributes": {},
@@ -69,6 +74,30 @@ Then the following 2 nodes will be created
             "attributes": {},
             "children": [],
             "content": "XML Developer's Guide"
+          },
+          {
+            "name": "genre",
+            "attributes": {},
+            "children": [],
+            "content": "Computer"
+          },
+          {
+            "name": "price",
+            "attributes": {},
+            "children": [],
+            "content": "44.95"
+          },
+          {
+            "name": "publish_date",
+            "attributes": {},
+            "children": [],
+            "content": "2000-10-01"
+          },
+          {
+            "name": "description",
+            "attributes": {},
+            "children": [],
+            "content": "An in-depth look at creating applications\n      with XML."
           }
         ],
         "content": ""
@@ -90,6 +119,30 @@ Then the following 2 nodes will be created
             "attributes": {},
             "children": [],
             "content": "Midnight Rain"
+          },
+          {
+            "name": "genre",
+            "attributes": {},
+            "children": [],
+            "content": "Fantasy"
+          },
+          {
+            "name": "price",
+            "attributes": {},
+            "children": [],
+            "content": "5.95"
+          },
+          {
+            "name": "publish_date",
+            "attributes": {},
+            "children": [],
+            "content": "2000-12-16"
+          },
+          {
+            "name": "description",
+            "attributes": {},
+            "children": [],
+            "content": "A former architect battles corporate zombies,\n      an evil sorceress, and her own childhood to become queen\n      of the world."
           }
         ],
         "content": ""
@@ -100,16 +153,22 @@ Then the following 2 nodes will be created
 }
 ```
 
+Which then is used to create the nodes.
+
 ## How to query
 
 You'd be able to query your books like:
 
 ```graphql
 {
-  allBooks {
+  allBooksXml {
     edges {
       node {
-        content
+        name
+        xmlChildren {
+          name
+          content
+        }
       }
     }
   }
@@ -120,19 +179,75 @@ Which would return:
 
 ```javascript
 {
-  allBooks: {
-    edges: [
-      {
-        node: {
-          content: "Gambardella, Matthew",
+  "data": {
+    "allBooksXml": {
+      "edges": [
+        {
+          "node": {
+            "name": "book",
+            "xmlChildren": [
+              {
+                "name": "author",
+                "content": "Gambardella, Matthew"
+              },
+              {
+                "name": "title",
+                "content": "XML Developer's Guide"
+              },
+              {
+                "name": "genre",
+                "content": "Computer"
+              },
+              {
+                "name": "price",
+                "content": "44.95"
+              },
+              {
+                "name": "publish_date",
+                "content": "2000-10-01"
+              },
+              {
+                "name": "description",
+                "content": "An in-depth look at creating applications\n      with XML."
+              }
+            ]
+          }
         },
-      },
-      {
-        node: {
-          content: "XML Developer's Guide",
-        },
-      },
-    ]
+        {
+          "node": {
+            "name": "book",
+            "xmlChildren": [
+              {
+                "name": "author",
+                "content": "Ralls, Kim"
+              },
+              {
+                "name": "title",
+                "content": "Midnight Rain"
+              },
+              {
+                "name": "genre",
+                "content": "Fantasy"
+              },
+              {
+                "name": "price",
+                "content": "5.95"
+              },
+              {
+                "name": "publish_date",
+                "content": "2000-12-16"
+              },
+              {
+                "name": "description",
+                "content": "A former architect battles corporate zombies,\n      an evil sorceress, and her own childhood to become queen\n      of the world."
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 }
 ```
+
+Note that the root element "catalog" is ignored, and nodes are created with the children elements.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

While writing a documentation page for `gbi`, I noticed that line numbering and some other options of `gatsby-remark-prismjs` weren't working here. Stepping through it with Intellij Idea's Debugger confirmed that the [`visit(markdownAST, `code`, node => {...}`](https://github.com/gatsbyjs/gatsby/blob/f4e8d618e4cc77624df9b3d1779b2dcac2fdfcc5/packages/gatsby-remark-prismjs/src/index.js#L22) branch of it was of course never reached, as this plugin already had processed it to HTML. 
So I changed the constructed `node.type` to `code`, just gave the read in file as `node.value` and added `node.lang` to the returned node, which are needed for further processing down the line.
It just seemed unnecessary to duplicate `gatsby-remark-prismjs`'s code-highlighting functionality by creating _nearly_ the same output (and it should prevent any future deviations).

## Related Issues
Fixes the issue I would have opened otherwise ; ).
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
