### PR TITLE
fix(gatsby-source-filesystem):  fix unhandled rejection by returning promise chain

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -345,8 +345,11 @@ module.exports = ({
     name,
   })
 
-  fileDownloadPromise.then(() => bar.tick())
+  processingCache[url] = fileDownloadPromise.then(node => {
+    bar.tick()
 
-  processingCache[url] = fileDownloadPromise
-  return fileDownloadPromise
+    return node
+  })
+
+  return processingCache[url]
 }


### PR DESCRIPTION
## Description
We weren't updating our promise chain which meant we weren't catching all variations of the promise. When using then or catch a new Promise is created. This one makes sure we are using the same promise.

Sadly I couldn't test if an unrejected promise was happening but I added a test to test for rejection.

### Repro from issue:

- Create a new Gatsby project (`gatsby new gatsby-bug-mvce`)
- Add these lines to `gatsby-node.js`:
```js
const { createRemoteFileNode } = require("gatsby-source-filesystem")

exports.sourceNodes = ({ actions, store, cache, createNodeId }) => {
  const { createNode } = actions

  return createRemoteFileNode({
    url: "https://httpstat.us/404",
    store,
    cache,
    createNode,
    createNodeId,
  })
  .catch(err => {
    console.log("caught error:", err)
  })
  .then(node => {
    console.log("created node:", node)
  })
}
```
https://github.com/antoinerousseau/gatsby-bug-mvce/commits/master

## Related Issues
#14178