### PR TITLE
use slash2 instead of slash

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -19,7 +19,7 @@
     "pretty-bytes": "^4.0.2",
     "progress": "^1.1.8",
     "read-chunk": "^3.0.0",
-    "slash": "^1.0.0",
+    "slash2": "^2.0.0",
     "valid-url": "^1.0.9",
     "xstate": "^3.1.0"
   },

--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -1,4 +1,4 @@
-const slash = require(`slash`)
+const slash = require(`slash2`)
 const path = require(`path`)
 const fs = require(`fs-extra`)
 const mime = require(`mime`)

--- a/packages/gatsby-source-filesystem/src/create-file-path.js
+++ b/packages/gatsby-source-filesystem/src/create-file-path.js
@@ -1,5 +1,5 @@
 const path = require(`path`)
-const slash = require(`slash`)
+const slash = require(`slash2`)
 
 function findFileNode({ node, getNode }) {
   // Find the file node.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
origin slash will return origin input if it contains noneasci [code here](https://github.com/sindresorhus/slash/blob/262981c1fca19193a20657ac99690214d9483d0e/index.js#L6),but path could contains NonAscii,
for example slash("foo\\测试") will return "foo\\测试" instead of “foo/测试”
slash2 remove this limit 
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
