### PR TITLE
fix(docs): side bar button style outline

### DIFF
--- a/www/src/components/sidebar/sticky-responsive-sidebar.js
+++ b/www/src/components/sidebar/sticky-responsive-sidebar.js
@@ -159,6 +159,7 @@ const styles = {
     visibility: `visible`,
     width: space[10],
     zIndex: zIndices.sidebarToggleButton,
+    outline: `none`,
     [mediaQueries.md]: { display: `none` },
   },
   sidebarToggleButtonInner: {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

fix mobile side bar button style, remove outline

### Before:
![image](https://user-images.githubusercontent.com/5300359/58430921-12eb0d00-80de-11e9-9bbe-d64c760a3a1e.png)

### After:
![image](https://user-images.githubusercontent.com/5300359/58430953-40d05180-80de-11e9-838b-1a4cb034e3b7.png)


