### PR TITLE
fix: cleanup stack traces for html build errors

### DIFF
--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
@@ -15,7 +15,7 @@ module.exports = function prepareStackTrace(error, source) {
     .filter(
       frame =>
         !frame.getFileName() ||
-        !frame.getFileName().match(/^webpack:\/+webpack\//)
+        !frame.getFileName().match(/^webpack:\/+(lib\/)?(webpack\/|\.cache\/)/)
     )
 
   error.codeFrame = getErrorSource(map, stack[0])
@@ -82,7 +82,7 @@ function CallSiteToString() {
     }
 
     if (fileName) {
-      fileLocation += fileName.replace(/^webpack:\/+/, ``)
+      fileLocation += fileName.replace(/^webpack:\/+(lib\/)?/, ``)
     } else {
       // Source code does not originate from a file and is not native, but we
       // can still get the source position inside the source string, e.g. in


### PR DESCRIPTION
This cleans up stack traces shown on html build errors a bit:
 - removes not useful call sites coming from webpack runtime internals or from .cache
 - removes `lib/` in front of src paths, letting users to actually "ctrl/cmd + click" on paths to get editor to proper location

before on the left pane / after on the right pane

<img width="1792" alt="Screenshot 2019-06-22 at 20 34 04" src="https://user-images.githubusercontent.com/419821/59967660-8b9e8700-952d-11e9-98c3-a62a2d200560.png">
