### PR TITLE
feat(gatsby-image): export TS interfaces of gatsby-image object types

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-interface FixedObject {
+export interface FixedObject {
   width: number
   height: number
   src: string
@@ -11,7 +11,7 @@ interface FixedObject {
   srcSetWebp?: string
 }
 
-interface FluidObject {
+export interface FluidObject {
   aspectRatio: number
   src: string
   srcSet: string


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

When passing optimized images through type-safe components, the need for using gatsby-image object types may emerge.

E.g.:

```tsx
import Img, { FixedObject } from 'gatsby-image';

type UserProps = {
  avatar: FixedObject;
  // ...
};

export default function User({ avatar }: UserProps) {
  return (
    <div>
      <Img fixed={avatar} />
      {/* ... */}
    </div>
  );
}
```