### PR TITLE
feat(gatsby): update graphiql-explorer

### DIFF
--- a/packages/gatsby-graphiql-explorer/package.json
+++ b/packages/gatsby-graphiql-explorer/package.json
@@ -27,12 +27,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.0.0",
-    "graphiql": "^0.13.0",
-    "graphiql-explorer": "^0.4.3",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "whatwg-fetch": "^3.0.0"
+    "@babel/runtime": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -45,9 +40,14 @@
     "babel-preset-gatsby-package": "^0.1.4",
     "cross-env": "^5.0.5",
     "css-loader": "^1.0.0",
+    "graphiql": "^0.13.0",
+    "graphiql-explorer": "^0.4.3",
     "html-webpack-plugin": "^3.2.0",
     "npm-run-all": "4.1.5",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "style-loader": "^0.21.0",
-    "webpack-cli": "^3.3.2"
+    "webpack-cli": "^3.3.2",
+    "whatwg-fetch": "^3.0.0"
   }
 }

--- a/packages/gatsby-graphiql-explorer/package.json
+++ b/packages/gatsby-graphiql-explorer/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "graphiql": "^0.13.0",
-    "graphiql-explorer": "^0.3.7",
+    "graphiql-explorer": "^0.4.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "whatwg-fetch": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10578,10 +10578,10 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.9:
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
-graphiql-explorer@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/graphiql-explorer/-/graphiql-explorer-0.3.7.tgz#92f1c0860d6371754373cb5107db8672dc3ee381"
-  integrity sha512-i24+xTe012/OAMFH/r9YL5QarSr/YqkP0Si0NspCnXKmJv7HzHueFUTRpFRPF1Ka9dLqiszrmOg/5stU4gCQnA==
+graphiql-explorer@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/graphiql-explorer/-/graphiql-explorer-0.4.3.tgz#86a60292faf96462e73530035ae84e678f27c0ea"
+  integrity sha512-8WST2MfVPesgspCDYOucZHhWjeL0du8GB/vy2o44qrI/Y0iLaZ9BwCVw6jEz658S8AgxcAkKBl1jPCkMRxsdsQ==
 
 graphiql@^0.13.0:
   version "0.13.0"


### PR DESCRIPTION
This brings all new niceties - see for what changed https://www.onegraph.com/blog/2019/05/30/GraphiQL_Explorer_2_0_A_Power_User_Release.html 

We just needed small tweak to hide "add new mutation"/"add new subscription" buttons 
that would be pretty confusing to Gatsby users and @sgrove just pushed changes ( https://github.com/OneGraph/graphiql-explorer/commit/56df94da93e7ee280a131953cda8cfd3851f92fd ) and published it, so we are ready for update :)