### PR TITLE
chore(gatsby-remark-graphviz): add --ignore for test directory

### DIFF
--- a/packages/gatsby-remark-graphviz/package.json
+++ b/packages/gatsby-remark-graphviz/package.json
@@ -41,7 +41,7 @@
   },
   "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz",
   "scripts": {
-    "build": "babel --out-dir . src",
+    "build": "babel --out-dir . src --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
   }


### PR DESCRIPTION
## Description
Ignores the __test__ directory when building `gatsby-remark-graphviz`. Whenever you run `yarn bootstrap` you get an untracked file.

![image](https://user-images.githubusercontent.com/1120926/59764190-8f1adf80-929b-11e9-8dd1-1f977a92e293.png)

