### PR TITLE
chore(docs): Fix typo

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -301,7 +301,7 @@ To get **all** the `CaseStudy` nodes with ShortText fields `id`, `slug`, `title`
 }
 ```
 
-When querying images you can use the `fixed`, `fluid` or `resize` nodes to get different sizes for the image (for example for using [gatsby-image](https://www.gatsbyjs.org/packages/gatsby-image/)). Their usage is documented at the [gatsby-plugin-sharp](https://www.gatsbyjs.org/packages/gatsby-plugin-sharp/) package. The only difference is that gatsby-source-contentful also allows setting only the `height` parameter for these node types, the height will then automatically be calculated according to the aspect ratio.
+When querying images you can use the `fixed`, `fluid` or `resize` nodes to get different sizes for the image (for example for using [gatsby-image](https://www.gatsbyjs.org/packages/gatsby-image/)). Their usage is documented at the [gatsby-plugin-sharp](https://www.gatsbyjs.org/packages/gatsby-plugin-sharp/) package. The only difference is that gatsby-source-contentful also allows setting only the `width` parameter for these node types, the height will then automatically be calculated according to the aspect ratio.
 
 ## More on Queries with Contentful and Gatsby
 


### PR DESCRIPTION
## Description

Fixes a typo in parameter name (height => width) in gatsby-source-contentful README.md