### PR TITLE
chore(www): Remove featured tag from unfeatured sites

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -585,7 +585,6 @@
     engagement, generate leads and achieve goals.
   categories:
     - Design
-    - Featured
     - Marketing
     - Portfolio
 - title: Design Systems Weekly
@@ -1253,7 +1252,6 @@
     - Marketing
     - Portfolio
     - Agency
-    - Featured
   built_by: Spacetime
   built_by_url: "https://www.heyspacetime.com/"
 - title: Eric Jinks


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

These sites show up as featured, even though they have `featured: false` set

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
