### PR TITLE
chore(docs): Updated the quick start link in Sourcing from WordPress 

### DIFF
--- a/docs/docs/sourcing-from-wordpress.md
+++ b/docs/docs/sourcing-from-wordpress.md
@@ -13,7 +13,7 @@ _Note: this guide uses the `gatsby-starter-default` to provide you with a knowle
 
 ### Quick start
 
-This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [Quick Start guide](/docs), then come back.
+This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [Quick Start guide](/docs/quick-start), then come back.
 
 ### gatsby-config.js
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Fixes the broken quick link to original quick-start guide
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Closes 1/6th of #13876 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
