### PR TITLE
chore(docs): Add note about pageContext being serialized

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -170,4 +170,4 @@ const Page = ({ pageContext }) => {
 export default Page
 ```
 
-Page context is serialized before being passed to pages: this means it can't be used to pass functions into components. 
+Page context is serialized before being passed to pages: this means it can't be used to pass functions into components.

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -169,3 +169,5 @@ const Page = ({ pageContext }) => {
 
 export default Page
 ```
+
+Page context is serialized before being passed to pages: this means it can't be used to pass functions into components. 

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -170,4 +170,4 @@ const Page = ({ pageContext }) => {
 export default Page
 ```
 
-Page context is serialized before being passed to pages: this means it can't be used to pass functions into components.
+Page context is serialized before being passed to pages: This means it can't be used to pass functions into components.


### PR DESCRIPTION
## Description

Add note about `pageContext` serialization to docs. This burned me because I was trying to pass along internationalization catalogs through `pageContext`, and any messages with interpolated variables were being silently stripped.

## Related Issues

n/a