### PR TITLE
chore(gatsby-plugin-typescript): Types install instruction

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -9,7 +9,6 @@ Provides drop-in support for TypeScript and TSX.
 ## How to use
 
 1.  Include the plugin in your `gatsby-config.js` file.
-1.  Install related type definition based on your installed packages.
 1.  Write your components in TSX or TypeScript.
 1.  You're good to go.
 
@@ -21,6 +20,8 @@ module.exports = {
   plugins: [...`gatsby-plugin-typescript`],
 }
 ```
+
+**\*Please note**: If packages don't ship with TypeScript definitions you'll need to manually install those type definitions, e.g. for React. A typical Gatsby project would need: `npm install --save-dev @types/react @types/react-dom @types/node.`\*
 
 ## Options
 

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -9,6 +9,7 @@ Provides drop-in support for TypeScript and TSX.
 ## How to use
 
 1.  Include the plugin in your `gatsby-config.js` file.
+1.  Install related type definition based on your installed packages.
 1.  Write your components in TSX or TypeScript.
 1.  You're good to go.
 

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -21,7 +21,7 @@ module.exports = {
 }
 ```
 
-**\*Please note**: If packages don't ship with TypeScript definitions you'll need to manually install those type definitions, e.g. for React. A typical Gatsby project would need: `npm install --save-dev @types/react @types/react-dom @types/node.`\*
+_**Please note**: If packages don't ship with TypeScript definitions you'll need to manually install those type definitions, e.g. for React. A typical Gatsby project would need: `npm install --save-dev @types/react @types/react-dom @types/node.`_
 
 ## Options
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When I'm finish did the instruction, I got an error `JSX element class does not support attributes because it does not have a 'props' property.` at react-helmet declaration

That's was because **I need to install @types/react-helmet** first, so I think that's important to mention they need to install type definition also.

![screenshot](https://i.ibb.co/mCV5cZ9/Screenshot-from-2019-05-14-19-22-29.png "react helmet error")

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
