### PR TITLE
fix(docs): Wrong import in TransitionState example

### DIFF
--- a/docs/docs/adding-page-transitions-with-plugin-transition-link.md
+++ b/docs/docs/adding-page-transitions-with-plugin-transition-link.md
@@ -113,7 +113,7 @@ If you want to access these props in one of your components instead of a page/te
 Here's an example using `TransitionState` and `react-pose` to trigger enter/exit transitions for a `Box` component.
 
 ```javascript
-import { TransitionLink } from "gatsby-plugin-transition-link"
+import { TransitionState } from "gatsby-plugin-transition-link"
 
 const Box = posed.div({
   hidden: { opacity: 0 },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
