### PR TITLE
Misc per-page-manifest fixes

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/1-production.js
+++ b/e2e-tests/production-runtime/cypress/integration/1-production.js
@@ -83,6 +83,13 @@ describe(`Production build tests`, () => {
       .should(`exist`)
   })
 
+  it(`should pass pathContext to props`, () => {
+    cy.visit(`/path-context`).waitForRouteChange()
+
+    // `bar` is set in gatsby-node createPages
+    cy.getTestElement(`path-context-foo`).contains(`bar`)
+  })
+
   it(`Uses env vars`, () => {
     cy.visit(`/env-vars`).waitForRouteChange()
 

--- a/e2e-tests/production-runtime/gatsby-node.js
+++ b/e2e-tests/production-runtime/gatsby-node.js
@@ -1,17 +1,30 @@
 exports.onCreatePage = ({ page, actions }) => {
-  if (page.path === `/client-only-paths/`) {
-    // create client-only-paths
-    page.matchPath = `/client-only-paths/*`
-    actions.createPage(page)
-  } else if (page.path === `/`) {
-    // use index page as template
-    // (mimics)
-    actions.createPage({
-      ...page,
-      path: `/duplicated`,
-      context: {
-        DOMMarker: `duplicated`,
-      },
-    })
+  switch (page.path) {
+    case `/client-only-paths/`:
+      // create client-only-paths
+      page.matchPath = `/client-only-paths/*`
+      actions.createPage(page)
+      break
+
+    case `/path-context/`:
+      actions.createPage({
+        ...page,
+        context: {
+          foo: `bar`,
+        },
+      })
+      break
+
+    case `/`:
+      // use index page as template
+      // (mimics)
+      actions.createPage({
+        ...page,
+        path: `/duplicated`,
+        context: {
+          DOMMarker: `duplicated`,
+        },
+      })
+      break
   }
 }

--- a/e2e-tests/production-runtime/src/pages/index.js
+++ b/e2e-tests/production-runtime/src/pages/index.js
@@ -51,6 +51,11 @@ const IndexPage = ({ pageContext }) => (
           Compilation Hash Page
         </Link>
       </li>
+      <li>
+        <Link to="/path-context/" data-testid="path-context">
+          Path Context
+        </Link>
+      </li>
     </ul>
   </Layout>
 )

--- a/e2e-tests/production-runtime/src/pages/path-context.js
+++ b/e2e-tests/production-runtime/src/pages/path-context.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import Layout from '../components/layout'
+import InstrumentPage from '../utils/instrument-page'
+
+const PathContextPage = ({ pathContext }) => (
+  <Layout>
+    <h1>Hello from a page that uses the old pathContext</h1>
+    <p>It was deprecated in favor of pageContext, but is still supported</p>
+    <p>
+      page.pathContext.foo =
+      <span data-testid="path-context-foo">{pathContext.foo}</span>
+    </p>
+  </Layout>
+)
+
+export default InstrumentPage(PathContextPage)

--- a/packages/gatsby/cache-dir/__tests__/static-entry.js
+++ b/packages/gatsby/cache-dir/__tests__/static-entry.js
@@ -1,5 +1,6 @@
 import React from "react"
 import fs from "fs"
+const { join } = require(`path`)
 
 import DevelopStaticEntry from "../develop-static-entry"
 
@@ -33,7 +34,10 @@ jest.mock(
 const MOCK_FILE_INFO = {
   [`${process.cwd()}/public/webpack.stats.json`]: `{}`,
   [`${process.cwd()}/public/chunk-map.json`]: `{}`,
-  [`${process.cwd()}/public/page-data/about/page-data.json`]: JSON.stringify({
+  [join(
+    process.cwd(),
+    `/public/page-data/about/page-data.json`
+  )]: JSON.stringify({
     componentChunkName: `page-component---src-pages-test-js`,
     path: `/about/`,
     webpackCompilationHash: `1234567890abcdef1234`,

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -152,6 +152,8 @@ export default (pagePath, callback) => {
       const props = {
         ...this.props,
         ...pageData.result,
+        // pathContext was deprecated in v2. Renamed to pageContext
+        pathContext: pageData.result ? pageData.result.pageContext : undefined,
       }
 
       const pageElement = createElement(


### PR DESCRIPTION
**Note: merges to `per-page-manifest`, not master. See https://github.com/gatsbyjs/gatsby/pull/13004 for more info**

## Description

1. Fixes failing `cache-dir/static-entry` tests on windows.
2. Adds `pathContext` back into the `static-entry.RouteHandler`. This was a regression, reported here: https://github.com/gatsbyjs/gatsby/pull/14359#issuecomment-496798210

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004