### PR TITLE
chore: use faster `existsSync`

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -10,6 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "async": "^2.1.2",
     "bluebird": "^3.5.0",
+    "fs-exists-cached": "^1.0.0",
     "fs-extra": "^7.0.0",
     "imagemin": "^6.0.0",
     "imagemin-mozjpeg": "^8.0.0",

--- a/packages/gatsby-plugin-sharp/src/safe-sharp.js
+++ b/packages/gatsby-plugin-sharp/src/safe-sharp.js
@@ -11,7 +11,7 @@
 
 const childProcess = require(`child_process`)
 const path = require(`path`)
-const fs = require(`fs`)
+const existsSync = require(`fs-exists-cached`).sync
 const semver = require(`semver`)
 
 const originalConsoleError = console.error
@@ -26,8 +26,8 @@ const getDetailedMessage = () => {
     // if both lock files exist
 
     if (
-      fs.existsSync(path.join(process.cwd(), `package-lock.json`)) &&
-      fs.existsSync(path.join(process.cwd(), `yarn.lock`))
+      existsSync(path.join(process.cwd(), `package-lock.json`)) &&
+      existsSync(path.join(process.cwd(), `yarn.lock`))
     ) {
       return null
     }

--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -1,6 +1,6 @@
 const _ = require(`lodash`)
 const ProgressBar = require(`progress`)
-const { existsSync } = require(`fs`)
+const existsSync = require(`fs-exists-cached`).sync
 const queue = require(`async/queue`)
 const { processFile } = require(`./process-file`)
 

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",
+    "fs-exists-cached": "^1.0.0",
     "fs-extra": "^7.0.0",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",

--- a/packages/gatsby-transformer-sharp/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sharp/src/extend-node-type.js
@@ -18,6 +18,7 @@ const {
 const sharp = require(`./safe-sharp`)
 const fs = require(`fs`)
 const fsExtra = require(`fs-extra`)
+const existsSync = require(`fs-exists-cached`).sync
 const imageSize = require(`probe-image-size`)
 const path = require(`path`)
 
@@ -418,7 +419,7 @@ module.exports = ({
           imageName
         )
 
-        if (!fsExtra.existsSync(publicPath)) {
+        if (!existsSync(publicPath)) {
           fsExtra.copy(details.absolutePath, publicPath, err => {
             if (err) {
               console.error(

--- a/packages/gatsby-transformer-sharp/src/safe-sharp.js
+++ b/packages/gatsby-transformer-sharp/src/safe-sharp.js
@@ -11,7 +11,7 @@
 
 const childProcess = require(`child_process`)
 const path = require(`path`)
-const fs = require(`fs`)
+const existsSync = require(`fs-exists-cached`).sync
 const semver = require(`semver`)
 
 const originalConsoleError = console.error
@@ -26,8 +26,8 @@ const getDetailedMessage = () => {
     // if both lock files exist
 
     if (
-      fs.existsSync(path.join(process.cwd(), `package-lock.json`)) &&
-      fs.existsSync(path.join(process.cwd(), `yarn.lock`))
+      existsSync(path.join(process.cwd(), `package-lock.json`)) &&
+      existsSync(path.join(process.cwd(), `yarn.lock`))
     ) {
       return null
     }

--- a/packages/gatsby/src/utils/get-static-dir.js
+++ b/packages/gatsby/src/utils/get-static-dir.js
@@ -1,5 +1,6 @@
 const fs = require(`fs-extra`)
 const chokidar = require(`chokidar`)
+const existsSync = require(`fs-exists-cached`).sync
 const nodePath = require(`path`)
 const { store } = require(`../redux`)
 
@@ -17,7 +18,7 @@ exports.copyStaticDirs = () => {
       // create an array of potential theme static folders
       .map(theme => nodePath.resolve(theme.themeDir, `static`))
       // filter out the static folders that don't exist
-      .filter(themeStaticPath => fs.existsSync(themeStaticPath))
+      .filter(themeStaticPath => existsSync(themeStaticPath))
       // copy the files for each folder into the user's build
       .map(folder =>
         fs.copySync(folder, nodePath.join(process.cwd(), `public`))
@@ -25,7 +26,7 @@ exports.copyStaticDirs = () => {
   }
 
   const staticDir = nodePath.join(process.cwd(), `static`)
-  if (!fs.existsSync(staticDir)) return Promise.resolve()
+  if (!existsSync(staticDir)) return Promise.resolve()
   return fs.copySync(staticDir, nodePath.join(process.cwd(), `public`))
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

`fs-exists-cached` is faster than native `fs.existsSync`, so use `fs-exists-cached` instead.

```js
const Benchmark = require('benchmark');

const { existsSync } = require('fs');
const { sync } = require('fs-exists-cached');

const suite = new Benchmark.Suite;

// add tests
suite.add('Native fs', function() {
  existsSync(__filename);
  existsSync('./package.json');
})
.add('fs-exists-cached', function() {
  sync(__filename);
  sync('./package.json');
})
// add listeners
.on('cycle', function(event) {
  console.log(String(event.target));
})
.on('complete', function() {
  console.log('Fastest is ' + this.filter('fastest').map('name'));
})
// run async
.run({ 'async': true });

// logs:
// => Native fs x 134,342 ops/sec ±3.16% (79 runs sampled)
// => fs-exists-cached x 17,560,674 ops/sec ±5.86% (77 runs sampled)
// -> Fastest is fs-exists-cached
```
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
None.
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
