### PR TITLE
[WIP] Add missing dependencies

### DIFF
--- a/starters/default/package.json
+++ b/starters/default/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "gatsby": "^2.7.1",
     "gatsby-image": "^2.1.0",
+    "gatsby-link": "^2.1.1",
     "gatsby-plugin-manifest": "^2.1.1",
     "gatsby-plugin-offline": "^2.1.1",
     "gatsby-plugin-react-helmet": "^3.0.12",


### PR DESCRIPTION
## Description

The default starter is missing some dependencies

- https://github.com/gatsbyjs/gatsby/blob/master/starters/default/src/components/header.js#L1

## Related Issues


