### PR TITLE
chore(www): Rm grey bg from blog post prev/next nav and footer

### DIFF
--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -230,7 +230,6 @@ class BlogPostTemplate extends React.Component {
         </Container>
         <div
           css={{
-            background: colors.ui.background,
             borderTop: `1px solid ${colors.ui.border.subtle}`,
             marginTop: space[9],
             [mediaQueries.md]: {


### PR DESCRIPTION
Just works better along the Newsletter signup form right above — before/after:

![image](https://user-images.githubusercontent.com/21834/58422258-69325e80-8092-11e9-962d-701dad687584.png)


![image](https://user-images.githubusercontent.com/21834/58422244-5f106000-8092-11e9-8bf7-f91ba85112c2.png)