### PR TITLE
docs: Amend package name

### DIFF
--- a/docs/docs/sourcing-from-the-filesystem.md
+++ b/docs/docs/sourcing-from-the-filesystem.md
@@ -69,7 +69,7 @@ The result is an array of File "nodes" (node is a fancy name for an object in a
 
 ## Transforming File nodes
 
-Once files have been sourced, various "transformer" plugins in the Gatsby ecosystem can then be used to transform File nodes into various other types of data. For example, a JSON file can be sourced using `gatsby-source-plugin`, and then the resulting File nodes can be transformed into JSON nodes using `gatsby-transformer-json`.
+Once files have been sourced, various "transformer" plugins in the Gatsby ecosystem can then be used to transform File nodes into various other types of data. For example, a JSON file can be sourced using `gatsby-source-filesystem`, and then the resulting File nodes can be transformed into JSON nodes using `gatsby-transformer-json`.
 
 ## Further reference and examples
 


### PR DESCRIPTION
It appears that in the section regarding sourcing and transforming JSON data, 'gatsby-source-plugin' is used where 'gatsby-source-filesystem' should have been.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
