### PR TITLE
Moved api-node-docs initialization so that it can be overridden.

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/index.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.js
@@ -11,12 +11,6 @@ const {
   handleMultipleReplaceRenderers,
 } = require(`./validate`)
 
-const apis = {
-  node: _.keys(nodeAPIs),
-  browser: _.keys(browserAPIs),
-  ssr: _.keys(ssrAPIs),
-}
-
 // Create a "flattened" array of plugins with all subplugins
 // brought to the top-level. This simplifies running gatsby-* files
 // for subplugins.
@@ -38,6 +32,12 @@ const flattenPlugins = plugins => {
 }
 
 module.exports = async (config = {}, rootDir = null) => {
+  const apis = {
+    node: _.keys(nodeAPIs),
+    browser: _.keys(browserAPIs),
+    ssr: _.keys(ssrAPIs),
+  }
+
   // Collate internal plugins, site config plugins, site default plugins
   const plugins = loadPlugins(config, rootDir)
 


### PR DESCRIPTION
This is a small change to move the api list initialization out of global scope so that my gatsby theme has a chance to override the allowed Gatsby APIs before it is initialized.

<details>
  <summary>Why would you want to do that?!</summary>

1. I'm working on integrating OrchardCore CMS with GatsbyJS by creating a number of themes and a plugin.
2. The themes are able to compose an entire site based on the structured data in the CMS but need to have a say in how the graphql page query is built, how the page query response is processed and contribute context to the created page nodes.
    * gatsby-theme-orchardcore-images needs to process the page query and look for any widgets containing images, then replace the url with a gatsby-image supported fluid object.
    * gatsby-theme-orchardcore-layers needs to contribute widget names from any of the dynamic CMS defined layers using a custom 'onCreateTemplate' API, so that the dynamically created template file will include all the correct imports and code splitting will include only the subset of widgets used on that one page. https://github.com/gatsbyjs/gatsby/issues/5995#issuecomment-502891938  
    * gatsby-theme-orchardcore-flows needs to search for widgets and add them as fragments to the page query using the 'sourcePageQuery' API.
    * Etc...  

3. I want to reuse the flexibility of the gatsby nodeRunner to support these custom APIs and allow my themes the same level of flexibility for building OrchardCore pages as the standard node API gives us when building sites.
4. Because gatsby's plugin-loader and nodeRunner by default prohibits plugins exporting and calling unknown Gatsby-APIs I need to be able to override the allowed API list in api-node-docs when loading my main theme. This is done as below but requires the PR change to work:
```
// gatsby-config.js

const apiList = require(`gatsby/dist/utils/api-node-docs`)

module.exports = _ => {

  // Tell gatsby to allow these non-standard API calls
  apiList.sourcePageQuery = true
  apiList.onCreatingTemplate = true
  apiList.onCreatingPage = true

  return ({...})
}
```
</details>

If interested in OrchardCore integration or how I'm solving code splitting, very early code is here: https://github.com/jrestall/gatsby-orchardcore