### PR TITLE
Add scroll tip to Building Apps docs page

### DIFF
--- a/docs/docs/building-apps-with-gatsby.md
+++ b/docs/docs/building-apps-with-gatsby.md
@@ -52,4 +52,6 @@ exports.onCreatePage = async ({ page, actions }) => {
 > 💡 Note: There's also a plugin to simplify the creation of client-only routes in your site:
 > [gatsby-plugin-create-client-paths](/packages/gatsby-plugin-create-client-paths/).
 
+> Tip: For applications with complex routing, you may want to override Gatsby's defualt scroll behavior with the [shouldUpdateScroll](/docs/browser-apis/#shouldUpdateScroll) Browser API.
+
 Check out the ["simple auth" example site](https://github.com/gatsbyjs/gatsby/blob/master/examples/simple-auth/README.md) for a demo implementing user authentication and restricted client-only routes.


### PR DESCRIPTION
## Motivation

Expand the Building Apps with Gatsby page, which is very short, and save people time searching.

## Description

I lost 1-2 days of my time trying to deal with dynamic routing in an integrated React app inside of Gatsby. Despite how many different combinations of @react/router, react-router, createHistory, createMemoryHistory, I could not figure out how on earth to get complex routing to work within a SPA page without gatsby scrolling to the top every time, and by trying to trick Gatsby, I couldn't get proper history working without it breaking somehow.

Despite the numerous Google searches, I could NOT find a way to disable Gatsby scroll behaviour, only many issues about it *not* happening. The solution, in the end, was horrendously simple, implement the `shouldUpdateScroll` browser API. By adding this I hope I save somebody at least a few hours of their time.

I thought of maybe adding it to the `<Link> / navigate()` doc page, but it's already long, and it's quite specific to SPA routing.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
