### PR TITLE
Fix future error in script check-versions.

### DIFF
--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -47,7 +47,7 @@ getPackages(process.cwd()).then(packages => {
       const depTypes = [`dependencies`, `devDependencies`, `peerDependencies`]
       outdated.forEach(p => {
         depTypes.forEach(depKey => {
-          if (pkg[depKey][p.name]) {
+          if (pkg[depKey] && pkg[depKey][p.name]) {
             next[depKey][p.name] = `^${graph.get(p.name).version}`
           }
         })


### PR DESCRIPTION
## Description

Currently there is no error, but this could prevent some future error.

I have noticed  in the script `scripts/check-versions.js` that when a package does not have some type of dependency, it gives an error of **access to the property**. 
Ejm.:
```
TypeError: Cannot read property 'lodash' of undefined.
```
For which I think it is convenient to add this small solution, that verifies if the object exists (type of dependency).
