### PR TITLE
fix(gatsby-source-contentful): add query to the subsequent api call

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -153,6 +153,7 @@ function pagedGet(
         method,
         query,
         skip + pageLimit,
+        pageLimit,
         aggregatedResponse
       )
     }

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -148,7 +148,13 @@ function pagedGet(
       aggregatedResponse.items = aggregatedResponse.items.concat(response.items)
     }
     if (skip + pageLimit <= response.total) {
-      return pagedGet(client, method, skip + pageLimit, aggregatedResponse)
+      return pagedGet(
+        client,
+        method,
+        query,
+        skip + pageLimit,
+        aggregatedResponse
+      )
     }
     return aggregatedResponse
   })


### PR DESCRIPTION
## Description

PR adds a missing argument `query` to the `pagedGet` invocation. See definition on [L134](https://github.com/gatsbyjs/gatsby/pull/14449/files#diff-6e25753afbe27b5e9223708cc884666fL134)

