### PR TITLE
fix(gatsby-source-shopify): Fix empty result error

### DIFF
--- a/packages/gatsby-source-shopify/src/lib.js
+++ b/packages/gatsby-source-shopify/src/lib.js
@@ -1,6 +1,6 @@
 import { GraphQLClient } from "graphql-request"
 import prettyjson from "prettyjson"
-import { get, last } from "lodash/fp"
+import { get, getOr, last } from "lodash/fp"
 
 /**
  * Create a Shopify Storefront GraphQL client for the provided name and token.
@@ -43,8 +43,7 @@ export const queryAll = async (
   aggregatedResponse = null
 ) => {
   const data = await queryOnce(client, query, first, after)
-
-  const edges = get([...path, `edges`], data)
+  const edges = getOr([], [...path, `edges`], data)
   const nodes = edges.map(edge => edge.node)
 
   aggregatedResponse = aggregatedResponse


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Return an empty array instead of undefined when preparing an empty query result

## Related Issues
fixes #14450, fixes #14420