### PR TITLE
feat(gatsby-source-wordpress): add option to send cookies

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -101,6 +101,8 @@ module.exports = {
           jwt_pass: process.env.JWT_PASSWORD,
           jwt_base_path: "/jwt-auth/v1/token", // Default - can skip if you are using https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
         },
+        // Set cookies that should be send with requests to wordpress as key value pairs
+        cookies: {},
         // Set verboseOutput to true to display a verbose output on `npm run develop` or `npm run build`
         // It can help you debug specific API Endpoints problems.
         verboseOutput: false,

--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -48,6 +48,7 @@ async function fetch({
   _acfOptionPageIds,
   _hostingWPCOM,
   _auth,
+  _cookies,
   _perPage,
   _concurrentRequests,
   _includedRoutes,
@@ -113,6 +114,13 @@ Mama Route URL: ${url}
       }
     }
 
+    if (_cookies) {
+      options.headers = {
+        ...options.headers,
+        Cookie: getCookieString(_cookies),
+      }
+    }
+
     allRoutes = await axios(options)
   } catch (e) {
     httpExceptionHandler(e)
@@ -161,6 +169,7 @@ Fetching the JSON data from ${validRoutes.length} valid API Routes...
           _verbose,
           _perPage,
           _auth,
+          _cookies,
           _accessToken,
           _concurrentRequests,
         })
@@ -246,6 +255,7 @@ async function fetchData({
   _verbose,
   _perPage,
   _auth,
+  _cookies,
   _accessToken,
   _concurrentRequests,
 }) {
@@ -267,6 +277,7 @@ async function fetchData({
     url,
     _perPage,
     _auth,
+    _cookies,
     _accessToken,
     _verbose,
     _concurrentRequests,
@@ -311,6 +322,7 @@ async function fetchData({
               _verbose,
               _perPage,
               _auth,
+              _cookies,
               _accessToken,
             })
           )
@@ -328,6 +340,7 @@ async function fetchData({
             _perPage,
             _auth,
             _accessToken,
+            _cookies,
           })
         )
       }
@@ -363,7 +376,15 @@ async function fetchData({
  * @returns
  */
 async function getPages(
-  { url, _perPage, _auth, _accessToken, _concurrentRequests, _verbose },
+  {
+    url,
+    _perPage,
+    _auth,
+    _cookies,
+    _accessToken,
+    _concurrentRequests,
+    _verbose,
+  },
   page = 1
 ) {
   try {
@@ -381,6 +402,13 @@ async function getPages(
       if (_accessToken) {
         o.headers = {
           Authorization: `Bearer ${_accessToken}`,
+        }
+      }
+
+      if (_cookies) {
+        o.headers = {
+          ...o.headers,
+          Cookie: getCookieString(_cookies),
         }
       }
 
@@ -683,6 +711,16 @@ const buildFullUrl = (baseUrl, fullPath, _hostingWPCOM) => {
  */
 const getManufacturer = route =>
   route.namespace.substring(0, route.namespace.lastIndexOf(`/`))
+
+/**
+ * Build a cookie header string from an object of key value pairs
+ *
+ * @param {any} cookies
+ */
+const getCookieString = cookies =>
+  Object.entries(cookies)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(`; `)
 
 fetch.getRawEntityType = getRawEntityType
 fetch.getRoutePath = getRoutePath

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -17,6 +17,7 @@ let _useACF = true
 let _acfOptionPageIds
 let _hostingWPCOM
 let _auth
+let _cookies
 let _perPage
 let _concurrentRequests
 let _includedRoutes
@@ -40,6 +41,7 @@ exports.sourceNodes = async (
     useACF = true,
     acfOptionPageIds = [],
     auth = {},
+    cookies = {},
     verboseOutput,
     perPage = 100,
     searchAndReplaceContentUrls = {},
@@ -51,6 +53,7 @@ exports.sourceNodes = async (
 ) => {
   const { createNode, touchNode } = actions
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  console.log(cookies)
 
   _verbose = verboseOutput
   _siteURL = `${protocol}://${normalizedBaseUrl}`
@@ -58,6 +61,7 @@ exports.sourceNodes = async (
   _acfOptionPageIds = acfOptionPageIds
   _hostingWPCOM = hostingWPCOM
   _auth = auth
+  _cookies = cookies
   _perPage = perPage
   _concurrentRequests = concurrentRequests
   _includedRoutes = includedRoutes
@@ -72,6 +76,7 @@ exports.sourceNodes = async (
     _acfOptionPageIds,
     _hostingWPCOM,
     _auth,
+    _cookies,
     _perPage,
     _concurrentRequests,
     _includedRoutes,

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -53,7 +53,6 @@ exports.sourceNodes = async (
 ) => {
   const { createNode, touchNode } = actions
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
-  console.log(cookies)
 
   _verbose = verboseOutput
   _siteURL = `${protocol}://${normalizedBaseUrl}`


### PR DESCRIPTION
## Description

This PR adds a "cookies" configuration option to gatsby-source-wordpress that takes an object of key value pairs to send as cookies with requests to the wordpress api.

## Related Issues

I previously created issue #15148 for this