### PR TITLE
chore(showcase): Removing F1vision site from showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1090,15 +1090,6 @@
   categories:
     - Marketing
     - Technology
-- title: F1 Vision
-  main_url: "https://www.f1vision.com/"
-  url: "https://www.f1vision.com/"
-  featured: false
-  categories:
-    - Marketing
-    - Entertainment
-    - Technology
-    - eCommerce
 - title: Yuuniworks Portfolio / Blog
   main_url: "https://www.yuuniworks.com/"
   url: "https://www.yuuniworks.com/"


### PR DESCRIPTION
## Description

The people behind this site switched it to a landing page saying this service is not available in the 2019 season, and with such it is not using Gatsby for the landing page, so I am removing it from the showcase for now.