### PR TITLE
fix(docs): add missing closing tag for mdx link

### DIFF
--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -28,7 +28,7 @@ date: 2019-01-29
 # Hello, world!
 ```
 
-Which can then be [queried with GraphQL](/docs/querying-with-graphql/:
+Which can then be [queried with GraphQL](/docs/querying-with-graphql/):
 
 **Note:** To query `Mdx` content, it must be included in the node system using a
 source like `gatsby-source-filesystem` first.


### PR DESCRIPTION
The trailing `)` was missing, so this link wasn't being parsed.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
