### PR TITLE
fix(PnP): updates the test to account for the property name change

### DIFF
--- a/packages/gatsby/src/utils/test-require-error.js
+++ b/packages/gatsby/src/utils/test-require-error.js
@@ -3,7 +3,10 @@
 export default (moduleName, err) => {
   // PnP will return the following code when a require is allowed per the
   // dependency tree rules but the requested file doesn't exist
-  if (err.code === `QUALIFIED_PATH_RESOLUTION_FAILED` || err.pnpCode === `QUALIFIED_PATH_RESOLUTION_FAILED`) {
+  if (
+    err.code === `QUALIFIED_PATH_RESOLUTION_FAILED` ||
+    err.pnpCode === `QUALIFIED_PATH_RESOLUTION_FAILED`
+  ) {
     return true
   }
 

--- a/packages/gatsby/src/utils/test-require-error.js
+++ b/packages/gatsby/src/utils/test-require-error.js
@@ -3,7 +3,7 @@
 export default (moduleName, err) => {
   // PnP will return the following code when a require is allowed per the
   // dependency tree rules but the requested file doesn't exist
-  if (err.code === `QUALIFIED_PATH_RESOLUTION_FAILED`) {
+  if (err.code === `QUALIFIED_PATH_RESOLUTION_FAILED` || err.pnpCode === `QUALIFIED_PATH_RESOLUTION_FAILED`) {
     return true
   }
 


### PR DESCRIPTION
## Description

We've slightly changed the thrown errors for compatibility reasons. Since lots of thing specifically check for `MODULE_NOT_FOUND`, we're moving the semantic error codes into a different property name (`pnpCode`) as to not override `code`.

I'm not sure why you use this regex instead of checking for `MODULE_NOT_FOUND` btw. Might make sense to add a comment about it if you remember why 🤔

Ref https://github.com/yarnpkg/berry/pull/279