### PR TITLE
Adds missing semicolon

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -315,7 +315,7 @@ export default ({ children }) => {
         }
       }
     `
-  )
+  );
   // highlight-end
   // highlight-start
   return (


### PR DESCRIPTION
The tutorial fails for me without this semicolon. Gatsby 2.6.5
