### PR TITLE
fix(gatsby-plugin-mdx): Use babel plugin to remove export keyword

### DIFF
--- a/packages/gatsby-plugin-mdx/utils/babel-plugin-remove-export-keywords/index.js
+++ b/packages/gatsby-plugin-mdx/utils/babel-plugin-remove-export-keywords/index.js
@@ -1,0 +1,14 @@
+module.exports = function removeExportKeywords() {
+  return {
+    visitor: {
+      ExportNamedDeclaration(path) {
+        const declaration = path.node.declaration;
+
+        // Ignore "export { Foo as default }" syntax
+        if (declaration) {
+          path.replaceWith(declaration);
+        }
+      }
+    }
+  };
+};

--- a/packages/gatsby-plugin-mdx/utils/babel-plugin-remove-export-keywords/index.test.js
+++ b/packages/gatsby-plugin-mdx/utils/babel-plugin-remove-export-keywords/index.test.js
@@ -1,0 +1,35 @@
+const babel = require("@babel/core");
+
+const plugin = require(".");
+
+const testContents = `
+export const foo = 'bar';
+/** @jsx mdx*/ export const _frontmatter = {
+  title: "Here's a title with the word export"
+};
+
+const MDXContent = function () {};
+export { MDXContent as default };
+`;
+const expectedResults = `const foo = 'bar';
+/** @jsx mdx*/
+
+const _frontmatter = {
+  title: "Here's a title with the word export"
+};
+
+const MDXContent = function () {};
+
+export { MDXContent as default };`
+
+describe("babel-plugin-remove-export-keyword", () => {
+  test("removes all export keywords", () => {
+    const result = babel.transform(testContents, {
+      configFile: false,
+      plugins: [plugin],
+      presets: [require("@babel/preset-react")]
+    });
+
+    expect(result.code).toEqual(expectedResults)
+  });
+});

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -7,6 +7,7 @@ const debug = require("debug")("gatsby-mdx:gen-mdx");
 
 const getSourcePluginsAsRemarkPlugins = require("./get-source-plugins-as-remark-plugins");
 const htmlAttrToJSXAttr = require("./babel-plugin-html-attr-to-jsx-attr");
+const removeExportKeywords = require("./babel-plugin-remove-export-keywords");
 const BabelPluginPluckImports = require("./babel-plugin-pluck-imports");
 
 /*
@@ -127,7 +128,7 @@ ${code}`;
     const instance = new BabelPluginPluckImports();
     const result = babel.transform(code, {
       configFile: false,
-      plugins: [instance.plugin, objRestSpread, htmlAttrToJSXAttr],
+      plugins: [instance.plugin, objRestSpread, htmlAttrToJSXAttr, removeExportKeywords],
       presets: [
         require("@babel/preset-react"),
         [
@@ -160,7 +161,6 @@ ${code}`;
         /export\s*{\s*MDXContent\s+as\s+default\s*};?/,
         "return MDXContent;"
       )
-      .replace(/\nexport /g, "\n");
   }
   /* results.html = renderToStaticMarkup(
    *   React.createElement(MDXRenderer, null, results.body)


### PR DESCRIPTION
For very large MDX documents babel will deopt styling. This
results in variations in whitespace that can't be handled
by the original regex for stripping the export keyword.

This replaces that functionality with a plugin.

## Related

- ChristopherBiscardi/gatsby-mdx#411
- https://github.com/mdx-js/mdx#618