### PR TITLE
[gatsby-remark-images] Add option for markdown captions

### DIFF
--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -14,7 +14,13 @@
     "mdast-util-definitions": "^1.2.0",
     "potrace": "^2.1.1",
     "query-string": "^6.1.0",
+    "rehype-document": "^3.0.1",
+    "rehype-format": "^2.3.2",
+    "rehype-stringify": "^6.0.0",
+    "remark-parse": "^6.0.3",
+    "remark-rehype": "^4.0.0",
     "slash": "^1.0.0",
+    "unified": "^7.1.0",
     "unist-util-select": "^1.5.0",
     "unist-util-visit-parents": "^2.0.1"
   },

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -14,6 +14,23 @@ const Promise = require(`bluebird`)
 const cheerio = require(`cheerio`)
 const slash = require(`slash`)
 
+const unified = require(`unified`)
+const markdown = require(`remark-parse`)
+const remark2rehype = require(`remark-rehype`)
+const doc = require(`rehype-document`)
+const format = require(`rehype-format`)
+const html = require(`rehype-stringify`)
+function markdownToHtml(markdownString) {
+  return unified()
+    .use(markdown)
+    .use(remark2rehype)
+    .use(doc)
+    .use(format)
+    .use(html)
+    .process(markdownString)
+    .then(x => x.contents)
+}
+
 // If the image is relative (not hosted elsewhere)
 // 1. Find the image file
 // 2. Find the image's size
@@ -30,6 +47,7 @@ module.exports = (
     backgroundColor: `white`,
     linkImagesToOriginal: true,
     showCaptions: false,
+    markdownCaptions: false,
     pathPrefix,
     withWebp: false,
     tracedSVG: false,
@@ -288,11 +306,11 @@ module.exports = (
       rawHTML = `
   <figure class="gatsby-resp-image-figure" style="${wrapperStyle}">
     ${rawHTML}
-    <figcaption class="gatsby-resp-image-figcaption">${getNodeTitle(
-      node,
-      alt,
-      defaultAlt
-    )}</figcaption>
+    <figcaption class="gatsby-resp-image-figcaption">${
+      options.markdownCaptions
+        ? markdownToHtml(getNodeTitle(node, alt, defaultAlt))
+        : getNodeTitle(node, alt, defaultAlt)
+    }</figcaption>
   </figure>
       `.trim()
     }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I've added a `markdownCaptions` parameter that when set to true, the plugin will parse the markdown into html using a little helper function.

I did however add quite a few dependencies to do this, which in turn might make the package bloated?

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #14474