### PR TITLE
docs(www): fix duplicate h1's from markdown and frontmatter

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -123,7 +123,7 @@ Gatsby supports two environments by default, the [development environment](#deve
 
 ### Filesystem
 
-The way files are organized. With Gatsby, it means having files in the same place as your website's or app's code instead of pulling data from an external [source](#source). Common filesystem usage in Gatsby includes Markdown content, images, data files, and other assets.
+The way files are organized. With Gatsby, it means having files in the same place as your website's or app's code instead of pulling data from an external [source](#data-source). Common filesystem usage in Gatsby includes Markdown content, images, data files, and other assets.
 
 ### Frontend
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -1,6 +1,8 @@
-import HorizontalNavList from "../../www/src/components/horizontal-nav-list.js"
+---
+title: "Glossary"
+---
 
-# Glossary
+import HorizontalNavList from "../../www/src/components/horizontal-nav-list.js"
 
 When you're new to Gatsby there can be a lot of words to learn. This glossary aims to give you a 10,000-foot overview of common terms and what they mean for Gatsby sites.
 

--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -114,6 +114,20 @@ export default ({ children }) => (
 > **Note**: the default export concept used in this code block is explained in more detail
 > in the docs below on [defining layouts](#defining-a-layout)
 
+## Combining frontmatter and imports
+
+If you would like to include frontmatter and import components, frontmatter needs to appear at the top of the file, imports can then follow after it:
+
+```mdx
+---
+title: "Building with Gatsby"
+---
+
+import { Chart } from "../components/chart"
+
+Markdown and more content...
+```
+
 ## Using JavaScript exports
 
 MDX supports `export` syntax as well, which enables specific use cases like providing data

--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -55,8 +55,8 @@ can be accessed in blocks of JSX in your MDX document:
 
 ```mdx
 ---
-title: "Building with Gatsby"
-author: "Jay Gatsby"
+title: Building with Gatsby
+author: Jay Gatsby
 ---
 
 <h1>{props.pageContext.frontmatter.title}</h1>
@@ -120,7 +120,7 @@ If you would like to include frontmatter and import components, frontmatter need
 
 ```mdx
 ---
-title: "Building with Gatsby"
+title: Building with Gatsby
 ---
 
 import { Chart } from "../components/chart"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Duplicate H1's were being added to the DOM on the Glossary page as a result of using a `#` instead of a frontmatter title. This just fixes the glossary file:

Also added a note in the MDX docs about using frontmatter with imports to clarify that this patter is supported behavior.

<details>
<summary>Screenshots</summary>

Before:
![image](https://user-images.githubusercontent.com/21114044/60059452-d6dda480-96a9-11e9-808e-fd7c2f3b5aac.png)

After: 
![image](https://user-images.githubusercontent.com/21114044/60059391-a0a02500-96a9-11e9-8ff9-46c93a727d47.png)

MDX Addition:
![image](https://user-images.githubusercontent.com/21114044/60059373-8d8d5500-96a9-11e9-88c0-5633996acea0.png)


</details>
