### PR TITLE
feat(gatsby-plugin-netlify): Add caching headers for immutable assets

### DIFF
--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot 1`] = `
+"## Created with gatsby-plugin-netlify
+
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: same-origin
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+/sw.js
+  Cache-Control: no-cache
+/offline-plugin-app-shell-fallback/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+/hi-folks/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/my-second-post/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/hello-world/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/404/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+/404.html
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+"
+`;

--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshot 1`] = `
+exports[`with caching headers 1`] = `
 "## Created with gatsby-plugin-netlify
 
 /*
@@ -8,10 +8,82 @@ exports[`snapshot 1`] = `
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
   Referrer-Policy: same-origin
+/component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js
+  Cache-Control: public, max-age=31536000, immutable
+/0-0180cd94ef2497ac7db8.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-templates-blog-post-js-517987eae96e75cddbe7.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-pages-404-js-53e6c51a5a7e73090f50.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-pages-index-js-0bdd01c77ee09ef0224c.js
+  Cache-Control: public, max-age=31536000, immutable
+/pages-manifest-ab11f09e0ca7ecd3b43e.js
+  Cache-Control: public, max-age=31536000, immutable
+/webpack-runtime-acaa8994f1f704475e21.js
+  Cache-Control: public, max-age=31536000, immutable
+/styles.1025963f4f2ec7abbad4.css
+  Cache-Control: public, max-age=31536000, immutable
+/styles-565f081c8374bbda155f.js
+  Cache-Control: public, max-age=31536000, immutable
+/app-f33c13590352da20930f.js
+  Cache-Control: public, max-age=31536000, immutable
 /static/*
   Cache-Control: public, max-age=31536000, immutable
 /sw.js
   Cache-Control: no-cache
+/offline-plugin-app-shell-fallback/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+/hi-folks/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/my-second-post/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/hello-world/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/404/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+/404.html
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+"
+`;
+
+exports[`without caching headers 1`] = `
+"## Created with gatsby-plugin-netlify
+
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: same-origin
 /offline-plugin-app-shell-fallback/
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script

--- a/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
@@ -1,0 +1,145 @@
+import buildHeadersProgram from "../build-headers-program"
+import path from "path"
+import os from "os"
+import { promises as fs } from "fs"
+
+test(`snapshot`, async () => {
+  const tmpDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), `gatsby-plugin-netlify-`)
+  )
+
+  const pluginData = {
+    pages: new Map(
+      Object.entries({
+        "/offline-plugin-app-shell-fallback/": {
+          jsonName: `offline-plugin-app-shell-fallback-a30`,
+          internalComponentName: `ComponentOfflinePluginAppShellFallback`,
+          path: `/offline-plugin-app-shell-fallback/`,
+          matchPath: undefined,
+          componentChunkName: `component---node-modules-gatsby-plugin-offline-app-shell-js`,
+          isCreatedByStatefulCreatePages: false,
+          context: {},
+          updatedAt: 1557740602268,
+          pluginCreator___NODE: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
+          pluginCreatorId: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
+        },
+        "/hi-folks/": {
+          jsonName: `hi-folks-a2b`,
+          internalComponentName: `ComponentHiFolks`,
+          path: `/hi-folks/`,
+          matchPath: undefined,
+          componentChunkName: `component---src-templates-blog-post-js`,
+          isCreatedByStatefulCreatePages: false,
+          context: {},
+          updatedAt: 1557740602330,
+          pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+          pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+        },
+        "/my-second-post/": {
+          jsonName: `my-second-post-2aa`,
+          internalComponentName: `ComponentMySecondPost`,
+          path: `/my-second-post/`,
+          matchPath: undefined,
+          componentChunkName: `component---src-templates-blog-post-js`,
+          isCreatedByStatefulCreatePages: false,
+          context: {},
+          updatedAt: 1557740602333,
+          pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+          pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+        },
+        "/hello-world/": {
+          jsonName: `hello-world-8bc`,
+          internalComponentName: `ComponentHelloWorld`,
+          path: `/hello-world/`,
+          matchPath: undefined,
+          componentChunkName: `component---src-templates-blog-post-js`,
+          isCreatedByStatefulCreatePages: false,
+          context: {},
+          updatedAt: 1557740602335,
+          pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+          pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+        },
+        "/404/": {
+          jsonName: `404-22d`,
+          internalComponentName: `Component404`,
+          path: `/404/`,
+          matchPath: undefined,
+          componentChunkName: `component---src-pages-404-js`,
+          isCreatedByStatefulCreatePages: true,
+          context: {},
+          updatedAt: 1557740602358,
+          pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+          pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+        },
+        "/": {
+          jsonName: `index`,
+          internalComponentName: `ComponentIndex`,
+          path: `/`,
+          matchPath: undefined,
+          componentChunkName: `component---src-pages-index-js`,
+          isCreatedByStatefulCreatePages: true,
+          context: {},
+          updatedAt: 1557740602361,
+          pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+          pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+        },
+        "/404.html": {
+          jsonName: `404-html-516`,
+          internalComponentName: `Component404Html`,
+          path: `/404.html`,
+          matchPath: undefined,
+          componentChunkName: `component---src-pages-404-js`,
+          isCreatedByStatefulCreatePages: true,
+          context: {},
+          updatedAt: 1557740602382,
+          pluginCreator___NODE: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
+          pluginCreatorId: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
+        },
+      })
+    ),
+    manifest: {
+      "main.js": `render-page.js`,
+      "main.js.map": `render-page.js.map`,
+      app: [
+        `webpack-runtime-acaa8994f1f704475e21.js`,
+        `styles.1025963f4f2ec7abbad4.css`,
+        `styles-565f081c8374bbda155f.js`,
+        `app-f33c13590352da20930f.js`,
+      ],
+      "component---node-modules-gatsby-plugin-offline-app-shell-js": [
+        `component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js`,
+      ],
+      "component---src-templates-blog-post-js": [
+        `0-0180cd94ef2497ac7db8.js`,
+        `component---src-templates-blog-post-js-517987eae96e75cddbe7.js`,
+      ],
+      "component---src-pages-404-js": [
+        `0-0180cd94ef2497ac7db8.js`,
+        `component---src-pages-404-js-53e6c51a5a7e73090f50.js`,
+      ],
+      "component---src-pages-index-js": [
+        `0-0180cd94ef2497ac7db8.js`,
+        `component---src-pages-index-js-0bdd01c77ee09ef0224c.js`,
+      ],
+      "pages-manifest": [`pages-manifest-ab11f09e0ca7ecd3b43e.js`],
+    },
+    pathPrefix: ``,
+    publicFolder: fileName => path.join(tmpDir, fileName),
+  }
+
+  const pluginOptions = {
+    headers: {},
+    mergeSecurityHeaders: true,
+    mergeLinkHeaders: true,
+    mergeCachingHeaders: true,
+    transformHeaders: x => x,
+    generateMatchPathRewrites: true,
+    plugins: [],
+  }
+
+  await buildHeadersProgram(pluginData, pluginOptions)
+
+  expect(
+    await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
+  ).toMatchSnapshot()
+})

--- a/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
@@ -10,9 +10,10 @@ const createPluginData = async () => {
   )
 
   return {
-    pages: new Map(
-      Object.entries({
-        "/offline-plugin-app-shell-fallback/": {
+    pages: new Map([
+      [
+        `/offline-plugin-app-shell-fallback/`,
+        {
           jsonName: `offline-plugin-app-shell-fallback-a30`,
           internalComponentName: `ComponentOfflinePluginAppShellFallback`,
           path: `/offline-plugin-app-shell-fallback/`,
@@ -24,7 +25,10 @@ const createPluginData = async () => {
           pluginCreator___NODE: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
           pluginCreatorId: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
         },
-        "/hi-folks/": {
+      ],
+      [
+        `/hi-folks/`,
+        {
           jsonName: `hi-folks-a2b`,
           internalComponentName: `ComponentHiFolks`,
           path: `/hi-folks/`,
@@ -36,7 +40,10 @@ const createPluginData = async () => {
           pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
           pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
         },
-        "/my-second-post/": {
+      ],
+      [
+        `/my-second-post/`,
+        {
           jsonName: `my-second-post-2aa`,
           internalComponentName: `ComponentMySecondPost`,
           path: `/my-second-post/`,
@@ -48,7 +55,10 @@ const createPluginData = async () => {
           pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
           pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
         },
-        "/hello-world/": {
+      ],
+      [
+        `/hello-world/`,
+        {
           jsonName: `hello-world-8bc`,
           internalComponentName: `ComponentHelloWorld`,
           path: `/hello-world/`,
@@ -60,7 +70,10 @@ const createPluginData = async () => {
           pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
           pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
         },
-        "/404/": {
+      ],
+      [
+        `/404/`,
+        {
           jsonName: `404-22d`,
           internalComponentName: `Component404`,
           path: `/404/`,
@@ -72,7 +85,10 @@ const createPluginData = async () => {
           pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
           pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
         },
-        "/": {
+      ],
+      [
+        `/`,
+        {
           jsonName: `index`,
           internalComponentName: `ComponentIndex`,
           path: `/`,
@@ -84,7 +100,10 @@ const createPluginData = async () => {
           pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
           pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
         },
-        "/404.html": {
+      ],
+      [
+        `/404.html`,
+        {
           jsonName: `404-html-516`,
           internalComponentName: `Component404Html`,
           path: `/404.html`,
@@ -96,8 +115,8 @@ const createPluginData = async () => {
           pluginCreator___NODE: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
           pluginCreatorId: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
         },
-      })
-    ),
+      ],
+    ]),
     manifest: {
       "main.js": `render-page.js`,
       "main.js.map": `render-page.js.map`,

--- a/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
@@ -1,7 +1,7 @@
 import buildHeadersProgram from "../build-headers-program"
 import path from "path"
 import os from "os"
-import { promises as fs } from "fs"
+import fs from "fs-extra"
 import { DEFAULT_OPTIONS } from "../constants"
 
 const createPluginData = async () => {

--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -25,8 +25,10 @@ export const SECURITY_HEADERS = {
   ],
 }
 
+export const IMMUTABLE_CACHING_HEADER = `Cache-Control: public, max-age=31536000, immutable`
+
 export const CACHING_HEADERS = {
-  "/static/*": [`Cache-Control: public, max-age=31536000, immutable`],
+  "/static/*": [IMMUTABLE_CACHING_HEADER],
   "/sw.js": [`Cache-Control: no-cache`],
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR adds long-term caching headers to the `_headers` file for any js files that have a hash in their filename. These are only added if the existing `mergeCachingHeaders` setting is enabled.

## Related Issues

Fixes #13902.