### PR TITLE
Fix the __experimentalThemes namespace

### DIFF
--- a/docs/tutorial/writing-documentation-with-docz.md
+++ b/docs/tutorial/writing-documentation-with-docz.md
@@ -35,7 +35,11 @@ Define `docz-theme-default` as a theme inside the `__experimentalThemes` of `gat
 ```js:title=gatsby-config.js
 module.exports = {
   //highlight-next-line
-  __experimentalThemes: [`gatsby-theme-docz`],
+  __experimentalThemes: [
+    {
+      resolve: "gatsby-theme-docz",
+    },
+  ],
   plugins: [`// your plugins go here`],
 }
 ```


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
If I declare the theme like the following
```
__experimentalThemes: [`gatsby-theme-docz`]
```

It will show up the Gatsby Default Starter pages instead of the Docz pages

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
