### PR TITLE
feat(gatsby-source-filesystem): add createFileNodeFromBuffer

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -274,7 +274,10 @@ The following example is adapted from the source of [`gatsby-source-mysql`](http
 // gatsby-node.js
 const createMySqlNodes = require(`./create-nodes`)
 
-exports.sourceNodes = async ({ actions, createNodeId, store, cache }, config) => {
+exports.sourceNodes = async (
+  { actions, createNodeId, store, cache },
+  config
+) => {
   const { createNode } = actions
   const { conn, queries } = config
   const { db, results } = await query(conn, queries)
@@ -283,20 +286,15 @@ exports.sourceNodes = async ({ actions, createNodeId, store, cache }, config) =>
     queries
       .map((query, i) => ({ ...query, ___sql: results[i] }))
       .forEach(result =>
-        createMySqlNodes(
-          result,
-          results,
+        createMySqlNodes(result, results, createNode, {
           createNode,
-          {
-            createNode,
-            createNodeId,
-            store,
-            cache,
-          },
-        ),
+          createNodeId,
+          store,
+          cache,
+        })
       )
     db.end()
-  } catch(e) {
+  } catch (e) {
     console.error(e)
     db.end()
   }
@@ -317,7 +315,7 @@ function attach(node, key, value, ctx) {
         cache: ctx.cache,
         createNode: ctx.createNode,
         createNodeId: ctx.createNodeId,
-      }),
+      })
     )
     value = `Buffer`
   }

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -100,10 +100,11 @@ To filter by the `name` you specified in the config, use `sourceInstanceName`:
 
 ## Helper functions
 
-`gatsby-source-filesystem` exports two helper functions:
+`gatsby-source-filesystem` exports three helper functions:
 
 - `createFilePath`
 - `createRemoteFileNode`
+- `createFileNodeFromBuffer`
 
 ### createFilePath
 
@@ -257,4 +258,93 @@ createRemoteFileNode({
   ext: ".jpg",
   name: "image",
 })
+```
+
+### createFileNodeFromBuffer
+
+When working with data that isn't already stored in a file, such as when querying binary/blob fields from a database, it's helpful to cache that data to the filesystem in order to use it with other transformers that accept files as input.
+
+The `createFileNodeFromBuffer` helper accepts a `Buffer`, caches its contents to disk, and creates a file node that points to it.
+
+## Example usage
+
+The following example is adapted from the source of [`gatsby-source-mysql`](https://github.com/malcolm-kee/gatsby-source-mysql):
+
+```js
+// gatsby-node.js
+const createMySqlNodes = require(`./create-nodes`)
+
+exports.sourceNodes = async ({ actions, createNodeId, store, cache }, config) => {
+  const { createNode } = actions
+  const { conn, queries } = config
+  const { db, results } = await query(conn, queries)
+
+  try {
+    queries
+      .map((query, i) => ({ ...query, ___sql: results[i] }))
+      .forEach(result =>
+        createMySqlNodes(
+          result,
+          results,
+          createNode,
+          {
+            createNode,
+            createNodeId,
+            store,
+            cache,
+          },
+        ),
+      )
+    db.end()
+  } catch(e) {
+    console.error(e)
+    db.end()
+  }
+}
+
+// create-nodes.js
+const { createFileNodeFromBuffer } = require(`gatsby-source-filesystem`)
+const createNodeHelpers = require(`gatsby-node-helpers`).default
+
+const { createNodeFactory } = createNodeHelpers({ typePrefix: `mysql` })
+
+function attach(node, key, value, ctx) {
+  if (Buffer.isBuffer(value)) {
+    ctx.linkChildren.push(parentNodeId =>
+      createFileNodeFromBuffer({
+        buffer: value,
+        store: ctx.store,
+        cache: ctx.cache,
+        createNode: ctx.createNode,
+        createNodeId: ctx.createNodeId,
+      }),
+    )
+    value = `Buffer`
+  }
+
+  node[key] = value
+}
+
+function createMySqlNodes({ name, __sql, idField, keys }, results, ctx) {
+  const MySqlNode = createNodeFactory(name)
+  ctx.linkChildren = []
+
+  return __sql.forEach(row => {
+    if (!keys) keys = Object.keys(row)
+
+    const node = { id: row[idField] }
+
+    for (const key of keys) {
+      attach(node, key, row[key], ctx)
+    }
+
+    node = ctx.createNode(node)
+
+    for (const link of ctx.linkChildren) {
+      link(node.id)
+    }
+  })
+}
+
+module.exports = createMySqlNodes
 ```

--- a/packages/gatsby-source-filesystem/src/__tests__/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-file-node-from-buffer.js
@@ -1,0 +1,167 @@
+jest.mock(`fs-extra`, () => {
+  return {
+    ensureDir: jest.fn(() => true),
+    writeFile: jest.fn((_f, _b, cb) => cb()),
+    stat: jest.fn(() => {
+      return {
+        isDirectory: jest.fn(),
+      }
+    }),
+  }
+})
+jest.mock(`../create-file-node`, () => {
+  return {
+    createFileNode: jest.fn(() => {
+      return { internal: {} }
+    }),
+  }
+})
+
+const { ensureDir, writeFile } = require(`fs-extra`)
+const { createFileNode } = require(`../create-file-node`)
+const createFileNodeFromBuffer = require(`../create-file-node-from-buffer`)
+
+const createMockBuffer = content => {
+  const buffer = Buffer.alloc(content.length)
+  buffer.write(content)
+  return buffer
+}
+
+const createMockCache = () => {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+  }
+}
+
+const bufferEq = (b1, b2) => Buffer.compare(b1, b2) === 0
+
+describe(`create-file-node-from-buffer`, () => {
+  const defaultArgs = {
+    store: {
+      getState: jest.fn(() => {
+        return {
+          program: {
+            directory: `__whatever__`,
+          },
+        }
+      }),
+    },
+    createNode: jest.fn(),
+    createNodeId: jest.fn(),
+  }
+
+  describe(`functionality`, () => {
+    afterEach(() => jest.clearAllMocks())
+
+    const setup = ({
+      hash,
+      buffer = createMockBuffer(`some binary content`),
+      cache = createMockCache(),
+    } = {}) =>
+      createFileNodeFromBuffer({
+        ...defaultArgs,
+        buffer,
+        hash,
+        cache,
+      })
+
+    it(`rejects when the buffer can't be read`, () => {
+      expect(setup({ buffer: null })).rejects.toEqual(
+        expect.stringContaining(`bad buffer`)
+      )
+    })
+
+    it(`caches the buffer's content locally`, async () => {
+      expect.assertions(2)
+
+      let output
+      writeFile.mockImplementationOnce((_f, buf, cb) => {
+        output = buf
+        cb()
+      })
+
+      const buffer = createMockBuffer(`buffer-content`)
+      await setup({ buffer })
+
+      expect(ensureDir).toBeCalledTimes(2)
+      expect(bufferEq(buffer, output)).toBe(true)
+    })
+
+    it(`uses cached file Promise for buffer with a matching hash`, async () => {
+      expect.assertions(3)
+
+      const cache = createMockCache()
+
+      await setup({ cache, hash: `same-hash` })
+      await setup({ cache, hash: `same-hash` })
+
+      expect(cache.get).toBeCalledTimes(1)
+      expect(cache.set).toBeCalledTimes(1)
+      expect(writeFile).toBeCalledTimes(1)
+    })
+
+    it(`uses cached file from previous run with a matching hash`, async () => {
+      expect.assertions(3)
+
+      const cache = createMockCache()
+      cache.get.mockImplementationOnce(() => `cached-file-path`)
+
+      await setup({ cache, hash: `cached-hash` })
+
+      expect(cache.get).toBeCalledWith(expect.stringContaining(`cached-hash`))
+      expect(cache.set).not.toBeCalled()
+      expect(createFileNode).toBeCalledWith(
+        expect.stringContaining(`cached-file-path`),
+        expect.any(Function),
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe(`validation`, () => {
+    it(`throws on invalid inputs: createNode`, () => {
+      expect(() => {
+        createFileNodeFromBuffer({
+          ...defaultArgs,
+          createNode: undefined,
+        })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"createNode must be a function, was undefined"`
+      )
+    })
+
+    it(`throws on invalid inputs: createNodeId`, () => {
+      expect(() => {
+        createFileNodeFromBuffer({
+          ...defaultArgs,
+          createNodeId: undefined,
+        })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"createNodeId must be a function, was undefined"`
+      )
+    })
+
+    it(`throws on invalid inputs: cache`, () => {
+      expect(() => {
+        createFileNodeFromBuffer({
+          ...defaultArgs,
+          cache: undefined,
+        })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"cache must be the Gatsby cache, was undefined"`
+      )
+    })
+
+    it(`throws on invalid inputs: store`, () => {
+      expect(() => {
+        createFileNodeFromBuffer({
+          ...defaultArgs,
+          store: undefined,
+        })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"store must be the redux store, was undefined"`
+      )
+    })
+  })
+})

--- a/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
@@ -133,7 +133,7 @@ const processingCache = {}
  */
 module.exports = ({
   buffer,
-  hash = md5Buffer(buffer),
+  hash,
   store,
   cache,
   createNode,
@@ -158,6 +158,14 @@ module.exports = ({
   }
   if (typeof cache !== `object`) {
     throw new Error(`cache must be the Gatsby cache, was ${typeof cache}`)
+  }
+
+  if (!buffer) {
+    return Promise.reject(`bad buffer: ${buffer}`)
+  }
+
+  if (!hash) {
+    hash = md5Buffer(buffer)
   }
 
   // Check if we already requested node for this remote file

--- a/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
@@ -3,7 +3,8 @@ const path = require(`path`)
 const fileType = require(`file-type`)
 
 const { createFileNode } = require(`./create-file-node`)
-const { md5Buffer, createFilePath } = require(`./utils`)
+const { createFilePath } = require(`./utils`)
+const { createContentDigest } = require(`gatsby/utils`)
 const cacheId = hash => `create-file-node-from-buffer-${hash}`
 
 /********************
@@ -165,7 +166,7 @@ module.exports = ({
   }
 
   if (!hash) {
-    hash = md5Buffer(buffer)
+    hash = createContentDigest(buffer)
   }
 
   // Check if we already requested node for this remote file

--- a/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
@@ -1,0 +1,184 @@
+const fs = require(`fs-extra`)
+const path = require(`path`)
+const fileType = require(`file-type`)
+
+const { createFileNode } = require(`./create-file-node`)
+const { md5Buffer, createFilePath } = require(`./utils`)
+const cacheId = hash => `create-file-node-from-buffer-${hash}`
+
+/********************
+ * Type Definitions *
+ ********************/
+
+/**
+ * @typedef {Redux}
+ * @see [Redux Docs]{@link https://redux.js.org/api-reference}
+ */
+
+/**
+ * @typedef {GatsbyCache}
+ * @see gatsby/packages/gatsby/utils/cache.js
+ */
+
+/**
+ * @typedef {CreateFileNodeFromBufferPayload}
+ * @typedef {Object}
+ * @description Create File Node From Buffer Payload
+ *
+ * @param  {Buffer} options.buffer
+ * @param  {String} options.hash
+ * @param  {Redux} options.store
+ * @param  {GatsbyCache} options.cache
+ * @param  {Function} options.createNode
+ */
+
+const CACHE_DIR = `.cache`
+const FS_PLUGIN_DIR = `gatsby-source-filesystem`
+
+/**
+ * writeBuffer
+ * --
+ * Write the contents of `buffer` to `filename`
+ *
+ *
+ * @param {String} filename
+ * @param {Buffer} buffer
+ * @returns {Promise<void>}
+ */
+const writeBuffer = (filename, buffer) =>
+  new Promise((resolve, reject) => {
+    fs.writeFile(filename, buffer, err => (err ? reject(err) : resolve()))
+  })
+
+/**
+ * processBufferNode
+ * --
+ * Write the buffer contents out to disk and return the fileNode
+ *
+ * @param {CreateFileNodeFromBufferPayload} options
+ * @return {Promise<Object>} Resolves with the fileNode
+ */
+async function processBufferNode({
+  buffer,
+  hash,
+  store,
+  cache,
+  createNode,
+  parentNodeId,
+  createNodeId,
+  ext,
+  name,
+}) {
+  // Ensure our cache directory exists.
+  const pluginCacheDir = path.join(
+    store.getState().program.directory,
+    CACHE_DIR,
+    FS_PLUGIN_DIR
+  )
+  await fs.ensureDir(pluginCacheDir)
+
+  // See if there's a cache file for this buffer's contents from
+  // a previous run
+  let filename = await cache.get(cacheId(hash))
+  if (!filename) {
+    // If the user did not provide an extension and we couldn't get
+    // one from remote file, try and guess one
+    if (typeof ext === `undefined`) {
+      const filetype = fileType(buffer)
+      ext = filetype ? `.${filetype.ext}` : `.bin`
+    }
+
+    await fs.ensureDir(path.join(pluginCacheDir, hash))
+    filename = createFilePath(path.join(pluginCacheDir, hash), name, ext)
+
+    // Cache the buffer contents
+    await writeBuffer(filename, buffer)
+
+    // Save the cache file path for future use
+    await cache.set(cacheId(hash), filename)
+  }
+
+  // Create the file node.
+  const fileNode = await createFileNode(filename, createNodeId, {})
+  fileNode.internal.description = `File "Buffer<${hash}>"`
+  fileNode.hash = hash
+  fileNode.parent = parentNodeId
+  // Override the default plugin as gatsby-source-filesystem needs to
+  // be the owner of File nodes or there'll be conflicts if any other
+  // File nodes are created through normal usages of
+  // gatsby-source-filesystem.
+  await createNode(fileNode, { name: `gatsby-source-filesystem` })
+
+  return fileNode
+}
+
+/**
+ * Index of promises resolving to File node from buffer cache
+ */
+const processingCache = {}
+
+/***************
+ * Entry Point *
+ ***************/
+
+/**
+ * createFileNodeFromBuffer
+ * --
+ *
+ * Cache a buffer's contents to disk
+ * First checks cache to ensure duplicate buffers aren't processed
+ *
+ * @param {CreateFileNodeFromBufferPayload} options
+ * @return {Promise<Object>}                  Returns the created node
+ */
+module.exports = ({
+  buffer,
+  hash = md5Buffer(buffer),
+  store,
+  cache,
+  createNode,
+  parentNodeId = null,
+  createNodeId,
+  ext,
+  name = hash,
+}) => {
+  // validation of the input
+  // without this it's notoriously easy to pass in the wrong `createNodeId`
+  // see gatsbyjs/gatsby#6643
+  if (typeof createNodeId !== `function`) {
+    throw new Error(
+      `createNodeId must be a function, was ${typeof createNodeId}`
+    )
+  }
+  if (typeof createNode !== `function`) {
+    throw new Error(`createNode must be a function, was ${typeof createNode}`)
+  }
+  if (typeof store !== `object`) {
+    throw new Error(`store must be the redux store, was ${typeof store}`)
+  }
+  if (typeof cache !== `object`) {
+    throw new Error(`cache must be the Gatsby cache, was ${typeof cache}`)
+  }
+
+  // Check if we already requested node for this remote file
+  // and return stored promise if we did.
+  if (processingCache[hash]) {
+    return processingCache[hash]
+  }
+
+  const bufferCachePromise = processBufferNode({
+    buffer,
+    hash,
+    store,
+    cache,
+    createNode,
+    parentNodeId,
+    createNodeId,
+    ext,
+    name,
+  })
+
+  processingCache[hash] = bufferCachePromise
+
+  return processingCache[hash]
+}

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -9,7 +9,11 @@ const fileType = require(`file-type`)
 const ProgressBar = require(`progress`)
 
 const { createFileNode } = require(`./create-file-node`)
-const { getRemoteFileExtension, getRemoteFileName } = require(`./utils`)
+const {
+  getRemoteFileExtension,
+  getRemoteFileName,
+  createFilePath,
+} = require(`./utils`)
 const cacheId = url => `create-remote-file-node-${url}`
 
 const bar = new ProgressBar(
@@ -55,18 +59,6 @@ const bar = new ProgressBar(
 
 const CACHE_DIR = `.cache`
 const FS_PLUGIN_DIR = `gatsby-source-filesystem`
-
-/**
- * createFilePath
- * --
- *
- * @param  {String} directory
- * @param  {String} filename
- * @param  {String} url
- * @return {String}
- */
-const createFilePath = (directory, filename, ext) =>
-  path.join(directory, `${filename}${ext}`)
 
 /********************
  * Queue Management *

--- a/packages/gatsby-source-filesystem/src/index.js
+++ b/packages/gatsby-source-filesystem/src/index.js
@@ -6,5 +6,6 @@ function loadNodeContent(fileNode) {
 
 exports.createFilePath = require(`./create-file-path`)
 exports.createRemoteFileNode = require(`./create-remote-file-node`)
+exports.createFileNodeFromBuffer = require(`./create-file-node-from-buffer`)
 
 exports.loadNodeContent = loadNodeContent

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -1,6 +1,5 @@
 const path = require(`path`)
 const Url = require(`url`)
-const crypto = require(`crypto`)
 
 /**
  * getParsedPath

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -72,19 +72,3 @@ export function slash(path) {
 export function createFilePath(directory, filename, ext) {
   return path.join(directory, `${filename}${ext}`)
 }
-
-/**
- * md5Buffer
- * --
- * Hashes the contents of a buffer using MD5
- *
- *
- * @param {Buffer}            buffer
- * @return {String}           hash
- */
-export function md5Buffer(buffer) {
-  return crypto
-    .createHash(`md5`)
-    .update(buffer)
-    .digest(`hex`)
-}

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -1,5 +1,6 @@
 const path = require(`path`)
 const Url = require(`url`)
+const crypto = require(`crypto`)
 
 /**
  * getParsedPath
@@ -57,4 +58,33 @@ export function slash(path) {
   }
 
   return path.replace(/\\/g, `/`)
+}
+
+/**
+ * createFilePath
+ * --
+ *
+ * @param  {String} directory
+ * @param  {String} filename
+ * @param  {String} url
+ * @return {String}
+ */
+export function createFilePath(directory, filename, ext) {
+  return path.join(directory, `${filename}${ext}`)
+}
+
+/**
+ * md5Buffer
+ * --
+ * Hashes the contents of a buffer using MD5
+ *
+ *
+ * @param {Buffer}            buffer
+ * @return {String}           hash
+ */
+export function md5Buffer(buffer) {
+  return crypto
+    .createHash(`md5`)
+    .update(buffer)
+    .digest(`hex`)
 }


### PR DESCRIPTION
## Description

In the same spirit as `createRemoteFileNode`, this PR adds a new named export to `gatsby-source-filesystem` intended for use with other source/transform plugins that have data stored in a buffer and wish to pass that data to other transforms that expect input in the form of a file node.

The API for `createFileNodeFromBuffer` is very similar to that of `createRemoteFileNode`, accepting a `Buffer` and optionally a precomputed content hash to skip duplicate work. This helper will write the contents of the buffer out to a file inside `gatsby-source-filesystem`'s disk cache and return a file node pointing to that cache file.

## Example

Here is a brief example of how this may be used within another source plugin:

```
// gatsby-node.js
const { createFileNodeFromBuffer } = require(`gatsby-source-filesystem`)

const { getBuffers } = require(`./internal`)

exports.sourceNodes = async ({ actions, createNodeId, store, cache }) => {
  const { createNode } = actions

  const buffers = await getBuffers()

  for (let i = 0; i < buffers.length; i++) {
    const buffer = buffers[i]
    const fileNode = await createFileNodeFromBuffer({
      buffer,
      store,
      cache,
      createNode,
      createNodeId,
    })
    // optionally do something with `fileNode` (it's just a normal file node)
  }
}
```

## TODO

- [x] implement `createFileNodeFromBuffer`
- [x] write tests

## Related Issues

Closes #14538 
