### PR TITLE
fix(docs): update Gatsby themes "Getting Started" link text to "Using a Gatsby Theme"

### DIFF
--- a/docs/docs/themes/what-are-gatsby-themes.md
+++ b/docs/docs/themes/what-are-gatsby-themes.md
@@ -29,7 +29,7 @@ Themes solve the problems that traditional starters experience:
 
 ## What's Next?
 
-- [Getting Started](/docs/themes/using-a-gatsby-theme)
+- [Using a Gatsby Theme](/docs/themes/using-a-gatsby-theme)
 - [Converting a Starter](/docs/themes/converting-a-starter)
 - [Building Themes](/docs/themes/building-themes)
 - [Conventions](/docs/themes/conventions)


### PR DESCRIPTION
## Description

Would it make sense to update the link text to "Using a Gatsby Theme" instead of "Getting Started" since the latter link does not exist yet? 

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/15388

After #15388 was merged, I noticed that the https://www.gatsbyjs.org/docs/themes/ page exists and does not even mention a "Getting Started" page. For consistency between https://www.gatsbyjs.org/docs/themes/using-a-gatsby-theme and https://www.gatsbyjs.org/docs/themes/, I'm proposing this PR's changes