### PR TITLE
fix(develop): fix "Unexpected token < in JSON at position 0" after restarting development server

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -220,6 +220,14 @@ async function startServer(program) {
 
   await apiRunnerNode(`onCreateDevServer`, { app })
 
+  // In case nothing before handled hot-update - send 404.
+  // This fixes "Unexpected token < in JSON at position 0" runtime
+  // errors after restarting development server and
+  // cause automatic hard refresh in the browser.
+  app.use(/.*\.hot-update\.json$/i, (req, res) => {
+    res.status(404).end()
+  })
+
   // Render an HTML page and serve it.
   app.use((req, res, next) => {
     res.sendFile(directoryPath(`public/index.html`), err => {


### PR DESCRIPTION
## Description

Sometimes when restarting development server we will be greeted with "Unexpected token < in JSON at position 0" error in runtime.

After some debugging this is where it originates - https://github.com/webpack/webpack/blob/v4.31.0/lib/web/JsonpMainTemplate.runtime.js#L53-L58 and after adding some logs/breakpoints there I found that we are trying to serve development `index.html`. This happens because of last catch-all request handler in development server that will serve index.html

To workaround this I added request handler that will target requests ending with `hot-update.json` (it's 2nd to last request handler, so if there is actual hot-update, it will be handled correctly - dev e2e tests should pass here 🤞 )

Before:
![Kapture 2019-05-20 at 2 34 25](https://user-images.githubusercontent.com/419821/57990693-5ecbff80-7aa9-11e9-9564-e9fbe1df77d3.gif)

After:
![Kapture 2019-05-20 at 2 38 56](https://user-images.githubusercontent.com/419821/57990697-62f81d00-7aa9-11e9-82b2-0f2cbcb39030.gif)

Note - there are possible other fixes - see comments in https://github.com/gatsbyjs/gatsby/issues/11541 regarding plugin configuration and using shorthand syntax. I searched for the issue too late, so there is potential for better fix. But I still think this should be in here (or maybe better catch-all to not serve `index.html`)