### PR TITLE
chore(showcase): Removing Austrilia Bureau Of Meteorology site

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1537,14 +1537,6 @@
   categories:
     - Directory
   featured: false
-- title: Bureau Of Meteorology (beta)
-  description: |
-    Help shape the future of Bureau services
-  url: "https://beta.bom.gov.au/"
-  main_url: "https://beta.bom.gov.au/"
-  categories:
-    - Meteorology
-  featured: false
 - title: Curbside
   description: |
     Connecting Stores with Mobile Customers


### PR DESCRIPTION
## Description

From usage of the Site Showcase Validator, This site is no longer online so I am removing it from the showcase.
