### PR TITLE
fix(docs): fix link to Contentful Marketplace

### DIFF
--- a/docs/docs/gatsby-vendor-partnership.md
+++ b/docs/docs/gatsby-vendor-partnership.md
@@ -98,7 +98,7 @@ In terms of what a "first-class" Gatsby Preview integration and partnership look
 
 - A button in the CMS editor where users can click through to Preview
 
-- Featured on a plugin marketplace, if applicable. Eg, [Contentful Marketplace](https://www.contentful.com/developers/marketplace/gatsby-preview/)
+- Featured on a plugin marketplace, if applicable. Eg, [Contentful Marketplace](https://www.contentful.com/developers/marketplace/gatsby-preview-sidebar/)
 
 #### Marketing & Sales:
 


### PR DESCRIPTION
## Description

On the https://www.gatsbyjs.org/docs/gatsby-vendor-partnership/ page, there's a note

```Featured on a plugin marketplace, if applicable. Eg, Contentful Marketplace```

However, the link "Contentful Marketplace" goes to https://www.contentful.com/developers/marketplace/gatsby-preview/ which is a 404. However https://www.contentful.com/developers/marketplace/gatsby-preview-sidebar/ loads. Is this the intended destination?

