### PR TITLE
fix(gatsby-source-contentful): Don't set default widths

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -323,7 +323,6 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
     args: {
       width: {
         type: GraphQLInt,
-        defaultValue: 400,
       },
       height: {
         type: GraphQLInt,
@@ -418,7 +417,6 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
     args: {
       maxWidth: {
         type: GraphQLInt,
-        defaultValue: 800,
       },
       maxHeight: {
         type: GraphQLInt,
@@ -546,7 +544,6 @@ exports.extendNodeType = ({ type, store }) => {
       args: {
         width: {
           type: GraphQLInt,
-          defaultValue: 400,
         },
         height: {
           type: GraphQLInt,


### PR DESCRIPTION
This isn't the expected behavior and doesn't track what
gatsby-transformer-sharp does.

Most people do set widths so having the default doesn't affect them
but if you want to constraint the height and not the width, this is
currently impossible as e.g. you set `height: 200` and `width: 400` will
still get set.


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->


<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->