### PR TITLE
fix(gatsby): update tsc definition of cache in NodePluginArgs

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -725,7 +725,7 @@ export interface NodePluginArgs {
   hasNodeChanged: Function
   reporter: Reporter
   getNodeAndSavePathDependency: Function
-  cache: Cache
+  cache: Cache["cache"]
   createNodeId: Function
   createContentDigest: Function
   tracing: Tracing


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR fixes the type of `cache` in `NodePluginArgs`. It should be the instance of cache, instead of Cache.
