### PR TITLE
chore(docs): Explain `setup` field at gatsby-plugin-feed README

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -78,10 +78,11 @@ Each feed must include `output`, `query`, and `title`. Additionally, it is stron
 
 `match` is an optional configuration, indicating which pages will have feed reference included. The accepted types of `match` are `string` or `undefined`. By default, when `match` is not configured, all pages will have feed reference inserted. If `string` is provided, it will be used to build a RegExp and then to test whether `pathname` of current page satisifed this regular expression. Only pages that satisifed this rule will have feed reference included.
 
-All additional options are passed through to the [`rss`][rss] utillity. For more info on those additional options, [explore the `itemOptions` section of the `rss` package](https://www.npmjs.com/package/rss#itemoptions).
+All additional options are merged with `query.site.siteMetadata`, and processed through `setup` option (which is a function). Return value of `setup` is, in turn, passed as a [feedOptions][rss-feedOptions] argument of the [`rss`][rss] utillity. For instance, you can return object containing `site_url` field from `setup` function to set the top-level `<link>` tag of the feed. For more info on those additional options, [explore the `itemOptions` section of the `rss` package](https://www.npmjs.com/package/rss#itemoptions).
 
 Check out an example of [how you could implement](https://www.gatsbyjs.org/docs/adding-an-rss-feed/) to your own site, with a custom `serialize` function, and additional functionality.
 
 _NOTE: This plugin only generates the `xml` file(s) when run in `production` mode! To test your feed, run: `gatsby build && gatsby serve`._
 
 [rss]: https://www.npmjs.com/package/rss
+[rss-feedOptions]: https://github.com/dylang/node-rss#feedoptions


### PR DESCRIPTION
I'm not a native English speaker, so please correct me if there's any awkward sentences/words.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Add an explanation about `setup` field of `gatsby-plugin-feed`.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Closes #14136.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
