### PR TITLE
fix(blog): update alt text for The Couch post to not use quotes

### DIFF
--- a/docs/blog/2019-06-19-how-the-couch-builds-websites-in-half-the-time-with-gatsby/index.md
+++ b/docs/blog/2019-06-19-how-the-couch-builds-websites-in-half-the-time-with-gatsby/index.md
@@ -12,7 +12,7 @@ tags:
   - performance
 ---
 
-![The homepage of thecouch.nyc showing a blue background with the message, "The Couch is a digital studio that makes weird and wonderful things for the internet."](./thecouch-nyc.png)
+![The homepage of thecouch.nyc showing a blue background with the message: The Couch is a digital studio that makes weird and wonderful things for the internet.](./thecouch-nyc.png)
 
 We recently spoke with Kevin Green, Co-founder and Lead Engineer at [The Couch](https://thecouch.nyc), about how Gatsby helps them speed up their workflow and offer their clients fast, feature-rich sites with extremely low hosting costs.
 
@@ -32,7 +32,7 @@ When [Prima](https://www.prima.co), an L.A.-based Cannabidiol (CBD) oil company,
 They came to us with a flood of content—something we’re not really that used to.
 </Pullquote>
 
-![The homepage of prima.co showing a young woman holding a bottle of CBD oil next to the message, "Welcome to the uprising rooted in hemp, heart, and real science."](./prima-co.png)
+![The homepage of prima.co showing a young woman holding a bottle of CBD oil next to the message: Welcome to the uprising rooted in hemp, heart, and real science.](./prima-co.png)
 
 Faced with a content-heavy project, Kevin considered his options. Rather than entrusting Prima’s content to a monolithic CMS—and risk slow loading times and an unhappy development experience—Kevin’s thoughts turned to a more modern solution: “Knowing this was going to be a super content- and image-heavy site, I wanted to build it static from the get-go.” By serving Prima’s content as static HTML, Kevin knew he would dramatically reduce the site’s loading time. His positive experiences with Gatsby on three previous production sites made him confident that it was the right tool for the job: “It’s hard for me to go any other route at this point. If I can go static, I’m always going to go static, and Gatsby’s going to be one of my top choices indefinitely.”
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The [blog post for the couch](https://www.gatsbyjs.org/blog/2019-06-19-how-the-couch-builds-websites-in-half-the-time-with-gatsby/) is failing to load from errors in `gatsby-remark-images`.

The alt text for the images has `"` marks which seem to be ending the attribute names in a weird, cross-site-scripty sort of error that I suspect is what is breaking the query to select imageElements in the remark images package. It seems to be giving the Gastsby responsive `<img>` tag a `classname` instead of `class` breaking the selector [here](https://github.com/gatsbyjs/gatsby/blob/68d9d6f9000cae6a4bca9342a81de70db4373cf5/packages/gatsby-remark-images/src/gatsby-browser.js#L18).

I'm a little confused as to why since I can't replicate in a small repo but this fix works locally for me with .org.

The html attributes get evaluated like this (and maybe have something to do with it):
```
alt="The homepage of thecouch.nyc showing a blue background with the message, " the couch is a digital studio that makes weird and wonderful things for the internet
```

To this (just one string for the alt text)yarn:
```
alt="The homepage of thecouch.nyc showing a blue background with the message: The Couch is a digital studio that makes weird and wonderful things for the internet."
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
