### PR TITLE
fix(starters): restore vertical spacing in blog post layout

### DIFF
--- a/starters/blog/src/templates/blog-post.js
+++ b/starters/blog/src/templates/blog-post.js
@@ -18,13 +18,19 @@ class BlogPostTemplate extends React.Component {
           title={post.frontmatter.title}
           description={post.frontmatter.description || post.excerpt}
         />
-        <h1>{post.frontmatter.title}</h1>
+        <h1
+          style={{
+            marginTop: rhythm(1),
+            marginBottom: 0,
+          }}
+        >
+          {post.frontmatter.title}
+        </h1>
         <p
           style={{
             ...scale(-1 / 5),
             display: `block`,
             marginBottom: rhythm(1),
-            marginTop: rhythm(-1),
           }}
         >
           {post.frontmatter.date}


### PR DESCRIPTION
fixes a sneaky side effect of removing negative margins in the layout for the starter-blog in #10758 