### PR TITLE
chore(sites): remove caddy site

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -513,20 +513,6 @@
     - Education
     - Web Development
     - Technology
-- title: Caddy Smells Like Trees
-  main_url: "https://caddysmellsliketrees.ru"
-  url: "https://caddysmellsliketrees.ru/en"
-  source_url: "https://github.com/podabed/caddysmellsliketrees.github.io"
-  description: >-
-    We play soul-searching songs for every day. They are merging in our forests
-    in such a way that it is difficult to separate them from each other, and
-    between them bellow bold deer poems.
-  categories:
-    - Music
-    - Gallery
-  built_by: Dmitrij Podabed, Alexander Nikitin
-  built_by_url: https://podabed.org
-  featured: false
 - title: Calpa's Blog
   main_url: "https://calpa.me/"
   url: "https://calpa.me/"


### PR DESCRIPTION
## Description

@podabed as info -- we're removing the site `https://caddysmellsliketrees.ru/en`.

I'm not exactly sure why, but it's not able to be accessed with e.g. a curl command, so is failing to be created and screenshotted, thus failing the build.

```
curl https://caddysmellsliketrees.ru/en
```

> curl: (35) error:1400442E:SSL routines:CONNECT_CR_SRVR_HELLO:tlsv1 alert protocol version

```
curl https://caddysmellsliketrees.ru/en
# no reply
```