### PR TITLE
FIX: failing build (null fields)

### DIFF
--- a/examples/using-i18n/gatsby-node.js
+++ b/examples/using-i18n/gatsby-node.js
@@ -101,7 +101,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   const postList = result.data.blog.edges
 
-  postList.forEach(({ node: post }) => {
+  postList.filter(({node: post}) => post.childMdx !== null).forEach(({ node: post }) => {
     // All files for a blogpost are stored in a folder
     // relativeDirectory is the name of the folder
     const slug = post.relativeDirectory


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

In dev mode I got this error: 
```
TypeError: Cannot read property 'frontmatter' of null
5:06:27 PM:   
5:06:27 PM:   - gatsby-node.js:108 postList.forEach
5:06:27 PM:     /opt/build/repo/gatsby-node.js:108:37
5:06:27 PM:   
5:06:27 PM:   - Array.forEach
5:06:27 PM:   
5:06:27 PM:   - gatsby-node.js:103 Object.exports.createPages
5:06:27 PM:     /opt/build/repo/gatsby-node.js:103:12

```

It was OK in `dev` but resulted in a failed deployment when building for production.

The issue was that when I had other files that were not .mdx in the "blog" folder, fields are `null`, so build failed. I just `.filter` before actually creating the pages, checking for non-null fields.
