### PR TITLE
Change gatsby-transformer-remark excerpt behavior

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -191,6 +191,20 @@ It's also possible to ask Gatsby to return excerpts formatted as HTML. You might
 }
 ```
 
+You can also get excerpts in Markdown format.
+
+```graphql
+{
+  allMarkdownRemark {
+    edges {
+      node {
+        excerpt(format: MARKDOWN)
+      }
+    }
+  }
+}
+```
+
 ## gray-matter options
 
 `gatsby-transformer-remark` uses [gray-matter](https://github.com/jonschlinkert/gray-matter) to parse markdown frontmatter, so you can specify any of the options mentioned [here](https://github.com/jonschlinkert/gray-matter#options) in the `gatsby-config.js` file.

--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -16,22 +16,6 @@ Object {
 }
 `;
 
-exports[`Excerpt is generated correctly from schema correctly loads a default excerpt 2`] = `
-Object {
-  "excerpt": "",
-  "excerptAst": Object {
-    "children": Array [],
-    "data": Object {
-      "quirksMode": false,
-    },
-    "type": "root",
-  },
-  "frontmatter": Object {
-    "title": "my little pony",
-  },
-}
-`;
-
 exports[`Excerpt is generated correctly from schema correctly loads an excerpt 1`] = `
 Object {
   "excerpt": "Where oh where is my little pony?",

--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -16,6 +16,22 @@ Object {
 }
 `;
 
+exports[`Excerpt is generated correctly from schema correctly loads a default excerpt 2`] = `
+Object {
+  "excerpt": "",
+  "excerptAst": Object {
+    "children": Array [],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+}
+`;
+
 exports[`Excerpt is generated correctly from schema correctly loads an excerpt 1`] = `
 Object {
   "excerpt": "Where oh where is my little pony?",
@@ -130,8 +146,7 @@ Object {
 
 exports[`Excerpt is generated correctly from schema correctly uses excerpt separator 1`] = `
 Object {
-  "excerpt": "Where oh where is my little pony?
-",
+  "excerpt": "Where oh where is my little pony?",
   "excerptAst": Object {
     "children": Array [
       Object {
@@ -159,6 +174,26 @@ Object {
   "frontmatter": Object {
     "title": "my little pony",
   },
+}
+`;
+
+exports[`Excerpt is generated correctly from schema given HTML correctly uses excerpt separator 1`] = `
+Object {
+  "excerpt": "<p>Where oh where <strong>is</strong> my little pony?</p>
+",
+}
+`;
+
+exports[`Excerpt is generated correctly from schema given MARKDOWN correctly uses excerpt separator 1`] = `
+Object {
+  "excerpt": "Where oh where **is** my little pony?
+",
+}
+`;
+
+exports[`Excerpt is generated correctly from schema given PLAIN correctly uses excerpt separator 1`] = `
+Object {
+  "excerpt": "Where oh where is my little pony?",
 }
 `;
 

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -222,6 +222,52 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     { pluginOptions: { excerpt_separator: `<!-- end -->` } }
   )
 
+  const contentWithSeparator = `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+Where oh where **is** my little pony?
+<!-- end -->
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla viverra, eros at efficitur pulvinar, lectus orci accumsan nisi, eu blandit elit nulla nec lectus. Integer porttitor imperdiet sapien. Quisque in orci sed nisi consequat aliquam. Aenean id mollis nisi. Sed auctor odio id erat facilisis venenatis. Quisque posuere faucibus libero vel fringilla.
+
+In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincidunt, sem velit vulputate enim, nec interdum augue enim nec mauris. Nulla iaculis ante sed enim placerat pretium. Nulla metus odio, facilisis vestibulum lobortis vitae, bibendum at nunc. Donec sit amet efficitur metus, in bibendum nisi. Vivamus tempus vel turpis sit amet auctor. Maecenas luctus vestibulum velit, at sagittis leo volutpat quis. Praesent posuere nec augue eget sodales. Pellentesque vitae arcu ut est varius venenatis id maximus sem. Curabitur non consectetur turpis.
+`
+
+  bootstrapTest(
+    `given PLAIN correctly uses excerpt separator`,
+    contentWithSeparator,
+    `excerpt(format: PLAIN)`,
+    node => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt).toMatch(`Where oh where is my little pony?`)
+    },
+    { pluginOptions: { excerpt_separator: `<!-- end -->` } }
+  )
+
+  bootstrapTest(
+    `given HTML correctly uses excerpt separator`,
+    contentWithSeparator,
+    `excerpt(format: HTML)`,
+    node => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt).toMatch(
+        `<p>Where oh where <strong>is</strong> my little pony?</p>`
+      )
+    },
+    { pluginOptions: { excerpt_separator: `<!-- end -->` } }
+  )
+
+  bootstrapTest(
+    `given MARKDOWN correctly uses excerpt separator`,
+    contentWithSeparator,
+    `excerpt(format: MARKDOWN)`,
+    node => {
+      expect(node).toMatchSnapshot()
+      expect(node.excerpt).toMatch(`Where oh where **is** my little pony?`)
+    },
+    { pluginOptions: { excerpt_separator: `<!-- end -->` } }
+  )
+
   const content = `---
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"


### PR DESCRIPTION
## Description

This commit changes `excerpt` behavior of `gatsby-transformer-remark`:

- Plain text even with separator
- New format for MARKDOWN

Previously, `PLAIN` excerpt returns different format with/without `excerpt_separator` because it respected `gray-matter`'s `excerpt` (which is raw markdown) when `excerpt_separator` is specified. Now, it applies the same logic used by without separator.

To keep the current behavior somewhere, we also introduces `MARKDOWN` format. So, `excerpt(format: MARKDOWN)` + `excerpt_separator` is identical with the current `excerpt(format: PLAIN)` + `excerpt_separator`.

## Related Issues

Addresses #4459 
