### PR TITLE
chore(docs): Unstubbing Winning over Developers page

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -463,7 +463,7 @@
         - title: Winning Over Different Stakeholders
           link: /docs/winning-over-stakeholders/
           items:
-            - title: Developers*
+            - title: Developers
               link: /docs/winning-over-developers/
             - title: Engineering Leaders*
               link: /docs/winning-over-engineering-leaders/


### PR DESCRIPTION
## Description

Removed the stub asterisk in the doc-links.yaml file for the "Winning Over Developers" page.

## Related Issues

Related to #14724 