### PR TITLE
Add running yarn to tutorial

### DIFF
--- a/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
+++ b/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
@@ -140,7 +140,7 @@ Add Gatsby develop and build scripts to the example site's `package.json`.
 Install all your packages by running yarn in the root directory.
 
 ```shell
-yarn 
+yarn
 ```
 
 Test your example site out to make sure everything is working as expected.

--- a/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
+++ b/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
@@ -137,6 +137,12 @@ Add Gatsby develop and build scripts to the example site's `package.json`.
 }
 ```
 
+Install all your packages by running yarn in the root directory.
+
+```shell
+yarn 
+```
+
 Test your example site out to make sure everything is working as expected.
 
 ```shell


### PR DESCRIPTION
When running yarn workspace example develop I was getting the following error

There was a problem loading the local develop command. Gatsby may not be installed in your site's "node_modules" directory. Perhaps you need to run "npm install"? You might need to delete your "package-lock.json" as well.

Packages need to be installed first

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
