### PR TITLE
fix(gatsby): Prefer nodes over inline objects in findRootNodeAncestor

### DIFF
--- a/packages/gatsby/src/db/node-tracking.js
+++ b/packages/gatsby/src/db/node-tracking.js
@@ -1,4 +1,5 @@
 const _ = require(`lodash`)
+const reporter = require(`gatsby-cli/lib/reporter`)
 
 /**
  * Map containing links between inline objects or arrays
@@ -111,32 +112,24 @@ exports.trackInlineObjectsInRootNode = trackInlineObjectsInRootNode
 const findRootNodeAncestor = (obj, predicate = null) => {
   const { getNode } = require(`./nodes`)
 
-  // Find the root node.
-  let rootNode = obj
-  let whileCount = 0
-  let rootNodeId
-  while (
-    (!predicate || !predicate(rootNode)) &&
-    (rootNodeId = getRootNodeId(rootNode) || rootNode.parent) &&
-    ((rootNode.parent && getNode(rootNode.parent) !== undefined) ||
-      getNode(rootNodeId)) &&
-    whileCount < 101
-  ) {
-    if (rootNodeId) {
-      rootNode = getNode(rootNodeId)
-    } else {
-      rootNode = getNode(rootNode.parent)
-    }
-    whileCount += 1
-    if (whileCount > 100) {
-      console.log(
-        `It looks like you have a node that's set its parent as itself`,
-        rootNode
-      )
-    }
+  let iterations = 0
+  let node = obj
+
+  while (iterations++ < 100) {
+    if (predicate && predicate(node)) return node
+
+    const parent = node.parent && getNode(node.parent)
+    const id = getRootNodeId(node)
+
+    if (!parent && !id) return node
+
+    node = parent || getNode(id)
   }
 
-  return !predicate || predicate(rootNode) ? rootNode : null
+  reporter.error(
+    `It looks like you have a node that's set its parent as itself:\n\n` + node
+  )
+  return null
 }
 
 function trackDbNodes() {

--- a/packages/gatsby/src/db/node-tracking.js
+++ b/packages/gatsby/src/db/node-tracking.js
@@ -120,10 +120,11 @@ const findRootNodeAncestor = (obj, predicate = null) => {
 
     const parent = node.parent && getNode(node.parent)
     const id = getRootNodeId(node)
+    const trackedParent = id && getNode(id)
 
-    if (!parent && !id) return node
+    if (!parent && !trackedParent) return node
 
-    node = parent || getNode(id)
+    node = parent || trackedParent
   }
 
   reporter.error(

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -3,6 +3,7 @@ const nodeStore = require(`../../db/nodes`)
 require(`../../db/__tests__/fixtures/ensure-loki`)()
 const { LocalNodeModel } = require(`../node-model`)
 const { build } = require(`..`)
+const { trackInlineObjectsInRootNode } = require(`../../db/node-tracking`)
 
 const nodes = require(`./fixtures/node-model`)
 
@@ -16,6 +17,9 @@ describe(`NodeModel`, () => {
     nodes.forEach(node =>
       store.dispatch({ type: `CREATE_NODE`, payload: node })
     )
+    // We need to call this manually because we don't dispatch createNode()
+    // but the raw action type directly
+    nodes.forEach(trackInlineObjectsInRootNode)
 
     const types = `
       union AllFiles = File | RemoteFile


### PR DESCRIPTION
* When calling `findRootNodeAncestor`, we should always prefer nodes looked up by `node.parent` over nodes looked up via node-tracking. This seems to fix the issue in #14827 -- although I'm not 100% sure why we have a node-tracking entry for author in the WeakMap.

* Also fixes the 2 tests in node-model which were broken (check with `describe.only` on the `findRootNodeAncestor` block)