### PR TITLE
fix(gatsby-cli): build successfully without optional dependencies

### DIFF
--- a/packages/gatsby-cli/src/reporter/reporters/index.js
+++ b/packages/gatsby-cli/src/reporter/reporters/index.js
@@ -1,3 +1,4 @@
+const semver = require(`semver`)
 const { isCI } = require(`ci-info`)
 
 let inkExists = false
@@ -6,7 +7,7 @@ try {
   // eslint-disable-next-line no-empty
 } catch (err) {}
 
-if (inkExists && !isCI) {
+if (inkExists && semver.satisfies(process.version, `>=8`) && !isCI) {
   module.exports = require(`./ink`).default
 } else {
   module.exports = require(`./yurnalist`)

--- a/packages/gatsby-cli/src/reporter/reporters/index.js
+++ b/packages/gatsby-cli/src/reporter/reporters/index.js
@@ -1,7 +1,12 @@
-const semver = require(`semver`)
 const { isCI } = require(`ci-info`)
 
-if (semver.satisfies(process.version, `>=8`) && !isCI) {
+let inkExists = false
+try {
+  inkExists = require.resolve(`ink`)
+  // eslint-disable-next-line no-empty
+} catch (err) {}
+
+if (inkExists && !isCI) {
   module.exports = require(`./ink`).default
 } else {
   module.exports = require(`./yurnalist`)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This PR solves the issue raised in #14370, where trying to build the site after installing without optional dependencies will fail due to `ink` not being installed. The change uses the straightforward solution proposed by @wardpeet of ensuring the module exists before using it, and defaulting to yurna in the case that it does not exist.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes #14370
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
