### PR TITLE
chore(docs): fixing broken url to quickstart

### DIFF
--- a/docs/docs/hosting-on-netlify.md
+++ b/docs/docs/hosting-on-netlify.md
@@ -10,7 +10,7 @@ Their free tier includes unlimited personal and commercial projects, HTTPS, cont
 
 ## Prerequisites
 
-This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [Quick Start guide](docs/quick-start) , then come back.
+This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [Quick Start guide](/docs/quick-start) , then come back.
 
 ### Hosting Setup
 


### PR DESCRIPTION
## Description

malformed url results in 404 page not found: https://www.gatsbyjs.org/docs/hosting-on-netlify/docs/quick-start

simple fix that appears to follow the established pattern is to precede the relative path with a slash to make it relative to the site root url.

## Related Issues
