### PR TITLE
feat(gatsby): Support absolute certificate paths for development

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/get-ssl-cert.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/get-ssl-cert.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gets ssl certs Custom SSL certificate loads a cert from a absolute paths 1`] = `
+Object {
+  "cert": "/foo.crt::file",
+  "certPath": "/foo.crt",
+  "key": "/foo.key::file",
+  "keyPath": "/foo.key",
+}
+`;
+
+exports[`gets ssl certs Custom SSL certificate loads a cert relative to a directory 1`] = `
+Object {
+  "cert": "/app/directory/foo.crt::file",
+  "certPath": "/app/directory/foo.crt",
+  "key": "/app/directory/foo.key::file",
+  "keyPath": "/app/directory/foo.key",
+}
+`;
+
+exports[`gets ssl certs Custom SSL certificate panic if cert and key are not both included 1`] = `
+Array [
+  Array [
+    "for custom ssl --https, --cert-file, and --key-file must be used together",
+  ],
+]
+`;
+
+exports[`gets ssl certs Custom SSL certificate panic if cert and key are not both included 2`] = `
+Array [
+  Array [
+    "for custom ssl --https, --cert-file, and --key-file must be used together",
+  ],
+]
+`;
+
+exports[`gets ssl certs automatic SSL certificate panics if certificate can't be created 1`] = `
+Array [
+  Array [
+    "
+Failed to generate dev SSL certificate",
+    [Error: mock error message],
+  ],
+]
+`;
+
+exports[`gets ssl certs automatic SSL certificate sets up dev cert 1`] = `
+Array [
+  Array [
+    "setting up automatic SSL certificate (may require sudo)
+",
+  ],
+]
+`;

--- a/packages/gatsby/src/utils/__tests__/get-ssl-cert.js
+++ b/packages/gatsby/src/utils/__tests__/get-ssl-cert.js
@@ -1,0 +1,74 @@
+jest.mock(`fs`, () => {
+  const fs = jest.requireActual(`fs`)
+  return {
+    ...fs,
+    readFileSync: jest.fn(file => `${file}::file`),
+  }
+})
+jest.mock(`gatsby-cli/lib/reporter`, () => {
+  return {
+    panic: jest.fn(),
+    info: jest.fn(),
+  }
+})
+jest.mock(`devcert-san`, () => {
+  return {
+    default: jest.fn(),
+  }
+})
+
+const devcertSan = require(`devcert-san`).default
+const reporter = require(`gatsby-cli/lib/reporter`)
+const getSslCert = require(`../get-ssl-cert`)
+
+describe(`gets ssl certs`, () => {
+  beforeEach(() => {
+    reporter.panic.mockClear()
+    reporter.info.mockClear()
+    devcertSan.mockClear()
+  })
+  describe(`Custom SSL certificate`, () => {
+    it.each([[{ certFile: `foo` }], [{ keyFile: `bar` }]])(
+      `panic if cert and key are not both included`,
+      args => {
+        getSslCert(args)
+
+        expect(reporter.panic.mock.calls).toMatchSnapshot()
+      }
+    )
+    it(`loads a cert relative to a directory`, () => {
+      expect(
+        getSslCert({
+          name: `mock-cert`,
+          certFile: `foo.crt`,
+          keyFile: `foo.key`,
+          directory: `/app/directory`,
+        })
+      ).resolves.toMatchSnapshot()
+    })
+    it(`loads a cert from a absolute paths`, () => {
+      expect(
+        getSslCert({
+          name: `mock-cert`,
+          certFile: `/foo.crt`,
+          keyFile: `/foo.key`,
+          directory: `/app/directory`,
+        })
+      ).resolves.toMatchSnapshot()
+    })
+  })
+  describe(`automatic SSL certificate`, () => {
+    it(`sets up dev cert`, () => {
+      getSslCert({ name: `mock-cert` })
+      expect(devcertSan).toBeCalledWith(`mock-cert`, { installCertutil: true })
+      expect(reporter.info.mock.calls).toMatchSnapshot()
+    })
+    it(`panics if certificate can't be created`, () => {
+      devcertSan.mockImplementation(() => {
+        throw new Error(`mock error message`)
+      })
+      getSslCert({ name: `mock-cert` })
+      expect(reporter.panic.mock.calls).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/gatsby/src/utils/get-ssl-cert.js
+++ b/packages/gatsby/src/utils/get-ssl-cert.js
@@ -3,6 +3,14 @@ const report = require(`gatsby-cli/lib/reporter`)
 const fs = require(`fs`)
 const path = require(`path`)
 
+const resolvePath = (directory, filePath) => {
+  // Support absolute paths
+  if (filePath[0] === `/`) {
+    return filePath
+  }
+  return path.join(directory, filePath)
+}
+
 module.exports = async ({ name, certFile, keyFile, directory }) => {
   // check that cert file and key file are both true or both false, if they are both
   // false, it defaults to the automatic ssl
@@ -13,8 +21,8 @@ module.exports = async ({ name, certFile, keyFile, directory }) => {
   }
 
   if (certFile && keyFile) {
-    const keyPath = path.join(directory, keyFile)
-    const certPath = path.join(directory, certFile)
+    const keyPath = resolvePath(directory, keyFile)
+    const certPath = resolvePath(directory, certFile)
 
     return await {
       keyPath,

--- a/packages/gatsby/src/utils/get-ssl-cert.js
+++ b/packages/gatsby/src/utils/get-ssl-cert.js
@@ -3,9 +3,9 @@ const report = require(`gatsby-cli/lib/reporter`)
 const fs = require(`fs`)
 const path = require(`path`)
 
-const resolvePath = (directory, filePath) => {
+const absoluteOrDirectory = (directory, filePath) => {
   // Support absolute paths
-  if (filePath[0] === `/`) {
+  if (path.isAbsolute(filePath)) {
     return filePath
   }
   return path.join(directory, filePath)
@@ -21,8 +21,8 @@ module.exports = async ({ name, certFile, keyFile, directory }) => {
   }
 
   if (certFile && keyFile) {
-    const keyPath = resolvePath(directory, keyFile)
-    const certPath = resolvePath(directory, certFile)
+    const keyPath = absoluteOrDirectory(directory, keyFile)
+    const certPath = absoluteOrDirectory(directory, certFile)
 
     return await {
       keyPath,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
All certificate paths are currently relative to the project directory. This change makes it support `/` and `~/`


```gatsby develop --https --key-file ~/.certs/star.dev.key --cert-file ~/.certs/star.dev.crt``` 

Before: `/Users/cranberyxl/gatsby-project/Users/cranberyxl/.certs/star.dev.key`

After: `/Users/cranberyxl/.certs/star.dev.key`



<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
