### PR TITLE
chore(docs): Added missing import

### DIFF
--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -138,7 +138,7 @@ Create flexible sizes for an image that stretches to fill its container. E.g. fo
 Once you've queried for a `fluid` image to retrieve its data, you can pass that data into the `Img` component:
 
 ```jsx
-import { useStaticQuery } from "gatsby"
+import { useStaticQuery, graphql } from "gatsby"
 import Img from "gatsby-image"
 
 export default () => {


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I had recently modified the examples in the docs. I completely missed an import in the second example. Added missing ```graphql``` import from **Images that stretch across a _fluid_ container** example.


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Adds to the fix on #14851
