### PR TITLE
fix(gatsby-plugin-catch-links): Fall back to default browser link handling when resources fail to fetch

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -286,7 +286,7 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
       view: window,
     })
 
-    hrefHandler.mockImplementation(() => {
+    setTimeout(() => {
       expect(hrefHandler).toHaveBeenCalledWith(
         `${sameOriginAndTopPath.pathname}`
       )
@@ -313,7 +313,7 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
       view: window,
     })
 
-    hrefHandler.mockImplementation(() => {
+    setTimeout(() => {
       expect(hrefHandler).toHaveBeenCalledWith(
         `${withAnchor.pathname}${withAnchor.hash}`
       )
@@ -340,7 +340,7 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
       view: window,
     })
 
-    hrefHandler.mockImplementation(() => {
+    setTimeout(() => {
       expect(hrefHandler).toHaveBeenCalledWith(
         `${withSearch.pathname}${withSearch.search}${withSearch.hash}`
       )
@@ -351,6 +351,49 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
     })
 
     withSearch.dispatchEvent(clickEvent)
+  })
+})
+
+describe(`navigation is routed through browser if resources have failed and the destination href`, () => {
+  // We're going to manually set up the event listener here
+  let hrefHandler
+  let eventDestroyer
+
+  beforeAll(() => {
+    hrefHandler = jest.fn()
+    eventDestroyer = catchLinks.default(window, hrefHandler)
+    global.___failedResources = true
+  })
+
+  afterAll(() => {
+    eventDestroyer()
+    delete global.___failedResources
+  })
+
+  it(`shares the same origin and top path`, done => {
+    const sameOriginAndTopPath = document.createElement(`a`)
+    sameOriginAndTopPath.setAttribute(
+      `href`,
+      `${window.location.href}/someSubPath`
+    )
+    document.body.appendChild(sameOriginAndTopPath)
+
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    })
+
+    setTimeout(() => {
+      expect(hrefHandler).not.toHaveBeenCalled()
+
+      sameOriginAndTopPath.remove()
+
+      done()
+    })
+
+    sameOriginAndTopPath.dispatchEvent(clickEvent)
   })
 })
 

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -367,7 +367,7 @@ describe(`navigation is routed through browser if resources have failed and the 
 
   afterAll(() => {
     eventDestroyer()
-    delete global.___failedResources
+    global.___failedResources = false
   })
 
   it(`shares the same origin and top path`, done => {

--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -286,7 +286,8 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
       view: window,
     })
 
-    setTimeout(() => {
+    window.addEventListener(`click`, function onClick() {
+      window.removeEventListener(`click`, onClick)
       expect(hrefHandler).toHaveBeenCalledWith(
         `${sameOriginAndTopPath.pathname}`
       )
@@ -313,7 +314,8 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
       view: window,
     })
 
-    setTimeout(() => {
+    window.addEventListener(`click`, function onClick() {
+      window.removeEventListener(`click`, onClick)
       expect(hrefHandler).toHaveBeenCalledWith(
         `${withAnchor.pathname}${withAnchor.hash}`
       )
@@ -340,7 +342,8 @@ describe(`navigation is routed through gatsby if the destination href`, () => {
       view: window,
     })
 
-    setTimeout(() => {
+    window.addEventListener(`click`, function onClick() {
+      window.removeEventListener(`click`, onClick)
       expect(hrefHandler).toHaveBeenCalledWith(
         `${withSearch.pathname}${withSearch.search}${withSearch.hash}`
       )
@@ -385,7 +388,8 @@ describe(`navigation is routed through browser if resources have failed and the 
       view: window,
     })
 
-    setTimeout(() => {
+    window.addEventListener(`click`, function onClick() {
+      window.removeEventListener(`click`, onClick)
       expect(hrefHandler).not.toHaveBeenCalled()
 
       sameOriginAndTopPath.remove()

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -106,6 +106,8 @@ export const hashShouldBeFollowed = (origin, destination) =>
     destination.pathname === origin.pathname)
 
 export const routeThroughBrowserOrApp = hrefHandler => event => {
+  if (window.___failedResources) return true
+
   if (userIsForcingNavigation(event)) return true
 
   if (navigationWasHandledElsewhere(event)) return true


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Essentially disables gatsby-plugin-catch-links if resources fail to fetch, as the resulting runtime error seems to prevent the router from responding to navigation events.

## Related Issues

Fixes #13903 

However would not fix links being broken by some other failure to hydrate or bootstrap the application. I'm also wary that I might be reaching into gatsby's internals with this approach, am open to ideas about how to achieve this fix using only public APIs.
