### PR TITLE
feat(gatsby): support symlinked directories

### DIFF
--- a/packages/gatsby/src/utils/get-static-dir.js
+++ b/packages/gatsby/src/utils/get-static-dir.js
@@ -20,13 +20,13 @@ exports.copyStaticDirs = () => {
       .filter(themeStaticPath => fs.existsSync(themeStaticPath))
       // copy the files for each folder into the user's build
       .map(folder =>
-        fs.copySync(folder, nodePath.join(process.cwd(), `public`))
+        fs.copySync(folder, nodePath.join(process.cwd(), `public`), { dereference: true })
       )
   }
 
   const staticDir = nodePath.join(process.cwd(), `static`)
   if (!fs.existsSync(staticDir)) return Promise.resolve()
-  return fs.copySync(staticDir, nodePath.join(process.cwd(), `public`))
+  return fs.copySync(staticDir, nodePath.join(process.cwd(), `public`), { dereference: true })
 }
 
 /**

--- a/packages/gatsby/src/utils/get-static-dir.js
+++ b/packages/gatsby/src/utils/get-static-dir.js
@@ -20,13 +20,17 @@ exports.copyStaticDirs = () => {
       .filter(themeStaticPath => fs.existsSync(themeStaticPath))
       // copy the files for each folder into the user's build
       .map(folder =>
-        fs.copySync(folder, nodePath.join(process.cwd(), `public`), { dereference: true })
+        fs.copySync(folder, nodePath.join(process.cwd(), `public`), {
+          dereference: true,
+        })
       )
   }
 
   const staticDir = nodePath.join(process.cwd(), `static`)
   if (!fs.existsSync(staticDir)) return Promise.resolve()
-  return fs.copySync(staticDir, nodePath.join(process.cwd(), `public`), { dereference: true })
+  return fs.copySync(staticDir, nodePath.join(process.cwd(), `public`), {
+    dereference: true,
+  })
 }
 
 /**


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

When the `static` directory, or any directory for that matter, is symlinked from somewhere outside the directory of Gatsby, it gives permission errors:
```bash
success run static queries - 0.049 s — 5/5 120.42 queries/second

 ERROR

EPERM: operation not permitted, symlink '/home/traction/projects/AwesomeDocs/website/static/' -> '/home/traction/projects/AwesomeDocs/website/.awesome/public'



  Error: EPERM: operation not permitted, symlink '/home/traction/projects/AwesomeDocs/website/static/' ->
'/home/traction/projects/AwesomeDocs/website/.awesome/public'

  - copy-sync.js:157 onLink
    [.awesome]/[fs-extra]/lib/copy-sync/copy-sync.js:157:15

  - copy-sync.js:52 getStats
    [.awesome]/[fs-extra]/lib/copy-sync/copy-sync.js:52:40

  - copy-sync.js:41 startCopy
    [.awesome]/[fs-extra]/lib/copy-sync/copy-sync.js:41:10

  - copy-sync.js:36 Object.copySync
    [.awesome]/[fs-extra]/lib/copy-sync/copy-sync.js:36:10

  - get-static-dir.js:34 exports.copyStaticDirs
    [.awesome]/[gatsby]/dist/utils/get-static-dir.js:34:13

  - build.js:96 build
    [.awesome]/[gatsby]/dist/commands/build.js:96:3
```
Dereferencing the symlinked directories while copying them enables any directories to be symlinked from anywhere without any issues. And as per my tests, this doesn't have any other side effects.
