### PR TITLE
fix(gatsby-telemetry): enable CI name for unsupported CI & fixed cpu count

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -185,10 +185,10 @@ module.exports = class AnalyticsTracker {
       nodeVersion: process.version,
       platform: os.platform(),
       release: os.release(),
-      cpus: cpus && cpus.length > 0 && cpus[0].model,
+      cpus: (cpus && cpus.length > 0 && cpus[0].model) || undefined,
       arch: os.arch(),
       ci: ci.isCI,
-      ciName: (ci.isCI && ci.name) || undefined,
+      ciName: (ci.isCI && ci.name) || process.env.CI_NAME || undefined,
       docker: isDocker(),
     }
     this.osInfo = osInfo


### PR DESCRIPTION
The ci_name doesn't appear to be a widely adopted standard but will help on a couple of places.