### PR TITLE
fix(PnP): use `require.resolve` on `setBabelPreset`

### DIFF
--- a/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
@@ -9,7 +9,7 @@ describe(`gatsby-plugin-emotion`, () => {
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: `@emotion/babel-preset-css-prop`,
+        name: expect.stringContaining(`@emotion/babel-preset-css-prop`),
         options: {
           sourceMap: true,
           autoLabel: true,
@@ -25,7 +25,7 @@ describe(`gatsby-plugin-emotion`, () => {
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: `@emotion/babel-preset-css-prop`,
+        name: expect.stringContaining(`@emotion/babel-preset-css-prop`),
         options: {
           sourceMap: true,
           autoLabel: true,
@@ -53,7 +53,7 @@ describe(`gatsby-plugin-emotion`, () => {
 
         expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
         expect(actions.setBabelPreset).toHaveBeenCalledWith({
-          name: `@emotion/babel-preset-css-prop`,
+          name: expect.stringContaining(`@emotion/babel-preset-css-prop`),
           options: {
             sourceMap: false,
             autoLabel: false,

--- a/packages/gatsby-plugin-emotion/src/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/gatsby-node.js
@@ -1,6 +1,6 @@
 export const onCreateBabelConfig = ({ actions }, pluginOptions) => {
   actions.setBabelPreset({
-    name: `@emotion/babel-preset-css-prop`,
+    name: require.resolve(`@emotion/babel-preset-css-prop`),
     options: {
       sourceMap: process.env.NODE_ENV !== `production`,
       autoLabel: process.env.NODE_ENV !== `production`,

--- a/packages/gatsby-plugin-flow/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-flow/src/__tests__/gatsby-node.js
@@ -9,7 +9,7 @@ describe(`gatsby-plugin-flow`, () => {
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: `@babel/preset-flow`,
+        name: expect.stringContaining(`@babel/preset-flow`),
       })
     })
   })

--- a/packages/gatsby-plugin-flow/src/gatsby-node.js
+++ b/packages/gatsby-plugin-flow/src/gatsby-node.js
@@ -1,5 +1,5 @@
 export const onCreateBabelConfig = ({ actions }, pluginOptions) => {
   actions.setBabelPreset({
-    name: `@babel/preset-flow`,
+    name: require.resolve(`@babel/preset-flow`),
   })
 }

--- a/packages/gatsby-plugin-glamor/src/gatsby-node.js
+++ b/packages/gatsby-plugin-glamor/src/gatsby-node.js
@@ -11,10 +11,10 @@ exports.onCreateWebpackConfig = ({ actions, plugins }) =>
 // Add Glamor babel plugin
 exports.onCreateBabelConfig = ({ actions }) => {
   actions.setBabelPlugin({
-    name: `glamor/babel-hoist`,
+    name: require.resolve(`glamor/babel-hoist`),
   })
   actions.setBabelPreset({
-    name: `@babel/preset-react`,
+    name: require.resolve(`@babel/preset-react`),
     options: {
       pragma: `Glamor.createElement`,
     },

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -21,7 +21,7 @@ describe(`gatsby-plugin-typescript`, () => {
       }
       onCreateBabelConfig({ actions }, options)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: `@babel/preset-typescript`,
+        name: expect.stringContaining(`@babel/preset-typescript`),
         options,
       })
     })

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -2,7 +2,7 @@ const resolvableExtensions = () => [`.ts`, `.tsx`]
 
 function onCreateBabelConfig({ actions }, options) {
   actions.setBabelPreset({
-    name: `@babel/preset-typescript`,
+    name: require.resolve(`@babel/preset-typescript`),
     options,
   })
 }


### PR DESCRIPTION
## Description

When adding a new Babel plugin or preset to the configuration we first need to send it through `require.resolve` so that the package making the actual require call (Gatsby itself) can know where to find the package (it couldn't know otherwise just with the name except by relying on the hoisting).

## Related Issues

n/a