### PR TITLE
fix(gatsby-source-contentful): Restricts images to 4000 max image width/height

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/extend-node-type.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/extend-node-type.js.snap
@@ -11,8 +11,7 @@ Object {
   "height": 3000,
   "src": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250",
   "srcSet": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 1x,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 1.5x,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=6000 2x",
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 1.5x",
   "width": 2250,
 }
 `;
@@ -54,8 +53,7 @@ Object {
   "srcSet": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=563&h=751 563w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1125&h=1500 1125w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 2250w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 3375w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=6000 4500w",
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 3375w",
 }
 `;
 
@@ -70,8 +68,7 @@ Object {
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=450&h=399&q=50&bg=rgb%3A000000 450w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=675&h=599&q=50&bg=rgb%3A000000 675w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=900&h=798&q=50&bg=rgb%3A000000 900w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1350&h=1197&q=50&bg=rgb%3A000000 1350w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=3990&q=50&bg=rgb%3A000000 4500w",
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1350&h=1197&q=50&bg=rgb%3A000000 1350w",
 }
 `;
 
@@ -86,8 +83,7 @@ Object {
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=300&h=400 300w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=450&h=600 450w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=600&h=800 600w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=900&h=1200 900w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=6000 4500w",
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=900&h=1200 900w",
 }
 `;
 
@@ -102,8 +98,7 @@ Object {
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=400&h=533 400w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=600&h=800 600w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=800&h=1067 800w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1200&h=1600 1200w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=6000 4500w",
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1200&h=1600 1200w",
 }
 `;
 
@@ -118,8 +113,7 @@ Object {
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=800&h=1067 800w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1200&h=1600 1200w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1600&h=2133 1600w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2400&h=3200 2400w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=4500&h=6000 4500w",
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2400&h=3200 2400w",
 }
 `;
 

--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/extend-node-type.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/extend-node-type.js.snap
@@ -10,8 +10,7 @@ Object {
   "baseUrl": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg",
   "height": 3000,
   "src": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250",
-  "srcSet": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 1x,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 1.5x",
+  "srcSet": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 1x",
   "width": 2250,
 }
 `;
@@ -52,8 +51,7 @@ Object {
   "src": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250",
   "srcSet": "//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=563&h=751 563w,
 //images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=1125&h=1500 1125w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 2250w,
-//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=3375&h=4500 3375w",
+//images.contentful.com/ubriaw6jfhm1/10TkaLheGeQG6qQGqWYqUI/5421d3108cbb699561acabd594fa2cb0/ryugj83mqwa1asojwtwb.jpg?w=2250&h=3000 2250w",
 }
 `;
 

--- a/packages/gatsby-source-contentful/src/__tests__/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/__tests__/extend-node-type.js
@@ -101,7 +101,7 @@ describe(`contentful extend node type`, () => {
       const resp = await resolveFixed(image, {
         width: 2250,
       })
-      expect(resp.srcSet.split(`,`).length).toBe(3)
+      expect(resp.srcSet.split(`,`).length).toBe(2)
       expect(resp).toMatchSnapshot()
     })
   })
@@ -141,7 +141,7 @@ describe(`contentful extend node type`, () => {
       const resp = await resolveFluid(image, {
         maxWidth: 2250,
       })
-      expect(resp.srcSet.split(`,`).length).toBe(5)
+      expect(resp.srcSet.split(`,`).length).toBe(4)
       expect(resp).toMatchSnapshot()
     })
   })

--- a/packages/gatsby-source-contentful/src/__tests__/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/__tests__/extend-node-type.js
@@ -101,7 +101,7 @@ describe(`contentful extend node type`, () => {
       const resp = await resolveFixed(image, {
         width: 2250,
       })
-      expect(resp.srcSet.split(`,`).length).toBe(2)
+      expect(resp.srcSet.split(`,`).length).toBe(1)
       expect(resp).toMatchSnapshot()
     })
   })
@@ -141,7 +141,7 @@ describe(`contentful extend node type`, () => {
       const resp = await resolveFluid(image, {
         maxWidth: 2250,
       })
-      expect(resp.srcSet.split(`,`).length).toBe(4)
+      expect(resp.srcSet.split(`,`).length).toBe(3)
       expect(resp).toMatchSnapshot()
     })
   })

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -20,6 +20,7 @@ const {
   ImageCropFocusType,
 } = require(`./schemes`)
 
+// @see https://www.contentful.com/developers/docs/references/images-api/#/reference/resizing-&-cropping/specify-width-&-height
 const CONTENTFUL_IMAGE_MAX_SIZE = 4000
 
 const isImage = image =>

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -20,7 +20,7 @@ const {
   ImageCropFocusType,
 } = require(`./schemes`)
 
-const contentful_max_size = 4000
+const CONTENTFUL_IMAGE_MAX_SIZE = 4000
 
 const isImage = image =>
   _.includes(
@@ -115,9 +115,9 @@ const resolveFixed = (image, options) => {
   fixedSizes.push(options.width * 3)
   fixedSizes = fixedSizes.map(Math.round)
 
-  // Filter out sizes larger than the image's width.
+  // Filter out sizes larger than the image's width and the contentful image's max size.
   const filteredSizes = fixedSizes.filter(
-    size => size <= contentful_max_size || size <= width
+    size => size <= CONTENTFUL_IMAGE_MAX_SIZE && size <= width
   )
 
   // Sort sizes for prettiness.
@@ -218,14 +218,18 @@ const resolveFluid = (image, options) => {
   fluidSizes.push(options.maxWidth * 3)
   fluidSizes = fluidSizes.map(Math.round)
 
-  // Filter out sizes larger than the image's maxWidth.
+  // Filter out sizes larger than the image's maxWidth and the contentful image's max size.
   const filteredSizes = fluidSizes.filter(
-    size => size <= contentful_max_size || size <= width
+    size => size <= CONTENTFUL_IMAGE_MAX_SIZE && size <= width
   )
 
   // Add the original image (if it isn't already in there) to ensure the largest image possible
   // is available for small images.
-  if (!filteredSizes.includes(parseInt(width))) filteredSizes.push(width)
+  if (
+    !filteredSizes.includes(parseInt(width)) &&
+    parseInt(width) < CONTENTFUL_IMAGE_MAX_SIZE
+  )
+    filteredSizes.push(width)
 
   // Sort sizes for prettiness.
   const sortedSizes = _.sortBy(filteredSizes)

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -238,9 +238,11 @@ const resolveFluid = (image, options) => {
   // is available for small images.
   if (
     !filteredSizes.includes(parseInt(width)) &&
-    parseInt(width) < CONTENTFUL_IMAGE_MAX_SIZE
-  )
+    parseInt(width) < CONTENTFUL_IMAGE_MAX_SIZE &&
+    Math.round(width / desiredAspectRatio) < CONTENTFUL_IMAGE_MAX_SIZE
+  ) {
     filteredSizes.push(width)
+  }
 
   // Sort sizes for prettiness.
   const sortedSizes = _.sortBy(filteredSizes)

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -20,6 +20,8 @@ const {
   ImageCropFocusType,
 } = require(`./schemes`)
 
+const contentful_max_size = 4000
+
 const isImage = image =>
   _.includes(
     [`image/jpeg`, `image/jpg`, `image/png`, `image/webp`, `image/gif`],
@@ -114,7 +116,9 @@ const resolveFixed = (image, options) => {
   fixedSizes = fixedSizes.map(Math.round)
 
   // Filter out sizes larger than the image's width.
-  const filteredSizes = fixedSizes.filter(size => size <= width)
+  const filteredSizes = fixedSizes.filter(
+    size => size <= contentful_max_size || size <= width
+  )
 
   // Sort sizes for prettiness.
   const sortedSizes = _.sortBy(filteredSizes)
@@ -215,7 +219,9 @@ const resolveFluid = (image, options) => {
   fluidSizes = fluidSizes.map(Math.round)
 
   // Filter out sizes larger than the image's maxWidth.
-  const filteredSizes = fluidSizes.filter(size => size <= width)
+  const filteredSizes = fluidSizes.filter(
+    size => size <= contentful_max_size || size <= width
+  )
 
   // Add the original image (if it isn't already in there) to ensure the largest image possible
   // is available for small images.

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -117,9 +117,14 @@ const resolveFixed = (image, options) => {
   fixedSizes = fixedSizes.map(Math.round)
 
   // Filter out sizes larger than the image's width and the contentful image's max size.
-  const filteredSizes = fixedSizes.filter(
-    size => size <= CONTENTFUL_IMAGE_MAX_SIZE && size <= width
-  )
+  const filteredSizes = fixedSizes.filter(size => {
+    const calculatedHeight = Math.round(size / desiredAspectRatio)
+    return (
+      size <= CONTENTFUL_IMAGE_MAX_SIZE &&
+      calculatedHeight <= CONTENTFUL_IMAGE_MAX_SIZE &&
+      size <= width
+    )
+  })
 
   // Sort sizes for prettiness.
   const sortedSizes = _.sortBy(filteredSizes)
@@ -220,9 +225,14 @@ const resolveFluid = (image, options) => {
   fluidSizes = fluidSizes.map(Math.round)
 
   // Filter out sizes larger than the image's maxWidth and the contentful image's max size.
-  const filteredSizes = fluidSizes.filter(
-    size => size <= CONTENTFUL_IMAGE_MAX_SIZE && size <= width
-  )
+  const filteredSizes = fluidSizes.filter(size => {
+    const calculatedHeight = Math.round(size / desiredAspectRatio)
+    return (
+      size <= CONTENTFUL_IMAGE_MAX_SIZE &&
+      calculatedHeight <= CONTENTFUL_IMAGE_MAX_SIZE &&
+      size <= width
+    )
+  })
 
   // Add the original image (if it isn't already in there) to ensure the largest image possible
   // is available for small images.


### PR DESCRIPTION
## Description
Since Contentful does not allow fetching images above `4000` in size, this PR restricts images to not go above that maximum size to prevent images from not even loading in large screens.

## Related Issues
Related to #14752 