### PR TITLE
fix(gatsby-plugin-netlify-cms): Fix minimizer for production builds with gatsby-plugins-netlify-cms

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -160,7 +160,13 @@ exports.onCreateWebpackConfig = (
      * config, they cause issues for our pre-bundled code.
      */
     mode: stage === `develop` ? `development` : `production`,
-    optimization: {},
+    optimization: {
+      /**
+       * Without this, node can get out of memory errors
+       * when building for production.
+       */
+      minimizer: gatsbyConfig.optimization.minimizer,
+    },
     devtool: stage === `develop` ? `cheap-module-source-map` : `source-map`,
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

When building for production with gatsby-plugin-netlify-cms, node hangs at 'Building production JavaScript and CSS bundles', eventually throwing an out of memory error.

I found out that the problem is with Webpack 'minimize'. 

Using the minimizer setting from the original Webpack configuration of Gatsby fixes the issue.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Possibly related to and fixes https://github.com/gatsbyjs/gatsby/issues/14418

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
