### PR TITLE
fix(gatsby-plugin-google-tagmanager): Properly communicate site title with GTM services

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -29,6 +29,18 @@ plugins: [
 ]
 ```
 
+#### Tracking routes
+
+This plugin will fire a new event called `gatsby-route-change` whenever a route is changed in your Gatsby application. To record this in Google Tag Manager, we will need to add a trigger to the desired tag to listen for the event:
+
+1. Visit the [Google Tag Manager console](https://tagmanager.google.com/) and click on the workspace for your site.
+2. Navigate to the desired tag using the 'Tags' tab of the menu on the right hand side.
+3. Under "Triggering", click the pencil icon, then the "+" button to add a new trigger.
+4. In the "Choose a trigger" window, click on the "+" button again.
+5. Choose the trigger type by clicking the pencil button and clicking "Custom event". For event name, enter `gatsby-route-change`.
+
+This tag will now catch every route change in Gatsby, and you can add Google tag services as you wish to it.
+
 #### Note
 
-Out of the box this plugin will simply load Google Tag Manager on the initial page/app load. It's up to you to fire tags based on changes in your app. To automatically track page changes, in GA for instance, you can configure your tags in GTM to trigger on [History Change](https://support.google.com/tagmanager/answer/7679322?hl=en&ref_topic=7679108).
+Out of the box this plugin will simply load Google Tag Manager on the initial page/app load. It's up to you to fire tags based on changes in your app. See the above "Tracking routes" section for an example.

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -2,5 +2,5 @@ exports.onRouteUpdate = ({ location }) => {
   // wrap inside a timeout to ensure the title has properly been changed
   setTimeout(() => {
     window.dataLayer.push({ event: `gatsby-route-change` })
-  }, 2000)
+  }, 50)
 }

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -1,0 +1,6 @@
+exports.onRouteUpdate = ({ location }) => {
+  // wrap inside a timeout to ensure the title has properly been changed
+  setTimeout(() => {
+    window.dataLayer.push({ event: `gatsby-route-change` })
+  }, 2000)
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This PR registers a Google Tag Manager event that will fire whenever the route in a Gatsby application changes. This fixes a previously described issue (#13968) which led to weird mismatched site titles and routes in Google Analytics. It also updates the documentation to give an example of how to use this event in your Google Analytics to detect Gatsby route changes.

I'm somewhat new to production-level JS development and I know this may not be entirely optimal (the 2000ms delay especially, it was just a number that seemed reasonable since some delay was necessary), so let me know what I can do to make this better!
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes #13968
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
