### PR TITLE
loader.js getPage -> loadPageSync

### DIFF
--- a/packages/gatsby/cache-dir/api-runner-browser.js
+++ b/packages/gatsby/cache-dir/api-runner-browser.js
@@ -4,7 +4,7 @@ const {
   getResourcesForPathnameSync,
   getResourceURLsForPathname,
   loadPage,
-  getPage,
+  loadPageSync,
 } = require(`./loader`).publicLoader
 
 exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
@@ -24,14 +24,14 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
       return undefined
     }
 
-    // Deprecated April 2019. Use `getPage` instead
+    // Deprecated April 2019. Use `loadPageSync` instead
     args.getResourcesForPathnameSync = getResourcesForPathnameSync
     // Deprecated April 2019. Use `loadPage` instead
     args.getResourcesForPathname = getResourcesForPathname
     // Deprecated April 2019. Use resources passed in `onPostPrefetch` instead
     args.getResourceURLsForPathname = getResourceURLsForPathname
     args.loadPage = loadPage
-    args.getPage = getPage
+    args.loadPageSync = loadPageSync
 
     const result = plugin.plugin[api](args, plugin.options)
     if (result && argTransform) {

--- a/packages/gatsby/cache-dir/ensure-resources.js
+++ b/packages/gatsby/cache-dir/ensure-resources.js
@@ -17,7 +17,7 @@ class EnsureResources extends React.Component {
 
     this.state = {
       location: { ...location },
-      pageResources: loader.getPageOr404(location.pathname),
+      pageResources: loader.loadPageOr404Sync(location.pathname),
     }
   }
 
@@ -34,7 +34,7 @@ class EnsureResources extends React.Component {
 
   static getDerivedStateFromProps({ location }, prevState) {
     if (prevState.location !== location) {
-      const pageResources = loader.getPageOr404(location.pathname)
+      const pageResources = loader.loadPageOr404Sync(location.pathname)
 
       return {
         pageResources,
@@ -60,7 +60,7 @@ class EnsureResources extends React.Component {
   retryResources(nextProps) {
     const { pathname } = nextProps.location
 
-    if (!loader.getPage(pathname)) {
+    if (!loader.loadPageSync(pathname)) {
       // Store the previous and next location before resolving resources
       const prevLocation = this.props.location
       this.nextLocation = nextProps.location

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -330,18 +330,18 @@ const queue = {
       .loadPage(rawPath)
       .then(result =>
         result === null && rawPath !== `/404.html`
-          ? queue.getPage(`/404.html`)
+          ? queue.loadPageSync(`/404.html`)
           : null
       ),
 
-  getPage: rawPath => pathScriptsCache[cleanAndFindPath(rawPath)],
+  loadPageSync: rawPath => pathScriptsCache[cleanAndFindPath(rawPath)],
 
-  getPageOr404: rawPath => {
-    const page = queue.getPage(rawPath)
+  loadPageOr404Sync: rawPath => {
+    const page = queue.loadPageSync(rawPath)
     if (page) {
       return page
     } else if (rawPath !== `/404.html`) {
-      return queue.getPage(`/404.html`)
+      return queue.loadPageSync(`/404.html`)
     } else {
       return null
     }
@@ -352,7 +352,7 @@ const queue = {
   // already loaded into the browser by the time this function is
   // called. Use the resource URLs passed in `onPostPrefetch` instead.
   getResourceURLsForPathname: path => {
-    const pageData = queue.getPage(path)
+    const pageData = queue.loadPageSync(path)
     if (pageData) {
       return createComponentUrls(pageData.componentChunkName)
     } else {
@@ -382,9 +382,9 @@ export const publicLoader = {
   },
   getResourcesForPathnameSync: rawPath => {
     console.warn(
-      `Warning: getResourcesForPathnameSync is deprecated. Use getPage instead`
+      `Warning: getResourcesForPathnameSync is deprecated. Use loadPageSync instead`
     )
-    return queue.getPage(rawPath)
+    return queue.loadPageSync(rawPath)
   },
   getResourceURLsForPathname: pathname => {
     console.warn(
@@ -395,8 +395,8 @@ export const publicLoader = {
 
   // Real methods
   loadPage: queue.loadPage,
-  getPage: queue.getPage,
-  getPageOr404: queue.getPageOr404,
+  loadPageSync: queue.loadPageSync,
+  loadPageOr404Sync: queue.loadPageOr404Sync,
 }
 
 export default queue

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -18,7 +18,7 @@ function maybeRedirect(pathname) {
 
   if (redirect != null) {
     if (process.env.NODE_ENV !== `production`) {
-      const pageResources = loader.getPage(pathname)
+      const pageResources = loader.loadPageSync(pathname)
 
       if (pageResources != null) {
         console.error(

--- a/packages/gatsby/cache-dir/public-page-renderer-dev.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-dev.js
@@ -5,7 +5,7 @@ import loader from "./loader"
 import JSONStore from "./json-store"
 
 const DevPageRenderer = ({ location }) => {
-  const pageResources = loader.getPage(location.pathname)
+  const pageResources = loader.loadPageSync(location.pathname)
   return React.createElement(JSONStore, {
     location,
     pageResources,

--- a/packages/gatsby/cache-dir/public-page-renderer-prod.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-prod.js
@@ -5,7 +5,7 @@ import InternalPageRenderer from "./page-renderer"
 import loader from "./loader"
 
 const ProdPageRenderer = ({ location }) => {
-  const pageResources = loader.getPageOr404(location.pathname)
+  const pageResources = loader.loadPageOr404Sync(location.pathname)
   if (!pageResources) {
     return null
   }

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -54,8 +54,8 @@ class RouteHandler extends React.Component {
       )
     }
 
-    const dev404PageResources = loader.getPage(`/dev-404-page`)
-    const real404PageResources = loader.getPage(`/404.html`)
+    const dev404PageResources = loader.loadPageSync(`/dev-404-page`)
+    const real404PageResources = loader.loadPageSync(`/404.html`)
     let custom404
     if (real404PageResources) {
       custom404 = (


### PR DESCRIPTION
**Note: merges to `per-page-manifest`, not master. See https://github.com/gatsbyjs/gatsby/pull/13004 for more info**

## Description

Renamed `getPage` to `loadPageSync` to be more consistent with js libraries (e.g `fs.readFileSync`).

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004