### PR TITLE
chore(gatsby): adds support for PnP in test-require-error

### DIFF
--- a/packages/gatsby/src/utils/test-require-error.js
+++ b/packages/gatsby/src/utils/test-require-error.js
@@ -1,6 +1,12 @@
 // This module is also copied into the .cache directory some modules copied there
 // from cache-dir can also use this module.
 export default (moduleName, err) => {
+  // PnP will return the following code when a require is allowed per the
+  // dependency tree rules but the requested file doesn't exist
+  if (err.code === `QUALIFIED_PATH_RESOLUTION_FAILED`) {
+    return true
+  }
+
   const regex = new RegExp(
     `Error: Cannot find module\\s.${moduleName.replace(
       /[-/\\^$*+?.()|[\]{}]/g,


### PR DESCRIPTION
## Description

The current implementation of `test-require-error` was simply checking the error message to figure out whether the exception thrown was caused by the file not existing. This didn't work under PnP since we throw semantic errors (the message is different depending on the reason why the require call failed).

Instead we should check for the `QUALIFIED_PATH_RESOLUTION_FAILED` code, which means that the dependency check was successful but the resolver was unable to find a file on the disk that would match the specified request.

## Related Issues

Needed to test #14208 w/ PnP