### PR TITLE
fix(gatsby): append headers when request is finished.

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -205,14 +205,21 @@ async function startServer(program) {
       const { headers, method } = req
       req
         .pipe(
-          got.stream(proxiedUrl, { headers, method }).on(`error`, err => {
-            const message = `Error when trying to proxy request "${
-              req.originalUrl
-            }" to "${proxiedUrl}"`
+          got
+            .stream(proxiedUrl, { headers, method })
+            .on(`error`, err => {
+              const message = `Error when trying to proxy request "${
+                req.originalUrl
+              }" to "${proxiedUrl}"`
 
-            report.error(message, err)
-            res.status(500).end()
-          })
+              report.error(message, err)
+              res.status(500).end()
+            })
+            .on(`response`, resp => {
+              Object.keys(resp.headers).forEach(key => {
+                res.setHeader(key, resp.headers[key])
+              })
+            })
         )
         .pipe(res)
     })


### PR DESCRIPTION
## Description

Headers from API calls were not being appended in the proxy.

So when calling an api-endpoint the `jwt-token` was not being appended and hence won't be accessible by the browser for future api calls.

This PR simply loops through the response from the stream and appends them to the original response object.

**Use case**
1. The Frontend sends a post request to perform an authentication operation. (This request is being proxied to the api)
2. The api responds with 200 and a set-cookie header containing the jwt token.
3. The frontend is supposed to receive the jwt token and then use it for future requests.

But since the headers from the backend is not being forwarded thru the proxy the frontend never receives the header and hence can't use it for future requests.

There might very well be an option that enables but I haven't been able to follow and from what I can understand from the code there doesn't seem to be one.

And I am not sure if the GOT stream is supposed to pipe the headers as well but from what I can tell it only seems to pipe the body since we do receive the correct body.
