### PR TITLE
Add status bar to bottom of screen during develop

### DIFF
--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -179,6 +179,7 @@ const reporter: Reporter = {
       span,
     }
   },
+  // Make private as we'll probably remove this in a future refactor.
   _setStage(stage) {
     if (reporterInstance.setStage) {
       reporterInstance.setStage(stage)

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -179,6 +179,11 @@ const reporter: Reporter = {
       span,
     }
   },
+  _setStage(stage) {
+    if (reporterInstance.setStage) {
+      reporterInstance.setStage(stage)
+    }
+  },
 }
 
 console.log = (...args) => reporter.log(util.format(...args))

--- a/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
@@ -11,9 +11,6 @@ function useInterval(callback, delay) {
 
   // Set up the interval.
   useEffect(() => {
-    // Call the function immediately.
-    // savedCallback.current()
-
     function tick() {
       savedCallback.current()
     }

--- a/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
@@ -1,6 +1,7 @@
 import React, { useContext, useState, useEffect, useRef } from "react"
 import { Box, Color, StdoutContext } from "ink"
 
+// Handy hook from https://overreacted.io/making-setinterval-declarative-with-react-hooks/
 function useInterval(callback, delay) {
   const savedCallback = useRef()
 
@@ -23,6 +24,7 @@ function useInterval(callback, delay) {
   }, [delay])
 }
 
+// Track the width and height of the terminal. Responsive app design baby!
 const useTerminalResize = () => {
   const { stdout } = useContext(StdoutContext)
   const [sizes, setSizes] = useState([stdout.columns, stdout.rows])
@@ -38,6 +40,7 @@ const useTerminalResize = () => {
   return sizes
 }
 
+// Query the site's graphql instance for the latest count.
 const fetchPageQueryCount = url =>
   fetch(`${url}___graphql`, {
     method: `post`,
@@ -59,6 +62,8 @@ const Develop = props => {
   fetchPageQueryCount(props.stage.context.url).then(count =>
     setPagesCount(count)
   )
+  // Query for latest page count every second.
+  // Built-in subscriptions would be nice.
   useInterval(() => {
     // POST to get pages count.
     fetchPageQueryCount(props.stage.context.url).then(count =>
@@ -69,9 +74,7 @@ const Develop = props => {
   const [width] = useTerminalResize()
 
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box>{` `}</Box>
-      <Box>{` `}</Box>
+    <Box flexDirection="column" marginTop={2}>
       <Box textWrap={`truncate`}>{`—`.repeat(width)}</Box>
       <Box height={1} flexDirection="row">
         <Color>{pagesCount} pages</Color>

--- a/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
@@ -1,0 +1,88 @@
+import React, { useContext, useState, useEffect, useRef } from "react"
+import { Box, Color, StdoutContext } from "ink"
+
+function useInterval(callback, delay) {
+  const savedCallback = useRef()
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  // Set up the interval.
+  useEffect(() => {
+    // Call the function immediately.
+    // savedCallback.current()
+
+    function tick() {
+      savedCallback.current()
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay)
+      return () => clearInterval(id)
+    }
+
+    return null
+  }, [delay])
+}
+
+const useTerminalResize = () => {
+  const { stdout } = useContext(StdoutContext)
+  const [sizes, setSizes] = useState([stdout.columns, stdout.rows])
+  useEffect(() => {
+    stdout.on(`resize`, () => {
+      setSizes([stdout.columns, stdout.rows])
+    })
+    return () => {
+      stdout.off(`resize`)
+    }
+  }, [stdout])
+
+  return sizes
+}
+
+const fetchPageQueryCount = url =>
+  fetch(`${url}___graphql`, {
+    method: `post`,
+    body: JSON.stringify({
+      query: `query MyQuery {
+  allSitePage {
+    totalCount
+  }
+}`,
+    }),
+    headers: { "Content-Type": `application/json` },
+  })
+    .then(res => res.json())
+    .then(json => json.data.allSitePage.totalCount)
+
+const Develop = props => {
+  const [pagesCount, setPagesCount] = useState(0)
+
+  fetchPageQueryCount(props.stage.context.url).then(count =>
+    setPagesCount(count)
+  )
+  useInterval(() => {
+    // POST to get pages count.
+    fetchPageQueryCount(props.stage.context.url).then(count =>
+      setPagesCount(count)
+    )
+  }, 1000)
+
+  const [width] = useTerminalResize()
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box>{` `}</Box>
+      <Box>{` `}</Box>
+      <Box textWrap={`truncate`}>{`—`.repeat(width)}</Box>
+      <Box height={1} flexDirection="row">
+        <Color>{pagesCount} pages</Color>
+        <Box flexGrow={1} />
+        <Color>{props.stage.context.appName}</Color>
+      </Box>
+    </Box>
+  )
+}
+
+export default Develop

--- a/packages/gatsby-cli/src/reporter/reporters/ink/reporter.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/reporter.js
@@ -171,7 +171,9 @@ export default class GatsbyReporter extends React.Component {
             />
           ))}
         </Box>
-        {stage.stage === `BootstrapFinished` && <Develop stage={stage} />}
+        {stage.stage === `DevelopBootstrapFinished` && (
+          <Develop stage={stage} />
+        )}
       </Box>
     )
   }

--- a/packages/gatsby-cli/src/reporter/reporters/ink/reporter.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/reporter.js
@@ -3,6 +3,7 @@ import { Static, Box } from "ink"
 import chalk from "chalk"
 import Spinner from "./components/spinner"
 import ProgressBar from "./components/progress-bar"
+import Develop from "./components/develop"
 import { Message } from "./components/messages"
 import isTTY from "../../../util/is-tty"
 import calcElapsedTime from "../../../util/calc-elapsed-time"
@@ -32,9 +33,14 @@ export default class GatsbyReporter extends React.Component {
     verbose: false,
     messages: [],
     activities: {},
+    stage: { stage: `init`, context: {} },
   }
 
   format = chalk
+
+  setStage = stage => {
+    this.setState({ stage })
+  }
 
   createActivity = ({ id, ...options }) => {
     this.setState(state => {
@@ -122,7 +128,7 @@ export default class GatsbyReporter extends React.Component {
   }
 
   render() {
-    const { activities, messages, disableColors } = this.state
+    const { activities, messages, disableColors, stage } = this.state
 
     const spinners = []
     const progressBars = []
@@ -165,6 +171,7 @@ export default class GatsbyReporter extends React.Component {
             />
           ))}
         </Box>
+        {stage.stage === `BootstrapFinished` && <Develop stage={stage} />}
       </Box>
     )
   }

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -429,14 +429,12 @@ module.exports = async (program: any) => {
 
   function printInstructions(appName, urls, useYarn) {
     report._setStage({
-      stage: `BootstrapFinished`,
+      stage: `DevelopBootstrapFinished`,
       context: {
         url: urls.localUrlForBrowser,
         appName,
       },
     })
-    // Clear the screen now that bootstrap is done.
-    console.log(`\x1B[2J\x1B[0f`)
     console.log(`You can now view ${chalk.bold(appName)} in the browser.`)
     console.log()
 

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -435,6 +435,7 @@ module.exports = async (program: any) => {
         appName,
       },
     })
+    // Clear the screen now that bootstrap is done.
     console.log(`\x1B[2J\x1B[0f`)
     console.log(`You can now view ${chalk.bold(appName)} in the browser.`)
     console.log()

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -428,7 +428,14 @@ module.exports = async (program: any) => {
   }
 
   function printInstructions(appName, urls, useYarn) {
-    console.log()
+    report._setStage({
+      stage: `BootstrapFinished`,
+      context: {
+        url: urls.localUrlForBrowser,
+        appName,
+      },
+    })
+    console.log(`\x1B[2J\x1B[0f`)
     console.log(`You can now view ${chalk.bold(appName)} in the browser.`)
     console.log()
 


### PR DESCRIPTION
This is a simple start but we'll be adding more things to the
status bar over the next few days.

<img width="717" alt="Screenshot 2019-06-18 17 28 24" src="https://user-images.githubusercontent.com/71047/59697653-89b38b80-91ee-11e9-9d9e-85c2646e3e36.png">



<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->


<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->