### PR TITLE
fix/feat(gatsby-source-drupal): Copy relationship meta (if any) to a node's field

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -179,8 +179,24 @@ exports.sourceNodes = async (
             node.relationships[`${k}___NODE`] = _.compact(
               v.data.map(data => (ids[data.id] ? createNodeId(data.id) : null))
             )
+            var meta = _.compact(
+              v.data.map(data => !_.isEmpty(data.meta) ? data.meta : null)
+            )
+            // If there's meta on the field and it's not an existing/internal one
+            // create a new node's field with that meta. It can't exist on both
+            // @see https://jsonapi.org/format/#document-resource-object-fields
+            if (!_.isEmpty(meta) && !(k in node)) {
+              node[k] = meta
+            }
+
           } else if (ids[v.data.id]) {
             node.relationships[`${k}___NODE`] = createNodeId(v.data.id)
+            // If there's meta on the field and it's not an existing/internal one
+            // create a new node's field with that meta. It can't exist on both
+            // @see https://jsonapi.org/format/#document-resource-object-fields
+            if (!_.isEmpty(v.data.meta) && !(k in node)) {
+              node[k] = v.data.meta
+            }
           }
         })
       }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -180,7 +180,7 @@ exports.sourceNodes = async (
               v.data.map(data => (ids[data.id] ? createNodeId(data.id) : null))
             )
             var meta = _.compact(
-              v.data.map(data => !_.isEmpty(data.meta) ? data.meta : null)
+              v.data.map(data => (!_.isEmpty(data.meta) ? data.meta : null))
             )
             // If there's meta on the field and it's not an existing/internal one
             // create a new node's field with that meta. It can't exist on both
@@ -188,7 +188,6 @@ exports.sourceNodes = async (
             if (!_.isEmpty(meta) && !(k in node)) {
               node[k] = meta
             }
-
           } else if (ids[v.data.id]) {
             node.relationships[`${k}___NODE`] = createNodeId(v.data.id)
             // If there's meta on the field and it's not an existing/internal one


### PR DESCRIPTION
## Description

Drupal data structure allows for properties that are part of a relationship, and not on the relationship itself. A common example for this is an image field, which relates to a file entity, but each relationship has an "alt" field. (See #10339).

I believe as far as content goes, this meta information belongs not to the relationship, but to the node that uses the relationship.

So this means that if there's meta on the relationship, it will be copied to a field name of the same name, for an image field as an example, this now works:

```graphql
{
  allTaxonomyTermSite {
    edges {
      node {
        relationships {
          field_logo {
            localFile {
              publicURL
            }
          }
        }
        field_logo {
          alt
          title
          width
          height
        }
      }
    }
  }
}
```

Ideally, I like this to be part of the relationship data, but I think this it not possible currently with the inference or by changing too much on gatsby.

I.e., if you have 

A ----> Relates to ----> B

This is properly handled if A has data and B has data, but what happens when the "relationship" has data, which is what's happening in this place.

I might have expected that instead of doing `node.relationships[`${ref.type}___NODE`] = UUID`, I could have done something like:

```jsx
node.relationships[`${ref.type}___NODE`] = {
  id: UUID,
  foo: bar
}
```

And support both, I bet this is a lot of changing.

Maybe with this added and schema customization this can be improved, or maybe adding schema customization to the source plugin as well, but I haven't gotten there yet.

## Related Issues

Fixes #10339 
Another approach to #14187 
https://www.drupal.org/project/jsonapi/issues/2860886#comment-12040685