### PR TITLE
feat(themes): Add gatsbyesque colors

### DIFF
--- a/themes/gatsby-starter-theme/package.json
+++ b/themes/gatsby-starter-theme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-theme-blog",
+  "name": "gatsby-starter-theme",
   "private": true,
   "version": "0.0.1",
   "scripts": {

--- a/themes/gatsby-theme-blog/src/theme/colors.js
+++ b/themes/gatsby-theme-blog/src/theme/colors.js
@@ -1,9 +1,8 @@
-const gatsby = `#663399`
-const gatsbyDarker = `#362066`
-const gatsbyBright = `#D9BAE8`
-const gray = `#48434F`
-const darkGray = `#232129`
-const almostBlack = `#1B1F23`
+const purple60 = `#663399`
+const purple30 = `#D9BAE8`
+const grey70 = `#48434F`
+const grey90 = `#232129`
+const black80 = `#1B1F23`
 const white = `#fff`
 const lightWhite = `rgba(255, 255, 255, 0.86)`
 const opaqueLightYellow = `rgba(255, 229, 100, 0.2)`
@@ -11,13 +10,13 @@ const opaqueLightWhite = `hsla(0, 0%, 100%, 0.2)`
 const lightGray = `hsla(0, 0%, 0%, 0.2)`
 
 export default {
-  text: darkGray,
+  text: grey90,
   background: white,
-  primary: gatsby,
-  secondary: almostBlack,
+  primary: purple60,
+  secondary: black80,
   muted: lightGray,
   highlight: opaqueLightYellow,
-  heading: darkGray,
+  heading: grey90,
   prism: {
     background: `#011627`,
     comment: `#809393`,
@@ -36,11 +35,11 @@ export default {
   modes: {
     dark: {
       text: lightWhite,
-      background: gatsbyDarker,
-      primary: gatsbyBright,
+      background: grey90,
+      primary: purple30,
       secondary: lightWhite,
       muted: opaqueLightWhite,
-      highlight: gray,
+      highlight: purple60,
       heading: white,
     },
   },

--- a/themes/gatsby-theme-blog/src/theme/colors.js
+++ b/themes/gatsby-theme-blog/src/theme/colors.js
@@ -1,6 +1,5 @@
 const purple60 = `#663399`
 const purple30 = `#D9BAE8`
-const grey70 = `#48434F`
 const grey90 = `#232129`
 const black80 = `#1B1F23`
 const white = `#fff`

--- a/themes/gatsby-theme-blog/src/theme/colors.js
+++ b/themes/gatsby-theme-blog/src/theme/colors.js
@@ -1,19 +1,19 @@
-const teal = `#66b9bf`
-const darkTeal = `#078092`
-const darkBlue = `#282c35`
-const darkGray = `#222`
-const almostBlack = `#1a1a1a`
+const gatsby = `#663399`
+const gatsbyDarker = `#362066`
+const gatsbyBright = `#D9BAE8`
+const gray = `#48434F`
+const darkGray = `#232129`
+const almostBlack = `#1B1F23`
 const white = `#fff`
-const lightWhite = `rgba(255, 255, 255, 0.88)`
+const lightWhite = `rgba(255, 255, 255, 0.86)`
 const opaqueLightYellow = `rgba(255, 229, 100, 0.2)`
 const opaqueLightWhite = `hsla(0, 0%, 100%, 0.2)`
 const lightGray = `hsla(0, 0%, 0%, 0.2)`
-const slateBlue = `hsl(222, 14%, 25%)`
 
 export default {
   text: darkGray,
   background: white,
-  primary: darkTeal,
+  primary: gatsby,
   secondary: almostBlack,
   muted: lightGray,
   highlight: opaqueLightYellow,
@@ -36,11 +36,11 @@ export default {
   modes: {
     dark: {
       text: lightWhite,
-      background: darkBlue,
-      primary: teal,
+      background: gatsbyDarker,
+      primary: gatsbyBright,
       secondary: lightWhite,
       muted: opaqueLightWhite,
-      highlight: slateBlue,
+      highlight: gray,
       heading: white,
     },
   },


### PR DESCRIPTION
## Description

Changes blog theme to use a Gatsbyesque default color palette based on @fk's guidelines

## Related Issues

Related to #14276