### PR TITLE
chore(docs): Fix typo in unit-testing

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -207,7 +207,7 @@ Run the tests again now and it should all work! You may get a message about
 the snapshot being written. This is created in a `__snapshots__` directory next
 to your tests. If you take a look at it, you will see that it is a JSON
 representation of the `<Header />` component. You should check your snapshot files
-into a source control system (for example, a GitHub repo) so that so that any changes are tracked in history.
+into a source control system (for example, a GitHub repo) so that any changes are tracked in history.
 This is particularly important to remember if you are using a continuous
 integration system such as Travis or CircleCI to run tests, as these will fail if the snapshot is not checked into source control.
 


### PR DESCRIPTION
## Description

Fixes a small typo on line 210 where the phrase "so that" was used twice in a row erroneously.