### PR TITLE
fix(gatsby): include includePrerelease in semver.satisfies check

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.js
@@ -213,7 +213,9 @@ function warnOnIncompatiblePeerDependency(name, packageJSON) {
   const gatsbyPeerDependency = _.get(packageJSON, `peerDependencies.gatsby`)
   if (
     gatsbyPeerDependency &&
-    !semver.satisfies(gatsbyVersion, gatsbyPeerDependency, { includePrerelease: true })
+    !semver.satisfies(gatsbyVersion, gatsbyPeerDependency, {
+      includePrerelease: true,
+    })
   ) {
     reporter.warn(
       `Plugin ${name} is not compatible with your gatsby version ${gatsbyVersion} - It requires gatsby@${gatsbyPeerDependency}`

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.js
@@ -213,7 +213,7 @@ function warnOnIncompatiblePeerDependency(name, packageJSON) {
   const gatsbyPeerDependency = _.get(packageJSON, `peerDependencies.gatsby`)
   if (
     gatsbyPeerDependency &&
-    !semver.satisfies(gatsbyVersion, gatsbyPeerDependency)
+    !semver.satisfies(gatsbyVersion, gatsbyPeerDependency, { includePrerelease: true })
   ) {
     reporter.warn(
       `Plugin ${name} is not compatible with your gatsby version ${gatsbyVersion} - It requires gatsby@${gatsbyPeerDependency}`


### PR DESCRIPTION
To get rid of warnings if canary and gatsby-dev-cli packages