### PR TITLE
tests: fix tests on windows

### DIFF
--- a/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
@@ -1,4 +1,5 @@
 import { onCreateBabelConfig } from "../gatsby-node"
+import * as path from "path"
 
 describe(`gatsby-plugin-emotion`, () => {
   describe(`onCreateBabelConfig`, () => {
@@ -9,7 +10,9 @@ describe(`gatsby-plugin-emotion`, () => {
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: expect.stringContaining(`@emotion/babel-preset-css-prop`),
+        name: expect.stringContaining(
+          path.join(`@emotion`, `babel-preset-css-prop`)
+        ),
         options: {
           sourceMap: true,
           autoLabel: true,
@@ -25,7 +28,9 @@ describe(`gatsby-plugin-emotion`, () => {
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: expect.stringContaining(`@emotion/babel-preset-css-prop`),
+        name: expect.stringContaining(
+          path.join(`@emotion`, `babel-preset-css-prop`)
+        ),
         options: {
           sourceMap: true,
           autoLabel: true,
@@ -53,7 +58,9 @@ describe(`gatsby-plugin-emotion`, () => {
 
         expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
         expect(actions.setBabelPreset).toHaveBeenCalledWith({
-          name: expect.stringContaining(`@emotion/babel-preset-css-prop`),
+          name: expect.stringContaining(
+            path.join(`@emotion`, `babel-preset-css-prop`)
+          ),
           options: {
             sourceMap: false,
             autoLabel: false,

--- a/packages/gatsby-plugin-flow/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-flow/src/__tests__/gatsby-node.js
@@ -1,4 +1,5 @@
 import { onCreateBabelConfig } from "../gatsby-node"
+import * as path from "path"
 
 describe(`gatsby-plugin-flow`, () => {
   describe(`onCreateBabelConfig`, () => {
@@ -9,7 +10,7 @@ describe(`gatsby-plugin-flow`, () => {
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: expect.stringContaining(`@babel/preset-flow`),
+        name: expect.stringContaining(path.join(`@babel`, `preset-flow`)),
       })
     })
   })

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -3,6 +3,7 @@ const {
   onCreateBabelConfig,
   onCreateWebpackConfig,
 } = require(`../gatsby-node`)
+const path = require(`path`)
 
 describe(`gatsby-plugin-typescript`, () => {
   describe(`resolvableExtensions`, () => {
@@ -21,7 +22,7 @@ describe(`gatsby-plugin-typescript`, () => {
       }
       onCreateBabelConfig({ actions }, options)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
-        name: expect.stringContaining(`@babel/preset-typescript`),
+        name: expect.stringContaining(path.join(`@babel`, `preset-typescript`)),
         options,
       })
     })


### PR DESCRIPTION
backslashes be damned

Fixes tests failing after I merged https://github.com/gatsbyjs/gatsby/pull/14288 without waiting for azure CI :(