### PR TITLE
fix(docs): Updating Docs so CommonJS syntax with wrapPageElement works

### DIFF
--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -153,7 +153,7 @@ exports.onPreRenderHTML = true
  * @returns {ReactNode} Wrapped element
  * @example
  * const React = require("react")
- * const Layout = require("./src/components/layout")
+ * const Layout = require("./src/components/layout").default
  *
  * exports.wrapPageElement = ({ element, props }) => {
  *   // props provide same data to Layout as Page element will get

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -146,7 +146,7 @@ exports.replaceComponentRenderer = true
  * @returns {ReactNode} Wrapped element
  * @example
  * const React = require("react")
- * const Layout = require("./src/components/layout")
+ * const Layout = require("./src/components/layout").default
  *
  * exports.wrapPageElement = ({ element, props }) => {
  *   // props provide same data to Layout as Page element will get


### PR DESCRIPTION
## Description

As with a discussion in #13667, switching to the CommonJS module syntax for the `wrapPageElement` was not exactly a one to one transition, but @wardpeet helped out and pointed out if you want to import a module that uses the `export default` ESM syntax, you can import such in CommonJS by doing `require('module').default`.

I updated the docs for `wrapPageElement` in gatsby-browser and gatsby-ssr to reflect this.

## Related Issues

Adressess #13667
