### PR TITLE
feat(themes): header/page-layout theme concept

### DIFF
--- a/themes/gatsby-starter-theme/gatsby-config.js
+++ b/themes/gatsby-starter-theme/gatsby-config.js
@@ -1,18 +1,14 @@
 module.exports = {
   __experimentalThemes: [
-    /*
     {
       resolve: `gatsby-theme-blog`,
       options: {},
     },
-    */
     {
       resolve: `gatsby-theme-notes`,
       options: {
-        // mdx: false,
-        notesPath: `/`,
-        // homeText: `HOME`,
-        // breadcrumbSeparator: `⚡️`,
+        mdx: false,
+        notesPath: `/notes`,
       },
     },
   ],

--- a/themes/gatsby-starter-theme/gatsby-config.js
+++ b/themes/gatsby-starter-theme/gatsby-config.js
@@ -1,16 +1,18 @@
 module.exports = {
   __experimentalThemes: [
+    /*
     {
       resolve: `gatsby-theme-blog`,
       options: {},
     },
+    */
     {
       resolve: `gatsby-theme-notes`,
       options: {
-        mdx: false,
-        notesPath: `/txt`,
-        homeText: `HOME`,
-        breadcrumbSeparator: `⚡️`,
+        // mdx: false,
+        notesPath: `/`,
+        // homeText: `HOME`,
+        // breadcrumbSeparator: `⚡️`,
       },
     },
   ],

--- a/themes/gatsby-starter-theme/src/gatsby-theme-header/index.js
+++ b/themes/gatsby-starter-theme/src/gatsby-theme-header/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Link } from 'gatsby'
+
+export default props =>
+  <header>
+    <h2>
+      Custom Header
+    </h2>
+    <ul>
+      <li>
+        <Link to='/'>Blog</Link>
+      </li>
+      <li>
+        <Link to='/txt'>Notes</Link>
+      </li>
+    </ul>
+  </header>

--- a/themes/gatsby-starter-theme/src/gatsby-theme-header/index.js
+++ b/themes/gatsby-starter-theme/src/gatsby-theme-header/index.js
@@ -12,6 +12,7 @@ export default props =>
         <Link to='/'>Blog</Link>
       </li>
       <li>
+        <Link to='/notes'>Notes</Link>
       </li>
     </ul>
   </header>

--- a/themes/gatsby-starter-theme/src/gatsby-theme-header/index.js
+++ b/themes/gatsby-starter-theme/src/gatsby-theme-header/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'gatsby'
+// import Header from 'gatsby-theme-blog/src/gatsby-theme-header'
 
 export default props =>
   <header>
@@ -11,7 +12,6 @@ export default props =>
         <Link to='/'>Blog</Link>
       </li>
       <li>
-        <Link to='/txt'>Notes</Link>
       </li>
     </ul>
   </header>

--- a/themes/gatsby-theme-blog/gatsby-config.js
+++ b/themes/gatsby-theme-blog/gatsby-config.js
@@ -9,6 +9,9 @@ module.exports = {
       github: `https://github.com/gatsbyjs/gatsby`,
     },
   },
+  __experimentalThemes: [
+    'gatsby-theme-header',
+  ],
   plugins: [
     /*
      * User override content

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -29,6 +29,7 @@
     "gatsby-remark-responsive-iframe": "^2.1.1",
     "gatsby-remark-smartypants": "^2.0.8",
     "gatsby-source-filesystem": "^2.0.23",
+    "gatsby-theme-header": "0.0.1",
     "gatsby-transformer-remark": "^2.3.0",
     "gatsby-transformer-sharp": "^2.1.15",
     "lodash.merge": "^4.6.1",

--- a/themes/gatsby-theme-blog/src/components/layout.js
+++ b/themes/gatsby-theme-blog/src/components/layout.js
@@ -1,68 +1,18 @@
 import React from "react"
 import { Link } from "gatsby"
 import { Global } from "@emotion/core"
-import { useColorMode, css, Styled, Layout, Container } from "theme-ui"
+import { css, Styled, Layout, Main, Container } from "theme-ui"
 import Header from 'gatsby-theme-header'
 
-import Toggle from "./toggle"
-import sun from "../../content/assets/sun.png"
-import moon from "../../content/assets/moon.png"
+// container 672
+// px 28
 
-const Title = props => {
-  const { location, title } = props
-  const rootPath = `${__PATH_PREFIX__}/`
-
-  if (location.pathname === rootPath) {
-    return (
-      <Styled.h1
-        css={css({
-          my: 0,
-          fontSize: 4,
-        })}
-      >
-        <Styled.a
-          as={Link}
-          css={{
-            color: `inherit`,
-            boxShadow: `none`,
-            textDecoration: `none`,
-          }}
-          to={`/`}
-        >
-          {title}
-        </Styled.a>
-      </Styled.h1>
-    )
-  } else {
-    return (
-      <Styled.h3
-        css={css({
-          my: 0,
-        })}
-      >
-        <Styled.a
-          as={Link}
-          css={css({
-            boxShadow: `none`,
-            textDecoration: `none`,
-            color: `primary`,
-          })}
-          to={`/`}
-        >
-          {title}
-        </Styled.a>
-      </Styled.h3>
-    )
-  }
-}
+// notes
+// container 769
+// padding 56
 
 export default props => {
   const { children } = props
-  const [colorMode, setColorMode] = useColorMode()
-  const isDark = colorMode === `dark`
-  const toggleColorMode = e => {
-    setColorMode(isDark ? `light` : `dark`)
-  }
 
   return (
     <Styled.root>
@@ -71,6 +21,7 @@ export default props => {
           styles={theme =>
             css({
               body: {
+                margin: 0,
                 color: `text`,
                 bg: `background`,
               },
@@ -78,12 +29,14 @@ export default props => {
           }
         />
         <Header />
-        <Container
-          css={css({
-            py: 4,
-          })}>
-          {children}
-        </Container>
+        <Main>
+          <Container
+            css={css({
+              py: 4,
+            })}>
+            {children}
+          </Container>
+        </Main>
       </Layout>
     </Styled.root>
   )

--- a/themes/gatsby-theme-blog/src/components/layout.js
+++ b/themes/gatsby-theme-blog/src/components/layout.js
@@ -1,9 +1,10 @@
 import React from "react"
 import { Link } from "gatsby"
 import { Global } from "@emotion/core"
-import { useColorMode, css, Styled, Layout, Header, Container } from "theme-ui"
-import Toggle from "./toggle"
+import { useColorMode, css, Styled, Layout, Container } from "theme-ui"
+import Header from 'gatsby-theme-header'
 
+import Toggle from "./toggle"
 import sun from "../../content/assets/sun.png"
 import moon from "../../content/assets/moon.png"
 
@@ -76,46 +77,11 @@ export default props => {
             })(theme)
           }
         />
+        <Header />
         <Container
           css={css({
             py: 4,
-          })}
-        >
-          <Header
-            css={css({
-              justifyContent: `space-between`,
-              alignItems: `center`,
-              mb: 4,
-            })}
-          >
-            <Title {...props} />
-            <Toggle
-              icons={{
-                checked: (
-                  <img
-                    alt="moon indicating dark mode"
-                    src={moon}
-                    width="16"
-                    height="16"
-                    role="presentation"
-                    css={{ pointerEvents: `none` }}
-                  />
-                ),
-                unchecked: (
-                  <img
-                    alt="sun indicating light mode"
-                    src={sun}
-                    width="16"
-                    height="16"
-                    role="presentation"
-                    css={{ pointerEvents: `none` }}
-                  />
-                ),
-              }}
-              checked={isDark}
-              onChange={toggleColorMode}
-            />
-          </Header>
+          })}>
           {children}
         </Container>
       </Layout>

--- a/themes/gatsby-theme-blog/src/components/layout.js
+++ b/themes/gatsby-theme-blog/src/components/layout.js
@@ -4,13 +4,6 @@ import { Global } from "@emotion/core"
 import { css, Styled, Layout, Main, Container } from "theme-ui"
 import Header from 'gatsby-theme-header'
 
-// container 672
-// px 28
-
-// notes
-// container 769
-// padding 56
-
 export default props => {
   const { children } = props
 

--- a/themes/gatsby-theme-blog/src/gatsby-theme-header/index.js
+++ b/themes/gatsby-theme-blog/src/gatsby-theme-header/index.js
@@ -1,0 +1,128 @@
+import React from 'react'
+import {
+  css,
+  Header,
+  Container,
+  Styled,
+  Box,
+  useColorMode,
+} from 'theme-ui'
+import { Link } from 'gatsby'
+import useSiteMetadata from '../hooks/use-site-metadata'
+import Toggle from '../components/toggle'
+import sun from "../../content/assets/sun.png"
+import moon from "../../content/assets/moon.png"
+
+const Title = props => {
+  return (
+    <Styled.h3 my={0}>
+      <Styled.a
+        as={Link}
+        to='/'
+        css={css({
+          boxShadow: `none`,
+          textDecoration: `none`,
+          color: `primary`,
+        })}>
+        {props.children}
+      </Styled.a>
+    </Styled.h3>
+  )
+  const { location, title } = props
+  const rootPath = `${__PATH_PREFIX__}/`
+
+  if (location.pathname === rootPath) {
+    return (
+      <Styled.h1
+        css={css({
+          my: 0,
+          fontSize: 4,
+        })}
+      >
+        <Styled.a
+          as={Link}
+          css={{
+            color: `inherit`,
+            boxShadow: `none`,
+            textDecoration: `none`,
+          }}
+          to={`/`}
+        >
+          {title}
+        </Styled.a>
+      </Styled.h1>
+    )
+  } else {
+    return (
+      <Styled.h3
+        css={css({
+          my: 0,
+        })}
+      >
+        <Styled.a
+          as={Link}
+          css={css({
+            boxShadow: `none`,
+            textDecoration: `none`,
+            color: `primary`,
+          })}
+          to={`/`}
+        >
+          {title}
+        </Styled.a>
+      </Styled.h3>
+    )
+  }
+}
+
+export default props => {
+  const metadata = useSiteMetadata()
+  const [ colorMode, setColorMode ] = useColorMode()
+  const isDark = colorMode === 'dark'
+  const toggleColorMode = e => {
+    setColorMode(isDark ? `light` : `dark`)
+  }
+
+  return (
+    <Header mb={4}>
+      <Container
+        css={css({
+          py: 3,
+          display: 'flex',
+          alignItems: 'center',
+        })}>
+        <Title>
+          {metadata.title}
+        </Title>
+        <Box mx='auto' />
+        {props.children}
+        <Toggle
+          icons={{
+            checked: (
+              <img
+                alt="moon indicating dark mode"
+                src={moon}
+                width="16"
+                height="16"
+                role="presentation"
+                css={{ pointerEvents: `none` }}
+              />
+            ),
+            unchecked: (
+              <img
+                alt="sun indicating light mode"
+                src={sun}
+                width="16"
+                height="16"
+                role="presentation"
+                css={{ pointerEvents: `none` }}
+              />
+            ),
+          }}
+          checked={isDark}
+          onChange={toggleColorMode}
+        />
+      </Container>
+    </Header>
+  )
+}

--- a/themes/gatsby-theme-blog/src/gatsby-theme-header/index.js
+++ b/themes/gatsby-theme-blog/src/gatsby-theme-header/index.js
@@ -28,6 +28,8 @@ const Title = props => {
       </Styled.a>
     </Styled.h3>
   )
+  // this would likely need to change with this pattern
+  /*
   const { location, title } = props
   const rootPath = `${__PATH_PREFIX__}/`
 
@@ -73,6 +75,7 @@ const Title = props => {
       </Styled.h3>
     )
   }
+  */
 }
 
 export default props => {

--- a/themes/gatsby-theme-blog/src/hooks/use-site-metadata.js
+++ b/themes/gatsby-theme-blog/src/hooks/use-site-metadata.js
@@ -1,0 +1,15 @@
+import { graphql, useStaticQuery } from "gatsby"
+
+export default () => {
+  const data = useStaticQuery(graphql`
+    {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+    }
+  `)
+
+  return data.site.siteMetadata
+}

--- a/themes/gatsby-theme-header/README.md
+++ b/themes/gatsby-theme-header/README.md
@@ -1,0 +1,47 @@
+
+# gatsby-theme-header
+
+Gatsby theme for including a shadowable page header component
+
+```sh
+npm i gatsby-theme-header
+```
+
+```js
+// gatsby-config.js
+module.exports = {
+  __experimentalThemes: [
+    'gatsby-theme-header',
+  ],
+}
+```
+
+To create a header component, shadow the component at `src/gatsby-theme-header/index.js`
+
+```js
+// example src/gatsby-theme-header/index.js
+import React from 'react'
+
+export default () =>
+  <header>
+    Hello, Header!
+  </header>
+```
+
+Next, in another Gatsby theme, import and use the Header component in your layout.
+
+```js
+// example theme layout components
+import React from 'react'
+import Header from 'gatsby-theme-header'
+
+export default props =>
+  <>
+    <Header />
+    <main>
+      {props.children}
+    </main>
+  </>
+```
+
+With this in place, the end-user or other themes can customize the header component by shadowing the same component.

--- a/themes/gatsby-theme-header/gatsby-config.js
+++ b/themes/gatsby-theme-header/gatsby-config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/themes/gatsby-theme-header/index.js
+++ b/themes/gatsby-theme-header/index.js
@@ -1,2 +1,1 @@
-// noop
 export { default } from './src/index'

--- a/themes/gatsby-theme-header/index.js
+++ b/themes/gatsby-theme-header/index.js
@@ -1,0 +1,2 @@
+// noop
+export { default } from './src'

--- a/themes/gatsby-theme-header/index.js
+++ b/themes/gatsby-theme-header/index.js
@@ -1,2 +1,2 @@
 // noop
-export { default } from './src'
+export { default } from './src/index'

--- a/themes/gatsby-theme-header/package.json
+++ b/themes/gatsby-theme-header/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gatsby-theme-header",
+  "version": "0.0.1",
+  "main": "index.js",
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "peerDependencies": {
+    "gatsby": "^2.8.5",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/themes/gatsby-theme-header/src/index.js
+++ b/themes/gatsby-theme-header/src/index.js
@@ -1,0 +1,2 @@
+// noop component for shadowing
+export default () => false

--- a/themes/gatsby-theme-notes/gatsby-config.js
+++ b/themes/gatsby-theme-notes/gatsby-config.js
@@ -2,7 +2,9 @@ module.exports = options => {
   const { mdx = true, mdxLayouts = {} } = options
 
   return {
-    __experimentalThemes: [],
+    __experimentalThemes: [
+      'gatsby-theme-header',
+    ],
     plugins: [
       mdx && {
         resolve: `gatsby-mdx`,

--- a/themes/gatsby-theme-notes/package.json
+++ b/themes/gatsby-theme-notes/package.json
@@ -33,6 +33,7 @@
     "gatsby-plugin-og-image": "0.0.1",
     "gatsby-plugin-redirects": "^1.0.0",
     "gatsby-source-filesystem": "^2.0.35",
+    "gatsby-theme-header": "0.0.1",
     "is-present": "^1.0.0",
     "react-feather": "^1.1.6",
     "theme-ui": "^0.0.12"

--- a/themes/gatsby-theme-notes/src/components/file-list.js
+++ b/themes/gatsby-theme-notes/src/components/file-list.js
@@ -3,7 +3,7 @@ import { Link } from "gatsby"
 import { Styled } from "theme-ui"
 
 export default ({ files }) => (
-  <ul css={{ padding: 0 }}>
+  <ul>
     {files.map(url => (
       <li key={url}>
         <Styled.a as={Link} to={url}>

--- a/themes/gatsby-theme-notes/src/components/layout.js
+++ b/themes/gatsby-theme-notes/src/components/layout.js
@@ -4,8 +4,6 @@ import { css } from "theme-ui"
 import { Layout, Main, Container } from "theme-ui"
 import Header from 'gatsby-theme-header'
 
-console.log('Header', typeof Header, <Header />)
-
 export default props => (
   <>
     <Global

--- a/themes/gatsby-theme-notes/src/components/layout.js
+++ b/themes/gatsby-theme-notes/src/components/layout.js
@@ -2,6 +2,9 @@ import React from "react"
 import { Global } from "@emotion/core"
 import { css } from "theme-ui"
 import { Layout, Main, Container } from "theme-ui"
+import Header from 'gatsby-theme-header'
+
+console.log('Header', typeof Header, <Header />)
 
 export default props => (
   <>
@@ -19,6 +22,7 @@ export default props => (
       })}
     />
     <Layout>
+      <Header />
       <Main>
         <Container>{props.children}</Container>
       </Main>

--- a/themes/gatsby-theme-notes/src/components/layout.js
+++ b/themes/gatsby-theme-notes/src/components/layout.js
@@ -1,21 +1,16 @@
 import React from "react"
 import { Global } from "@emotion/core"
-import { css } from "theme-ui"
-import { Layout, Main, Container } from "theme-ui"
+import { css, Styled, Layout, Main, Container } from "theme-ui"
 import Header from 'gatsby-theme-header'
 
 export default props => (
-  <>
+  <Styled.root>
     <Global
       styles={css({
-        "*": {
-          boxSizing: `border-box`,
-        },
         body: {
           margin: 0,
           color: `text`,
           bg: `background`,
-          fontFamily: `body`,
         },
       })}
     />
@@ -25,5 +20,5 @@ export default props => (
         <Container>{props.children}</Container>
       </Main>
     </Layout>
-  </>
+  </Styled.root>
 )

--- a/themes/package.json
+++ b/themes/package.json
@@ -1,12 +1,13 @@
 {
   "private": true,
   "scripts": {
-    "start": "yarn workspace gatsby-starter-theme-blog start"
+    "start": "yarn workspace gatsby-starter-theme start"
   },
   "workspaces": [
     "gatsby-theme-blog-core",
     "gatsby-theme-blog-mdx",
     "gatsby-theme-blog",
+    "gatsby-theme-header",
     "gatsby-starter-theme",
     "gatsby-theme-notes"
   ]


### PR DESCRIPTION
## Description

This is a demonstration of an idea I mentioned to @ChristopherBiscardi the other day. When composing multiple themes together in a single site, there are a few different ways to share page layout components (e.g. headers/footers/etc) across multiple paths. One option is to leave page layout concerns to the end user building their site. While this approach is very intentional and flexible, it does require more work than simply installing a theme.

Another approach is to build page layout into individual themes and allow the user to import and reuse layout components from one theme in another. This also requires some amount of work to set up.

With the approach demonstrated in this PR, the page header component is provided by a separate `gatsby-theme-header` theme than can be imported, shadowed, and customized by themes or sites. Here, `gatsby-theme-header` is a dependency of both the blog and notes themes. Each one imports the `Header` component for use in its own layout. The notes theme imports the component without shadowing it. The blog theme imports the component *and* shadows the header component to include site metadata as the title and the dark mode toggle switch. The notes theme also uses this shadowed header component to render in its own layout.

The example `gatsby-theme-starter` site also shadows the header component to add a link to the `/notes` path (this hasn't been styled to match the themes, but is included as a demo). 

I've kept this scoped to a single component for demonstration purposes, but the idea could be handled with something like a `gatsby-theme-page-layout` theme that included multiple components.

### Questions

- What are your general thoughts on utilizing a pattern like this?
- Are there any obvious problems with this approach that I'm missing?
- Is this too complex (or too confusing) for the official themes?

## Related Issues

Related #14276

