### PR TITLE
Fixing links in awesome-gatsby.md

### DIFF
--- a/docs/docs/awesome-gatsby.md
+++ b/docs/docs/awesome-gatsby.md
@@ -6,15 +6,15 @@ A curated list of interesting Gatsby community projects and learning resources.
 
 ## Site showcase
 
-See the [site showcase](/showcase/)
+See the [site showcase](https://www.gatsbyjs.org/showcase/)
 
 ## Starters
 
-See the [library of official and community starters](/starters/)
+See the [library of official and community starters](https://www.gatsbyjs.org/starters/)
 
 ## Plugins
 
-See the [library of official and community plugins](/plugins/)
+See the [library of official and community plugins](https://www.gatsbyjs.org/plugins/)
 
 ## Tools
 
@@ -45,8 +45,8 @@ See the [library of official and community plugins](/plugins/)
 
 ## Gatsby tutorials
 
-- [Official tutorial](/tutorial/)
-- [Creating a blog with Gatsby](/blog/2017-07-19-creating-a-blog-with-gatsby/)
+- [Official tutorial](https://www.gatsbyjs.org/tutorial/)
+- [Creating a blog with Gatsby](https://www.gatsbyjs.org/blog/2017-07-19-creating-a-blog-with-gatsby/)
 - [Level Up Tutorials series on creating a blog](https://www.youtube.com/watch?v=b2H7fWhQcdE&list=PLLnpHn493BHHfoINKLELxDch3uJlSapxg)
 - [Level up Tutorials Pro Gatsby series](https://www.leveluptutorials.com/store/products/tutorials/lut-dd020)
 - [Giraffe Academy series on getting started with Gatsby](https://www.youtube.com/playlist?list=PLLAZ4kZ9dFpMXuwazIt4mWtTuqOHdjRlk)


### PR DESCRIPTION
The **https://www.gatsbyjs.org/docs/awesome-gatsby/** leads to this markdown file in Github, but
here some links are broken. I changed finally all the relative links (only a single one was working properly) and the links work now properly.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixed links in the **awesome-gatsby.md**

## Related Issues

The same problem may be present in other docu files, which I may slowly review and eventually send an MR. 
