### PR TITLE
fix(www): Add og:url meta property to fix LinkedIn shares

### DIFF
--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -37,9 +37,11 @@ const renderAst = new rehypeReact({
 
 class BlogPostTemplate extends React.Component {
   render() {
-    const post = this.props.data.markdownRemark
-    const prev = this.props.pageContext.prev
-    const next = this.props.pageContext.next
+    const {
+      pageContext: { prev, next },
+      data: { markdownRemark: post },
+      location: { href },
+    } = this.props
     const prevNextLinkStyles = {
       "&&": {
         borderBottom: 0,
@@ -73,7 +75,7 @@ class BlogPostTemplate extends React.Component {
         <link rel="canonical" href={post.frontmatter.canonicalLink} />
       )
     }
-
+    console.log(this.props)
     return (
       <Layout location={this.props.location}>
         <Container>
@@ -109,10 +111,7 @@ class BlogPostTemplate extends React.Component {
               <meta property="og:description" content={post.excerpt} />
               <meta name="twitter:description" content={post.excerpt} />
               <meta property="og:title" content={post.frontmatter.title} />
-              <meta
-                property="og:url"
-                content={post.frontmatter.canonicalLink}
-              />
+              <meta property="og:url" content={href} />
               {post.frontmatter.image && (
                 <meta
                   property="og:image"

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -109,6 +109,10 @@ class BlogPostTemplate extends React.Component {
               <meta property="og:description" content={post.excerpt} />
               <meta name="twitter:description" content={post.excerpt} />
               <meta property="og:title" content={post.frontmatter.title} />
+              <meta
+                property="og:url"
+                content={post.frontmatter.canonicalLink}
+              />
               {post.frontmatter.image && (
                 <meta
                   property="og:image"

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -75,7 +75,6 @@ class BlogPostTemplate extends React.Component {
         <link rel="canonical" href={post.frontmatter.canonicalLink} />
       )
     }
-    console.log(this.props)
     return (
       <Layout location={this.props.location}>
         <Container>


### PR DESCRIPTION
## Description

Adds the `og:url` meta tag to the `blog` template to try and resolve the issue. I don't have a way to share a local page to test unfortunately though... However, I can't see any negatives to having this additional data on the page.

## Related Issues

I believe this fixes #14093
