### PR TITLE
fix(docs): fix link to wrapRootElement in migration guide

### DIFF
--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -579,7 +579,7 @@ In order to track page views, you can use the [`onRouteUpdate`](/docs/browser-ap
 
 ### Browser API `wrapRootComponent` was replaced with `wrapRootElement`
 
-Use new [`wrapRootElement`](/docs/browser-apis/#wrapRootComponent) API:
+Use new [`wrapRootElement`](/docs/browser-apis/#wrapRootElement) API:
 We now pass `component` Element instead of `Root` Component and expect that `wrapRootElement` will return Element and not Component. This change was needed to keep all wrapping APIs uniform.
 
 ```diff


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

A small change to fix a broken link.