### PR TITLE
fix(docs): Fix broken link on site showcase blog post

### DIFF
--- a/docs/blog/2018-07-20-why-we-built-the-site-showcase/index.md
+++ b/docs/blog/2018-07-20-why-we-built-the-site-showcase/index.md
@@ -17,7 +17,7 @@ The Site Showcase was developed by Cassie Beckley ([@ThatOtherPerson](https://gi
 
 ## Submitting your site
 
-If you've built a site with Gatsby and would like it to appear in the Site Showcase, please [submit your site](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/site-showcase-submissions.md).
+If you've built a site with Gatsby and would like it to appear in the Site Showcase, please [submit your site](https://github.com/gatsbyjs/gatsby/blob/master/docs/contributing/site-showcase-submissions.md).
 
 ## Why build a site showcase?
 

--- a/docs/blog/2018-07-20-why-we-built-the-site-showcase/index.md
+++ b/docs/blog/2018-07-20-why-we-built-the-site-showcase/index.md
@@ -17,7 +17,7 @@ The Site Showcase was developed by Cassie Beckley ([@ThatOtherPerson](https://gi
 
 ## Submitting your site
 
-If you've built a site with Gatsby and would like it to appear in the Site Showcase, please [submit your site](https://github.com/gatsbyjs/gatsby/blob/master/docs/contributing/site-showcase-submissions.md).
+If you've built a site with Gatsby and would like it to appear in the Site Showcase, please [submit your site](https://www.gatsbyjs.org/contributing/site-showcase-submissions/).
 
 ## Why build a site showcase?
 


### PR DESCRIPTION
## Description

Fixed broken link on the https://www.gatsbyjs.org/blog/2018-07-20-why-we-built-the-site-showcase/ blog post for the "submit your site" link:

`
If you’ve built a site with Gatsby and would like it to appear in the Site Showcase, please submit your site.
`

The link previously was https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/site-showcase-submissions.md and I updated it to https://www.gatsbyjs.org/contributing/site-showcase-submissions/