### PR TITLE
chore(docs): Unstubbing Build Caching page

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -447,7 +447,7 @@
           link: /docs/resource-handling-and-service-workers/
         - title: Data Storage (Redux)*
           link: /docs/data-storage-redux/
-        - title: Build Caching*
+        - title: Build Caching
           link: /docs/build-caching/
         - title: Terminology
           link: /docs/gatsby-internals-terminology/


### PR DESCRIPTION
## Description

This page is no longer a stub so removing the asterisk from the docs-links.yaml file
