### PR TITLE
docs(quick-start): fixed link to quick start guide

### DIFF
--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -4,7 +4,7 @@ title: Tailwind CSS
 
 Tailwind is a utility-first CSS framework for rapidly building custom user interfaces. This guide will show you how to get started with Gatsby and [Tailwind CSS](https://tailwindcss.com/).
 
-This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [**Quick Start guide**](/docs/docs/quick-start.md), then come back.
+This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [**Quick Start guide**](/docs/quick-start), then come back.
 
 ### Overview
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Just changed the link referencing the Quick Start Guide as it had a .md extension which doesn't seem to work anymore. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->