### PR TITLE
chore(showcase): Add Sandbox at Northeastern

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -5883,3 +5883,16 @@
   built_by: Pol Milian
   built_by_url: https://github.com/Polcius/
   featured: false
+- title: Sandbox
+  url: https://www.sandboxneu.com/
+  main_url: https://www.sandboxneu.com/
+  source_url: https://github.com/sandboxneu/sandboxneu.com
+  description: >
+    Official website of Sandbox, a Northeastern University student group that builds software for researchers.
+  categories:
+    - Marketing
+    - Research
+    - Student
+  built_by: Sandbox at Northeastern
+  built_by_url: https://github.com/sandboxneu/
+  featured: false


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Adds the site for Sandbox, a Northeastern University student group, to the Gatsby showcase. The Core team over at Sandbox absolutely loved the Gatsby development experience and figured we'd share what we came up with 😊
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
None
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
