### PR TITLE
Add headless CMS integration into plugins slider.

### DIFF
--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -97,6 +97,10 @@ class Plugins extends Component {
                   pluginName: `gatsby-plugin-google-analytics`,
                 },
                 {
+                  text: `a headless CMS integration?`,
+                  pluginName: `gatsby-source-kentico-cloud`,
+                },
+                {
                   text: `Wordpress integration?`,
                   pluginName: `gatsby-source-wordpress`,
                 },


### PR DESCRIPTION
## Description

In the plugins slider, there are various sample plugins and integrations, however, I missed there some headless CMS integration.
