### PR TITLE
fix(gatsby-plugin-offline): Drop preload link for json from offline shell

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-ssr.js
@@ -1,0 +1,21 @@
+export const onPreRenderHTML = ({
+  getHeadComponents,
+  pathname,
+  replaceHeadComponents,
+}) => {
+  if (pathname !== `/offline-plugin-app-shell-fallback/`) return
+
+  const headComponents = getHeadComponents()
+
+  const filteredHeadComponents = headComponents.filter(
+    ({ type, props }) =>
+      !(
+        type === `link` &&
+        props.as === `fetch` &&
+        props.rel === `preload` &&
+        props.href.startsWith(`/static/d/`)
+      )
+  )
+
+  replaceHeadComponents(filteredHeadComponents)
+}


### PR DESCRIPTION
**Description:**

Drop preload link for .json from offline shell

**Related Issues:**

- fixes #7713 
- fixes #10672