### PR TITLE
Add Oerol Festival to sites.yml

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -6380,3 +6380,17 @@
   built_by: Bytom Foundation
   built_by_url: https://bytom.io/
   featured: false
+- title: Oerol Festival
+  url: https://www.oerol.nl/nl/
+  main_url: https://www.oerol.nl/en/
+  description: >
+    Oerol is a cultural festival on the island of Terschelling in the Netherlands that is held annually in June. 
+    The ten-day festival is focused on live, public theatre as well as music and visual arts.
+  categories:
+    - Event
+    - Events
+    - Entertainment
+    - Festival
+  built_by: Oberon
+  built_by_url: https://oberon.nl/
+  featured: false


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Adds [Oerol Festival](https://oerol.nl/) to the showcase.  
This is a fully featured festival website build on Gatsby & [CraftCMS](https://craftcms.com/).  
It contains the latest news, several info pages, and of course, the entire programming of the festival.  
Tickets are bought through an external system, although ticket sale statuses are being displayed for every item in the programming.  
It is translated to [English](https://oerol.nl/en/), [Dutch](https://oerol.nl/nl/), and [Fries](https://www.oerol.nl/fy/)

I know 'Festival' is a new category, but I do think it should be one.  
I think we're the first to build this kind of website with gatsby. (and are probably planning to do more 😄 )

Further references:

- [Wikipedia page](https://en.wikipedia.org/wiki/Oerol_Festival)
- [Tripadvisor](https://www.tripadvisor.com/Attraction_Review-g227907-d10020586-Reviews-Oerol_Festival-Terschelling_Friesland_Province.html)
