### PR TITLE
chore(docs): update api-reference for component shadowing

### DIFF
--- a/docs/docs/themes/api-reference.md
+++ b/docs/docs/themes/api-reference.md
@@ -68,7 +68,13 @@ exports.createPages = async ({ graphql, actions }, themeOptions) => {
 
 ## Component Shadowing
 
-Gatsby Themes allow you to customize any file in a theme's `src` directory by following a file naming convention.
+You can import files from a Gatsby Theme into your project. For example, if you're using `gatsby-theme-tomato`, which has a `Layout` component located at `src/components/layout.js`, you can import it into your poject like this: 
+
+```js
+import Layout from 'gatsby-theme-tomato/src/components/Layout'
+```
+
+Gatsby Themes also allows you to customize any file in a theme's `src` directory by following a file naming convention.
 If you're using `gatsby-theme-tomato` which uses a `ProfileCard` component located at `src/components/profile-card.js` you can override the component by creating `src/gatsby-theme-tomato/components/profile-card.js`. If you want to see what props are passed you can do so by putting the props into a `pre` tag:
 
 ```js:title=src/gatsby-theme-tomato/components/profile-card.js

--- a/docs/docs/themes/api-reference.md
+++ b/docs/docs/themes/api-reference.md
@@ -68,10 +68,10 @@ exports.createPages = async ({ graphql, actions }, themeOptions) => {
 
 ## Component Shadowing
 
-You can import files from a Gatsby Theme into your project. For example, if you're using `gatsby-theme-tomato`, which has a `Layout` component located at `src/components/layout.js`, you can import it into your poject like this: 
+You can import files from a Gatsby Theme into your project. For example, if you're using `gatsby-theme-tomato`, which has a `Layout` component located at `src/components/layout.js`, you can import it into your poject like this:
 
 ```js
-import Layout from 'gatsby-theme-tomato/src/components/Layout'
+import Layout from "gatsby-theme-tomato/src/components/Layout"
 ```
 
 Gatsby Themes also allows you to customize any file in a theme's `src` directory by following a file naming convention.

--- a/docs/docs/themes/api-reference.md
+++ b/docs/docs/themes/api-reference.md
@@ -68,7 +68,7 @@ exports.createPages = async ({ graphql, actions }, themeOptions) => {
 
 ## Component Shadowing
 
-You can import files from a Gatsby Theme into your project. For example, if you're using `gatsby-theme-tomato`, which has a `Layout` component located at `src/components/layout.js`, you can import it into your poject like this:
+You can import files from a Gatsby Theme into your project. For example, if you're using `gatsby-theme-tomato`, which has a `Layout` component located at `src/components/layout.js`, you can import it into your project like this:
 
 ```js
 import Layout from "gatsby-theme-tomato/src/components/Layout"

--- a/docs/docs/themes/api-reference.md
+++ b/docs/docs/themes/api-reference.md
@@ -74,7 +74,7 @@ You can import files from a Gatsby Theme into your project. For example, if you'
 import Layout from "gatsby-theme-tomato/src/components/Layout"
 ```
 
-Gatsby Themes also allows you to customize any file in a theme's `src` directory by following a file naming convention.
+Gatsby Themes also allow you to customize any file in a theme's `src` directory by following a file naming convention.
 If you're using `gatsby-theme-tomato` which uses a `ProfileCard` component located at `src/components/profile-card.js` you can override the component by creating `src/gatsby-theme-tomato/components/profile-card.js`. If you want to see what props are passed you can do so by putting the props into a `pre` tag:
 
 ```js:title=src/gatsby-theme-tomato/components/profile-card.js


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Update api-reference to describe how to import components from a theme into your project

## Related Issues

Fixes #14462
