### PR TITLE
Expanded GraphQL playground docs

### DIFF
--- a/docs/docs/using-graphql-playground.md
+++ b/docs/docs/using-graphql-playground.md
@@ -20,6 +20,23 @@ To access this experimental feature utilizing GraphQL Playground with Gatsby, ad
 
 Use `npm run develop` instead of `gatsby develop` and access it when the development server is running on `https://localhost:8000/___graphql`
 
-To still be able to use `gatsby develop` you would require the dotenv package to your gatsby-config.js file and add an [environment variable](/docs/environment-variables/) file, typically called `.env.development`. Finally, add `GATSBY_GRAPHQL_IDE=playground` to the `.env.development` file.
+To still be able to use `gatsby develop` you would need to install the [dotenv](https://github.com/motdotla/dotenv) package.
+
+```
+npm install dotenv -S
+```
+
+Next, you will need to add the following to your gatsby-config.js file.
+
+```
+// Initialize dotenv
+require('dotenv').config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+```
+
+Then you will need to add an [environment variable](/docs/environment-variables/) file to the root directory of your project, typically called `.env.development`. 
+
+Finally, add `GATSBY_GRAPHQL_IDE=playground` to the `.env.development` file.
 
 ![An image pointing out where to find the GraphQl schema](images/playground-schema.png)


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I expanded and clarified the instructions on how to enable GraphQL playground with the `gatsby develop` command so they would be a step-by-step walkthrough. This will help reduce confusion and the need to potentially reference other docs to figure out how to enable the alternate Graphql IDE.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
