### PR TITLE
fix: filter out frames that are not matched to source location

### DIFF
--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
@@ -14,8 +14,11 @@ module.exports = function prepareStackTrace(error, source) {
     .map(frame => wrapCallSite(map, frame))
     .filter(
       frame =>
-        !frame.getFileName() ||
-        !frame.getFileName().match(/^webpack:\/+(lib\/)?(webpack\/|\.cache\/)/)
+        frame.wasConverted &&
+        (!frame.getFileName() ||
+          !frame
+            .getFileName()
+            .match(/^webpack:\/+(lib\/)?(webpack\/|\.cache\/)/))
     )
 
   error.codeFrame = getErrorSource(map, stack[0])
@@ -55,6 +58,7 @@ function wrapCallSite(map, frame) {
   frame.getColumnNumber = () => position.column + 1
   frame.getScriptNameOrSourceURL = () => position.source
   frame.toString = CallSiteToString
+  frame.wasConverted = true
   return frame
 }
 


### PR DESCRIPTION
This fixes `[object Object]` showing up in stack traces for html rendering errors

i.e:
```
WebpackError: ReferenceError: window is not defined
    at IndexPage (src/pages/index.js:8:19)
    at [object Object]
    at [object Object]
```
will turn into:
```
WebpackError: ReferenceError: window is not defined
    at IndexPage (src/pages/index.js:8:19)
```