### PR TITLE
feat(gatsby): Refine typing on createPages’ graphql function

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -600,7 +600,13 @@ export interface PluginOptions {
 export type PluginCallback = (err: Error | null, result?: any) => void
 
 export interface CreatePagesArgs extends ParentSpanPluginArgs {
-  graphql: Function
+  graphql<TData>(
+    query: string,
+    variables?: Record<string, unknown>
+  ): Promise<{
+    errors?: any
+    data?: TData
+  }>
   traceId: string
   waitForCascadingActions: boolean
 }

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -600,9 +600,9 @@ export interface PluginOptions {
 export type PluginCallback = (err: Error | null, result?: any) => void
 
 export interface CreatePagesArgs extends ParentSpanPluginArgs {
-  graphql<TData>(
+  graphql<TData, TVariables = any>(
     query: string,
-    variables?: Record<string, unknown>
+    variables?: TVariables
   ): Promise<{
     errors?: any
     data?: TData


### PR DESCRIPTION
## Description

This PR expands the typing on createPages’ graphql function:
- Accepts `TData` as generic
- Accepts `query: string` as first param
- Accepts `variables?: Record<string, unknown>` as second param
- Returns `errors?: any` and `data?: TData`

Below is example code that will be properly typed with this PR merged.

`gatsby-node.ts`

```ts
import { GatsbyNode } from 'gatsby'
import { loadPagesQuery, loadPagesQueryVariables } from './src/types/__generated__/loadPagesQuery'

export const gatsbyNode: GatsbyNode = {
  createPages: async ({ graphql, actions }) => {
    const { createPage } = actions

    const oneThousandPosts = await graphql<loadPagesQuery, loadPagesQueryVariables>(
      `
        query loadPagesQuery($limit: Int!) {
          allMarkdownRemark(limit: $limit) {
            edges {
              node {
                frontmatter {
                  slug
                }
              }
            }
          }
        }
      `,
      { limit: 1000 }, // this will be typed
    )

    if (oneThousandPosts.errors) {
      throw oneThousandPosts.errors
    }

    oneThousandPosts.data.allMarkdownRemark.edges.forEach(edge => {
      createPage({
        path: `/blog/${edge.node.frontmatter.slug}/`,
        ... rest of code
      })
    })
  },
}
```