### PR TITLE
chore(themes-starters): replace wildcard to caret version selector in starter themes

### DIFF
--- a/themes/gatsby-starter-blog-theme/package-lock.json
+++ b/themes/gatsby-starter-blog-theme/package-lock.json
@@ -925,6 +925,14 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.2.tgz",
       "integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz",
+      "integrity": "sha512-ZQIMAA2kLUWiUeMZNJDTeCwYRx1l8SQL0kHktze4COT22occKpDML1GDUXP5/sxhOMrZO8vZw773ni4H5Snrsg==",
+      "requires": {
+        "@emotion/memoize": "0.7.2"
+      }
+    },
     "@emotion/memoize": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.2.tgz",
@@ -1405,105 +1413,19 @@
       "resolved": "https://registry.npmjs.org/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz",
       "integrity": "sha512-MNodHp46og+Sdde/LCxTLrxcD5Dimu21R/Fer2raXMG1XtHSV2+vZnkIV87OPAxuf2NiDj1W5hN7Q2MYUfQQ8w=="
     },
-    "@styled-system/background": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.0.12.tgz",
-      "integrity": "sha512-CFDLrq6KwZgVwBOMaDnEDJWMELsg4slmjFGHvpxU3bi/JHbEepzksGoY/j2QroIh1lm8sS7vIzl1a6xMtMoytQ==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/border": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.0.12.tgz",
-      "integrity": "sha512-jU8Xz5ZXipEtVJsPAKmpO1tCZSymXr2gyYW9ZVQKztDIn4SFortNqkhIiBEZ528qowVYZte7OQWpecTIOYB5wQ==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/color": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.0.12.tgz",
-      "integrity": "sha512-bNh1a10CzarHj5rrPyJsVq+WRRdnv7H4SEEngNt07HV6Iq/ds7Gcrp+QJzGtqmF2u3BPSFRLhj9tNQGhFhPq7A==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/core": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.0.12.tgz",
-      "integrity": "sha512-AScxlT6JQ5bQ4XS5pYmDgv3rGCJtTxK9gEfDtmOU2d+7gGhzG/7DtoxnOlXufUn6xNIm9GL0izyOLti73e9YHg==",
-      "requires": {
-        "object-assign": "^4.1.1"
-      }
-    },
     "@styled-system/css": {
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.11.tgz",
       "integrity": "sha512-rq/KO2SEpUbk9dWIRdWEkNL3w6Eds55KGdAcD+9DttqrC+FwPXfk27ebmTMfwyIAiDES9uW7z57Bo6v34VUNqw=="
     },
-    "@styled-system/flexbox": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.0.12.tgz",
-      "integrity": "sha512-2EETVEFHK+HYeHEcxwJ0UXxyQWF4WX0JuP1KwsS/yLzMQ20O1PGnaj6RxGxHpGWnWNl5XNEvAUcUIvktH4Yfvw==",
+    "@theme-ui/typography": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/typography/-/typography-0.2.1.tgz",
+      "integrity": "sha512-wo6lDXqkyfEYJyJA4BXCCeB/KP33RK88E5YaUynGy1hut5Q0isbcaI38ueWLAThSTvu8QLl2rxaWEuNbHDLACA==",
       "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/grid": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.0.12.tgz",
-      "integrity": "sha512-sZ+JWJANSrBCn9U9ZSfw3qWLvNjJc9MQLW662M+M37RG+FZg+lzgzXhnhuS4iBVV3UK1YsMFdGMs+VKdMN3N3A==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/layout": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.0.12.tgz",
-      "integrity": "sha512-5FlVI95S0JkWBSl3X9uCS/wv+laBaXalTqCoWC6XM4bwh3vN5LjSR6KSwRUvV6+CVEHb272lR3Kkjxn+OUcv1Q==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/position": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.0.12.tgz",
-      "integrity": "sha512-TRnmp+xrwvcUa45kb9t+u+2L7ImjM+xqlTjtUyCk9K0FhBdE0jqSwUuh/LnnAbM6pSHeije31XKtbZXF1XeG/w==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/shadow": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.0.12.tgz",
-      "integrity": "sha512-ErOTpAUrITYsqNb6j/qq8NZAoWORq/JkwQ56OS02n/B7K4eA79CwMsOLhs5E6bspgw5Gdg10CVrDnm1p1fquhw==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/space": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.0.12.tgz",
-      "integrity": "sha512-Mv+YJGIjuzq0yi1GWuKj9zAZtGg01wF/VdP4E0XMZpnR4spqD4pMlLRK+iuiBMbN1mHPy1iymEQP8Epe5S8euQ==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/typography": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.0.12.tgz",
-      "integrity": "sha512-PbEDVNnVWie82B6ot0lozmwKkZGGlhWGH+kVx4kXzpgKRD518qVc2fTPtwidCC11s/T/+p1teCkxa6Rbsv9rjg==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/variant": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.0.12.tgz",
-      "integrity": "sha512-X0pH3Bf7YEyZmUYE8kTX1cFDjHKIBhkZfkO7POB7WKN1qqVz+k3ioPIhZm9u1QWr4XYZ6bvmqAzZJ/W0cQIZ7A==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
+        "compass-vertical-rhythm": "^1.4.5",
+        "modularscale": "^2.0.1",
+        "object-assign": "^4.1.1"
       }
     },
     "@types/configstore": {
@@ -7273,9 +7195,9 @@
       }
     },
     "gatsby-image": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.3.tgz",
-      "integrity": "sha512-FRmKHkbvbJXYzdjxWaTr0Btm3yZCIFiEMXPf6VFTCaMGXzRUW30mCpaffqy10frpr9769zZC55LT01k4VHKaBA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.4.tgz",
+      "integrity": "sha512-wlbqGsfIX2+ILz/fk/94fDShc5zfhTlj7vYGyTFZfKombvwPXFAJD6pey4zTBZUUBrxMt2tROMXNnmFi3wGyww==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "object-fit-images": "^3.2.4",
@@ -7341,9 +7263,9 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.6.tgz",
-      "integrity": "sha512-Ft3pP2jpJVaMK4zXFfK7cy8VDZqwBqXs5Y//hWM5rFEaRSgHevl4cYMNb/5pKcYrk+MaxVOGCUUsMiwd0P/bsw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.7.tgz",
+      "integrity": "sha512-sXubUJhKO8nC4vEe7ME1htlQ4LPtRC7hhZF3fHl26gy5zNuHiCVtHZROoVIaiEY7UECGZzX8CjEblGVNgSmD2A==",
       "requires": {
         "@babel/core": "^7.4.3",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
@@ -7421,9 +7343,9 @@
       }
     },
     "gatsby-plugin-sharp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.1.tgz",
-      "integrity": "sha512-NoAf3HK9xT9YdTd8rHf9SoBJoq9uZ+qLxTVe9xdAeOusGrnPIndbZIbPKzzBrhJZ94kihEf7ehEfGCwsh6c1Sw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.2.tgz",
+      "integrity": "sha512-e7+4EWLhcucRHFjtDTJFe04IjvLyh0U6Q+CqqcYmL/veIDTVf7XvGefiKlcFxG8ys6l2d3gd3L4+nR8WzV6lCA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "async": "^2.1.2",
@@ -7631,9 +7553,9 @@
       }
     },
     "gatsby-remark-prismjs": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.0.tgz",
-      "integrity": "sha512-87UMtykDD8+kkR77MaY6pnJtqntUw0r8vqcsKxtgMkup9TMpwKvb8JHj2eSpl1NGdQDDjovYVNfkOfroQrkaJw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.1.tgz",
+      "integrity": "sha512-V0rzHqmVgzJX6WSse4d29wfSv4Y8zm1Qfl3xwbMngiSENZ8gLvCiMDKZGrV8QcwJNyUyDsBDCNakGKyCvTu5EA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "parse-numeric-range": "^0.0.2",
@@ -7687,9 +7609,9 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.1.tgz",
-      "integrity": "sha512-B01of7+bvpyaJz6uF4mM/kVfZrkxB28kfg+csHE9Ro8w+4+qGAFG/HKYGOCQxeKNL/yI6Uw8KeKLMW14KVD0UA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.2.tgz",
+      "integrity": "sha512-mrlQ00Es+qjb2MCIEHAkv/F3yfR5IgI8z2q54tqpxu4amlUy3SQH5ThJDGD7Ya574ub9aKdHOr8virTssmTDgA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "better-queue": "^3.8.7",
@@ -7807,13 +7729,14 @@
       }
     },
     "gatsby-theme-blog": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-0.0.9.tgz",
-      "integrity": "sha512-pNgInwexTz+8k4vCrbXgqp3jvcqujZAke2GGplhP2vuLAm9rsIyXObsQH5lU4SdjsH+Jxf1dkRYroubaO+CPGg==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-0.0.10.tgz",
+      "integrity": "sha512-RqGyifxZHWQyZKvHTR4p7nNYGI6hy1GrkJ8LorisCYaBeYBFI3xrxt5F+31VB8twU2k+/8VLUYo7ulF1n5AMkw==",
       "requires": {
         "@emotion/core": "^10.0.10",
         "@mdx-js/mdx": "^1.0.15",
         "@mdx-js/react": "^1.0.15",
+        "@theme-ui/typography": "^0.2.0",
         "gatsby-image": "^2.0.31",
         "gatsby-plugin-emotion": "^4.0.6",
         "gatsby-plugin-feed": "^2.0.14",
@@ -7829,28 +7752,28 @@
         "gatsby-remark-responsive-iframe": "^2.1.1",
         "gatsby-remark-smartypants": "^2.0.8",
         "gatsby-source-filesystem": "^2.0.23",
-        "gatsby-theme-ui": "^0.1.5",
+        "gatsby-theme-ui": "^0.2.0",
         "gatsby-transformer-sharp": "^2.1.15",
         "lodash.merge": "^4.6.1",
         "prismjs": "^1.15.0",
         "react-helmet": "^5.2.0",
+        "react-switch": "^5.0.0",
         "remark-slug": "^5.1.1",
-        "theme-ui": "^0.1.5",
-        "theme-ui-typography": "^0.1.3",
+        "theme-ui": "^0.2.0",
         "typeface-merriweather": "0.0.72",
         "typeface-montserrat": "0.0.54",
         "typography-theme-wordpress-2016": "^0.16.18"
       }
     },
     "gatsby-theme-ui": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-ui/-/gatsby-theme-ui-0.1.7.tgz",
-      "integrity": "sha512-w2p31ZjbWU6YWelnxbtGYFreocMycalJl5/YK/jtC/CuFRNaOqCbLuCL2AFU/RPQvhWdY19MFDjS0h2IEuD+aw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-ui/-/gatsby-theme-ui-0.2.0.tgz",
+      "integrity": "sha512-TS5ykhCpcb7/IRJbjDBw0uRytpsh/inJvbpiyrm8IrOGdtdev+3G1qpwJgZ/Qs7mkMYAyFxZ7IwJWIPOqfWqRg=="
     },
     "gatsby-transformer-sharp": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.0.tgz",
-      "integrity": "sha512-5M+1I2r+x4UBTTQapzCGYX8bO2OOFRF7NqE2emXBqquepqi7IdiUahK6c5/C0vXwpvTnXgHZt8xg13zuRm8rKw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.1.tgz",
+      "integrity": "sha512-KmUqtvt3ry8bL6RMfHwMgRH4AJcDOJgGMTyLeULUScDoKTSriColPhbXMmJzM4Gsq3NUNqJkRo9qvNxBqnSWtQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "bluebird": "^3.5.0",
@@ -10539,9 +10462,9 @@
       }
     },
     "mini-svg-data-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.0.3.tgz",
-      "integrity": "sha512-YBaqsh6GE+4jQhLNkFYEagH2o4bVTlGGpEvkuwtwc+1NBGXqpcVCnsUGkGp75ovPXxtF2GsDYzUwyhfC0hntiA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.1.3.tgz",
+      "integrity": "sha512-EeKOmdzekjdPe53/GdxmUpNgDQFkNeSte6XkJmOBt4BfWL6FQ9G9RtLNh+JMjFS3LhdpSICMIkZdznjiecASHQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -12959,6 +12882,14 @@
         "shallowequal": "^1.0.1"
       }
     },
+    "react-switch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.0.tgz",
+      "integrity": "sha512-+zxY9xj9dMc8Y4gv/kkqQrirfEiIQ+SlQfJDW1Wi81L3xoh1fcbBYyJyh0TnhM/U/b6HxuBmkmU4Ooxgtuoavw==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -14857,26 +14788,6 @@
         "inline-style-parser": "0.1.1"
       }
     },
-    "styled-system": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.0.12.tgz",
-      "integrity": "sha512-QWtzon68s0Igbo9cGnNv1BBjfWw6SKXyLDRmXbzwiCd5d93b5Yzzfrx9FM2emy1Up012TU3h4vGj/q++uAYafQ==",
-      "requires": {
-        "@styled-system/background": "^5.0.12",
-        "@styled-system/border": "^5.0.12",
-        "@styled-system/color": "^5.0.12",
-        "@styled-system/core": "^5.0.12",
-        "@styled-system/flexbox": "^5.0.12",
-        "@styled-system/grid": "^5.0.12",
-        "@styled-system/layout": "^5.0.12",
-        "@styled-system/position": "^5.0.12",
-        "@styled-system/shadow": "^5.0.12",
-        "@styled-system/space": "^5.0.12",
-        "@styled-system/typography": "^5.0.12",
-        "@styled-system/variant": "^5.0.12",
-        "object-assign": "^4.1.1"
-      }
-    },
     "stylehacks": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -15155,27 +15066,21 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theme-ui": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.1.7.tgz",
-      "integrity": "sha512-Hs+iPyPBlcT1ieD6krMKa32JxTOoHy4gJaznT2KqhpzQ2fnQJBqTVXMF2AFrqHCHK+CaL1s+qqjb7q/NSqCccg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.2.tgz",
+      "integrity": "sha512-ce29BzEP2pSogQ5XxtEUDXcwdtcb1SdPgJCZdFi7sfglA2vdADY6CdRXxZ6cVrdeVaDQQMtSaIbFghpplZbGMg==",
       "requires": {
+        "@emotion/is-prop-valid": "^0.8.1",
         "@styled-system/css": "^5.0.5",
-        "lodash.merge": "^4.6.0",
-        "react": "^16.8.0",
-        "styled-system": "^5.0.5"
-      }
-    },
-    "theme-ui-typography": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/theme-ui-typography/-/theme-ui-typography-0.1.7.tgz",
-      "integrity": "sha512-2aRk1//Fp9qwvdIW+wBCzQiE3w8PWHwH/e1J68zNEvKpL4H2gciE3A8b3RSGk6buqWn92+oZWITb5T3LG9LNFw==",
-      "requires": {
-        "compass-vertical-rhythm": "^1.4.5",
-        "css-what": "^2.1.3",
-        "lodash.merge": "^4.6.1",
-        "modularscale": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "typography": "^0.16.19"
+        "deepmerge": "^3.2.0",
+        "react": "^16.8.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
+        }
       }
     },
     "through": {
@@ -15448,39 +15353,10 @@
       "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-0.0.54.tgz",
       "integrity": "sha512-Typhap0PWT299+Va0G/8ZtycHMXrH4gBWKfiW977KEBx5rXUUCa70gvqLx1fdA0WAo6bhSAQmo8uc+QFAmjPww=="
     },
-    "typography": {
-      "version": "0.16.19",
-      "resolved": "https://registry.npmjs.org/typography/-/typography-0.16.19.tgz",
-      "integrity": "sha512-zfsyjPPB1RaK8TzU3REta6EGDZa++YQ6g/CWw7hy/8xQK1qyzFWisMIw5J+Yg1KyiVgcchmxlgMcMA6JAJ9oew==",
-      "requires": {
-        "compass-vertical-rhythm": "^1.4.5",
-        "decamelize": "^1.2.0",
-        "gray-percentage": "^2.0.0",
-        "lodash": "^4.13.1",
-        "modularscale": "^1.0.2",
-        "object-assign": "^4.1.0",
-        "typography-normalize": "^0.16.19"
-      },
-      "dependencies": {
-        "modularscale": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/modularscale/-/modularscale-1.0.2.tgz",
-          "integrity": "sha1-So8TrzKl5SFPxuLPxSkGSr/X2Hc=",
-          "requires": {
-            "lodash.isnumber": "^3.0.0"
-          }
-        }
-      }
-    },
     "typography-breakpoint-constants": {
       "version": "0.16.19",
       "resolved": "https://registry.npmjs.org/typography-breakpoint-constants/-/typography-breakpoint-constants-0.16.19.tgz",
       "integrity": "sha512-vXjfV9hwAXIOf5+U5GN137ahBkK+sj1TJu/5ksmP+8XB/D80lmGb/m0nKviWaQ3t7HLrK848VGrFS+6E2vcmVg=="
-    },
-    "typography-normalize": {
-      "version": "0.16.19",
-      "resolved": "https://registry.npmjs.org/typography-normalize/-/typography-normalize-0.16.19.tgz",
-      "integrity": "sha512-vtnSv/uGBZVbd4e/ZhZB9HKBgKKlWQUXw74+ADIHHxzKp27CEf8PSR8TX1zF2qSyQ9/qMdqLwXYz8yRQFq9JLQ=="
     },
     "typography-theme-wordpress-2016": {
       "version": "0.16.19",

--- a/themes/gatsby-starter-blog-theme/package.json
+++ b/themes/gatsby-starter-blog-theme/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "gatsby": "^2.13.1",
-    "gatsby-theme-blog": "*",
+    "gatsby-theme-blog": "^0.0.10",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/themes/gatsby-starter-notes-theme/package-lock.json
+++ b/themes/gatsby-starter-notes-theme/package-lock.json
@@ -955,26 +955,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
       "integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
     },
-    "@emotion/styled": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.14.tgz",
-      "integrity": "sha512-Ae8d5N/FmjvZKXjqWcjfhZhjCdkvxZSqD95Q72BYDNQnsOKLHIA4vWlMolLXDNkw1dIxV3l2pp82Z87HXj6eYQ==",
-      "requires": {
-        "@emotion/styled-base": "^10.0.14",
-        "babel-plugin-emotion": "^10.0.14"
-      }
-    },
-    "@emotion/styled-base": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.14.tgz",
-      "integrity": "sha512-1nC5iO/Rk0DY47M5wXCyWpbo/woiwXWfVbNKDM3QRi7CKq8CwC++PQ5HgiYflFrAt1vjzIVZqnzrIn3idUoQgg==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "@emotion/is-prop-valid": "0.8.2",
-        "@emotion/serialize": "^0.11.8",
-        "@emotion/utils": "0.11.2"
-      }
-    },
     "@emotion/stylis": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
@@ -1433,9 +1413,9 @@
       "integrity": "sha512-MNodHp46og+Sdde/LCxTLrxcD5Dimu21R/Fer2raXMG1XtHSV2+vZnkIV87OPAxuf2NiDj1W5hN7Q2MYUfQQ8w=="
     },
     "@styled-system/css": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-2.0.4.tgz",
-      "integrity": "sha512-Y7D+rqEpQk4311GDrzRtO5yreILywX8JiFYWyXhB5eG8Qz7kF4KKhpta54e5GA/FGFcPF47HVKjcuATf3hqsMQ=="
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.11.tgz",
+      "integrity": "sha512-rq/KO2SEpUbk9dWIRdWEkNL3w6Eds55KGdAcD+9DttqrC+FwPXfk27ebmTMfwyIAiDES9uW7z57Bo6v34VUNqw=="
     },
     "@types/configstore": {
       "version": "2.1.1",
@@ -3288,16 +3268,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
-    "compass-vertical-rhythm": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/compass-vertical-rhythm/-/compass-vertical-rhythm-1.4.5.tgz",
-      "integrity": "sha512-bJo3IYX7xmmZCDYjrT2XolaiNjGZ4E2JvUGxpdU0ecbH4ZLK786wvc8aHKVrGrKct9JlkmJbUi8YLrQWvOc+uA==",
-      "requires": {
-        "convert-css-length": "^1.0.1",
-        "object-assign": "^4.1.0",
-        "parse-unit": "^1.0.1"
-      }
-    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -3412,11 +3382,6 @@
         "date-now": "^0.1.4"
       }
     },
-    "console-polyfill": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.1.2.tgz",
-      "integrity": "sha1-ls/tUcr3gYn2mVcubxgnHcN8DjA="
-    },
     "constant-case": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
@@ -3448,15 +3413,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "convert-css-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-1.0.2.tgz",
-      "integrity": "sha512-ecV7j3hXyXN1X2XfJBzhMR0o1Obv0v3nHmn0UiS3ACENrzbxE/EknkiunS/fCwQva0U62X1GChi8GaPh4oTlLg==",
-      "requires": {
-        "console-polyfill": "^0.1.2",
-        "parse-unit": "^1.0.1"
-      }
     },
     "convert-hrtime": {
       "version": "2.0.0",
@@ -4020,6 +3976,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -4410,16 +4371,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-    },
-    "emotion-theming": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.14.tgz",
-      "integrity": "sha512-zMGhPSYz48AAR6DYjQVaZHeO42cYKPq4VyB1XjxzgR62/NmO99679fx8qDDB1QZVYGkRWZtsOe+zJE/e30XdbA==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "@emotion/weak-memoize": "0.2.3",
-        "hoist-non-react-statics": "^3.3.0"
-      }
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -6479,10 +6430,43 @@
         "prop-types": "^15.6.1"
       }
     },
-    "gatsby-mdx": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/gatsby-mdx/-/gatsby-mdx-0.6.3.tgz",
-      "integrity": "sha512-jrSXGul8KRqTcwHdZHYl2HmRMjbgfnb0WlFEUt2r/kzeF46BvkHA0PqnWnCrTL3HBzLbY/3mX/KFbaFxlr/nYA==",
+    "gatsby-page-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.2.tgz",
+      "integrity": "sha512-8fG4KuLtck5q2HPdHmFs69a34CAO2cL1js7WCuFPma3P53lLF5Ui1v5o6cTouF3Yms3Gah8piM3zIWhG7mCHtQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "bluebird": "^3.5.0",
+        "chokidar": "2.1.2",
+        "fs-exists-cached": "^1.0.0",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "micromatch": "^3.1.10",
+        "slash": "^1.0.0"
+      }
+    },
+    "gatsby-plugin-compile-es6-packages": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-compile-es6-packages/-/gatsby-plugin-compile-es6-packages-1.1.0.tgz",
+      "integrity": "sha512-YjB9LDyUBcWfVVF8mN+t4OziYghys08nb2vpYgW+sqXO4giHRLWpANFmVUXW+H2c1g8fAwPlKYcwDXyqNunibw==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "regex-escape": "^3.4.8"
+      }
+    },
+    "gatsby-plugin-emotion": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.0.tgz",
+      "integrity": "sha512-6Wrw47MK7j2OLgdjUmJVgdMtykFT9PNan2UTAjIWqquNMJgWWa96iM5kS4DnExhlwfyb50vji/SaWjW8JrUI8w==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@emotion/babel-preset-css-prop": "^10.0.5"
+      }
+    },
+    "gatsby-plugin-mdx": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.7.tgz",
+      "integrity": "sha512-sXubUJhKO8nC4vEe7ME1htlQ4LPtRC7hhZF3fHl26gy5zNuHiCVtHZROoVIaiEY7UECGZzX8CjEblGVNgSmD2A==",
       "requires": {
         "@babel/core": "^7.4.3",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
@@ -6499,6 +6483,7 @@
         "mdast-util-to-string": "^1.0.4",
         "mdast-util-toc": "^3.0.0",
         "mime": "^2.3.1",
+        "p-queue": "^5.0.0",
         "pretty-bytes": "^5.1.0",
         "remark": "^10.0.0",
         "remark-retext": "^3.1.2",
@@ -6534,39 +6519,6 @@
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
         }
-      }
-    },
-    "gatsby-page-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.2.tgz",
-      "integrity": "sha512-8fG4KuLtck5q2HPdHmFs69a34CAO2cL1js7WCuFPma3P53lLF5Ui1v5o6cTouF3Yms3Gah8piM3zIWhG7mCHtQ==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "bluebird": "^3.5.0",
-        "chokidar": "2.1.2",
-        "fs-exists-cached": "^1.0.0",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "micromatch": "^3.1.10",
-        "slash": "^1.0.0"
-      }
-    },
-    "gatsby-plugin-compile-es6-packages": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-compile-es6-packages/-/gatsby-plugin-compile-es6-packages-1.1.0.tgz",
-      "integrity": "sha512-YjB9LDyUBcWfVVF8mN+t4OziYghys08nb2vpYgW+sqXO4giHRLWpANFmVUXW+H2c1g8fAwPlKYcwDXyqNunibw==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "regex-escape": "^3.4.8"
-      }
-    },
-    "gatsby-plugin-emotion": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.0.tgz",
-      "integrity": "sha512-6Wrw47MK7j2OLgdjUmJVgdMtykFT9PNan2UTAjIWqquNMJgWWa96iM5kS4DnExhlwfyb50vji/SaWjW8JrUI8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "@emotion/babel-preset-css-prop": "^10.0.5"
       }
     },
     "gatsby-plugin-meta-redirect": {
@@ -6633,9 +6585,9 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.1.tgz",
-      "integrity": "sha512-B01of7+bvpyaJz6uF4mM/kVfZrkxB28kfg+csHE9Ro8w+4+qGAFG/HKYGOCQxeKNL/yI6Uw8KeKLMW14KVD0UA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.2.tgz",
+      "integrity": "sha512-mrlQ00Es+qjb2MCIEHAkv/F3yfR5IgI8z2q54tqpxu4amlUy3SQH5ThJDGD7Ya574ub9aKdHOr8virTssmTDgA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "better-queue": "^3.8.7",
@@ -6758,24 +6710,30 @@
       }
     },
     "gatsby-theme-notes": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-0.0.1.tgz",
-      "integrity": "sha512-r5bsrFSkztWlE7gNbxxHakU0fU5dUu8O3MIFYlMrfaQChT6jyUqH7U0QrymCLlr5cXatnRpakefl3SV//kmmKw==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-0.0.2.tgz",
+      "integrity": "sha512-0UJDLi6qiWxYw3qIIXMggLN3g4EUUa5eB18TKad3T8AkZxzlr9I43ZRyStaFGewlovUEGQGg+m4BuNDci4NMSg==",
       "requires": {
         "@emotion/core": "^10.0.10",
         "@mdx-js/mdx": "^1.0.19",
         "@mdx-js/react": "^1.0.16",
-        "gatsby-mdx": "^0.6.3",
         "gatsby-plugin-compile-es6-packages": "^1.1.0",
         "gatsby-plugin-emotion": "^4.0.6",
+        "gatsby-plugin-mdx": "^1.0.5",
         "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-plugin-og-image": "0.0.1",
         "gatsby-plugin-redirects": "^1.0.0",
         "gatsby-source-filesystem": "^2.0.35",
+        "gatsby-theme-ui": "^0.2.0",
         "is-present": "^1.0.0",
         "react-feather": "^1.1.6",
-        "theme-ui": "^0.0.12"
+        "theme-ui": "^0.2.0"
       }
+    },
+    "gatsby-theme-ui": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-ui/-/gatsby-theme-ui-0.2.0.tgz",
+      "integrity": "sha512-TS5ykhCpcb7/IRJbjDBw0uRytpsh/inJvbpiyrm8IrOGdtdev+3G1qpwJgZ/Qs7mkMYAyFxZ7IwJWIPOqfWqRg=="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -7036,11 +6994,6 @@
         "section-matter": "^1.0.0",
         "strip-bom-string": "^1.0.0"
       }
-    },
-    "gray-percentage": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gray-percentage/-/gray-percentage-2.0.0.tgz",
-      "integrity": "sha1-tyonTRsTeRBKAFC2OyB9xT/lb5k="
     },
     "gud": {
       "version": "1.0.0",
@@ -8540,16 +8493,6 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -9096,14 +9039,6 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
-      }
-    },
-    "modularscale": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/modularscale/-/modularscale-1.0.2.tgz",
-      "integrity": "sha1-So8TrzKl5SFPxuLPxSkGSr/X2Hc=",
-      "requires": {
-        "lodash.isnumber": "^3.0.0"
       }
     },
     "moment": {
@@ -9661,6 +9596,14 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
     },
+    "p-queue": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-5.0.0.tgz",
+      "integrity": "sha512-6QfeouDf236N+MAxHch0CVIy8o/KBnmhttKjxZoOkUlzqU+u9rZgEyXH3OdckhTgawbqf5rpzmyR+07+Lv0+zg==",
+      "requires": {
+        "eventemitter3": "^3.1.0"
+      }
+    },
     "p-retry": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
@@ -9838,11 +9781,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-    },
-    "parse-unit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
     },
     "parse5": {
       "version": "5.1.0",
@@ -12695,15 +12633,6 @@
         "inline-style-parser": "0.1.1"
       }
     },
-    "styled-system": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-4.2.4.tgz",
-      "integrity": "sha512-44X7n09gDvwx7yjquEXsjiNALK0dxGgAJdpO5cb/PdL+D4mhSLKWig4/EhH4vHJLbwu/kumURHyvKxygaBfg0A==",
-      "requires": {
-        "@babel/runtime": "^7.4.2",
-        "prop-types": "^15.7.2"
-      }
-    },
     "stylehacks": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -12911,21 +12840,14 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theme-ui": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.0.12.tgz",
-      "integrity": "sha512-vFutGQJgYuxI9ZfusWCx6wknCrthULhxhGBCQhhXOSs32Av0l5KvycMowAsLeEcBD5EifPronQncfmwUI8zQmA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.2.tgz",
+      "integrity": "sha512-ce29BzEP2pSogQ5XxtEUDXcwdtcb1SdPgJCZdFi7sfglA2vdADY6CdRXxZ6cVrdeVaDQQMtSaIbFghpplZbGMg==",
       "requires": {
-        "@emotion/core": "^10.0.0",
-        "@emotion/styled": "^10.0.0",
-        "@mdx-js/react": "^1.0.0",
-        "@styled-system/css": "^2.0.0",
-        "css-what": "^2.1.3",
-        "emotion-theming": "^10.0.0",
-        "lodash.get": "^4.4.0",
-        "lodash.merge": "^4.6.0",
-        "react": "^16.8.0",
-        "styled-system": "^4.0.0",
-        "typography": "^0.16.0"
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@styled-system/css": "^5.0.5",
+        "deepmerge": "^3.2.0",
+        "react": "^16.8.0"
       }
     },
     "through": {
@@ -13134,25 +13056,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typography": {
-      "version": "0.16.19",
-      "resolved": "https://registry.npmjs.org/typography/-/typography-0.16.19.tgz",
-      "integrity": "sha512-zfsyjPPB1RaK8TzU3REta6EGDZa++YQ6g/CWw7hy/8xQK1qyzFWisMIw5J+Yg1KyiVgcchmxlgMcMA6JAJ9oew==",
-      "requires": {
-        "compass-vertical-rhythm": "^1.4.5",
-        "decamelize": "^1.2.0",
-        "gray-percentage": "^2.0.0",
-        "lodash": "^4.13.1",
-        "modularscale": "^1.0.2",
-        "object-assign": "^4.1.0",
-        "typography-normalize": "^0.16.19"
-      }
-    },
-    "typography-normalize": {
-      "version": "0.16.19",
-      "resolved": "https://registry.npmjs.org/typography-normalize/-/typography-normalize-0.16.19.tgz",
-      "integrity": "sha512-vtnSv/uGBZVbd4e/ZhZB9HKBgKKlWQUXw74+ADIHHxzKp27CEf8PSR8TX1zF2qSyQ9/qMdqLwXYz8yRQFq9JLQ=="
     },
     "ua-parser-js": {
       "version": "0.7.20",

--- a/themes/gatsby-starter-notes-theme/package.json
+++ b/themes/gatsby-starter-notes-theme/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "gatsby": "^2.13.1",
-    "gatsby-theme-notes": "*",
+    "gatsby-theme-notes": "^0.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/themes/gatsby-starter-theme/package-lock.json
+++ b/themes/gatsby-starter-theme/package-lock.json
@@ -955,26 +955,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
       "integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
     },
-    "@emotion/styled": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.14.tgz",
-      "integrity": "sha512-Ae8d5N/FmjvZKXjqWcjfhZhjCdkvxZSqD95Q72BYDNQnsOKLHIA4vWlMolLXDNkw1dIxV3l2pp82Z87HXj6eYQ==",
-      "requires": {
-        "@emotion/styled-base": "^10.0.14",
-        "babel-plugin-emotion": "^10.0.14"
-      }
-    },
-    "@emotion/styled-base": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.14.tgz",
-      "integrity": "sha512-1nC5iO/Rk0DY47M5wXCyWpbo/woiwXWfVbNKDM3QRi7CKq8CwC++PQ5HgiYflFrAt1vjzIVZqnzrIn3idUoQgg==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "@emotion/is-prop-valid": "0.8.2",
-        "@emotion/serialize": "^0.11.8",
-        "@emotion/utils": "0.11.2"
-      }
-    },
     "@emotion/stylis": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
@@ -1442,105 +1422,19 @@
       "resolved": "https://registry.npmjs.org/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz",
       "integrity": "sha512-MNodHp46og+Sdde/LCxTLrxcD5Dimu21R/Fer2raXMG1XtHSV2+vZnkIV87OPAxuf2NiDj1W5hN7Q2MYUfQQ8w=="
     },
-    "@styled-system/background": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.0.12.tgz",
-      "integrity": "sha512-CFDLrq6KwZgVwBOMaDnEDJWMELsg4slmjFGHvpxU3bi/JHbEepzksGoY/j2QroIh1lm8sS7vIzl1a6xMtMoytQ==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/border": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.0.12.tgz",
-      "integrity": "sha512-jU8Xz5ZXipEtVJsPAKmpO1tCZSymXr2gyYW9ZVQKztDIn4SFortNqkhIiBEZ528qowVYZte7OQWpecTIOYB5wQ==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/color": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.0.12.tgz",
-      "integrity": "sha512-bNh1a10CzarHj5rrPyJsVq+WRRdnv7H4SEEngNt07HV6Iq/ds7Gcrp+QJzGtqmF2u3BPSFRLhj9tNQGhFhPq7A==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/core": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.0.12.tgz",
-      "integrity": "sha512-AScxlT6JQ5bQ4XS5pYmDgv3rGCJtTxK9gEfDtmOU2d+7gGhzG/7DtoxnOlXufUn6xNIm9GL0izyOLti73e9YHg==",
-      "requires": {
-        "object-assign": "^4.1.1"
-      }
-    },
     "@styled-system/css": {
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.11.tgz",
       "integrity": "sha512-rq/KO2SEpUbk9dWIRdWEkNL3w6Eds55KGdAcD+9DttqrC+FwPXfk27ebmTMfwyIAiDES9uW7z57Bo6v34VUNqw=="
     },
-    "@styled-system/flexbox": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.0.12.tgz",
-      "integrity": "sha512-2EETVEFHK+HYeHEcxwJ0UXxyQWF4WX0JuP1KwsS/yLzMQ20O1PGnaj6RxGxHpGWnWNl5XNEvAUcUIvktH4Yfvw==",
+    "@theme-ui/typography": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/typography/-/typography-0.2.1.tgz",
+      "integrity": "sha512-wo6lDXqkyfEYJyJA4BXCCeB/KP33RK88E5YaUynGy1hut5Q0isbcaI38ueWLAThSTvu8QLl2rxaWEuNbHDLACA==",
       "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/grid": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.0.12.tgz",
-      "integrity": "sha512-sZ+JWJANSrBCn9U9ZSfw3qWLvNjJc9MQLW662M+M37RG+FZg+lzgzXhnhuS4iBVV3UK1YsMFdGMs+VKdMN3N3A==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/layout": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.0.12.tgz",
-      "integrity": "sha512-5FlVI95S0JkWBSl3X9uCS/wv+laBaXalTqCoWC6XM4bwh3vN5LjSR6KSwRUvV6+CVEHb272lR3Kkjxn+OUcv1Q==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/position": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.0.12.tgz",
-      "integrity": "sha512-TRnmp+xrwvcUa45kb9t+u+2L7ImjM+xqlTjtUyCk9K0FhBdE0jqSwUuh/LnnAbM6pSHeije31XKtbZXF1XeG/w==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/shadow": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.0.12.tgz",
-      "integrity": "sha512-ErOTpAUrITYsqNb6j/qq8NZAoWORq/JkwQ56OS02n/B7K4eA79CwMsOLhs5E6bspgw5Gdg10CVrDnm1p1fquhw==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/space": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.0.12.tgz",
-      "integrity": "sha512-Mv+YJGIjuzq0yi1GWuKj9zAZtGg01wF/VdP4E0XMZpnR4spqD4pMlLRK+iuiBMbN1mHPy1iymEQP8Epe5S8euQ==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/typography": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.0.12.tgz",
-      "integrity": "sha512-PbEDVNnVWie82B6ot0lozmwKkZGGlhWGH+kVx4kXzpgKRD518qVc2fTPtwidCC11s/T/+p1teCkxa6Rbsv9rjg==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
-      }
-    },
-    "@styled-system/variant": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.0.12.tgz",
-      "integrity": "sha512-X0pH3Bf7YEyZmUYE8kTX1cFDjHKIBhkZfkO7POB7WKN1qqVz+k3ioPIhZm9u1QWr4XYZ6bvmqAzZJ/W0cQIZ7A==",
-      "requires": {
-        "@styled-system/core": "^5.0.12"
+        "compass-vertical-rhythm": "^1.4.5",
+        "modularscale": "^2.0.1",
+        "object-assign": "^4.1.1"
       }
     },
     "@types/configstore": {
@@ -5130,16 +5024,6 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
-    "emotion-theming": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.14.tgz",
-      "integrity": "sha512-zMGhPSYz48AAR6DYjQVaZHeO42cYKPq4VyB1XjxzgR62/NmO99679fx8qDDB1QZVYGkRWZtsOe+zJE/e30XdbA==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "@emotion/weak-memoize": "0.2.3",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -7320,9 +7204,9 @@
       }
     },
     "gatsby-image": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.3.tgz",
-      "integrity": "sha512-FRmKHkbvbJXYzdjxWaTr0Btm3yZCIFiEMXPf6VFTCaMGXzRUW30mCpaffqy10frpr9769zZC55LT01k4VHKaBA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.4.tgz",
+      "integrity": "sha512-wlbqGsfIX2+ILz/fk/94fDShc5zfhTlj7vYGyTFZfKombvwPXFAJD6pey4zTBZUUBrxMt2tROMXNnmFi3wGyww==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "object-fit-images": "^3.2.4",
@@ -7337,63 +7221,6 @@
         "@babel/runtime": "^7.0.0",
         "@types/reach__router": "^1.0.0",
         "prop-types": "^15.6.1"
-      }
-    },
-    "gatsby-mdx": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/gatsby-mdx/-/gatsby-mdx-0.6.3.tgz",
-      "integrity": "sha512-jrSXGul8KRqTcwHdZHYl2HmRMjbgfnb0WlFEUt2r/kzeF46BvkHA0PqnWnCrTL3HBzLbY/3mX/KFbaFxlr/nYA==",
-      "requires": {
-        "@babel/core": "^7.4.3",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
-        "@babel/preset-env": "^7.4.3",
-        "@babel/preset-react": "^7.0.0",
-        "core-js": "2",
-        "dataloader": "^1.4.0",
-        "debug": "^4.0.1",
-        "escape-string-regexp": "^1.0.5",
-        "fs-extra": "^7.0.0",
-        "gray-matter": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "lodash": "^4.17.10",
-        "mdast-util-to-string": "^1.0.4",
-        "mdast-util-toc": "^3.0.0",
-        "mime": "^2.3.1",
-        "pretty-bytes": "^5.1.0",
-        "remark": "^10.0.0",
-        "remark-retext": "^3.1.2",
-        "retext-english": "^3.0.2",
-        "slash": "^2.0.0",
-        "static-site-generator-webpack-plugin": "^3.4.2",
-        "underscore.string": "^3.3.4",
-        "unist-util-map": "^1.0.4",
-        "unist-util-remove": "^1.0.1",
-        "unist-util-visit": "^1.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "slash": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
-        }
       }
     },
     "gatsby-page-utils": {
@@ -7454,9 +7281,9 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.6.tgz",
-      "integrity": "sha512-Ft3pP2jpJVaMK4zXFfK7cy8VDZqwBqXs5Y//hWM5rFEaRSgHevl4cYMNb/5pKcYrk+MaxVOGCUUsMiwd0P/bsw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.7.tgz",
+      "integrity": "sha512-sXubUJhKO8nC4vEe7ME1htlQ4LPtRC7hhZF3fHl26gy5zNuHiCVtHZROoVIaiEY7UECGZzX8CjEblGVNgSmD2A==",
       "requires": {
         "@babel/core": "^7.4.3",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
@@ -7573,9 +7400,9 @@
       }
     },
     "gatsby-plugin-sharp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.1.tgz",
-      "integrity": "sha512-NoAf3HK9xT9YdTd8rHf9SoBJoq9uZ+qLxTVe9xdAeOusGrnPIndbZIbPKzzBrhJZ94kihEf7ehEfGCwsh6c1Sw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.2.tgz",
+      "integrity": "sha512-e7+4EWLhcucRHFjtDTJFe04IjvLyh0U6Q+CqqcYmL/veIDTVf7XvGefiKlcFxG8ys6l2d3gd3L4+nR8WzV6lCA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "async": "^2.1.2",
@@ -7783,9 +7610,9 @@
       }
     },
     "gatsby-remark-prismjs": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.0.tgz",
-      "integrity": "sha512-87UMtykDD8+kkR77MaY6pnJtqntUw0r8vqcsKxtgMkup9TMpwKvb8JHj2eSpl1NGdQDDjovYVNfkOfroQrkaJw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.1.tgz",
+      "integrity": "sha512-V0rzHqmVgzJX6WSse4d29wfSv4Y8zm1Qfl3xwbMngiSENZ8gLvCiMDKZGrV8QcwJNyUyDsBDCNakGKyCvTu5EA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "parse-numeric-range": "^0.0.2",
@@ -7839,9 +7666,9 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.1.tgz",
-      "integrity": "sha512-B01of7+bvpyaJz6uF4mM/kVfZrkxB28kfg+csHE9Ro8w+4+qGAFG/HKYGOCQxeKNL/yI6Uw8KeKLMW14KVD0UA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.2.tgz",
+      "integrity": "sha512-mrlQ00Es+qjb2MCIEHAkv/F3yfR5IgI8z2q54tqpxu4amlUy3SQH5ThJDGD7Ya574ub9aKdHOr8virTssmTDgA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "better-queue": "^3.8.7",
@@ -7959,13 +7786,14 @@
       }
     },
     "gatsby-theme-blog": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-0.0.9.tgz",
-      "integrity": "sha512-pNgInwexTz+8k4vCrbXgqp3jvcqujZAke2GGplhP2vuLAm9rsIyXObsQH5lU4SdjsH+Jxf1dkRYroubaO+CPGg==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-0.0.10.tgz",
+      "integrity": "sha512-RqGyifxZHWQyZKvHTR4p7nNYGI6hy1GrkJ8LorisCYaBeYBFI3xrxt5F+31VB8twU2k+/8VLUYo7ulF1n5AMkw==",
       "requires": {
         "@emotion/core": "^10.0.10",
         "@mdx-js/mdx": "^1.0.15",
         "@mdx-js/react": "^1.0.15",
+        "@theme-ui/typography": "^0.2.0",
         "gatsby-image": "^2.0.31",
         "gatsby-plugin-emotion": "^4.0.6",
         "gatsby-plugin-feed": "^2.0.14",
@@ -7981,82 +7809,49 @@
         "gatsby-remark-responsive-iframe": "^2.1.1",
         "gatsby-remark-smartypants": "^2.0.8",
         "gatsby-source-filesystem": "^2.0.23",
-        "gatsby-theme-ui": "^0.1.5",
+        "gatsby-theme-ui": "^0.2.0",
         "gatsby-transformer-sharp": "^2.1.15",
         "lodash.merge": "^4.6.1",
         "prismjs": "^1.15.0",
         "react-helmet": "^5.2.0",
+        "react-switch": "^5.0.0",
         "remark-slug": "^5.1.1",
-        "theme-ui": "^0.1.5",
-        "theme-ui-typography": "^0.1.3",
+        "theme-ui": "^0.2.0",
         "typeface-merriweather": "0.0.72",
         "typeface-montserrat": "0.0.54",
         "typography-theme-wordpress-2016": "^0.16.18"
       }
     },
     "gatsby-theme-notes": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-0.0.1.tgz",
-      "integrity": "sha512-r5bsrFSkztWlE7gNbxxHakU0fU5dUu8O3MIFYlMrfaQChT6jyUqH7U0QrymCLlr5cXatnRpakefl3SV//kmmKw==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-0.0.2.tgz",
+      "integrity": "sha512-0UJDLi6qiWxYw3qIIXMggLN3g4EUUa5eB18TKad3T8AkZxzlr9I43ZRyStaFGewlovUEGQGg+m4BuNDci4NMSg==",
       "requires": {
         "@emotion/core": "^10.0.10",
         "@mdx-js/mdx": "^1.0.19",
         "@mdx-js/react": "^1.0.16",
-        "gatsby-mdx": "^0.6.3",
         "gatsby-plugin-compile-es6-packages": "^1.1.0",
         "gatsby-plugin-emotion": "^4.0.6",
+        "gatsby-plugin-mdx": "^1.0.5",
         "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-plugin-og-image": "0.0.1",
         "gatsby-plugin-redirects": "^1.0.0",
         "gatsby-source-filesystem": "^2.0.35",
+        "gatsby-theme-ui": "^0.2.0",
         "is-present": "^1.0.0",
         "react-feather": "^1.1.6",
-        "theme-ui": "^0.0.12"
-      },
-      "dependencies": {
-        "@styled-system/css": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-2.0.4.tgz",
-          "integrity": "sha512-Y7D+rqEpQk4311GDrzRtO5yreILywX8JiFYWyXhB5eG8Qz7kF4KKhpta54e5GA/FGFcPF47HVKjcuATf3hqsMQ=="
-        },
-        "styled-system": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-4.2.4.tgz",
-          "integrity": "sha512-44X7n09gDvwx7yjquEXsjiNALK0dxGgAJdpO5cb/PdL+D4mhSLKWig4/EhH4vHJLbwu/kumURHyvKxygaBfg0A==",
-          "requires": {
-            "@babel/runtime": "^7.4.2",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "theme-ui": {
-          "version": "0.0.12",
-          "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.0.12.tgz",
-          "integrity": "sha512-vFutGQJgYuxI9ZfusWCx6wknCrthULhxhGBCQhhXOSs32Av0l5KvycMowAsLeEcBD5EifPronQncfmwUI8zQmA==",
-          "requires": {
-            "@emotion/core": "^10.0.0",
-            "@emotion/styled": "^10.0.0",
-            "@mdx-js/react": "^1.0.0",
-            "@styled-system/css": "^2.0.0",
-            "css-what": "^2.1.3",
-            "emotion-theming": "^10.0.0",
-            "lodash.get": "^4.4.0",
-            "lodash.merge": "^4.6.0",
-            "react": "^16.8.0",
-            "styled-system": "^4.0.0",
-            "typography": "^0.16.0"
-          }
-        }
+        "theme-ui": "^0.2.0"
       }
     },
     "gatsby-theme-ui": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-ui/-/gatsby-theme-ui-0.1.7.tgz",
-      "integrity": "sha512-w2p31ZjbWU6YWelnxbtGYFreocMycalJl5/YK/jtC/CuFRNaOqCbLuCL2AFU/RPQvhWdY19MFDjS0h2IEuD+aw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-ui/-/gatsby-theme-ui-0.2.0.tgz",
+      "integrity": "sha512-TS5ykhCpcb7/IRJbjDBw0uRytpsh/inJvbpiyrm8IrOGdtdev+3G1qpwJgZ/Qs7mkMYAyFxZ7IwJWIPOqfWqRg=="
     },
     "gatsby-transformer-sharp": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.0.tgz",
-      "integrity": "sha512-5M+1I2r+x4UBTTQapzCGYX8bO2OOFRF7NqE2emXBqquepqi7IdiUahK6c5/C0vXwpvTnXgHZt8xg13zuRm8rKw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.1.tgz",
+      "integrity": "sha512-KmUqtvt3ry8bL6RMfHwMgRH4AJcDOJgGMTyLeULUScDoKTSriColPhbXMmJzM4Gsq3NUNqJkRo9qvNxBqnSWtQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "bluebird": "^3.5.0",
@@ -10176,11 +9971,6 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
@@ -10782,9 +10572,9 @@
       }
     },
     "mini-svg-data-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.0.3.tgz",
-      "integrity": "sha512-YBaqsh6GE+4jQhLNkFYEagH2o4bVTlGGpEvkuwtwc+1NBGXqpcVCnsUGkGp75ovPXxtF2GsDYzUwyhfC0hntiA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.1.3.tgz",
+      "integrity": "sha512-EeKOmdzekjdPe53/GdxmUpNgDQFkNeSte6XkJmOBt4BfWL6FQ9G9RtLNh+JMjFS3LhdpSICMIkZdznjiecASHQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -13207,6 +12997,14 @@
         "shallowequal": "^1.0.1"
       }
     },
+    "react-switch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.0.tgz",
+      "integrity": "sha512-+zxY9xj9dMc8Y4gv/kkqQrirfEiIQ+SlQfJDW1Wi81L3xoh1fcbBYyJyh0TnhM/U/b6HxuBmkmU4Ooxgtuoavw==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -15115,26 +14913,6 @@
         "inline-style-parser": "0.1.1"
       }
     },
-    "styled-system": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.0.12.tgz",
-      "integrity": "sha512-QWtzon68s0Igbo9cGnNv1BBjfWw6SKXyLDRmXbzwiCd5d93b5Yzzfrx9FM2emy1Up012TU3h4vGj/q++uAYafQ==",
-      "requires": {
-        "@styled-system/background": "^5.0.12",
-        "@styled-system/border": "^5.0.12",
-        "@styled-system/color": "^5.0.12",
-        "@styled-system/core": "^5.0.12",
-        "@styled-system/flexbox": "^5.0.12",
-        "@styled-system/grid": "^5.0.12",
-        "@styled-system/layout": "^5.0.12",
-        "@styled-system/position": "^5.0.12",
-        "@styled-system/shadow": "^5.0.12",
-        "@styled-system/space": "^5.0.12",
-        "@styled-system/typography": "^5.0.12",
-        "@styled-system/variant": "^5.0.12",
-        "object-assign": "^4.1.1"
-      }
-    },
     "stylehacks": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -15413,27 +15191,21 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theme-ui": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.1.7.tgz",
-      "integrity": "sha512-Hs+iPyPBlcT1ieD6krMKa32JxTOoHy4gJaznT2KqhpzQ2fnQJBqTVXMF2AFrqHCHK+CaL1s+qqjb7q/NSqCccg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.2.tgz",
+      "integrity": "sha512-ce29BzEP2pSogQ5XxtEUDXcwdtcb1SdPgJCZdFi7sfglA2vdADY6CdRXxZ6cVrdeVaDQQMtSaIbFghpplZbGMg==",
       "requires": {
+        "@emotion/is-prop-valid": "^0.8.1",
         "@styled-system/css": "^5.0.5",
-        "lodash.merge": "^4.6.0",
-        "react": "^16.8.0",
-        "styled-system": "^5.0.5"
-      }
-    },
-    "theme-ui-typography": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/theme-ui-typography/-/theme-ui-typography-0.1.7.tgz",
-      "integrity": "sha512-2aRk1//Fp9qwvdIW+wBCzQiE3w8PWHwH/e1J68zNEvKpL4H2gciE3A8b3RSGk6buqWn92+oZWITb5T3LG9LNFw==",
-      "requires": {
-        "compass-vertical-rhythm": "^1.4.5",
-        "css-what": "^2.1.3",
-        "lodash.merge": "^4.6.1",
-        "modularscale": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "typography": "^0.16.19"
+        "deepmerge": "^3.2.0",
+        "react": "^16.8.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
+        }
       }
     },
     "through": {
@@ -15706,39 +15478,10 @@
       "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-0.0.54.tgz",
       "integrity": "sha512-Typhap0PWT299+Va0G/8ZtycHMXrH4gBWKfiW977KEBx5rXUUCa70gvqLx1fdA0WAo6bhSAQmo8uc+QFAmjPww=="
     },
-    "typography": {
-      "version": "0.16.19",
-      "resolved": "https://registry.npmjs.org/typography/-/typography-0.16.19.tgz",
-      "integrity": "sha512-zfsyjPPB1RaK8TzU3REta6EGDZa++YQ6g/CWw7hy/8xQK1qyzFWisMIw5J+Yg1KyiVgcchmxlgMcMA6JAJ9oew==",
-      "requires": {
-        "compass-vertical-rhythm": "^1.4.5",
-        "decamelize": "^1.2.0",
-        "gray-percentage": "^2.0.0",
-        "lodash": "^4.13.1",
-        "modularscale": "^1.0.2",
-        "object-assign": "^4.1.0",
-        "typography-normalize": "^0.16.19"
-      },
-      "dependencies": {
-        "modularscale": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/modularscale/-/modularscale-1.0.2.tgz",
-          "integrity": "sha1-So8TrzKl5SFPxuLPxSkGSr/X2Hc=",
-          "requires": {
-            "lodash.isnumber": "^3.0.0"
-          }
-        }
-      }
-    },
     "typography-breakpoint-constants": {
       "version": "0.16.19",
       "resolved": "https://registry.npmjs.org/typography-breakpoint-constants/-/typography-breakpoint-constants-0.16.19.tgz",
       "integrity": "sha512-vXjfV9hwAXIOf5+U5GN137ahBkK+sj1TJu/5ksmP+8XB/D80lmGb/m0nKviWaQ3t7HLrK848VGrFS+6E2vcmVg=="
-    },
-    "typography-normalize": {
-      "version": "0.16.19",
-      "resolved": "https://registry.npmjs.org/typography-normalize/-/typography-normalize-0.16.19.tgz",
-      "integrity": "sha512-vtnSv/uGBZVbd4e/ZhZB9HKBgKKlWQUXw74+ADIHHxzKp27CEf8PSR8TX1zF2qSyQ9/qMdqLwXYz8yRQFq9JLQ=="
     },
     "typography-theme-wordpress-2016": {
       "version": "0.16.19",

--- a/themes/gatsby-starter-theme/package.json
+++ b/themes/gatsby-starter-theme/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "gatsby": "^2.13.1",
-    "gatsby-theme-blog": "*",
-    "gatsby-theme-notes": "*",
+    "gatsby-theme-blog": "^0.0.10",
+    "gatsby-theme-notes": "^0.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-blog",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "A Gatsby theme for miscellaneous blogging with a dark/light mode",
   "main": "index.js",
   "license": "MIT",

--- a/themes/gatsby-theme-notes/package.json
+++ b/themes/gatsby-theme-notes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-notes",
   "description": "Gatsby Theme for adding a notes section to your website",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "John Otander",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
With this renovate bot _should_ update lock file when new theme version is released

Potential issues with this:
versions in themes package.json need to be kept to date (so while lerna has some issues with handling versioning for now), those will need to be commited manually (ideally in same order as with lerna - first commit, then publish)