### PR TITLE
fix(gatsby): adds the missing micromatch dependency

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -88,6 +88,7 @@
     "lodash": "^4.17.10",
     "md5": "^2.2.1",
     "md5-file": "^3.1.1",
+    "micromatch": "^3.1.10",
     "mime": "^2.2.0",
     "mini-css-extract-plugin": "^0.4.0",
     "mitt": "^1.1.2",


### PR DESCRIPTION
## Description

Package required here:

https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/redux/run-sift.js#L6

## Related Issues

n/a
