### PR TITLE
fix: update queries example line number in Github URL

### DIFF
--- a/docs/docs/query-behind-the-scenes.md
+++ b/docs/docs/query-behind-the-scenes.md
@@ -2,7 +2,7 @@
 title: How Queries Work
 ---
 
-We're talking about GraphQL queries here. These can be tagged graphql expressions at the bottom of your component source file (e.g [query for Gatsby frontpage](https://github.com/gatsbyjs/gatsby/blob/master/www/src/pages/index.js#L243)), StaticQueries within your components (e.g [showcase site details](https://github.com/gatsbyjs/gatsby/blob/master/www/src/components/showcase-details.js#L103)), or fragments created by plugins (e.g [gatsby-source-contentful](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/src/fragments.js)).
+We're talking about GraphQL queries here. These can be tagged graphql expressions at the bottom of your component source file (e.g [query for Gatsby frontpage](https://github.com/gatsbyjs/gatsby/blob/master/www/src/pages/index.js#L165)), StaticQueries within your components (e.g [showcase site details](https://github.com/gatsbyjs/gatsby/blob/master/www/src/components/showcase-details.js#L103)), or fragments created by plugins (e.g [gatsby-source-contentful](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/src/fragments.js)).
 
 Note that we are NOT talking about queries involved in the creation of your pages, which is usually performed in your site's gatsby-node.js (e.g [Gatsby's website](https://github.com/gatsbyjs/gatsby/blob/master/www/gatsby-node.js#L165)). We're only talking about queries that are tied to particular pages or templates.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The link was pointing to a presumably old line that doesn't exist anymore in the new version of the docs file. I just updated it to point to the new line number : )

## Related Issues

Addresses #15434
