### PR TITLE
fix(gatsby-cli): log correct version

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -328,6 +328,7 @@ module.exports = argv => {
 
   try {
     const { version } = require(`../package.json`)
+    cli.version(`version`, version)
     setDefaultTags({ gatsbyCliVersion: version })
   } catch (e) {
     // ignore


### PR DESCRIPTION
## Description

Set the cli version consistently for local and global usage

## Related Issues

Fixes #13076