### PR TITLE
fix(gatsby-cli): Added better-opn as a dependency

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@babel/runtime": "^7.0.0",
+    "better-opn": "^0.1.4",
     "bluebird": "^3.5.0",
     "chalk": "^2.4.2",
     "ci-info": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4998,7 +4998,7 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
-better-opn@0.1.4:
+better-opn@0.1.4, better-opn@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/better-opn/-/better-opn-0.1.4.tgz#271d03bd8bcb8406d2d9d4cda5c0944d726ea171"
   integrity sha512-7V92EnOdjWOB9lKsVsthCcu1FdFT5qNJVTiOgGy5wPuTsSptMMxm2G1FGHgWu22MyX3tyDRzTWk4lxY2Ppdu7A==


### PR DESCRIPTION
## Description
Added better-opn as a dependency to gatsby-cli

## Related Issues
Closes #15073
