### PR TITLE
chore(www): enable cross-domain measurement for google analytics

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -202,6 +202,7 @@ module.exports = {
       options: {
         trackingId: GA.identifier,
         anonymize: true,
+        allowLinker: true,
       },
     },
     {

--- a/www/gatsby-ssr.js
+++ b/www/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react"
 import wrapRoot from "./wrap-root-element"
 
-export const onRenderBody = ({ setHeadComponents }) => {
+export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
   setHeadComponents([
     <link
       rel="dns-prefetch"
@@ -12,6 +12,22 @@ export const onRenderBody = ({ setHeadComponents }) => {
       rel="dns-prefetch"
       key="dns-prefetch-google-analytics"
       href="https://www.google-analytics.com"
+    />,
+  ])
+
+  const attachCode = `
+  if (ga) {
+    ga('require', 'linker');
+    ga('linker:autoLink', ['gatsbyjs.com']);
+  }`
+
+  // use with the `allowLinker` option of gatsby-plugin-google-analytics
+  setPostBodyComponents([
+    <script
+      key="ga-linker"
+      dangerouslySetInnerHTML={{
+        __html: attachCode,
+      }}
     />,
   ])
 }


### PR DESCRIPTION
## Description

This will be paired with a similar change on gatsbyjs.com

Note: please review (and approve :) ) but don't merge yet.