### PR TITLE
Change suggested directory for page templates

### DIFF
--- a/packages/gatsby-plugin-create-client-paths/README.md
+++ b/packages/gatsby-plugin-create-client-paths/README.md
@@ -20,4 +20,4 @@ Then configure via `gatsby-config.js`:
 ```
 
 In this example, all paths prefixed by `/app/` will render the route described
-in `src/pages/app.js`.
+in `src/templates/app.js`.


### PR DESCRIPTION
I was having the errors mentioned [here](https://github.com/gatsbyjs/gatsby/issues/3425) and [here](https://stackoverflow.com/questions/54402112/gatsby-develop-command-runs-but-gatsby-build-gives-error), which were fixed by moving the page file from the `pages` directory to the `templates` directory. `pages` appears to work when using `gatsby develop` but not when using `gatsby build`.

## Description

I was having the errors mentioned [here](https://github.com/gatsbyjs/gatsby/issues/3425) and [here](https://stackoverflow.com/questions/54402112/gatsby-develop-command-runs-but-gatsby-build-gives-error) while using [`gatsby-plugin-create-client-paths`](https://www.gatsbyjs.org/packages/gatsby-plugin-create-client-paths/), which were fixed by moving the page file from the `pages` directory to the `templates` directory. `pages` appears to work when using `gatsby develop` but not when using `gatsby build`

## Related Issues

Might be related to #3425 (now closed)