### PR TITLE
chore(docs): fix wordpress-source-plugin-tutorial typo

### DIFF
--- a/docs/docs/wordpress-source-plugin-tutorial.md
+++ b/docs/docs/wordpress-source-plugin-tutorial.md
@@ -18,7 +18,7 @@ The same authentication schemes supported by the WP-API are supported in wp-grap
 
 While each source plugin may operate differently from others, it’s worth going through this tutorial because you will almost definitely be using a source plugin in most Gatsby sites you build. This tutorial will walk you through the basics of connecting your Gatsby site to a CMS, pulling in data, and using React to render that data in beautiful ways on your site.
 
-If you’d like to look at the growing number source plugins available to you, search for “source” in the [Gatsby plugin library](/plugins/?=source).
+If you’d like to look at the growing number of source plugins available to you, search for “source” in the [Gatsby plugin library](/plugins/?=source).
 
 ### Creating a site with the `gatsby-source-wordpress` plugin
 


### PR DESCRIPTION
## Description

Add an accidentally omitted preposition (of) on line 21.