### PR TITLE
fix(gatsby): Move importing of match-paths.json outside of loader.js

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -7,6 +7,7 @@ import emitter from "./emitter"
 import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
 import loader, { setApiRunnerForLoader } from "./loader"
 import syncRequires from "./sync-requires"
+import matchPaths from "./match-paths.json"
 
 window.___emitter = emitter
 setApiRunnerForLoader(apiRunner)
@@ -49,6 +50,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   )[0]
 
   loader.addDevRequires(syncRequires)
+  loader.addMatchPaths(matchPaths)
   Promise.all([
     loader.loadPage(`/dev-404-page/`),
     loader.loadPage(`/404.html`),

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -3,8 +3,6 @@ import prefetchHelper from "./prefetch"
 import { match } from "@reach/router/lib/utils"
 import normalizePagePath from "./normalize-page-path"
 import stripPrefix from "./strip-prefix"
-// Generated during bootstrap
-import matchPaths from "./match-paths.json"
 
 const preferDefault = m => (m && m.default) || m
 
@@ -13,6 +11,7 @@ const pageNotFoundPaths = new Set()
 let apiRunner
 let syncRequires = {}
 let asyncRequires = {}
+let matchPaths = {}
 
 const fetchedPageData = {}
 const pageDatas = {}
@@ -194,11 +193,20 @@ const loadComponent = componentChunkName => {
 }
 
 const queue = {
+  // gatsby-link can be used as a standalone library. Since it depends
+  // on window.___loader, we have to assume the code calls loader.js
+  // but without a gatsby build having occured. In this case,
+  // `async-requires.js, match-paths.json` etc won't exist. Therefore,
+  // we import those assets in production-app.js, and then dynamically
+  // set them onto the loader
   addDevRequires: devRequires => {
     syncRequires = devRequires
   },
   addProdRequires: prodRequires => {
     asyncRequires = prodRequires
+  },
+  addMatchPaths: _matchPaths => {
+    matchPaths = _matchPaths
   },
   // Hovering on a link is a very strong indication the user is going to
   // click on it soon so let's start prefetching resources for this

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -12,6 +12,7 @@ import {
 import emitter from "./emitter"
 import PageRenderer from "./page-renderer"
 import asyncRequires from "./async-requires"
+import matchPaths from "./match-paths.json"
 import loader, { setApiRunnerForLoader } from "./loader"
 import EnsureResources from "./ensure-resources"
 
@@ -21,6 +22,7 @@ window.___loader = loader
 window.___webpackCompilationHash = window.webpackCompilationHash
 
 loader.addProdRequires(asyncRequires)
+loader.addMatchPaths(matchPaths)
 setApiRunnerForLoader(apiRunner)
 
 navigationInit()


### PR DESCRIPTION
## Description

As raised in https://github.com/gatsbyjs/gatsby/issues/14729, Gatsby-link can be used independently of Gatsby itself. And it depends on `loader.js` to enqueue pages for prefetching. Gatsby prescribes [overriding those loader functions to be noops](https://www.gatsbyjs.org/docs/visual-testing-with-storybook/), but it still has to compile `loader.js`.

The problem is that the [per-page-manifest](https://github.com/gatsbyjs/gatsby/pull/13004) changes introduced a `match-paths.json` into the loader itself. Which won't compile if a gatsby build hasn't occured. To fix, I moved it out into production-app.js and app.js, and then dynamically set it. 

## Related Issues

- Fixes https://github.com/gatsbyjs/gatsby/issues/14729
