### PR TITLE
feat: add a nodeFilter option

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -152,6 +152,10 @@ For example, to filter locales on only germany `localeFilter: locale => locale.c
 
 List of locales and their codes can be found in Contentful app -> Settings -> Locales
 
+**`nodeFilter`** [function][optional] [default: `(node) => true`]
+
+Before `gatsby-source-contentful` calls `createNode` for each content type, entry, and asset, it first checks with `nodeFilter` to see whether it should. It passes the node to `nodeFilter`, and only calls `createNode` if `nodeFilter` returns true. This is an opportunity to filter out nodes before they're created based on custom business logic.
+
 **`forceFullSync`** [boolean][optional] [default: `false`]
 
 Prevents the use of sync tokens when accessing the Contentful API.

--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -53,6 +53,8 @@ describe(`Process contentful data`, () => {
   it(`creates nodes for each entry`, () => {
     const createNode = jest.fn()
     const createNodeId = jest.fn()
+    const nodeFilter = () => true
+
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
     contentTypeItems.forEach((contentTypeItem, i) => {
       normalize.createContentTypeNodes({
@@ -66,9 +68,33 @@ describe(`Process contentful data`, () => {
         foreignReferenceMap,
         defaultLocale,
         locales,
+        nodeFilter,
       })
     })
     expect(createNode.mock.calls).toMatchSnapshot()
+  })
+
+  it(`filters out nodes using the nodeFilter`, () => {
+    const createNode = jest.fn()
+    const createNodeId = jest.fn()
+    const nodeFilter = () => false
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    contentTypeItems.forEach((contentTypeItem, i) => {
+      normalize.createContentTypeNodes({
+        contentTypeItem,
+        restrictedNodeFields,
+        conflictFieldPrefix,
+        entries: entryList[i].map(normalize.fixIds),
+        createNode,
+        createNodeId,
+        resolvable,
+        foreignReferenceMap,
+        defaultLocale,
+        locales,
+        nodeFilter,
+      })
+    })
+    expect(createNode.mock.calls.length).toBe(0)
   })
 
   it(`creates nodes for each asset`, () => {
@@ -76,6 +102,7 @@ describe(`Process contentful data`, () => {
     const createNodeId = jest.fn()
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
     const assets = currentSyncData.assets
+    const nodeFilter = () => true
     assets.forEach(assetItem => {
       normalize.createAssetNodes({
         assetItem,
@@ -83,9 +110,29 @@ describe(`Process contentful data`, () => {
         createNodeId,
         defaultLocale,
         locales,
+        nodeFilter,
       })
     })
     expect(createNode.mock.calls).toMatchSnapshot()
+  })
+
+  it(`filters out asset nodes using the nodeFilter`, () => {
+    const createNode = jest.fn()
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+    const assets = currentSyncData.assets
+    const nodeFilter = () => false
+    assets.forEach(assetItem => {
+      normalize.createAssetNodes({
+        assetItem,
+        createNode,
+        createNodeId,
+        defaultLocale,
+        locales,
+        nodeFilter,
+      })
+    })
+    expect(createNode.mock.calls.length).toBe(0)
   })
 })
 

--- a/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
@@ -101,6 +101,21 @@ describe(`Options validation`, () => {
     expect(reporter.panic).not.toBeCalled()
   })
 
+  it(`Passes with a nodeFilter option`, () => {
+    validateOptions(
+      {
+        reporter,
+      },
+      {
+        spaceId: `spaceId`,
+        accessToken: `accessToken`,
+        nodeFilter: () => false,
+      }
+    )
+
+    expect(reporter.panic).not.toBeCalled()
+  })
+
   it(`Fails with missing required options`, () => {
     validateOptions(
       {

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -191,6 +191,7 @@ exports.sourceNodes = async (
       }
     })
 
+  const nodeFilter = pluginConfig.get(`nodeFilter`) || (() => true)
   contentTypeItems.forEach((contentTypeItem, i) => {
     normalize.createContentTypeNodes({
       contentTypeItem,
@@ -203,6 +204,7 @@ exports.sourceNodes = async (
       foreignReferenceMap,
       defaultLocale,
       locales,
+      nodeFilter,
     })
   })
 
@@ -213,6 +215,7 @@ exports.sourceNodes = async (
       createNodeId,
       defaultLocale,
       locales,
+      nodeFilter,
     })
   })
 

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -244,6 +244,7 @@ exports.createContentTypeNodes = ({
   foreignReferenceMap,
   defaultLocale,
   locales,
+  nodeFilter,
 }) => {
   const contentTypeItemId = contentTypeItem.name
   locales.forEach(locale => {
@@ -482,11 +483,15 @@ exports.createContentTypeNodes = ({
 
     contentTypeNode.internal.contentDigest = contentDigest
 
-    createNode(contentTypeNode)
-    entryNodes.forEach(entryNode => {
+    if (nodeFilter(contentTypeNode)) {
+      createNode(contentTypeNode)
+    }
+
+    entryNodes.filter(nodeFilter).forEach(entryNode => {
       createNode(entryNode)
     })
-    childrenNodes.forEach(entryNode => {
+
+    childrenNodes.filter(nodeFilter).forEach(entryNode => {
       createNode(entryNode)
     })
   })
@@ -498,6 +503,7 @@ exports.createAssetNodes = ({
   createNodeId,
   defaultLocale,
   locales,
+  nodeFilter,
 }) => {
   locales.forEach(locale => {
     const localesFallback = buildFallbackChain(locales)
@@ -543,6 +549,8 @@ exports.createAssetNodes = ({
 
     assetNode.internal.contentDigest = contentDigest
 
-    createNode(assetNode)
+    if (nodeFilter(assetNode)) {
+      createNode(assetNode)
+    }
   })
 }

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -34,6 +34,7 @@ const optionsSchema = Joi.object().keys({
   forceFullSync: Joi.boolean(),
   // default plugins passed by gatsby
   plugins: Joi.array(),
+  nodeFilter: Joi.func(),
 })
 
 const maskedFields = [`accessToken`, `spaceId`]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR introduces a `nodeFilter` config option to the `gatsby-source-contentful` plugin. `nodeFilter` is a function that, when defined, will be called before calling `createNode` on each content type/entry/asset in Contentful, allowing other plugins (and `gatsby-node.js`) to control whether nodes are created based on particular business logic.
