### PR TITLE
Ryan L. | updated SiteMetaData and Layout components to allow for customizing Twitter cards across the site

### DIFF
--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -154,7 +154,12 @@ class DefaultLayout extends React.Component {
 
     return (
       <>
-        <SiteMetadata pathname={this.props.location.pathname} />
+        <SiteMetadata
+          pathname={this.props.location.pathname}
+          metaDescription={this.props.metaDescription}
+          metaImage={this.props.metaImage}
+          metaTitle={this.props.metaTitle}
+        />
         <SkipNavLink css={skipLink}>Skip to main content</SkipNavLink>
         <Banner />
         <Navigation pathname={this.props.location.pathname} />

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -144,6 +144,12 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
 
       return (
         <Layout
+          metaDescription={data.sitesYaml.description}
+          metaImage={`https://www.gatsbyjs.org${
+            data.sitesYaml.childScreenshot.screenshotFile.childImageSharp.resize
+              .src
+          }`}
+          metaTitle={`${data.sitesYaml.title}: Showcase | GatsbyJS`}
           location={parent.props.location}
           isModal={isModal}
           modalBackgroundPath={parent.getExitLocation()}
@@ -252,25 +258,6 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
             >
               <Helmet>
                 <title>{data.sitesYaml.title}: Showcase | GatsbyJS</title>
-                <meta
-                  property="og:image"
-                  content={`https://www.gatsbyjs.org${
-                    data.sitesYaml.childScreenshot.screenshotFile
-                      .childImageSharp.resize.src
-                  }`}
-                />
-                <meta
-                  name="twitter:image"
-                  content={`https://www.gatsbyjs.org${
-                    data.sitesYaml.childScreenshot.screenshotFile
-                      .childImageSharp.resize.src
-                  }`}
-                />
-                <meta name="twitter:card" content="summary_large_image" />
-                <meta
-                  name="og:title"
-                  value={`${data.sitesYaml.title}: Showcase | GatsbyJS`}
-                />
                 <meta
                   property="og:image:width"
                   content={

--- a/www/src/components/site-metadata.js
+++ b/www/src/components/site-metadata.js
@@ -4,7 +4,7 @@ import { graphql, useStaticQuery } from "gatsby"
 
 import gatsbyIcon from "../assets/gatsby-icon.png"
 
-const SiteMetadata = ({ pathname }) => {
+const SiteMetadata = props => {
   const {
     site: {
       siteMetadata: { siteUrl, title, twitter },
@@ -21,27 +21,42 @@ const SiteMetadata = ({ pathname }) => {
     }
   `)
 
-  return (
-    <Helmet defaultTitle={title} titleTemplate={`%s | ${title}`}>
-      <html lang="en" />
-      <link rel="canonical" href={`${siteUrl}${pathname}`} />
-      <meta name="docsearch:version" content="2.0" />
-      <meta
-        name="viewport"
-        content="width=device-width,initial-scale=1,shrink-to-fit=no,viewport-fit=cover"
-      />
+  const {
+    metaImage = `${siteUrl}${gatsbyIcon}`,
+    metaTitle = title,
+    metaDescription = `${siteUrl}`,
+  } = props
 
-      <meta property="og:url" content={siteUrl} />
-      <meta property="og:type" content="website" />
-      <meta property="og:locale" content="en" />
-      <meta property="og:site_name" content={title} />
-      <meta property="og:image" content={`${siteUrl}${gatsbyIcon}`} />
-      <meta property="og:image:width" content="512" />
-      <meta property="og:image:height" content="512" />
-
-      <meta name="twitter:card" content="summary" />
-      <meta name="twitter:site" content={twitter} />
+  const generateMetaTags = (type, content) => (
+    <Helmet>
+      <meta property={`og:${type}`} content={content} />
+      <meta name={`twitter:${type}`} content={content} />
     </Helmet>
+  )
+
+  return (
+    <React.Fragment>
+      <Helmet>
+        <html lang="en" />
+        <link rel="canonical" href={`${siteUrl}${props.pathname}`} />
+        <meta name="docsearch:version" content="2.0" />
+        <meta
+          name="viewport"
+          content="width=device-width,initial-scale=1,shrink-to-fit=no,viewport-fit=cover"
+        />
+        <meta property="og:url" content={siteUrl} />
+        <meta property="og:type" content="website" />
+        <meta property="og:locale" content="en" />
+        <meta property="og:site_name" content={metaTitle} />
+        <meta property="og:image:width" content="512" />
+        <meta property="og:image:height" content="512" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content={twitter} />
+      </Helmet>
+      {generateMetaTags(`description`, metaDescription)}
+      {generateMetaTags(`image`, metaImage)}
+      {generateMetaTags(`title`, metaTitle)}
+    </React.Fragment>
   )
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
While I was working on #14468, I checked other parts of the Gatsby site and noticed that Twitter cards were broken elsewhere. I thought that by updating the `SiteMetaData` component that is pulled in by `Layout`, props to customize Twitter cards could be passed to `Layout` and subsequently `SiteMetaData`. There are defaults in place so that Twitter cards should always be available. 
Before:
<img width="1100" alt="Screen Shot 2019-06-11 at 9 01 49 PM" src="https://user-images.githubusercontent.com/18073651/59318497-452b6b80-8c95-11e9-9ce2-a9c383493699.png">

After: 
<img width="1165" alt="Screen Shot 2019-06-11 at 9 08 01 PM" src="https://user-images.githubusercontent.com/18073651/59318520-53798780-8c95-11e9-93ed-e8cdf980d7ee.png">
(an image size prop can be added to change the size of the image shown for Twitter cards

Showcase sites: 
<img width="1144" alt="Screen Shot 2019-06-11 at 7 37 42 PM" src="https://user-images.githubusercontent.com/18073651/59318624-9d626d80-8c95-11e9-8424-6dc101001acd.png">


My hope is that this will eliminate the need to add the necessary meta tags with React Helmet, and instead pass props to `Layout`.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
