### PR TITLE
chore(showcase): Updated Aman Mittal's portfolio domain

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1472,13 +1472,13 @@
 - title: Timeline Theme Portfolio
   description: |
     I'm Aman Mittal, a software developer.
-  main_url: "http://www.amanhimself.me/"
-  url: "http://www.amanhimself.me/"
+  main_url: "https://amanhimself.dev/"
+  url: "https://amanhimself.dev/"
   categories:
     - Web Development
     - Portfolio
   built_by: Aman Mittal
-  built_by_url: "http://www.amanhimself.me/"
+  built_by_url: "https://amanhimself.dev/"
 - title: Ocean artUp
   description: >
     Science outreach site built using styled-components and Contentful. It


### PR DESCRIPTION
## Description

Running the site showcase validator popped up that Aman's old domain wasn't working but he moved the Gatsby site to a new domain.

@amandeepmittal's website swapped from a .me domain to a .dev domain. Updating the showcase to point to the new location.