### PR TITLE
fix(gatsby-plugin-sharp): create job before async-queue processing

### DIFF
--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -59,6 +59,15 @@ exports.scheduleJob = async (
   })
 
   if (!isQueued) {
+    // Create image job
+    boundActionCreators.createJob(
+      {
+        id: `processing image ${job.inputPath}`,
+        imagesCount: 1,
+      },
+      { name: `gatsby-plugin-sharp` }
+    )
+
     q.push(cb => {
       runJobs(
         inputFileKey,
@@ -86,10 +95,12 @@ function runJobs(
 
   // Delete the input key from the toProcess list so more jobs can be queued.
   delete toProcess[inputFileKey]
-  boundActionCreators.createJob(
+
+  // Update job info
+  boundActionCreators.setJob(
     {
       id: `processing image ${job.inputPath}`,
-      imagesCount: _.values(toProcess[inputFileKey]).length,
+      imagesCount: jobs.length,
     },
     { name: `gatsby-plugin-sharp` }
   )


### PR DESCRIPTION
## Description
Fixes sharp queuing. We use `async/queue` inside gatsby-plugin-sharp which async adds tasks to the queue. This means jobs are created when the queue is processed not when they are added. This can lead to timing issues when waiting for all jobs to be done.

We move creation of jobs before we add things to the queue.
