### PR TITLE
chore(gatsby-remark-images-contentful) Use createContentDigest helper

### DIFF
--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -33,6 +33,6 @@
   "author": "Khaled Garbaya <khaledgarbaya@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.15"
   }
 }

--- a/packages/gatsby-remark-images-contentful/src/__tests__/index.js
+++ b/packages/gatsby-remark-images-contentful/src/__tests__/index.js
@@ -63,6 +63,7 @@ const createPluginOptions = (content, imagePaths = `/`) => {
         dir: dirName,
       }
     },
+    createContentDigest: jest.fn().mockReturnValue(`contentDigest`),
   }
 }
 

--- a/packages/gatsby-remark-images-contentful/src/index.js
+++ b/packages/gatsby-remark-images-contentful/src/index.js
@@ -1,4 +1,3 @@
-const crypto = require(`crypto`)
 const select = require(`unist-util-select`)
 const sharp = require(`./safe-sharp`)
 const axios = require(`axios`)
@@ -15,7 +14,16 @@ const { buildResponsiveSizes } = require(`./utils`)
 // 5. Set the html w/ aspect ratio helper.
 
 module.exports = async (
-  { files, markdownNode, markdownAST, pathPrefix, getNode, reporter, cache },
+  {
+    files,
+    markdownNode,
+    markdownAST,
+    pathPrefix,
+    getNode,
+    reporter,
+    cache,
+    createContentDigest,
+  },
   pluginOptions
 ) => {
   const defaults = {
@@ -50,10 +58,7 @@ module.exports = async (
     const fileName = srcSplit[srcSplit.length - 1]
     const options = _.defaults(pluginOptions, defaults)
 
-    const optionsHash = crypto
-      .createHash(`md5`)
-      .update(JSON.stringify(options))
-      .digest(`hex`)
+    const optionsHash = createContentDigest(options)
 
     const cacheKey = `remark-images-ctf-${fileName}-${optionsHash}`
     let cahedRawHTML = await cache.get(cacheKey)


### PR DESCRIPTION
## Description
Makes use of `createContentDigest` helper (instead of `crypto`) in `gatsby-remark-images-contentful` package

## Related Issues
Related to #8805
