### PR TITLE
fix(gatsby-source-mongodb): fix null values

### DIFF
--- a/packages/gatsby-source-mongodb/src/stringify-object-ids.js
+++ b/packages/gatsby-source-mongodb/src/stringify-object-ids.js
@@ -3,16 +3,14 @@ const ObjectID = require(`mongodb`).ObjectID
 module.exports = function stringifyObjectIds(val) {
   if (val instanceof ObjectID) {
     return val.toHexString()
-  } else if (val && typeof val === `object`) {
-    if (Array.isArray(val)) {
-      return val.map(el => stringifyObjectIds(el))
-    } else {
-      const keys = Object.keys(val)
-      return keys.reduce((obj, key) => {
-        obj[key] = stringifyObjectIds(val[key])
-        return obj
-      }, {})
-    }
+  } else if (Array.isArray(val)) {
+    return val.map(el => stringifyObjectIds(el))
+  } else if (val && val.constructor === Object) {
+    const keys = Object.keys(val)
+    return keys.reduce((obj, key) => {
+      obj[key] = stringifyObjectIds(val[key])
+      return obj
+    }, {})
   } else {
     return val
   }

--- a/packages/gatsby-source-mongodb/src/stringify-object-ids.js
+++ b/packages/gatsby-source-mongodb/src/stringify-object-ids.js
@@ -3,7 +3,7 @@ const ObjectID = require(`mongodb`).ObjectID
 module.exports = function stringifyObjectIds(val) {
   if (val instanceof ObjectID) {
     return val.toHexString()
-  } else if (typeof val === `object`) {
+  } else if (val && typeof val === `object`) {
     if (Array.isArray(val)) {
       return val.map(el => stringifyObjectIds(el))
     } else {


### PR DESCRIPTION
## Description

when `preserveObjectIds: true` is enabled this function would throw on line 12 due to a `Object.key` if a value is `null`.

## Related Issues

no issue yet, why open an issue if you could fix it directly 😉