### PR TITLE
fix(gatsby): various Typescript definitions

### DIFF
--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -22,7 +22,7 @@ export interface CreateFilePathArgs {
 export interface CreateRemoteFileNodeArgs {
   url: string
   store: Store
-  cache: Cache
+  cache: Cache["cache"]
   createNode: Function
   createNodeId: Function
   parentNodeId?: string

--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -12,6 +12,13 @@ export function createRemoteFileNode(
   args: CreateRemoteFileNodeArgs
 ): Promise<FileSystemNode>
 
+/**
+ * @see https://www.gatsbyjs.org/packages/gatsby-source-filesystem/?=files#createfilenodefrombuffer
+ */
+export function createFileNodeFromBuffer(
+  args: CreateFileNodeFromBufferArgs
+): Promise<FileSystemNode>
+
 export interface CreateFilePathArgs {
   node: Node
   getNode: Function
@@ -34,6 +41,18 @@ export interface CreateRemoteFileNodeArgs {
   ext?: string
   name?: string
   reporter: object
+}
+
+export interface CreateFileNodeFromBufferArgs {
+  buffer: Buffer
+  store: Store
+  cache: Cache["cache"]
+  createNode: Function
+  createNodeId: Function
+  parentNodeId?: string
+  hash?: string
+  ext?: string
+  name?: string
 }
 
 export interface FileSystemNode extends Node {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -856,11 +856,12 @@ export interface Actions {
   createRedirect(
     redirect: {
       fromPath: string
-      isPermanent: boolean
+      isPermanent?: boolean
       toPath: string
-      redirectInBrowser: boolean
-      force: boolean
-      statusCode: number
+      redirectInBrowser?: boolean
+      force?: boolean
+      statusCode?: number
+      [key: string]: unknown
     },
     plugin?: ActionPlugin
   ): void

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -792,7 +792,7 @@ export interface Actions {
   createNode(node: Node, plugin?: ActionPlugin, options?: ActionOptions): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#touchNode */
-  touchNode(node: { nodeId: string; plugin?: ActionPlugin }): void
+  touchNode(node: { nodeId: string }, plugin?: ActionPlugin): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createNodeField */
   createNodeField(


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Hi folks, sorry about these droplet of tiny fixes, I wasn't actively looking for issues & only fix them as I go. If you keep this one open for a few days, I'll push here whenever I find more issues.

- [gatsby] Fix `touchNode` def so `plugin` is the 2nd argument instead of being nested in the first one ([reference](https://github.com/gatsbyjs/gatsby/blob/7c6a623f6d468b81c8771bbaddc003a6430bc3fd/packages/gatsby/src/redux/actions/public.js#L749-L770))

- [gatsby] Fix `createRedirect` def: make `fromPath` & `toPath` the only 2 required fields ([reference](https://github.com/gatsbyjs/gatsby/blob/7c6a623f6d468b81c8771bbaddc003a6430bc3fd/packages/gatsby/src/redux/actions/public.js#L1141-L1163))

- [gatsby-source-filesystem] Fix Cache definition in createRemoteFileNode args (related to [this one](https://github.com/gatsbyjs/gatsby/pull/14955))

- [gatsby-source-filesystem] add definition for createFileNodeFromBuffer ([reference](https://github.com/gatsbyjs/gatsby/blob/f55250e67b89a2cbfda7700719f1019702249604/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js#L135))

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
