### PR TITLE
chore(starters): add gatsby-starter-primer

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2435,3 +2435,17 @@
     - Contact form and Google Map components
     - Animation
     - documentation and component library can be found at mdboostrap's website
+- url: https://gatsby-starter-primer.netlify.com/
+  repo: https://github.com/thomaswangio/gatsby-starter-primer
+  description: A Gatsby starter featuring GitHub Primer Design System and React components
+  tags:
+    - Primer
+    - Design System
+    - SEO
+    - Portfolio
+    - Landing Page
+  features:
+    - Primer React Components
+    - Styled Components
+    - Gatsby Image
+    - Better SEO component with appropriate OG image and appropriate fallback meta tags

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2439,10 +2439,9 @@
   repo: https://github.com/thomaswangio/gatsby-starter-primer
   description: A Gatsby starter featuring GitHub Primer Design System and React components
   tags:
-    - Primer
-    - Design System
+    - Styling:Primer
+    - Styling:CSS-in-JS
     - SEO
-    - Portfolio
     - Landing Page
   features:
     - Primer React Components


### PR DESCRIPTION
## Description

Adding Gatsby Primer Starter, a starter to showcase open source projects using the Github Primer Design System and React Component library. Uses styled-components, Gatsby Image with custom image of Octocat holding Gatsby logo, and a better SEO component that is optimized for Twitter/FB sharing.
