### PR TITLE
feat(graphiql-explorer): allow hiding explorer using query param

### DIFF
--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -27,9 +27,6 @@ function locationQuery(params) {
   return (
     `?` +
     Object.keys(params)
-      .filter(function(key) {
-        return Boolean(params[key])
-      })
       .map(function(key) {
         return encodeURIComponent(key) + `=` + encodeURIComponent(params[key])
       })
@@ -42,6 +39,7 @@ const graphqlParamNames = {
   query: true,
   variables: true,
   operationName: true,
+  explorerIsOpen: true,
 }
 const otherParams = {}
 for (var k in parameters) {
@@ -135,9 +133,14 @@ ${queryExample}
 `
 }
 
-const storedExplorerPaneState = window.localStorage
-  ? window.localStorage.getItem(`graphiql:graphiqlExplorerOpen`) !== `false`
-  : true
+const storedExplorerPaneState =
+  typeof parameters.explorerIsOpen !== `undefined`
+    ? parameters.explorerIsOpen === `false`
+      ? false
+      : true
+    : window.localStorage
+    ? window.localStorage.getItem(`graphiql:graphiqlExplorerOpen`) !== `false`
+    : true
 
 class App extends React.Component {
   state = {
@@ -197,6 +200,8 @@ class App extends React.Component {
         newExplorerIsOpen
       )
     }
+    parameters.explorerIsOpen = newExplorerIsOpen
+    updateURL()
     this.setState({ explorerIsOpen: newExplorerIsOpen })
   }
 


### PR DESCRIPTION
it will be useful to control if explorer pane is open for https://www.gatsbyjs.org/docs/graphql-reference/ where it doesn't looks very well if explorer is open (due to iframe being very narrow):
![Screenshot 2019-05-28 at 18 59 36](https://user-images.githubusercontent.com/419821/58498714-e935f280-817e-11e9-884c-a4821cd7df2e.png)
