### PR TITLE
chore(starters): add gatsby-starter-default-typescript

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2718,3 +2718,13 @@
     - Styling with SCSS
     - Offline support
     - Web App Manifest
+- url: https://gatsby-starter-default-typescript.netlify.com/
+  repo: https://github.com/andykenward/gatsby-starter-default-typescript
+  description: Starter Default Typescript
+  tags:
+    - typescript
+  features:
+    - TypeScript
+    - Typing generation for GraphQL using GraphQL Code Generator
+    - Comes with React Helmet for adding site meta tags
+    - Based on Gatsby Starter Default

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2722,7 +2722,7 @@
   repo: https://github.com/andykenward/gatsby-starter-default-typescript
   description: Starter Default Typescript
   tags:
-    - typescript
+    - TypeScript
   features:
     - TypeScript
     - Typing generation for GraphQL using GraphQL Code Generator


### PR DESCRIPTION
## Description

Adding a starter forked from gatsby-starter-default but using TypeScript & generates typings for GraphQL using [GraphQL Code Generator](https://graphql-code-generator.com/)
