### PR TITLE
docs: Update deploying-to-heroku.md

### DIFF
--- a/docs/docs/deploying-to-heroku.md
+++ b/docs/docs/deploying-to-heroku.md
@@ -26,25 +26,41 @@ You can optionally add the buildpacks to `app.json` if you want to take advantag
 }
 ```
 
-Add a `heroku-postbuild` script in your `package.json`:
+Heroku will automatically detect and run the `build` script from your `package.json` which should already look like this:
 
 ```json:title=package.json
 {
   "scripts": {
-    "heroku-postbuild": "gatsby build"
+    "build": "gatsby build",
   }
 }
 ```
 
 Finally, add a `static.json` file in the root of your project to define the directory where your static assets will be. You can check all the options for this file in the [heroku-buildpack-static](https://github.com/heroku/heroku-buildpack-static#configuration) configuration.
 
+The following configuration will give you a good start point in line with Gatsby's [suggested approach to caching](https://www.gatsbyjs.org/docs/caching/).
+
 ```json:title=static.json
 {
   "root": "public/",
   "headers": {
-    "/**.js": {
+    "/**/": {
       "Cache-Control": "public, max-age=0, must-revalidate"
+    },
+    "/**.css": {
+      "Cache-Control": "public, max-age=31536000, immutable"
+    },
+    "/**.js": {
+      "Cache-Control": "public, max-age=31536000, immutable"
+    },
+    "/static/**": {
+      "Cache-Control": "public, max-age=31536000, immutable"
+    },
+    "/icons/*.png": {
+      "Cache-Control": "public, max-age=31536000, immutable"
     }
-  }
+  },
+  "https_only": true,
+  "error_page": "404.html"
 }
 ```

--- a/docs/docs/deploying-to-heroku.md
+++ b/docs/docs/deploying-to-heroku.md
@@ -38,7 +38,7 @@ Heroku will automatically detect and run the `build` script from your `package.j
 
 Finally, add a `static.json` file in the root of your project to define the directory where your static assets will be. You can check all the options for this file in the [heroku-buildpack-static](https://github.com/heroku/heroku-buildpack-static#configuration) configuration.
 
-The following configuration will give you a good start point in line with Gatsby's [suggested approach to caching](https://www.gatsbyjs.org/docs/caching/).
+The following configuration will give you a good start point in line with Gatsby's [suggested approach to caching](/docs/caching/).
 
 ```json:title=static.json
 {

--- a/docs/docs/deploying-to-heroku.md
+++ b/docs/docs/deploying-to-heroku.md
@@ -31,7 +31,7 @@ Heroku will automatically detect and run the `build` script from your `package.j
 ```json:title=package.json
 {
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build"
   }
 }
 ```


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The `heroku-postbuild` script is no longer needed here as `build` script is now auto-detected.

I've also expanded the example config to include: 

- defaults for cache-control, in line with Gatsby caching docs
- error page routing, to Gatsby 404
- HTTPS Only, just seemed sensible

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
