### PR TITLE
chore(docs): Fix gatsby-image examples

### DIFF
--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -67,20 +67,22 @@ Automatically create images for different resolutions at a set width or height â
 Once you've queried for a `fixed` image to retrieve its data, you can pass that data into the `Img` component:
 
 ```jsx
-import { useStaticQuery } from "gatsby"
+import { useStaticQuery, graphql } from "gatsby"
 import Img from "gatsby-image"
 
 export default () => {
-  const data = useStaticQuery(query`
-    file(relativePath: { eq: "images/default.jpg" }) {
-      childImageSharp {
-        # Specify a fixed image and fragment.
-        # The default width is 400 pixels
-        // highlight-start
-        fixed {
-          ...GatsbyImageSharpFixed
+  const data = useStaticQuery(graphql`
+    query {
+      file(relativePath: { eq: "images/default.jpg" }) {
+        childImageSharp {
+          # Specify a fixed image and fragment.
+          # The default width is 400 pixelss
+          // highlight-start
+          fixed {
+            ...GatsbyImageSharpFixed
+          }
+          // highlight-end
         }
-        // highlight-end
       }
     }
   `)
@@ -140,16 +142,18 @@ import { useStaticQuery } from "gatsby"
 import Img from "gatsby-image"
 
 export default () => {
-  const data = useStaticQuery(query`
-    file(relativePath: { eq: "images/default.jpg" }) {
-      childImageSharp {
-        # Specify a fluid image and fragment
-        # The default maxWidth is 800 pixels
-        // highlight-start
-        fluid {
-          ...GatsbyImageSharpFluid
+  const data = useStaticQuery(graphql`
+    query {
+      file(relativePath: { eq: "images/default.jpg" }) {
+        childImageSharp {
+          # Specify a fluid image and fragment
+          # The default maxWidth is 800 pixels
+          // highlight-start
+          fluid {
+            ...GatsbyImageSharpFluid
+          }
+          // highlight-end
         }
-        // highlight-end
       }
     }
   `)


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

There are two examples in this docs. I was learning how to use gatsby-image and pasted the code examples in my local example to find errors about there's no ```query``` which has been imported. I read through the useStaticQuery docs to figure out how to make this work. I have made the changes which make the examples work. 

PS: This would be my ever open source contribution.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #14850