### PR TITLE
docs: revert quoted typo fix

### DIFF
--- a/docs/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/index.md
+++ b/docs/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/index.md
@@ -16,7 +16,7 @@ Gatsby is **great** from a multititude of perspectives. Our community is **great
 As such--this post focuses on just a single element of what makes Gatsby great: performance. To prime the discussion, let's consider [this post on the `webdev` subreddit on Reddit](https://www.reddit.com/r/webdev/comments/9z5dsr/how_does_reactjs_have_such_a_fast_website/?st=jtqbllhm&sh=60148ea7).
 
 <Pullquote citation="reddit/r/webdev">
-Genuine question, every page is loaded immediately [sic] on click. Seriously never seen such a quick website before. Any insight as to how they're able to achieve this?
+Genuine question, every page is loaded immediatley [sic] on click. Seriously never seen such a quick website before. Any insight as to how they're able to achieve this?
 </Pullquote>
 
 Fun fact--that website in question is [reactjs.org](https://reactjs.org) which, as you may or may not know, is an application built with and powered by Gatsby 💪


### PR DESCRIPTION
## description
Marcy pointed out that we shouldn't have fixed a piece of text because of [sic] being mentioned.

This PR reverts it

## Related Issues
https://github.com/gatsbyjs/gatsby/pull/15301#discussion_r299906410