### PR TITLE
fix: Dont use createPageDependency from actions

### DIFF
--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -19,7 +19,7 @@ exports.sourceNodes = async (
   { actions, createNodeId, cache, createContentDigest },
   options
 ) => {
-  const { addThirdPartySchema, createPageDependency, createNode } = actions
+  const { addThirdPartySchema, createNode } = actions
   const {
     url,
     typeName,
@@ -89,7 +89,10 @@ exports.sourceNodes = async (
   createNode(node)
 
   const resolver = (parent, args, context) => {
-    createPageDependency({ path: context.path, nodeId: nodeId })
+    context.nodeModel.createPageDependency({
+      path: context.path,
+      nodeId: nodeId,
+    })
     return {}
   }
 


### PR DESCRIPTION
We recently reorganized our redux actions to not pass internal actions to node APIs. This included `createPageDependency`, which was marked as `@private`.
This unfortunately broke `gatsby-source-graphql` which picked `createPageDependency` from `actions`. This PR changes this to take `createPageDependency` from the resolver `context`.

Fixes  #14637