### PR TITLE
chore(gatsby-dev-cli): wrap ignore pattern in quotes (build scripts)

### DIFF
--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -37,9 +37,9 @@
   "main": "index.js",
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli",
   "scripts": {
-    "build": "babel src --out-dir dist --ignore **/__tests__",
+    "build": "babel src --out-dir dist --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "babel -w src --out-dir dist --ignore **/__tests__"
+    "watch": "babel -w src --out-dir dist --ignore \"**/__tests__\""
   }
 }


### PR DESCRIPTION
This is pretty confusing issue - before this change, something replaces ignore pattern with something else:

```
$ babel src --out-dir dist --ignore **/__tests__
entry [ '/Users/misiek/.nvm/versions/node/v10.9.0/bin/node',
  '/Users/misiek/dev/gatsby/packages/gatsby-dev-cli/node_modules/.bin/babel',
  'src',
  '--out-dir',
  'dist',
  '--ignore',
  'src/__tests__' ]
```
See `src/__tests__` instead of `**/__tests`. In some cases this would cause broken releases - i.e. https://unpkg.com/gatsby-dev-cli@2.4.16/dist/watch.js - watch file is not the code there it's compiled tests (wat).

wrapping pattern in quotes (or using `--ignore=pattern`) fixes this:
```
$ babel src --out-dir dist --ignore "**/__tests__"
entry [ '/Users/misiek/.nvm/versions/node/v10.9.0/bin/node',
  '/Users/misiek/dev/gatsby/packages/gatsby-dev-cli/node_modules/.bin/babel',
  'src',
  '--out-dir',
  'dist',
  '--ignore',
  '**/__tests__' ]
```
so let's go with that

More things that are confusing - this seems to happen only with `gatsby-dev-cli` - most of our packages use same build script but it doesn't happen there 🤷‍♂ 