### PR TITLE
fix(gatsby-source-mongodb): fix mapping function signature

### DIFF
--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -2,7 +2,10 @@
   "name": "gatsby-source-mongodb",
   "description": "Source plugin for pulling data into Gatsby from MongoDB collections",
   "version": "2.0.19",
-  "author": "jhermans85@hotmail.com",
+  "authors": [
+    "jhermans85@hotmail.com",
+    "hi@elmar.codes"
+  ],
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },

--- a/packages/gatsby-source-mongodb/src/__tests__/mapping.js
+++ b/packages/gatsby-source-mongodb/src/__tests__/mapping.js
@@ -20,7 +20,6 @@ const params = {
   text: `someText`,
   mediaType: `someMediaType`,
   createContentDigest: jest.fn().mockReturnValue(`contentDigest`),
-  createNode: jest.fn(),
 }
 
 test(`it returns an object`, () => {
@@ -30,8 +29,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
-      params.createContentDigest,
-      params.createNode
+      params.createContentDigest
     )
   ).toHaveProperty(`id`)
   expect(
@@ -40,8 +38,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
-      params.createContentDigest,
-      params.createNode
+      params.createContentDigest
     )
   ).toHaveProperty(`parent`)
   expect(
@@ -50,8 +47,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
-      params.createContentDigest,
-      params.createNode
+      params.createContentDigest
     )
   ).toHaveProperty(`children`)
   expect(
@@ -60,8 +56,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
-      params.createContentDigest,
-      params.createNode
+      params.createContentDigest
     )
   ).toHaveProperty(`internal`)
   expect(
@@ -70,8 +65,7 @@ test(`it returns an object`, () => {
       params.key,
       params.text,
       params.mediaType,
-      params.createContentDigest,
-      params.createNode
+      params.createContentDigest
     )
   ).toHaveProperty(`someKey`)
 })
@@ -95,8 +89,7 @@ test(`it returns a transformed object`, () => {
       params.key,
       params.text,
       params.mediaType,
-      params.createContentDigest,
-      params.createNode
+      params.createContentDigest
     )
   ).toMatchObject(desiredResult)
 })

--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -129,7 +129,7 @@ function createNodes(
                 mediaItemFieldKey,
                 node[mediaItemFieldKey],
                 mapObj[mediaItemFieldKey],
-                createNode
+                createContentDigest
               )
 
               node[`${mediaItemFieldKey}___NODE`] = mappingChildNode.id

--- a/packages/gatsby-source-mongodb/src/mapping.js
+++ b/packages/gatsby-source-mongodb/src/mapping.js
@@ -1,14 +1,7 @@
 const camelCase = require(`lodash.camelcase`)
 const isString = require(`lodash.isstring`)
 
-module.exports = function(
-  node,
-  key,
-  text,
-  mediaType,
-  createContentDigest,
-  createNode
-) {
+module.exports = function(node, key, text, mediaType, createContentDigest) {
   const str = isString(text) ? text : ` `
   const id = `${node.id}${key}MappingNode`
   const mappingNode = {


### PR DESCRIPTION
## Description

In the mapping function (`map: {...}` in options), there was a mismatch of the function parameter.

Used `createNode` in place of `createContentDigest`.

## Related Issues

#13293