### PR TITLE
fix(gatsby): Resolve group and distinct field

### DIFF
--- a/packages/gatsby/src/db/nodes-query.js
+++ b/packages/gatsby/src/db/nodes-query.js
@@ -7,9 +7,8 @@ function chooseQueryEngine(args) {
   const { backend } = require(`./nodes`)
 
   const { queryArgs, gqlType } = args
-  // TODO: Need to get group and distinct `field` arg from projection
-  const { filter, sort } = queryArgs
-  const fields = getQueryFields({ filter, sort })
+  const { filter, sort, group, distinct } = queryArgs
+  const fields = getQueryFields({ filter, sort, group, distinct })
 
   // NOTE: `hasFieldResolvers` is also true for Date fields
   if (

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -112,10 +112,9 @@ module.exports = (args: Object) => {
   // If nodes weren't provided, then load them from the DB
   const nodes = args.nodes || getNodesByType(gqlType.name)
 
-  const { filter, sort } = queryArgs
+  const { filter, sort, group, distinct } = queryArgs
   const siftFilter = getFilters(prepareQueryArgs(filter))
-  const fieldsToSift = getQueryFields({ filter, sort })
-  // FIXME: fieldsToSift must include the `field` arg on `group` and `distinct`
+  const fieldsToSift = getQueryFields({ filter, sort, group, distinct })
 
   // If the the query for single node only has a filter for an "id"
   // using "eq" operator, then we'll just grab that ID and return it.

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -753,8 +753,7 @@ Object {
         expect(results.data).toEqual(expected)
       })
 
-      // FIXME: This is not yet possible
-      it.skip(`groups query results by foreign key field`, async () => {
+      it(`groups query results by foreign key field`, async () => {
         const query = `
           {
             allMarkdown {
@@ -764,7 +763,7 @@ Object {
                   node {
                     frontmatter {
                       title
-                      date
+                      date(formatString: "YYYY-MM-DD")
                     }
                   }
                 }
@@ -865,8 +864,7 @@ Object {
         expect(results.data).toEqual(expected)
       })
 
-      // FIXME: This is not yet possible
-      it.skip(`returns distinct values on foreign-key field`, async () => {
+      it(`returns distinct values on foreign-key field`, async () => {
         const query = `
           {
             allMarkdown {


### PR DESCRIPTION
When querying nodes, we used to only call field resolvers on `filter` fields. Since #14423 we do the same for `sort` fields. This PR does the same for the fields specified in the `field` argument to `group` and `distinct` queries.
It is not quite as straightforward as `filter`/`sort`, because we don't get the field in the query arguments, but have to look it up on the `group`/`distinct` field in the selection set.

Fixes #11368