### PR TITLE
Fix typography plugin not working

### DIFF
--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -55,6 +55,7 @@ npm install --save gatsby-plugin-typography react-typography typography typograp
 ```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [
+    `gatsby-plugin-typography`,
     {
       resolve: `gatsby-plugin-typography`,
       options: {
@@ -63,6 +64,7 @@ module.exports = {
     },
   ],
 }
+
 ```
 
 The `gatsby-config.js` is another special file that Gatsby will automatically recognize. This is where you add plugins and other site configuration.


### PR DESCRIPTION
Add gatsby-plugin-typography and some curly brackets before the resolve part

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
