### PR TITLE
fix(gatsby-theme-blog): drop path.join to support windows

### DIFF
--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -3,7 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { joinPath } = require(`gatsby-core-utils`)
+const { urlResolve } = require(`gatsby-core-utils`)
 
 const debug = Debug(`gatsby-theme-blog`)
 
@@ -169,7 +169,7 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
 
   const toPostPath = node => {
     const { dir } = path.parse(node.relativePath)
-    return joinPath(basePath, dir, node.name)
+    return urlResolve(basePath, dir, node.name)
   }
 
   // Make sure it's an MDX node

--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -168,7 +168,7 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
 
   const toPostPath = node => {
     const { dir } = path.parse(node.relativePath)
-    return path.join(basePath, dir, node.name)
+    return [basePath, dir, node.name].join(`/`).replace(/\/{2,}/g, `/`)
   }
 
   // Make sure it's an MDX node

--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -3,7 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { joinPath } = require(`gatsby/utils/path`)
+const { joinPath } = require(`gatsby/dist/utils/path`)
 
 const debug = Debug(`gatsby-theme-blog`)
 

--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -3,7 +3,17 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { joinPath } = require(`gatsby/dist/utils/path`)
+
+let joinPath
+try {
+  joinPath = require(`gatsby/utils`).joinPath
+} catch (err) {
+  // continue regardless of error
+}
+
+if (!joinPath) {
+  joinPath = (...paths) => paths.join(`/`).replace(/\/{2,}/g, `/`)
+}
 
 const debug = Debug(`gatsby-theme-blog`)
 

--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -3,6 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
+const { joinPath } = require(`gatsby/utils/path`)
 
 const debug = Debug(`gatsby-theme-blog`)
 
@@ -168,7 +169,7 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
 
   const toPostPath = node => {
     const { dir } = path.parse(node.relativePath)
-    return [basePath, dir, node.name].join(`/`).replace(/\/{2,}/g, `/`)
+    return joinPath(basePath, dir, node.name)
   }
 
   // Make sure it's an MDX node

--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -3,17 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-
-let joinPath
-try {
-  joinPath = require(`gatsby/utils`).joinPath
-} catch (err) {
-  // continue regardless of error
-}
-
-if (!joinPath) {
-  joinPath = (...paths) => paths.join(`/`).replace(/\/{2,}/g, `/`)
-}
+const { joinPath } = require(`gatsby-core-utils`)
 
 const debug = Debug(`gatsby-theme-blog`)
 

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -23,6 +23,7 @@
     "@mdx-js/react": "^1.0.23",
     "@theme-ui/prism": "^0.2.8",
     "@theme-ui/typography": "^0.2.5",
+    "gatsby-core-utils": "^1.0.0",
     "gatsby-image": "^2.2.5",
     "gatsby-plugin-emotion": "^4.1.1",
     "gatsby-plugin-feed": "^2.3.3",

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -23,7 +23,7 @@
     "@mdx-js/react": "^1.0.23",
     "@theme-ui/prism": "^0.2.8",
     "@theme-ui/typography": "^0.2.5",
-    "gatsby-core-utils": "^1.0.0",
+    "gatsby-core-utils": "^1.0.1",
     "gatsby-image": "^2.2.5",
     "gatsby-plugin-emotion": "^4.1.1",
     "gatsby-plugin-feed": "^2.3.3",

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -23,7 +23,7 @@
     "@mdx-js/react": "^1.0.23",
     "@theme-ui/prism": "^0.2.8",
     "@theme-ui/typography": "^0.2.5",
-    "gatsby-core-utils": "^1.0.1",
+    "gatsby-core-utils": "^1.0.3",
     "gatsby-image": "^2.2.5",
     "gatsby-plugin-emotion": "^4.1.1",
     "gatsby-plugin-feed": "^2.3.3",

--- a/themes/gatsby-theme-notes/gatsby-node.js
+++ b/themes/gatsby-theme-notes/gatsby-node.js
@@ -3,7 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { joinPath } = require(`gatsby/utils/path`)
+const { joinPath } = require(`gatsby/dist/utils/path`)
 
 const debug = Debug(`gatsby-theme-notes`)
 

--- a/themes/gatsby-theme-notes/gatsby-node.js
+++ b/themes/gatsby-theme-notes/gatsby-node.js
@@ -3,6 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
+const { joinPath } = require(`gatsby/utils/path`)
 
 const debug = Debug(`gatsby-theme-notes`)
 
@@ -35,7 +36,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   const toNotesPath = node => {
     const { dir } = path.parse(node.parent.relativePath)
-    return [basePath, dir, node.parent.name].join(`/`).replace(/\/{2,}/g, `/`)
+    return joinPath(basePath, dir, node.parent.name)
   }
 
   const result = await graphql(`

--- a/themes/gatsby-theme-notes/gatsby-node.js
+++ b/themes/gatsby-theme-notes/gatsby-node.js
@@ -3,7 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { joinPath } = require(`gatsby-core-utils`)
+const { urlResolve } = require(`gatsby-core-utils`)
 
 const debug = Debug(`gatsby-theme-notes`)
 
@@ -36,7 +36,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   const toNotesPath = node => {
     const { dir } = path.parse(node.parent.relativePath)
-    return joinPath(basePath, dir, node.parent.name)
+    return urlResolve(basePath, dir, node.parent.name)
   }
 
   const result = await graphql(`

--- a/themes/gatsby-theme-notes/gatsby-node.js
+++ b/themes/gatsby-theme-notes/gatsby-node.js
@@ -35,7 +35,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   const toNotesPath = node => {
     const { dir } = path.parse(node.parent.relativePath)
-    return path.join(basePath, dir, node.parent.name)
+    return [basePath, dir, node.parent.name].join(`/`).replace(/\/{2,}/g, `/`)
   }
 
   const result = await graphql(`

--- a/themes/gatsby-theme-notes/gatsby-node.js
+++ b/themes/gatsby-theme-notes/gatsby-node.js
@@ -3,17 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-
-let joinPath
-try {
-  joinPath = require(`gatsby/utils`).joinPath
-} catch (err) {
-  // continue regardless of error
-}
-
-if (!joinPath) {
-  joinPath = (...paths) => paths.join(`/`).replace(/\/{2,}/g, `/`)
-}
+const { joinPath } = require(`gatsby-core-utils`)
 
 const debug = Debug(`gatsby-theme-notes`)
 

--- a/themes/gatsby-theme-notes/gatsby-node.js
+++ b/themes/gatsby-theme-notes/gatsby-node.js
@@ -3,7 +3,17 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { joinPath } = require(`gatsby/dist/utils/path`)
+
+let joinPath
+try {
+  joinPath = require(`gatsby/utils`).joinPath
+} catch (err) {
+  // continue regardless of error
+}
+
+if (!joinPath) {
+  joinPath = (...paths) => paths.join(`/`).replace(/\/{2,}/g, `/`)
+}
 
 const debug = Debug(`gatsby-theme-notes`)
 

--- a/themes/gatsby-theme-notes/package.json
+++ b/themes/gatsby-theme-notes/package.json
@@ -33,6 +33,7 @@
     "@emotion/core": "^10.0.14",
     "@mdx-js/mdx": "^1.0.24",
     "@mdx-js/react": "^1.0.23",
+    "gatsby-core-utils": "^1.0.0",
     "gatsby-plugin-compile-es6-packages": "^1.1.0",
     "gatsby-plugin-emotion": "^4.1.1",
     "gatsby-plugin-mdx": "^1.0.11",

--- a/themes/gatsby-theme-notes/package.json
+++ b/themes/gatsby-theme-notes/package.json
@@ -33,7 +33,7 @@
     "@emotion/core": "^10.0.14",
     "@mdx-js/mdx": "^1.0.24",
     "@mdx-js/react": "^1.0.23",
-    "gatsby-core-utils": "^1.0.1",
+    "gatsby-core-utils": "^1.0.3",
     "gatsby-plugin-compile-es6-packages": "^1.1.0",
     "gatsby-plugin-emotion": "^4.1.1",
     "gatsby-plugin-mdx": "^1.0.11",

--- a/themes/gatsby-theme-notes/package.json
+++ b/themes/gatsby-theme-notes/package.json
@@ -33,7 +33,7 @@
     "@emotion/core": "^10.0.14",
     "@mdx-js/mdx": "^1.0.24",
     "@mdx-js/react": "^1.0.23",
-    "gatsby-core-utils": "^1.0.0",
+    "gatsby-core-utils": "^1.0.1",
     "gatsby-plugin-compile-es6-packages": "^1.1.0",
     "gatsby-plugin-emotion": "^4.1.1",
     "gatsby-plugin-mdx": "^1.0.11",


### PR DESCRIPTION
## Description
creating urls with path.join isn working on osx & linux but sadly not on windows. This PR fixes that. I join by `/` and replace `//` or more into one `/`

before:
![image](https://user-images.githubusercontent.com/1120926/60610331-e9e82700-9dc3-11e9-9461-1dfd12cc8617.png)


after:
![image](https://user-images.githubusercontent.com/1120926/60610218-9ece1400-9dc3-11e9-9211-6b924f7e676e.png)
