### PR TITLE
fix(www): upgrade gatsby-remark-images 

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -44,7 +44,7 @@
     "gatsby-remark-copy-linked-files": "^2.0.5",
     "gatsby-remark-embed-video": "^1.7.0",
     "gatsby-remark-graphviz": "^1.0.11",
-    "gatsby-remark-images": "^2.0.1",
+    "gatsby-remark-images": "^3.0.14",
     "gatsby-remark-normalize-paths": "^1.0.0",
     "gatsby-remark-prismjs": "^3.0.2",
     "gatsby-remark-responsive-iframe": "^2.0.5",


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This will fix inline jsx images that have been a problem on the blog and in other mdx like docs

Current: 
![image](https://user-images.githubusercontent.com/21114044/59311068-77bd7000-8c65-11e9-8267-eab44c3409f5.png)

With Fix:
![image](https://user-images.githubusercontent.com/21114044/59311089-84da5f00-8c65-11e9-97b5-1f9eb644bae2.png)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
