### PR TITLE
fix(gatsby-remark-images): captions do not show fallback based on filename

### DIFF
--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -177,7 +177,7 @@ exports[`it uses tracedSVG placeholder when enabled 1`] = `
   >
     <span
       class=\\"gatsby-resp-image-background-image\\"
-      style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/svg+xml,%3csvg \\\\'MOCK SVG\\\\'%3c/svg%3e'); background-size: cover; display: block;\\"
+      style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/svg+xml,%3csvg /'MOCK SVG/'%3c/svg%3e'); background-size: cover; display: block;\\"
     ></span>
     <img
         class=\\"gatsby-resp-image-image\\"

--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -177,7 +177,7 @@ exports[`it uses tracedSVG placeholder when enabled 1`] = `
   >
     <span
       class=\\"gatsby-resp-image-background-image\\"
-      style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/svg+xml,%3csvg /'MOCK SVG/'%3c/svg%3e'); background-size: cover; display: block;\\"
+      style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/svg+xml,%3csvg \\\\'MOCK SVG\\\\'%3c/svg%3e'); background-size: cover; display: block;\\"
     ></span>
     <img
         class=\\"gatsby-resp-image-image\\"
@@ -222,6 +222,35 @@ exports[`showCaptions display alt as caption if title was not found 1`] = `
   </a>
     <figcaption class=\\"gatsby-resp-image-figcaption\\">some alt</figcaption>
   </figure>"
+`;
+
+exports[`showCaptions display nothing as caption if no title or alt 1`] = `
+"<a
+    class=\\"gatsby-resp-image-link\\"
+    href=\\"not-a-real-dir/images/my-image.jpeg\\"
+    style=\\"display: block\\"
+    target=\\"_blank\\"
+    rel=\\"noopener\\"
+  >
+    <span
+    class=\\"gatsby-resp-image-wrapper\\"
+    style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
+  >
+    <span
+      class=\\"gatsby-resp-image-background-image\\"
+      style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"
+    ></span>
+    <img
+        class=\\"gatsby-resp-image-image\\"
+        style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;box-shadow:inset 0px 0px 0px 400px white;\\"
+        alt=\\"my image\\"
+        title=\\"\\"
+        src=\\"not-a-real-dir/images/my-image.jpeg\\"
+        srcset=\\"not-a-real-dir/images/my-image.jpeg, not-a-real-dir/images/my-image.jpeg\\"
+        sizes=\\"(max-width: 650px) 100vw, 650px\\"
+      />
+  </span>
+  </a>"
 `;
 
 exports[`showCaptions display title as caption 1`] = `

--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -224,35 +224,6 @@ exports[`showCaptions display alt as caption if title was not found 1`] = `
   </figure>"
 `;
 
-exports[`showCaptions display nothing as caption if no title or alt 1`] = `
-"<a
-    class=\\"gatsby-resp-image-link\\"
-    href=\\"not-a-real-dir/images/my-image.jpeg\\"
-    style=\\"display: block\\"
-    target=\\"_blank\\"
-    rel=\\"noopener\\"
-  >
-    <span
-    class=\\"gatsby-resp-image-wrapper\\"
-    style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
-  >
-    <span
-      class=\\"gatsby-resp-image-background-image\\"
-      style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"
-    ></span>
-    <img
-        class=\\"gatsby-resp-image-image\\"
-        style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;box-shadow:inset 0px 0px 0px 400px white;\\"
-        alt=\\"my image\\"
-        title=\\"\\"
-        src=\\"not-a-real-dir/images/my-image.jpeg\\"
-        srcset=\\"not-a-real-dir/images/my-image.jpeg, not-a-real-dir/images/my-image.jpeg\\"
-        sizes=\\"(max-width: 650px) 100vw, 650px\\"
-      />
-  </span>
-  </a>"
-`;
-
 exports[`showCaptions display title as caption 1`] = `
 "<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
     <a

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -382,6 +382,5 @@ describe(`showCaptions`, () => {
     const node = nodes.pop()
     const $ = cheerio.load(node.value)
     expect($(`figcaption`).length).toBe(0)
-    expect(node.value).toMatchSnapshot()
   })
 })

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -369,4 +369,19 @@ describe(`showCaptions`, () => {
     expect($(`figcaption`).text()).toEqual(`some alt`)
     expect(node.value).toMatchSnapshot()
   })
+
+  it(`display nothing as caption if no title or alt`, async () => {
+    const imagePath = `images/my-image.jpeg`
+    const content = `![](./${imagePath})`
+
+    const nodes = await plugin(createPluginOptions(content, imagePath), {
+      showCaptions: true,
+    })
+    expect(nodes.length).toBe(1)
+
+    const node = nodes.pop()
+    const $ = cheerio.load(node.value)
+    expect($(`figcaption`).length).toBe(0)
+    expect(node.value).toMatchSnapshot()
+  })
 })

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -81,10 +81,10 @@ module.exports = (
     }
   }
 
-  const getNodeTitle = (node, alt) => {
+  const getNodeTitle = (node, alt, defaultAlt) => {
     if (node.title) {
       return node.title
-    } else if (alt && alt.length > 0) {
+    } else if (alt && alt.length > 0 && alt !== defaultAlt) {
       return alt
     }
     return ``
@@ -250,7 +250,7 @@ module.exports = (
         : options.wrapperStyle
 
     // Construct new image node w/ aspect ratio placeholder
-    const showCaptions = options.showCaptions && getNodeTitle(node, alt)
+    const showCaptions = options.showCaptions && getNodeTitle(node, alt, defaultAlt)
     let rawHTML = `
   <span
     class="${imageWrapperClass}"
@@ -288,7 +288,8 @@ module.exports = (
     ${rawHTML}
     <figcaption class="gatsby-resp-image-figcaption">${getNodeTitle(
       node,
-      alt
+      alt,
+      defaultAlt
     )}</figcaption>
   </figure>
       `.trim()

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -250,7 +250,8 @@ module.exports = (
         : options.wrapperStyle
 
     // Construct new image node w/ aspect ratio placeholder
-    const showCaptions = options.showCaptions && getNodeTitle(node, alt, defaultAlt)
+    const showCaptions =
+      options.showCaptions && getNodeTitle(node, alt, defaultAlt)
     let rawHTML = `
   <span
     class="${imageWrapperClass}"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixed an issue where captions would show the image filename if no caption/alt was given.

## Related Issues

Fixes #14188