### PR TITLE
feat(gatsby): enable babel-loader for all dependencies

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
@@ -1,8 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`webpack utils js returns correct rule 1`] = `
+exports[`webpack utils js returns default values without any options 1`] = `
 Object {
   "exclude": /core-js\\|event-source-polyfill\\|webpack-hot-middleware\\\\/client/,
+  "test": /\\\\\\.\\(js\\|mjs\\|jsx\\)\\$/,
+  "type": "javascript/auto",
+  "use": Array [
+    Object {
+      "loader": "<PROJECT_ROOT>/packages/gatsby/src/utils/babel-loader.js",
+      "options": Object {},
+    },
+  ],
+}
+`;
+
+exports[`webpack utils js returns the correct exclude paths 1`] = `
+Object {
+  "exclude": /core-js\\|event-source-polyfill\\|webpack-hot-middleware\\\\/client\\|node_modules/,
   "test": /\\\\\\.\\(js\\|mjs\\|jsx\\)\\$/,
   "type": "javascript/auto",
   "use": Array [

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`webpack utils js returns correct rule 1`] = `
+Object {
+  "exclude": /core-js\\|event-source-polyfill\\|webpack-hot-middleware\\\\/client/,
+  "test": /\\\\\\.\\(js\\|mjs\\|jsx\\)\\$/,
+  "type": "javascript/auto",
+  "use": Array [
+    Object {
+      "loader": "<PROJECT_ROOT>/packages/gatsby/src/utils/babel-loader.js",
+      "options": Object {},
+    },
+  ],
+}
+`;

--- a/packages/gatsby/src/utils/__tests__/webpack-utils.js
+++ b/packages/gatsby/src/utils/__tests__/webpack-utils.js
@@ -11,19 +11,15 @@ beforeAll(async () => {
 })
 
 describe(`webpack utils`, () => {
-  describe(`mjs`, () => {
-    it(`adds .mjs rule`, () => {
-      expect(config.rules.mjs).toEqual(expect.any(Function))
+  describe(`js`, () => {
+    it(`adds .js rule`, () => {
+      expect(config.rules.js).toEqual(expect.any(Function))
     })
 
     it(`returns correct rule`, () => {
-      const rule = config.rules.mjs()
+      const rule = config.rules.js()
 
-      expect(rule).toEqual({
-        include: /node_modules/,
-        test: /\.mjs$/,
-        type: `javascript/auto`,
-      })
+      expect(rule).toMatchSnapshot()
     })
   })
 })

--- a/packages/gatsby/src/utils/__tests__/webpack-utils.js
+++ b/packages/gatsby/src/utils/__tests__/webpack-utils.js
@@ -16,8 +16,16 @@ describe(`webpack utils`, () => {
       expect(config.rules.js).toEqual(expect.any(Function))
     })
 
-    it(`returns correct rule`, () => {
+    it(`returns default values without any options`, () => {
       const rule = config.rules.js()
+
+      expect(rule).toMatchSnapshot()
+    })
+
+    it(`returns the correct exclude paths`, () => {
+      const rule = config.rules.js({
+        exclude: [`node_modules`],
+      })
 
       expect(rule).toMatchSnapshot()
     })

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -295,32 +295,14 @@ module.exports = async ({
   {
     let js = (options = {}) => {
       return {
-        test: /\.jsx?$/,
+        test: /\.(js|mjs|jsx)$/,
         exclude: /core-js|event-source-polyfill|webpack-hot-middleware\/client/,
+        type: `javascript/auto`,
         use: [loaders.js(options)],
       }
     }
 
     rules.js = js
-  }
-
-  /**
-   * mjs loader:
-   * webpack 4 has issues automatically dealing with
-   * the .mjs extension, thus we need to explicitly
-   * add this rule to use the default webpack js loader
-   */
-  {
-    let mjs = (options = {}) => {
-      return {
-        test: /\.mjs$/,
-        include: /node_modules/,
-        type: `javascript/auto`,
-        ...options,
-      }
-    }
-
-    rules.mjs = mjs
   }
 
   {

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -296,7 +296,7 @@ module.exports = async ({
     let js = (options = {}) => {
       return {
         test: /\.jsx?$/,
-        exclude: /core-js/,
+        exclude: /core-js|event-source-polyfill|webpack-hot-middleware\/client/,
         use: [loaders.js(options)],
       }
     }

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -293,10 +293,14 @@ module.exports = async ({
    * JavaScript loader via babel, excludes node_modules
    */
   {
-    let js = (options = {}) => {
+    let js = ({ exclude = [], ...options } = {}) => {
+      const excludeRegex = [
+        `core-js|event-source-polyfill|webpack-hot-middleware/client`,
+      ].concat(exclude)
+
       return {
         test: /\.(js|mjs|jsx)$/,
-        exclude: /core-js|event-source-polyfill|webpack-hot-middleware\/client/,
+        exclude: new RegExp(excludeRegex.join(`|`)),
         type: `javascript/auto`,
         use: [loaders.js(options)],
       }

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -296,7 +296,7 @@ module.exports = async ({
     let js = (options = {}) => {
       return {
         test: /\.jsx?$/,
-        exclude: vendorRegex,
+        exclude: /core-js/,
         use: [loaders.js(options)],
       }
     }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -250,7 +250,7 @@ module.exports = async (program, directory, suppliedStage) => {
 
     // speedup the build, we only include node_modules on production builds
     // TODO add option to force build node_modules
-    if (stage !== `develop`) {
+    if (stage === `develop`) {
       jsOptions.exclude = [`node_modules`]
     }
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -248,8 +248,8 @@ module.exports = async (program, directory, suppliedStage) => {
   function getModule() {
     const jsOptions = {}
 
-    // speedup the build, we only include node_modules on production builds
-    // TODO add option to force build node_modules
+    // Speedup 🏎️💨 the build! We only include transpilation of node_modules on production builds
+    // TODO create gatsby plugin to enable this behaviour on develop (only when people are requesting this feature)
     if (stage === `develop`) {
       jsOptions.exclude = [`node_modules`]
     }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -245,11 +245,19 @@ module.exports = async (program, directory, suppliedStage) => {
     }
   }
 
-  function getModule(config) {
+  function getModule() {
+    const jsOptions = {}
+
+    // speedup the build, we only include node_modules on production builds
+    // TODO add option to force build node_modules
+    if (stage !== `develop`) {
+      jsOptions.exclude = [`node_modules`]
+    }
+
     // Common config for every env.
     // prettier-ignore
     let configRules = [
-      rules.js(),
+      rules.js(jsOptions),
       rules.yaml(),
       rules.fonts(),
       rules.images(),

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -249,7 +249,6 @@ module.exports = async (program, directory, suppliedStage) => {
     // Common config for every env.
     // prettier-ignore
     let configRules = [
-      rules.mjs(),
       rules.js(),
       rules.yaml(),
       rules.fonts(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -18426,10 +18426,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dev-utils@^4.2.1:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.2.tgz#e8f2ffdbf27bfb13ee88ac18e20c83163aac0659"
-  integrity sha512-HwN0EE+9DS7wB0kKy6Bc5kUTUGUAOyZorJeb+ZGeTrxd1ZNwEJn1TfCRuNpRRa+Iu3VeYBcQ2pjuordJ4eqmfA==
+react-dev-utils@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.3.tgz#5b42d9ea58d5e9e017a2f57a40a8af408a3a46fb"
+  integrity sha512-uvmkwl5uMexCmC0GUv1XGQP0YjfYePJufGg4YYiukhqk2vN1tQxwWJIBERqhOmSi80cppZg8mZnPP/kOMf1sUQ==
   dependencies:
     address "1.0.3"
     babel-code-frame "6.26.0"


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
I ran gatsby through babel-loader to make sure babel-preset-env can adds it's polyfills for all dependencies so we don't break on older browsers. This will also help us for modern builds so our modern build will have fewer polyfills than our classic one.

To give you an idea on how much slower it is. The first run on a big website takes about double so that's something to wonder about.

| **default-starter** | no babel cache | babel cache |
|-----------------------------------------|----------------|-------------|
| transpile node_modules (no babel-cache) | 5,5623s | 2,887s |
| exclude node_modules (no babel-cache) | 3,148s | 2,224s |
| diff | 76% | 29% |

| **gatsbyjs.org** | no babel cache | babel cache |
|-----------------------------------------|----------------|-------------|
| transpile node_modules (no babel-cache) | 31,487s | 14,684s |
| exclude node_modules (no babel-cache) | 15,896s | 10,804s |
| diff | 98% | 36% |


| **default-starter** | runtime 1 | runtime 2 | runtime 3  |
|-----------------------------------------|----------------|-------------|-------------|
| transpile node_modules (no babel-cache) | 5,198s | 5,768s | 5,721s |
| transpile node_modules (babel-cache)    | 2,771s | 2,958s | 2,932s |
| exclude node_modules (no babel-cache) | 2,937s | 3,339s | 3,168s |
| exclude node_modules (babel-cache)    | 2,172s | 2,283s | 2,217s |


| **gatsbyjs.org** | runtime 1 | runtime 2 | runtime 3  |
|-----------------------------------------|----------------|-------------|-------------|
| transpile node_modules (no babel-cache) | 30.013s | 32.846s | 31.602s |
| transpile node_modules (babel-cache)    | 14.761s | 15.519s | 13.771s |
| exclude node_modules (no babel-cache) | 15.686s | 16.385s | 15.617s |
| exclude node_modules (babel-cache)    | 12.336s | 10.532s | 9.545s |

# bundle info
http://wardpeet-filestorage.surge.sh/gatsby-store/pr-14111

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/12409
https://github.com/gatsbyjs/gatsby/issues/12399
https://github.com/gatsbyjs/gatsby/issues/13427
https://github.com/gatsbyjs/gatsby/issues/5553
https://github.com/gatsbyjs/gatsby/issues/7064
https://github.com/gatsbyjs/gatsby/pull/13241