### PR TITLE
fix(gatsby): restore client-only-paths behaviour

### DIFF
--- a/e2e-tests/development-runtime/src/pages/client-only-paths.js
+++ b/e2e-tests/development-runtime/src/pages/client-only-paths.js
@@ -13,15 +13,11 @@ const routes = [`/`, `/profile`, `/dashboard`]
 
 const basePath = `/client-only-paths`
 
-const ClientOnlyPathPage = props => (
+const ClientOnlyPathPage = () => (
   <Layout>
-    <Router
-      location={props.location}
-      basepath={basePath}
-      id="client-only-paths-sub-router"
-    >
-      <Page path="/" page="index" />
-      <Page path="/:page" />
+    <Router id="client-only-paths-sub-router">
+      <Page path="/client-only-paths/" page="index" />
+      <Page path="/client-only-paths/:page" />
     </Router>
     <ul>
       {routes.map(route => (

--- a/e2e-tests/development-runtime/src/pages/paths.js
+++ b/e2e-tests/development-runtime/src/pages/paths.js
@@ -7,7 +7,7 @@ const NotFound = () => <h1>Not Found in App</h1>
 
 const AppPage = () => (
   <Router>
-    <App path="/app" />
+    <App path="/paths/app" />
     <NotFound default />
   </Router>
 )

--- a/e2e-tests/production-runtime/src/pages/client-only-paths.js
+++ b/e2e-tests/production-runtime/src/pages/client-only-paths.js
@@ -13,15 +13,11 @@ const routes = [`/`, `/profile`, `/dashboard`]
 
 const basePath = `/client-only-paths`
 
-const ClientOnlyPathPage = props => (
+const ClientOnlyPathPage = () => (
   <Layout>
-    <Router
-      location={props.location}
-      basepath={basePath}
-      id="client-only-paths-sub-router"
-    >
-      <Page path="/" page="index" />
-      <Page path="/:page" />
+    <Router id="client-only-paths-sub-router">
+      <Page path="/client-only-paths/" page="index" />
+      <Page path="/client-only-paths/:page" />
     </Router>
     <ul>
       {routes.map(route => (

--- a/e2e-tests/production-runtime/src/pages/paths.js
+++ b/e2e-tests/production-runtime/src/pages/paths.js
@@ -7,7 +7,7 @@ const NotFound = () => <h1>Not Found in App</h1>
 
 const AppPage = () => (
   <Router>
-    <App path="/app" />
+    <App path="/paths/app" />
     <NotFound default />
   </Router>
 )

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -19,6 +19,21 @@ import stripPrefix from "./strip-prefix"
 // Generated during bootstrap
 import matchPaths from "./match-paths.json"
 
+/*
+In gatsby v2 if Router is used in page using matchPaths
+paths need to contain full path.
+For example:
+  - page have `/app/*` matchPath
+  - inside template user needs to use `/app/xyz` as path
+Setting `basepath` default prop keeps current behaviour
+to not introduce breaking change.
+Remove this in v3
+*/
+Router.defaultProps = {
+  ...Router.defaultProps,
+  basepath: __BASE_PATH__,
+}
+
 const loader = new ProdLoader(asyncRequires, matchPaths)
 setLoader(loader)
 loader.setApiRunner(apiRunner)

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -14,6 +14,21 @@ import EnsureResources from "./ensure-resources"
 
 import { reportError, clearError } from "./error-overlay-handler"
 
+/*
+In gatsby v2 if Router is used in page using matchPaths
+paths need to contain full path.
+For example:
+  - page have `/app/*` matchPath
+  - inside template user needs to use `/app/xyz` as path
+Setting `basepath` default prop keeps current behaviour
+to not introduce breaking change.
+Remove this in v3
+*/
+Router.defaultProps = {
+  ...Router.defaultProps,
+  basepath: __BASE_PATH__,
+}
+
 if (window.__webpack_hot_middleware_reporter__ !== undefined) {
   const overlayErrorID = `webpack`
   // Report build errors


### PR DESCRIPTION
Fixes regression introduced in https://github.com/gatsbyjs/gatsby/pull/13197

Fixes #15401