### PR TITLE
fix(docs): update LernaJS link from https://lernajs.io/ to https://lerna.js.org/

### DIFF
--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -5,7 +5,7 @@ title: Setting Up Your Local Dev Environment
 This page outlines how to get set up to contribute to Gatsby core and its ecosystem. For instructions on working with docs, visit the [docs contributions](/contributing/docs-contributions/) page. For blog and website setup instructions, visit the [blog and website contributions](/contributing/blog-and-website-contributions/) page.
 
 > Gatsby uses a "monorepo" pattern to manage its many dependencies and relies on
-> [Lerna](https://lernajs.io/) and [Yarn](https://yarnpkg.com/en/) to configure the repository for both active development and documentation infrastructure changes.
+> [Lerna](https://lerna.js.org/) and [Yarn](https://yarnpkg.com/en/) to configure the repository for both active development and documentation infrastructure changes.
 
 ## Using Yarn
 


### PR DESCRIPTION
## Description

On the https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/ page, the Lerna 
link to https://lernajs.io/ website does not load with a "This site can’t be reached" error. 

However, https://lerna.js.org/ does load. If you go to https://github.com/lerna/lerna you'll also see that they link to https://lerna.js.org/
