### PR TITLE
#14651 Fix `gatsby new` bug on initing a new project in a path with spaces

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -17,8 +17,10 @@ const {
 const isTTY = require(`./util/is-tty`)
 const spawn = (cmd: string, options: any) => {
   const [file, ...args] = cmd.split(/\s+/)
-  return execa(file, args, { stdio: `inherit`, ...options })
+  return spawnWithArgs(file, args, options)
 }
+const spawnWithArgs = (file: string, args: string[], options: any) =>
+  execa(file, args, { stdio: `inherit`, ...options })
 
 // Checks the existence of yarn package and user preference if it exists
 // We use yarnpkg instead of yarn to avoid conflict with Hadoop yarn
@@ -152,11 +154,15 @@ const clone = async (hostInfo: any, rootPath: string) => {
     url = hostInfo.https({ noCommittish: true, noGitPlus: true })
   }
 
-  const branch = hostInfo.committish ? `-b ${hostInfo.committish}` : ``
+  const branch = hostInfo.committish ? [`-b`, `hostInfo.committish`] : [``]
 
   report.info(`Creating new site from git: ${url}`)
 
-  await spawn(`git clone ${branch} ${url} ${rootPath} --single-branch`)
+  const args = [`clone`, ...branch, url, rootPath, `--single-branch`].filter(
+    arg => Boolean(arg)
+  )
+
+  await spawnWithArgs(`git`, args)
 
   report.success(`Created starter directory layout`)
 


### PR DESCRIPTION
## Description

When running `gatsby new` in an empty directory, call `git clone` for with args as array to preserve potential spaces in the user's path.

It would likely be a good idea to remove the `cmd.split(/\s+/)` logic altogether, but I don't see it causing any other issues at the moment. In the interesting of maintaining a small footprint here is a first pass at a solution.

## Related Issues

Fixes #14651 

