### PR TITLE
chore: change workflows around ~ use less resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,8 @@ aliases:
           - /docs.+/
           - /blog.+/
     requires:
-      - bootstrap
+      # only run whne node 10 passes, don't waste resources
+      - unit_tests_node10
 
 commands:
   e2e-test:
@@ -107,12 +108,14 @@ jobs:
 
   lint:
     executor: node
+    parallelism: 2
     steps:
       - checkout
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *persist_cache
-      - run: yarn lint
+      - run: yarn lint:code
+      - run: yarn lint:other
 
   unit_tests_node8:
     executor:
@@ -209,22 +212,22 @@ workflows:
   build-test:
     jobs:
       - bootstrap
-      - lint
+      - lint:
+          requires:
+            - bootstrap
       - unit_tests_node8:
           <<: *ignore_docs
           requires:
-            - bootstrap
+            - lint
       - unit_tests_node10:
           <<: *ignore_docs
           requires:
-            - bootstrap
+            - lint
       - unit_tests_node12:
           <<: *ignore_docs
           requires:
-            - bootstrap
-      - unit_tests_www:
-          requires:
-            - bootstrap
+            - lint
+      - unit_tests_www
       - integration_tests_long_term_caching:
           <<: *e2e-test-workflow
       - integration_tests_gatsby_pipeline:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ aliases:
           - /docs.+/
           - /blog.+/
     requires:
-      # only run whne node 10 passes, don't waste resources
-      - unit_tests_node10
+      - lint
+      - unit_tests_node8
 
 commands:
   e2e-test:
@@ -218,15 +218,17 @@ workflows:
       - unit_tests_node8:
           <<: *ignore_docs
           requires:
-            - lint
+            - bootstrap
       - unit_tests_node10:
           <<: *ignore_docs
           requires:
             - lint
+            - unit_tests_node8
       - unit_tests_node12:
           <<: *ignore_docs
           requires:
             - lint
+            - unit_tests_node8
       - unit_tests_www
       - integration_tests_long_term_caching:
           <<: *e2e-test-workflow


### PR DESCRIPTION
## Description
Move some requires around to hopefully use less resources on failing builds.

Idea is to not run e2e tests if gatsby fails.

![image](https://user-images.githubusercontent.com/1120926/60102008-229d5600-975d-11e9-94c9-0e9c5cd52671.png)


