### PR TITLE
docs: Document sorting with runQuery

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -553,6 +553,23 @@ exports.createResolvers = ({ createResolvers }) => {
 }
 ```
 
+When using `runQuery` to sort query results, be aware that both `sort.fields`
+and `sort.order` are `GraphQLList` fields. Also, nested fields on `sort.fields`
+have to be provided in dot-notation (not separated by triple underscores).
+For example:
+
+```js
+context.nodeModel.runQuery({
+  query: {
+    sort: {
+      fields: ["frontmatter.publishedAt"],
+      order: ["DESC"],
+    },
+  },
+  type: "MarkdownRemark",
+})
+```
+
 ### Custom query fields
 
 One powerful approach enabled by `createResolvers` is adding custom root query


### PR DESCRIPTION
Using `sort` with `runQuery` is a bit different, because single values on `sort.fields` or `sort.order` will not automatically be converted to single-item arrays; and `sort.fields` needs the internal enum values, not the enum keys that can be used in Graph_i_ql.