### PR TITLE
fix(docs): Updating Gatsby themes "Getting Started" link

### DIFF
--- a/docs/docs/themes/what-are-gatsby-themes.md
+++ b/docs/docs/themes/what-are-gatsby-themes.md
@@ -29,7 +29,7 @@ Themes solve the problems that traditional starters experience:
 
 ## What's Next?
 
-- [Getting Started](/docs/themes/getting-started)
+- [Getting Started](/docs/themes/using-a-gatsby-theme)
 - [Converting a Starter](/docs/themes/converting-a-starter)
 - [Building Themes](/docs/themes/building-themes)
 - [Conventions](/docs/themes/conventions)


### PR DESCRIPTION
I noticed the link on the https://www.gatsbyjs.org/docs/themes/what-are-gatsby-themes/ page for "Getting Started" was broken as it referred to a path that was recently removed.

## Description

This hopefully fixes the link as I see https://www.gatsbyjs.org/docs/themes/using-a-gatsby-theme/ loads but https://www.gatsbyjs.org/docs/themes/getting-started does not
