### PR TITLE
fix(gatsby): Find identifiers only in the first argument when extracting queries from useStaticQuery

### DIFF
--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -972,6 +972,116 @@ Map {
     ],
     "kind": "Document",
   },
+  "static-query-hooks.js" => Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "hash": 407706182,
+        "isHook": true,
+        "isStaticQuery": true,
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 29,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 21,
+            "start": 6,
+          },
+          "value": "StaticQueryName",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 29,
+            "start": 22,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 27,
+                "start": 24,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 27,
+                  "start": 24,
+                },
+                "value": "foo",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "text": "query StaticQueryName { foo }",
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
+  "static-query-hooks-with-type-parameter.ts" => Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "hash": 407706182,
+        "isHook": true,
+        "isStaticQuery": true,
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 29,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 21,
+            "start": 6,
+          },
+          "value": "StaticQueryName",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 29,
+            "start": 22,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 27,
+                "start": 24,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 27,
+                  "start": 24,
+                },
+                "value": "foo",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "text": "query StaticQueryName { foo }",
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
 }
 `;
 

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -1082,7 +1082,7 @@ Map {
     ],
     "kind": "Document",
   },
-  "static-query-in-separate-variable.js" => Object {
+  "static-query-hooks-in-separate-variable.js" => Object {
     "definitions": Array [
       Object {
         "directives": Array [],
@@ -1096,7 +1096,7 @@ Map {
         },
         "name": Object {
           "kind": "Name",
-          "value": "staticQueryInSeparateVariableJs3748317405",
+          "value": "staticQueryHooksInSeparateVariableJs3748317405",
         },
         "operation": "query",
         "selectionSet": Object {
@@ -1240,20 +1240,20 @@ Also note that we are currently unable to use queries defined in files other tha
     ],
     Array [
       "
-We were unable to find the declaration of variable \\"strangeQueryName\\", which you passed as the \\"query\\" prop into the useStaticQuery declaration in \\"static-query-not-defined.js\\".
+We were unable to find the declaration of variable \\"strangeQueryName\\", which you passed as the \\"query\\" prop into the useStaticQuery declaration in \\"static-query-hooks-not-defined.js\\".
 
 Perhaps the variable name has a typo?
 
-Also note that we are currently unable to use queries defined in files other than the file where the useStaticQuery is defined. If you're attempting to import the query, please move it into \\"static-query-not-defined.js\\". If being able to import queries from another file is an important capability for you, we invite your help fixing it.
+Also note that we are currently unable to use queries defined in files other than the file where the useStaticQuery is defined. If you're attempting to import the query, please move it into \\"static-query-hooks-not-defined.js\\". If being able to import queries from another file is an important capability for you, we invite your help fixing it.
 ",
     ],
     Array [
       "
-We were unable to find the declaration of variable \\"strangeQueryName\\", which you passed as the \\"query\\" prop into the useStaticQuery declaration in \\"static-query-imported.js\\".
+We were unable to find the declaration of variable \\"strangeQueryName\\", which you passed as the \\"query\\" prop into the useStaticQuery declaration in \\"static-query-hooks-imported.js\\".
 
 Perhaps the variable name has a typo?
 
-Also note that we are currently unable to use queries defined in files other than the file where the useStaticQuery is defined. If you're attempting to import the query, please move it into \\"static-query-imported.js\\". If being able to import queries from another file is an important capability for you, we invite your help fixing it.
+Also note that we are currently unable to use queries defined in files other than the file where the useStaticQuery is defined. If you're attempting to import the query, please move it into \\"static-query-hooks-imported.js\\". If being able to import queries from another file is an important capability for you, we invite your help fixing it.
 ",
     ],
   ],

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -1082,6 +1082,138 @@ Map {
     ],
     "kind": "Document",
   },
+  "static-query-in-separate-variable.js" => Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "hash": 3748317405,
+        "isHook": true,
+        "isStaticQuery": true,
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 47,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "value": "staticQueryInSeparateVariableJs3748317405",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 47,
+            "start": 0,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 46,
+                "start": 2,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 19,
+                  "start": 2,
+                },
+                "value": "allMarkdownRemark",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 46,
+                  "start": 20,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 45,
+                      "start": 22,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 26,
+                        "start": 22,
+                      },
+                      "value": "blah",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 45,
+                        "start": 27,
+                      },
+                      "selections": Array [
+                        Object {
+                          "alias": undefined,
+                          "arguments": Array [],
+                          "directives": Array [],
+                          "kind": "Field",
+                          "loc": Object {
+                            "end": 44,
+                            "start": 29,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 33,
+                              "start": 29,
+                            },
+                            "value": "node",
+                          },
+                          "selectionSet": Object {
+                            "kind": "SelectionSet",
+                            "loc": Object {
+                              "end": 44,
+                              "start": 34,
+                            },
+                            "selections": Array [
+                              Object {
+                                "alias": undefined,
+                                "arguments": Array [],
+                                "directives": Array [],
+                                "kind": "Field",
+                                "loc": Object {
+                                  "end": 42,
+                                  "start": 36,
+                                },
+                                "name": Object {
+                                  "kind": "Name",
+                                  "loc": Object {
+                                    "end": 42,
+                                    "start": 36,
+                                  },
+                                  "value": "cheese",
+                                },
+                                "selectionSet": undefined,
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "text": "{ allMarkdownRemark { blah { node { cheese }}}}",
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
 }
 `;
 
@@ -1106,8 +1238,34 @@ Perhaps the variable name has a typo?
 Also note that we are currently unable to use queries defined in files other than the file where the <StaticQuery> is defined. If you're attempting to import the query, please move it into \\"query-imported.js\\". If being able to import queries from another file is an important capability for you, we invite your help fixing it.
 ",
     ],
+    Array [
+      "
+We were unable to find the declaration of variable \\"strangeQueryName\\", which you passed as the \\"query\\" prop into the useStaticQuery declaration in \\"static-query-not-defined.js\\".
+
+Perhaps the variable name has a typo?
+
+Also note that we are currently unable to use queries defined in files other than the file where the useStaticQuery is defined. If you're attempting to import the query, please move it into \\"static-query-not-defined.js\\". If being able to import queries from another file is an important capability for you, we invite your help fixing it.
+",
+    ],
+    Array [
+      "
+We were unable to find the declaration of variable \\"strangeQueryName\\", which you passed as the \\"query\\" prop into the useStaticQuery declaration in \\"static-query-imported.js\\".
+
+Perhaps the variable name has a typo?
+
+Also note that we are currently unable to use queries defined in files other than the file where the useStaticQuery is defined. If you're attempting to import the query, please move it into \\"static-query-imported.js\\". If being able to import queries from another file is an important capability for you, we invite your help fixing it.
+",
+    ],
   ],
   "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
     Object {
       "type": "return",
       "value": undefined,

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -153,12 +153,12 @@ export default () => {
   const data = useStaticQuery<HomepageQuery>(graphql\`query StaticQueryName { foo }\`);
   return <div>{data.doo}</div>;
 }`,
-    "static-query-missing-argument.js": `import { graphql, useStaticQuery } from 'gatsby'
+    "static-query-hooks-missing-argument.js": `import { graphql, useStaticQuery } from 'gatsby'
 export default () => {
   const data = useStaticQuery();
   return <div>{data.doo}</div>;
 }`,
-    "static-query-in-separate-variable.js": `import React from "react"
+    "static-query-hooks-in-separate-variable.js": `import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 
 const query = graphql\`{ allMarkdownRemark { blah { node { cheese }}}}\`
@@ -167,14 +167,14 @@ export default () => {
   const data = useStaticQuery(query);
   return <div>{data.doo}</div>;
 }`,
-    "static-query-not-defined.js": `import React from "react"
+    "static-query-hooks-not-defined.js": `import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 
 export default () => {
   const data = useStaticQuery(strangeQueryName);
   return <div>{data.pizza}</div>;
 }`,
-    "static-query-imported.js": `import React from "react"
+    "static-query-hooks-imported.js": `import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import strangeQueryName from "./another-file.js"
 

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -143,6 +143,21 @@ export default () => (
     render={data => <div>{data.pizza}</div>}
   />
 )`,
+    "static-query-hooks.js": `import { graphql, useStaticQuery } from 'gatsby'
+export default () => {
+  const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
+  return <div>{data.doo}</div>;
+}`,
+    "static-query-hooks-with-type-parameter.ts": `import { graphql, useStaticQuery } from 'gatsby'
+export default () => {
+  const data = useStaticQuery<HomepageQuery>(graphql\`query StaticQueryName { foo }\`);
+  return <div>{data.doo}</div>;
+}`,
+    "static-query-missing-argument.js": `import { graphql, useStaticQuery } from 'gatsby'
+export default () => {
+const data = useStaticQuery();
+return <div>{data.doo}</div>;
+}`,
   }
 
   const parser = new FileParser()

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -155,8 +155,32 @@ export default () => {
 }`,
     "static-query-missing-argument.js": `import { graphql, useStaticQuery } from 'gatsby'
 export default () => {
-const data = useStaticQuery();
-return <div>{data.doo}</div>;
+  const data = useStaticQuery();
+  return <div>{data.doo}</div>;
+}`,
+    "static-query-in-separate-variable.js": `import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+const query = graphql\`{ allMarkdownRemark { blah { node { cheese }}}}\`
+
+export default () => {
+  const data = useStaticQuery(query);
+  return <div>{data.doo}</div>;
+}`,
+    "static-query-not-defined.js": `import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export default () => {
+  const data = useStaticQuery(strangeQueryName);
+  return <div>{data.pizza}</div>;
+}`,
+    "static-query-imported.js": `import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+import strangeQueryName from "./another-file.js"
+
+export default () => {
+  const data = useStaticQuery(strangeQueryName);
+  return <div>{data.pizza}</div>;
 }`,
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Previously it traversed the whole CallExpression for identifiers and it was picking up identifiers used as type parameters, but now it looks directly at the first argument and sees if it's an `Identifier`.

I've also done the same for the TaggedTemplateExpression case.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #14345.