### PR TITLE
fix(www): fix alignment of share icon

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -436,7 +436,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                       {` `}
                     </a>
                     <ShareMenu
-                      css={{ display: `flex`, minWidth: 32, minHeight: 32 }}
+                      css={{ display: `flex`, alignItems: `center`, minWidth: 32, minHeight: 32 }}
                       url={data.sitesYaml.main_url}
                       title={data.sitesYaml.title}
                       image={`https://www.gatsbyjs.org${

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -436,7 +436,12 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                       {` `}
                     </a>
                     <ShareMenu
-                      css={{ display: `flex`, alignItems: `center`, minWidth: 32, minHeight: 32 }}
+                      css={{
+                        display: `flex`,
+                        alignItems: `center`,
+                        minWidth: 32,
+                        minHeight: 32,
+                      }}
                       url={data.sitesYaml.main_url}
                       title={data.sitesYaml.title}
                       image={`https://www.gatsbyjs.org${


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixes share icon alignment (it was happening on firefox)

Before:
![image](https://user-images.githubusercontent.com/7075515/57484945-c9e32e00-7280-11e9-9c26-87dc433bec22.png)

After:
![image](https://user-images.githubusercontent.com/7075515/57484953-d10a3c00-7280-11e9-80fa-35de39468920.png)

There is no related issue.

Awesome project, I'm glad collaborating with it!
