### PR TITLE
fix(gatsby-source-shopify): fix pages query path

### DIFF
--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -144,7 +144,7 @@ const createPageNodes = async (
   endpoint,
   query,
   nodeFactory,
-  { client, createNode, formatMsg, verbose, imageArgs, paginationSize },
+  { client, createNode, formatMsg, verbose, paginationSize },
   f = async () => {}
 ) => {
   // Message printed when fetching is complete.
@@ -154,7 +154,7 @@ const createPageNodes = async (
   await forEach(
     await queryAll(client, [endpoint], query, paginationSize),
     async entity => {
-      const node = await nodeFactory(imageArgs)(entity)
+      const node = await nodeFactory(entity)
       createNode(node)
       await f(entity)
     }

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -65,7 +65,7 @@ export const sourceNodes = async (
       createNodes(`blogs`, BLOGS_QUERY, BlogNode, args),
       createNodes(`collections`, COLLECTIONS_QUERY, CollectionNode, args),
       createNodes(`productTypes`, PRODUCT_TYPES_QUERY, ProductTypeNode, args),
-      createNodes(`pages`, PAGES_QUERY, PageNode, args),
+      createPageNodes(`pages`, PAGES_QUERY, PageNode, args),
       createNodes(`products`, PRODUCTS_QUERY, ProductNode, args, async x => {
         if (x.variants)
           await forEach(x.variants.edges, async edge =>
@@ -137,5 +137,27 @@ const createShopPolicies = async ({
         createNode
       )
     )
+  if (verbose) console.timeEnd(msg)
+}
+
+const createPageNodes = async (
+  endpoint,
+  query,
+  nodeFactory,
+  { client, createNode, formatMsg, verbose, imageArgs, paginationSize },
+  f = async () => {}
+) => {
+  // Message printed when fetching is complete.
+  const msg = formatMsg(`fetched and processed ${endpoint}`)
+
+  if (verbose) console.time(msg)
+  await forEach(
+    await queryAll(client, [endpoint], query, paginationSize),
+    async entity => {
+      const node = await nodeFactory(imageArgs)(entity)
+      createNode(node)
+      await f(entity)
+    }
+  )
   if (verbose) console.timeEnd(msg)
 }

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -146,4 +146,4 @@ export const ProductVariantNode = imageArgs =>
 
 export const ShopPolicyNode = createNodeFactory(SHOP_POLICY)
 
-export const PagesNode = createNodeFactory(PAGE)
+export const PageNode = _imageArgs => createNodeFactory(PAGE)

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -146,4 +146,4 @@ export const ProductVariantNode = imageArgs =>
 
 export const ShopPolicyNode = createNodeFactory(SHOP_POLICY)
 
-export const PageNode = _imageArgs => createNodeFactory(PAGE)
+export const PageNode = createNodeFactory(PAGE)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Shopify page nodes are empty because the fetch results aren't using the `shop` key. I'm unsure how you want to handle this, so I duplicated `createNodes` and removed `shop` from the query path.

`PageNode` also needs to be updated to prevent `TypeError: nodeFactory(...) is not a function`.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
