### PR TITLE
showcase metatag images size fix [#14469]

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -123,6 +123,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               }
               childScreenshot {
                 screenshotFile {
+                  publicURL
                   childImageSharp {
                     resize(width: 200, height: 200) {
                       src
@@ -255,15 +256,13 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                 <meta
                   property="og:image"
                   content={`https://www.gatsbyjs.org${
-                    data.sitesYaml.childScreenshot.screenshotFile
-                      .childImageSharp.resize.src
+                    data.sitesYaml.childScreenshot.screenshotFile.publicURL
                   }`}
                 />
                 <meta
                   name="twitter:image"
                   content={`https://www.gatsbyjs.org${
-                    data.sitesYaml.childScreenshot.screenshotFile
-                      .childImageSharp.resize.src
+                    data.sitesYaml.childScreenshot.screenshotFile.publicURL
                   }`}
                 />
               </Helmet>

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -251,7 +251,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               }}
             >
               <Helmet>
-                <title>{data.sitesYaml.title}</title>
+                <title>{data.sitesYaml.title}: Showcase | GatsbyJS</title>
                 <meta
                   property="og:image"
                   content={`https://www.gatsbyjs.org${
@@ -267,6 +267,10 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                   }`}
                 />
                 <meta name="twitter:card" content="summary_large_image" />
+                <meta
+                  name="og:title"
+                  value={`${data.sitesYaml.title}: Showcase | GatsbyJS`}
+                />
                 <meta
                   property="og:image:width"
                   content={

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -255,13 +255,15 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                 <meta
                   property="og:image"
                   content={`https://www.gatsbyjs.org${
-                    data.sitesYaml.childScreenshot.screenshotFile.publicURL
+                    data.sitesYaml.childScreenshot.screenshotFile
+                      .childImageSharp.resize.src
                   }`}
                 />
                 <meta
                   name="twitter:image"
                   content={`https://www.gatsbyjs.org${
-                    data.sitesYaml.childScreenshot.screenshotFile.publicURL
+                    data.sitesYaml.childScreenshot.screenshotFile
+                      .childImageSharp.resize.src
                   }`}
                 />
               </Helmet>

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -123,7 +123,6 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
               }
               childScreenshot {
                 screenshotFile {
-                  publicURL
                   childImageSharp {
                     resize(width: 200, height: 200) {
                       src

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -266,6 +266,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                       .childImageSharp.resize.src
                   }`}
                 />
+                <meta name="twitter:card" content="summary_large_image" />
               </Helmet>
               <div
                 css={{

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -267,6 +267,20 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                   }`}
                 />
                 <meta name="twitter:card" content="summary_large_image" />
+                <meta
+                  property="og:image:width"
+                  content={
+                    data.sitesYaml.childScreenshot.screenshotFile
+                      .childImageSharp.resize.width
+                  }
+                />
+                <meta
+                  property="og:image:height"
+                  content={
+                    data.sitesYaml.childScreenshot.screenshotFile
+                      .childImageSharp.resize.height
+                  }
+                />
               </Helmet>
               <div
                 css={{

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -111,13 +111,10 @@ export const pageQuery = graphql`
             fluid(maxWidth: 700) {
               ...GatsbyImageSharpFluid_noBase64
             }
-            resize(
-              width: 1500
-              height: 1500
-              cropFocus: CENTER
-              toFormat: JPG
-            ) {
+            resize(width: 1200, height: 627, cropFocus: NORTH, toFormat: JPG) {
               src
+              height
+              width
             }
           }
         }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Replaced the meta tag with the publicURL for the showcase images as the current images
 (eg: https://www.gatsbyjs.org/static/cbaf442ed29638ce3775856ede4ac483/d808c/8990f01f5a6d31fce109c16ab078b499.jpg) are cropped improperly.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes #14469 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
