### PR TITLE
fix(blog): Fixed typo in docs/blog

### DIFF
--- a/docs/blog/2017-02-21-1-0-progress-update-where-came-from-where-going/index.md
+++ b/docs/blog/2017-02-21-1-0-progress-update-where-came-from-where-going/index.md
@@ -13,7 +13,7 @@ as you develop, ship, and maintain sites.
 
 This framework would have to be:
 
-- **universal**, work for all types of sites from simple brocurewares to complex
+- **universal**, work for all types of sites from simple brochureware to complex
   web-apps.
 - **simple**, not requiring any setup to start using and with thoughtful APIs to
   extend the framework.
@@ -260,7 +260,7 @@ instantly.
 
 This pattern of _colocating_ your queries next to your views is copied from the
 [Relay data framework from Facebook](https://facebook.github.io/relay/).
-Colocaton makes it easy to fully understand your views as everything necessary
+Colocation makes it easy to fully understand your views as everything necessary
 for that view is fully described there.
 
 A simple example of how this works in practice.


### PR DESCRIPTION
## Description
I was going through this blog post and found a couple of possible typos: 
* `brocurewares` -> `brochureware`
* `Colocaton` -> `Colocation`

## Related Issues
There isn't any issue related to this. I stumbled upon this while going through them. If this doesn't need a fix, please feel free to close this PR. Thank you (^_^)
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
