### PR TITLE
fix(gatsby-dev-cli): add missing awaits and other various fixes

### DIFF
--- a/packages/gatsby-dev-cli/src/local-npm-registry/index.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/index.js
@@ -64,5 +64,5 @@ exports.publishPackagesLocallyAndInstall = async ({
 
   const packagesToInstall = _.intersection(packagesToPublish, localPackages)
 
-  installPackages({ packagesToInstall })
+  await installPackages({ packagesToInstall })
 }

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -37,12 +37,14 @@ function watch(
       if (err) {
         if (retry >= MAX_COPY_RETRIES) {
           console.error(err)
-          return reject(err)
+          reject(err)
+          return
         } else {
           setTimeout(
             () => realCopyPath({ ...arg, retry: retry + 1 }),
             500 * Math.pow(2, retry)
           )
+          return
         }
       }
 
@@ -50,7 +52,7 @@ function watch(
       if (!quiet) {
         console.log(`Copied ${oldPath} to ${newPath}`)
       }
-      return resolve()
+      resolve()
     })
   }
 

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -69,12 +69,14 @@ function watch(
     }, new Set())
 
     await Promise.all(
-      [...packagesToClear].map(async packageToClear => {
-        await del([
-          `node_modules/${packageToClear}/**/*.{js,js.map}`,
-          `!node_modules/${packageToClear}/node_modules/**/*.{js,js.map}`,
-        ])
-      })
+      [...packagesToClear].map(
+        async packageToClear =>
+          await del([
+            `node_modules/${packageToClear}/**/*.{js,js.map}`,
+            `!node_modules/${packageToClear}/node_modules/**/*.{js,js.map}`,
+            `!node_modules/${packageToClear}/src/**/*.{js,js.map}`,
+          ])
+      )
     )
   }
   // check packages deps and if they depend on other packages from monorepo

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -113,6 +113,7 @@ function watch(
     /\.git/i,
     /\.DS_Store/,
     /[/\\]__tests__[/\\]/i,
+    /\.npmrc/i,
   ].concat(
     allPackagesToWatch.map(p => new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`))
   )


### PR DESCRIPTION
there were couple issues in https://github.com/gatsbyjs/gatsby/pull/14347 did wasn't spotted and that caused some PRs to fail e2e/integration tests because of it

this adds some missing awaits, retry mechanism for copying files (seems like Promise.all copying hundreds of files cause weird ENOENT errors randomly)

EDIT: failing tests on this PR are example of those errors