### PR TITLE
chore: clean up invalid Markdown

### DIFF
--- a/docs/docs/creating-slugs-for-pages.md
+++ b/docs/docs/creating-slugs-for-pages.md
@@ -36,7 +36,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
 ## Query created slugs
 
-Open refresh Graph_i_QL, then run this GraphQL query to see all your slugs:
+Open refresh GraphiQL, then run this GraphQL query to see all your slugs:
 
 ```graphql
 {

--- a/docs/docs/introducing-graphiql.md
+++ b/docs/docs/introducing-graphiql.md
@@ -2,17 +2,17 @@
 title: Introducing GraphiQL
 ---
 
-In this guide, you'll be learning to use something called Graph_i_QL, a tool that helps you structure GraphQL queries correctly.
+In this guide, you'll be learning to use something called GraphiQL, a tool that helps you structure GraphQL queries correctly.
 
-## What is Graph_i_QL?
+## What is GraphiQL?
 
-Graph_i_QL is the GraphQL integrated development environment (IDE). It's a powerful (and all-around awesome) tool
+GraphiQL is the GraphQL integrated development environment (IDE). It's a powerful (and all-around awesome) tool
 you'll use often while building Gatsby websites.
 
 You can access it when your site's development server is running--normally at
 <http://localhost:8000/___graphql>.
 
-## Example of using Graph_i_QL
+## Example of using GraphiQL
 
 When you have <http://localhost:8000/___graphql> open, it will look something like what this video shows. In the video below, watch someone poke around the built-in `Site` "type" and see what fields are available
 on it—including the `siteMetadata` object.
@@ -22,15 +22,15 @@ on it—including the `siteMetadata` object.
   <p>Your browser does not support the video element.</p>
 </video>
 
-## How to use Graph_i_QL
+## How to use GraphiQL
 
-When the development server is running for one of your Gatsby sites, open Graph_i_QL at <http://localhost:8000/___graphql> and play with your data! Press <kbd>Ctrl + Space</kbd> (or use <kbd>Shift + Space</kbd> as an alternate keyboard shortcut) to bring up the autocomplete window and <kbd>Ctrl + Enter</kbd> to run the GraphQL query.
+When the development server is running for one of your Gatsby sites, open GraphiQL at <http://localhost:8000/___graphql> and play with your data! Press <kbd>Ctrl + Space</kbd> (or use <kbd>Shift + Space</kbd> as an alternate keyboard shortcut) to bring up the autocomplete window and <kbd>Ctrl + Enter</kbd> to run the GraphQL query.
 
-Make sure to check out the Graph_i_QL docs in the upper right-hand corner of the IDE. It's easy to miss them, but they're worth visiting!
+Make sure to check out the GraphiQL docs in the upper right-hand corner of the IDE. It's easy to miss them, but they're worth visiting!
 
 ![A diagram pointing out where to find the GraphiQl docs](images/graphiql-docs.png)
 
 ## Other resources
 
-- See [Tutorial Part 5: Source Plugins](/tutorial/part-five/) for a more complete example of using Graph_i_QL
-- See the [README for Graph_i_QL](https://github.com/graphql/graphiql)
+- See [Tutorial Part 5: Source Plugins](/tutorial/part-five/) for a more complete example of using GraphiQL
+- See the [README for GraphiQL](https://github.com/graphql/graphiql)

--- a/docs/docs/sourcing-from-the-filesystem.md
+++ b/docs/docs/sourcing-from-the-filesystem.md
@@ -8,7 +8,7 @@ This guide will walk you through sourcing data from the filesystem.
 
 This guide assumes that you have a Gatsby project set up. If you need to set up a project, please reference the [Quick Start Guide](https://github.com/gatsbyjs/gatsby/tree/master/docs).
 
-It will also be useful if you are familiar with [Graph_i_QL](/docs/introducing-graphiql/), a tool that helps you structure your queries correctly.
+It will also be useful if you are familiar with [GraphiQL](/docs/introducing-graphiql/), a tool that helps you structure your queries correctly.
 
 ## Using `gatsby-source-filesystem`
 
@@ -43,7 +43,7 @@ module.exports = {
 
 Save the `gatsby-config.js` file, and restart the Gatsby development server.
 
-Open up Graph_i_QL.
+Open up GraphiQL.
 
 If you bring up the autocomplete window, you'll see:
 

--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -7,11 +7,11 @@ typora-copy-images-to: ./
 
 ## What's in this tutorial?
 
-In this tutorial, you'll be learning about how to pull data into your Gatsby site using GraphQL and source plugins. Before you learn about these plugins, however, you'll want to know how to use something called Graph_i_QL, a tool that helps you structure your queries correctly.
+In this tutorial, you'll be learning about how to pull data into your Gatsby site using GraphQL and source plugins. Before you learn about these plugins, however, you'll want to know how to use something called GraphiQL, a tool that helps you structure your queries correctly.
 
-## Introducing Graph_i_QL
+## Introducing GraphiQL
 
-Graph_i_QL is the GraphQL integrated development environment (IDE). It's a powerful (and all-around awesome) tool
+GraphiQL is the GraphQL integrated development environment (IDE). It's a powerful (and all-around awesome) tool
 you'll use often while building Gatsby websites.
 
 You can access it when your site's development server is running—normally at
@@ -24,9 +24,9 @@ You can access it when your site's development server is running—normally at
 
 Here you poke around the built-in `Site` "type" and see what fields are available
 on it—including the `siteMetadata` object you queried earlier. Try opening
-Graph_i_QL and play with your data! Press <kbd>Ctrl + Space</kbd> (or use <kbd>Shift + Space</kbd> as an alternate keyboard shortcut) to bring up
+GraphiQL and play with your data! Press <kbd>Ctrl + Space</kbd> (or use <kbd>Shift + Space</kbd> as an alternate keyboard shortcut) to bring up
 the autocomplete window and <kbd>Ctrl + Enter</kbd> to run the GraphQL query. You'll be
-using Graph_i_QL a lot more through the remainder of the tutorial.
+using GraphiQL a lot more through the remainder of the tutorial.
 
 ## Source plugins
 
@@ -74,7 +74,7 @@ module.exports = {
 }
 ```
 
-Save that and restart the gatsby development server. Then open up Graph_i_QL
+Save that and restart the gatsby development server. Then open up GraphiQL
 again.
 
 If you bring up the autocomplete window, you'll see:
@@ -101,8 +101,8 @@ The result is an array of File "nodes" (node is a fancy name for an object in a
 
 ## Build a page with a GraphQL query
 
-Building new pages with Gatsby often starts in Graph_i_QL. You first sketch out
-the data query by playing in Graph_i_QL then copy this to a React page component
+Building new pages with Gatsby often starts in GraphiQL. You first sketch out
+the data query by playing in GraphiQL then copy this to a React page component
 to start building the UI.
 
 Let's try this.

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -136,7 +136,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 }
 ```
 
-Restart the development server and open or refresh Graph_i_QL. Then run this
+Restart the development server and open or refresh GraphiQL. Then run this
 GraphQL query to see your new slugs.
 
 ```graphql

--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -78,7 +78,7 @@ module.exports = {
 }
 ```
 
-Restart the development server then refresh (or open again) Graph_i_QL and look
+Restart the development server then refresh (or open again) GraphiQL and look
 at the autocomplete:
 
 ![markdown-autocomplete](markdown-autocomplete.png)
@@ -201,7 +201,7 @@ In your index page's GraphQL query, change `allMarkdownRemark` to
 `allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC })`. _Note: There are 3 underscores between `frontmatter` and `date`._ Save
 this and the sort order should be fixed.
 
-Try opening Graph_i_QL and playing with different sort options. You can sort the
+Try opening GraphiQL and playing with different sort options. You can sort the
 `allFile` connection along with other connections.
 
 For more documentation on our query operators, explore our [GraphQL reference guide.](/docs/graphql-reference/)


### PR DESCRIPTION
MDX follows the Markdown spec of not converting contained underscores into `em` tags. This means that we have a few stragglers in the docs that don't look right (e.g. "Graph_i_QL").

This changes those out.