### PR TITLE
chore(docs): Removing stub asterisk for few pages

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -473,11 +473,11 @@
           items:
             - title: Developers
               link: /docs/winning-over-developers/
-            - title: Engineering Leaders*
+            - title: Engineering Leaders
               link: /docs/winning-over-engineering-leaders/
             - title: Marketers
               link: /docs/winning-over-marketers/
-            - title: Executives*
+            - title: Executives
               link: /docs/winning-over-executives/
             - title: Clients*
               link: /docs/winning-over-clients/


### PR DESCRIPTION
## Description

Removing asterisks for "Winning over Engineering Leaders" and "Winning over Executive" pages as they are no longer stubs.