### PR TITLE
fix(tutorials): rename "advanced" to "additional

### DIFF
--- a/docs/tutorial/additional-tutorials.md
+++ b/docs/tutorial/additional-tutorials.md
@@ -1,0 +1,7 @@
+---
+title: Additional Tutorials
+---
+
+There are many use cases for Gatsby, from the very common "happy paths" to more specific and complex integrations. With additional Gatsby tutorials, learn about more topics that go beyond [the basics](/tutorial/) and gain development superpowers.
+
+<GuideList slug={props.slug} />

--- a/docs/tutorial/advanced-tutorials.md
+++ b/docs/tutorial/advanced-tutorials.md
@@ -1,7 +1,0 @@
----
-title: Advanced Tutorials
----
-
-There are many use cases for Gatsby, from the very common "happy paths" to more specific and complex integrations. With the advanced Gatsby tutorials, learn about topics that go beyond [the basics](/tutorial/) and gain development superpowers.
-
-<GuideList slug={props.slug} />

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -23,8 +23,8 @@ In these intermediate tutorials, you'll learn how to pull data from almost anywh
 7.  [Programmatically create pages from data](/tutorial/part-seven/): Learn how to programmatically create a set of pages for your blog posts.
 8.  [Preparing a site to go live](/tutorial/part-eight/): Learn how to audit your site for performance and best practices for accessibility, SEO, and more.
 
-## Advanced tutorials
+## Additional tutorials
 
-There are many use cases for Gatsby, some which aren't covered in beginner or advanced tutorials to keep you focused while learning. The advanced Gatsby tutorials section is a collection of advanced use cases shown step-by-step, such as using source plugins for images and CMS content.
+There are many use cases for Gatsby, some which aren't covered in the first set of tutorials to keep you focused while learning. Gatsby's Additional Tutorials section is a collection of resources showing how to complete even more Gatsby tasks step-by-step, such as using source plugins for images and CMS content.
 
-Go deeper with the [advanced Gatsby tutorials](/tutorial/advanced-tutorials/).
+Go deeper with [additional Gatsby tutorials](/tutorial/additional-tutorials/).

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -247,7 +247,7 @@ Lighthouse is a great tool for site improvements and learning -- Continue lookin
 
 ## That's all, folks
 
-Well, not quite; just for this tutorial. There are also [Advanced Tutorials](/tutorial/advanced-tutorials/) to check out for more guided use cases.
+Well, not quite; just for this tutorial. There are [Additional Tutorials](/tutorial/additional-tutorials/) to check out for more guided use cases.
 
 This is just the beginning. Keep going!
 

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -268,7 +268,12 @@ exports.createPages = ({ graphql, actions, reporter }) => {
 
   createRedirect({
     fromPath: `/docs/advanced-tutorials/`,
-    toPath: `/tutorial/advanced-tutorials/`,
+    toPath: `/tutorial/additional-tutorials/`,
+    isPermanent: true,
+  })
+  createRedirect({
+    fromPath: `/docs/advanced-tutorials/`,
+    toPath: `/tutorial/additional-tutorials/`,
     isPermanent: true,
   })
   createRedirect({

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -272,7 +272,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
     isPermanent: true,
   })
   createRedirect({
-    fromPath: `/docs/advanced-tutorials/`,
+    fromPath: `/tutorial/advanced-tutorials/`,
     toPath: `/tutorial/additional-tutorials/`,
     isPermanent: true,
   })

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -528,8 +528,6 @@
           link: /docs/gatsby-vendor-partnership/
         - title: Agency Partnership Program
           link: /docs/gatsby-agency-partnership/
-    - title: Advanced Tutorials
-      link: /tutorial/advanced-tutorials/
     - title: Commands (Gatsby CLI)
       link: /docs/gatsby-cli/
     - title: Cheat Sheet

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -111,8 +111,8 @@
           link: /tutorial/part-eight/#add-page-metadata
         - title: Keep making it better
           link: /tutorial/part-eight/#keep-making-it-better
-    - title: Advanced Tutorials
-      link: /tutorial/advanced-tutorials/
+    - title: Additional Tutorials
+      link: /tutorial/additional-tutorials/
       items:
         - title: Making a Site with User Authentication
           link: /tutorial/authentication-tutorial/

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -27,13 +27,14 @@ class IndexRoute extends React.Component {
             </h1>
             <p>Gatsby is a blazing fast modern site generator for React.</p>
             <h2>Get Started</h2>
-            <p>There are four main ways to get started with Gatsby:</p>
+            <p>There are five main ways to get started with Gatsby:</p>
             <ol>
               <li>
-                <Link to="/tutorial/">Tutorial</Link>: Step-by-step instructions
-                on how to install Gatsby and start a project: written for people
-                without Gatsby or web development experience, though it has
-                helped developers of all skill levels.
+                <Link to="/tutorial/">Tutorials</Link>: Step-by-step
+                instructions on how to install Gatsby and start a project:
+                written for people without Gatsby or web development experience,
+                though these learning resources have helped developers of all
+                skill levels.
               </li>
               <li>
                 <Link to="/docs/quick-start">Quick start</Link>: One page
@@ -52,11 +53,6 @@ class IndexRoute extends React.Component {
                     <Link to="/docs/guides/">Reference Guides</Link>: Learn
                     about the many different topics around building with Gatsby,
                     like sourcing data, deployment, and more.
-                  </li>
-                  <li>
-                    <Link to="/ecosystem/">Ecosystem</Link>: Check out libraries
-                    for Gatsby starters and plugins, as well as external
-                    community resources.
                   </li>
                   <li>
                     <Link to="/docs/api-reference/">Gatsby API Reference</Link>:
@@ -78,13 +74,6 @@ class IndexRoute extends React.Component {
                     Dig into how Gatsby works behind the scenes.
                   </li>
                   <li>
-                    <Link to="/tutorial/advanced-tutorials/">
-                      Advanced Tutorials
-                    </Link>
-                    : Learn about topics that are too large for a doc and
-                    warrant a tutorial.
-                  </li>
-                  <li>
                     <Link to="/docs/using-gatsby-professionally/">
                       Using Gatsby Professionally
                     </Link>
@@ -93,6 +82,11 @@ class IndexRoute extends React.Component {
                     Gatsby professionally.
                   </li>
                 </ul>
+              </li>
+              <li>
+                Check out the <Link to="/ecosystem/">Ecosystem</Link> libraries
+                for Gatsby starters and plugins, as well as external community
+                resources.
               </li>
             </ol>
             <p>


### PR DESCRIPTION
As an outcome of the Tutorials planning meeting with @amberleyromo, this PR gives us room to add step-by-step content that isn't necessarily advanced in nature. This is intended to be an interim measure ahead of the big Tutorials overhaul where the step-by-step learning approach will evolve completely.

Future changes we anticipate after this PR:
- Additional Tutorials could have topical groupings added to it, such as "Working with Wordpress" or "e-commerce tutorials"
- Until we fully think through a Building _for_ Gatsby section, Additional Tutorials could link off to plugin/theme authoring tutorials in the docs. (i.e. "Looking to build Gatsby themes or plugins? Check out the docs")