### PR TITLE
fix(gatsby): Normalize paths for run queries before caching

### DIFF
--- a/packages/gatsby/src/utils/normalize-page-path.js
+++ b/packages/gatsby/src/utils/normalize-page-path.js
@@ -1,0 +1,14 @@
+// This is a duplicate of the runtime util
+// file cache-dir/normalize-page-path.js
+module.exports = path => {
+  if (path === undefined) {
+    return path
+  }
+  if (path === `/`) {
+    return `/`
+  }
+  if (path.charAt(path.length - 1) === `/`) {
+    return path.slice(0, -1)
+  }
+  return path
+}

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -4,6 +4,7 @@ const path = require(`path`)
 const { store } = require(`../redux`)
 const fs = require(`fs`)
 const pageDataUtil = require(`../utils/page-data`)
+const normalizePagePath = require(`../utils/normalize-page-path`)
 const telemetry = require(`gatsby-telemetry`)
 const url = require(`url`)
 const { createHash } = require(`crypto`)
@@ -248,6 +249,7 @@ class WebsocketManager {
   }
 
   emitPageData(data: QueryResult) {
+    data.id = normalizePagePath(data.id)
     this.pageResults.set(data.id, data)
     if (this.isInitialised) {
       this.websocket.send({ type: `pageQueryResult`, payload: data })


### PR DESCRIPTION
Fixes #14903


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->


<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->