### PR TITLE
fix(gatsby): improve `externals` webpack configuration to better support yarn PnP

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -451,8 +451,11 @@ module.exports = async (program, directory, suppliedStage) => {
   }
 
   if (stage === `build-html` || stage === `develop-html`) {
-    // Packages we want to externalize to save space
+    // Packages we want to externalize to save some build time
+    // https://github.com/gatsbyjs/gatsby/pull/14208#pullrequestreview-240178728
     const externalList = [
+      `@reach/router/lib/history`,
+      `@reach/router`,
       `common-tags`,
       /^core-js\//,
       `crypto`,
@@ -467,7 +470,7 @@ module.exports = async (program, directory, suppliedStage) => {
       `zlib`,
     ]
 
-    // Packages we want to externalize because the user should provide them
+    // Packages we want to externalize because meant to be user-provided
     const userExternalList = [
       `es6-promise`,
       `minimatch`,
@@ -475,8 +478,6 @@ module.exports = async (program, directory, suppliedStage) => {
       `react-helmet`,
       `react`,
       /^react-dom\//,
-      `@react/router`,
-      `@reach/router/lib/history`,
     ]
 
     const checkItem = (item, request) => {

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -451,47 +451,61 @@ module.exports = async (program, directory, suppliedStage) => {
   }
 
   if (stage === `build-html` || stage === `develop-html`) {
+    // Packages we want to externalize to save space
     const externalList = [
-      // match `lodash` and `lodash/foo`
-      // but not things like `lodash-es`
-      `lodash`,
-      /^lodash\//,
-      `react`,
-      /^react-dom\//,
-      `pify`,
-      `@reach/router`,
-      `@reach/router/lib/history`,
       `common-tags`,
+      /^core-js\//,
+      `crypto`,
+      `debug`,
+      `fs`,
+      `https`,
+      `http`,
+      `lodash`,
       `path`,
       `semver`,
-      `react-helmet`,
-      `minimatch`,
-      `fs`,
-      /^core-js\//,
-      `es6-promise`,
-      `crypto`,
+      /^lodash\//,
       `zlib`,
-      `http`,
-      `https`,
-      `debug`,
     ]
+
+    // Packages we want to externalize because the user should provide them
+    const userExternalList = [
+      `es6-promise`,
+      `minimatch`,
+      `pify`,
+      `react-helmet`,
+      `react`,
+      /^react-dom\//,
+      `@react/router`,
+      `@reach/router/lib/history`,
+    ]
+
+    const checkItem = (item, request) => {
+      if (typeof item === `string` && item === request) {
+        return true
+      } else if (item instanceof RegExp && item.test(request)) {
+        return true
+      }
+      return false
+    }
+
+    const isExternal = request => {
+      if (externalList.some(item => checkItem(item, request))) {
+        return `umd ${require.resolve(request)}`
+      }
+      if (userExternalList.some(item => checkItem(item, request))) {
+        return `umd ${request}`
+      }
+      return null
+    }
 
     config.externals = [
       function(context, request, callback) {
-        if (
-          externalList.some(item => {
-            if (typeof item === `string` && item === request) {
-              return true
-            } else if (item instanceof RegExp && item.test(request)) {
-              return true
-            }
-
-            return false
-          })
-        ) {
-          return callback(null, `umd ${request}`)
+        const external = isExternal(request)
+        if (external !== null) {
+          callback(null, external)
+        } else {
+          callback()
         }
-        return callback()
       },
     ]
   }


### PR DESCRIPTION
## Description

This diff. A few notes:

- I looked at what packages were dependencies of Gatsby itself and assumed that they were meant to be pinned (and that all the other ones were meant to be provided by the consumer). I can change this list if it doesn't look right (for example I would have thought that `es6-promise` was meant to be pinned by Gatsby, but it isn't listed in its dependencies so I haven't added it).

- I tested locally (on `^2.2.9`) but there's at least one other PR needed for Gatsby master to unbreak w/ PnP so I can't test it against master at the moment. Hopefully the CI will provide good signal 😃

cc @pieh, since I think you implemented the external list

## Related Issues

Fixes #12948

