### PR TITLE
Make structured errors around loading gatsby-config.js files

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.js
+++ b/packages/gatsby-cli/src/structured-errors/error-map.js
@@ -51,6 +51,31 @@ const errorMap = {
     type: `GRAPHQL`,
     level: `ERROR`,
   },
+  // Config errors
+  "10123": {
+    text: context =>
+      `We encountered an error while trying to load your site's ${
+        context.configName
+      }. Please fix the error and try again.`,
+    type: `CONFIG`,
+    level: `ERROR`,
+  },
+  "10124": {
+    text: context =>
+      `It looks like you were trying to add the config file? Please rename "${
+        context.nearMatch
+      }" to "${context.configName}.js"`,
+    type: `CONFIG`,
+    level: `ERROR`,
+  },
+  "10125": {
+    text: context =>
+      `Your ${
+        context.configName
+      } file is in the wrong place. You've placed it in the src/ directory. It must instead be at the root of your site next to your package.json file.`,
+    type: `CONFIG`,
+    level: `ERROR`,
+  },
 }
 
 module.exports = { errorMap, defaultError: errorMap[``] }

--- a/packages/gatsby-cli/src/structured-errors/error-schema.js
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.js
@@ -10,7 +10,7 @@ const errorSchema = Joi.object().keys({
   text: Joi.string(),
   stack: Joi.array().items(Joi.object({}).unknown()),
   level: Joi.string().valid([`ERROR`, `WARNING`, `INFO`, `DEBUG`]),
-  type: Joi.string().valid([`GRAPHQL`]),
+  type: Joi.string().valid([`GRAPHQL`, `CONFIG`]),
   filePath: Joi.string(),
   location: Joi.object({
     start: Position.required(),

--- a/packages/gatsby/src/bootstrap/get-config-file.js
+++ b/packages/gatsby/src/bootstrap/get-config-file.js
@@ -51,7 +51,6 @@ module.exports = async function getConfigFile(
     } else if (existsSync(path.join(rootDir, `src`, configName + `.js`))) {
       report.panic({
         id: `10125`,
-        error: err,
         context: {
           configName,
         },

--- a/packages/gatsby/src/bootstrap/get-config-file.js
+++ b/packages/gatsby/src/bootstrap/get-config-file.js
@@ -3,7 +3,6 @@ const levenshtein = require(`fast-levenshtein`)
 const fs = require(`fs-extra`)
 const testRequireError = require(`../utils/test-require-error`).default
 const report = require(`gatsby-cli/lib/reporter`)
-const chalk = require(`chalk`)
 const path = require(`path`)
 const existsSync = require(`fs-exists-cached`).sync
 
@@ -32,20 +31,31 @@ module.exports = async function getConfigFile(
       })
     )
     if (!testRequireError(configPath, err)) {
-      report.panic(
-        `We encountered an error while trying to load your site's ${configName}. Please fix the error and try again.`,
-        err
-      )
+      report.panic({
+        id: `10123`,
+        error: err,
+        context: {
+          configName,
+          message: err.message,
+        },
+      })
     } else if (nearMatch) {
-      report.panic(
-        `It looks like you were trying to add the config file? Please rename "${chalk.bold(
-          nearMatch
-        )}" to "${chalk.bold(configName)}"`
-      )
-    } else if (existsSync(path.join(rootDir, `src`, configName))) {
-      report.panic(
-        `Your ${configName} file is in the wrong place. You've placed it in the src/ directory. It must instead be at the root of your site next to your package.json file.`
-      )
+      report.panic({
+        id: `10124`,
+        error: err,
+        context: {
+          configName,
+          nearMatch,
+        },
+      })
+    } else if (existsSync(path.join(rootDir, `src`, configName + `.js`))) {
+      report.panic({
+        id: `10125`,
+        error: err,
+        context: {
+          configName,
+        },
+      })
     }
   }
 


### PR DESCRIPTION
These errors were generally already fine (other than odd formatting — the error text is at the end of the regular message as you can see in original error screenshot):

original:
<img width="1028" alt="Screenshot 2019-06-29 07 12 44" src="https://user-images.githubusercontent.com/71047/60385373-60d89500-9a3d-11e9-8b21-6dc6dfbff8c1.png">

new:
<img width="887" alt="Screenshot 2019-06-29 07 14 16" src="https://user-images.githubusercontent.com/71047/60385390-82d21780-9a3d-11e9-88e9-a84d030e3b88.png">

Also the check if the gatsby-config.js was in the src directory wasn't working at all before as we didn't append the extension to the file path. That's fixed now.

<img width="1318" alt="Screenshot 2019-06-29 07 15 37" src="https://user-images.githubusercontent.com/71047/60385407-b319b600-9a3d-11e9-8c95-d9aafcf5ecaa.png">

I _really_ dislike our stack traces so might work INK-ifying that now.
