### PR TITLE
fix(gatsby): regression ~ show non structured grapqhl errors

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/__snapshots__/graphql-runner.js.snap
+++ b/packages/gatsby/src/bootstrap/__tests__/__snapshots__/graphql-runner.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`grapqhl-runner should throw a structured error when created from createPage file 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        Object {
+          "context": Object {
+            "fromGraphQLFunction": true,
+            "sourceMessage": "Cannot query field boyhowdy on RootQueryType",
+          },
+          "filePath": "my-gatsby-project/gatsby-node.js",
+          "id": "85901",
+          "location": Object {
+            "start": Object {
+              "column": 17,
+              "line": 32,
+            },
+          },
+        },
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
@@ -3,6 +3,16 @@ jest.mock(`graphql`)
 const createGraphqlRunner = require(`../graphql-runner`)
 const { graphql } = require(`graphql`)
 
+const createStore = (schema = {}) => {
+  return {
+    getState: () => {
+      return {
+        schema,
+      }
+    },
+  }
+}
+
 describe(`grapqhl-runner`, () => {
   let reporter
 
@@ -13,7 +23,7 @@ describe(`grapqhl-runner`, () => {
   })
 
   it(`should return the result when grapqhl has no errors`, async () => {
-    const graphqlRunner = createGraphqlRunner({}, reporter)
+    const graphqlRunner = createGraphqlRunner(createStore(), reporter)
 
     const expectation = {
       data: {
@@ -28,7 +38,7 @@ describe(`grapqhl-runner`, () => {
   })
 
   it(`should return an errors array when structured errors found`, async () => {
-    const graphqlRunner = createGraphqlRunner({}, reporter)
+    const graphqlRunner = createGraphqlRunner(createStore(), reporter)
 
     const expectation = {
       errors: [
@@ -46,7 +56,7 @@ describe(`grapqhl-runner`, () => {
   })
 
   it(`should throw a structured error when created from createPage file`, async () => {
-    const graphqlRunner = createGraphqlRunner({}, reporter)
+    const graphqlRunner = createGraphqlRunner(createStore(), reporter)
 
     const errorObject = {
       stack: `Error

--- a/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
@@ -1,0 +1,68 @@
+jest.mock(`graphql`)
+
+const createGraphqlRunner = require(`../graphql-runner`)
+const { graphql } = require(`graphql`)
+
+describe(`grapqhl-runner`, () => {
+  let reporter
+
+  beforeEach(() => {
+    reporter = {
+      panicOnBuild: jest.fn(),
+    }
+  })
+
+  it(`should return the result when grapqhl has no errors`, async () => {
+    const graphqlRunner = createGraphqlRunner({}, reporter)
+
+    const expectation = {
+      data: {
+        gatsby: `is awesome`,
+      },
+    }
+    graphql.mockImplementation(() => Promise.resolve(expectation))
+
+    const result = await graphqlRunner({}, {})
+    expect(reporter.panicOnBuild).not.toHaveBeenCalled()
+    expect(result).toBe(expectation)
+  })
+
+  it(`should return an errors array when structured errors found`, async () => {
+    const graphqlRunner = createGraphqlRunner({}, reporter)
+
+    const expectation = {
+      errors: [
+        {
+          message: `Cannot query field boyhowdy on RootQueryType`,
+          locations: [{ line: 1, column: 3 }],
+        },
+      ],
+    }
+    graphql.mockImplementation(() => Promise.resolve(expectation))
+
+    const result = await graphqlRunner({}, {})
+    expect(reporter.panicOnBuild).not.toHaveBeenCalled()
+    expect(result).toBe(expectation)
+  })
+
+  it(`should throw a structured error when created from createPage file`, async () => {
+    const graphqlRunner = createGraphqlRunner({}, reporter)
+
+    const errorObject = {
+      stack: `Error
+      at createPages (my-gatsby-project/gatsby-node.js:32:17)
+      `,
+      message: `Cannot query field boyhowdy on RootQueryType`,
+    }
+
+    graphql.mockImplementation(() =>
+      Promise.resolve({
+        errors: [errorObject],
+      })
+    )
+
+    await graphqlRunner({}, {})
+    expect(reporter.panicOnBuild).toHaveBeenCalled()
+    expect(reporter.panicOnBuild).toMatchSnapshot()
+  })
+})

--- a/packages/gatsby/src/bootstrap/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/graphql-runner.js
@@ -1,0 +1,50 @@
+const { graphql } = require(`graphql`)
+const stackTrace = require(`stack-trace`)
+const withResolverContext = require(`../schema/context`)
+const errorParser = require(`../query/error-parser`).default
+
+const createGraphqlRunner = (schema, reporter) => (query, context = {}) =>
+  graphql(
+    schema,
+    query,
+    context,
+    withResolverContext(context, schema),
+    context
+  ).then(result => {
+    if (result.errors) {
+      const structuredErrors = result.errors
+        .map(e => {
+          // Find the file where graphql was called.
+          const file = stackTrace
+            .parse(e)
+            .find(file => /createPages/.test(file.functionName))
+
+          if (file) {
+            const structuredError = errorParser({
+              message: e.message,
+              location: {
+                start: { line: file.lineNumber, column: file.columnNumber },
+              },
+              filePath: file.fileName,
+            })
+            structuredError.context = {
+              ...structuredError.context,
+              fromGraphQLFunction: true,
+            }
+            return structuredError
+          }
+
+          return null
+        })
+        .filter(Boolean)
+
+      if (structuredErrors.length) {
+        // panic on build exits the process
+        reporter.panicOnBuild(structuredErrors)
+      }
+    }
+
+    return result
+  })
+
+module.exports = createGraphqlRunner

--- a/packages/gatsby/src/bootstrap/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/graphql-runner.js
@@ -3,8 +3,10 @@ const stackTrace = require(`stack-trace`)
 const withResolverContext = require(`../schema/context`)
 const errorParser = require(`../query/error-parser`).default
 
-const createGraphqlRunner = (schema, reporter) => (query, context = {}) =>
-  graphql(
+const createGraphqlRunner = (store, reporter) => (query, context = {}) => {
+  const schema = store.getState().schema
+
+  return graphql(
     schema,
     query,
     context,
@@ -46,5 +48,6 @@ const createGraphqlRunner = (schema, reporter) => (query, context = {}) =>
 
     return result
   })
+}
 
 module.exports = createGraphqlRunner

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -12,7 +12,6 @@ const telemetry = require(`gatsby-telemetry`)
 
 const apiRunnerNode = require(`../utils/api-runner-node`)
 const getBrowserslist = require(`../utils/browserslist`)
-const { graphql } = require(`graphql`)
 const { store, emitter } = require(`../redux`)
 const loadPlugins = require(`./load-plugins`)
 const loadThemes = require(`./load-themes`)
@@ -21,17 +20,17 @@ const getConfigFile = require(`./get-config-file`)
 const tracer = require(`opentracing`).globalTracer()
 const preferDefault = require(`./prefer-default`)
 const nodeTracking = require(`../db/node-tracking`)
-const withResolverContext = require(`../schema/context`)
-const stackTrace = require(`stack-trace`)
-import errorParser from "../query/error-parser"
 // Add `util.promisify` polyfill for old node versions
 require(`util.promisify/shim`)()
 
 // Show stack trace on unhandled promises.
 process.on(`unhandledRejection`, (reason, p) => {
+  console.log(reason)
+
   report.panic(reason)
 })
 
+const createGraphqlRunner = require(`./graphql-runner`)
 const { extractQueries } = require(`../query/query-watcher`)
 const requiresWriter = require(`./requires-writer`)
 const { writeRedirects } = require(`./redirects-writer`)
@@ -385,46 +384,7 @@ module.exports = async (args: BootstrapArgs) => {
     payload: _.flattenDeep([extensions, apiResults]),
   })
 
-  const graphqlRunner = (query, context = {}) => {
-    const schema = store.getState().schema
-    return graphql(
-      schema,
-      query,
-      context,
-      withResolverContext(context, schema),
-      context
-    ).then(result => {
-      if (result.errors) {
-        report.panicOnBuild(
-          result.errors
-            .map(e => {
-              // Find the file where graphql was called.
-              const file = stackTrace
-                .parse(e)
-                .find(file => /createPages/.test(file.functionName))
-              if (file) {
-                const structuredError = errorParser({
-                  message: e.message,
-                  location: {
-                    start: { line: file.lineNumber, column: file.columnNumber },
-                  },
-                  filePath: file.fileName,
-                })
-                structuredError.context = {
-                  ...structuredError.context,
-                  fromGraphQLFunction: true,
-                }
-                return structuredError
-              }
-              return null
-            })
-            .filter(_.isObject)
-        )
-      }
-
-      return result
-    })
-  }
+  const graphqlRunner = createGraphqlRunner(store.getState().schema, report)
 
   // Collect pages.
   activity = report.activityTimer(`createPages`, {

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -382,7 +382,7 @@ module.exports = async (args: BootstrapArgs) => {
     payload: _.flattenDeep([extensions, apiResults]),
   })
 
-  const graphqlRunner = createGraphqlRunner(store.getState().schema, report)
+  const graphqlRunner = createGraphqlRunner(store, report)
 
   // Collect pages.
   activity = report.activityTimer(`createPages`, {

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -25,8 +25,6 @@ require(`util.promisify/shim`)()
 
 // Show stack trace on unhandled promises.
 process.on(`unhandledRejection`, (reason, p) => {
-  console.log(reason)
-
   report.panic(reason)
 })
 


### PR DESCRIPTION
## Description
It looks like we're eating graphql errors not coming from createPages functions. I refactored graphql-runner a little bit so I could write a unit test for it.

## Related Issues
Fixes #15261
