### PR TITLE
fix(gatsby-cli): move `react` to peerDependencies

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -34,7 +34,6 @@
     "opentracing": "^0.14.3",
     "pretty-error": "^2.1.1",
     "prompts": "^2.1.0",
-    "react": "^16.8.4",
     "resolve-cwd": "^2.0.0",
     "semver": "^6.0.0",
     "source-map": "0.5.7",
@@ -54,6 +53,9 @@
   "optionalDependencies": {
     "ink": "^2.0.5",
     "ink-spinner": "^3.0.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8.4"
   },
   "files": [
     "lib"


### PR DESCRIPTION
`react` in `dependencies` caused problem if parent directory's
node_modules had `react` installed.

fixes #14862