### PR TITLE
docs: update one-way relational note for clarity

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -158,7 +158,7 @@ There are currently some things to keep in mind when building your content model
 
 1.  At the moment, fields that do not have at least one populated instance will not be created in the GraphQL schema.
 
-2.  When using reference fields, be aware that this source plugin will automatically create the reverse reference. You do not need to create references on both content types. For simplicity, it is easier to put a single reference field on either the parent or child in child/parent relationships.
+2.  When using reference fields, be aware that this source plugin will automatically create the reverse reference. You do not need to create references on both content types.
 
 ## How to query for nodes
 

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -158,7 +158,7 @@ There are currently some things to keep in mind when building your content model
 
 1.  At the moment, fields that do not have at least one populated instance will not be created in the GraphQL schema.
 
-2.  When using reference fields, be aware that this source plugin will automatically create the reverse reference. You do not need to create references on both content types. For simplicity, it is easier to put the reference field on the child in child/parent relationships.
+2.  When using reference fields, be aware that this source plugin will automatically create the reverse reference. You do not need to create references on both content types. For simplicity, it is easier to put a single reference field on either the parent or child in child/parent relationships.
 
 ## How to query for nodes
 


### PR DESCRIPTION
It looks like there isn't a difference if the relation field is either on the parent or the child. The main note here is that you shouldn't include the relationship in _both_ cases, but specifying that it's just on the child was confusing and in our case, results in an awkward way to think about and approach content entries.

i.e. adding "Columns" entries to a column container parent is easier to do from the parent entry rather than the reversal.