### PR TITLE
docs: fix broken wordpress images

### DIFF
--- a/docs/tutorial/image-tutorial.md
+++ b/docs/tutorial/image-tutorial.md
@@ -253,7 +253,7 @@ export const query = graphql`
 
 Your demo site should look something like this:
 
-![Demo site example](./images/wordpress-image-tutorial.gif)
+![Demo site example](../docs/images/wordpress-image-tutorial.gif)
 
 ### Testing your image loading speed and effects
 
@@ -261,6 +261,6 @@ It is useful and can be fun to purposefully slow down your browser to see image 
 
 Open your browser console and change the network speed to something slower. In Chrome, you can click on the “network” tab, then on the drop down arrow next to the word “Online.” Then click “Slow 3G.” Now, reload your page and watch the blur-up and SVG effects in action. The network tab also shows statistics on when each image loaded and how much time it took them to load.
 
-![Network](./images/network.png)
+![Network](../docs/images/network.png)
 
-![Slow 3G](./images/slow-3g.png)
+![Slow 3G](../docs/images/slow-3g.png)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes the broken images on the Adding Images to a WordPress site tutorial: https://www.gatsbyjs.org/tutorial/image-tutorial/

## Related Issues
Fixes [#15087](https://github.com/gatsbyjs/gatsby/issues/15087)
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
