### PR TITLE
fix(gatsby): respect the GATSBY_CPU_COUNT env var, if set, by default for sharp

### DIFF
--- a/packages/gatsby/src/utils/__tests__/cpu-core-count.js
+++ b/packages/gatsby/src/utils/__tests__/cpu-core-count.js
@@ -1,0 +1,22 @@
+jest.mock(`../physical-cpu-count`, () => 1)
+const getCPUCoreCount = require(`../cpu-core-count`)
+
+beforeEach(() => {
+  delete process.env.GATSBY_CPU_COUNT
+})
+
+test(`it defaults to physical CPU count, if override not detected`, () => {
+  expect(getCPUCoreCount()).toBe(1)
+})
+
+test(`it does not use env far override, if useEnvVar is false`, () => {
+  process.env.GATSBY_CPU_COUNT = 9001
+
+  expect(getCPUCoreCount(false)).not.toBe(Number(process.env.GATSBY_CPU_COUNT))
+})
+
+test(`uses env var override, if exists`, () => {
+  process.env.GATSBY_CPU_COUNT = 9001
+
+  expect(getCPUCoreCount()).toBe(Number(process.env.GATSBY_CPU_COUNT))
+})

--- a/packages/gatsby/src/utils/cpu-core-count.js
+++ b/packages/gatsby/src/utils/cpu-core-count.js
@@ -4,7 +4,7 @@
  * @returns {number} Count of the requested type of CPU cores. Defaults to number of physical cores or 1
  */
 
-const cpuCoreCount = (useEnvVar = false) => {
+const cpuCoreCount = (useEnvVar = true) => {
   try {
     let coreCount = require(`./physical-cpu-count`) || 1
 


### PR DESCRIPTION
## Description

Existing calls to `sharp.concurrency(cpuCoreCount())` are currently ignoring `GATSBY_CPU_COUNT` and will always use the physical CPU count, which can result in resource starvation in virtualised/container-based environments at build time.

The proposed change in this PR switches the default behaviour to observe and respect `GATSBY_CPU_COUNT`.