### PR TITLE
fix(renovate): fix config to include themes starters (hopefully)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
   "extends": ["config:base"],
   "includePaths": [
     "starters/**",
-    "themes/gatsby-starter-blog-theme",
-    "themes/gatsby-starter-notes-theme",
-    "themes/gatsby-starter-theme"
+    "themes/gatsby-starter-blog-theme/**",
+    "themes/gatsby-starter-notes-theme/**",
+    "themes/gatsby-starter-theme/**"
   ],
   "major": {
     "enabled": false


### PR DESCRIPTION
Seems like renovate doesn't pick up starters from there directory


From renovate dashboard:
```
DEBUG: Found renovate.json config file
INFO: Repository config
{
  "configFile": "renovate.json",
  "config": {
    "extends": [
      "config:base"
    ],
    "includePaths": [
      "starters/**",
      "themes/gatsby-starter-blog-theme",
      "themes/gatsby-starter-notes-theme",
      "themes/gatsby-starter-theme"
    ],
    "major": {
      "enabled": false
    },
    "prHourlyLimit": 2,
    "prConcurrentLimit": 20,
    "rebaseStalePrs": false,
    "rangeStrategy": "bump",
    "bumpVersion": null,
    "semanticCommitScope": "starters"
  }
}

[...]

DEBUG: Matched 3 file(s) for manager npm: starters/blog/package.json, starters/default/package.json, starters/hello-world/package.json
```
It didn't pick up those new ones, so this is blind test hoping it will allow renovate to find them