### PR TITLE
[www] sites - add AwesomeDocs website

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -6281,3 +6281,16 @@
   built_by: Vazco
   built_by_url: https://www.vazco.eu
   featured: false
+- title: AwesomeDocs
+  main_url: "https://awesomedocs.traction.one/"
+  url: "https://awesomedocs.traction.one/install"
+  source_url: "https://github.com/AwesomeDocs/website"
+  description: An awesome documentation website generator!
+  featured: false
+  categories:
+    - Open Source
+    - Web Development
+    - Technology
+    - Documentation
+  built_by: Sankarsan Kampa
+  built_by_url: "https://traction.one"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Adding AwesomeDocs to sites showcase. AwesomeDocs is a documentation site generator made with Gatsby that builds documentation website from markdown files.
