### PR TITLE
feat(docs): theme doc updates

### DIFF
--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -2,4 +2,18 @@
 title: Building Themes
 ---
 
-_Updated theme authoring docs are coming soon!_
+We're working on more comprehensive written documentation to support building themes.
+
+In the meantime, check out these resources:
+
+## Gatsby Themes Authoring (Video course)
+
+Watch the new [Egghead course on Authoring Gatsby Themes](https://egghead.io/courses/gatsby-theme-authoring).
+
+## Read through source code
+
+Check out how some existing themes are built:
+
+- The official [Gatsby blog theme](https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-theme-blog)
+- The official [Gatsby notes theme](https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-theme-notes)
+- The [Apollo themes](https://github.com/apollographql/gatsby-theme-apollo/tree/master/packages). (\_You might also be interested in the [Apollo case study on themes](https://www.gatsbyjs.org/blog/2019-07-03-using-themes-for-distributed-docs/) on the blog.)

--- a/docs/docs/themes/what-are-gatsby-themes.md
+++ b/docs/docs/themes/what-are-gatsby-themes.md
@@ -29,12 +29,9 @@ Themes solve the problems that traditional starters experience:
 
 ## What's Next?
 
-- [Getting Started](/docs/themes/using-a-gatsby-theme)
-- [Converting a Starter](/docs/themes/converting-a-starter)
+- [Using a Gatsby Theme](/docs/themes/using-a-gatsby-theme)
+- [Using Multiple Gatsby Themes](/docs/themes/using-multiple-gatsby-themes)
 - [Building Themes](/docs/themes/building-themes)
-- [Conventions](/docs/themes/conventions)
-- [Theme Composition](/docs/themes/theme-composition)
-- [API Reference](/docs/themes/api-reference)
 
 ## Related blog posts
 


### PR DESCRIPTION
# Description

A few updates to the theme docs:
- Updated links in "What are Gatsby Themes?"
- Temporary content for "Building Themes" docs