### PR TITLE
docs(gatsby-plugin-sitemap): fix the link to default options

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -23,7 +23,7 @@ generated sitemap will include all of your site's pages, except the ones you exc
 
 ## Options
 
-The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L34) can be overridden.
+The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/8291044020254b04eb47b021101e79743794243a/packages/gatsby-plugin-sitemap/src/internals.js#L45-L78) can be overridden.
 
 We _ALWAYS_ exclude the following pages: `/dev-404-page/`,`/404` &`/offline-plugin-app-shell-fallback/`, this cannot be changed.
 


### PR DESCRIPTION
Always use the SHA! Otherwise, the wrong line gets highlighted ;)

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Used the SHA when linking to the default options, so that the link is truly permanent. And fixed the line numbers to highlight.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
