### PR TITLE
fix(telemetry): Ensure we strip paths with additional layer of `\` escaping

### DIFF
--- a/packages/gatsby-telemetry/src/__tests__/error-helpers.js
+++ b/packages/gatsby-telemetry/src/__tests__/error-helpers.js
@@ -52,7 +52,7 @@ describe(`Errors Helpers`, () => {
         expect.stringContaining(errormessage)
       )
       expect(sanitizedErrorString).toEqual(
-        expect.not.stringContaining(process.cwd())
+        expect.not.stringContaining(process.cwd().replace(`\\`, `\\\\`))
       )
     })
 

--- a/packages/gatsby-telemetry/src/error-helpers.js
+++ b/packages/gatsby-telemetry/src/error-helpers.js
@@ -1,18 +1,19 @@
 const { sep } = require(`path`)
 
 // Removes all user paths
+const regexpEscape = str => str.replace(/[-[/{}()*+?.\\^$|]/g, `\\$&`)
 const cleanPaths = (str, separator = sep) => {
   const stack = process.cwd().split(separator)
 
-  // windows still has the 'C:' but unix has '' but C:
-  // is not a big deal so we'll let it slip
   while (stack.length > 1) {
     const currentPath = stack.join(separator)
-    const currentRegex = new RegExp(
-      currentPath.replace(/[-[/{}()*+?.\\^$|]/g, `\\$&`),
-      `g`
-    )
+    const currentRegex = new RegExp(regexpEscape(currentPath), `g`)
     str = str.replace(currentRegex, `$SNIP`)
+
+    const currentPath2 = stack.join(separator + separator)
+    const currentRegex2 = new RegExp(regexpEscape(currentPath2), `g`)
+    str = str.replace(currentRegex2, `$SNIP`)
+
     stack.pop()
   }
   return str


### PR DESCRIPTION
Depending on how/where we capture events and errors with paths. The path separators might be escaped once or twice. 
This PR works around it by in a bit hacky way but it seems to be working well with both Linux and Windows (although / is less likely to be escaped)