### PR TITLE
docs:gatsby-source-wordpress Removed reference to unrelated plugins

### DIFF
--- a/docs/tutorial/image-tutorial.md
+++ b/docs/tutorial/image-tutorial.md
@@ -70,7 +70,8 @@ module.exports = {
 
 ### Installing plugins to help with images
 
-Now you’ll configure gatsby-source-filesystem to load the image directory, add a GraphQL query to a page, add an image to the page, and then view the result in the browser.
+Now you will need to add the `gatsby-transformer-sharp` and `gatsby-plugin-sharp` plugins to `gatsby-config.js`, add a GraphQL query to a page, add an image to the page, and then view the result in the browser.
+
 First, you’ll need to install a few plugins and their dependencies:
 
 ```shell
@@ -111,7 +112,6 @@ module.exports = {
       },
     },
     // highlight-start
-    "gatsby-plugin-react-helmet",
     "gatsby-transformer-sharp",
     "gatsby-plugin-sharp",
     // highlight-end


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

There were unrelated references to gatsby-source-filesystem and gatsby-plugin-react-helmet. These have been removed to save confusion.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
