### PR TITLE
fix(using-remark): Fix missing = in code snippet

### DIFF
--- a/examples/using-remark/src/pages/2018-01-27---custom-components/index.md
+++ b/examples/using-remark/src/pages/2018-01-27---custom-components/index.md
@@ -151,8 +151,8 @@ For example if you have a series of header components:
 
 ```javascript
 const PrimaryTitle = styled.h1`…`
-const SecondaryTitle styled.h2`…`
-const TertiaryTitle styled.h3`…`
+const SecondaryTitle = styled.h2`…`
+const TertiaryTitle = styled.h3`…`
 ```
 
 You can map headers defined in markdown to these components:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR fixes the two missing `=` in the first code snippet after this anchor: https://using-remark.gatsbyjs.org/custom-components/#mapping-from-generic-html-elements

## Related Issues

None
