### PR TITLE
fix(babel-preset-gatsby): Ensure the spread operator works correctly on Sets

### DIFF
--- a/packages/babel-preset-gatsby/src/__tests__/index.js
+++ b/packages/babel-preset-gatsby/src/__tests__/index.js
@@ -44,6 +44,12 @@ it(`Specifies proper presets and plugins for test stage`, () => {
         regenerator: true,
       },
     ],
+    [
+      expect.stringContaining(path.join(`@babel`, `plugin-transform-spread`)),
+      {
+        loose: false,
+      },
+    ],
   ])
 })
 
@@ -97,6 +103,12 @@ it(`Specifies proper presets and plugins for build-html stage`, () => {
       {
         helpers: true,
         regenerator: true,
+      },
+    ],
+    [
+      expect.stringContaining(path.join(`@babel`, `plugin-transform-spread`)),
+      {
+        loose: false,
       },
     ],
   ])

--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -77,6 +77,12 @@ module.exports = function preset(_, options = {}) {
           regenerator: true,
         },
       ],
+      [
+        resolve(`@babel/plugin-transform-spread`),
+        {
+          loose: false, // Fixes #14848
+        },
+      ],
     ],
   }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The current @babel/preset-env config defaults to loose transforms which results in incorrect semantics when the spread operator is applied to a Set.

Executing

```js
[...new Set([1, 2, 2, 3])]
```
results in

```js
[Set(1, 2, 3)]
```

when

```js
[1, 2, 3]
```

is expected.

This PR ensures that the expected result is obtained by configuring `@babel/plugin-transform-spread` to follow ECMAScript semantics.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Fixes #14848

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
