### PR TITLE
revert gatsby-plugin-offline and update getResourceURLsForPathname

### DIFF
--- a/packages/gatsby/cache-dir/api-runner-browser.js
+++ b/packages/gatsby/cache-dir/api-runner-browser.js
@@ -28,7 +28,6 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
     args.getResourcesForPathnameSync = getResourcesForPathnameSync
     // Deprecated April 2019. Use `loadPage` instead
     args.getResourcesForPathname = getResourcesForPathname
-    // Deprecated April 2019. Use resources passed in `onPostPrefetch` instead
     args.getResourceURLsForPathname = getResourceURLsForPathname
     args.loadPage = loadPage
     args.loadPageSync = loadPageSync

--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -198,11 +198,10 @@ exports.onPrefetchPathname = true
  * Called when prefetching for a pathname is successful. Allows
  * for plugins with custom prefetching logic.
  * @param {object} $0
- * @param {string} $0.path The pathname whose resources have now been prefetched
- * @param {resourceUrls} $0.resourceUrls An array of resource URLs (page data and component) that have been prefetched for this path
+ * @param {string} $0.pathname The pathname whose resources have now been prefetched
  * @param {pluginOptions} pluginOptions
  */
-exports.onPostPrefetch = true
+exports.onPostPrefetchPathname = true
 
 /**
  * Plugins can take over prefetching logic. If they do, they should call this


### PR DESCRIPTION
**Note: merges to `per-page-manifest`, not master. See https://github.com/gatsbyjs/gatsby/pull/13004 for more info**

## Description

Addresses https://github.com/gatsbyjs/gatsby/pull/13004#issuecomment-496310446. For the `per-page-manifest` work, I replaced `onPostPrefetchPathname` with `onPostPrefetch`, which is passed the prefetched resource URLs vs forcing the offline plugin to request them via `getResourceURLsForPathname`. Unfortunately, this broke backwards compatibility, since I removed `onPostPrefetchPathname`, which is a gatsby browser API. At the time, I thought this was necessary, since there's no prefetching of query results by data path anymore. But having reviewed the code again, I realized we can simply pass the prefetch URL for the page-data.json instead.

So this PR reverts all changes to the offline plugin, and updates `getResourceURLsForPathname` to return the page-data.json URL instead of the query result URL.

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004