### PR TITLE
fix(www): links in post-preview-component

### DIFF
--- a/www/src/components/blog-post-preview-item.js
+++ b/www/src/components/blog-post-preview-item.js
@@ -75,7 +75,7 @@ const BlogPostPreviewItem = ({ post, className }) => (
         textIndent: `-100%`,
         whiteSpace: `nowrap`,
         zIndex: 0,
-        pointer-events: 'none',
+        pointerEvents: 'none',
         "&&": { border: 0 },
       }}
     >

--- a/www/src/components/blog-post-preview-item.js
+++ b/www/src/components/blog-post-preview-item.js
@@ -75,7 +75,7 @@ const BlogPostPreviewItem = ({ post, className }) => (
         textIndent: `-100%`,
         whiteSpace: `nowrap`,
         zIndex: 0,
-        pointerEvents: 'none',
+        pointerEvents: `none`,
         "&&": { border: 0 },
       }}
     >

--- a/www/src/components/blog-post-preview-item.js
+++ b/www/src/components/blog-post-preview-item.js
@@ -75,6 +75,7 @@ const BlogPostPreviewItem = ({ post, className }) => (
         textIndent: `-100%`,
         whiteSpace: `nowrap`,
         zIndex: 0,
+        pointer-events: 'none',
         "&&": { border: 0 },
       }}
     >


### PR DESCRIPTION
Clicking anywhere within the center section on a contributor page goes to the same blogpost.

It was always the oldest blogpost, the last one in the HTML order.
What you are really clicking on is the "read more" label that makes the entire section a clickable target.

example: go to https://www.gatsbyjs.org/contributors/shannon-soper/ and click anywhere (but the name-tag) in the center section.

Added `pointer-events: none` to the CSS to prevent this.
Is this a servicable solution, what would be ideal?
/cc @marcysutton 	

edit: woops, went CSS, it's a JS object, camelcasing, I'm rusty
aaaaaaaaaaaand forgot to use backticks, that's what I get for using the github's web-interface.