### PR TITLE
Remove jsonDataPaths from pre-existing redux state

### DIFF
--- a/packages/gatsby/src/redux/index.js
+++ b/packages/gatsby/src/redux/index.js
@@ -24,6 +24,10 @@ const readState = () => {
         state.nodesByType.get(type).set(node.id, node)
       })
     }
+    // jsonDataPaths was removed in the per-page-manifest
+    // changes. Explicitly delete it here to cover case where user
+    // runs gatsby the first time after upgrading.
+    delete state[`jsonDataPaths`]
     return state
   } catch (e) {
     // ignore errors.


### PR DESCRIPTION
**Note: merges to `per-page-manifest`, not master. See https://github.com/gatsbyjs/gatsby/pull/13004 for more info**

## Description

When users update to per-page-manifest, they'll still have `jsonDataPaths`. So will get the following error:

```
error Unexpected key "jsonDataPaths" found in preloadedState argument passed to createStore. Expected to
```

So we explicitly ensure it's delete before loading into redux.

## Related Issues

- Sub-PR of https://github.com/gatsbyjs/gatsby/pull/13004