### PR TITLE
fix(*): fix gatsby-cli dep in source-filesystem & plugin-sharp

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -801,6 +801,7 @@ exports.createResolvers = ({
   createNodeId,
   createResolvers,
   store,
+  reporter,
 }) => {
   const { createNode } = actions
   createResolvers({
@@ -814,6 +815,7 @@ exports.createResolvers = ({
             cache,
             createNode,
             createNodeId,
+            reporter,
           })
         },
       },

--- a/examples/using-gatsby-image/plugins/gatsby-source-remote-images/gatsby-node.js
+++ b/examples/using-gatsby-image/plugins/gatsby-source-remote-images/gatsby-node.js
@@ -1,7 +1,14 @@
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
 exports.onCreateNode = async (
-  { actions: { createNode }, node, createContentDigest, store, cache },
+  {
+    actions: { createNode },
+    node,
+    createContentDigest,
+    store,
+    cache,
+    reporter,
+  },
   { filter, nodeName = `localFile` }
 ) => {
   if (filter(node)) {
@@ -11,6 +18,7 @@ exports.onCreateNode = async (
       cache,
       createNode,
       createNodeId: createContentDigest,
+      reporter,
     })
 
     if (fileNode) {

--- a/examples/using-gatsby-source-graphql/gatsby-node.js
+++ b/examples/using-gatsby-source-graphql/gatsby-node.js
@@ -5,7 +5,7 @@ const dateformat = require(`dateformat`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 const { makeBlogPath } = require(`./src/utils`)
 
-exports.createPages = async ({ actions, graphql, reporter }) => {
+exports.createPages = async ({ actions, graphql }) => {
   const { data } = await graphql(`
     query {
       cms {
@@ -35,6 +35,7 @@ exports.createResolvers = ({
   createNodeId,
   createResolvers,
   store,
+  reporter,
 }) => {
   const { createNode } = actions
   createResolvers({

--- a/examples/using-gatsby-source-graphql/gatsby-node.js
+++ b/examples/using-gatsby-source-graphql/gatsby-node.js
@@ -5,7 +5,7 @@ const dateformat = require(`dateformat`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 const { makeBlogPath } = require(`./src/utils`)
 
-exports.createPages = async ({ actions, graphql }) => {
+exports.createPages = async ({ actions, graphql, reporter }) => {
   const { data } = await graphql(`
     query {
       cms {
@@ -64,6 +64,7 @@ exports.createResolvers = ({
             cache,
             createNode,
             createNodeId,
+            reporter,
           })
         },
       },

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -33,6 +33,7 @@
     "object.entries": "^1.1.0",
     "opentracing": "^0.14.3",
     "pretty-error": "^2.1.1",
+    "progress": "^2.0.3",
     "prompts": "^2.1.0",
     "react": "^16.8.4",
     "resolve-cwd": "^2.0.0",

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -93,13 +93,88 @@ const reporter: Reporter = {
     const spanArgs = parentSpan ? { childOf: parentSpan } : {}
     const span = tracer.startSpan(name, spanArgs)
 
-    const activity = reporterInstance.createActivity(name)
+    const activity = reporterInstance.createActivity({
+      type: `spinner`,
+      id: name,
+      status: ``,
+    })
 
     return {
-      ...activity,
+      start() {
+        activity.update({
+          startTime: process.hrtime(),
+        })
+      },
+      setStatus(status) {
+        activity.update({
+          status: status,
+        })
+      },
       end() {
         span.finish()
-        activity.end()
+        activity.done()
+      },
+      span,
+    }
+  },
+
+  /**
+   * Create a progress bar for an activity
+   * @param {string} name - Name of activity.
+   * @param {number} total - Total items to be processed.
+   * @param {number} start - Start count to show.
+   * @param {ActivityArgs} activityArgs - optional object with tracer parentSpan
+   * @returns {ActivityTracker} The activity tracker.
+   */
+  createProgress(
+    name: string,
+    total,
+    start = 0,
+    activityArgs: ActivityArgs = {}
+  ): ActivityTracker {
+    const { parentSpan } = activityArgs
+    const spanArgs = parentSpan ? { childOf: parentSpan } : {}
+    const span = tracer.startSpan(name, spanArgs)
+
+    let hasStarted = false
+    let current = start
+    const activity = reporterInstance.createActivity({
+      type: `progress`,
+      id: name,
+      current,
+      total,
+    })
+
+    return {
+      start() {
+        if (hasStarted) {
+          return
+        }
+
+        hasStarted = true
+        activity.update({
+          startTime: process.hrtime(),
+        })
+      },
+      setStatus(status) {
+        activity.update({
+          status: status,
+        })
+      },
+      tick() {
+        activity.update({
+          current: ++current,
+        })
+      },
+      done() {
+        span.finish()
+        activity.done()
+      },
+      set total(value) {
+        total = value
+        activity.update({
+          total: value,
+        })
       },
       span,
     }

--- a/packages/gatsby-cli/src/reporter/reporters/ink/components/progress-bar.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/components/progress-bar.js
@@ -1,0 +1,43 @@
+import React from "react"
+import { Box } from "ink"
+import calcElapsedTime from "../../../../util/calc-elapsed-time"
+
+const maxWidth = 30
+const minWidth = 10
+
+const getLength = prop => String(prop).length
+
+export default function ProgressBar({ message, current, total, startTime }) {
+  const percentage = total ? Math.round((current / total) * 100) : 0
+  const terminalWidth = process.stdout.columns || 80
+  const availableWidth =
+    terminalWidth -
+    getLength(message) -
+    getLength(current) -
+    getLength(total) -
+    getLength(percentage) -
+    11 // margins + extra characters
+
+  const progressBarWidth = Math.max(
+    minWidth,
+    Math.min(maxWidth, availableWidth)
+  )
+
+  return (
+    <Box flexDirection="row">
+      <Box marginRight={3} width={progressBarWidth}>
+        [
+        <Box width={progressBarWidth - 2}>
+          {`=`.repeat(((progressBarWidth - 2) * percentage) / 100)}
+        </Box>
+        ]
+      </Box>
+      <Box marginRight={1}>{calcElapsedTime(startTime)} s</Box>
+      <Box marginRight={1}>
+        {current}/{total}
+      </Box>
+      <Box marginRight={1}>{`` + percentage}%</Box>
+      <Box textWrap="truncate">{message}</Box>
+    </Box>
+  )
+}

--- a/packages/gatsby-cli/src/reporter/reporters/ink/components/spinner.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/components/spinner.js
@@ -1,13 +1,6 @@
 import React from "react"
-import convertHrtime from "convert-hrtime"
 import { Box } from "ink"
 import Spinner from "ink-spinner"
-
-export const calcElapsedTime = startTime => {
-  const elapsed = process.hrtime(startTime)
-
-  return convertHrtime(elapsed)[`seconds`].toFixed(3)
-}
 
 export default function Activity({ name, status }) {
   let statusText = name

--- a/packages/gatsby-cli/src/reporter/reporters/yurnalist/index.js
+++ b/packages/gatsby-cli/src/reporter/reporters/yurnalist/index.js
@@ -1,7 +1,8 @@
 // @flow
 
 const { createReporter } = require(`yurnalist`)
-const convertHrtime = require(`convert-hrtime`)
+const ProgressBar = require(`progress`)
+const calcElapsedTime = require(`../../../util/calc-elapsed-time`)
 
 const VERBOSE = process.env.gatsby_log_level === `verbose`
 const reporter = createReporter({ emoji: true, verbose: VERBOSE })
@@ -29,36 +30,69 @@ module.exports = {
   info: reporter.info.bind(reporter),
   warn: reporter.warn.bind(reporter),
   log: reporter.log.bind(reporter),
-  /**
-   * Time an activity.
-   * @param {string} name - Name of activity.
-   * @returns {string} The elapsed time of activity.
-   */
-  createActivity(name) {
-    const spinner = reporter.activity()
-    const start = process.hrtime()
-    let status
 
-    const elapsedTime = () => {
-      var elapsed = process.hrtime(start)
-      return `${convertHrtime(elapsed)[`seconds`].toFixed(3)} s`
+  createActivity: activity => {
+    let start
+
+    if (activity.type === `spinner`) {
+      const spinner = reporter.activity()
+      let status
+
+      return {
+        update: newState => {
+          if (newState.startTime) {
+            start = newState.startTime
+            spinner.tick(activity.id)
+          }
+          if (newState.status) {
+            status = newState.status
+            spinner.tick(`${activity.id} — ${newState.status}`)
+          }
+        },
+        done: () => {
+          const str = status
+            ? `${activity.id} — ${calcElapsedTime(start)} — ${status}`
+            : `${activity.id} — ${calcElapsedTime(start)}`
+          reporter.success(str)
+          spinner.end()
+        },
+      }
+    }
+
+    if (activity.type === `progress`) {
+      const bar = new ProgressBar(
+        ` [:bar] :current/:total :elapsed s :percent ${activity.id}`,
+        {
+          total: 0,
+          width: 30,
+          clear: true,
+        }
+      )
+      return {
+        update: newState => {
+          if (newState.startTime) {
+            start = newState.startTime
+          }
+          if (newState.total) {
+            bar.total = newState.total
+          }
+          if (newState.current) {
+            bar.tick()
+          }
+        },
+        done: () => {
+          reporter.success(
+            `${activity.id} — ${bar.curr}/${bar.total} - ${calcElapsedTime(
+              start
+            )} s`
+          )
+        },
+      }
     }
 
     return {
-      start: () => {
-        spinner.tick(name)
-      },
-      setStatus: s => {
-        status = s
-        spinner.tick(`${name} — ${status}`)
-      },
-      end: () => {
-        const str = status
-          ? `${name} — ${elapsedTime()} — ${status}`
-          : `${name} — ${elapsedTime()}`
-        reporter.success(str)
-        spinner.end()
-      },
+      update: () => {},
+      done: () => {},
     }
   },
 }

--- a/packages/gatsby-cli/src/util/calc-elapsed-time.js
+++ b/packages/gatsby-cli/src/util/calc-elapsed-time.js
@@ -1,0 +1,7 @@
+const convertHrtime = require(`convert-hrtime`)
+
+module.exports = startTime => {
+  const elapsed = process.hrtime(startTime)
+
+  return convertHrtime(elapsed)[`seconds`].toFixed(3)
+}

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -19,7 +19,7 @@
     "mini-svg-data-uri": "^1.0.0",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",
-    "progress": "^1.1.8",
+    "progress": "^2.0.3",
     "semver": "^5.6.0",
     "sharp": "^0.22.1",
     "svgo": "^1.2.0"

--- a/packages/gatsby-plugin-sharp/src/__tests__/utils.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/utils.js
@@ -1,0 +1,23 @@
+jest.mock(`gatsby-cli/lib/reporter`)
+jest.mock(`progress`)
+const { createProgress } = require(`../utils`)
+const reporter = require(`gatsby-cli/lib/reporter`)
+const progress = require(`progress`)
+
+describe(`createProgress`, () => {
+  it(`should use createProgress from gatsby-cli when available`, () => {
+    createProgress(`test`)
+    expect(reporter.createProgress).toBeCalled()
+    expect(progress).not.toBeCalled()
+  })
+
+  it(`should fallback to a local implementation`, () => {
+    reporter.createProgress = null
+    const bar = createProgress(`test`)
+    expect(progress).toHaveBeenCalledTimes(1)
+    expect(bar).toHaveProperty(`start`, expect.any(Function))
+    expect(bar).toHaveProperty(`tick`, expect.any(Function))
+    expect(bar).toHaveProperty(`done`, expect.any(Function))
+    expect(bar).toHaveProperty(`total`)
+  })
+})

--- a/packages/gatsby-plugin-sharp/src/__tests__/utils.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/utils.js
@@ -5,14 +5,27 @@ const reporter = require(`gatsby-cli/lib/reporter`)
 const progress = require(`progress`)
 
 describe(`createProgress`, () => {
+  beforeEach(() => {
+    progress.mockClear()
+  })
+
   it(`should use createProgress from gatsby-cli when available`, () => {
-    createProgress(`test`)
+    createProgress(`test`, reporter)
     expect(reporter.createProgress).toBeCalled()
     expect(progress).not.toBeCalled()
   })
 
-  it(`should fallback to a local implementation`, () => {
+  it(`should fallback to a local implementation when createProgress does not exists on reporter`, () => {
     reporter.createProgress = null
+    const bar = createProgress(`test`, reporter)
+    expect(progress).toHaveBeenCalledTimes(1)
+    expect(bar).toHaveProperty(`start`, expect.any(Function))
+    expect(bar).toHaveProperty(`tick`, expect.any(Function))
+    expect(bar).toHaveProperty(`done`, expect.any(Function))
+    expect(bar).toHaveProperty(`total`)
+  })
+
+  it(`should fallback to a local implementation when no reporter is present`, () => {
     const bar = createProgress(`test`)
     expect(progress).toHaveBeenCalledTimes(1)
     expect(bar).toHaveProperty(`start`, expect.any(Function))

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -110,7 +110,8 @@ function queueImageResizing({ file, args = {}, reporter }) {
   const finishedPromise = scheduleJob(
     job,
     boundActionCreators,
-    pluginOptions
+    pluginOptions,
+    reporter
   ).then(() => {
     queue.delete(prefixedSrc)
   })

--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -1,8 +1,8 @@
 const _ = require(`lodash`)
-const ProgressBar = require(`progress`)
 const { existsSync } = require(`fs`)
 const queue = require(`async/queue`)
 const { processFile } = require(`./process-file`)
+const { createProgress } = require(`./utils`)
 
 const toProcess = {}
 let totalJobs = 0
@@ -10,13 +10,14 @@ const q = queue((task, callback) => {
   task(callback)
 }, 1)
 
-const bar = new ProgressBar(
-  `Generating image thumbnails [:bar] :current/:total :elapsed secs :percent`,
-  {
-    total: 0,
-    width: 30,
+let bar
+// when the queue is empty we stop the progressbar
+q.drain = () => {
+  if (bar) {
+    bar.done()
   }
-)
+  totalJobs = 0
+}
 
 exports.scheduleJob = async (
   job,
@@ -50,6 +51,10 @@ exports.scheduleJob = async (
     deferred.resolve = resolve
     deferred.reject = reject
   })
+  if (totalJobs === 0) {
+    bar = createProgress(`Generating image thumbnails`)
+    bar.start()
+  }
 
   totalJobs += 1
 
@@ -107,6 +112,7 @@ function runJobs(
 
   // We're now processing the file's jobs.
   let imagesFinished = 0
+
   bar.total = totalJobs
 
   try {

--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -23,6 +23,7 @@ exports.scheduleJob = async (
   job,
   boundActionCreators,
   pluginOptions,
+  reporter,
   reportStatus = true
 ) => {
   const inputFileKey = job.inputPath.replace(/\./g, `%2E`)
@@ -52,7 +53,7 @@ exports.scheduleJob = async (
     deferred.reject = reject
   })
   if (totalJobs === 0) {
-    bar = createProgress(`Generating image thumbnails`)
+    bar = createProgress(`Generating image thumbnails`, reporter)
     bar.start()
   }
 

--- a/packages/gatsby-plugin-sharp/src/utils.js
+++ b/packages/gatsby-plugin-sharp/src/utils.js
@@ -1,0 +1,29 @@
+const ProgressBar = require(`progress`)
+const reporter = require(`gatsby-cli/lib/reporter`)
+
+// TODO remove in V3
+export function createProgress(message) {
+  if (reporter.createProgress) {
+    return reporter.createProgress(message)
+  }
+
+  const bar = new ProgressBar(
+    ` [:bar] :current/:total :elapsed s :percent ${message}`,
+    {
+      total: 0,
+      width: 30,
+      clear: true,
+    }
+  )
+
+  return {
+    start() {},
+    tick() {
+      bar.tick()
+    },
+    done() {},
+    set total(value) {
+      bar.total = value
+    },
+  }
+}

--- a/packages/gatsby-plugin-sharp/src/utils.js
+++ b/packages/gatsby-plugin-sharp/src/utils.js
@@ -1,9 +1,8 @@
 const ProgressBar = require(`progress`)
-const reporter = require(`gatsby-cli/lib/reporter`)
 
 // TODO remove in V3
-export function createProgress(message) {
-  if (reporter.createProgress) {
+export function createProgress(message, reporter) {
+  if (reporter && reporter.createProgress) {
     return reporter.createProgress(message)
   }
 

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -25,6 +25,7 @@ const downloadContentfulAssets = async gatsbyFunctions => {
     store,
     cache,
     getNodes,
+    reporter,
   } = gatsbyFunctions
 
   // Any ContentfulAsset nodes will be downloaded, cached and copied to public/static
@@ -62,6 +63,7 @@ const downloadContentfulAssets = async gatsbyFunctions => {
             cache,
             createNode,
             createNodeId,
+            reporter,
           })
 
           if (fileNode) {

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -222,6 +222,7 @@ exports.sourceNodes = async (
       store,
       cache,
       getNodes,
+      reporter,
     })
   }
 

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -261,6 +261,7 @@ exports.sourceNodes = async (
           createNodeId,
           parentNodeId: node.id,
           auth,
+          reporter,
         })
       } catch (err) {
         reporter.error(err)

--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -33,6 +33,7 @@ export interface CreateRemoteFileNodeArgs {
   httpHeaders?: object
   ext?: string
   name?: string
+  reporter: object
 }
 
 export interface FileSystemNode extends Node {

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -17,7 +17,7 @@
     "md5-file": "^3.1.1",
     "mime": "^2.2.0",
     "pretty-bytes": "^4.0.2",
-    "progress": "^1.1.8",
+    "progress": "^2.0.3",
     "read-chunk": "^3.0.0",
     "valid-url": "^1.0.9",
     "xstate": "^3.1.0"

--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -19,30 +19,31 @@ jest.mock(`got`, () => {
     stream: jest.fn(),
   }
 })
-jest.mock(
-  `progress`,
-  () =>
-    class ProgressBar {
-      static total = 0
-      static tick = jest.fn(() => (ProgressBar.total -= 1))
 
-      total = ProgressBar.total
-      tick = ProgressBar.tick
-    }
-)
+jest.mock(`gatsby-cli/lib/reporter`, () => {
+  return {
+    createProgress: jest.fn(),
+  }
+})
 jest.mock(`../create-file-node`, () => {
   return {
     createFileNode: jest.fn(),
   }
 })
+const { createProgress } = require(`gatsby-cli/lib/reporter`)
+const progressBar = {
+  start: jest.fn(),
+  total: 0,
+  tick: jest.fn(),
+}
+createProgress.mockImplementation(() => progressBar)
+
 const got = require(`got`)
-const ProgressBar = require(`progress`)
 const createRemoteFileNode = require(`../create-remote-file-node`)
 const { createFileNode } = require(`../create-file-node`)
 
 beforeEach(() => {
-  ProgressBar.total = 0
-  ProgressBar.tick.mockClear()
+  progressBar.tick.mockClear()
 })
 
 describe(`create-remote-file-node`, () => {
@@ -73,8 +74,8 @@ describe(`create-remote-file-node`, () => {
 
         expect(value).rejects.toMatch(`wrong url: `)
 
-        expect(ProgressBar.total).toBe(0)
-        expect(ProgressBar.tick).not.toHaveBeenCalled()
+        expect(progressBar.total).toBe(0)
+        expect(progressBar.tick).not.toHaveBeenCalled()
       })
     })
   })
@@ -141,7 +142,8 @@ describe(`create-remote-file-node`, () => {
     it(`invokes ProgressBar tick`, async () => {
       await setup()
 
-      expect(ProgressBar.tick).toHaveBeenCalledTimes(1)
+      expect(progressBar.total).toBe(1)
+      expect(progressBar.tick).toHaveBeenCalledTimes(1)
     })
 
     describe(`requesting remote image`, () => {

--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -30,13 +30,13 @@ jest.mock(`../create-file-node`, () => {
     createFileNode: jest.fn(),
   }
 })
-const { createProgress } = require(`gatsby-cli/lib/reporter`)
+const reporter = require(`gatsby-cli/lib/reporter`)
 const progressBar = {
   start: jest.fn(),
   total: 0,
   tick: jest.fn(),
 }
-createProgress.mockImplementation(() => progressBar)
+reporter.createProgress.mockImplementation(() => progressBar)
 
 const got = require(`got`)
 const createRemoteFileNode = require(`../create-remote-file-node`)
@@ -53,6 +53,7 @@ describe(`create-remote-file-node`, () => {
     cache: {},
     createNode: jest.fn(),
     createNodeId: jest.fn(),
+    reporter,
   }
 
   describe(`basic functionality`, () => {

--- a/packages/gatsby-source-filesystem/src/__tests__/utils.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/utils.js
@@ -33,14 +33,27 @@ describe(`create remote file node`, () => {
 })
 
 describe(`createProgress`, () => {
+  beforeEach(() => {
+    progress.mockClear()
+  })
+
   it(`should use createProgress from gatsby-cli when available`, () => {
-    createProgress(`test`)
+    createProgress(`test`, reporter)
     expect(reporter.createProgress).toBeCalled()
     expect(progress).not.toBeCalled()
   })
 
-  it(`should fallback to a local implementation`, () => {
+  it(`should fallback to a local implementation when createProgress does not exists on reporter`, () => {
     reporter.createProgress = null
+    const bar = createProgress(`test`, reporter)
+    expect(progress).toHaveBeenCalledTimes(1)
+    expect(bar).toHaveProperty(`start`, expect.any(Function))
+    expect(bar).toHaveProperty(`tick`, expect.any(Function))
+    expect(bar).toHaveProperty(`done`, expect.any(Function))
+    expect(bar).toHaveProperty(`total`)
+  })
+
+  it(`should fallback to a local implementation when no reporter is present`, () => {
     const bar = createProgress(`test`)
     expect(progress).toHaveBeenCalledTimes(1)
     expect(bar).toHaveProperty(`start`, expect.any(Function))

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -6,19 +6,15 @@ const { isWebUri } = require(`valid-url`)
 const Queue = require(`better-queue`)
 const readChunk = require(`read-chunk`)
 const fileType = require(`file-type`)
-const ProgressBar = require(`progress`)
+const { createProgress } = require(`./utils`)
 
 const { createFileNode } = require(`./create-file-node`)
 const { getRemoteFileExtension, getRemoteFileName } = require(`./utils`)
 const cacheId = url => `create-remote-file-node-${url}`
 
-const bar = new ProgressBar(
-  `Downloading remote files [:bar] :current/:total :elapsed secs :percent`,
-  {
-    total: 0,
-    width: 30,
-  }
-)
+let bar
+// Keep track of the total number of jobs we push in the queue
+let totalJobs = 0
 
 /********************
  * Type Definitions *
@@ -82,6 +78,14 @@ const queue = new Queue(pushToQueue, {
   id: `url`,
   merge: (old, _, cb) => cb(old),
   concurrent: process.env.GATSBY_CONCURRENT_DOWNLOAD || 200,
+})
+
+// when the queue is empty we stop the progressbar
+queue.on(`drain`, () => {
+  if (bar) {
+    bar.done()
+  }
+  totalJobs = 0
 })
 
 /**
@@ -271,9 +275,6 @@ const pushTask = task =>
       })
   })
 
-// Keep track of the total number of jobs we push in the queue
-let totalJobs = 0
-
 /***************
  * Entry Point *
  ***************/
@@ -327,6 +328,11 @@ module.exports = ({
 
   if (!url || isWebUri(url) === undefined) {
     return Promise.reject(`wrong url: ${url}`)
+  }
+
+  if (totalJobs === 0) {
+    bar = createProgress(`Downloading remote files`)
+    bar.start()
   }
 
   totalJobs += 1

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -31,6 +31,11 @@ let totalJobs = 0
  */
 
 /**
+ * @typedef {Reporter}
+ * @see gatsby/packages/gatsby-cli/lib/reporter.js
+ */
+
+/**
  * @typedef {Auth}
  * @type {Object}
  * @property {String} htaccess_pass
@@ -47,6 +52,7 @@ let totalJobs = 0
  * @param  {GatsbyCache} options.cache
  * @param  {Function} options.createNode
  * @param  {Auth} [options.auth]
+ * @param  {Reporter} [options.reporter]
  */
 
 const CACHE_DIR = `.cache`
@@ -301,6 +307,7 @@ module.exports = ({
   createNodeId,
   ext = null,
   name = null,
+  reporter,
 }) => {
   // validation of the input
   // without this it's notoriously easy to pass in the wrong `createNodeId`
@@ -331,7 +338,7 @@ module.exports = ({
   }
 
   if (totalJobs === 0) {
-    bar = createProgress(`Downloading remote files`)
+    bar = createProgress(`Downloading remote files`, reporter)
     bar.start()
   }
 

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -1,5 +1,7 @@
 const path = require(`path`)
 const Url = require(`url`)
+const ProgressBar = require(`progress`)
+const reporter = require(`gatsby-cli/lib/reporter`)
 
 /**
  * getParsedPath
@@ -38,6 +40,33 @@ export function getRemoteFileExtension(url) {
  */
 export function getRemoteFileName(url) {
   return getParsedPath(url).name
+}
+
+// TODO remove in V3
+export function createProgress(message) {
+  if (reporter.createProgress) {
+    return reporter.createProgress(message)
+  }
+
+  const bar = new ProgressBar(
+    ` [:bar] :current/:total :elapsed s :percent ${message}`,
+    {
+      total: 0,
+      width: 30,
+      clear: true,
+    }
+  )
+
+  return {
+    start() {},
+    tick() {
+      bar.tick()
+    },
+    done() {},
+    set total(value) {
+      bar.total = value
+    },
+  }
 }
 
 /**

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -1,7 +1,6 @@
 const path = require(`path`)
 const Url = require(`url`)
 const ProgressBar = require(`progress`)
-const reporter = require(`gatsby-cli/lib/reporter`)
 
 /**
  * getParsedPath
@@ -43,8 +42,8 @@ export function getRemoteFileName(url) {
 }
 
 // TODO remove in V3
-export function createProgress(message) {
-  if (reporter.createProgress) {
+export function createProgress(message, reporter) {
+  if (reporter && reporter.createProgress) {
     return reporter.createProgress(message)
   }
 

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -25,7 +25,7 @@ import {
 } from "./queries"
 
 export const sourceNodes = async (
-  { actions: { createNode, touchNode }, createNodeId, store, cache },
+  { actions: { createNode, touchNode }, createNodeId, store, cache, reporter },
   { shopName, accessToken, verbose = true, paginationSize = 250 }
 ) => {
   const client = createClient(shopName, accessToken)
@@ -38,7 +38,14 @@ export const sourceNodes = async (
     console.log(formatMsg(`starting to fetch data from Shopify`))
 
     // Arguments used for file node creation.
-    const imageArgs = { createNode, createNodeId, touchNode, store, cache }
+    const imageArgs = {
+      createNode,
+      createNodeId,
+      touchNode,
+      store,
+      cache,
+      reporter,
+    }
 
     // Arguments used for node creation.
     const args = {

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -23,7 +23,7 @@ const { createNodeFactory, generateNodeId } = createNodeHelpers({
 
 const downloadImageAndCreateFileNode = async (
   { url, nodeId },
-  { createNode, createNodeId, touchNode, store, cache }
+  { createNode, createNodeId, touchNode, store, cache, reporter }
 ) => {
   let fileNodeID
 
@@ -43,6 +43,7 @@ const downloadImageAndCreateFileNode = async (
     createNode,
     createNodeId,
     parentNodeId: nodeId,
+    reporter,
   })
 
   if (fileNode) {

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -24,7 +24,15 @@ let _excludedRoutes
 let _normalizer
 
 exports.sourceNodes = async (
-  { actions, getNode, store, cache, createNodeId, createContentDigest },
+  {
+    actions,
+    getNode,
+    store,
+    cache,
+    createNodeId,
+    createContentDigest,
+    reporter,
+  },
   {
     baseUrl,
     protocol,
@@ -123,6 +131,7 @@ exports.sourceNodes = async (
     touchNode,
     getNode,
     _auth,
+    reporter,
   })
 
   // Creates links between elements and parent element.

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -477,6 +477,7 @@ exports.downloadMediaFiles = async ({
   touchNode,
   getNode,
   _auth,
+  reporter,
 }) =>
   Promise.all(
     entities.map(async e => {
@@ -511,6 +512,7 @@ exports.downloadMediaFiles = async ({
               createNodeId,
               parentNodeId: e.id,
               auth: _auth,
+              reporter,
             })
 
             if (fileNode) {

--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -16,7 +16,15 @@ const screenshotQueue = new Queue(
 )
 
 exports.onPreBootstrap = (
-  { store, cache, actions, createNodeId, getNodesByType, createContentDigest },
+  {
+    store,
+    cache,
+    actions,
+    createNodeId,
+    getNodesByType,
+    createContentDigest,
+    reporter,
+  },
   pluginOptions
 ) => {
   const { createNode, touchNode } = actions
@@ -46,6 +54,7 @@ exports.onPreBootstrap = (
         createNodeId,
         parentNodeId: n.id,
         createContentDigest,
+        reporter,
       })
     } else {
       // Screenshot hasn't yet expired, touch the image node
@@ -119,6 +128,7 @@ const createScreenshotNode = async ({
   createNodeId,
   parentNodeId,
   createContentDigest,
+  reporter,
 }) => {
   try {
     let fileNode, expires
@@ -139,6 +149,7 @@ const createScreenshotNode = async ({
         createNode,
         createNodeId,
         parentNodeId,
+        reporter,
       })
       expires = screenshotResponse.data.expires
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17472,15 +17472,15 @@ process@~0.5.1:
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
   integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-  integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
-
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
   integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
+
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-inflight@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description
I forgot to add gatsby-cli as a dependency in gatsby-source-filesystem & gatsby-plugin-sharp 🤦‍♂. 

Instead of adding it to dependencies we should accept it as a parameter based on the #4118 PR. This makes more sense as we probably get trouble with logging in the future.

I published some versions to test, please install the ones that are in your package.json
`npm install gatsby-plugin-sharp@reporter-npm`
`npm install gatsby-source-contentful@@reporter-npm`
`npm install gatsby-source-drupal@reporter-npm`
`npm install gatsby-source-filesystem@reporter-npm`
`npm install gatsby-source-shopify@reporter-npm`
`npm install gatsby-source-wordpress@reporter-npm`
`npm install gatsby-transformer-screenshot@reporter-npm`
`npm install gatsby-transformer-sqip@reporter-npm`

## Related Issues
Fixes #14875