### PR TITLE
chore(gatsby-plugin-preact): Update to Preact X beta

### DIFF
--- a/packages/gatsby-plugin-preact/README.md
+++ b/packages/gatsby-plugin-preact/README.md
@@ -6,6 +6,8 @@ While Preact doesn't provide full support for the React ecosystem, it is an
 intriguing option for Gatsby sites as it saves ~30kb of JavaScript vs. using
 React.
 
+> **Note:** This plugin uses Preact X, which is currently in beta, since Preact 8 is incompatible with Gatsby v2
+
 ## Install
 
 `npm install --save gatsby-plugin-preact preact preact-compat`

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -24,7 +24,8 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0",
+    "preact": "^10.0.0-beta.1"
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact",
   "scripts": {

--- a/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
@@ -10,9 +10,8 @@ describe(`gatsby-plugin-preact`, () => {
     expect(actions.setWebpackConfig).toHaveBeenCalledWith({
       resolve: {
         alias: {
-          react: `preact-compat`,
-          "react-dom": `preact-compat`,
-          "create-react-class": `preact-compat/lib/create-react-class`,
+          react: `preact/compat`,
+          "react-dom": `preact/compat`,
         },
       },
     })

--- a/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
@@ -4,7 +4,7 @@ describe(`gatsby-plugin-preact`, () => {
   it(`sets the correct webpack config`, () => {
     const actions = { setWebpackConfig: jest.fn() }
 
-    onCreateWebpackConfig({ stage: `develop`, actions })
+    onCreateWebpackConfig({ stage: `build-javascript`, actions })
 
     expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1)
     expect(actions.setWebpackConfig).toHaveBeenCalledWith({
@@ -17,10 +17,10 @@ describe(`gatsby-plugin-preact`, () => {
     })
   })
 
-  it(`does not invoke setWebpackConfig when stage is develop-html`, () => {
+  it(`does not invoke setWebpackConfig when stage is develop`, () => {
     const actions = { setWebpackConfig: jest.fn() }
 
-    onCreateWebpackConfig({ stage: `develop-html`, actions })
+    onCreateWebpackConfig({ stage: `develop`, actions })
 
     expect(actions.setWebpackConfig).not.toHaveBeenCalled()
   })

--- a/packages/gatsby-plugin-preact/src/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-node.js
@@ -6,9 +6,8 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
     actions.setWebpackConfig({
       resolve: {
         alias: {
-          react: `preact-compat`,
-          "react-dom": `preact-compat`,
-          "create-react-class": `preact-compat/lib/create-react-class`,
+          react: `preact/compat`,
+          "react-dom": `preact/compat`,
         },
       },
     })

--- a/packages/gatsby-plugin-preact/src/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-node.js
@@ -2,7 +2,7 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
   // Requiring the server version of React-dom is hardcoded right now
   // in the development server. So we'll just avoid loading Preact there
   // for now.
-  if (stage !== `develop-html`) {
+  if (stage !== `develop`) {
     actions.setWebpackConfig({
       resolve: {
         alias: {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR updates `gatsby-plugin-preact` to use the Preact X beta, since Preact 8 is incompatible with Gatsby v2.

## Related Issues

Fixes #13380 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
