### PR TITLE
chore(starters): add gatsby-elm-starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2540,3 +2540,10 @@
     - Styling with SCSS
     - Offline support
     - Web App Manifest
+- url: https://jovial-jones-806326.netlify.com/
+  repo: https://github.com/GabeAtWork/gatsby-elm-starter
+  description: An Elm-in-Gatsby integration, based on gatsby-plugin-elm
+  tags:
+    - Elm
+  features:
+    - Elm language integration


### PR DESCRIPTION
## Description

Adds an Elm starter for Gatsby, based on [gatsby-plugin-elm](https://github.com/wking-io/gatsby-plugin-elm)
