### PR TITLE
fix(www): use end of day, use correct iso timestamp

### DIFF
--- a/www/src/components/events/__tests__/events.js
+++ b/www/src/components/events/__tests__/events.js
@@ -1,0 +1,44 @@
+import React from "react"
+import { render } from "react-testing-library"
+import { useStaticQuery } from "gatsby"
+
+import Events from "../events"
+
+const toEvent = (date, id) => {
+  return {
+    id,
+    data: {
+      date: date,
+      type: `event`,
+      name: `something something`,
+    },
+  }
+}
+
+const mockEvents = events =>
+  useStaticQuery.mockReturnValueOnce({
+    allAirtable: {
+      nodes: events,
+    },
+  })
+
+describe(`<Events />`, () => {
+  it(`displays no events text if 0 events`, () => {
+    mockEvents([])
+    const { getByText } = render(<Events />)
+
+    expect(getByText(`No events are scheduled right now.`)).toBeVisible()
+  })
+
+  it(`splits upcoming and past events`, () => {
+    mockEvents([`1990-10-08`, `2100-10-08`, `2200-10-08`].map(toEvent))
+
+    const { getByText } = render(<Events />)
+    const upcoming = getByText(`Upcoming Events`)
+    const past = getByText(`Past Events`)
+
+    ;[upcoming, past].forEach(el => {
+      expect(el.nextSibling.querySelectorAll(`li`).length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/www/src/components/events/event.js
+++ b/www/src/components/events/event.js
@@ -2,6 +2,13 @@ import React from "react"
 import { css } from "@emotion/core"
 import GatsbyLogo from "../../monogram.svg"
 
+const displayDate = date =>
+  date.toLocaleDateString(`en-US`, {
+    year: `numeric`,
+    month: `long`,
+    day: `numeric`,
+  })
+
 const Event = ({
   name,
   organizer_fname,
@@ -32,7 +39,7 @@ const Event = ({
         />
       )}
       <strong>{url ? <a href={url}>{name}</a> : name}</strong> —{` `}
-      {date}
+      {displayDate(date)}
       {` `}({location})
     </p>
     <p>

--- a/www/src/components/events/events.js
+++ b/www/src/components/events/events.js
@@ -4,10 +4,9 @@ import Event from "./event"
 
 const Events = () => {
   const events = useCommunityEvents()
-  const upcoming = events.filter(event => new Date(event.date) >= Date.now())
-  const past = events
-    .filter(event => new Date(event.date) < Date.now())
-    .reverse()
+
+  const upcoming = events.filter(event => event.date >= Date.now())
+  const past = events.filter(event => event.date < Date.now()).reverse()
 
   return events.length > 0 ? (
     <>

--- a/www/src/hooks/use-community-events.js
+++ b/www/src/hooks/use-community-events.js
@@ -6,6 +6,7 @@ const useCommunityEvents = () => {
   } = useStaticQuery(graphql`
     {
       allAirtable(
+        sort: { order: ASC, fields: [data___Date_of_Event] }
         filter: { data: { Approved_for_posting_on_event_page: { eq: true } } }
       ) {
         nodes {
@@ -25,22 +26,13 @@ const useCommunityEvents = () => {
     }
   `)
 
-  const events = nodes
-    .sort((a, b) => new Date(a.data.date) - new Date(b.data.date))
-    .map(event => {
-      return {
-        id: event.id,
-        ...event.data,
-        date: new Date(`${event.data.date} 00:00:00`).toLocaleDateString(
-          `en-US`,
-          {
-            year: `numeric`,
-            month: `long`,
-            day: `numeric`,
-          }
-        ),
-      }
-    })
+  const events = nodes.map(event => {
+    return {
+      id: event.id,
+      ...event.data,
+      date: new Date(`${event.data.date}T23:59:59.999Z`),
+    }
+  })
 
   return events
 }


### PR DESCRIPTION
## Description

Dates are fun. This seems to do the trick, specifically:

1. Uses a sort with GraphQL instead of client-side JS
1. Uses _end_ of day instead of start of day
    - If there's something obviously wrong or better here--happy to tweak
1. Keep date objects in data store, leave formatting up to React component

This fixes a few issues, namely that a date like `2019-05-03 00:00:00` (`new Date('2019-05-03 00:00:00')` is an invalid date in some browsers (like Safari) and so was filtering _all_ the events to not show once it hits the browser.

## Related Issues

Fixes #13844
