### PR TITLE
chore(docs): Update TailwindCSS CSS-in-JS instructions

### DIFF
--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -20,8 +20,10 @@ You have to install and configure Tailwind for both of these methods, so this gu
 1. Install Tailwind
 
 ```shell
-npm install tailwindcss --save-dev
+npm install tailwindcss@0.7.4 --save-dev
 ```
+
+> Note: This version of this guide doesn't work with Tailwind 1.0 and above. The Gatsby Team is working on this.
 
 2. Generate Tailwind config file
 


### PR DESCRIPTION
Update tailwind-css.md to inform users that Tailwind 1.0.0 and above isn't currently compatible; this would've saved me a couple hours and a headache

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Tailwind 1.0 and 1.0.1 released very recently, and unfortunately I happened to start learning Gatsby this week as well. I was trying to get Tailwind to work for a couple hours until I dove deeper and discovered that 

1. Tailwind just got a major update
2. The Gatsby docs don't mention this and currently don't provide a guide on how to implement Tailwind v1.

I made this change so that Gatsby users who visit this page can know which version currently works with the guide. Would've saved me a headache and a couple hours as well, haha



<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

N/A

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
