### PR TITLE
chore(graphql-reference): bump gatsby

### DIFF
--- a/examples/graphql-reference/package.json
+++ b/examples/graphql-reference/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "LekoArts <hello@lekoarts.de>",
   "dependencies": {
-    "gatsby": "^2.7.3",
+    "gatsby": "^2.7.4",
     "gatsby-image": "^2.0.22",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.6",


### PR DESCRIPTION
previous bump happened before graphiql-explorer changes were published - this bump again is to force deps installation in preview runner