### PR TITLE
fix(www): updated copy on webinar banner

### DIFF
--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -49,9 +49,9 @@ const Banner = () => (
     <InnerContainer>
       <Content>
         <OutboundLink href="https://www.gatsbyjs.com/impossible-foods-webinar/">
-          Register now
+          Watch now
         </OutboundLink>
-        {`: "ImpossibleFoods.com: Combining Gatsby + Contentful for Speed, Scale and Flexibility" Webinar 6/26 10am PT`}
+        {`: "ImpossibleFoods.com: Combining Gatsby + Contentful for Speed, Scale and Flexibility"`}
       </Content>
     </InnerContainer>
   </BannerContainer>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Updates the webinar banner to say watch instead of register as per request of Linda

![image](https://user-images.githubusercontent.com/21114044/60456224-ebfc8b00-9bf5-11e9-8a45-b25068aa8c64.png)
