### PR TITLE
chore(gatsby-plugin-sitemap): tweak documentation for clarity

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -25,6 +25,14 @@ generated sitemap will include all of your site's pages, except the ones you exc
 
 The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sitemap/src/internals.js#L34) can be overridden.
 
+The options are as follows:
+
+- `query` (GraphQL Query) The query for the data you need to generate the sitemap. It's required to get the `site.siteMetadata.siteUrl`. If you override the query, you probably will need to set a `serializer` to return the correct data for the sitemap.
+- `output` (string) The filepath and name. Defaults to `/sitemap.xml`.
+- `exclude` (array of strings) An array of paths to exclude from the sitemap.
+- `createLinkInHead` (boolean) Whether to populate the `<head>` of your site with a link to the sitemap.
+- `serialize` (function) Takes the output of the data query and lets you return an array of sitemap entries.
+
 We _ALWAYS_ exclude the following pages: `/dev-404-page/`,`/404` &`/offline-plugin-app-shell-fallback/`, this cannot be changed.
 
 Example:
@@ -58,7 +66,15 @@ plugins: [
               }
             }
           }
-      }`
+      }`,
+      serialize: ({ site, allSitePage }) =>
+        allSitePage.edges.map(edge => {
+          return {
+            url: site.siteMetadata.siteUrl + edge.node.path,
+            changefreq: `daily`,
+            priority: 0.7,
+          }
+        })
     }
   }
 ]


### PR DESCRIPTION
## Description

This PR enables custom data models inside the query option of this plugin.

I also added a bit more documentation to the README.md to make it clearer which options you can override and what they do.