### PR TITLE
chore(www): update banner for new webinar

### DIFF
--- a/www/src/components/__tests__/banner.js
+++ b/www/src/components/__tests__/banner.js
@@ -3,10 +3,12 @@ import { render } from "react-testing-library"
 
 import Banner from "../banner"
 
-test(`it renders an external link`, () => {
-  const { getByText } = render(<Banner />)
+const matchers = [`Watch now`, `Register now`]
 
-  const link = getByText(`Watch now`)
+const getElement = utils => utils.getByText(text => matchers.includes(text))
+
+test(`it renders an external link`, () => {
+  const link = getElement(render(<Banner />))
 
   expect(link.getAttribute(`href`)).toContain(`https://`)
 })

--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -48,10 +48,10 @@ const Banner = () => (
   <BannerContainer className="banner">
     <InnerContainer>
       <Content>
-        <OutboundLink href="https://www.gatsbyjs.com/gatsby-themes/">
+        <OutboundLink href="https://www.gatsbyjs.com/gatsby-plugins/">
           Watch now
         </OutboundLink>
-        {`: "Making Gatsby Even Greater With Themes — Better, Faster, Flexible-er".`}
+        {`: "What Can Gatsby Plugins Do?" - See what Gatsby plugins are capable of!`}
       </Content>
     </InnerContainer>
   </BannerContainer>

--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -49,9 +49,9 @@ const Banner = () => (
     <InnerContainer>
       <Content>
         <OutboundLink href="https://www.gatsbyjs.com/gatsby-plugins/">
-          Watch now
+          Register now
         </OutboundLink>
-        {`: "What Can Gatsby Plugins Do?" - See what Gatsby plugins are capable of!`}
+        {`: "What Can Gatsby Plugins Do?" - Learn about different types of plugins and how to build one!`}
       </Content>
     </InnerContainer>
   </BannerContainer>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Updates the homepage banner to link to the new webinar on Gatsby plugins instead of the past webinar for themes.


## Preview 
![image](https://user-images.githubusercontent.com/21114044/58045794-c82b2d00-7b00-11e9-8823-409db61ec449.png)
