### PR TITLE
fix(www): removed asterisk behind 'Preparing for Deployment' page

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -28,7 +28,7 @@
         - title: Deploying & Hosting
           link: /docs/deploying-and-hosting/
           items:
-            - title: Preparing your Site for Deployment*
+            - title: Preparing your Site for Deployment
               link: /docs/preparing-for-deployment/
             - title: Deploying to AWS Amplify
               link: /docs/deploying-to-aws-amplify/


### PR DESCRIPTION
## Description
Page [preparing for deployment](https://www.gatsbyjs.org/docs/preparing-for-deployment/) is completed but I forgot to remove the asterisk.
- removed asterisk behind 'Preparing a Site for Deployment'