### PR TITLE
fix(gatsby-source-filesystem): fix createRemoteFileNode ts types

### DIFF
--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -10,7 +10,7 @@ export function createFilePath(args: CreateFilePathArgs): string
  */
 export function createRemoteFileNode(
   args: CreateRemoteFileNodeArgs
-): FileSystemNode
+): Promise<FileSystemNode>
 
 export interface CreateFilePathArgs {
   node: Node


### PR DESCRIPTION
## Description

`createRemoteFileNode` returns a Promise, but that's not what the TypeScript definitions file says.
This PR fixes the typings to indicate that it returns a `Promise<FileSystemNode>` instead of a `FileSystemNode`.

## Related Issues

Fixes #13619

Related: #12348
