### PR TITLE
Use v4 instead of v1 uuids

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -1,4 +1,3 @@
-const { createHash } = require(`crypto`)
 const uuidv4 = require(`uuid/v4`)
 const EventStorage = require(`./event-storage`)
 const { sanitizeErrors, cleanPaths } = require(`./error-helpers`)
@@ -18,7 +17,7 @@ module.exports = class AnalyticsTracker {
   osInfo // lazy
   trackingEnabled // lazy
   componentVersion
-  sessionId = uuidv4()
+  sessionId = this.getSessionId()
 
   constructor() {
     try {
@@ -29,6 +28,15 @@ module.exports = class AnalyticsTracker {
     } catch (e) {
       // ignore
     }
+  }
+
+  // We might have two instances of this lib loaded, one from globally installed gatsby-cli and one from local gatsby.
+  // Hence we need to use process level globals that are not scoped to this module
+  getSessionId() {
+    return (
+      process.gatsbyTelemetrySessionId ||
+      (process.gatsbyTelemetrySessionId = uuidv4())
+    )
   }
 
   getTagsFromEnv() {

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -1,5 +1,5 @@
 const { createHash } = require(`crypto`)
-const uuid = require(`uuid/v4`)
+const uuidv4 = require(`uuid/v4`)
 const EventStorage = require(`./event-storage`)
 const { sanitizeErrors, cleanPaths } = require(`./error-helpers`)
 const ci = require(`ci-info`)
@@ -18,7 +18,7 @@ module.exports = class AnalyticsTracker {
   osInfo // lazy
   trackingEnabled // lazy
   componentVersion
-  sessionId = uuid()
+  sessionId = uuidv4()
 
   constructor() {
     try {
@@ -177,7 +177,7 @@ module.exports = class AnalyticsTracker {
     }
     let machineId = this.store.getConfig(`telemetry.machineId`)
     if (!machineId) {
-      machineId = uuid()
+      machineId = uuidv4()
       this.store.updateConfig(`telemetry.machineId`, machineId)
     }
     this.machineId = machineId

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -1,4 +1,5 @@
-const uuid = require(`uuid/v1`)
+const { createHash } = require(`crypto`)
+const uuid = require(`uuid/v4`)
 const EventStorage = require(`./event-storage`)
 const { sanitizeErrors, cleanPaths } = require(`./error-helpers`)
 const ci = require(`ci-info`)


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/15407 with a patch to ensure we always have a single sessionId for the duration of the nodejs runtime.