### PR TITLE
Show structured errors for graphql errors from the graphql function used in gatsby-node.js

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -22,6 +22,8 @@ const tracer = require(`opentracing`).globalTracer()
 const preferDefault = require(`./prefer-default`)
 const nodeTracking = require(`../db/node-tracking`)
 const withResolverContext = require(`../schema/context`)
+const stackTrace = require(`stack-trace`)
+import errorParser from "../query/error-parser"
 // Add `util.promisify` polyfill for old node versions
 require(`util.promisify/shim`)()
 
@@ -385,13 +387,37 @@ module.exports = async (args: BootstrapArgs) => {
 
   const graphqlRunner = (query, context = {}) => {
     const schema = store.getState().schema
+    console.log(`super`)
     return graphql(
       schema,
       query,
       context,
       withResolverContext(context, schema),
       context
-    )
+    ).then(result => {
+      if (result.errors) {
+        report.panicOnBuild(
+          result.errors.map(e => {
+            // Find the file where graphql was called.
+            const file = stackTrace
+              .parse(e)
+              .find(file => /createPages/.test(file.functionName))
+            if (file) {
+              return errorParser({
+                message: e.message,
+                location: {
+                  start: { line: file.lineNumber, column: file.columnNumber },
+                },
+                filePath: file.fileName,
+              })
+            }
+            return null
+          })
+        )
+      }
+
+      return result
+    })
   }
 
   // Collect pages.

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -387,7 +387,6 @@ module.exports = async (args: BootstrapArgs) => {
 
   const graphqlRunner = (query, context = {}) => {
     const schema = store.getState().schema
-    console.log(`super`)
     return graphql(
       schema,
       query,


### PR DESCRIPTION
Fixes #15212

Error before:
<img width="567" alt="Screenshot 2019-06-28 15 20 05" src="https://user-images.githubusercontent.com/71047/60374264-6a6be980-99b8-11e9-9c87-166bbfa11caa.png">

Error after:
<img width="884" alt="Screenshot 2019-06-28 15 20 36" src="https://user-images.githubusercontent.com/71047/60374271-6f309d80-99b8-11e9-8c35-f8d98c8548ac.png">
