### PR TITLE
Title doesn't update when opening in a new tab until focused

### DIFF
--- a/www/src/components/site-metadata.js
+++ b/www/src/components/site-metadata.js
@@ -22,7 +22,7 @@ const SiteMetadata = ({ pathname }) => {
   `)
 
   return (
-    <Helmet defaultTitle={title} titleTemplate={`%s | ${title}`}>
+    <Helmet defer={false} defaultTitle={title} titleTemplate={`%s | ${title}`}>
       <html lang="en" />
       <link rel="canonical" href={`${siteUrl}${pathname}`} />
       <meta name="docsearch:version" content="2.0" />


### PR DESCRIPTION
When opening a link from Gatsby site in a new tab (via cmd+click for example), the new tab title is not correctly updated from its default title. 
Related to:
- [315](https://github.com/nfl/react-helmet/issues/315)
- [314](https://github.com/nfl/react-helmet/issues/314)


