### PR TITLE
Fix broken create-content-digest.js link

### DIFF
--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -31,7 +31,7 @@ Reserved for plugins who wish to extend other nodes.
 
 Digest "Hash" (for example `md5sum`) of the content of this node.
 
-The digest should be unique to the content of this node since it's used for caching. If the content changes, this digest should also change. There's a helper function called [createContentDigest](/packages/gatsby/src/utils/create-content-digest.js) to create an `md5` digest.
+The digest should be unique to the content of this node since it's used for caching. If the content changes, this digest should also change. There's a helper function called [createContentDigest](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js) to create an `md5` digest.
 
 ### `mediaType`
 


### PR DESCRIPTION
## Description

Fixes a broken link to `create-content-digest.js` and closes the first task inside #14693 

## Related Issues

Closes the first task inside #14693 
