### PR TITLE
chore: quick typo fix and unmark recently finished stub

### DIFF
--- a/docs/docs/winning-over-developers.md
+++ b/docs/docs/winning-over-developers.md
@@ -15,7 +15,7 @@ Some things that developers care about include:
 
 Here's an example of a basic explanation of Gatsby for developers:
 
-> Gatsby is a free, open-source, React-based framework for building fast websites and applications. Gatsby streamlines the setup and configuration of your build, it can pull data into your UI from any and all of your sources, and amazing performance and current web best practices are build into Gatsby sites.
+> Gatsby is a free, open-source, React-based framework for building fast websites and applications. Gatsby streamlines the setup and configuration of your build, it can pull data into your UI from any and all of your sources, and amazing performance and current web best practices are built into Gatsby sites.
 
 ## Specific benefits
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -463,7 +463,7 @@
         - title: Winning Over Different Stakeholders
           link: /docs/winning-over-stakeholders/
           items:
-            - title: Developers*
+            - title: Developers
               link: /docs/winning-over-developers/
             - title: Engineering Leaders*
               link: /docs/winning-over-engineering-leaders/


### PR DESCRIPTION
Was reading over the (awesome and recently finished!) winning over developers doc.

Quick fix for one type and unmarking as a stub in the sidebar.