### PR TITLE
fix[gatsby-plugin-offline]: Ommit per-page-manifest preload link

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-ssr.js
@@ -13,7 +13,8 @@ export const onPreRenderHTML = ({
         type === `link` &&
         props.as === `fetch` &&
         props.rel === `preload` &&
-        props.href.startsWith(`/static/d/`)
+        (props.href.startsWith(`/static/d/`) ||
+          props.href.startsWith(`/page-data/`))
       )
   )
 


### PR DESCRIPTION
## Description

Removes the preload link, when the offline plugin is used, also for per-page-manifest data which are located differently under `/public/page-data/`.
