### PR TITLE
fix(www): provide timezone to date to fix dates that dont match up

### DIFF
--- a/www/src/components/blog-post-preview-item.js
+++ b/www/src/components/blog-post-preview-item.js
@@ -6,6 +6,7 @@ import { colors, fonts } from "../utils/presets"
 
 const formatDate = dateString =>
   new Date(dateString).toLocaleDateString(`en-EN`, {
+    timeZone: `UTC`,
     month: `long`,
     day: `numeric`,
     year: `numeric`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Noticed dates on the blog preview cards differ from the dates displayed in the post:

![image](https://user-images.githubusercontent.com/21114044/59071485-13bd3500-887c-11e9-91c2-0fe6120e4a3c.png)
![image](https://user-images.githubusercontent.com/21114044/59071489-191a7f80-887c-11e9-9710-02d7dde744f9.png)

This addresses that:

![image](https://user-images.githubusercontent.com/21114044/59071508-2df71300-887c-11e9-8e2c-169309e7ba42.png)

![image](https://user-images.githubusercontent.com/21114044/59071522-39e2d500-887c-11e9-94f7-a344ca3323eb.png)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
