### PR TITLE
chore(docs): add contributing examples note; move schema customization, etc.

### DIFF
--- a/docs/contributing/code-contributions.md
+++ b/docs/contributing/code-contributions.md
@@ -9,6 +9,7 @@ On this page:
 - [Repo setup](#repo-setup)
 - [Creating your own plugins and loaders](#creating-your-own-plugins-and-loaders)
 - [Making changes to the starter Library](#making-changes-to-the-starter-library)
+- [Contributing example sites](#contributing-example-sites)
 - [Using Docker to set up test environments](#using-docker-to-set-up-test-environments)
 - [Development tools](#development-tools)
 
@@ -39,6 +40,12 @@ GITHUB_API_TOKEN=YOUR_TOKEN_HERE
 ```
 
 The `.env.development` file is ignored by git. Your token should never be committed.
+
+## Contributing example sites
+
+Gatsby's policy is that "Using" example sites (like those in the [examples part of the repo](https://github.com/gatsbyjs/gatsby/tree/master/examples)) should only be around plugins that are maintained by the core team as it's hard to keep things up to date otherwise.
+
+To contribute example sites, it is recommended to create your own GitHub repo and link to it from your source plugin, etc.
 
 ## Using Docker to set up test environments
 

--- a/docs/docs/gatsby-internals.md
+++ b/docs/docs/gatsby-internals.md
@@ -1,5 +1,5 @@
 ---
-title: Gatsby Internals
+title: Behind the Scenes with Gatsby Internals
 ---
 
 Curious how Gatsby works under the hood? The pages in this section describe how a Gatsby build works from an internal code/architecture point of view. It should be useful for anyone who needs to work on the internals of Gatsby, or for those who are simply curious how it all works, or perhaps you're a plugin author and need to understand how core works to track down a bug? Come one, come all!

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -146,8 +146,6 @@
               link: /docs/adding-markdown-pages/
             - title: Adding a List of Markdown Blog Posts
               link: /docs/adding-a-list-of-markdown-blog-posts/
-        - title: Customizing the GraphQL Schema
-          link: /docs/schema-customization/
         - title: Plugins
           link: /docs/plugins/
           items:
@@ -358,6 +356,8 @@
           link: /docs/node-model/
         - title: Node Interface
           link: /docs/node-interface/
+        - title: Customizing the GraphQL Schema
+          link: /docs/schema-customization/
         - title: API Philosophy
           link: /docs/api-specification/
     - title: Releases & Migration


### PR DESCRIPTION
## Description

I had a few of these small changes stashed on my machine, so I grouped them into one PR.

- Added "Behind the Scenes" to the page title for the Gatsby Internals doc
- Added a note about contributing examples, in reference to #14291
- Moved Schema Customization into the Gatsby API section of the sidebar (cc @freiksenet @stefanprobst)