### PR TITLE
fix(docs): Fix broken links in tutorial sidebar

### DIFF
--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -11,10 +11,8 @@
           link: /tutorial/part-zero/#overview-of-core-technologies
         - title: Familiarize with the command line
           link: /tutorial/part-zero/#familiarize-yourself-with-the-command-line
-        - title: Install Node.js
-          link: /tutorial/part-zero/#install-nodejs
-        - title: Familiarize with npm
-          link: /tutorial/part-zero/#familiarize-yourself-with-npm
+        - title: Install Node.js and npm
+          link: /tutorial/part-zero/#-install-nodejs-and-npm
         - title: Install Git
           link: /tutorial/part-zero/#install-git
         - title: Using the Gatsby CLI
@@ -64,7 +62,7 @@
       ui: steps
       items:
         - title: Recap of the first half of the tutorial
-          link: /tutorial/part-four/#recap-of-first-half-of-the-tutorial
+          link: /tutorial/part-four/#recap-of-the-first-half-of-the-tutorial
         - title: Data in Gatsby
           link: /tutorial/part-four/#data-in-gatsby
         - title: How Gatsby uses GraphQL


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
Hi!

## Description
I've found some broken links in the sidebar of the tutorial section and fixed them.
And I saw that the _Familiarize with npm_ section was removed in 0392a87c325e857769ea86ba7a9a4cafebbdd0e9, so I removed the link to it.

## Related Issues
There are no related issues.
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Cheers!
