### PR TITLE
fix(gatsby-transformer-remark): fix spaces between text-bearing block-level elements in plain text excerpts

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -448,6 +448,114 @@ Where oh [*where*](nick.com) **_is_** ![that pony](pony.png)?`,
   )
 
   bootstrapTest(
+    `excerpt does not have leading or trailing spaces`,
+    `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+
+ My pony likes space on the left and right! `,
+    `excerpt`,
+    node => {
+      expect(node.excerpt).toMatch(`My pony likes space on the left and right!`)
+    },
+    {}
+  )
+
+  bootstrapTest(
+    `excerpt has spaces between paragraphs`,
+    `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+
+My pony is little.
+
+Little is my pony.`,
+    `excerpt`,
+    node => {
+      expect(node.excerpt).toMatch(`My pony is little. Little is my pony.`)
+    },
+    {}
+  )
+
+  bootstrapTest(
+    `excerpt has spaces between headings`,
+    `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+
+# Ponies: The Definitive Guide
+
+# What time is it?
+
+It's pony time.`,
+    `excerpt`,
+    node => {
+      expect(node.excerpt).toMatch(
+        `Ponies: The Definitive Guide What time is it? It's pony time.`
+      )
+    },
+    {}
+  )
+
+  bootstrapTest(
+    `excerpt has spaces between table cells`,
+    `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+
+| Pony           | Owner    |
+| -------------- | -------- |
+| My Little Pony | Me, Duh  |`,
+    `excerpt`,
+    node => {
+      expect(node.excerpt).toMatch(`Pony Owner My Little Pony Me, Duh`)
+    },
+    {}
+  )
+
+  bootstrapTest(
+    `excerpt converts linebreaks into spaces`,
+    `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+
+If my pony ain't broke,${`  `}
+don't fix it.`,
+    // ^ Explicit syntax for trailing spaces to not get accidentally trimmed.
+    `excerpt`,
+    node => {
+      expect(node.excerpt).toMatch(`If my pony ain't broke, don't fix it.`)
+    },
+    {}
+  )
+
+  bootstrapTest(
+    `excerpt does not have more than one space between elements`,
+    `---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+
+# Pony express
+
+[some-link]: https://pony.my
+
+Pony express had nothing on my little pony.`,
+    `excerpt`,
+    node => {
+      expect(node.excerpt).toMatch(
+        `Pony express Pony express had nothing on my little pony.`
+      )
+    },
+    {}
+  )
+
+  bootstrapTest(
     `given raw html in the text body, this html is not escaped`,
     `---
 title: "my little pony"

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -77,6 +77,19 @@ const safeGetCache = ({ getCache, cache }) => id => {
  */
 const ASTPromiseMap = new Map()
 
+/**
+ * Set of all Markdown node types which, when encountered, generate an extra to
+ * separate text.
+ *
+ * @type {Set<string>}
+ */
+const SpaceMarkdownNodeTypesSet = new Set([
+  `paragraph`,
+  `heading`,
+  `tableCell`,
+  `break`,
+])
+
 module.exports = (
   {
     type,
@@ -461,18 +474,18 @@ module.exports = (
           node => {
             if (excerptSeparator && node.value === excerptSeparator) {
               isBeforeSeparator = false
-              return
-            }
-            if (node.type === `text` || node.type === `inlineCode`) {
+            } else if (node.type === `text` || node.type === `inlineCode`) {
               excerptNodes.push(node.value)
-            }
-            if (node.type === `image`) {
+            } else if (node.type === `image`) {
               excerptNodes.push(node.alt)
+            } else if (SpaceMarkdownNodeTypesSet.has(node.type)) {
+              // Add a space when encountering one of these node types.
+              excerptNodes.push(` `)
             }
           }
         )
 
-        const excerptText = excerptNodes.join(``)
+        const excerptText = excerptNodes.join(``).trim()
 
         if (excerptSeparator) {
           return excerptText


### PR DESCRIPTION
## Description

Fixes excerpt generation (in plain text mode) to add spaces between text-bearing block-level elements (i.e. paragraphs, headings, table cells) as well as line breaks.

That way, for the Markdown document

```markdown
Paragraph 

# Heading

Broken  
Line

| TableCell |
| --------- |
| TableCell |
```

the plain-text excerpt becomes `Paragraph Heading Broken Line TableCell TableCell` instead of `ParagraphHeadingBrokenLineTableCellTableCell`.

## Related Issues

Fixes #14528.