### PR TITLE
fix(www): skip starter showcase entries that don't have screenshots

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -413,6 +413,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
                   slug
                   stub
                 }
+                hasScreenshot
               }
               url
               repo
@@ -531,6 +532,13 @@ exports.createPages = ({ graphql, actions, reporter }) => {
       const starters = _.filter(result.data.allStartersYaml.edges, edge => {
         const slug = _.get(edge, `node.fields.starterShowcase.slug`)
         if (!slug) {
+          return null
+        } else if (!_.get(edge, `node.fields.hasScreenshot`)) {
+          reporter.warn(
+            `Starter showcase entry "${
+              edge.node.repo
+            }" seems offline. Skipping.`
+          )
           return null
         } else {
           return edge
@@ -762,6 +770,13 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
       gatsbyDependencies: [[`no data`, `0`]],
       miscDependencies: [[`no data`, `0`]],
     }
+
+    // determine if screenshot is available
+    const screenshotNode = node.children
+      .map(childID => getNode(childID))
+      .find(node => node.internal.type === `Screenshot`)
+
+    createNodeField({ node, name: `hasScreenshot`, value: !!screenshotNode })
 
     if (!process.env.GITHUB_API_TOKEN) {
       return createNodeField({

--- a/www/src/pages/ecosystem.js
+++ b/www/src/pages/ecosystem.js
@@ -72,7 +72,10 @@ export const ecosystemQuery = graphql`
   ) {
     allStartersYaml(
       filter: {
-        fields: { starterShowcase: { slug: { in: $featuredStarters } } }
+        fields: {
+          starterShowcase: { slug: { in: $featuredStarters } }
+          hasScreenshot: { eq: true }
+        }
       }
     ) {
       edges {

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -193,7 +193,10 @@ export const pageQuery = graphql`
     }
     allStartersYaml(
       filter: {
-        fields: { starterShowcase: { slug: { in: $featuredStarters } } }
+        fields: {
+          starterShowcase: { slug: { in: $featuredStarters } }
+          hasScreenshot: { eq: true }
+        }
       }
       sort: { order: DESC, fields: [fields___starterShowcase___stars] }
     ) {

--- a/www/src/pages/starters.js
+++ b/www/src/pages/starters.js
@@ -16,7 +16,7 @@ export default StarterLibraryWrapper
 
 export const showcaseQuery = graphql`
   query SiteShowcaseQuery {
-    allStartersYaml {
+    allStartersYaml(filter: { fields: { hasScreenshot: { eq: true } } }) {
       edges {
         node {
           id


### PR DESCRIPTION
This is copy of similar handling of site showcase entries (originally added in https://github.com/gatsbyjs/gatsby/pull/11398 ) for starter showcase 