### PR TITLE
fix(gatsby-transformer-sqip): make it work again

### DIFF
--- a/packages/gatsby-transformer-sqip/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sqip/src/extend-node-type.js
@@ -53,7 +53,7 @@ async function sqipSharp({ type, cache, getNodeAndSavePathDependency, store }) {
   return {
     sqip: {
       type: new GraphQLObjectType({
-        name: `Sqip`,
+        name: `SqipSharp`,
         fields: {
           svg: { type: GraphQLString },
           dataURI: { type: GraphQLString },
@@ -150,7 +150,7 @@ async function sqipContentful({ type, cache, store }) {
   return {
     sqip: {
       type: new GraphQLObjectType({
-        name: `Sqip`,
+        name: `SqipContentful`,
         fields: {
           svg: { type: GraphQLString },
           dataURI: { type: GraphQLString },

--- a/packages/gatsby-transformer-sqip/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sqip/src/extend-node-type.js
@@ -143,7 +143,9 @@ async function sqipContentful({ type, cache, store }) {
   const cacheImage = require(`gatsby-source-contentful/cache-image`)
 
   const program = store.getState().program
-  const cacheDir = resolve(`${program.directory}/.cache/sqip/`)
+  const cacheDir = resolve(
+    `${program.directory}/node_modules/.cache/gatsby-transformer-sqip/`
+  )
 
   await ensureDir(cacheDir)
 

--- a/packages/gatsby-transformer-sqip/src/generate-sqip.js
+++ b/packages/gatsby-transformer-sqip/src/generate-sqip.js
@@ -89,26 +89,6 @@ module.exports = async function generateSqip(options) {
       }
 
       await cache.set(cacheKey, primitiveData)
-    } else {
-      debug(`generate sqip for ${name}`)
-      const result = await queue.add(
-        async () =>
-          new Promise((resolve, reject) => {
-            try {
-              const result = sqip({
-                filename: absolutePath,
-                ...sqipOptions,
-              })
-              resolve(result)
-            } catch (error) {
-              reject(error)
-            }
-          })
-      )
-
-      svg = result.final_svg
-
-      await writeFile(cachePath, svg)
     }
 
     primitiveData = {


### PR DESCRIPTION
## Description

### Issue 1

When sharp & contentful are enabled, gatsby crashes with:

```
Error: Schema must contain uniquely named types but contains multiple types named "Sqip".
```


This fixes the issue by using two different names for both SQIP objects


## Issue 2

Contentful does not cache sqips in richt folder (`node_modules/.cache/...`)

## Issue 3

In one of the merges in the last PR, one of us added code from the old queueing system.

This lead to broken and/or duplicate SQIP generation 😓 

It for sure was because the code was pretty weird, with this and the last PR it should be more maintainable now :)