### PR TITLE
Refactor gatsby-plugin-google-analytics gatsby-browser.js

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,34 +1,33 @@
-exports.onRouteUpdate = function({ location }) {
-  // Don't track while developing.
-  if (process.env.NODE_ENV === `production` && typeof ga === `function`) {
-    if (
-      location &&
-      typeof window.excludeGAPaths !== `undefined` &&
-      window.excludeGAPaths.some(rx => rx.test(location.pathname))
-    ) {
-      return
-    }
-
-    // wrap inside a timeout to make sure react-helmet is done with it's changes (https://github.com/gatsbyjs/gatsby/issues/9139)
-    // reactHelmet is using requestAnimationFrame so we should use it too: https://github.com/nfl/react-helmet/blob/5.2.0/src/HelmetUtils.js#L296-L299
-    const sendPageView = () => {
-      window.ga(
-        `set`,
-        `page`,
-        location
-          ? location.pathname + location.search + location.hash
-          : undefined
-      )
-      window.ga(`send`, `pageview`)
-    }
-
-    if (`requestAnimationFrame` in window) {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(sendPageView)
-      })
-    } else {
-      // simulate 2 rAF calls
-      setTimeout(sendPageView, 32)
-    }
+exports.onRouteUpdate = ({ location }) => {
+  if (process.env.NODE_ENV !== `production` || typeof ga !== `function`) {
+    return null
   }
+
+  const pathIsExcluded =
+    location &&
+    typeof window.excludeGAPaths !== `undefined` &&
+    window.excludeGAPaths.some(rx => rx.test(location.pathname))
+
+  if (pathIsExcluded) return null
+
+  // wrap inside a timeout to make sure react-helmet is done with it's changes (https://github.com/gatsbyjs/gatsby/issues/9139)
+  // reactHelmet is using requestAnimationFrame so we should use it too: https://github.com/nfl/react-helmet/blob/5.2.0/src/HelmetUtils.js#L296-L299
+  const sendPageView = () => {
+    const pagePath = location
+      ? location.pathname + location.search + location.hash
+      : undefined
+    window.ga(`set`, `page`, pagePath)
+    window.ga(`send`, `pageview`)
+  }
+
+  if (`requestAnimationFrame` in window) {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(sendPageView)
+    })
+  } else {
+    // simulate 2 rAF calls
+    setTimeout(sendPageView, 32)
+  }
+
+  return null
 }


### PR DESCRIPTION
## Description

The gatsby-browser.js file in gatsby-plugin-google-analytics and
gatsby-plugin-google-gtag have borderline identical functionality howeve
that is slightly obscured as their implementation is slightly different,
notably gatsby-plugin-google-analytics does not use the early return
pattern which means the nesting of everything is different if you try
and diff the two files.

This commit makes gatsby-plugin-google-analytics use the early return
pattern to make it applying the same changes to this an
gatsby-plugin-google-gtag easier.


Run `diff -u packages/gatsby-plugin-google-analytics/src/gatsby-browser.js packages/gatsby-plugin-google-gtag/src/gatsby-browser.js` to see that the contents is now nearly identical
