### PR TITLE
remove tailwind.js as dependency in postcss config

### DIFF
--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -51,7 +51,7 @@ Create a postcss.config.js in your project's root folder with the following cont
 
 ```javascript:title=postcss.config.js
 module.exports = () => ({
-  plugins: [require("tailwindcss")("./tailwind.js")],
+  plugins: [require("tailwindcss")],
 })
 ```
 


### PR DESCRIPTION
When following this guide, I included the pointer to `tailwind.js` in the postcss config, but it broke when I ran `gatsby develop`. I checked the tailwind site, and they do not include `tailwind.js` in the postcss config [here](https://tailwindcss.com/docs/installation/#using-tailwind-with-postcss). Not sure if this was a change caused by the recent tailwind release, but removing it and running `gatsby develop` seems to work.

## Description

removes `(./tailwind.js)` from tailwind postcss documentation
