### PR TITLE
chore(docs): Update e-commerce tutorial

### DIFF
--- a/docs/docs/ecommerce-tutorial/index.md
+++ b/docs/docs/ecommerce-tutorial/index.md
@@ -134,17 +134,15 @@ const buttonStyles = {
   letterSpacing: "1.5px",
 }
 
-const Checkout = class extends React.Component {
+class Checkout extends React.Component {
   // Initialise Stripe.js with your publishable key.
   // You can find your key in the Dashboard:
   // https://dashboard.stripe.com/account/apikeys
   componentDidMount() {
-    this.stripe = window.Stripe("pk_test_jG9s3XMdSjZF9Kdm5g59zlYd", {
-      betas: ["checkout_beta_4"],
-    })
+    this.stripe = window.Stripe("pk_test_jG9s3XMdSjZF9Kdm5g59zlYd")
   }
 
-  async redirectToCheckout(event) {
+  redirectToCheckout = async (event) => {
     event.preventDefault()
     const { error } = await this.stripe.redirectToCheckout({
       items: [{ sku: "sku_DjQJN2HJ1kkvI3", quantity: 1 }],
@@ -178,16 +176,14 @@ You imported React, added a button with some styles, and introduced some React f
 
 ```js:title=src/components/checkout.js
   componentDidMount() {
-    this.stripe = window.Stripe('pk_test_jG9s3XMdSjZF9Kdm5g59zlYd', {
-      betas: ['checkout_beta_4'],
-    })
+    this.stripe = window.Stripe('pk_test_jG9s3XMdSjZF9Kdm5g59zlYd')
   }
 ```
 
 This identifies you with the Stripe platform, validates the checkout request against your products and security settings, and processes the payment on your Stripe account.
 
 ```js:title=src/components/checkout.js
-  async redirectToCheckout(event) {
+  redirectToCheckout = async (event) => {
     event.preventDefault()
     const { error } = await this.stripe.redirectToCheckout({
       items: [{ sku: 'sku_DjQJN2HJ1kkvI3', quantity: 1 }],


### PR DESCRIPTION
- Removed the legacy betas:['beta_version'] of Stripe Checkout as there is latest production version avalaible shown in the link: https://stripe.com/docs/payments/checkout/migration-from-beta 

- Converted the redirectedToCheckout function to arrow one. It's because otherwise you need to bind the function to the class 'this'. But since in button, the function is being called using 'this' and it looks neat without appending (.bind(this)), so I simple changed the function to arrow one to natively bind to class 'this'

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
