### PR TITLE
docs(tutorial): Update linking-between-pages

### DIFF
--- a/docs/docs/linking-between-pages.md
+++ b/docs/docs/linking-between-pages.md
@@ -25,7 +25,7 @@ export default () => (
 )
 ```
 
-The above code will add a link to the contact page, automatically rendered in HTML as `<a href="/contact/">` but with added performance benefits.
+The above code will add a link to the contact page, automatically rendered in HTML as `<a href="/contact/">` but with added performance benefits. The link's value is based off of the page's filename which in this case would be `contact.js`.
 
 > **Note:** the value `"/"` for the `to` property will take users to the home page.
 


### PR DESCRIPTION
## Description

I wanted to add clarification about if the link's value is based on a component or file name. The tutorial at `/tutorial/part-one/#linking-between-pages/` explains what the link value is expecting the filename to be but I thought that was missing from this page.

## Related Issues

n/a