### PR TITLE
chore(starters): add gatsby-typescript-starter-default

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1,3 +1,15 @@
+- url: https://gatsby-typescript-starter-default.netlify.com/
+  repo: https://github.com/RobertoMSousa/gatsby-typescript-starter-default
+  description: Simple gatsby starter using typescript and eslint instead of outdated tslint.
+  tags:
+    - TypeScript
+    - SEO
+    - Linting
+  features:
+    - Comes with React Helmet for adding site meta tags
+    - Includes plugins for offline support out of the box
+    - TypeScript
+    - Prettier & eslint to format & check the code
 - url: https://gatsby-advanced-blog-system.danilowoz.now.sh/blog
   repo: https://github.com/danilowoz/gatsby-advanced-blog-system
   description: Create a complete blog from scratch with pagination, categories, featured posts, author, SEO and navigation.

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -3021,7 +3021,7 @@
     - ESLint + optional rule enforcement with Husky
     - Prettier
     - Netlify ready
-    - url: https://gatsby-typescript-starter-default.netlify.com/
+- url: https://gatsby-typescript-starter-default.netlify.com/
   repo: https://github.com/RobertoMSousa/gatsby-typescript-starter-default
   description: Simple gatsby starter using typescript and eslint instead of outdated tslint.
   tags:

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1,15 +1,3 @@
-- url: https://gatsby-typescript-starter-default.netlify.com/
-  repo: https://github.com/RobertoMSousa/gatsby-typescript-starter-default
-  description: Simple gatsby starter using typescript and eslint instead of outdated tslint.
-  tags:
-    - TypeScript
-    - SEO
-    - Linting
-  features:
-    - Comes with React Helmet for adding site meta tags
-    - Includes plugins for offline support out of the box
-    - TypeScript
-    - Prettier & eslint to format & check the code
 - url: https://gatsby-advanced-blog-system.danilowoz.now.sh/blog
   repo: https://github.com/danilowoz/gatsby-advanced-blog-system
   description: Create a complete blog from scratch with pagination, categories, featured posts, author, SEO and navigation.
@@ -3006,3 +2994,15 @@
     - Featured post
     - Next and prev post
     - SEO component
+- url: https://gatsby-typescript-starter-default.netlify.com/
+  repo: https://github.com/RobertoMSousa/gatsby-typescript-starter-default
+  description: Simple gatsby starter using typescript and eslint instead of outdated tslint.
+  tags:
+    - TypeScript
+    - SEO
+    - Linting
+  features:
+    - Comes with React Helmet for adding site meta tags
+    - Includes plugins for offline support out of the box
+    - TypeScript
+    - Prettier & eslint to format & check the code


### PR DESCRIPTION
## Description
There are no starters using eslint and prettier with typescript and since officially since the tslint will be deprecated it would be good for devs to start using eslint instead.
