### PR TITLE
feat(gatsby-remark-images): enable relative images in jsx content

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -50,7 +50,7 @@ module.exports = (
   // This will allow the use of html image tags
   // const rawHtmlNodes = select(markdownAST, `html`)
   let rawHtmlNodes = []
-  visitWithParents(markdownAST, `html`, (node, ancestors) => {
+  visitWithParents(markdownAST, [`html`, `jsx`], (node, ancestors) => {
     const inLink = ancestors.some(findParentLinks)
 
     rawHtmlNodes.push({ node, inLink })


### PR DESCRIPTION
Enables image processing for MDX with JSX tags for content such as the example
below.

```html
<figure>
  <img alt="The modularization of the CMS" height="400" src="./modular-cms-architecture.png" />
  <figcaption>
   The modularization of the CMS
  </figcaption>
</figure>
```

Issue can be reproduced without this change by looking at `/` (index.mdx) in this repro repo: https://github.com/ChristopherBiscardi/gatsby-mdx-remark-images-jsx-tags-repro. Note that the markdown syntax works and the JSX does not before this change, and after this change the JSX syntax works as well.