### PR TITLE
refactor(detect-port): no longer use promisify for function that already returns promise

### DIFF
--- a/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
+++ b/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
@@ -1,5 +1,4 @@
-const { promisify } = require(`util`)
-const detectPort = promisify(require(`detect-port`))
+const detectPort = require(`detect-port`)
 const report = require(`gatsby-cli/lib/reporter`)
 
 const readlinePort = (port, rlInterface) => {


### PR DESCRIPTION
## Description

This is the simplest of PRs, but reading through the code it bothered me that we promisified [something that already returns a promise](https://github.com/node-modules/detect-port#usage).
