### PR TITLE
feat(gatsby-cli): improve version output

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -314,8 +314,8 @@ function getLocalGatsbyVersion() {
 
 function getVersionInfo() {
   const { version } = require(`../package.json`)
-  const localVersion = isLocalGatsbySite()
-  if (localVersion) {
+  const isGatsbySite = isLocalGatsbySite()
+  if (isGatsbySite) {
     // we need to get the version from node_modules
     let gatsbyVersion = getLocalGatsbyVersion()
 

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -301,6 +301,18 @@ function isLocalGatsbySite() {
   return inGatsbySite
 }
 
+function getVersionInfo() {
+  const { version } = require(`../package.json`)
+  const localVersion = isLocalGatsbySite()
+  if (localVersion) {
+    return `Gatsby CLI version: ${version}
+Gatsby version: ${localVersion.replace(/^[^\d]+/, ``)}
+  Note: this is the Gatsby version for the site at: ${process.cwd()}`
+  } else {
+    return `Gatsby CLI version: ${version}`
+  }
+}
+
 module.exports = argv => {
   let cli = yargs()
   let isLocalSite = isLocalGatsbySite()
@@ -328,7 +340,11 @@ module.exports = argv => {
 
   try {
     const { version } = require(`../package.json`)
-    cli.version(`version`, version)
+    cli.version(
+      `version`,
+      `Show the version of the Gatsby CLI and the Gatsby package in the current project`,
+      getVersionInfo()
+    )
     setDefaultTags({ gatsbyCliVersion: version })
   } catch (e) {
     // ignore

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -25,7 +25,7 @@ function buildLocalCommands(cli, isLocalSite) {
 
   // 'not dead' query not available in browserslist used in Gatsby v1
   const DEFAULT_BROWSERS =
-    installedGatsbyVersion() === 1
+    getLocalGatsbyMajorVersion() === 1
       ? [`> 1%`, `last 2 versions`, `IE >= 9`]
       : [`>0.25%`, `not dead`]
 
@@ -37,26 +37,14 @@ function buildLocalCommands(cli, isLocalSite) {
     siteInfo.browserslist = json.browserslist || siteInfo.browserslist
   }
 
-  function installedGatsbyVersion() {
-    let majorVersion
-    try {
-      const packageInfo = require(path.join(
-        process.cwd(),
-        `node_modules`,
-        `gatsby`,
-        `package.json`
-      ))
-      try {
-        setDefaultTags({ installedGatsbyVersion: packageInfo.version })
-      } catch (e) {
-        // ignore
-      }
-      majorVersion = parseInt(packageInfo.version.split(`.`)[0], 10)
-    } catch (err) {
-      /* ignore */
+  function getLocalGatsbyMajorVersion() {
+    let version = getLocalGatsbyVersion()
+
+    if (version) {
+      version = Number(version.split(`.`)[0])
     }
 
-    return majorVersion
+    return version
   }
 
   function resolveLocalCommand(command) {
@@ -298,15 +286,45 @@ function isLocalGatsbySite() {
   } catch (err) {
     /* ignore */
   }
-  return inGatsbySite
+  return !!inGatsbySite
+}
+
+function getLocalGatsbyVersion() {
+  let version
+  try {
+    const packageInfo = require(path.join(
+      process.cwd(),
+      `node_modules`,
+      `gatsby`,
+      `package.json`
+    ))
+    version = packageInfo.version
+
+    try {
+      setDefaultTags({ installedGatsbyVersion: version })
+    } catch (e) {
+      // ignore
+    }
+  } catch (err) {
+    /* ignore */
+  }
+
+  return version
 }
 
 function getVersionInfo() {
   const { version } = require(`../package.json`)
   const localVersion = isLocalGatsbySite()
   if (localVersion) {
+    // we need to get the version from node_modules
+    let gatsbyVersion = getLocalGatsbyVersion()
+
+    if (!gatsbyVersion) {
+      gatsbyVersion = `unknown`
+    }
+
     return `Gatsby CLI version: ${version}
-Gatsby version: ${localVersion.replace(/^[^\d]+/, ``)}
+Gatsby version: ${gatsbyVersion}
   Note: this is the Gatsby version for the site at: ${process.cwd()}`
   } else {
     return `Gatsby CLI version: ${version}`


### PR DESCRIPTION
## Description

This change improves the output of `gatsby --version`. If run in a Gatsby project the output will look something like this:

```txt
Gatsby CLI version: 2.6.13
Gatsby version: 2.9.9
Note: this is the Gatsby version for the site at: /Users/iansu/Projects/oss/gatsby-test-blog
```

If run outside of a Gatsby project the output will look like this:

```txt
Gatsby CLI version: 2.6.13
```

## Related Issues

There's no issue for this but there is a maintainers team discussion: https://github.com/orgs/gatsbyjs/teams/maintainers/discussions/65?from_comment=7#discussion-65-comment-7
