### PR TITLE
feat(gatsby): Switch to name based package filtering for speed

### DIFF
--- a/packages/gatsby/src/utils/gatsby-dependents.js
+++ b/packages/gatsby/src/utils/gatsby-dependents.js
@@ -1,10 +1,12 @@
 import { store } from "../redux"
 import rpt from "read-package-tree"
+import { promisify } from "util"
 
+const rptAsync = promisify(rpt)
 // Returns [Object] with name and path
 module.exports = async () => {
   const { program } = store.getState()
-  const allNodeModules = await rpt(program.directory, (node, moduleName) =>
+  const allNodeModules = await rptAsync(program.directory, (node, moduleName) =>
     /gatsby/.test(moduleName)
   )
   return allNodeModules.children

--- a/packages/gatsby/src/utils/gatsby-dependents.js
+++ b/packages/gatsby/src/utils/gatsby-dependents.js
@@ -4,8 +4,8 @@ import rpt from "read-package-tree"
 // Returns [Object] with name and path
 module.exports = async () => {
   const { program } = store.getState()
-  const allNodeModules = await rpt(program.directory, (node, kidName) =>
-    /gatsby/.test(kidName)
+  const allNodeModules = await rpt(program.directory, (node, moduleName) =>
+    /gatsby/.test(moduleName)
   )
   return allNodeModules.children
 }

--- a/packages/gatsby/src/utils/gatsby-dependents.js
+++ b/packages/gatsby/src/utils/gatsby-dependents.js
@@ -4,10 +4,8 @@ import rpt from "read-package-tree"
 // Returns [Object] with name and path
 module.exports = async () => {
   const { program } = store.getState()
-  const allNodeModules = await rpt(program.directory)
-  return allNodeModules.children.filter(
-    node =>
-      (node.package.dependencies && node.package.dependencies[`gatsby`]) ||
-      (node.package.peerDependencies && node.package.peerDependencies[`gatsby`])
+  const allNodeModules = await rpt(program.directory, (node, kidName) =>
+    /gatsby/.test(kidName)
   )
+  return allNodeModules.children
 }


### PR DESCRIPTION
We introduced a `gatsby-dependents` util in https://github.com/gatsbyjs/gatsby/pull/15269 and use it on https://github.com/gatsbyjs/gatsby/pull/15284 for selective transpilation of dependencies. 

Previously, we were parsing the entire dependency tree and recursively figuring out dependencies that include `gatsby` as a dep or peer dep. 

The new heuristic is what @KyleAMathews recommends in https://github.com/gatsbyjs/gatsby/pull/15179#issuecomment-506321410. It only gets dependencies that include `gatsby` in the package name. As Kyle explains in the linked comment, it is:

- much faster (~10x)
- extremely unlikely that a target package that needs transpilation (a theme or a package that includes a gatsby query) would not include the name, `gatsby` (see babel plugins for prior art)