### PR TITLE
chore(starters): add gatsby-starter-typescript-jest

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -3071,3 +3071,19 @@
     - Switch the dark mode according to the system theme
     - Scss
     - Pagination
+- url: https://gatsby-starter-typescript-jest.netlify.com/
+  repo: https://github.com/denningk/gatsby-starter-typescript-jest
+  description: Barebones Gatsby starter with Typescript, Jest, GitLab-CI, and other useful configurations
+  tags:
+    - TypeScript
+    - Testing
+    - AWS
+    - Linting
+    - SEO
+  features:
+    - All components from default Gatsby starter converted to TypeScript
+    - Jest testing configured for TypeScript with ts-jest
+    - Detailed guide on how to deploy using AWS S3 buckets included in README
+    - .gitlab-ci.yml file with blanks that can be customized for any Gatsby project
+    - Configurations for EditorConfig, Prettier, and ESLint (for TypeScript)
+    

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -3086,4 +3086,3 @@
     - Detailed guide on how to deploy using AWS S3 buckets included in README
     - .gitlab-ci.yml file with blanks that can be customized for any Gatsby project
     - Configurations for EditorConfig, Prettier, and ESLint (for TypeScript)
-    


### PR DESCRIPTION
Barebones Gatsby starter containing configurations for Typescript, Jest (ts-jest), EditorConfig, ESLint, Prettier, GitHub pull request templates, and even Gitlab-CI. I couldn't find a starter that included TypeScript with Jest testing (ts-jest). 

I also wrote a detailed guide on [how to deploy your Gatsby site to an S3 bucket automatically and manually](https://github.com/denningk/gatsby-starter-typescript-jest#deploying-your-gatsby-site-to-an-S3-Bucket). I included it in the README for this starter.

Please let me know if there is anything you'd like me to change. Thanks you guys rock!
