### PR TITLE
chore(docs): Fix use of navigate

### DIFF
--- a/docs/tutorial/authentication-tutorial.md
+++ b/docs/tutorial/authentication-tutorial.md
@@ -253,21 +253,26 @@ Though the routing is working now, you still can access all routes without restr
 To check if a user can access the content, you can wrap the restricted content inside a PrivateRoute component:
 
 ```jsx:title=src/components/privateRoute.js
-import React from "react"
-import { navigate } from "gatsby"
-import { isLoggedIn } from "../services/auth"
-
-const PrivateRoute = ({ component: Component, location, ...rest }) => {
-  if (!isLoggedIn() && location.pathname !== `/app/login`) {
-    // If the user is not logged in, redirect to the login page.
-    navigate(`/app/login`)
-    return null
+import React, { Component } from 'react';
+import { navigate } from 'gatsby';
+import { isLoggedIn } from '../services/auth';
+class PrivateRoute extends Component {
+  componentDidMount() {
+    const { location } = this.props;
+    let noOnLoginPage = location.pathname !== `/app/login`;
+    if (!isLoggedIn() && noOnLoginPage) {
+      navigate('/app/login');
+      return null;
+    }
   }
-
-  return <Component {...rest} />
+  render() {
+    const { component: Component, ...rest } = this.props;
+    return <Component {...rest} />;
+  }
 }
 
-export default PrivateRoute
+export default PrivateRoute;
+
 ```
 
 And now you can edit your Router to use the PrivateRoute component:

--- a/docs/tutorial/authentication-tutorial.md
+++ b/docs/tutorial/authentication-tutorial.md
@@ -253,26 +253,25 @@ Though the routing is working now, you still can access all routes without restr
 To check if a user can access the content, you can wrap the restricted content inside a PrivateRoute component:
 
 ```jsx:title=src/components/privateRoute.js
-import React, { Component } from 'react';
-import { navigate } from 'gatsby';
-import { isLoggedIn } from '../services/auth';
+import React, { Component } from "react"
+import { navigate } from "gatsby"
+import { isLoggedIn } from "../services/auth"
 class PrivateRoute extends Component {
   componentDidMount() {
-    const { location } = this.props;
-    let noOnLoginPage = location.pathname !== `/app/login`;
+    const { location } = this.props
+    let noOnLoginPage = location.pathname !== `/app/login`
     if (!isLoggedIn() && noOnLoginPage) {
-      navigate('/app/login');
-      return null;
+      navigate("/app/login")
+      return null
     }
   }
   render() {
-    const { component: Component, ...rest } = this.props;
-    return <Component {...rest} />;
+    const { component: Component, ...rest } = this.props
+    return <Component {...rest} />
   }
 }
 
-export default PrivateRoute;
-
+export default PrivateRoute
 ```
 
 And now you can edit your Router to use the PrivateRoute component:


### PR DESCRIPTION
The navigate fn will not work on build since it needs access to the window which is only available in componentDidMount.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
