### PR TITLE
Add config variable to avoid canonical redirect

### DIFF
--- a/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/.eslintrc.json
+++ b/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "graphql": false
+  }
+} 

--- a/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/README.md
+++ b/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/README.md
@@ -1,0 +1,22 @@
+# using-**DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT**
+
+To test this example site locally run the following commands from this directory
+
+```bash
+npm run build
+cd public
+python -m SimpleHTTPServer 9000
+```
+
+Assuming that `disableLoadTimeCanonicalRedirectCheck` is
+still set to `true` in gatsby-config.js, navigate to
+http://localhost:9000/index.html in a web browser and notice that the URL does
+not change to http://localhost:9000, which is Gatsby's default behavior.
+
+This behavior is desirable when:
+
+- embedding a Gatsby application in a host web page
+- serving a Gatsby application via an Nginx alias or similar
+- serving a Gatsby application from an S3 sub-bucket or similar
+
+PRs containing additional use-cases would be most welcome.

--- a/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/gatsby-config.js
+++ b/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/gatsby-config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  disableLoadTimeCanonicalRedirectCheck: true,
+}

--- a/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/package.json
+++ b/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "using-disable-load-time-canonical-redirect-check",
+  "private": true,
+  "description": "Gatsby example site using disableLoadTimeCanonicalRedirectCheck config option",
+  "author": "xivarsribes@vistaprint.com",
+  "dependencies": {
+    "gatsby": "../gatsby/packages/gatsby",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "start": "npm run develop",
+    "serve": "gatsby serve"
+  }
+}

--- a/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/src/pages/index.js
+++ b/examples/using-__DISABLE_LOAD_TIME_CANONICAL_REDIRECT_CHECK__/src/pages/index.js
@@ -1,0 +1,17 @@
+import React from "react"
+
+const Home = () => (
+  <div>
+    <p>
+      By default, Gatsby will change http://localhost:9000/index.html to
+      http://localhost:9000 in order to make the canonical path match the URL.
+    </p>
+    <p>
+      The default behavior is undesireable in many circumstances (see README.md)
+      and the `disableLoadTimeCanonicalRedirectCheck` configuration option can
+      be used to disable it.
+    </p>
+  </div>
+)
+
+export default Home

--- a/packages/gatsby/cache-dir/.eslintrc.json
+++ b/packages/gatsby/cache-dir/.eslintrc.json
@@ -4,6 +4,7 @@
   },
   "globals": {
     "__PATH_PREFIX__": false,
+    "__DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT__": false,
     "___emitter": false
   }
 }

--- a/packages/gatsby/cache-dir/__tests__/static-entry.js
+++ b/packages/gatsby/cache-dir/__tests__/static-entry.js
@@ -171,6 +171,7 @@ describe(`static-entry sanity checks`, () => {
   beforeEach(() => {
     global.__PATH_PREFIX__ = ``
     global.__BASE_PATH__ = ``
+    global.__DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT__ = false
   })
 
   const methodsToCheck = [

--- a/packages/gatsby/cache-dir/__tests__/static-entry.js
+++ b/packages/gatsby/cache-dir/__tests__/static-entry.js
@@ -225,6 +225,7 @@ describe(`static-entry`, () => {
   beforeEach(() => {
     global.__PATH_PREFIX__ = ``
     global.__BASE_PATH__ = ``
+    global.__DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT__ = false
   })
 
   test(`onPreRenderHTML can be used to replace headComponents`, done => {

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -73,6 +73,8 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   // - it's the offline plugin shell (/offline-plugin-app-shell-fallback/)
   if (
     pagePath &&
+    // Prevent navigation when acting as a single/static page generator
+    !__DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT__ &&
     __BASE_PATH__ + pagePath !== browserLoc.pathname &&
     !(
       loader.findMatchPath(stripPrefix(browserLoc.pathname, __BASE_PATH__)) ||

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -393,6 +393,7 @@ export default (pagePath, callback) => {
     replacePostBodyComponents,
     pathname: pagePath,
     pathPrefix: __PATH_PREFIX__,
+    disableLoadTimeCanonicalRedirectCheck: __DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT__,
   })
 
   const html = `<!DOCTYPE html>${renderToStaticMarkup(

--- a/packages/gatsby/src/joi-schemas/joi.js
+++ b/packages/gatsby/src/joi-schemas/joi.js
@@ -17,6 +17,7 @@ export const gatsbyConfigSchema = Joi.object()
         relativeOnly: true,
       })
     ),
+    disableLoadTimeCanonicalRedirectCheck: Joi.boolean(),
     siteMetadata: Joi.object({
       siteUrl: stripTrailingSlash(Joi.string()).uri(),
     }).unknown(),

--- a/packages/gatsby/src/utils/eslint-config.js
+++ b/packages/gatsby/src/utils/eslint-config.js
@@ -8,6 +8,7 @@ module.exports = schema => {
         graphql: true,
         __PATH_PREFIX__: true,
         __BASE_PATH__: true, // this will rarely, if ever, be used by consumers
+        __DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT__: false,
       },
       extends: `react-app`,
       plugins: [`graphql`],

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -189,6 +189,8 @@ module.exports = async (program, directory, suppliedStage) => {
         __ASSET_PREFIX__: JSON.stringify(
           program.prefixPaths ? assetPrefix : ``
         ),
+        __DISABLE_LOAD_TIME_CANONICAL_CHECK_REDIRECT__: store.getState().config
+          .disableLoadTimeCanonicalRedirectCheck,
       }),
     ]
 


### PR DESCRIPTION
## Description

This PR introduces a config variable that allows you to disable redirect when a page loads, in case the paths are different when generated and when displayed.

This used together with https://github.com/wardpeet/gatsby-plugin-static-site allows to use gatsby as a static page generator instead of a static site generator

## Related Issues

This PR is basically the same one as https://github.com/gatsbyjs/gatsby/pull/11914 and fixes https://github.com/gatsbyjs/gatsby/issues/4337
