### PR TITLE
add types for gatsby-image/withIEPolyfill to fix #14592

### DIFF
--- a/packages/gatsby-image/withIEPolyfill/index.d.ts
+++ b/packages/gatsby-image/withIEPolyfill/index.d.ts
@@ -8,6 +8,5 @@ interface GatsbyImageWithIEPolyfillProps extends GatsbyImageProps {
 }
 
 export default class GatsbyImageWithIEPolyfill extends React.Component<
-  GatsbyImageWithIEPolyfillProps,
-  any
+  GatsbyImageWithIEPolyfillProps
 > {}

--- a/packages/gatsby-image/withIEPolyfill/index.d.ts
+++ b/packages/gatsby-image/withIEPolyfill/index.d.ts
@@ -1,0 +1,13 @@
+import * as React from "react"
+
+import GatsbyImage, { GatsbyImageProps } from "../index"
+
+interface GatsbyImageWithIEPolyfillProps extends GatsbyImageProps {
+  objectFit?: `fill` | `contain` | `cover` | `none` | `scale-down`
+  objectPosition?: string
+}
+
+export default class GatsbyImageWithIEPolyfill extends React.Component<
+  GatsbyImageWithIEPolyfillProps,
+  any
+> {}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

add types for `gatsby-image/withIEPolyfill`

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
fixes #14592 