### PR TITLE
Use v4 instead of v1 uuids

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -1,5 +1,5 @@
 const { createHash } = require(`crypto`)
-const uuid = require(`uuid/v1`)
+const uuid = require(`uuid/v4`)
 const EventStorage = require(`./event-storage`)
 const { sanitizeErrors, cleanPaths } = require(`./error-helpers`)
 const ci = require(`ci-info`)

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -1,5 +1,5 @@
 const { createHash } = require(`crypto`)
-const uuid = require(`uuid/v4`)
+const uuidv4 = require(`uuid/v4`)
 const EventStorage = require(`./event-storage`)
 const { sanitizeErrors, cleanPaths } = require(`./error-helpers`)
 const ci = require(`ci-info`)
@@ -18,7 +18,7 @@ module.exports = class AnalyticsTracker {
   osInfo // lazy
   trackingEnabled // lazy
   componentVersion
-  sessionId = uuid()
+  sessionId = uuidv4()
 
   constructor() {
     try {
@@ -177,7 +177,7 @@ module.exports = class AnalyticsTracker {
     }
     let machineId = this.store.getConfig(`telemetry.machineId`)
     if (!machineId) {
-      machineId = uuid()
+      machineId = uuidv4()
       this.store.updateConfig(`telemetry.machineId`, machineId)
     }
     this.machineId = machineId


### PR DESCRIPTION
## Description

I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of Gatsby.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found two occurrences where v1 UUIDs were being used instead of v4 UUIDs and I was wondering if any of these cases really require the semantically much more complex v1 UUIDs or whether we could live equally well with purely random v4 UUIDs?

At least the test suite still passes after my changes, so apparently this doesn't seem to introduce any known regressions.

I'd be really curious to understand the motivation for choosing v1 over v4 UUIDs in the first place, so any feedback on this would be highly appreciated!

## Related Issues

none