### PR TITLE
fix(www): Add horizontal padding to footer

### DIFF
--- a/www/src/components/shared/footer-links.js
+++ b/www/src/components/shared/footer-links.js
@@ -8,10 +8,8 @@ const FooterList = styled.ul`
   border-top: 1px solid ${colors.ui.border.subtle};
   font-size: ${fontSizes[1]};
   margin: 0;
-  padding: 0;
-  padding-top: ${space[9]};
+  padding: ${space[9]} ${space[6]};
   margin-top: ${space[9]};
-  padding-bottom: ${space[9]};
   list-style: none;
   text-align: center;
   width: 100%;


### PR DESCRIPTION

## Description

On small screens having no horizontal padding on the footer feels wrong since most content has a horizontal padding of `${space[6]}`. This PR adds some padding to make it consistent with the page layout.

Before:
![www gatsbyjs org_(iPhone 5_SE)-before](https://user-images.githubusercontent.com/10158587/60267148-db909b80-98e9-11e9-9564-55d8676241bd.png)

After:
![www gatsbyjs org_(iPhone 5_SE)-after](https://user-images.githubusercontent.com/10158587/60267154-e0554f80-98e9-11e9-9a22-4c3c6b14cdf7.png)

