### PR TITLE
Fix wrong unit testing documentation link

### DIFF
--- a/starters/default/package.json
+++ b/starters/default/package.json
@@ -31,7 +31,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing/\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The current link sends you to a wrong page. This PR changes it to the correct link.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
