### PR TITLE
feat(actions): Add Site Showcase Validator Action

### DIFF
--- a/.github/actions/gatsby-site-showcase-validator/Dockerfile
+++ b/.github/actions/gatsby-site-showcase-validator/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:10-slim
+
+LABEL com.github.actions.name="gatsby-site-showcase-validator"
+LABEL com.github.actions.description="Check Gatsby's Site Showcase to validate all sites are built with Gatsby"
+LABEL com.github.actions.icon="monitor"
+LABEL com.github.actions.color="purple"
+
+# Copy the action's code into the container
+COPY . .
+
+# Install dependencies
+RUN yarn
+
+# Start node app
+ENTRYPOINT [ "node", "/index.js" ]

--- a/.github/actions/gatsby-site-showcase-validator/README.md
+++ b/.github/actions/gatsby-site-showcase-validator/README.md
@@ -1,0 +1,5 @@
+# Gatsby Site Showcase Validator
+
+A simple node script that visits and checks all of the sites in the [Site Showcase](https://www.gatsbyjs.org/showcase/) for Gatsby.
+
+Run locally [using act](https://github.com/nektos/act): `act -a "gatsby-site-showcase-validator"`

--- a/.github/actions/gatsby-site-showcase-validator/index.js
+++ b/.github/actions/gatsby-site-showcase-validator/index.js
@@ -1,0 +1,80 @@
+// Load in modules
+const fetch = require("node-fetch")
+const yaml = require("js-yaml")
+const cheerio = require("cheerio")
+const chalk = require("chalk")
+
+async function run() {
+  // Grab down sites.yml
+  let url =
+    "https://raw.githubusercontent.com/gatsbyjs/gatsby/master/docs/sites.yml"
+
+  let yamlStr
+
+  try {
+    yamlStr = await fetch(url).then(resp => resp.text())
+  } catch (err) {
+    console.log(`[Err]: ${err.message}`)
+    process.exit(1)
+  }
+
+  // Parse YAML
+  let parsedYaml = yaml.safeLoad(yamlStr, "utf8")
+
+  let sitesVisited = 0
+  let nonGatsbySiteCount = 0
+  let erroredOut = 0
+  let totalSitesCount = parsedYaml.length
+
+  // Loop over each site
+  for (let site of parsedYaml) {
+    let siteUrl = site.main_url
+
+    let siteHtml
+
+    // Fetch site
+    try {
+      siteHtml = await fetch(siteUrl).then(resp => resp.text())
+    } catch (err) {
+      console.log(
+        `${chalk.red(`[Err]`)}: ${site.title} (${siteUrl}) ran into an error: ${
+          err.message
+        }`
+      )
+      sitesVisited++
+      erroredOut++
+      continue // Skip the rest of the check for this particular site
+    }
+
+    // Pass html into a parser
+    let $ = cheerio.load(siteHtml)
+
+    // Most Gatsby sites have an id of "___gatsby"
+    let gatsbyContainer = $("#___gatsby")
+
+    if (gatsbyContainer.length !== 0) {
+      // The site is a gatsby site don't do anything
+      sitesVisited++
+    } else {
+      // The site is not a gatsby site, print out some info
+      console.log(
+        `${chalk.yellow(`[Notice]`)}: ${
+          site.title
+        } (${siteUrl}) is not a Gatsby site`
+      )
+      sitesVisited++
+      nonGatsbySiteCount++
+    }
+  }
+
+  console.log(
+    chalk.green(
+      `We visited ${sitesVisited}/${totalSitesCount} sites. Out of them, ${nonGatsbySiteCount} sites were not a Gatsby site and ${erroredOut} errored out when visiting it.`
+    )
+  )
+
+  // If there are any non Gatsby sites, fail (non-zero exit code)
+  process.exit(nonGatsbySiteCount > 0 ? 1 : 0)
+}
+
+run()

--- a/.github/actions/gatsby-site-showcase-validator/package.json
+++ b/.github/actions/gatsby-site-showcase-validator/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gatsby-site-showcase-validator-action",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true,
+  "dependencies": {
+    "chalk": "^2.4.2",
+    "cheerio": "^1.0.0-rc.2",
+    "js-yaml": "^3.12.2",
+    "node-fetch": "^2.3.0"
+  },
+  "scripts": {
+    "start": "node ./index.js"
+  }
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -11,3 +11,12 @@ action "high-priority-prs" {
     "SLACK_CHANNEL_ID",
   ]
 }
+
+workflow "Site Showcase Validator workflow" {
+  resolves = ["gatsby-site-showcase-validator"]
+  on = "schedule(0 0 * * *)"
+}
+
+action "gatsby-site-showcase-validator" {
+  uses = "./.github/actions/gatsby-site-showcase-validator"
+}


### PR DESCRIPTION
## Description

This adds my [Gatsby Site Showcase Validator](https://github.com/lannonbr/gatsby-site-showcase-validator) action into the Gatsby repo. It will run on a daily basis.

In the future we can extend this workflow to possibly send messages or auto-open issues, but this is a start to merge the current codebase into the Gatsby repo first and then we can extend it at a later date.

## Related Issues

Closes #12895