### PR TITLE
fix(gatsby-plugin-feed): Fixed a typo

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -10,7 +10,7 @@ const publicPath = `./public`
 
 const warnMessage = (error, behavior) => `
   gatsby-plugin-feed was initialized in gatsby-config.js without a ${error}.
-  This means that we the plugin will use ${behavior}, which may not match your use case.
+  This means that the plugin will use ${behavior}, which may not match your use case.
   This behavior will be removed in the next major release of gatsby-plugin-feed.
   For more info, check out: https://gatsby.app/adding-rss-feed
 `


### PR DESCRIPTION
Recently got initialization error message several times and noticed this typo.

