### PR TITLE
chore(docs): Create "Preparing a Site for Deployment" page

### DIFF
--- a/docs/docs/deploying-to-netlify.md
+++ b/docs/docs/deploying-to-netlify.md
@@ -13,26 +13,6 @@ HTTPS, asset acceleration, and a lot more.
 Their free tier includes unlimited personal and commercial projects, HTTPS,
 continuous deployment from public or private repos and more.
 
-## Getting Started - Gatsby
-
-First, we'll want to create a new Gatsby project. If you don't already have Gatsby installed, install it:
-
-```shell
-npm install --global gatsby-cli
-```
-
-Next, we'll create a new Gatsby site:
-
-```shell
-gatsby new my-gatsby-site
-```
-
-Finally, change into the new site directory:
-
-```shell
-cd my-gatsby-site
-```
-
 **NOTE**: There is no need to build the site, Netlify can handle that for us.
 
 ## Getting Started - Netlify

--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -6,21 +6,7 @@ title: Deploying to Now
 
 This guide will show you how to get started in a few quick steps:
 
-## Step 1: Getting Started with Gatsby
-
-If you haven't already [set up a Gatsby project](/docs/quick-start) you can do so by first installing Gatsby globally:
-
-```shell
-npm install --global gatsby-cli
-```
-
-Then generate a project with the following command:
-
-```shell
-gatsby new <your project name>
-```
-
-## Step 2: Getting Now
+## Step 1: Getting Now
 
 You can use Now by installing [Now Desktop](https://zeit.co/docs/v2/getting-started/installation/#now-desktop), which also installs Now CLI and keeps it up-to-date automatically.
 
@@ -30,7 +16,7 @@ To install Now CLI quickly with npm, use the following:
 npm install -g now
 ```
 
-## Step 3: Preparing to Deploy
+## Step 2: Preparing to Deploy
 
 With Now CLI installed, we can go on to deploy our previously setup Gatsby project by first creating a `now.json` file with the following contents:
 
@@ -65,7 +51,7 @@ The final step is to add a script to the `package.json` which will build our app
 }
 ```
 
-## Step 4: Deploying
+## Step 3: Deploying
 
 You can deploy your application by running the following in the root of the project directory, where the `now.json` is:
 

--- a/docs/docs/deploying-to-s3-cloudfront.md
+++ b/docs/docs/deploying-to-s3-cloudfront.md
@@ -5,26 +5,6 @@ title: Deploying to S3/Cloudfront
 In this guide, we'll walk through how to host & publish your next Gatsby site to AWS using [S3](https://aws.amazon.com/s3/).
 Additionally - but very recommended - you can add CloudFront, a global CDN to make your site _even faster_.
 
-## Getting Started - Gatsby
-
-First, we'll want to create a new Gatsby project. If you don't already have Gatsby installed, install it:
-
-```shell
-npm install --global gatsby-cli
-```
-
-Next, we'll create a new Gatsby site:
-
-```shell
-gatsby new my-gatsby-site
-```
-
-Finally, change into the new site directory:
-
-```shell
-cd my-gatsby-site
-```
-
 ## Getting Started - AWS CLI
 
 Create a [IAM account](https://console.aws.amazon.com/iam/home?#) with administration permissions and create a access id and secret for it.

--- a/docs/docs/deploying-to-surge.md
+++ b/docs/docs/deploying-to-surge.md
@@ -10,21 +10,7 @@ Their generous free tier permits unlimited publishing, using custom domains, bas
 
 This guide will show you how to get started in a few quick steps:
 
-## Step 1: Getting Started with Gatsby
-
-If you don't already [have a Gatsby project](/docs/quick-start), start by installing Gatsby:
-
-```shell
-npm install -g gatsby-cli
-```
-
-Then, generate a project with the following:
-
-```shell
-gatsby new <project name>
-```
-
-## Step 2: Getting Surge
+## Step 1: Getting Surge
 
 To install the surge CLI with `npm`, paste the following into your terminal:
 
@@ -32,7 +18,7 @@ To install the surge CLI with `npm`, paste the following into your terminal:
 npm install -g surge
 ```
 
-## Step 3: Preparing to Deploy
+## Step 2: Preparing to Deploy
 
 Build a site by running this command in your project's root directory:
 
@@ -42,7 +28,7 @@ gatsby build
 
 This generates a publishable version of your site in the `./public` folder.
 
-## Step 4: Deploying
+## Step 3: Deploying
 
 You can deploy your site by running the following in the root of the project directory.
 
@@ -56,7 +42,7 @@ Press `enter` to confirm that the path to your `build/` folder is correct, and t
 
 You're done! Your terminal will output the address of the domain where your site was deployed.
 
-## Step 5: Bonus - Remembering a Domain
+## Step 4: Bonus - Remembering a Domain
 
 To ensure future deploys are sent to the same location, you can store the domain name in a [`CNAME`](https://surge.sh/help/remembering-a-domain) file from your project root. Assuming your site was deployed to `https://my-cool-domain.surge.sh`, run the following command:
 

--- a/docs/docs/hosting-on-netlify.md
+++ b/docs/docs/hosting-on-netlify.md
@@ -8,10 +8,6 @@ Netlify is an excellent option for deploying Gatsby sites. Netlify is a unified 
 
 Their free tier includes unlimited personal and commercial projects, HTTPS, continuous deployment from public or private repos and more.
 
-## Prerequisites
-
-This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [Quick Start guide](/docs/quick-start) , then come back.
-
 ### Hosting Setup
 
 There are two ways, we can host our site.

--- a/docs/docs/preparing-for-deployment.md
+++ b/docs/docs/preparing-for-deployment.md
@@ -52,3 +52,5 @@ If you have a server from one of the following providers, you should read the in
 - [Render](/docs/deploying-to-render)
 - [Surge](/docs/deploying-to-surge)
 - [GitHub Pages](/docs/how-gatsby-works-with-github-pages)
+
+If you don't see the hosting you are interested, it's possible to add other hosting providers through [contributions to the docs](/contributing/docs-contributions).

--- a/docs/docs/preparing-for-deployment.md
+++ b/docs/docs/preparing-for-deployment.md
@@ -2,7 +2,53 @@
 title: Preparing a Site for Deployment
 ---
 
-This is a stub. Help our community expand it.
+## Create new Gatsby project
 
-Please use the [Gatsby Style Guide](/contributing/gatsby-style-guide/) to ensure your
-pull request gets accepted.
+First thing you need to do is generate and configure your new Gatsby project.
+If you haven't already [set up a Gatsby project](/docs/quick-start) you can do so by first installing Gatsby globally:
+
+```shell
+npm install --global gatsby-cli
+```
+
+Then generate a project with the following command:
+
+```shell
+gatsby new your-new-project
+```
+
+Finally, change into the new site directory:
+
+```shell
+cd your-new-project
+```
+
+## Generate your site
+
+To generate static files in the simplest way, write
+
+```shell
+gatsby build
+```
+
+Then in the `Public` directory will be files to copy to the server.
+
+## Adding a Path Prefix
+
+If you want to specific Path Prefix, for example `example.com/blog/` instead of `example.com/` read [Adding a Path Prefix](/docs/path-prefix)
+
+## Specific deploy
+
+Additional actions may be required depending on which server you use.
+If you have a server from one of the following providers, you should read the individual subpages:
+
+- [AWS Amplify](/docs/deploying-to-aws-amplify)
+- [S3/Cloudfront](/docs/deploying-to-s3-cloudfront)
+- [Aerobatic](/docs/deploying-to-aerobatic)
+- [Heroku](/docs/deploying-to-heroku)
+- [Now](/docs/deploying-to-now)
+- [GitLab Pages](/docs/deploying-to-gitlab-pages)
+- [Netlify](/docs/hosting-on-netlify)
+- [Render](/docs/deploying-to-render)
+- [Surge](/docs/deploying-to-surge)
+- [GitHub Pages](/docs/how-gatsby-works-with-github-pages)


### PR DESCRIPTION
## Description
I have completed the "Preparing a Site for Deployment" page and removed instructions on how to generate a gatsby project from subpages for strictly deploying