### PR TITLE
chore(gatsby-source-filesystem): Deprecate fields

### DIFF
--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -77,7 +77,13 @@ export interface FileSystemNode extends Node {
   // stats
   atime: Date
   atimeMs: number
+  /**
+   * @deprecated Use `birthTime` instead
+   */
   birthtime: Date
+  /**
+   * @deprecated Use `birthTime` instead
+   */
   birthtimeMs: number
   ctime: Date
   ctimeMs: number

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -183,3 +183,14 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
 }
 
 exports.setFieldsOnGraphQLNodeType = require(`./extend-file-node`)
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+  type File implements Node {
+    birthtime: Date @deprecated(reason: "Use \`birthTime\` instead")
+    birthtimeMs: Float @deprecated(reason: "Use \`birthTime\` instead")
+  }
+  `
+  createTypes(typeDefs)
+}

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -187,7 +187,7 @@ exports.setFieldsOnGraphQLNodeType = require(`./extend-file-node`)
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = `
-  type File implements Node {
+  type File implements Node @infer {
     birthtime: Date @deprecated(reason: "Use \`birthTime\` instead")
     birthtimeMs: Float @deprecated(reason: "Use \`birthTime\` instead")
   }


### PR DESCRIPTION
## Description

I've just added a schema customization option to deprecate redundant birth time field versions.

## Related Issues

Addresses https://github.com/gatsbyjs/gatsby/issues/15287
