### PR TITLE
feat(gatsby): Add `ogv` support to webpack media rule

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -367,7 +367,7 @@ module.exports = async ({
   rules.media = () => {
     return {
       use: [loaders.url()],
-      test: /\.(mp4|webm|wav|mp3|m4a|aac|oga|flac)$/,
+      test: /\.(mp4|webm|ogv|wav|mp3|m4a|aac|oga|flac)$/,
     }
   }
 


### PR DESCRIPTION
`mp4|webm|ogv` combination is the standard for an optimal HTML5 `video` browsers compatibility.

See http://camendesign.co.uk/code/video_for_everybody