### PR TITLE
chore(showcase): Added enginehub.org

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -6277,3 +6277,16 @@
     - Beauty
   built_by: Ask Phill
   built_by_url: https://askphill.com
+- title: EngineHub.org
+  url: https://enginehub.org
+  main_url: https://enginehub.org
+  source_url: https://github.com/EngineHub/enginehub-website
+  description: >
+    The landing pages for EngineHub, the organisation behind WorldEdit, WorldGuard, CraftBook, and more
+  categories:
+    - Landing Page
+    - Technology
+    - Open Source
+  built_by: Matthew Miller
+  built_by_url: https://matthewmiller.dev
+  featured: false


### PR DESCRIPTION
## Description

Added the EngineHub website, the organisation behind the Minecraft mods WorldEdit, WorldGuard, and Craftbook