### PR TITLE
fix(gatsby-source-drupal): provide alt field on image types

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -223,7 +223,7 @@ exports.sourceNodes = async (
             if (/^node--|^paragraph--/.test(type) && node.relationships[type]) {
               const nodeEntityId = _.toString(node.relationships[type])
               const parentEntity = nodes[nodeEntityId]
-              let parentDrupalId = ""
+              let parentDrupalId = ``
 
               if (!parentEntity) {
                 continue
@@ -276,7 +276,7 @@ exports.sourceNodes = async (
                               rel.data &&
                               rel.data.id === node.drupal_id &&
                               rel.data.type &&
-                              rel.data.type === "file--file" &&
+                              rel.data.type === `file--file` &&
                               rel.data.meta &&
                               rel.data.meta.alt
                             ) {

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -277,10 +277,9 @@ exports.sourceNodes = async (
                               rel.data.id === node.drupal_id &&
                               rel.data.type &&
                               rel.data.type === `file--file` &&
-                              rel.data.meta &&
-                              rel.data.meta.alt
+                              rel.data.meta
                             ) {
-                              node.alt = rel.data.meta.alt
+                              node.meta = rel.data.meta
                             }
                           }
                         }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -203,13 +203,13 @@ exports.sourceNodes = async (
       }
 
       node.internal.contentDigest = createContentDigest(node)
-      nodes.push(node)
+      nodes[node.id] = node
     })
   })
 
   let nodeDatumsBreak = false
 
-  // Map media to their entities
+  // Map media entities
   for (const i in nodes) {
     if (nodes[i]) {
       const node = nodes[i]
@@ -300,7 +300,7 @@ exports.sourceNodes = async (
   downloadingFilesActivity.start()
 
   // Download all files (await for each pool to complete to fix concurrency issues)
-  await asyncPool(concurrentFileRequests, nodes, async node => {
+  await asyncPool(concurrentFileRequests, _.toArray(nodes), async node => {
     // If we have basicAuth credentials, add them to the request.
     const auth =
       typeof basicAuth === `object`


### PR DESCRIPTION
Image `alt` data was not being referenced in GraphQL as per issue #10339.

I have added a fix which references the `alt` tag within the file entity. This now enables the ability to gain access to the `alt` data within the GraphQL query

**GraphQL example**
```
{
  allNodeBlogArticle {
    edges {
      node {
        title 
        relationships {
          field_cover_image {
            localFile {
              publicURL
              childImageSharp {
                fluid(quality: 80, maxWidth: 768) {
                  src
                }
              }
            }
            alt
          }
          field_technical_article {
            ... on paragraph__image_column_width_ {
              relationships {
                field_image {
                  alt
                }
              }
            }
          }
        }
      }
    }
  }
}
```