### PR TITLE
[docs] update contributing docs for clarity

### DIFF
--- a/docs/contributing/blog-and-website-contributions.md
+++ b/docs/contributing/blog-and-website-contributions.md
@@ -2,7 +2,7 @@
 title: Blog & Website Contributions
 ---
 
-We wholeheartedly welcome contributions to the Gatsby blog and website! 
+We wholeheartedly welcome contributions to the Gatsby blog and website!
 
 Here are some things to keep in mind when deciding where to contribute to Gatsby:
 

--- a/docs/contributing/blog-and-website-contributions.md
+++ b/docs/contributing/blog-and-website-contributions.md
@@ -2,11 +2,13 @@
 title: Blog & Website Contributions
 ---
 
-We wholeheartedly welcome contributions to the Gatsby blog and website! Instructions on this page:
+We wholeheartedly welcome contributions to the Gatsby blog and website! 
 
-- [Contributing to the blog](#contributing-to-the-blog)
-  - [Blog post format](#blog-post-format)
-- [Making changes to the website](#making-changes-to-the-website)
+Here are some things to keep in mind when deciding where to contribute to Gatsby:
+
+- [Blog posts](#contributing-to-the-blog) work best for case studies and time-sensitive storytelling (see the [blog post format](#blog-post-format)).
+- [Docs](/contributing/docs-contributions/) are more evergreen and discoverable learning materials that go beyond any one case study or situation.
+- [Website changes](#making-changes-to-the-website) that improve either of these are always welcome!
 
 ## Contributing to the blog
 

--- a/docs/contributing/blog-and-website-contributions.md
+++ b/docs/contributing/blog-and-website-contributions.md
@@ -7,7 +7,7 @@ We wholeheartedly welcome contributions to the Gatsby blog and website!
 Here are some things to keep in mind when deciding where to contribute to Gatsby:
 
 - [Blog posts](#contributing-to-the-blog) work best for case studies and time-sensitive storytelling (see the [blog post format](#blog-post-format)).
-- [Docs](/contributing/docs-contributions/) are more evergreen and discoverable learning materials that go beyond any one case study or situation.
+- [Docs](/contributing/docs-contributions/) are more evergreen -- or continually relevant -- and discoverable learning materials that go beyond any one case study or situation.
 - [Website changes](#making-changes-to-the-website) that improve either of these are always welcome!
 
 ## Contributing to the blog

--- a/docs/contributing/blog-and-website-contributions.md
+++ b/docs/contributing/blog-and-website-contributions.md
@@ -7,7 +7,7 @@ We wholeheartedly welcome contributions to the Gatsby blog and website!
 Here are some things to keep in mind when deciding where to contribute to Gatsby:
 
 - [Blog posts](#contributing-to-the-blog) work best for case studies and time-sensitive storytelling (see the [blog post format](#blog-post-format)).
-- [Docs](/contributing/docs-contributions/) are more evergreen -- or continually relevant -- and discoverable learning materials that go beyond any one case study or situation.
+- [Docs](/contributing/docs-contributions/) are continually relevant and discoverable learning materials that go beyond any one case study or situation.
 - [Website changes](#making-changes-to-the-website) that improve either of these are always welcome!
 
 ## Contributing to the blog

--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -19,7 +19,7 @@ On this page:
 
 ## Top priorities
 
-Check the GitHub repo for issues labeled with ["documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or ["documentation" and "help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22help+wanted%22) to see all documentation issues that are ready for community help. Once you start a PR to address one of these issues, you can remove the "help wanted" label. As well, examine the list of articles that haven't been fully fleshed out at the [Stub List](/contributing/stub-list).
+Check the GitHub repo for issues labeled with ["documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or ["documentation" and "help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22help+wanted%22) to see all documentation issues that are ready for community help. Once you start a Pull Request to address one of these issues, you can remove the "help wanted" label. As well, examine the list of articles that haven't been fully fleshed out at the [Stub List](/contributing/stub-list).
 
 ## Options for contributing to the Gatsby docs
 

--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -15,6 +15,8 @@ On this page:
 - [Claim your swag](#claim-your-swag)
 - [Want more?](#want-more)
 
+> _When deciding where to contribute to Gatsby (docs or [blog](/contributing/blog-and-website-contributions/)?), check out the [docs templates](/contributing/docs-templates/) page._
+
 ## Top priorities
 
 Check the GitHub repo for issues labeled with ["documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or ["documentation" and "help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22help+wanted%22) to see all documentation issues that are ready for community help. Once you start a PR to address one of these issues, you can remove the "help wanted" label. As well, examine the list of articles that haven't been fully fleshed out at the [Stub List](/contributing/stub-list).

--- a/docs/contributing/docs-templates.md
+++ b/docs/contributing/docs-templates.md
@@ -13,14 +13,14 @@ title: Docs Templates
 5.  [Plugin README template](#plugin-readme-template)
 6.  [Starter README template](#starter-readme-template)
 
-## The Gatsby Way of writing learning materials
+## The Gatsby way of writing learning materials
 
-Docs guides, recipes, and tutorials are intended to facilitate learning about Gatsby from a variety of perspectives and skill-sets.
+Docs reference guides, recipes, and tutorials teach Gatsby concepts to users with a variety of learning styles and skill-sets.
 
 Here are some things to keep in mind when deciding where to contribute to Gatsby:
 
 - [Blog posts](/contributing/docs-contributions#contributing-to-the-blog) are primarily made for case studies and time-sensitive storytelling.
-- [Reference guides](#reference-guides), in contrast, are evergreen, easy-to-discover documentation articles that go beyond any one case study or situation.
+- [Reference guides](#reference-guides), in contrast, are evergreen -- or continually relevant -- and discoverable documentation articles that go beyond any one case study or situation.
 - [Recipes](#recipes) add concise, easy-to-follow instructions for common Gatsby tasks. They are smaller units than tutorials.
 - [Tutorials](#tutorials) should provide step-by-step guidance for Gatsby workflows, listing all pre-requisites and not assuming knowledge or skipping steps.
 

--- a/docs/contributing/docs-templates.md
+++ b/docs/contributing/docs-templates.md
@@ -6,16 +6,16 @@ title: Docs Templates
 2.  [Reference guides](#reference-guides)
     - [Reference guide template](#reference-guide-template)
     - [Reference guide overview template](#reference-guide-overview-template)
-4.  [Recipes](#recipes)
+3.  [Recipes](#recipes)
     - [Recipe template](#recipe-template)
-5.  [Tutorials](#tutorials)
+4.  [Tutorials](#tutorials)
     - [Tutorial template](#tutorial-template)
-6.  [Plugin README template](#plugin-readme-template)
-7.  [Starter README template](#starter-readme-template)
+5.  [Plugin README template](#plugin-readme-template)
+6.  [Starter README template](#starter-readme-template)
 
 ## The Gatsby Way of writing learning materials
 
-Docs guides, recipes, and tutorials are intended to facilitate learning about Gatsby from a variety of perspectives and skill-sets. 
+Docs guides, recipes, and tutorials are intended to facilitate learning about Gatsby from a variety of perspectives and skill-sets.
 
 Here are some things to keep in mind when deciding where to contribute to Gatsby:
 
@@ -210,20 +210,19 @@ Recipes should be short. If you're finding a recipe is becoming too long to fit 
 ### Recipe template
 
 ````markdown
-
 ## Recipe name
 
 ### Requirements
 
 - A Gatsby site with two page components: `index.js` and `contact.js`
 - The Gatsby <Link /> component
-- The Gatsby CLI method `gatsby develop` 
+- The Gatsby CLI method `gatsby develop`
 
 ### Directions
 
 1. Open the index page component (src/pages/index.js), import the <Link />
-component from Gatsby, add a <Link /> component above the header, and give
-it a `to` property with the value of "/contact/" for the pathname:
+   component from Gatsby, add a <Link /> component above the header, and give
+   it a `to` property with the value of "/contact/" for the pathname:
 
 ```jsx:title=src/pages/index.js
 import React from "react"
@@ -236,11 +235,12 @@ export default () => (
   </div>
 )
 ```
+
 2. Run `gatsby develop` and navigate to the index page. You should have a link
-that takes you to the contact page when clicked!
+   that takes you to the contact page when clicked!
 
 // optional:
-For a working example, check out __this example.__
+For a working example, check out **this example.**
 ````
 
 ## Tutorials

--- a/docs/contributing/docs-templates.md
+++ b/docs/contributing/docs-templates.md
@@ -20,7 +20,7 @@ Docs guides, recipes, and tutorials are intended to facilitate learning about Ga
 Here are some things to keep in mind when deciding where to contribute to Gatsby:
 
 - [Blog posts](/contributing/docs-contributions#contributing-to-the-blog) are primarily made for case studies and time-sensitive storytelling.
-- [Reference guides](#reference-guides), in contrast, are evergreen, easy-to-discover documentation pieces that go beyond any one case study or situation.
+- [Reference guides](#reference-guides), in contrast, are evergreen, easy-to-discover documentation articles that go beyond any one case study or situation.
 - [Recipes](#recipes) add concise, easy-to-follow instructions for common Gatsby tasks. They are smaller units than tutorials.
 - [Tutorials](#tutorials) should provide step-by-step guidance for Gatsby workflows, listing all pre-requisites and not assuming knowledge or skipping steps.
 
@@ -36,7 +36,7 @@ Reference guide articles cover discrete topics as documentation with links to ot
 
 Reference guide sections provide canonical information on how and why to build things with Gatsby for a variety of scenarios.
 
-### What should a guide article be about?
+### What should a reference guide be about?
 
 We need guide articles to describe every concept and task you can accomplish with Gatsby.
 
@@ -46,23 +46,23 @@ Each guide article should explain exactly one concept and that concept should be
 
 [Linking Between Pages](/docs/linking-between-pages/)
 
-### What if I want to include multiple tasks and concepts in a guide article?
+### What if I want to include multiple tasks and concepts in a reference guide?
 
 If you find yourself wanting to include multiple related topics in one article, consider splitting each into its own individual guide and referencing the other topics under sections called “Prerequisites” and/or "Other Resources" sections in the related guide articles.
 
 It’s more ideal to have many articles that cover a broad range of technical topics rather than smashing too many topics into one article.
 
-If you find yourself wanting to teach the reader how to accomplish a series of related tasks, you might want to write a tutorial.
+If you find yourself wanting to teach the reader how to accomplish a series of related tasks, you might want to write a tutorial. For short and super common how-to instructions for a single task, a recipe may work best.
 
 ### When to write a reference guide vs. a tutorial, vs. a recipe?
 
-[Reference guide articles](#reference-guide-template) cover discrete topics as documentation with links to other resources. A reference guide explains a task or concept without the step-by-step context provided by a tutorial or recipe.
+[Reference guide articles](#reference-guide-template) cover discrete topics as documentation while linking to other resources and guides. A reference guide explains a task or concept without the step-by-step context provided by a tutorial or recipe.
 
-[Tutorials](#tutorial-template) guide users through a series of related tasks they can string together successfully, with minimal distractions or detours.
+[Tutorials](#tutorial-template) guide users through a series of related tasks they can string together successfully. Listing prerequisites up front and limiting distractions or links away from the instructions can make a focused tutorial.
 
-[Recipes](#recipe-template) are a happy medium between step-by-step tutorials and crawling the full reference guides, by providing step-by-step guidance for small, common tasks.
+[Recipes](#recipe-template) are a happy medium between step-by-step tutorials and crawling the full reference guides, by providing step-by-step guidance for short, common Gatsby tasks.
 
-### How to choose a guide article topic?
+### How to choose a reference guide topic?
 
 Guide topics should be chosen based on these priorities:
 
@@ -72,7 +72,7 @@ Guide topics should be chosen based on these priorities:
 4.  Articles listed in the "Backlog" or "To prioritize" sections of the [Learning / Devrel Roadmap](https://github.com/gatsbyjs/gatsby/projects/10) on GitHub
 5.  Articles that you or other community members would like to see
 
-### Length of a guide
+### Length of a reference guide
 
 Ideally, a guide's table of contents would fit above the fold on a desktop computer screen. This means the outline is easily consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
 
@@ -124,8 +124,7 @@ If there are disadvantages Gatsby has, state those here as well and any known bu
 
 ## Other resources
 
-If there are other resources you think readers would benefit from or next steps they might want to take after reading your article, add
-them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blogposts, outside tutorials, etc.).
+If there are other resources you think readers would benefit from or next steps they might want to take after reading your article, add them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blog posts, outside tutorials, etc.).
 
 - Link to a blog post
 - Link to a YouTube tutorial
@@ -141,17 +140,17 @@ them at the bottom in an "Other Resources" section. You can also mention here an
 
 [Deploying and Hosting](/docs/deploying-and-hosting/)
 
-### What should a guide overview be about?
+### What should a reference guide overview be about?
 
 Each overview should give a short introduction of its section of the guides and list the relevant subtopics.
 
-### Length of a guide overview article
+### Length of a reference guide overview
 
 Ideally, a guide overview fits above the fold on a desktop computer screen. This means the outline is easily consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
 
-### When should I create a new guide overview article?
+### When should I create a new reference guide overview?
 
-Guide overview articles are essentially new parent categories that help organize all the guide articles. Here’s how to decide if you should create a new guide overview article:
+Guide overview articles are essentially new parent categories that help organize all the reference guides. Here’s how to decide if you should create a new reference guide overview:
 
 1.  [Stub articles](/contributing/stub-list/) (docs that already exist on the site but don't have content in them yet)
 2.  Article sections with the [help wanted and type:documentation](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22type%3A+documentation%22) labels on GitHub
@@ -184,7 +183,7 @@ Assume the reader has basic programming knowledge like the command line, code ed
 
 ## Other resources
 
-- Link to a blogpost
+- Link to a blog post
 - Link to a YouTube tutorial
 - Link to an example site
 - Link to source code for a live site
@@ -196,7 +195,7 @@ Assume the reader has basic programming knowledge like the command line, code ed
 
 ## Recipes
 
-[Docs Recipes](/docs/recipes/) should act as discoverable, concise instructions for completing common Gatsby tasks without having to navigate elsewhere. A recipe should list requirements and a few short steps to complete a task, listing actionable instructions inline and omitting everything else. Recipes are smaller units than tutorials: multiple recipes could be linked from a reference guide or tutorial.
+[Docs Recipes](/docs/recipes/) should act as discoverable, concise instructions for completing common Gatsby tasks without having to navigate elsewhere. A recipe should include requirements and a few short steps to complete a task, listing actionable instructions inline and omitting everything else. Recipes are smaller units than tutorials: multiple recipes could be linked from a reference guide or tutorial.
 
 The components of a recipe are:
 
@@ -330,7 +329,7 @@ If there are more parts to the tutorial, link to the next step here.
 ## Other resources
 
 If there are other resources you think readers would benefit from or next steps they might want to take after reading your article, add
-them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blogposts, outside tutorials, etc.).
+them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blog posts, outside tutorials, etc.).
 
 - Link to a blog post
 - Link to a YouTube tutorial

--- a/docs/contributing/docs-templates.md
+++ b/docs/contributing/docs-templates.md
@@ -21,7 +21,7 @@ Here are some things to keep in mind when deciding where to contribute to Gatsby
 
 - [Blog posts](/contributing/docs-contributions#contributing-to-the-blog) are primarily made for case studies and time-sensitive storytelling.
 - [Reference guides](#reference-guides), in contrast, are evergreen -- or continually relevant -- and discoverable documentation articles that go beyond any one case study or situation.
-- [Recipes](#recipes) add concise, easy-to-follow instructions for common Gatsby tasks. They are smaller units than tutorials.
+- [Recipes](#recipes) add concise, discoverable, and easy-to-follow instructions for common Gatsby tasks. They are smaller units than tutorials.
 - [Tutorials](#tutorials) should provide step-by-step guidance for Gatsby workflows, listing all pre-requisites and not assuming knowledge or skipping steps.
 
 ### Why use templates?
@@ -177,7 +177,7 @@ The section overview should be a 2-5 sentence explanation of the category and an
 
 Assume the reader has basic programming knowledge like the command line, code editors, and beginning familiarity with React and GraphQL concepts. Beyond that assumed knowledge, list any other prerequisites to reading and understanding your article. Does the reader need to read another document first, install a particular plugin, or already know a certain skill? List those things here.
 
-## Guides in this section
+## Reference guides in this section
 
 <GuideList slug={props.slug} />
 
@@ -195,7 +195,9 @@ Assume the reader has basic programming knowledge like the command line, code ed
 
 ## Recipes
 
-[Docs Recipes](/docs/recipes/) should act as discoverable, concise instructions for completing common Gatsby tasks without having to navigate elsewhere. A recipe should include requirements and a few short steps to complete a task, listing actionable instructions inline and omitting everything else. Recipes are smaller units than tutorials: multiple recipes could be linked from a reference guide or tutorial.
+[Docs Recipes](/docs/recipes/) should act as discoverable, concise instructions for completing common Gatsby tasks without having to navigate elsewhere. A recipe should include requirements and a few short steps to complete a task, listing actionable instructions inline and omitting everything else.
+
+Recipes are smaller units than tutorials, each limited to a single feature or task. Multiple recipes could be linked from a reference guide or tutorial, however the content should be consolidated in the Recipes section for discoverability.
 
 The components of a recipe are:
 

--- a/docs/contributing/docs-templates.md
+++ b/docs/contributing/docs-templates.md
@@ -3,69 +3,82 @@ title: Docs Templates
 ---
 
 1.  [Why use templates?](#why-use-templates)
-2.  [Guide](#guide)
-    - [Guide template](#guide-template)
-3.  [Guide overview](#guide-overview)
-    - [Guide overview template](#guide-overview-template)
-4.  [Tutorial](#tutorial)
+2.  [Reference guides](#reference-guides)
+    - [Reference guide template](#reference-guide-template)
+    - [Reference guide overview template](#reference-guide-overview-template)
+4.  [Recipes](#recipes)
+    - [Recipe template](#recipe-template)
+5.  [Tutorials](#tutorials)
     - [Tutorial template](#tutorial-template)
-5.  [Plugin README template](#plugin-readme-template)
-6.  [Starter README template](#starter-readme-template)
+6.  [Plugin README template](#plugin-readme-template)
+7.  [Starter README template](#starter-readme-template)
 
-## The Gatsby Way(TM) of writing guides
+## The Gatsby Way of writing learning materials
+
+Docs guides, recipes, and tutorials are intended to facilitate learning about Gatsby from a variety of perspectives and skill-sets. 
+
+Here are some things to keep in mind when deciding where to contribute to Gatsby:
+
+- [Blog posts](/contributing/docs-contributions#contributing-to-the-blog) are primarily made for case studies and time-sensitive storytelling.
+- [Reference guides](#reference-guides), in contrast, are evergreen, easy-to-discover documentation pieces that go beyond any one case study or situation.
+- [Recipes](#recipes) add concise, easy-to-follow instructions for common Gatsby tasks. They are smaller units than tutorials.
+- [Tutorials](#tutorials) should provide step-by-step guidance for Gatsby workflows, listing all pre-requisites and not assuming knowledge or skipping steps.
 
 ### Why use templates?
 
 Here are templates (models) to follow when contributing to Gatsby docs to ensure that the docs accomplish their purpose. If you have a good reason to deviate from the following template structures, mention those reasons in the PR so others can give proper feedback.
 
-## Guide
+## Reference guides
 
-### What are guide articles?
+### What are reference guide articles?
 
-Guide articles are found under the "Guides" category in the docs.
+Reference guide articles cover discrete topics as documentation with links to other resources. A reference guide explains a Gatsby concept or technique without the step-by-step context provided by a tutorial or recipe.
 
-### Near-perfect example of a guide article
-
-[Add a 404 page](/docs/add-404-page/) is an example of a guide that isn't perfect yet. As you read through this template, take note of where that article can be improved.
+Reference guide sections provide canonical information on how and why to build things with Gatsby for a variety of scenarios.
 
 ### What should a guide article be about?
 
-We need guide articles to describe every task you can accomplish with Gatsby.
+We need guide articles to describe every concept and task you can accomplish with Gatsby.
 
-Each guide article should explain exactly one task and that task should be
-apparent from the article's title.
+Each guide article should explain exactly one concept and that concept should be apparent from the article's title. [Overview guides](#reference-guide-overview) can list child pages to present multiple ways of getting a job done while limiting the scope of each individual article (e.g. Styling Your Site, Using Layout Components, Standard Global CSS Files, etc.)
 
-#### What if I want to include multiple tasks and concepts in a guide article?
+### Near-perfect example of a reference guide
 
-If you find yourself wanting to include multiple related topics in one article, consider splitting each into its own individual guide and referencing the other topics under sections called “Prerequisites” and/or "Other
-Resources" sections in the related guide articles.
+[Linking Between Pages](/docs/linking-between-pages/)
+
+### What if I want to include multiple tasks and concepts in a guide article?
+
+If you find yourself wanting to include multiple related topics in one article, consider splitting each into its own individual guide and referencing the other topics under sections called “Prerequisites” and/or "Other Resources" sections in the related guide articles.
 
 It’s more ideal to have many articles that cover a broad range of technical topics rather than smashing too many topics into one article.
 
 If you find yourself wanting to teach the reader how to accomplish a series of related tasks, you might want to write a tutorial.
 
-#### When to write a guide vs. a tutorial?
+### When to write a reference guide vs. a tutorial, vs. a recipe?
 
-A guide explains a discrete task without the step-by-step context provided by a tutorial.
+[Reference guide articles](#reference-guide-template) cover discrete topics as documentation with links to other resources. A reference guide explains a task or concept without the step-by-step context provided by a tutorial or recipe.
 
-Guides cover the smallest possible topic, while tutorials can cover a series of related tasks that you string together.
+[Tutorials](#tutorial-template) guide users through a series of related tasks they can string together successfully, with minimal distractions or detours.
 
-#### How to choose a guide article topic?
+[Recipes](#recipe-template) are a happy medium between step-by-step tutorials and crawling the full reference guides, by providing step-by-step guidance for small, common tasks.
 
-Topics should be chosen based on these priorities:
+### How to choose a guide article topic?
 
-1.  Stub articles (already exist on the site but just don't have content in them yet)
-2.  Articles requested in the In Progress epics in GitHub Zenhub
-3.  Articles requested in the Roadmap in GitHub Zenhub
-4.  Articles that you or other community members would like to see
+Guide topics should be chosen based on these priorities:
+
+1.  [Stub articles](/contributing/stub-list/) (docs that already exist on the site but don't have content in them yet)
+2.  Articles with the [help wanted and type:documentation](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22type%3A+documentation%22) labels on GitHub
+3.  Articles related to improving [key learning workflows](https://github.com/gatsbyjs/gatsby/issues/13708)
+4.  Articles listed in the "Backlog" or "To prioritize" sections of the [Learning / Devrel Roadmap](https://github.com/gatsbyjs/gatsby/projects/10) on GitHub
+5.  Articles that you or other community members would like to see
 
 ### Length of a guide
 
-Ideally, a guide fits above the fold on the computer screen. This means the entire guide is visible at one glance, so the person viewing the screen doesn't need to scroll to view the whole guide.
+Ideally, a guide's table of contents would fit above the fold on a desktop computer screen. This means the outline is easily consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
 
-If it needs to extend beyond the fold, try to keep it to the length of a piece of 8.5x11" paper (standard US paper size). This is a somewhat arbitrarily chosen standard that will nevertheless help us keep guides short, consistent, and printable should anyone ever want to print a Gatsby book :)
+The content of a reference guide should provide just enough information to be actionable. Linking out to other materials and guides outside of Gatsby's core concepts is recommended to limit the scope to critical and unique parts of Gatsby development.
 
-### Guide template
+### Reference guide template
 
 You can copy and paste the markdown text below and fill it in with your own information
 
@@ -74,25 +87,25 @@ You can copy and paste the markdown text below and fill it in with your own info
 title: Querying Data with GraphQL
 ---
 
-### Introductory paragraph
+## Introductory paragraph
 
 The introductory paragraph should be a 1-2 sentence explanation of the main
 topic and answer the following question:
 
 What is the purpose of this guide?
 
-### Prerequisites (if any)
+## Prerequisites (if any)
 
 If applicable, list any prerequisites to reading and understanding your article. Does the reader need to read another document first, install a particular plugin, or already know a certain skill? List those things here.
 
-### The facts
+## The facts
 
 What are the facts you know about the topic of this guide?
 
 Keep paragraphs short (around 1-4 sentences). People are more likely to read
 several short paragraphs instead of a huge block of text.
 
-### Example
+## Example
 
 Readers will likely use doc articles as a quick reference to look up syntax.
 Articles should have a basic, real-world example that shows common use cases of its syntax.
@@ -103,18 +116,18 @@ Provide at least one example of how the task gets accomplished. A code snippet i
 
 //See this [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code) on how to format code examples
 
-### Gatsby advantages
+## Gatsby advantages
 
 Does Gatsby address this topic uniquely in some way? If so, state the unique advantages Gatsby provides to the user.
 
 If there are disadvantages Gatsby has, state those here as well and any known bugs or issues the Gatsby community is working on.
 
-### Other resources
+## Other resources
 
 If there are other resources you think readers would benefit from or next steps they might want to take after reading your article, add
 them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blogposts, outside tutorials, etc.).
 
-- Link to a blogpost
+- Link to a blog post
 - Link to a YouTube tutorial
 - Link to an example site
 - Link to source code for a live site
@@ -122,7 +135,7 @@ them at the bottom in an "Other Resources" section. You can also mention here an
 - Links to starters
 ```
 
-## Guide overview
+## Reference guide overview
 
 ### Near-perfect example of a guide overview
 
@@ -130,36 +143,30 @@ them at the bottom in an "Other Resources" section. You can also mention here an
 
 ### What should a guide overview be about?
 
-Each overview should give a short overview of its section of the guides and ideally fit “above the fold” (the reader can see the whole guide overview article on desktop without scrolling).
-
-The goal: by skimming over the list of guide overview articles, a person new to Gatsby should get a good overview of what functionality Gatsby is capable of and what they can accomplish with Gatsby.
+Each overview should give a short introduction of its section of the guides and list the relevant subtopics.
 
 ### Length of a guide overview article
 
-Ideally, a guide overview fits above the fold on the computer screen, which means the entire guide is visible in one glance, so the person viewing the screen doesn't need to scroll to view the whole guide.
-
-If it needs to extend beyond the fold, try to keep it to the length of a piece of 8.5x11" paper (standard US paper size). This is a somewhat arbitrarily chosen standard that will nevertheless help us keep guides short, consistent, and printable should anyone ever want to print a Gatsby book :)
+Ideally, a guide overview fits above the fold on a desktop computer screen. This means the outline is easily consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
 
 ### When should I create a new guide overview article?
 
 Guide overview articles are essentially new parent categories that help organize all the guide articles. Here’s how to decide if you should create a new guide overview article:
 
-1.  Stub articles (already exist on the site but just don't have content in them yet)
-2.  Articles requested in the In Progress epics in GitHub Zenhub
-3.  Articles requested in the Roadmap in GitHub Zenhub
-4.  Articles that you or other community members would like to see
+1.  [Stub articles](/contributing/stub-list/) (docs that already exist on the site but don't have content in them yet)
+2.  Article sections with the [help wanted and type:documentation](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22type%3A+documentation%22) labels on GitHub
+3.  Article sections related to improving [key learning workflows](https://github.com/gatsbyjs/gatsby/issues/13708), like "e-commerce"
+4.  Article sections listed in the "Backlog" or "To prioritize" sections of the [Learning / Devrel Roadmap](https://github.com/gatsbyjs/gatsby/projects/10) on GitHub
+5.  Article sections that you or other community members would like to see
 
-## Guide overview template
+## Reference guide overview template
 
 You can copy and paste the markdown text below and fill it in with your own information
 
 ```markdown
 ---
 title: Testing
-overview: true
 ---
-
-## title: Testing
 
 ## Section overview
 
@@ -187,7 +194,58 @@ Assume the reader has basic programming knowledge like the command line, code ed
 
 ---
 
-## Tutorial
+## Recipes
+
+[Docs Recipes](/docs/recipes/) should act as discoverable, concise instructions for completing common Gatsby tasks without having to navigate elsewhere. A recipe should list requirements and a few short steps to complete a task, listing actionable instructions inline and omitting everything else. Recipes are smaller units than tutorials: multiple recipes could be linked from a reference guide or tutorial.
+
+The components of a recipe are:
+
+- The name of the recipe, which should describe a single task
+- Requirements and prerequisites
+- Step-by-step directions
+- A link to a working example
+
+Recipes should be short. If you're finding a recipe is becoming too long to fit on the Docs Recipes page due to including many prerequisites or steps, consider writing a tutorial instead.
+
+### Recipe template
+
+````markdown
+
+## Recipe name
+
+### Requirements
+
+- A Gatsby site with two page components: `index.js` and `contact.js`
+- The Gatsby <Link /> component
+- The Gatsby CLI method `gatsby develop` 
+
+### Directions
+
+1. Open the index page component (src/pages/index.js), import the <Link />
+component from Gatsby, add a <Link /> component above the header, and give
+it a `to` property with the value of "/contact/" for the pathname:
+
+```jsx:title=src/pages/index.js
+import React from "react"
+import { Link } from "gatsby"
+
+export default () => (
+  <div style={{ color: `purple` }}>
+    <Link to="/contact/">Contact</Link>
+    <p>What a world.</p>
+  </div>
+)
+```
+2. Run `gatsby develop` and navigate to the index page. You should have a link
+that takes you to the contact page when clicked!
+
+// optional:
+For a working example, check out __this example.__
+````
+
+## Tutorials
+
+In contrast to recipes and reference guides, tutorials are step-by-step instructions for a series of related Gatsby tasks. Tutorials are grouped into Gatsby Fundamentals and Intermediate Tutorials ("The Gatsby Tutorial"), as well as Advanced Tutorials which can be explored individually as needed.
 
 ### Near perfect example of a tutorial
 
@@ -195,21 +253,15 @@ Assume the reader has basic programming knowledge like the command line, code ed
 
 ### What should a tutorial be about?
 
-We need tutorials to explain how to perform a series of related tasks with Gatsby.
-
-### When to write a guide vs. a tutorial?
-
-A guide explains a discrete task without the step-by-step context provided by a tutorial.
-
-Guides cover the smallest possible topic, while tutorials can cover a series of related tasks that you string together.
+We need tutorials to guide users of all skill levels through performing a series of related tasks with Gatsby.
 
 ### How to choose a tutorial topic?
 
 Topics should be chosen based on these priorities:
 
-1.  Stub articles (already exist on the site but just don't have content in them yet)
-2.  Tutorials requested in the In Progress epics in GitHub Zenhub
-3.  Tutorials requested in the Roadmap in GitHub Zenhub
+1.  Tutorials related to improving [key learning workflows](https://github.com/gatsbyjs/gatsby/issues/13708)
+2.  Tutorials listed in the "Backlog" or "To prioritize" sections of the [Learning / Devrel Roadmap](https://github.com/gatsbyjs/gatsby/projects/10) on GitHub
+3.  Tutorials with the [help wanted and type:documentation](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22type%3A+documentation%22) labels on GitHub
 4.  Tutorials that you or other community members would like to see
 
 ## Length of a tutorial
@@ -224,10 +276,8 @@ You can copy and paste the markdown text below and fill it in with your own info
 
 ```markdown
 ---
-title: Title
+title: How to Create a Decoupled Drupal Site with Gatsby
 ---
-
-## title: How to create a decoupled Drupal site with Gatsby
 
 ## What’s contained in this tutorial?
 
@@ -282,7 +332,7 @@ If there are more parts to the tutorial, link to the next step here.
 If there are other resources you think readers would benefit from or next steps they might want to take after reading your article, add
 them at the bottom in an "Other Resources" section. You can also mention here any resources that helped you write the article (blogposts, outside tutorials, etc.).
 
-- Link to a blogpost
+- Link to a blog post
 - Link to a YouTube tutorial
 - Link to an example site
 - Link to source code for a live site

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -49,9 +49,9 @@ class IndexRoute extends React.Component {
                 Gatsby docs:
                 <ul>
                   <li>
-                    <Link to="/docs/guides/">Guides</Link>: Dive deeper into
-                    different topics around building with Gatsby, like sourcing
-                    data, deployment, and more.
+                    <Link to="/docs/guides/">Reference Guides</Link>: Learn
+                    about the many different topics around building with Gatsby,
+                    like sourcing data, deployment, and more.
                   </li>
                   <li>
                     <Link to="/ecosystem/">Ecosystem</Link>: Check out libraries
@@ -59,8 +59,8 @@ class IndexRoute extends React.Component {
                     community resources.
                   </li>
                   <li>
-                    <Link to="/docs/api-reference/">API Reference</Link>: Learn
-                    more about Gatsby APIs and configuration.
+                    <Link to="/docs/api-reference/">Gatsby API Reference</Link>:
+                    Learn more about Gatsby APIs and configuration.
                   </li>
                   <li>
                     <Link to="/docs/releases-and-migration/">
@@ -74,8 +74,8 @@ class IndexRoute extends React.Component {
                     Read high-level overviews of the Gatsby approach.
                   </li>
                   <li>
-                    <Link to="/docs/behind-the-scenes/">Behind the Scenes</Link>
-                    : Dig into how Gatsby works under the hood.
+                    <Link to="/docs/gatsby-internals/">Gatsby Internals</Link>:
+                    Dig into how Gatsby works behind the scenes.
                   </li>
                   <li>
                     <Link to="/tutorial/advanced-tutorials/">
@@ -91,11 +91,6 @@ class IndexRoute extends React.Component {
                     : Learn tips and tricks for how to explain Gatsby to others
                     at work, so that you have more opportunities to work with
                     Gatsby professionally.
-                  </li>
-                  <li>
-                    <Link to="/contributing/">Contributing</Link>: Find guides
-                    on the Gatsby.js community, code of conduct, and how to get
-                    started contributing.
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
## Description

Since #14071 was merged, I went through the contributing docs for blog posts & docs contributions to distinguish between different kinds of learning materials and update the templates. This formalizes some text around something I've mentioned a few times recently: what should be in a blog post vs. a reference guide article vs. a tutorial:


- [Blog posts](https://www.gatsbyjs.org/contributing/docs-contributions#contributing-to-the-blog) are primarily made for case studies and time-sensitive storytelling.
- [Reference guides](https://www.gatsbyjs.org/contributing/docs-templates#reference-guides), in contrast, are evergreen, easy-to-discover documentation pieces that go beyond any one case study or situation.
- [Recipes](https://www.gatsbyjs.org/contributing/docs-templates#recipes) add concise, easy-to-follow instructions for common Gatsby tasks. They are smaller units than tutorials.
- [Tutorials](https://www.gatsbyjs.org/contributing/docs-templates#tutorials) should provide step-by-step guidance for Gatsby workflows, listing all pre-requisites and not assuming knowledge or skipping steps.

The next step will be to go through the recipes and update them to match the new format (see the `docs-templates.md` page in this PR)!
