### PR TITLE
chore(docs): Update Storybook doc to account for StaticQuery

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -83,17 +83,24 @@ module.exports = ({ config }) => {
     require.resolve("@babel/preset-env"),
   ]
 
-  // use @babel/plugin-proposal-class-properties for class arrow functions
   config.module.rules[0].use[0].options.plugins = [
+    // use @babel/plugin-proposal-class-properties for class arrow functions
     require.resolve("@babel/plugin-proposal-class-properties"),
+    // use babel-plugin-remove-graphql-queries to remove static queries from components when rendering in storybook
+    require.resolve("babel-plugin-remove-graphql-queries"),
   ]
 
   // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
   config.resolve.mainFields = ["browser", "module", "main"]
 
+  // Set the NODE_ENV to 'production' so that babel-plugin-remove-graphql-queries can remove static queries
+  process.env.NODE_ENV = "production"
+
   return config
 }
 ```
+
+> Note that if you're using a [StaticQuery](https://www.gatsbyjs.org/docs/static-query/) in your components, `babel-plugin-remove-graphql-queries` is required to render them in Storybook. This is because the queries are run at build time in Gatsby, and will not have been run when rendering the components directly.
 
 **For Storybook v4:**
 
@@ -111,9 +118,11 @@ module.exports = (baseConfig, env, defaultConfig) => {
     require.resolve("@babel/preset-env"),
   ]
 
-  // use @babel/plugin-proposal-class-properties for class arrow functions
   defaultConfig.module.rules[0].use[0].options.plugins = [
+    // use @babel/plugin-proposal-class-properties for class arrow functions
     require.resolve("@babel/plugin-proposal-class-properties"),
+    // use babel-plugin-remove-graphql-queries to render components that use static queries
+    require.resolve("babel-plugin-remove-graphql-queries"),
   ]
 
   // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint

--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -121,12 +121,15 @@ module.exports = (baseConfig, env, defaultConfig) => {
   defaultConfig.module.rules[0].use[0].options.plugins = [
     // use @babel/plugin-proposal-class-properties for class arrow functions
     require.resolve("@babel/plugin-proposal-class-properties"),
-    // use babel-plugin-remove-graphql-queries to render components that use static queries
+    // use babel-plugin-remove-graphql-queries to remove static queries from components when rendering in storybook
     require.resolve("babel-plugin-remove-graphql-queries"),
   ]
 
   // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
   defaultConfig.resolve.mainFields = ["browser", "module", "main"]
+
+  // Set the NODE_ENV to 'production' so that babel-plugin-remove-graphql-queries can remove static queries
+  process.env.NODE_ENV = "production"
 
   return defaultConfig
 }


### PR DESCRIPTION
updated visual-testing-with-storybook to account for static query errors in storybook

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR is to address https://github.com/gatsbyjs/gatsby/issues/14196 by updating the Storybook documentation. This specifically adds mention of static query errors and updates the suggested `webpack.config.js` changes to account for it.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixed #14196
Related to #10662
