### PR TITLE
Add yarn install command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 1. **Install the Gatsby CLI.**
 
    ```shell
+   # NPM users
    npm install -g gatsby-cli
+   # Yarn users
+   yarn global add gatsby-cli
 
    ```
 


### PR DESCRIPTION
## Description

Depend on yarn.lock in the repository I think we should have install command for yarn user in getting start guide.