### PR TITLE
Handle types wrapped in js array in createResolvers

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -489,8 +489,13 @@ const addCustomResolveFunctions = async ({ schemaComposer, parentSpan }) => {
             const originalFieldConfig = tc.getFieldConfig(fieldName)
             const originalTypeName = originalFieldConfig.type.toString()
             const originalResolver = originalFieldConfig.resolve
-            const fieldTypeName =
-              fieldConfig.type && fieldConfig.type.toString()
+            let fieldTypeName
+            if (fieldConfig.type) {
+              fieldTypeName = Array.isArray(fieldConfig.type)
+                ? stringifyArray(fieldConfig.type)
+                : fieldConfig.type.toString()
+            }
+
             if (
               !fieldTypeName ||
               fieldTypeName.replace(/!/g, ``) ===
@@ -737,6 +742,11 @@ const reportParsingError = error => {
     throw error
   }
 }
+
+const stringifyArray = arr =>
+  `[${arr.map(item =>
+    Array.isArray(item) ? stringifyArray(item) : item.toString()
+  )}]`
 
 // TODO: Import this directly from graphql-compose once we update to v7
 const isNamedTypeComposer = type =>


### PR DESCRIPTION
When providing a field config to `createResolvers`, a list `type` can be passed as either `"[String]"` (brackets are part of the string), or `["String"]`. When checking if the provided type equals the defined type, we currently only handle the first, but not the second case (because `[].toString()` does not include brackets)