### PR TITLE
fix(www): added og and twitter meta description to showcase

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -285,6 +285,18 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                       .childImageSharp.resize.height
                   }
                 />
+                <meta
+                  property="og:description"
+                  content={
+                    data.sitesYaml.description || data.sitesYaml.main_url
+                  }
+                />
+                <meta
+                  name="twitter:description"
+                  content={
+                    data.sitesYaml.description || data.sitesYaml.main_url
+                  }
+                />
               </Helmet>
               <div
                 css={{


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The original purpose of this issue was to address Twitter cards not working for individual "Showcase" entries. This was fixed in  #14560, but did not have a description in the cards. I was asked to add the description to the Twitter cards.
Before: 
<img width="1066" alt="Screen Shot 2019-06-11 at 7 31 03 PM" src="https://user-images.githubusercontent.com/18073651/59314280-a138c480-8c82-11e9-971d-d1f997e53f87.png">

After: 
<img width="1144" alt="Screen Shot 2019-06-11 at 7 37 42 PM" src="https://user-images.githubusercontent.com/18073651/59314310-c4fc0a80-8c82-11e9-855f-b561e7e33d75.png">


## Related Issues
 #14560 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
