### PR TITLE
[ gatsby-source-drupal] Losing relationships data if no ID provided.

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -182,6 +182,10 @@ exports.sourceNodes = async (
           } else if (ids[v.data.id]) {
             node.relationships[`${k}___NODE`] = createNodeId(v.data.id)
           }
+          if (typeof node.relationships[`${k}___NODE`] === 'undefined') {
+            // Do not lose relationships data.
+            node.relationships[k] = v.data
+          }
         })
       }
 


### PR DESCRIPTION
In some cases, we are losing relationships data if there no id. Here some example:

I'm using Drupal 8 JSON:API and I need to get images in different sizes from Node. I'm using [Consumer Image Styles](https://www.drupal.org/project/consumer_image_styles) to achieve this, as it has done on Contenta. My changes on a field level transform my JSON to this:

`field_image: {
  data: {...}
  links: {...}
}`

so we are losing this data because we don't have `type` and `id` params. 