### PR TITLE
docs(www): add forking as first step in contributing to blog

### DIFF
--- a/docs/contributing/blog-and-website-contributions.md
+++ b/docs/contributing/blog-and-website-contributions.md
@@ -16,7 +16,8 @@ Note: Before adding a blog post ensure you have approval from a member of the Ga
 
 To add a new blog post to the gatsbyjs.org blog:
 
-- Clone [the Gatsby repo](https://github.com/gatsbyjs/gatsby/) and navigate to `/www`
+- Fork the [the Gatsby repo](https://github.com/gatsbyjs/gatsby/)
+- Clone your forked repo and navigate to `/www`
 - Run `yarn` to install all of the website's dependencies. ([Why Yarn?](/contributing/setting-up-your-local-dev-environment#using-yarn))
 - Run `npm run develop` to preview the blog at `http://localhost:8000/blog`.
 - The content for the blog lives in the `/docs/blog` folder. Make additions or modifications here.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The first step of contributing to the Gatsby blog should be to fork the Gatsby repo. See the second last step: "Commit and push to your fork".

<img width="703" alt="Screen Shot 2019-06-18 at 11 03 33 PM" src="https://user-images.githubusercontent.com/41944255/59740570-59371600-921d-11e9-86b2-58ee8e6e0ef7.png">

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
