### PR TITLE
fix(gatsby-plugin-offline): use networkFirst caching for page-data.json files

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -92,7 +92,7 @@ exports.onPostBuild = (args, pluginOptions) => {
       },
       {
         // page-data.json files are not content hashed
-        urlPattern: /^https:?:*page-data\.json/,
+        urlPattern: /^https?:.*\page-data\/.*\/page-data\.json/,
         handler: `networkFirst`,
       },
       {

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -91,6 +91,11 @@ exports.onPostBuild = (args, pluginOptions) => {
         handler: `cacheFirst`,
       },
       {
+        // page-data.json files are not content hashed
+        urlPattern: /^https:?:*page-data\.json/,
+        handler: `networkFirst`,
+      },
+      {
         // Add runtime caching of various other page resources
         urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
         handler: `staleWhileRevalidate`,


### PR DESCRIPTION
## Description

`page-data.json` files are not content hashed. Their value can change between builds and the filename will remain the same. Therefore, in the offline plugin, we should use [networkFirst](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#network-falling-back-to-cache) strategy.

## Related Issues

- https://github.com/gatsbyjs/gatsby/pull/13004
