### PR TITLE
feat(gatsby-transformer-sharp): Add default types for ImageSharp

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -47,7 +47,7 @@ exports.sourceNodes = (
 
   if (createTypes) {
     createTypes(`
-      type File implements Node {
+      type File implements Node @infer {
         id: ID!
       }
     `)

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -43,7 +43,15 @@ exports.sourceNodes = (
   { actions, getNode, createNodeId, hasNodeChanged, reporter, emitter },
   pluginOptions
 ) => {
-  const { createNode, deleteNode } = actions
+  const { createNode, deleteNode, createTypes } = actions
+
+  if (createTypes) {
+    createTypes(`
+      type File implements Node {
+        id: ID!
+      }
+    `)
+  }
 
   // Validate that the path exists.
   if (!fs.existsSync(pluginOptions.path)) {

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -43,15 +43,7 @@ exports.sourceNodes = (
   { actions, getNode, createNodeId, hasNodeChanged, reporter, emitter },
   pluginOptions
 ) => {
-  const { createNode, deleteNode, createTypes } = actions
-
-  if (createTypes) {
-    createTypes(`
-      type File implements Node @infer {
-        id: ID!
-      }
-    `)
-  }
+  const { createNode, deleteNode } = actions
 
   // Validate that the path exists.
   if (!fs.existsSync(pluginOptions.path)) {

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -18,3 +18,15 @@ exports.onPreExtractQueries = async ({ store, getNodesByType }) => {
     `${program.directory}/.cache/fragments/image-sharp-fragments.js`
   )
 }
+
+exports.sourceNodes = ({ actions }) => {
+  const { createTypes } = actions
+
+  if (createTypes) {
+    createTypes(`
+      type ImageSharp implements Node {
+        id: ID!
+      }
+    `)
+  }
+}

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -24,7 +24,7 @@ exports.sourceNodes = ({ actions }) => {
 
   if (createTypes) {
     createTypes(`
-      type ImageSharp implements Node {
+      type ImageSharp implements Node @infer {
         id: ID!
       }
     `)


### PR DESCRIPTION
Now that themes is _almost_ ready to go, we've surfaced upon an issue in https://github.com/ChristopherBiscardi/gatsby-themes-stable-test/issues/1 where a theme without any content will break with 

```
There was an error in your GraphQL query:

Unknown type "ImageSharpFixed".

File: node_modules/gatsby-transformer-sharp/src/fragments.js:5:37
```

This occurs because the node the above definition is trying to create a fragment on (`ImageSharp`) doesn't exist because no image file was present in the project. 

To fix this, we need to add default types for `ImageSharp`, `File` and more in the respective plugins that _own_ them. 

CC @freiksenet @pieh @KyleAMathews 