### PR TITLE
fix(gatsby-plugin-preact): Make preact/compat server render HTML

### DIFF
--- a/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
@@ -12,6 +12,7 @@ describe(`gatsby-plugin-preact`, () => {
         alias: {
           react: `preact/compat`,
           "react-dom": `preact/compat`,
+          "react-dom/server": `preact/compat`,
         },
       },
     })

--- a/packages/gatsby-plugin-preact/src/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-node.js
@@ -8,6 +8,7 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
         alias: {
           react: `preact/compat`,
           "react-dom": `preact/compat`,
+          "react-dom/server": `preact/compat`,
         },
       },
     })


### PR DESCRIPTION
## Description

This just aliases `react-dom/server` to `preact/compat` so that SSR works as currently it doesn’t.