### PR TITLE
fix(gatsby-plugin-manifest): use content-digest helper from utils file

### DIFF
--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -38,9 +38,11 @@ jest.mock(`sharp`, () => {
   return sharp
 })
 
-jest.mock(`gatsby/dist/utils/create-content-digest`, () =>
-  jest.fn(() => `contentDigest`)
-)
+jest.mock(`gatsby/utils`, () => {
+  return {
+    createContentDigest: jest.fn(() => `contentDigest`),
+  }
+})
 
 const fs = require(`fs`)
 const path = require(`path`)

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -4,9 +4,11 @@ jest.mock(`fs`, () => {
   }
 })
 
-jest.mock(`gatsby/dist/utils/create-content-digest`, () =>
-  jest.fn(() => `contentDigest`)
-)
+jest.mock(`gatsby/utils`, () => {
+  return {
+    createContentDigest: jest.fn(() => `contentDigest`),
+  }
+})
 
 const { onRenderBody } = require(`../gatsby-ssr`)
 

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -1,7 +1,7 @@
 import fs from "fs"
 import path from "path"
 import sharp from "./safe-sharp"
-import createContentDigest from "gatsby/dist/utils/create-content-digest"
+import { createContentDigest } from "gatsby/utils"
 import { defaultIcons, doesIconExist, addDigestToPath } from "./common"
 
 sharp.simd(true)

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { withPrefix as fallbackWithPrefix, withAssetPrefix } from "gatsby"
 import fs from "fs"
-import createContentDigest from "gatsby/dist/utils/create-content-digest"
+import { createContentDigest } from "gatsby/utils"
 
 import { defaultIcons, addDigestToPath } from "./common.js"
 


### PR DESCRIPTION
## Description
While working on https://github.com/gatsbyjs/gatsby/pull/15405 I've noticed manifest plugin isn't importing from gatsby/utils but from the file directly.

## Related Issues
https://github.com/gatsbyjs/gatsby/pull/15405
