### PR TITLE
fix(docs): Fix more broken blog post links 

### DIFF
--- a/docs/blog/2017-10-17-building-i18n-with-gatsby/index.md
+++ b/docs/blog/2017-10-17-building-i18n-with-gatsby/index.md
@@ -79,7 +79,7 @@ To get started, you'll need to install a few packages:
 ## Setting up
 
 This is straight from the
-[i18n code examples](https://react.i18next.com/components/i18next-instance.html),
+[i18n code examples](https://react.i18next.com/latest/i18next-instance),
 but copied here for convenience. You'll need to create an i18n component and
 import it somewhere (we did it in our index layout):
 

--- a/docs/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/index.md
+++ b/docs/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/index.md
@@ -198,7 +198,7 @@ export default function Contact() {
 
 Pretty vanilla looking component! We are rendering a `form` with some validation and functionality provided by the excellent libraries [`yup`](https://www.npmjs.com/package/yup) and [`Formik`](https://github.com/jaredpalmer/formik). The likelihood that these libraries are used in _all_ routes in our application is unlikely--yet this is traditionally the approach that many take with bundling their client-side JS libraries. This means that even if a particular route (e.g. `/about`) is _not using_ certain libraries that they will still likely be included in a monolithic JavaScript bundle containing all dependencies. However--Gatsby, your friendly _web app compiler_, is a little smarter!
 
-We use code-splitting (enabled via our internalized dependency [Webpack](https://webpackjs.org)), and in particular, our approach prioritizes app-level dependencies (libraries used by the majority or all routes) coupled with route-based code splitting for dependencies that are likely only used on a particular route. To more fully understand this, let's take a look at a sample structure produced by our build process: `gatsby build`.
+We use code-splitting (enabled via our internalized dependency [Webpack](https://webpack.js.org)), and in particular, our approach prioritizes app-level dependencies (libraries used by the majority or all routes) coupled with route-based code splitting for dependencies that are likely only used on a particular route. To more fully understand this, let's take a look at a sample structure produced by our build process: `gatsby build`.
 
 ```title=public/
 ├── 404


### PR DESCRIPTION
## Description

For https://www.gatsbyjs.org/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/,
the https://webpackjs.org link does not resolve but https://webpack.js.org does

For https://www.gatsbyjs.org/blog/2017-10-17-building-i18n-with-gatsby/,
the https://react.i18next.com/components/i18next-instance.html link does not resolve
but https://react.i18next.com/latest/i18next-instance does

Apologies if my PRs are a bit spammy but it seems that links commonly are updated and broken. I wish there was an automated way to detect and fix this. The technique I've been using is to check sites like https://www.deadlinkchecker.com and https://www.brokenlinkcheck.com