### PR TITLE
fix(www): Set `background-color: white` for `html`

### DIFF
--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -24,6 +24,7 @@ const _options = {
   overrideStyles: ({ rhythm }) => {
     return {
       html: {
+        backgroundColor: colors.white,
         WebkitFontSmoothing: `antialiased`,
         MozOsxFontSmoothing: `grayscale`,
       },


### PR DESCRIPTION
This sets `#fff` as the default background for `html`, and thus prevents the user-defined default background color (see e.g. [here](https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use) on how to set this in Firefox) from interfering with the design of gatsbyjs.org.

Context: #14772

---

Before: 

![image](https://user-images.githubusercontent.com/21834/59619223-50b1e300-912a-11e9-9623-00996f739bcf.png)

After: 

![image](https://user-images.githubusercontent.com/21834/59619333-95d61500-912a-11e9-8792-8808f50d946c.png)

