### PR TITLE
fix(gatsby): Fix ordering for node links when search field isn't id

### DIFF
--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -783,7 +783,7 @@ describe(`GraphQL type inference`, () => {
       const nodes = [
         {
           id: `1`,
-          linkedOnCustomField: [`test1`, `test3`],
+          linkedOnCustomField: [`test3`, `test1`],
           internal: { type: `Test` },
         },
       ].concat(getMappingNodes())
@@ -802,20 +802,28 @@ describe(`GraphQL type inference`, () => {
         }
       )
 
-      expect(result.errors).not.toBeDefined()
-      expect(result.data.allTest.edges.length).toEqual(1)
-      expect(
-        result.data.allTest.edges[0].node.linkedOnCustomField
-      ).toBeDefined()
-      expect(
-        result.data.allTest.edges[0].node.linkedOnCustomField.length
-      ).toEqual(2)
-      expect(
-        result.data.allTest.edges[0].node.linkedOnCustomField[0].label
-      ).toEqual(`First node`)
-      expect(
-        result.data.allTest.edges[0].node.linkedOnCustomField[1].label
-      ).toEqual(`Third node`)
+      expect(result).toMatchInlineSnapshot(`
+Object {
+  "data": Object {
+    "allTest": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "linkedOnCustomField": Array [
+              Object {
+                "label": "Third node",
+              },
+              Object {
+                "label": "First node",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+}
+`)
     })
   })
 

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -146,10 +146,21 @@ const link = ({ by = `id`, from }) => async (source, args, context, info) => {
     }
   }, fieldValue)
 
-  return context.nodeModel.runQuery(
+  const result = await context.nodeModel.runQuery(
     { query: args, firstOnly: !(returnType instanceof GraphQLList), type },
     { path: context.path }
   )
+  if (
+    returnType instanceof GraphQLList &&
+    Array.isArray(fieldValue) &&
+    Array.isArray(result)
+  ) {
+    return fieldValue.map(value =>
+      result.find(obj => getValueAt(obj, by) === value)
+    )
+  } else {
+    return result
+  }
 }
 
 const fileByPath = ({ from }) => (source, args, context, info) => {


### PR DESCRIPTION
Fixes #14162 

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
