### PR TITLE
feat(www): Link to individual `/guidelines/` pages

### DIFF
--- a/www/src/components/shared/footer-links.js
+++ b/www/src/components/shared/footer-links.js
@@ -48,6 +48,9 @@ const FooterLinks = props => (
       <Link to="/accessibility-statement">Accessibility Statement</Link>
     </li>
     <li>
+      <a href="/guidelines/logo/">Logo &amp; Assets</a>
+    </li>
+    <li>
       <a href="https://www.gatsbyjs.com">Gatsbyjs.com</a>
     </li>
   </FooterList>

--- a/www/src/data/sidebars/contributing-links.yaml
+++ b/www/src/data/sidebars/contributing-links.yaml
@@ -65,6 +65,16 @@
               link: /contributing/submit-to-starter-library/
             - title: Submit to Plugin Library
               link: /contributing/submit-to-plugin-library/
+    - title: Gatsby Brand Guidelines
+      items:
+        - title: Color
+          link: /guidelines/color/
+        - title: Logo
+          link: /guidelines/logo/
+        - title: Typography
+          link: /guidelines/typography/
+        - title: Design Tokens
+          link: /guidelines/design-tokens/
     - title: RFC Process
       link: /contributing/rfc-process/
     - title: Gatsby's Governance Model*


### PR DESCRIPTION
* link to the individual pages (_Logo_, _Colors_, _Typography_, _Design Tokens_) from the https://www.gatsbyjs.org/contributing/ sidebar — since there's no `gatsbyjs.org/guidelines/` landing page yet, these are grouped in a _Gatsby Brand Guidelines_ sidebar item for now
* link _Logo & Assets_ (to http://gatsbyjs.org/guidelines/logo) in the footer

Ref. #14427 and https://github.com/gatsbyjs/gatsby/issues/14427#issuecomment-504339694