### PR TITLE
fix(www): Center footer links

### DIFF
--- a/www/src/components/shared/footer-links.js
+++ b/www/src/components/shared/footer-links.js
@@ -21,12 +21,12 @@ const FooterList = styled.ul`
 
     &:not(:last-of-type) {
       margin-right: 1em;
-    }
 
-    &:not(:last-of-type):after {
-      color: ${colors.grey[30]};
-      content: "•";
-      padding-left: 1em;
+      &:after {
+        color: ${colors.grey[30]};
+        content: "•";
+        padding-left: 1em;
+      }
     }
 
     a {

--- a/www/src/components/shared/footer-links.js
+++ b/www/src/components/shared/footer-links.js
@@ -18,15 +18,15 @@ const FooterList = styled.ul`
 
   li {
     display: inline-block;
+    &:after {
+      color: ${colors.grey[30]};
+      content: "•";
+      padding-left: 1em;
+      padding-right: 1em;
+    }
 
-    &:not(:last-of-type) {
-      margin-right: 1em;
-
-      &:after {
-        color: ${colors.grey[30]};
-        content: "•";
-        padding-left: 1em;
-      }
+    &:last-of-type:after {
+      content: none;
     }
 
     a {

--- a/www/src/components/shared/footer-links.js
+++ b/www/src/components/shared/footer-links.js
@@ -18,16 +18,15 @@ const FooterList = styled.ul`
 
   li {
     display: inline-block;
-    margin-right: 1em;
 
-    &:after {
+    &:not(:last-of-type) {
+      margin-right: 1em;
+    }
+
+    &:not(:last-of-type):after {
       color: ${colors.grey[30]};
       content: "•";
       padding-left: 1em;
-    }
-
-    &:last-of-type:after {
-      content: "";
     }
 
     a {


### PR DESCRIPTION
This tweak fixes the footer links horizontal centering by removing the spaces after the last list item. 

Tested on mobile & desktop Chrome, Firefox & Safari.