### PR TITLE
fix(gatsby): fallback for non-existing config

### DIFF
--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -69,7 +69,7 @@ module.exports = async program => {
     getConfigFile(program.directory, `gatsby-config`)
   )
 
-  const { pathPrefix: configPathPrefix } = config
+  const { pathPrefix: configPathPrefix } = config || {}
 
   const pathPrefix = prefixPaths && configPathPrefix ? configPathPrefix : `/`
 


### PR DESCRIPTION
This is a proposed way of doing it, I would love to have feedback or a conversation on how to fix/address this in a more Gatsby way.

## Description

I found that with changing from Gatsby `v2.3.36` to `v2.4.2`, a Gatsby website would not be able to be served using `gatsby serve` when there is no `gatsby-config.js` file in the root folder of the project.  This was due to the destructuring on line 72 in the `gatsby/src/commands/serve.js` file, which threw a `TypeError` when the command tried to destructure from `undefined`. 

I tried to solve this error by having a fallback to an empty object. But another (and maybe better) approach could also be that it is clearly documented as a needed file in the structure and to add it to the `gatsby-starter-hello-world` Starter project.

## Related Issues

This issue was addressed in #13910 
