### PR TITLE
chore(docs): Links between the pages in section 'community'

### DIFF
--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -66,6 +66,7 @@ tagged with **gatsby** or
 [ask your own question](https://hashnode.com/create/question) or [share your story](https://hashnode.com/create/story) and add the `gatsby` tag.
 
 ## Learn More About Gatsby:
+
 - [Why Contribute to Gatsby?](https://www.gatsbyjs.org/contributing/why-contribute-to-gatsby/)
 - [Gatsby Community Events](https://www.gatsbyjs.org/contributing/events/)
 - [Where to Participate in the Community?](https://www.gatsbyjs.org/contributing/where-to-participate/)

--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -64,3 +64,11 @@ Many members of the community also use Hashnode to ask questions and share their
 the [existing questions and posts](https://hashnode.com/n/gatsby)
 tagged with **gatsby** or
 [ask your own question](https://hashnode.com/create/question) or [share your story](https://hashnode.com/create/story) and add the `gatsby` tag.
+
+## Learn More About Gatsby:
+- [Why Contribute to Gatsby?](https://www.gatsbyjs.org/contributing/why-contribute-to-gatsby/)
+- [Gatsby Community Events](https://www.gatsbyjs.org/contributing/events/)
+- [Where to Participate in the Community?](https://www.gatsbyjs.org/contributing/where-to-participate/)
+- [Organize a Gatsby Event](https://www.gatsbyjs.org/contributing/organize-a-gatsby-event/)
+- [How to Run a Gatsby Workshop](https://www.gatsbyjs.org/contributing/how-to-run-a-gatsby-workshop/)
+- [How to Pitch Gatsby](https://www.gatsbyjs.org/contributing/how-to-pitch-gatsby/)

--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -67,9 +67,9 @@ tagged with **gatsby** or
 
 ## Learn More About Gatsby:
 
-- [Why Contribute to Gatsby?](https://www.gatsbyjs.org/contributing/why-contribute-to-gatsby/)
-- [Gatsby Community Events](https://www.gatsbyjs.org/contributing/events/)
-- [Where to Participate in the Community?](https://www.gatsbyjs.org/contributing/where-to-participate/)
-- [Organize a Gatsby Event](https://www.gatsbyjs.org/contributing/organize-a-gatsby-event/)
-- [How to Run a Gatsby Workshop](https://www.gatsbyjs.org/contributing/how-to-run-a-gatsby-workshop/)
-- [How to Pitch Gatsby](https://www.gatsbyjs.org/contributing/how-to-pitch-gatsby/)
+- [Why Contribute to Gatsby?](/contributing/why-contribute-to-gatsby/)
+- [Gatsby Community Events](/contributing/events/)
+- [Where to Participate in the Community?](/contributing/where-to-participate/)
+- [Organize a Gatsby Event](/contributing/organize-a-gatsby-event/)
+- [How to Run a Gatsby Workshop](/contributing/how-to-run-a-gatsby-workshop/)
+- [How to Pitch Gatsby](/contributing/how-to-pitch-gatsby/)

--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -36,4 +36,4 @@ To request support and submit your event to the Gatsby events page, apply at the
 
 ## Related Links:
 
-- [Gatsby's Community Events](https://www.gatsbyjs.org/contributing/events/)
+- [Gatsby's Community Events](/contributing/events/)

--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -35,4 +35,5 @@ To request support and submit your event to the Gatsby events page, apply at the
 [Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
 
 ## Related Links:
+
 - [Gatsby's Community Events](https://www.gatsbyjs.org/contributing/events/)

--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -33,3 +33,6 @@ There are several ways Gatsby may support your event:
 To request support and submit your event to the Gatsby events page, apply at the link below.
 
 [Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
+
+## Related Links:
+- [Gatsby's Community Events](https://www.gatsbyjs.org/contributing/events/)


### PR DESCRIPTION
Fix #13649. 

## Description
Adds related links in docs/contributing/community.md and docs/contributing/organize-a-gatsby-event.md.