### PR TITLE
docs(www): link to plugin README templates from plugins guide

### DIFF
--- a/docs/contributing/submit-to-plugin-library.md
+++ b/docs/contributing/submit-to-plugin-library.md
@@ -8,7 +8,8 @@ In order to add your plugin to the [Plugin Library](/plugins/), you need to:
 
 1.  publish a package to npm (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages)),
 2.  include the [required files](/docs/files-gatsby-looks-for-in-a-plugin/) in your plugin code,
-3.  and **include a `keywords` field** in your plugin's `package.json`, containing `gatsby` and `gatsby-plugin`.
+3.  **include a `keywords` field** in your plugin's `package.json`, containing `gatsby` and `gatsby-plugin`,
+4.  and document your plugin with a README, there are [plugin templates](/contributing/docs-templates/#plugin-readme-template) available to be used as reference.
 
 After doing so, Algolia will take up to 12 hours to add it to the library search index (the exact time necessary is still unknown), and wait for the daily rebuild of https://gatsbyjs.org to automatically include your plugin page to the website. Then, all you have to do is share your wonderful plugin with the community!
 

--- a/docs/docs/creating-plugins.md
+++ b/docs/docs/creating-plugins.md
@@ -9,6 +9,7 @@ You may be looking to build and perhaps publish a plugin that doesn't exist yet,
 - Each Gatsby plugin can be created as an npm package or as a [local plugin](/docs/creating-a-local-plugin/)
 - A `package.json` is required
 - Plugins implement the Gatsby APIs for [Node](/docs/node-apis/), [server-side rendering](/docs/ssr-apis/), and the [browser](/docs/browser-apis/)
+- There are [plugin templates](/contributing/docs-templates/#plugin-readme-template) available to be used as reference.
 
 This section of the docs includes the following guides:
 

--- a/docs/docs/creating-plugins.md
+++ b/docs/docs/creating-plugins.md
@@ -9,7 +9,6 @@ You may be looking to build and perhaps publish a plugin that doesn't exist yet,
 - Each Gatsby plugin can be created as an npm package or as a [local plugin](/docs/creating-a-local-plugin/)
 - A `package.json` is required
 - Plugins implement the Gatsby APIs for [Node](/docs/node-apis/), [server-side rendering](/docs/ssr-apis/), and the [browser](/docs/browser-apis/)
-- There are [plugin templates](/contributing/docs-templates/#plugin-readme-template) available to be used as reference.
 
 This section of the docs includes the following guides:
 


### PR DESCRIPTION
update creating-plugins guide to include plugin template link

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

update creating-plugins guide to include plugin template link

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Fixes issue #14774
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
