### PR TITLE
fix(gatsby-cli): depend upon @hapi/joi

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@babel/runtime": "^7.0.0",
+    "@hapi/joi": "^15.1.0",
     "better-opn": "^0.1.4",
     "bluebird": "^3.5.0",
     "chalk": "^2.4.2",

--- a/packages/gatsby-cli/src/structured-errors/__tests__/construct-error.js
+++ b/packages/gatsby-cli/src/structured-errors/__tests__/construct-error.js
@@ -1,0 +1,37 @@
+const constructError = require(`../construct-error`)
+
+let log
+let processExit
+beforeEach(() => {
+  log = jest.spyOn(console, `log`).mockImplementation(() => {})
+  processExit = jest.spyOn(process, `exit`).mockImplementation(() => {})
+
+  log.mockReset()
+  processExit.mockReset()
+})
+
+afterAll(() => {
+  console.log.mockClear()
+  process.exit.mockClear()
+})
+
+test(`it exits on invalid error schema`, () => {
+  constructError({ details: { context: {}, lol: `invalid` } })
+
+  expect(processExit).toHaveBeenCalledWith(1)
+})
+
+test(`it logs error on invalid schema`, () => {
+  constructError({ details: { context: {}, lol: `invalid` } })
+
+  expect(log).toHaveBeenCalledWith(
+    `Failed to validate error`,
+    expect.any(Object)
+  )
+})
+
+test(`it passes through on valid error schema`, () => {
+  constructError({ details: { context: {} } })
+
+  expect(log).not.toHaveBeenCalled()
+})

--- a/packages/gatsby-cli/src/structured-errors/__tests__/error-map.js
+++ b/packages/gatsby-cli/src/structured-errors/__tests__/error-map.js
@@ -1,0 +1,23 @@
+const { errorMap, defaultError } = require(`../error-map`)
+
+test(`it defaults to generic error`, () => {
+  expect(defaultError).toEqual(
+    expect.objectContaining({
+      level: `ERROR`,
+    })
+  )
+
+  expect(defaultError.text({})).toEqual(`There was an error`)
+})
+
+test(`it supports structured lookups`, () => {
+  const error = errorMap[`95312`]
+
+  expect(error).toEqual(
+    expect.objectContaining({
+      text: expect.any(Function),
+      docsUrl: `https://gatsby.dev/debug-html`,
+      level: `ERROR`,
+    })
+  )
+})

--- a/packages/gatsby-cli/src/structured-errors/__tests__/error-schema.js
+++ b/packages/gatsby-cli/src/structured-errors/__tests__/error-schema.js
@@ -1,0 +1,13 @@
+const schema = require(`../error-schema`)
+
+test(`throws invalid on an invalid error`, () => {
+  expect(schema.validate({ lol: `true` })).rejects.toBeDefined()
+})
+
+test(`does not throw on a valid schema`, () => {
+  expect(
+    schema.validate({
+      context: {},
+    })
+  ).resolves.toEqual(expect.any(Object))
+})

--- a/packages/gatsby-cli/src/structured-errors/construct-error.js
+++ b/packages/gatsby-cli/src/structured-errors/construct-error.js
@@ -1,4 +1,4 @@
-const Joi = require(`joi`)
+const Joi = require(`@hapi/joi`)
 const stackTrace = require(`stack-trace`)
 const errorSchema = require(`./error-schema`)
 const { errorMap, defaultError } = require(`./error-map`)

--- a/packages/gatsby-cli/src/structured-errors/error-schema.js
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.js
@@ -1,4 +1,4 @@
-const Joi = require(`joi`)
+const Joi = require(`@hapi/joi`)
 
 const Position = Joi.object().keys({
   line: Joi.number(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,11 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
+"@hapi/address@2.x.x":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
+  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
+
 "@hapi/hoek@6.x.x":
   version "6.2.4"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-6.2.4.tgz#4b95fbaccbfba90185690890bdf1a2fbbda10595"
@@ -2168,6 +2173,16 @@
     "@hapi/marker" "1.x.x"
     "@hapi/topo" "3.x.x"
     isemail "3.x.x"
+
+"@hapi/joi@^15.1.0":
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.0.tgz#940cb749b5c55c26ab3b34ce362e82b6162c8e7a"
+  integrity sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==
+  dependencies:
+    "@hapi/address" "2.x.x"
+    "@hapi/hoek" "6.x.x"
+    "@hapi/marker" "1.x.x"
+    "@hapi/topo" "3.x.x"
 
 "@hapi/marker@1.x.x":
   version "1.0.0"


### PR DESCRIPTION
## Description

Fixes #15220

Note: we now depend upon different versions of `@hapi/joi` but that should be fine.

```
=> Found "@hapi/joi@14.5.0"
info Has been hoisted to "@hapi/joi"
info Reasons this module exists
   - "workspace-aggregator-1d652547-46c4-4b25-9983-c166b546202f" depends on it
   - Hoisted from "_project_#gatsby-plugin-feed#@hapi#joi"
   - Hoisted from "_project_#gatsby-source-contentful#@hapi#joi"
   - Hoisted from "_project_#gatsby#@hapi#joi"
info Disk size without dependencies: "312KB"
info Disk size with unique dependencies: "520KB"
info Disk size with transitive dependencies: "568KB"
info Number of shared dependencies: 5
=> Found "gatsby-cli#@hapi/joi@15.1.0"
info This module exists because "_project_#gatsby-cli" depends on it.
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
