### PR TITLE
fix(gatsby-plugin-create-client-paths): set matchPath correctly

### DIFF
--- a/packages/gatsby-plugin-create-client-paths/README.md
+++ b/packages/gatsby-plugin-create-client-paths/README.md
@@ -20,4 +20,4 @@ Then configure via `gatsby-config.js`:
 ```
 
 In this example, all paths prefixed by `/app/` will render the route described
-in `src/pages/app/index.js`.
+in `src/pages/app.js`.

--- a/packages/gatsby-plugin-create-client-paths/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-create-client-paths/src/__tests__/gatsby-node.js
@@ -1,0 +1,48 @@
+const { onCreatePage } = require(`../gatsby-node`)
+
+describe(`onCreatePage`, () => {
+  let createPage
+
+  beforeEach(() => {
+    createPage = jest.fn()
+  })
+
+  afterEach(() => {
+    createPage.mockRestore()
+  })
+
+  it(`calls createPage with correct matchPath`, () => {
+    onCreatePage(
+      {
+        page: {
+          path: `/app/`,
+          matchPath: undefined,
+        },
+        actions: {
+          createPage,
+        },
+      },
+      { prefixes: [`/*`, `/app/*`] }
+    )
+    expect(createPage).toHaveBeenCalledWith({
+      matchPath: `/app/*`,
+      path: `/app/`,
+    })
+  })
+
+  it(`doesn't set matchPath if already set`, () => {
+    onCreatePage(
+      {
+        page: {
+          path: `/app/`,
+          matchPath: `/app/*`,
+        },
+        actions: {
+          createPage,
+        },
+      },
+      { prefixes: [`/*`, `/app/*`] }
+    )
+    expect(createPage).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/gatsby-plugin-create-client-paths/src/gatsby-node.js
+++ b/packages/gatsby-plugin-create-client-paths/src/gatsby-node.js
@@ -18,7 +18,7 @@ exports.onCreatePage = ({ page, store, actions }, { prefixes }) => {
       return resolve()
     }
 
-    prefixes.some(prefix => {
+    prefixes.forEach(prefix => {
       if (!re[prefix]) {
         // Remove the * from the prefix and memoize
         const trimmedPrefix = prefix.replace(/\*$/, ``)


### PR DESCRIPTION
Array.some short circuits early whereas we _need_ to run through all to get the _best_ match 


Fixes https://github.com/gatsbyjs/gatsby/issues/15011