### PR TITLE
[schema] Merge user-defined types with plugin-defined types

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -19,6 +19,10 @@ require(`../../db/__tests__/fixtures/ensure-loki`)()
 
 const nodes = require(`./fixtures/node-model`)
 
+jest.mock(`gatsby-cli/lib/reporter`)
+const report = require(`gatsby-cli/lib/reporter`)
+afterEach(() => report.warn.mockClear())
+
 describe(`Build schema`, () => {
   beforeAll(() => {
     addDefaultApiRunnerMock()
@@ -271,8 +275,374 @@ describe(`Build schema`, () => {
       expect(arg.defaultValue).toEqual(false)
     })
 
-    // TODO: Define what "handles being called multiple times mean"
-    it.todo(`handles being called multiple times`)
+    it(`merges user-defined type with plugin-defined type`, async () => {
+      createTypes(
+        `type PluginDefined implements Node @infer { foo: Int, baz: PluginDefinedNested }
+         type PluginDefinedNested { foo: Int }`,
+        {
+          name: `some-gatsby-plugin`,
+        }
+      )
+      createTypes(
+        `type PluginDefined implements Node @dontInfer { bar: Int, qux: PluginDefinedNested }
+         type PluginDefinedNested { bar: Int }`,
+        {
+          name: `default-site-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const PluginDefinedNested = schema.getType(`PluginDefinedNested`)
+      const nestedFields = PluginDefinedNested.getFields()
+      const PluginDefined = schema.getType(`PluginDefined`)
+      const fields = PluginDefined.getFields()
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
+      expect(Object.keys(fields)).toEqual([
+        `foo`,
+        `baz`,
+        `bar`,
+        `qux`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(PluginDefined._gqcExtensions).toEqual(
+        expect.objectContaining({
+          createdFrom: `sdl`,
+          plugin: `default-site-plugin`,
+          infer: false,
+        })
+      )
+    })
+
+    it(`merges user-defined type (Gatsby type-builder) with plugin-defined type`, async () => {
+      createTypes(
+        `type PluginDefined implements Node @infer { foo: Int, baz: PluginDefinedNested }
+         type PluginDefinedNested { foo: Int }`,
+        {
+          name: `some-gatsby-plugin`,
+        }
+      )
+      createTypes(
+        [
+          buildObjectType({
+            name: `PluginDefined`,
+            interfaces: [`Node`],
+            extensions: {
+              infer: false,
+            },
+            fields: {
+              bar: `Int`,
+              qux: `PluginDefinedNested`,
+            },
+          }),
+          buildObjectType({
+            name: `PluginDefinedNested`,
+            fields: {
+              bar: `Int`,
+            },
+          }),
+        ],
+        {
+          name: `default-site-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const PluginDefinedNested = schema.getType(`PluginDefinedNested`)
+      const nestedFields = PluginDefinedNested.getFields()
+      const PluginDefined = schema.getType(`PluginDefined`)
+      const fields = PluginDefined.getFields()
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
+      expect(Object.keys(fields)).toEqual([
+        `foo`,
+        `baz`,
+        `bar`,
+        `qux`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(PluginDefined._gqcExtensions).toEqual(
+        expect.objectContaining({
+          createdFrom: `typeBuilder`,
+          plugin: `default-site-plugin`,
+          infer: false,
+        })
+      )
+    })
+
+    it(`merges user-defined type with plugin-defined type (Gatsby type-builder)`, async () => {
+      createTypes(
+        [
+          buildObjectType({
+            name: `PluginDefined`,
+            interfaces: [`Node`],
+            extensions: {
+              infer: true,
+            },
+            fields: {
+              foo: `Int`,
+              baz: `PluginDefinedNested`,
+            },
+          }),
+          buildObjectType({
+            name: `PluginDefinedNested`,
+            fields: {
+              foo: `Int`,
+            },
+          }),
+        ],
+        {
+          name: `some-gatsby-plugin`,
+        }
+      )
+      createTypes(
+        `type PluginDefined implements Node @dontInfer {
+           bar: Int
+           qux: PluginDefinedNested
+         }
+         type PluginDefinedNested { bar: Int }`,
+        {
+          name: `default-site-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const PluginDefinedNested = schema.getType(`PluginDefinedNested`)
+      const nestedFields = PluginDefinedNested.getFields()
+      const PluginDefined = schema.getType(`PluginDefined`)
+      const fields = PluginDefined.getFields()
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
+      expect(Object.keys(fields)).toEqual([
+        `foo`,
+        `baz`,
+        `bar`,
+        `qux`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(PluginDefined._gqcExtensions).toEqual(
+        expect.objectContaining({
+          createdFrom: `sdl`,
+          plugin: `default-site-plugin`,
+          infer: false,
+        })
+      )
+    })
+
+    it(`merges user-defined type (Gatsby type-builder) with plugin-defined type (Gatsby type-builder)`, async () => {
+      createTypes(
+        [
+          buildObjectType({
+            name: `PluginDefined`,
+            interfaces: [`Node`],
+            extensions: {
+              infer: true,
+            },
+            fields: {
+              foo: `Int`,
+              baz: `PluginDefinedNested`,
+            },
+          }),
+          buildObjectType({
+            name: `PluginDefinedNested`,
+            fields: {
+              foo: `Int`,
+            },
+          }),
+        ],
+        {
+          name: `some-gatsby-plugin`,
+        }
+      )
+      createTypes(
+        [
+          buildObjectType({
+            name: `PluginDefined`,
+            interfaces: [`Node`],
+            extensions: {
+              infer: false,
+            },
+            fields: {
+              bar: `Int`,
+              qux: `PluginDefinedNested`,
+            },
+          }),
+          buildObjectType({
+            name: `PluginDefinedNested`,
+            fields: {
+              bar: `Int`,
+            },
+          }),
+        ],
+        {
+          name: `default-site-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const PluginDefinedNested = schema.getType(`PluginDefinedNested`)
+      const nestedFields = PluginDefinedNested.getFields()
+      const PluginDefined = schema.getType(`PluginDefined`)
+      const fields = PluginDefined.getFields()
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
+      expect(Object.keys(fields)).toEqual([
+        `foo`,
+        `baz`,
+        `bar`,
+        `qux`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(PluginDefined._gqcExtensions).toEqual(
+        expect.objectContaining({
+          createdFrom: `typeBuilder`,
+          plugin: `default-site-plugin`,
+          infer: false,
+        })
+      )
+    })
+
+    // FIXME: Fails for PluginDefined.qux with PluginDefinedNested
+    it.skip(`merges user-defined type (graphql-js) with plugin-defined type`, async () => {
+      createTypes(
+        `type PluginDefined implements Node @infer { foo: Int, baz: PluginDefinedNested }
+         type PluginDefinedNested { foo: Int }`,
+        {
+          name: `some-gatsby-plugin`,
+        }
+      )
+      const PluginDefinedNestedType = new GraphQLObjectType({
+        name: `PluginDefinedNested`,
+        fields: {
+          bar: { type: GraphQLString },
+        },
+      })
+      const PluginDefinedType = new GraphQLObjectType({
+        name: `PluginDefined`,
+        fields: {
+          bar: { type: GraphQLString },
+          qux: { type: PluginDefinedNestedType },
+        },
+      })
+      createTypes([PluginDefinedType, PluginDefinedNestedType], {
+        name: `default-site-plugin`,
+      })
+      const schema = await buildSchema()
+      const PluginDefinedNested = schema.getType(`PluginDefinedNested`)
+      const nestedFields = PluginDefinedNested.getFields()
+      const PluginDefined = schema.getType(`PluginDefined`)
+      const fields = PluginDefined.getFields()
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
+      expect(Object.keys(fields)).toEqual([
+        `foo`,
+        `baz`,
+        `bar`,
+        `qux`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(PluginDefined._gqcExtensions).toEqual(
+        expect.objectContaining({
+          createdFrom: `graphql-js`,
+          plugin: `default-site-plugin`,
+          infer: true,
+        })
+      )
+    })
+
+    it(`merges user-defined type with plugin-defined type (graphql-js)`, async () => {
+      const PluginDefinedNestedType = new GraphQLObjectType({
+        name: `PluginDefinedNested`,
+        fields: {
+          foo: { type: GraphQLString },
+        },
+      })
+      const PluginDefinedType = new GraphQLObjectType({
+        name: `PluginDefined`,
+        fields: {
+          foo: { type: GraphQLString },
+          baz: { type: PluginDefinedNestedType },
+        },
+      })
+      createTypes([PluginDefinedType, PluginDefinedNestedType], {
+        name: `some-gatsby-plugin`,
+      })
+      createTypes(
+        `type PluginDefined implements Node @infer { bar: Int, qux: PluginDefinedNested }
+         type PluginDefinedNested { bar: Int }`,
+        {
+          name: `default-site-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const PluginDefinedNested = schema.getType(`PluginDefinedNested`)
+      const nestedFields = PluginDefinedNested.getFields()
+      const PluginDefined = schema.getType(`PluginDefined`)
+      const fields = PluginDefined.getFields()
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
+      expect(Object.keys(fields)).toEqual([
+        `foo`,
+        `baz`,
+        `bar`,
+        `qux`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(PluginDefined._gqcExtensions).toEqual(
+        expect.objectContaining({
+          createdFrom: `sdl`,
+          plugin: `default-site-plugin`,
+          infer: true,
+        })
+      )
+    })
+
+    it(`does not merge plugin-defined type with type defined by other plugin`, async () => {
+      createTypes(
+        `type PluginDefined implements Node { foo: Int, baz: PluginDefinedNested }
+         type PluginDefinedNested { foo: Int }`,
+        {
+          name: `some-gatsby-plugin`,
+        }
+      )
+      createTypes(
+        `type PluginDefined implements Node { bar: Int, qux: PluginDefinedNested }
+         type PluginDefinedNested { bar: Int }`,
+        {
+          name: `some-other-gatsby-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const nestedFields = schema.getType(`PluginDefinedNested`).getFields()
+      const fields = schema.getType(`PluginDefined`).getFields()
+      expect(Object.keys(nestedFields)).toEqual([`foo`])
+      expect(Object.keys(fields)).toEqual([
+        `foo`,
+        `baz`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(report.warn).toHaveBeenCalledWith(
+        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+          `\`PluginDefinedNested\`, which has already been defined by the plugin ` +
+          `\`some-gatsby-plugin\`.`
+      )
+      expect(report.warn).toHaveBeenCalledWith(
+        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+          `\`PluginDefined\`, which has already been defined by the plugin ` +
+          `\`some-gatsby-plugin\`.`
+      )
+    })
 
     it(`displays error message for reserved Node interface`, () => {
       const typeDefs = [
@@ -719,8 +1089,8 @@ describe(`Build schema`, () => {
   })
 })
 
-const createTypes = types => {
-  store.dispatch({ type: `CREATE_TYPES`, payload: types })
+const createTypes = (types, plugin) => {
+  store.dispatch({ type: `CREATE_TYPES`, payload: types, plugin })
 }
 
 const createCreateResolversMock = resolvers => {

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -18,11 +18,16 @@ module.exports.build = async ({ parentSpan }) => {
 
   const typeConflictReporter = new TypeConflictReporter()
 
+  // Ensure that user-defined types are processed last
+  const sortedTypes = types.sort(
+    type => type.plugin && type.plugin.name === `default-site-plugin`
+  )
+
   const schemaComposer = createSchemaComposer()
   const schema = await buildSchema({
     schemaComposer,
     nodeStore,
-    types,
+    types: sortedTypes,
     thirdPartySchemas,
     typeMapping,
     typeConflictReporter,


### PR DESCRIPTION
continued from  #13663

When defining GraphQL types with `createTypes`, allow users to extend types which have already been defined by plugins, while disallowing plugins to modify types defined by other plugins.

This works for merging:
*  SDL into SDL
* typeBuilder into SDL
* SDL into typeBuilder
* typeBuilder into typeBuilder
* SDL into graphql-js

BUT NOT FOR:
* graphql-js into SDL (see the skipped test)
This last one does NOT work in cases where the graphql-js type has a field that references an ObjectType that is already defined in the schema composer - those will be duplicated. I'm a bit hesitant if we should add complexity for fixing this scenario? It's sort of the reason why TypeBuilders are preferable in the first place.
