### PR TITLE
[www] Homepage Call To Actions

### DIFF
--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -69,7 +69,7 @@ const MastheadContent = () => (
       tracking="MasterHead -> Get Started"
       icon={<ArrowForwardIcon />}
     >
-      Get Started
+      Start Using Gatsby
     </Button>
   </div>
 )

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -133,7 +133,7 @@ class IndexRoute extends React.Component {
                   overrideCSS={{ marginTop: space[4] }}
                   icon={<ArrowForwardIcon />}
                 >
-                  Get Started
+                  Start Using Gatsby
                 </Button>
               </div>
             </Container>


### PR DESCRIPTION
## Description

This is a suggestion to improve (imo) the main call to action on the homepage which is currently `Get Started` into the more active `Start Using Gatsby`.

It's a small change but one that I suspect will make a difference. `Get Started` feels like it's the beginning of a long journey that  I might not have time for right now. `Start Using Gatsby` sounds more immediate and less intimidating - which it is!