### PR TITLE
docs(fix): update yarn run watch --scope option

### DIFF
--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -28,8 +28,8 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
 - Create a topic branch: `git checkout -b topics/new-feature-name`
 - See [docs setup instructions](/contributing/docs-contributions#docs-site-setup-instructions) below for docs-only changes.
 - Run `yarn run watch` from the root of the repo to watch for changes to packages' source code and compile these changes on-the-fly as you work.
-  - Note that the watch command can be resource intensive. To limit it to the packages you're working on, add a scope flag, like `yarn run watch -- --scope={gatsby,gatsby-cli}`.
-  - To watch just one package, run `yarn run watch -- --scope=gatsby`.
+  - Note that the watch command can be resource intensive. To limit it to the packages you're working on, add a scope flag, like `yarn run watch --scope={gatsby,gatsby-cli}`.
+  - To watch just one package, run `yarn run watch --scope=gatsby`.
 - Install [gatsby-dev-cli](/packages/gatsby-dev-cli/) globally: `yarn global add gatsby-dev-cli`
 - Run `yarn install` in each of the sites you're testing.
 - For each of your Gatsby test sites, run the `gatsby-dev` command inside the test site's directory to copy


### PR DESCRIPTION
Using double dash to forward options to shell scripts emits the following warning:
```sh
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```