### PR TITLE
fix(gatsby-cli): Only init git repository if no git repository exists (second attempt)

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -27,6 +27,24 @@ const shouldUseYarn = () => {
   }
 }
 
+const isAlreadyGitRepository = async () => {
+  try{
+    return await spawn(`git rev-parse --is-inside-work-tree`)
+    .then( (output) => {
+      if(output.failed){
+        return false;
+      } else {
+        return true;
+      }
+    })
+    .catch(() =>{
+      return false;
+    })
+  } catch(err){
+    return false
+  }
+}
+
 // Initialize newly cloned directory as a git repo
 const gitInit = async rootPath => {
   report.info(`Initialising git in ${rootPath}`)

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -148,9 +148,10 @@ const clone = async (hostInfo: any, rootPath: string) => {
   await fs.remove(sysPath.join(rootPath, `.git`))
 
   await install(rootPath)
-  await gitInit(rootPath)
+  const isGit = await isAlreadyGitRepository()
+  if(!isGit) await gitInit(rootPath)
   await maybeCreateGitIgnore(rootPath)
-  await createInitialGitCommit(rootPath, url)
+  if(!isGit) await createInitialGitCommit(rootPath, url)
 }
 
 type InitOptions = {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This is the same PR as #13096 since the head branch of the PR had commits for another PR and the head repo could not be changed.

This checks the working directory to see if an existing git repository exists when gatsby new mysite to prevent generating nested .git folders. If no .git folder is found backtracking through the working directory's path, a new git repository is initialized.

## Related Issues
Fixes #12858
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
