### PR TITLE
fix(lerna): add themes packages to workspaces

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,11 +11,7 @@
     }
   },
   "loglevel": "success",
-  "packages": [
-    "packages/*",
-    "themes/gatsby-theme-blog",
-    "themes/gatsby-theme-notes"
-  ],
+  "packages": ["packages/*"],
   "version": "independent",
   "npmClient": "yarn",
   "registry": "https://registry.npmjs.org/",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "watch": "lerna run watch --no-sort --stream --concurrency 999"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "themes/gatsby-theme-blog",
+    "themes/gatsby-theme-notes"
   ]
 }


### PR DESCRIPTION
`packages` in `lerna.json` is ignored when `useWorkspaces` is set to true