### PR TITLE
fix(gatsby-image): Update TypeScript types

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -27,10 +27,8 @@ export interface FluidObject {
 interface GatsbyImageProps {
   resolutions?: FixedObject
   sizes?: FluidObject
-  fixed?: FixedObject
-  fluid?: FluidObject
-  fixedImages?: FixedObject[]
-  fluidImages?: FluidObject[]
+  fixed?: FixedObject | FixedObject[]
+  fluid?: FluidObject | FluidObject[]
   fadeIn?: boolean
   title?: string
   alt?: string


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

In the course of merging #13395, the implementation was switched from using separate
`fluidImages` and `fixedImages` props to overloading `fluid` and `fixed` to take arrays.
The TypeScript types were not updated to match this. This fixes the types to reflect that: https://www.gatsbyjs.org/packages/gatsby-image/#gatsby-image-props