### PR TITLE
feat(gatsby-remark-copy-linked-files): handle flash object tags

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -210,6 +210,18 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalled()
   })
 
+  it(`can copy flash from object elements with the value attribute`, async () => {
+    const path = `myMovie.swf`
+
+    const markdownAST = remark.parse(
+      `<object type="application/x-shockwave-flash">\n<param name="movie" value="${path}" />\n</object>`
+    )
+
+    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).toHaveBeenCalled()
+  })
+
   it(`can copy HTML videos when some siblings are in ignore extensions`, async () => {
     const path = `videos/sample-video.mp4`
     const path1 = `images/sample-image.jpg`

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -267,6 +267,11 @@ module.exports = (
       `src`
     ).forEach(processUrl)
 
+    // Handle flash embed tags.
+    extractUrlAttributeAndElement($(`object param[value]`), `value`).forEach(
+      processUrl
+    )
+
     // Handle a tags.
     extractUrlAttributeAndElement($(`a[href]`), `href`).forEach(processUrl)
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Closes #14380
