### PR TITLE
chore(docs): fill out winning over developers stub

### DIFF
--- a/docs/docs/winning-over-developers.md
+++ b/docs/docs/winning-over-developers.md
@@ -1,15 +1,72 @@
 ---
 title: Winning Over Developers
-issue: https://github.com/gatsbyjs/gatsby/issues/14040
 ---
 
-Often developers are the main evangelists of Gatsby, because they use it and can see the benefit.
+Developers are often the primary evangelists of Gatsby because they are the primary users of the framework. If you're a developer, you may find that simply talking to other developers about why *you* like Gatsby is enough to get them interested. Here are some talking points to help support your conversations with developers.
 
-Also, if you're a developer, it's often easier to explain why Gatsby is good to other developers rather than difference audiences, because you can simply explain why you like it.
+Some things that developers care about include:
 
---
+- **Site Performance** Building sites that are fast and that stay fast as new tools and technology get incorporated.
+- **Working with the best tools and technologies** Getting to use new technologies and having the flexibility to pick the right tools for the job.
+- **Not getting bogged down in configuration and setup** These things are often time consuming, frustrating, and prevent developers from getting to focus on the work they actually care about. 
+- **Developing as efficiently and effectively as possible** The more things can be streamlined, automated, and/or simplified, the better.
 
-This is a stub. Help our community expand it.
+## Basic Explanation
 
-Please use the [Gatsby Style Guide](/contributing/gatsby-style-guide/) to ensure your
-pull request gets accepted.
+Here's an example of a basic explanation of Gatsby for developers:
+
+> Gatsby is a free, open-source, React-based framework for building fast websites and applications. Gatsby streamlines the setup and configuration of your build, it can pull data into your UI from any and all of your sources, and amazing performance and current web best practices  are build into Gatsby sites.
+
+## Specific benefits
+
+Gatsby has many benefits that give developers the freedom to build great websites and use the skills and tools they love. Some specific talking points are listed below.
+
+### Site speed
+
+> Gatsby was built with performance in mind from its inception, and Gatsby sites are consistently 2-3x faster than similar sites built with other tools – pages load in milliseconds rather than seconds. Gatsby's automated performance optimizations include pre-fetching resources, code splitting, statically generating HTML, and Google's [PRPL Pattern](/docs/prpl-pattern/).  If you want to take a deeper dive into Gatsby's performance features, check out [Web Performance 101 – also, why is Gatsby so fast?](/blog/2017-09-13-why-is-gatsby-so-fast/).
+
+### Modern web tools
+
+> Gatsby sites are built with React - currently the most popular framework for developing web apps, and data can be pulled into your React components via GraphQL. Gatsby is also built to pull data from any source so you can pick the best tool for each job and function your site needs to perform. Pull data from the best content management tools, the best e-commerce tools, whatever databases you're using, and more. 
+
+### Plugins and features
+
+> Just about every feature you could want for building a state-of-the-art website or web app is available through Gatsby. If the feature isn't already built in, there's an extensive library of available plugins. There's a list of features, their availability, and comparisons with other site building options available on the [Features page](/features/). The complete list of currently available plugins can be found on the [Plugins page](/plugins/).
+
+### Community and documentation
+
+> You'd be hard-pressed to find a more active and welcoming open-source community than Gatsby. Documentation is thorough, detailed, and doesn't make any assumptions about your experience-level going in. The Gatsby team is committed to transparency and working in the open so the community can follow and participate in Gatsby's development and direction. Everyone is encouraged to contribute to Gatsby and every contribution is valued.
+
+### Brings focus to the front end
+
+> A benefit that frequently comes up in discussions of Gatsby is how it helps bring more focus to font-end development and a clearer division between front-end and back-end tasks. Complicated tooling and configuration can consume a lot of development time and can pull front-end developers away from doing what they do best. Because Gatsby requires minimal tooling and configuration, front-end developers can spend more time making great UI's and back-end developers can focus on adding the features and integrations that make your product better.
+
+## Common concerns
+
+You may find that many of your developer friends and colleagues have some questions or concerns about Gatsby. Here are some common examples and responses you can provide to help alleviate those concerns.
+
+### Our site uses a lot of dynamic content and components. Isn't Gatsby a static site generator?
+
+> It is, but there's more to it. Gatsby statically generates HTML content using React DOM and server-side APIs – it's an important part of how Gatsby delivers exceptional speed and better security. However, this static HTML content can then be enhanced with client-side JavaScript via React hydration. You can learn more about this in Dustin Schau's blog post [Beyond Static: Building Dynamic apps with Gatsby](/blog/2018-10-15-beyond-static-intro/).
+
+### Do I have to learn GraphQL to use Gatsby?
+
+> GraphQL is used to pull the content from all your different sources into Gatsby in a consistent, unified way. You don't have to use GraphQL to do this, but learning GraphQL will equip you to create new integrations more easily (and it may not be as challenging as you think). Amberly Romo digs into some of the pros and cons in her post on [Using Gatsby without GraphQL](/blog/2018-10-25-using-gatsby-without-graphql/).
+
+### Our content team needs to be able to make site updates, but they're not super technical. Are they going to be able to work with a Gatsby site?
+
+> Gatsby can pull content from any different source, including all-in-one CMSs like WordPress and Drupal as well as the various headless CMSs out there, so your content team can work with whichever content editor suits their needs and preferences, including the CMS they're already using. 
+
+## Case studies
+
+Sometimes the most effective way to get a developer's attention is to show them examples of real sites and dev teams using Gatsby. Here are some case studies you might want to share:
+
+- [Delicious Simplicity <3 Gatsby: Building Happily Ever After](/blog/2019-06-08-delicious-simplicity-case-study-part-1/)
+- [Beyond Static: Haptic Media Uses Gatsby to Build a Dynamic Web App](/blog/2019-02-05-hapticmedia-case-study/)
+- [IBM Uses Gatsby to Manage Enterprise-Level Content](/blog/2018-12-17-ibm-case-study/#big-company-big-website)
+
+For even more examples of Gatsby sites, [check out the Showcase](/showcase/)
+
+## Conclusion
+
+Many developers like being early adopters when exciting new tools come along, but they are just as likely to be skeptical when it seems like that new tool might be just another "flavor of the month." Luckily, Gatsby stands up to scrutiny. The information provided here is a great starting point for conversations with developers about Gatsby. From there, encourage developers to check it out for themselves. That may be all the convincing they need.

--- a/docs/docs/winning-over-developers.md
+++ b/docs/docs/winning-over-developers.md
@@ -2,20 +2,20 @@
 title: Winning Over Developers
 ---
 
-Developers are often the primary evangelists of Gatsby because they are the primary users of the framework. If you're a developer, you may find that simply talking to other developers about why *you* like Gatsby is enough to get them interested. Here are some talking points to help support your conversations with developers.
+Developers are often the primary evangelists of Gatsby because they are the primary users of the framework. If you're a developer, you may find that simply talking to other developers about why _you_ like Gatsby is enough to get them interested. Here are some talking points to help support your conversations with developers.
 
 Some things that developers care about include:
 
 - **Site Performance** Building sites that are fast and that stay fast as new tools and technology get incorporated.
 - **Working with the best tools and technologies** Getting to use new technologies and having the flexibility to pick the right tools for the job.
-- **Not getting bogged down in configuration and setup** These things are often time consuming, frustrating, and prevent developers from getting to focus on the work they actually care about. 
+- **Not getting bogged down in configuration and setup** These things are often time consuming, frustrating, and prevent developers from getting to focus on the work they actually care about.
 - **Developing as efficiently and effectively as possible** The more things can be streamlined, automated, and/or simplified, the better.
 
 ## Basic Explanation
 
 Here's an example of a basic explanation of Gatsby for developers:
 
-> Gatsby is a free, open-source, React-based framework for building fast websites and applications. Gatsby streamlines the setup and configuration of your build, it can pull data into your UI from any and all of your sources, and amazing performance and current web best practices  are build into Gatsby sites.
+> Gatsby is a free, open-source, React-based framework for building fast websites and applications. Gatsby streamlines the setup and configuration of your build, it can pull data into your UI from any and all of your sources, and amazing performance and current web best practices are build into Gatsby sites.
 
 ## Specific benefits
 
@@ -23,11 +23,11 @@ Gatsby has many benefits that give developers the freedom to build great website
 
 ### Site speed
 
-> Gatsby was built with performance in mind from its inception, and Gatsby sites are consistently 2-3x faster than similar sites built with other tools – pages load in milliseconds rather than seconds. Gatsby's automated performance optimizations include pre-fetching resources, code splitting, statically generating HTML, and Google's [PRPL Pattern](/docs/prpl-pattern/).  If you want to take a deeper dive into Gatsby's performance features, check out [Web Performance 101 – also, why is Gatsby so fast?](/blog/2017-09-13-why-is-gatsby-so-fast/).
+> Gatsby was built with performance in mind from its inception, and Gatsby sites are consistently 2-3x faster than similar sites built with other tools – pages load in milliseconds rather than seconds. Gatsby's automated performance optimizations include pre-fetching resources, code splitting, statically generating HTML, and Google's [PRPL Pattern](/docs/prpl-pattern/). If you want to take a deeper dive into Gatsby's performance features, check out [Web Performance 101 – also, why is Gatsby so fast?](/blog/2017-09-13-why-is-gatsby-so-fast/).
 
 ### Modern web tools
 
-> Gatsby sites are built with React - currently the most popular framework for developing web apps, and data can be pulled into your React components via GraphQL. Gatsby is also built to pull data from any source so you can pick the best tool for each job and function your site needs to perform. Pull data from the best content management tools, the best e-commerce tools, whatever databases you're using, and more. 
+> Gatsby sites are built with React - currently the most popular framework for developing web apps, and data can be pulled into your React components via GraphQL. Gatsby is also built to pull data from any source so you can pick the best tool for each job and function your site needs to perform. Pull data from the best content management tools, the best e-commerce tools, whatever databases you're using, and more.
 
 ### Plugins and features
 
@@ -55,7 +55,7 @@ You may find that many of your developer friends and colleagues have some questi
 
 ### Our content team needs to be able to make site updates, but they're not super technical. Are they going to be able to work with a Gatsby site?
 
-> Gatsby can pull content from any different source, including all-in-one CMSs like WordPress and Drupal as well as the various headless CMSs out there, so your content team can work with whichever content editor suits their needs and preferences, including the CMS they're already using. 
+> Gatsby can pull content from any different source, including all-in-one CMSs like WordPress and Drupal as well as the various headless CMSs out there, so your content team can work with whichever content editor suits their needs and preferences, including the CMS they're already using.
 
 ## Case studies
 


### PR DESCRIPTION
## Description

I've drafted a "Winning Over Developers" stakeholder page to replace the current stub. This follows the format present on the "Winning Over Marketers" page. Please do give feedback - I want to make sure I'm getting the messaging right.

## Related Issues

Partially addresses [#14040](https://github.com/gatsbyjs/gatsby/issues/14040). Pull requests to replace the Engineering Leader and Executive stakeholder stubs will follow in the next week or so. 
