### PR TITLE
feat(gatsby): Handle duplicated fragment definitions

### DIFF
--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -3,7 +3,6 @@ import path from "path"
 const normalize = require(`normalize-path`)
 import glob from "glob"
 const levenshtein = require(`fast-levenshtein`)
-const fs = require(`fs`)
 
 import { validate } from "graphql"
 import { IRTransforms } from "@gatsbyjs/relay-compiler"
@@ -119,8 +118,6 @@ class Runner {
           ),
         []
       )
-
-    fs.writeFileSync(path.join(this.base, `testfiles`), files.join(`\n`))
 
     files = files.filter(d => !d.match(/\.d\.ts$/))
 

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -121,11 +121,6 @@ class Runner {
 
     files = files.filter(d => !d.match(/\.d\.ts$/))
 
-    // Added this to avoid the duplicate definitions RelayParser error
-    // Worst hack ever
-    files = files.filter(d => !d.match(/\/gatsby-transformer-sharp\//))
-    files = files.filter(d => !d.match(/\/gatsby\//))
-
     files = files.map(normalize)
 
     // We should be able to remove the following and preliminary tests do suggest

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -115,7 +115,12 @@ class Runner {
         []
       )
     files = files.filter(d => !d.match(/\.d\.ts$/))
-    files = files.filter(d => !d.match(/gatsby/))
+
+    // Added this to avoid the duplicate definitions RelayParser error
+    // Worst hack ever
+    files = files.filter(d => !d.match(/\/gatsby-transformer-sharp\//))
+    files = files.filter(d => !d.match(/\/gatsby\//))
+
     files = files.map(normalize)
 
     // Ensure all page components added as they're not necessarily in the

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -12,9 +12,7 @@ import ASTConvert from "@gatsbyjs/relay-compiler/lib/ASTConvert"
 import GraphQLCompilerContext from "@gatsbyjs/relay-compiler/lib/GraphQLCompilerContext"
 import filterContextForNode from "@gatsbyjs/relay-compiler/lib/filterContextForNode"
 const _ = require(`lodash`)
-const util = require(`util`)
-const readPackageTree = require(`read-package-tree`)
-const readPackageTreeAsync = util.promisify(readPackageTree)
+import getGatsbyDependents from "../utils/gatsby-dependents"
 
 import { store } from "../redux"
 const { boundActionCreators } = require(`../redux/actions`)
@@ -104,14 +102,7 @@ class Runner {
   async parseEverything() {
     const filesRegex = path.join(`/**`, `*.+(t|j)s?(x)`)
 
-    const allNodeModules = await readPackageTreeAsync(this.base, () => true)
-
-    const modulesThatUseGatsby = allNodeModules.children.filter(
-      node =>
-        (node.package.dependencies && node.package.dependencies[`gatsby`]) ||
-        (node.package.peerDependencies &&
-          node.package.peerDependencies[`gatsby`])
-    )
+    const modulesThatUseGatsby = await getGatsbyDependents()
 
     let files = [
       path.join(this.base, `src`),

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -11,7 +11,6 @@ import ASTConvert from "@gatsbyjs/relay-compiler/lib/ASTConvert"
 import GraphQLCompilerContext from "@gatsbyjs/relay-compiler/lib/GraphQLCompilerContext"
 import filterContextForNode from "@gatsbyjs/relay-compiler/lib/filterContextForNode"
 const _ = require(`lodash`)
-import getGatsbyDependents from "../utils/gatsby-dependents"
 
 import { store } from "../redux"
 const { boundActionCreators } = require(`../redux/actions`)
@@ -103,14 +102,11 @@ class Runner {
   async parseEverything() {
     const filesRegex = path.join(`/**`, `*.+(t|j)s?(x)`)
 
-    const modulesThatUseGatsby = await getGatsbyDependents()
-
     let files = [
       path.join(this.base, `src`),
       path.join(this.base, `.cache`, `fragments`),
     ]
       .concat(this.additional.map(additional => path.join(additional, `src`)))
-      .concat(modulesThatUseGatsby.map(module => module.path))
       .reduce(
         (merged, folderPath) =>
           merged.concat(

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -131,6 +131,11 @@ class Runner {
 
     files = files.map(normalize)
 
+    // We should be able to remove the following and preliminary tests do suggest
+    // that they aren't needed anymore since we transpile node_modules now
+    // However, there could be some cases (where a page is outside of src for example)
+    // that warrant keeping this and removing later once we have more confidence (and tests)
+
     // Ensure all page components added as they're not necessarily in the
     // pages directory e.g. a plugin could add a page component. Plugins
     // *should* copy their components (if they add a query) to .cache so that
@@ -140,6 +145,7 @@ class Runner {
     files = files.concat(
       Array.from(store.getState().components.keys(), c => normalize(c))
     )
+
     files = _.uniq(files)
 
     let parser = new FileParser()

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -131,6 +131,15 @@ class Runner {
 
     files = files.map(normalize)
 
+    // Ensure all page components added as they're not necessarily in the
+    // pages directory e.g. a plugin could add a page component. Plugins
+    // *should* copy their components (if they add a query) to .cache so that
+    // our babel plugin to remove the query on building is active.
+    // Otherwise the component will throw an error in the browser of
+    // "graphql is not defined".
+    files = files.concat(
+      Array.from(store.getState().components.keys(), c => normalize(c))
+    )
     files = _.uniq(files)
 
     let parser = new FileParser()

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -101,6 +101,7 @@ class Runner {
     const filesRegex = path.join(`/**`, `*.+(t|j)s?(x)`)
     let files = [
       path.join(this.base, `src`),
+      path.join(this.base, `node_modules`),
       path.join(this.base, `.cache`, `fragments`),
     ]
       .concat(this.additional.map(additional => path.join(additional, `src`)))
@@ -114,14 +115,15 @@ class Runner {
         []
       )
     files = files.filter(d => !d.match(/\.d\.ts$/))
+    files = files.filter(d => !d.match(/gatsby/))
     files = files.map(normalize)
 
     // Ensure all page components added as they're not necessarily in the
-    // pages directory e.g. a plugin could add a page component.  Plugins
+    // pages directory e.g. a plugin could add a page component. Plugins
     // *should* copy their components (if they add a query) to .cache so that
-    // our babel plugin to remove the query on building is active (we don't
-    // run babel on code in node_modules). Otherwise the component will throw
-    // an error in the browser of "graphql is not defined".
+    // our babel plugin to remove the query on building is active.
+    // Otherwise the component will throw an error in the browser of
+    // "graphql is not defined".
     files = files.concat(
       Array.from(store.getState().components.keys(), c => normalize(c))
     )

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -131,15 +131,6 @@ class Runner {
 
     files = files.map(normalize)
 
-    // Ensure all page components added as they're not necessarily in the
-    // pages directory e.g. a plugin could add a page component. Plugins
-    // *should* copy their components (if they add a query) to .cache so that
-    // our babel plugin to remove the query on building is active.
-    // Otherwise the component will throw an error in the browser of
-    // "graphql is not defined".
-    files = files.concat(
-      Array.from(store.getState().components.keys(), c => normalize(c))
-    )
     files = _.uniq(files)
 
     let parser = new FileParser()

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -246,18 +246,10 @@ module.exports = async (program, directory, suppliedStage) => {
   }
 
   function getModule() {
-    const jsOptions = {}
-
-    // Speedup 🏎️💨 the build! We only include transpilation of node_modules on production builds
-    // TODO create gatsby plugin to enable this behaviour on develop (only when people are requesting this feature)
-    if (stage === `develop`) {
-      jsOptions.exclude = [`node_modules`]
-    }
-
     // Common config for every env.
     // prettier-ignore
     let configRules = [
-      rules.js(jsOptions),
+      rules.js(),
       rules.yaml(),
       rules.fonts(),
       rules.images(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -17095,10 +17095,17 @@ read-package-tree@^5.1.6:
     read-package-json "^2.0.0"
     readdir-scoped-modules "^1.0.0"
 
+<<<<<<< HEAD
 read-package-tree@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.3.1.tgz#a32cb64c7f31eb8a6f31ef06f9cedf74068fe636"
   integrity sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==
+=======
+read-package-tree@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.3.0.tgz#4f95472e45e7145fb77f4069d12844b139f5ea12"
+  integrity sha512-Gi64+EWmi4515E1rPR77ae/Ip8cjFQTlsWytSYJj974U0tSnxm67pyXltbDjB1lvLw4dc85HbtidGL1K2c/oxw==
+>>>>>>> Only parse modules that use gatsby in deps or peer deps
   dependencies:
     read-package-json "^2.0.0"
     readdir-scoped-modules "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17095,17 +17095,10 @@ read-package-tree@^5.1.6:
     read-package-json "^2.0.0"
     readdir-scoped-modules "^1.0.0"
 
-<<<<<<< HEAD
 read-package-tree@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.3.1.tgz#a32cb64c7f31eb8a6f31ef06f9cedf74068fe636"
   integrity sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==
-=======
-read-package-tree@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.3.0.tgz#4f95472e45e7145fb77f4069d12844b139f5ea12"
-  integrity sha512-Gi64+EWmi4515E1rPR77ae/Ip8cjFQTlsWytSYJj974U0tSnxm67pyXltbDjB1lvLw4dc85HbtidGL1K2c/oxw==
->>>>>>> Only parse modules that use gatsby in deps or peer deps
   dependencies:
     read-package-json "^2.0.0"
     readdir-scoped-modules "^1.0.0"


### PR DESCRIPTION
Now that we run babel-loader for all dependencies after https://github.com/gatsbyjs/gatsby/pull/14111, we should finally be able to support queries in dependencies!

This pull request adds `node_modules` as one of the folders to parse through. There are a couple of things to consider here though:

1. Parsing through everything causes a `GraphQL Error: RelayParser: Encountered duplicate defintitions for one or more documents: each document must have a unique name` because of `GatsbyImageSharpFixed` etc (assuming these are coming from `gatsby-plugin-sharp`) My quick fix for this was filtering out any paths that contain `/gatsby/` but of course we can't do that. How should we filter these out? 

1. This significantly slows down the `extract queries from components` phase since it now has to parse ~18000 files compared to like 10 before. One way to speed this up would be to filter deps by only ones that have `gatsby` as a dep or peer dep (since they would need the `graphql` export from `gatsby` to query)

Thoughts?

### Todo

- [x] Better heuristic for filtering out duplicate fragments
- [x] Better filter to reduce number of files parsed

### How do I test this?

Install `gatsby-seo` from npm (our SEO component extracted to a separate package) and use as a dependency. 

### Edit 

We've reverted the addition to parsing `node_modules` because it depends on some other follow up work by @wardpeet. This PR just handles fragment duplication for now. 