### PR TITLE
Add a link to the REPL doc page in the Gatsby docs

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -278,7 +278,7 @@ function buildLocalCommands(cli, isLocalSite) {
 
   cli.command({
     command: `repl`,
-    desc: `Get a node repl with context of Gatsby environment, see (add docs link here)`,
+    desc: `Get a node repl with context of Gatsby environment, see (https://www.gatsbyjs.org/docs/gatsby-repl/)`,
     handler: getCommandHandler(`repl`, (args, cmd) => {
       process.env.NODE_ENV = process.env.NODE_ENV || `development`
       return cmd(args)


### PR DESCRIPTION

## Description

Just going through the CLI docs to see how `gatsby repl` works internally so I can [document it](https://github.com/gatsbyjs/gatsby/issues/7484#issuecomment-504092944).

Figured I'd start here 🤓


## Related Issues
Related to #7484

