### PR TITLE
feat(gatsby-source-shopify): add configurable 'paginationSize' parameter

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -52,6 +52,11 @@ plugins: [
       // much time was required to fetch and process the data.
       // Defaults to true.
       verbose: true,
+
+      // Number of records to fetch on each request when building the cache
+      // at startup. If your application encounters timeout errors during
+      // startup, try decreasing this number.
+      initialQuerySize: 250,
     },
   },
 ]

--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -56,7 +56,7 @@ plugins: [
       // Number of records to fetch on each request when building the cache
       // at startup. If your application encounters timeout errors during
       // startup, try decreasing this number.
-      initialQuerySize: 250,
+      paginationSize: 250,
     },
   },
 ]

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -24,7 +24,7 @@ import {
 
 export const sourceNodes = async (
   { actions: { createNode, touchNode }, createNodeId, store, cache },
-  { shopName, accessToken, verbose = true, initialQuerySize = 250 }
+  { shopName, accessToken, verbose = true, paginationSize = 250 }
 ) => {
   const client = createClient(shopName, accessToken)
 
@@ -46,7 +46,7 @@ export const sourceNodes = async (
       formatMsg,
       verbose,
       imageArgs,
-      initialQuerySize,
+      paginationSize,
     }
 
     // Message printed when fetching is complete.
@@ -94,7 +94,7 @@ const createNodes = async (
   endpoint,
   query,
   nodeFactory,
-  { client, createNode, formatMsg, verbose, imageArgs, initialQuerySize },
+  { client, createNode, formatMsg, verbose, imageArgs, paginationSize },
   f = async () => {}
 ) => {
   // Message printed when fetching is complete.
@@ -102,7 +102,7 @@ const createNodes = async (
 
   if (verbose) console.time(msg)
   await forEach(
-    await queryAll(client, [`shop`, endpoint], query, initialQuerySize),
+    await queryAll(client, [`shop`, endpoint], query, paginationSize),
     async entity => {
       const node = await nodeFactory(imageArgs)(entity)
       createNode(node)

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -24,7 +24,7 @@ import {
 
 export const sourceNodes = async (
   { actions: { createNode, touchNode }, createNodeId, store, cache },
-  { shopName, accessToken, verbose = true }
+  { shopName, accessToken, verbose = true, initialQuerySize = 250 }
 ) => {
   const client = createClient(shopName, accessToken)
 
@@ -46,6 +46,7 @@ export const sourceNodes = async (
       formatMsg,
       verbose,
       imageArgs,
+      initialQuerySize,
     }
 
     // Message printed when fetching is complete.
@@ -93,7 +94,7 @@ const createNodes = async (
   endpoint,
   query,
   nodeFactory,
-  { client, createNode, formatMsg, verbose, imageArgs },
+  { client, createNode, formatMsg, verbose, imageArgs, initialQuerySize },
   f = async () => {}
 ) => {
   // Message printed when fetching is complete.
@@ -101,7 +102,7 @@ const createNodes = async (
 
   if (verbose) console.time(msg)
   await forEach(
-    await queryAll(client, [`shop`, endpoint], query),
+    await queryAll(client, [`shop`, endpoint], query, initialQuerySize),
     async entity => {
       const node = await nodeFactory(imageArgs)(entity)
       createNode(node)


### PR DESCRIPTION
## Description

Cache building queries at startup result in timeouts. This PR adds a configurable "first" parameter to allow developers to reduce the "first" parameter on the GraphQL queries to Shopify.

## Related Issues

[Addresses #14300](https://github.com/gatsbyjs/gatsby/issues/14300)
