### PR TITLE
fix(docs): Fix broken link on docs contribution page

### DIFF
--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -34,7 +34,7 @@ When working on the Gatsby.js documentation, you can choose between two major st
 
 If you find a broken image URL in the Gatsby docs, it should be fixed and kept relative to the site source rather than linked to the remote repo on GitHub. This ensures that when the site is deployed, all images are included in the build.
 
-To address missing images, check the doc or tutorial source [in the Gatsby repo](https://github.com/gatsbyjs/gatsby/docs) to see if it was moved in its history and if the images are still in its old location. Check to see if those images are also referenced from more than one doc. If they aren't, move them to the new directory location (and update URL references relative to the content, if necessary). If they are referenced in more than one location, use relative paths and don't duplicate images.
+To address missing images, check the doc or tutorial source [in the Gatsby repo](https://github.com/gatsbyjs/gatsby/tree/master/docs) to see if it was moved in its history and if the images are still in its old location. Check to see if those images are also referenced from more than one doc. If they aren't, move them to the new directory location (and update URL references relative to the content, if necessary). If they are referenced in more than one location, use relative paths and don't duplicate images.
 
 If you find a broken link in the Gatsby docs, feel free to fix it and submit a PR!
 


### PR DESCRIPTION
## Description

Fix broken link from https://github.com/gatsbyjs/gatsby/docs to http://github.com/gatsbyjs/gatsby/tree/master/docs

You can find the broken link on the https://www.gatsbyjs.org/contributing/docs-contributions/ page for the "in the Gatsby repo" link:

`
To address missing images, check the doc or tutorial source [in the Gatsby repo](https://github.com/gatsbyjs/gatsby/docs)
`

The https://github.com/gatsbyjs/gatsby/tree/master/docs link is used elsewhere within this document as well