### PR TITLE
chore(docs): Update tutorial in context on new VS Code behaviour

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -138,7 +138,7 @@ You can use Prettier directly in your editor using the [Prettier VS Code plugin]
 
 1.  Open the extensions view on VS Code (View => Extensions).
 2.  Search for "Prettier - Code formatter".
-3.  Click "Install". After installation you'll be prompted to restart VS Code to enable the extension.
+3.  Click "Install". (VS Code will automatically enable the extension after download)
 
 > 💡 If you're not using VS Code, check out the Prettier docs for [install instructions](https://prettier.io/docs/en/install.html) or [other editor integrations](https://prettier.io/docs/en/editors.html).
 

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -138,7 +138,7 @@ You can use Prettier directly in your editor using the [Prettier VS Code plugin]
 
 1.  Open the extensions view on VS Code (View => Extensions).
 2.  Search for "Prettier - Code formatter".
-3.  Click "Install". (VS Code will automatically enable the extension after download)
+3.  Click "Install". (After installation you'll be prompted to restart VS Code to enable the extension. Newer versions of VS Code will automatically enable the extension after download.)
 
 > 💡 If you're not using VS Code, check out the Prettier docs for [install instructions](https://prettier.io/docs/en/install.html) or [other editor integrations](https://prettier.io/docs/en/editors.html).
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Latest version of VS Code automatically enables the extension after download. So there will not be a dialog to reload editor. 

Reference Link: https://code.visualstudio.com/updates/v1_31#_no-reload-on-install

<!--
## Related Issues


  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
