### PR TITLE
chore(docs): Add partiallyActive to unit testing docs

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -139,6 +139,7 @@ module.exports = {
       activeStyle,
       getProps,
       innerRef,
+      partiallyActive,
       ref,
       replace,
       to,


### PR DESCRIPTION
Currently the `partiallyActive` prop on `gatsby-link` is not included in the list of props that are invalid for an `a` tag in the gatsby mocks for unit tests. When using this prop, unit tests will add `partiallyActive` to `a` tags which causes React to throw warnings as the tests are run.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
