### PR TITLE
fix(docs): Fix link markdown format in pair programming doc

### DIFF
--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -26,7 +26,7 @@ We also expect the following from pair programming participants:
 
 - These sessions tend to work best when you have a specific goal for the session.
 - If you're new to building with Gatsby we recommend [working through the tutorial](https://www.gatsbyjs.org/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
-- If you're new to contributing to open source we recommend following the ("Setting Up Your Local Dev Environment" guide)[https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/] before your session.
+- If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) before your session.
 - All participants are expected to adhere to [Gatsby’s code of conduct](/contributing/code-of-conduct/)
 - We will ask if it’s okay to record our session; you are _not_ required to let us record
 - If the session is recorded, we may post the recording on [Gatsby’s YouTube channel](https://www.youtube.com/channel/UCjnp770qk7ujOq8Q9wiC82w)


### PR DESCRIPTION
There was a typo in markdown format for a link in Pair Programming doc.

