### PR TITLE
feat: add gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-full
+
+RUN npm -g install gatsby-dev-cli

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,35 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: >
+      yarn run bootstrap &&
+      cd ./examples/gatsbygram &&
+      yarn install &&
+      gatsby-dev --set-path-to-repo ../.. &&
+      gatsby-dev --scan-once &&
+      npx gatsby build &&
+      cd ../.. &&
+      touch /tmp/done.txt
+    command: >
+      yarn run watch --scope={gatsby,gatsby-image,gatsby-link}
+  - openMode: split-right
+    before: >
+      cd ./examples/gatsbygram
+    command: >
+      gp await-port 8000 &&
+      gatsby-dev --set-path-to-repo ../.. &&
+      gatsby-dev
+  - before: >
+      cd ./examples/gatsbygram
+    init: |
+      until [ -f /tmp/done.txt ]
+      do
+          sleep 2
+      done
+    command: >
+      npx gatsby develop
+ports:
+  - port: 8000
+    onOpen: open-preview
+  - port: 31997 # yarn mutex
+    onOpen: ignore


### PR DESCRIPTION
Hey Gatsby folks 👋 

this PR adds support for onboarding contributors through Gitpod, a free online dev environment. The PR will allow anyone to get up and running with a browser-based dev environment in a few seconds, lowering the barrier for any code contributions.

This is what a dev environment looks like:
<img width="1364" alt="Screenshot 2019-06-21 at 19 35 27" src="https://user-images.githubusercontent.com/372735/59940763-d059ed80-945b-11e9-8a82-9a44919961c8.png">

The environment starts with a pre-built state of the given branch. On startup three processes are started in three different terminals watching changes in core and the example I picked (gatsbygram). All is based on a configuration file (`.gitpod.yml`) so hopefully pretty transparent. In case it is not, we're always happy to help.

Give it a try: https://gitpod.io/#https://github.com/svenefftinge/gatsby

Shaving off [the local setup](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) and a five minutes of build, I hope this will streamline your onboarding process a lot.

I also added a proposal for documentation. So if you think this is useful, please advice how and where you'd prefer to see information about this and of course feedback on the configuration would be great, too.

P.S.: Awesome framework! We really enjoyed building [our website](https://github.com/gitpod-io/website) with Gatsby.

