### PR TITLE
fix(www): Sidebar z-index; add „zIndices“ tokens

### DIFF
--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "@emotion/styled"
 import { OutboundLink } from "gatsby-plugin-google-analytics"
 
-import { colors, space, sizes, fonts } from "../utils/presets"
+import { colors, space, sizes, fonts, zIndices } from "../utils/presets"
 
 const horizontalPadding = space[6]
 const backgroundColor = colors.gatsby
@@ -12,7 +12,7 @@ const BannerContainer = styled(`aside`)`
   height: ${sizes.bannerHeight};
   position: fixed;
   width: 100%;
-  z-index: 3;
+  z-index: ${zIndices.banner};
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
 `

--- a/www/src/components/feedback-widget/widget-wrapper.js
+++ b/www/src/components/feedback-widget/widget-wrapper.js
@@ -8,6 +8,7 @@ import {
   radii,
   shadows,
   space,
+  zIndices,
 } from "../../utils/presets"
 
 const boldEntry = keyframes`
@@ -35,7 +36,7 @@ const WrapperDiv = styled(`div`)`
   opacity: 0.5;
   padding: ${space[6]} 0;
   width: 100%;
-  z-index: 2;
+  z-index: ${zIndices.feedbackWidget};
 
   [tabindex="-1"]:focus {
     outline: none;

--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -12,6 +12,7 @@ import {
   shadows,
   sizes,
   fontSizes,
+  zIndices,
 } from "../utils/presets"
 import { breakpointGutter } from "../utils/styles"
 import Banner from "../components/banner"
@@ -103,7 +104,7 @@ class DefaultLayout extends React.Component {
                 bottom: `unset`,
                 minHeight: `100%`,
                 minWidth: `100%`,
-                zIndex: 10,
+                zIndex: zIndices.modal,
                 overflowY: `auto`,
                 backgroundColor: `rgba(255, 255, 255, 0.95)`,
               },

--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -18,6 +18,7 @@ import {
   fontSizes,
   lineHeights,
   fonts,
+  zIndices,
 } from "../utils/presets"
 import { svgStyles } from "../utils/styles"
 
@@ -73,7 +74,7 @@ const MobileNavigation = () => (
         bottom: 0,
         left: 0,
         right: 0,
-        zIndex: 10,
+        zIndex: zIndices.navigation,
         borderTop: `1px solid ${colors.ui.border.subtle}`,
         background: colors.white,
         height: sizes.headerHeight,

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -14,6 +14,7 @@ import {
   mediaQueries,
   sizes,
   fonts,
+  zIndices,
 } from "../utils/presets"
 import { breakpointGutter } from "../utils/styles"
 
@@ -67,7 +68,7 @@ const Navigation = ({ pathname }) => {
         left: 0,
         right: 0,
         top: sizes.bannerHeight,
-        zIndex: 2,
+        zIndex: zIndices.navigation,
         // use this to test if the header items are properly aligned to the logo
         // wordmark
         // "&:before": {

--- a/www/src/components/sidebar/sticky-responsive-sidebar.js
+++ b/www/src/components/sidebar/sticky-responsive-sidebar.js
@@ -10,6 +10,7 @@ import {
   space,
   mediaQueries,
   sizes,
+  zIndices,
 } from "../../utils/presets"
 import { rhythm } from "../../utils/typography"
 import ScrollPositionProvider, {
@@ -120,7 +121,7 @@ const styles = {
     top: 0,
     transition: `opacity ${transition.speed.slow} ${transition.curve.default}`,
     width: 320,
-    zIndex: 10,
+    zIndex: zIndices.sidebar,
     [mediaQueries.md]: {
       height: `calc(100vh - ${sizes.headerHeight} - ${sizes.bannerHeight})`,
       maxWidth: `none`,
@@ -157,7 +158,7 @@ const styles = {
     right: space[6],
     visibility: `visible`,
     width: space[10],
-    zIndex: 20,
+    zIndex: zIndices.sidebarToggleButton,
     [mediaQueries.md]: { display: `none` },
   },
   sidebarToggleButtonInner: {

--- a/www/src/utils/presets.js
+++ b/www/src/utils/presets.js
@@ -11,6 +11,7 @@ import {
   fontSizes,
   transition,
   fonts as fontTokens,
+  zIndices,
 } from "./tokens"
 import { rhythm } from "./typography"
 
@@ -34,4 +35,5 @@ export {
   space,
   fontSizes,
   fonts,
+  zIndices,
 }

--- a/www/src/utils/styles.js
+++ b/www/src/utils/styles.js
@@ -10,6 +10,7 @@ import {
   lineHeights,
   fonts,
 } from "./presets"
+import { zIndices } from "./tokens"
 
 const stripeAnimation = keyframes({
   "0%": { backgroundPosition: `0 0` },
@@ -194,7 +195,7 @@ export const skipLink = {
   padding: 0,
   overflow: `hidden`,
   position: `absolute`,
-  zIndex: 100,
+  zIndex: zIndices.skipLink,
   fontSize: fontSizes[1],
   ":focus": {
     padding: space[4],

--- a/www/src/utils/tokens/index.js
+++ b/www/src/utils/tokens/index.js
@@ -10,6 +10,7 @@ import space from "./space"
 import transition from "./transition"
 import fontSizes from "./font-sizes"
 import fonts from "./fonts"
+import zIndices from "./z-indices"
 
 export {
   breakpoints,
@@ -24,4 +25,5 @@ export {
   transition,
   fontSizes,
   fonts,
+  zIndices,
 }

--- a/www/src/utils/tokens/z-indices.js
+++ b/www/src/utils/tokens/z-indices.js
@@ -1,0 +1,9 @@
+export default {
+  feedbackWidget: 2,
+  navigation: 5,
+  banner: 10,
+  modal: 10,
+  sidebar: 10,
+  sidebarToggleButton: 20,
+  skipLink: 100,
+}


### PR DESCRIPTION
- fix sidebar navigation on mobile being covered by the mobile navigation, a regression I introduced in  #14259 while trying to fix the feedback widget on smaller screens covering the mobile navigation:
![image](https://user-images.githubusercontent.com/21834/58380161-1aab9400-7fae-11e9-97c7-3eb27e7b6e39.png) (note that the last link in the sidebar, "Gatsby REPL", is covered by the mobile navigation)
- add `tokens/z-indices` (as per https://system-ui.com/theme)