### PR TITLE
feat(gatsby-plugin-netlify-cms): add custom favicon to cms section

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -171,6 +171,13 @@ Customize the path to Netlify CMS on your Gatsby site.
 Customize the value of the `title` tag in your CMS HTML (shows in the browser
 bar).
 
+### `htmlFavicon`
+
+(_optional_, type: `string`, default: `""`)
+
+Customize the value of the `favicon` tag in your CMS HTML (shows in the browser 
+bar).
+
 ## Example
 
 Here is the plugin with example values for all options (note that no option is
@@ -185,6 +192,7 @@ plugins: [
       enableIdentityWidget: true,
       publicPath: `admin`,
       htmlTitle: `Content Manager`,
+      htmlFavicon: `path/to/favicon`,
     },
   },
 ]

--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -175,7 +175,7 @@ bar).
 
 (_optional_, type: `string`, default: `""`)
 
-Customize the value of the `favicon` tag in your CMS HTML (shows in the browser 
+Customize the value of the `favicon` tag in your CMS HTML (shows in the browser
 bar).
 
 ## Example

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -55,6 +55,7 @@ exports.onCreateWebpackConfig = (
     publicPath = `admin`,
     enableIdentityWidget = true,
     htmlTitle = `Content Manager`,
+    htmlFavicon = ``,
     manualInit = false,
   }
 ) => {
@@ -135,6 +136,7 @@ exports.onCreateWebpackConfig = (
        */
       new HtmlWebpackPlugin({
         title: htmlTitle,
+        favicon: htmlFavicon,
         chunks: [`cms`],
         excludeAssets: [/cms.css/],
       }),


### PR DESCRIPTION
## Description

This pull request adds the ability to define an optional `favicon` field in the plugin, `gatsby-plugin-netlify-cms`. It leverages the `favicon` option defined by the [HTML Webpack Plugin](https://github.com/jantimon/html-webpack-plugin). I've also updated the relevant documentation page describing how to add the property.

This is my first PR to this repo, let me know if there's anything additional you need to review this PR, thanks!
