### PR TITLE
fix(gatsby-transformer-react-docgen): always create description nodes

### DIFF
--- a/packages/gatsby-transformer-react-docgen/src/on-node-create.js
+++ b/packages/gatsby-transformer-react-docgen/src/on-node-create.js
@@ -25,7 +25,7 @@ function createDescriptionNode(
 ) {
   const { createNode } = actions
 
-  delete node.description;
+  delete node.description
 
   const descriptionNode = {
     id: createNodeId(descId(node.id)),

--- a/packages/gatsby-transformer-react-docgen/src/on-node-create.js
+++ b/packages/gatsby-transformer-react-docgen/src/on-node-create.js
@@ -23,8 +23,9 @@ function createDescriptionNode(
   createNodeId,
   createContentDigest
 ) {
-  if (!entry.description) return node
   const { createNode } = actions
+
+  delete node.description;
 
   const descriptionNode = {
     id: createNodeId(descId(node.id)),


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Gatsby started warning about `description` being resolved by two fields. In practice what was happening is that sometimes it'd just be the inferred string and other times the node here. This changes ensures that description is always a `ComponentDescription` node

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
