### PR TITLE
chore: update readme and docs

### DIFF
--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -37,7 +37,7 @@ gatsby new netlify-cms-tutorial https://github.com/gatsbyjs/gatsby-starter-hello
 Now move into the newly created directory and install the Gatsby plugin for Netlify CMS:
 
 ```shell
-cd netlify-cms-tutorial && npm install --save netlify-cms gatsby-plugin-netlify-cms
+cd netlify-cms-tutorial && npm install --save netlify-cms-app gatsby-plugin-netlify-cms
 ```
 
 Gatsby plugins are registered in a file called `gatsby-config.js` in the site root. Create that file
@@ -203,4 +203,4 @@ created by following this guide. You can also reach out to the Netlify CMS commu
 [Gitter](https://gitter.im/netlify/netlifycms). Lastly, if you'd like to move into a more complete
 boilerplate to get going with Gatsby and Netlify CMS, you can clone and deploy the [official Gatsby
 Netlify CMS starter](https://github.com/AustinGreen/gatsby-starter-netlify-cms) to Netlify with [one
-click](https://app.netlify.com/start/deploy?repository=https://github.com/AustinGreen/gatsby-starter-netlify-cms&stack=cms).
+click](https://app.netlify.com/start/deploy?repository=https://github.com/netlify-templates/gatsby-starter-netlify-cms&stack=cms).

--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -22,7 +22,7 @@ _Note: this guide uses the Gatsby Hello World starter to provide a very basic un
 Netlify CMS can work with your Gatsby site. If you get stuck, compare your code to the [example
 project](https://github.com/erquhart/gatsby-netlify-cms-example). If you'd like to start with a full
 blown template, check out
-[gatsby-starter-netlify-cms](https://github.com/AustinGreen/gatsby-starter-netlify-cms)._
+[gatsby-starter-netlify-cms][1]._
 
 ### Setup
 
@@ -202,5 +202,6 @@ mentioned in the beginning of this guide, if you got stuck, you can compare your
 created by following this guide. You can also reach out to the Netlify CMS community on
 [Gitter](https://gitter.im/netlify/netlifycms). Lastly, if you'd like to move into a more complete
 boilerplate to get going with Gatsby and Netlify CMS, you can clone and deploy the [official Gatsby
-Netlify CMS starter](https://github.com/AustinGreen/gatsby-starter-netlify-cms) to Netlify with [one
-click](https://app.netlify.com/start/deploy?repository=https://github.com/netlify-templates/gatsby-starter-netlify-cms&stack=cms).
+Netlify CMS starter][1] to Netlify with [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify-templates/gatsby-starter-netlify-cms&stack=cms) .
+
+[1]: https://github.com/netlify-templates/gatsby-starter-netlify-cms

--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -1,8 +1,10 @@
 # gatsby-plugin-netlify-cms
 
-**Gatsby v1 and Netlify CMS 1.x require [`gatsby-plugin-netlify-cms@^2.0.0`](https://github.com/gatsbyjs/gatsby/blob/gatsby-plugin-netlify-cms@2.0.1/packages/gatsby-plugin-netlify-cms/README.md).**
+**Gatsby v1 and Netlify CMS 1.x require [`gatsby-plugin-netlify-cms@^2.0.0`][1].**
 
-**Gatsby v2 and Netlify CMS 2.x require `gatsby-plugin-netlify-cms@^3.0.0`, which is documented below.**
+**Gatsby v2 and Netlify CMS 2.x require [`gatsby-plugin-netlify-cms@^3.0.0`][2].**
+
+**Gatsby v2 and Netlify CMS (netlify-cms-app) 2.9.x required `gatsby-plugin-netlify-cms@^4.0.0`, which is documented below.**
 
 ## Overview
 
@@ -13,10 +15,12 @@ Its built for non-technical and technical editors alike, and its super easy to
 install and configure. For more details, check out the [docs
 site](https://netlifycms.org).
 
+**Note:** `gatsby-plugin-netlify-cms@^4.0.0` changes the requirement for Netlify CMS to use a new library published `netlify-cms-app@^2.9.x` and is a **breaking change**.
+
 ## Install
 
 ```shell
-npm install --save netlify-cms gatsby-plugin-netlify-cms
+npm install --save netlify-cms-app gatsby-plugin-netlify-cms
 ```
 
 ## How to use
@@ -69,11 +73,11 @@ The js module might look like this:
 
 ```javascript
 /**
- * The default export of `netlify-cms` is an object with all of the Netlify CMS
+ * The default export of `netlify-cms-app` is an object with all of the Netlify CMS
  * extension registration methods, such as `registerWidget` and
  * `registerPreviewTemplate`.
  */
-import CMS from "netlify-cms"
+import CMS from "netlify-cms-app"
 
 /**
  * Any imported styles will automatically be applied to the editor preview
@@ -118,13 +122,13 @@ plugins: [
 The js module might look like this:
 
 ```javascript
-import CMS, { init } from "netlify-cms"
+import CMS from "netlify-cms-app"
 
 /**
  * Optionally pass in a config object. This object will be merged into `config.yml` if it exists
  */
 
-init({
+CMS.init({
   config: {
     backend: {
       name: "git-gateway",
@@ -190,3 +194,6 @@ plugins: [
 
 For help with integrating Netlify CMS with Gatsby, check out the community
 [Gitter](https://gitter.im/netlify/netlifycms).
+
+[1]: https://github.com/gatsbyjs/gatsby/blob/gatsby-plugin-netlify-cms@2.0.1/packages/gatsby-plugin-netlify-cms/README.md
+[2]: https://github.com/gatsbyjs/gatsby/blob/gatsby-plugin-netlify-cms@3.0.18/packages/gatsby-plugin-netlify-cms/README.md


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Update docs to use `netlify-cms-app` instead of `netlify-cms` peer now.

## Related Issues

applies to #13036 which was a major bump of the plugin