### PR TITLE
fix(gatsby-remark-images): Escape HTML characters for image caption

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -142,11 +142,7 @@ module.exports = (
     const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `)
 
     const alt = _.escape(
-      overWrites.alt
-      ? overWrites.alt
-      : node.alt
-      ? node.alt
-      : defaultAlt
+      overWrites.alt ? overWrites.alt : node.alt ? node.alt : defaultAlt
     )
 
     const title = node.title ? node.title : ``

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -141,11 +141,13 @@ module.exports = (
     const fileNameNoExt = fileName.replace(/\.[^/.]+$/, ``)
     const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `)
 
-    const alt = overWrites.alt
+    const alt = _.escape(
+      overWrites.alt
       ? overWrites.alt
       : node.alt
       ? node.alt
       : defaultAlt
+    )
 
     const title = node.title ? node.title : ``
 


### PR DESCRIPTION
## Description

Escape HTML character(s) in `alt` attribute of `<img>`.

## Related Issues

#14495
