### PR TITLE
docs(gatsby-plugin-jss): Fix resolve string in readme

### DIFF
--- a/packages/gatsby-plugin-jss/README.md
+++ b/packages/gatsby-plugin-jss/README.md
@@ -26,7 +26,7 @@ const theme = {
 
 plugins: [
   {
-    resolve: "jss",
+    resolve: "gatsby-plugin-jss",
     options: { theme },
   },
 ]


### PR DESCRIPTION
In JSS plugin's README, the resolve string was incorrect and would cause compiling to fail.