### PR TITLE
docs: fix link to quick start guide

### DIFF
--- a/docs/docs/sourcing-from-contentful.md
+++ b/docs/docs/sourcing-from-contentful.md
@@ -10,7 +10,7 @@ Actually, the way Contentful handles bits of content means that you can push con
 
 ## Prerequisites
 
-This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [Quick Start guide](/docs), then come back.
+This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [Quick Start guide](/docs/quick-start), then come back.
 
 ## Pulling data in and pushing data out
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
Updated the Quick Link URL in the docs
## Description
I don't know if should remove `Pulling data in and pushing data out` section as I am a newbie in Js.
Thanks
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
#13945
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
