### PR TITLE
Change default Referrer-Policy to no-referrer-when-downgrade

### DIFF
--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -21,7 +21,7 @@ export const SECURITY_HEADERS = {
     `X-Frame-Options: DENY`,
     `X-XSS-Protection: 1; mode=block`,
     `X-Content-Type-Options: nosniff`,
-    `Referrer-Policy: same-origin`,
+    `Referrer-Policy: no-referrer-when-downgrade`,
   ],
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Changing this will allow support for passing referrer data on to integrated advertising scripts and subsequent subdomain destinations.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Related to #13452