### PR TITLE
chore(docs): Fix broken anchor link

### DIFF
--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -18,7 +18,7 @@ support for MDX so you can start your blog. The posts will live in
 - [Add MDX files](#add-mdx-files)
 - [Generate slugs](#generate-slugs)
 - [Create pages](#create-pages-from-sourced-mdx-files)
-- [Make a template](#make-a-template-for-your-post)
+- [Make a template](#make-a-template-for-your-posts)
 
 ## Source MDX pages from the filesystem
 


### PR DESCRIPTION
## Description

* Fixes broken anchor link to `Make a template for your posts` section on MDX documentation.

## Related Issues

* N/A