### PR TITLE
chore(www): update links that went to support to instead go to .com's contact page

### DIFF
--- a/docs/blog/2018-08-13-using-decoupled-drupal-with-gatsby/index.md
+++ b/docs/blog/2018-08-13-using-decoupled-drupal-with-gatsby/index.md
@@ -56,4 +56,4 @@ Using Gatsby together with Drupal offers a powerful, full-featured, open-source,
 - Read [a Drupal agency’s introduction to Gatsby](https://www.mediacurrent.com/what-is-gatsby.js/)
 - Watch [Kyle Mathews’ presentation on Gatsby + Drupal](https://2017.badcamp.net/session/coding-development/beginner/headless-drupal-building-blazing-fast-websites-reactgatsbyjs)
 - Get started with Robert Ngo’s [Decoupling Drupal with Gatsby tutorial](https://evolvingweb.ca/blog/decoupling-drupal-gatsby) and watch his [Evolving Web 2018 Drupal conference presentation](https://www.youtube.com/watch?v=s5kUJRGDz6I).
-- [Get expert help](https://www.gatsbyjs.com/support/#contact-us)
+- [Get in touch with the team](https://www.gatsbyjs.com/contact-us)

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -20,7 +20,7 @@ These sessions are intended for people who:
 - would like to work on an issue or pull request related to Gatsby, or
 - are using Gatsby for a personal, open source, charity or education project
 
-If you're interested in support for a commercial Gatsby project, please [get in touch via the support page](https://www.gatsbyjs.com/support/).
+If you're interested in support for a commercial Gatsby project, please [get in touch via the contact page](https://www.gatsbyjs.com/contact-us/).
 
 We also expect the following from pair programming participants:
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I think the title about sums it up. We aren't directing anyone to the /support page anymore, in favor of /contact-us, there is a redirect on .com that will take care of any other links, but this updates all links (2) to it from .org.
