### PR TITLE
fix(gatsby-source-contentful): include locale in asset cache key

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
@@ -1,0 +1,80 @@
+const { downloadContentfulAssets } = require(`../download-contentful-assets`)
+
+jest.mock(
+  `progress`,
+  () =>
+    class MockProgress {
+      constructor() {
+        this.tick = jest.fn()
+      }
+    }
+)
+
+jest.mock(`gatsby-source-filesystem`, () => {
+  return {
+    createRemoteFileNode: jest.fn(({ url }) => {
+      return {
+        url,
+      }
+    }),
+  }
+})
+
+const fixtures = [
+  {
+    id: `aa1beda4-b14a-50f5-89a8-222992a46a41`,
+    contentful_id: `idJjXOxmNga8CSnQGEwTw`,
+    internal: {
+      owner: `gatsby-source-contentful`,
+      type: `ContentfulAsset`,
+    },
+    title: `TundraUS`,
+    node_locale: `en-US`,
+    file: {
+      url: `//images.ctfassets.net/testing/us-image.jpeg`,
+    },
+    localFile: {
+      base: `us-image.jpeg`,
+    },
+  },
+  {
+    id: `586c12ca-fbe3-5acd-94ee-7598bf3f6d77`,
+    contentful_id: `idJjXOxmNga8CSnQGEwTw`,
+    internal: {
+      owner: `gatsby-source-contentful`,
+      type: `ContentfulAsset`,
+    },
+    title: `TundraFR`,
+    node_locale: `fr`,
+    file: {
+      url: `//images.ctfassets.net/testing/fr-image.jpg`,
+    },
+    localFile: {
+      base: `fr-image.jpg`,
+    },
+  },
+]
+
+describe.only(`downloadContentfulAssets`, () => {
+  it(`derives unique cache key from node locale and id`, async () => {
+    const cache = {
+      get: jest.fn(() => Promise.resolve(null)),
+      set: jest.fn(() => Promise.resolve(null)),
+    }
+    await downloadContentfulAssets({
+      actions: { touchNode: jest.fn() },
+      getNodes: () => fixtures,
+      cache,
+    })
+
+    fixtures.forEach(n => {
+      expect(cache.get).toHaveBeenCalledWith(
+        `contentful-asset-${n.contentful_id}-${n.node_locale}`
+      )
+      expect(cache.set).toHaveBeenCalledWith(
+        `contentful-asset-${n.contentful_id}-${n.node_locale}`,
+        expect.anything()
+      )
+    })
+  })
+})

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -42,7 +42,8 @@ const downloadContentfulAssets = async gatsbyFunctions => {
       bar.total = totalJobs
 
       let fileNodeID
-      const remoteDataCacheKey = `contentful-asset-${node.contentful_id}`
+      const { contentful_id: id, node_locale: locale } = node
+      const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
       const cacheRemoteData = await cache.get(remoteDataCacheKey)
       const url = `http://${node.file.url.slice(2)}`
 


### PR DESCRIPTION
## Description

This PR fixes an issue in gatsby-source-contentful (with `downloadLocal: true`) where the cache key derived for each Contentful asset was not always unique. When a Contentful space has more than one locale, an asset can define a file per locale. So given these two nodes pointing at the same contentful asset:

```
{
  "data": {
    "allContentfulAsset": {
      "nodes": [
        {
          "id": "aa1beda4-b14a-50f5-89a8-222992a46a41",
          "contentful_id": "idJjXOxmNga8CSnQGEwTw",
          "title": "FlagUS",
          "node_locale": "en-US",
          "file": {
            "url": "//images.ctfassets.net/__testing__/us-image.jpg"
          },
          "localFile": {
            "base": "us-image.jpg"
          }
        },
        {
          "id": "586c12ca-fbe3-5acd-94ee-7598bf3f6d77",
          "contentful_id": "idJjXOxmNga8CSnQGEwTw",
          "title": "FlagFR",
          "node_locale": "fr",
          "file": {
            "url": "//images.ctfassets.net/__testing__/fr-image.jpg"
          },
          "localFile": {
            "base": "us-image.jpg"
            //      ^^^^^^^^^^^^^^ wrong value due to bad cache key
            // The right value is "fr-image.jpg"
          }
        }
      ]
    }
  }
}
```

Both the files pointed at `nodes.*.file.url` will be downloaded and cached with key `contentful-asset-idJjXOxmNga8CSnQGEwTw`.

With this PR, the cache keys are now `contentful-asset-idJjXOxmNga8CSnQGEwTw-en-US` and `contentful-asset-idJjXOxmNga8CSnQGEwTw-fr` respectively and the attached `localeFile` will be correct.


## Steps to reproduce bug

1. Prepare a Contentful space with more than one locale
1. Create a multi-locale asset with more than one image set
1. Configure a gatsby project with gatsby-source-contentful and the `downloadLocal` option set to true
1. Start gatsby and query for the assets:
    ```
    {
      allContentfulAsset {
        nodes {
          contentful_id
          node_locale
          file {
            url
          }
          localFile {
            base
          }
        }
      }
    }
    ```
1. Expectation: It should all be fine because the cache isn't hit on first access
1. Restart gatsby and this time it will hit the cache
1. Rerun the query above and notice the same response now has the wrong values under `localFile`