### PR TITLE
chore(blog): fix links on contributor pages

### DIFF
--- a/www/src/components/blog-post-preview-item.js
+++ b/www/src/components/blog-post-preview-item.js
@@ -12,7 +12,7 @@ const formatDate = dateString =>
   })
 
 const BlogPostPreviewItem = ({ post, className }) => (
-  <article className={className}>
+  <article css={{ position: `relative` }} className={className}>
     <Link to={post.fields.slug} css={{ "&&": { color: colors.text.primary } }}>
       <h2 css={{ marginTop: 0 }}>{post.frontmatter.title}</h2>
       <p>

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -49,7 +49,6 @@ const Tags = ({ pageContext, data, location }) => {
             post={node}
             key={node.fields.slug}
             css={{
-              position: `relative`,
               marginTop: space[9],
               marginBottom: space[9],
             }}

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -64,7 +64,6 @@ class BlogPostsIndex extends React.Component {
                   marginBottom:
                     index === allMdx.edges.length - 1 ? 0 : space[8],
                   ...pullIntoGutter,
-                  position: `relative`,
                   [breakpointGutter]: {
                     padding: space[9],
                     boxShadow: shadows.raised,

--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -91,7 +91,7 @@ class ContributorPageTemplate extends React.Component {
                 <BlogPostPreviewItem
                   post={node}
                   key={node.fields.slug}
-                  css={{ marginBottom: space[9], position: `relative` }}
+                  css={{ marginBottom: space[9] }}
                 />
               ))}
             </div>

--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -13,7 +13,12 @@ import FooterLinks from "../components/shared/footer-links"
 class ContributorPageTemplate extends React.Component {
   render() {
     const contributor = this.props.data.authorYaml
-    const allMdx = this.props.data.allMdx
+
+    const posts = this.props.data.allMdx.nodes.filter(
+      post =>
+        post.frontmatter.author && post.frontmatter.author.id === contributor.id
+    )
+
     return (
       <Layout location={this.props.location}>
         <Helmet>
@@ -82,20 +87,13 @@ class ContributorPageTemplate extends React.Component {
               </div>
             </div>
             <div css={{ padding: `${space[7]} ${space[6]}` }}>
-              {allMdx.edges.map(({ node }) => {
-                if (node.frontmatter.author) {
-                  if (node.frontmatter.author.id === contributor.id) {
-                    return (
-                      <BlogPostPreviewItem
-                        post={node}
-                        key={node.fields.slug}
-                        css={{ marginBottom: space[9] }}
-                      />
-                    )
-                  }
-                }
-                return null
-              })}
+              {posts.map(node => (
+                <BlogPostPreviewItem
+                  post={node}
+                  key={node.fields.slug}
+                  css={{ marginBottom: space[9], position: `relative` }}
+                />
+              ))}
             </div>
           </Container>
           <FooterLinks />
@@ -137,10 +135,8 @@ export const pageQuery = graphql`
         frontmatter: { draft: { ne: true } }
       }
     ) {
-      edges {
-        node {
-          ...BlogPostPreview_item
-        }
+      nodes {
+        ...BlogPostPreview_item
       }
     }
   }


### PR DESCRIPTION
## Description

All contributor pages are currently linking to the last post's link due to the `position: absolute` on the link(s) but the missing `position: relative` on the `article` element. This fixes that.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
