### PR TITLE
fix(gatsby): Exclude gatsby itself in gatsby-dependents

### DIFF
--- a/packages/gatsby/src/utils/gatsby-dependents.js
+++ b/packages/gatsby/src/utils/gatsby-dependents.js
@@ -6,8 +6,10 @@ const rptAsync = promisify(rpt)
 // Returns [Object] with name and path
 module.exports = async () => {
   const { program } = store.getState()
-  const allNodeModules = await rptAsync(program.directory, (node, moduleName) =>
-    /gatsby/.test(moduleName)
+  const allNodeModules = await rptAsync(
+    program.directory,
+    // Include anything that has `gatsby` in its name but not `gatsby` itself
+    (node, moduleName) => /gatsby/.test(moduleName) && moduleName !== `gatsby`
   )
   return allNodeModules.children
 }


### PR DESCRIPTION
After the new heuristic change in https://github.com/gatsbyjs/gatsby/pull/15308, it seems `gatsby` itself is being included. That is a problem since this includes the Dev 404 pages twice (once because it is copied over to `.cache` and once here in `node_modules` itself)

This PR fixes that by excluding `gatsby` itself _always_. 