### PR TITLE
fix(docs): fix broken icon link in Tutorial Part Eight

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -85,7 +85,7 @@ Quoting [Google](https://developers.google.com/web/fundamentals/web-app-manifest
 npm install --save gatsby-plugin-manifest
 ```
 
-2. Add a favicon for your app under `src/images/icon.png`. For the purposes of this tutorial you can use [this example icon](./icon.png), should you not have one available. The icon is necessary to build all images for the manifest. For more information, look at the docs for [`gatsby-plugin-manifest`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md).
+2. Add a favicon for your app under `src/images/icon.png`. For the purposes of this tutorial you can use [this example icon](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/docs/tutorial/part-eight/icon.png), should you not have one available. The icon is necessary to build all images for the manifest. For more information, look at the docs for [`gatsby-plugin-manifest`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md).
 
 3. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
 


### PR DESCRIPTION
## Description

In the current version of the tutorial, the link to the example icon leads here: https://www.gatsbyjs.org/tutorial/part-eight/icon.png, which turns up as a "Page not found" (assuming this is a 404).

It looks like the link to the icon isn't accounted for in the build process. Following the contributing suggestions [here](https://www.gatsbyjs.org/contributing/gatsby-style-guide/#format-code-blocks-inline-code-and-images), I'm grabbing the raw source for the icon, which is [this link](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/docs/tutorial/part-eight/icon.png).

Please let me know if there's a better way to include a live link to this icon (a cloudinary link, some other link, etc.).


## Related Issues

Fixes #14999
