### PR TITLE
fix(gatsby): reevaluate page query when page context is modified

### DIFF
--- a/packages/gatsby/src/redux/machines/__tests__/page-component.js
+++ b/packages/gatsby/src/redux/machines/__tests__/page-component.js
@@ -68,4 +68,12 @@ describe(`bootstrap`, () => {
     await sleep()
     expect(runQueuedQueries).toBeCalledWith(path)
   })
+
+  it(`will queue query when page context is changed`, async () => {
+    const service = getService({ isInBootstrap: false })
+    service.send({ type: `PAGE_CONTEXT_MODIFIED`, path: `/a/test.md` })
+    // there is setTimeout in action handler for `CONTEXT_CHANGES`
+    await sleep()
+    expect(enqueueExtractedQueryId).toBeCalledWith(`/a/test.md`)
+  })
 })

--- a/packages/gatsby/src/redux/machines/page-component.js
+++ b/packages/gatsby/src/redux/machines/page-component.js
@@ -22,6 +22,9 @@ module.exports = Machine(
       NEW_PAGE_CREATED: {
         actions: `setPage`,
       },
+      PAGE_CONTEXT_MODIFIED: {
+        actions: `rerunPageQuery`,
+      },
       QUERY_EXTRACTION_GRAPHQL_ERROR: `queryExtractionGraphQLError`,
       QUERY_EXTRACTION_BABEL_ERROR: `queryExtractionBabelError`,
     },
@@ -76,6 +79,14 @@ module.exports = Machine(
       isNotBootstrapping: context => !context.isInBootstrap,
     },
     actions: {
+      rerunPageQuery: (_ctx, event) => {
+        const queryUtil = require(`../../query`)
+        // Wait a bit as calling this function immediately triggers
+        // an Action call which Redux squawks about.
+        setTimeout(() => {
+          queryUtil.enqueueExtractedQueryId(event.path)
+        }, 0)
+      },
       runPageComponentQueries: (context, event) => {
         const queryUtil = require(`../../query`)
         // Wait a bit as calling this function immediately triggers

--- a/packages/gatsby/src/redux/reducers/components.js
+++ b/packages/gatsby/src/redux/reducers/components.js
@@ -40,6 +40,11 @@ module.exports = (state = new Map(), action) => {
         service = services.get(action.payload.componentPath)
         if (!service.state.context.pages.includes(action.payload.path)) {
           service.send({ type: `NEW_PAGE_CREATED`, path: action.payload.path })
+        } else if (action.contextModified) {
+          service.send({
+            type: `PAGE_CONTEXT_MODIFIED`,
+            path: action.payload.path,
+          })
         }
       }
 


### PR DESCRIPTION
## Description

When page context is updated by createPage the path is not marked as dirty and page query is not reevaluated resulting in the page not updating in develop mode.

It was already fixed by my in https://github.com/gatsbyjs/gatsby/pull/11048 but it appeared again in v2.2.11 because of refactoring by @KyleAMathews in https://github.com/gatsbyjs/gatsby/commit/91086d43e9b69ba357f7f7ad6bbf2eb0b8b5fbff

I added a basic test, but I'm not sure how to write a test to prevent this kind of regression in the future. If anyone has any ideas I would be happy to add a test.

## Related Issues

Related to #6097, May be related to #11691