### PR TITLE
chore: Bugifx update all package repository fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
       - <<: *persist_cache
       - run: yarn lint:code
       - run: yarn lint:other
+      - run: yarn check-repo-fields
 
   unit_tests_node8:
     executor:

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "scripts": {
     "bootstrap": "npm-run-all -s check-versions lerna-prepare",
     "check-versions": "babel-node scripts/check-versions.js",
+    "check-repo-fields": "babel-node scripts/check-repo-fields.js",
     "format": "npm run format:code && npm run format:other && npm run format:svg",
     "format:other": "npm run prettier -- --write",
     "format:code": "npm run lint:code -- --fix",

--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -2,6 +2,12 @@
   "name": "babel-plugin-remove-graphql-queries",
   "version": "2.7.0",
   "author": "Jason Quense <monastic.panic@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/babel-plugin-remove-graphql-queries"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-plugin-remove-graphql-queries#readme",
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -2,6 +2,12 @@
   "name": "babel-preset-gatsby-package",
   "version": "0.2.0",
   "author": "Philipp Spiess <hello@philippspiess.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/babel-preset-gatsby-package"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby-package#readme",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-optional-chaining": "^7.0.0",

--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -2,6 +2,12 @@
   "name": "babel-preset-gatsby",
   "version": "0.2.1",
   "author": "Philipp Spiess <hello@philippspiess.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/babel-preset-gatsby"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby#readme",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -67,7 +67,11 @@
   ],
   "license": "MIT",
   "main": "lib/index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-cli"
+  },
   "scripts": {
     "build": "babel src --out-dir lib --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-codemods/package.json
+++ b/packages/gatsby-codemods/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-codemods#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-codemods"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-codemods"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-cypress/package.json
+++ b/packages/gatsby-cypress/package.json
@@ -3,7 +3,11 @@
   "version": "0.2.0",
   "description": "Cypress tools for Gatsby projects",
   "main": "index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-cypress"
+  },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress#readme",
   "author": "David Bailey <david.j.b@vivaldi.net>",
   "license": "MIT",

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -35,7 +35,11 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-dev-cli"
+  },
   "scripts": {
     "build": "babel src --out-dir dist --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-graphiql-explorer/package.json
+++ b/packages/gatsby-graphiql-explorer/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-graphiql-explorer#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-graphiql-explorer"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-image/package.json
+++ b/packages/gatsby-image/package.json
@@ -26,7 +26,11 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-image"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -30,7 +30,11 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-link"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-page-utils/package.json
+++ b/packages/gatsby-page-utils/package.json
@@ -13,7 +13,12 @@
   ],
   "author": "Yvonnick FRIN <frin.yvonnick@gmail.com>",
   "license": "MIT",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-page-utils",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-page-utils"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-page-utils#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -25,7 +25,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-canonical-urls"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-catch-links/package.json
+++ b/packages/gatsby-plugin-catch-links/package.json
@@ -26,7 +26,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-catch-links"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-coffeescript/package.json
+++ b/packages/gatsby-plugin-coffeescript/package.json
@@ -33,7 +33,11 @@
     "gatsby": "^2.0.0"
   },
   "readme": "README.md",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-coffeescript"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-create-client-paths/package.json
+++ b/packages/gatsby-plugin-create-client-paths/package.json
@@ -25,7 +25,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-create-client-paths"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -28,7 +28,11 @@
     "cxs": ">=5.0.0",
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-cxs"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -29,7 +29,11 @@
     "@emotion/core": "^10.0.5",
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-emotion"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-facebook-analytics/package.json
+++ b/packages/gatsby-plugin-facebook-analytics/package.json
@@ -29,7 +29,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-facebook-analytics"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",

--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -32,7 +32,11 @@
   "peerDependencies": {
     "gatsby": "^2.4.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-feed"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-flow/package.json
+++ b/packages/gatsby-plugin-flow/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-flow#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-flow"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-flow"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-plugin-fullstory/package.json
+++ b/packages/gatsby-plugin-fullstory/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-fullstory#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-fullstory"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-fullstory"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-plugin-glamor/package.json
+++ b/packages/gatsby-plugin-glamor/package.json
@@ -27,7 +27,11 @@
     "gatsby": "^2.0.0",
     "glamor": "^2.20.29"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-glamor"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -29,7 +29,11 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-google-analytics"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-google-gtag/package.json
+++ b/packages/gatsby-plugin-google-gtag/package.json
@@ -28,7 +28,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-google-gtag"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-google-tagmanager"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-guess-js/package.json
+++ b/packages/gatsby-plugin-guess-js/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-guess-js#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-guess-js"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-guess-js"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-plugin-jss/package.json
+++ b/packages/gatsby-plugin-jss/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.32"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-jss"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-layout/package.json
+++ b/packages/gatsby-plugin-layout/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-layout#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-layout"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-layout"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-plugin-less/package.json
+++ b/packages/gatsby-plugin-less/package.json
@@ -28,7 +28,11 @@
     "gatsby": "^2.0.0",
     "less": "^3.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-less"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__,theme-test.js",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-lodash/package.json
+++ b/packages/gatsby-plugin-lodash/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-lodash"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -32,7 +32,11 @@
   "peerDependencies": {
     "gatsby": "^2.4.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-manifest"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -4,9 +4,14 @@
   "description": "mdx integration for gatsby",
   "main": "index.js",
   "license": "MIT",
-  "homepage": "https://github.com/ChristopherBiscardi/gatsby-mdx/tree/master/packages/gatsby-mdx#readme",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-mdx#readme",
   "scripts": {
     "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-mdx"
   },
   "peerDependencies": {
     "@mdx-js/mdx": "^1.0.0",

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -39,7 +39,11 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-netlify-cms"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -37,7 +37,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-netlify"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-no-sourcemaps/package.json
+++ b/packages/gatsby-plugin-no-sourcemaps/package.json
@@ -15,7 +15,11 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-no-sourcemaps"
+  },
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },

--- a/packages/gatsby-plugin-nprogress/package.json
+++ b/packages/gatsby-plugin-nprogress/package.json
@@ -26,7 +26,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-nprogress"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -34,7 +34,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.100"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-offline"
+  },
   "scripts": {
     "build": "npm run build:src && npm run build:sw-append",
     "build:src": "babel src --out-dir . --ignore **/__tests__,src/sw-append.js",

--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -17,7 +17,12 @@
     "Steven Natera <tektekpush@gmail.com> (https://twitter.com/stevennatera)"
   ],
   "license": "MIT",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-page-creator"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",

--- a/packages/gatsby-plugin-postcss/package.json
+++ b/packages/gatsby-plugin-postcss/package.json
@@ -28,7 +28,11 @@
     "gatsby": "^2.0.0"
   },
   "readme": "README.md",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-postcss"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -27,7 +27,11 @@
     "gatsby": "^2.0.0",
     "preact": "^10.0.0-beta.1"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-preact"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-react-css-modules/package.json
+++ b/packages/gatsby-plugin-react-css-modules/package.json
@@ -34,7 +34,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-react-css-modules"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -38,7 +38,11 @@
     "gatsby": "^2.0.0",
     "react-helmet": "^5.1.3"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-react-helmet"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__,**/__mocks__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-remove-trailing-slashes/package.json
+++ b/packages/gatsby-plugin-remove-trailing-slashes/package.json
@@ -25,7 +25,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-remove-trailing-slashes"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -30,7 +30,11 @@
     "node-sass": "^4.9.0"
   },
   "readme": "README.md",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-sass"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -42,7 +42,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-sharp"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -28,7 +28,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-sitemap"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -28,7 +28,11 @@
     "gatsby": "^2.0.32",
     "styled-components": ">=2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-styled-components"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-styled-jsx/package.json
+++ b/packages/gatsby-plugin-styled-jsx/package.json
@@ -27,7 +27,11 @@
     "gatsby": "^2.0.0",
     "styled-jsx": "^3.0.2"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-styled-jsx"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-styletron"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -29,7 +29,11 @@
     "gatsby": "^2.0.0"
   },
   "readme": "README.md",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-stylus"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-subfont#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-subfont"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-subfont"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-plugin-twitter/package.json
+++ b/packages/gatsby-plugin-twitter/package.json
@@ -25,7 +25,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-twitter"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -31,7 +31,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-typescript"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-typography/package.json
+++ b/packages/gatsby-plugin-typography/package.json
@@ -35,7 +35,11 @@
     "react-typography": "^0.16.1 || ^1.0.0-alpha.0",
     "typography": "^0.16.0 || ^1.0.0-alpha.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-typography"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -30,7 +30,11 @@
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-react-router-scroll"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-autolink-headers/package.json
+++ b/packages/gatsby-remark-autolink-headers/package.json
@@ -30,7 +30,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-autolink-headers"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-code-repls/package.json
+++ b/packages/gatsby-remark-code-repls/package.json
@@ -35,7 +35,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-code-repls"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -37,7 +37,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-copy-linked-files"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -35,7 +35,11 @@
     "gatsby": "^2.0.0"
   },
   "private": false,
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-custom-blocks"
+  },
   "scripts": {
     "build": "babel --out-dir . --ignore **/__tests__ src",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -31,7 +31,11 @@
   },
   "license": "MIT",
   "main": "index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-embed-snippet"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-graphviz/package.json
+++ b/packages/gatsby-remark-graphviz/package.json
@@ -39,7 +39,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-graphviz"
+  },
   "scripts": {
     "build": "babel --out-dir . src --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -8,6 +8,12 @@
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-images-contentful"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images-contentful#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "axios": "^0.19.0",

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -39,7 +39,11 @@
     "gatsby": "^2.0.0",
     "gatsby-plugin-sharp": "^2.0.0-beta.5"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-images"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-katex/package.json
+++ b/packages/gatsby-remark-katex/package.json
@@ -31,7 +31,11 @@
     "gatsby": "^2.0.0",
     "katex": "^0.10.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-katex"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -32,7 +32,11 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-prismjs"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -34,7 +34,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-responsive-iframe"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-remark-smartypants/package.json
+++ b/packages/gatsby-remark-smartypants/package.json
@@ -29,7 +29,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-remark-smartypants"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -39,7 +39,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.33"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-contentful"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -31,7 +31,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-drupal"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-faker/package.json
+++ b/packages/gatsby-source-faker/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-faker"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -37,7 +37,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-filesystem"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -31,7 +31,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-graphql"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-hacker-news"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -33,7 +33,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-lever"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-medium/package.json
+++ b/packages/gatsby-source-medium/package.json
@@ -26,7 +26,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-medium"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -32,7 +32,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-mongodb"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-source-npm-package-search/package.json
+++ b/packages/gatsby-source-npm-package-search/package.json
@@ -3,6 +3,12 @@
   "description": "Search NPM packages and pull NPM & GitHub metadata from Algolia's NPM index",
   "version": "2.1.0",
   "author": "james.a.stack@gmail.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-npm-package-search"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-npm-package-search#readme",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "algoliasearch": "^3.25.1"

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -7,8 +7,12 @@
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "npm run build -- --watch"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopfiy#readme",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-shopify"
+  },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },

--- a/packages/gatsby-source-wikipedia/package.json
+++ b/packages/gatsby-source-wikipedia/package.json
@@ -24,7 +24,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wikipedia"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-wikipedia"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -37,7 +37,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-source-wordpress"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -46,7 +46,11 @@
   ],
   "license": "MIT",
   "main": "lib/index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-telemetry"
+  },
   "scripts": {
     "build": "babel src --out-dir lib --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-asciidoc/package.json
+++ b/packages/gatsby-transformer-asciidoc/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-asciidoc"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-csv/package.json
+++ b/packages/gatsby-transformer-csv/package.json
@@ -29,7 +29,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-csv"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-documentationjs/package.json
+++ b/packages/gatsby-transformer-documentationjs/package.json
@@ -29,7 +29,11 @@
   "peerDependencies": {
     "gatsby": "^2.2.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-documentationjs"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-excel/package.json
+++ b/packages/gatsby-transformer-excel/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-excel"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-hjson/package.json
+++ b/packages/gatsby-transformer-hjson/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-hjson"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-javascript-frontmatter/package.json
+++ b/packages/gatsby-transformer-javascript-frontmatter/package.json
@@ -3,6 +3,7 @@
   "description": "Gatsby transformer plugin for JavaScript to extract exports.frontmatter statically.",
   "version": "2.1.0",
   "author": "Jacob Bolda <me@jacobbolda.com>",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter#readme",
   "dependencies": {
     "@babel/parser": "^7.0.0",
     "@babel/runtime": "^7.0.0",
@@ -25,7 +26,11 @@
     "gatsby": "^2.0.15",
     "gatsby-source-filesystem": "^2.0.3"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-javascript-frontmatter"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-javascript-static-exports/package.json
+++ b/packages/gatsby-transformer-javascript-static-exports/package.json
@@ -28,7 +28,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-javascript-static-exports"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-json/package.json
+++ b/packages/gatsby-transformer-json/package.json
@@ -26,7 +26,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-json"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-pdf/package.json
+++ b/packages/gatsby-transformer-pdf/package.json
@@ -28,7 +28,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-pdf"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -33,7 +33,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-react-docgen"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -45,7 +45,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.88"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-remark"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-screenshot/package.json
+++ b/packages/gatsby-transformer-screenshot/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.33"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-screenshot"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "build-lambda-package": "npm run prepare-lambda-package && cp chrome/headless_shell.tar.gz lambda-dist && cd lambda-dist && zip -rq ../lambda-package.zip .",

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -33,7 +33,11 @@
     "gatsby": "^2.0.33",
     "gatsby-plugin-sharp": "^2.0.0-beta.3"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-sharp"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -39,7 +39,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-sqip"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",

--- a/packages/gatsby-transformer-toml/package.json
+++ b/packages/gatsby-transformer-toml/package.json
@@ -27,7 +27,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-toml"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -28,7 +28,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-xml"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -28,7 +28,11 @@
   "peerDependencies": {
     "gatsby": "^2.0.15"
   },
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-transformer-yaml"
+  },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-utils/package.json
+++ b/packages/gatsby-utils/package.json
@@ -7,12 +7,13 @@
     "gatsby-core-utils"
   ],
   "author": "Ward Peeters <ward@coding-tech.com>",
-  "homepage": "https://www.gatsbyjs.org/",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-utils#readme",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gatsbyjs/gatsby.git"
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-utils"
   },
   "scripts": {
     "build": "babel src --out-dir dist/ --ignore **/__tests__",

--- a/packages/graphql-skip-limit/package.json
+++ b/packages/graphql-skip-limit/package.json
@@ -26,7 +26,11 @@
   ],
   "license": "MIT",
   "main": "dist/index.js",
-  "repository": "https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/graphql-skip-limit"
+  },
   "scripts": {
     "build": "babel src --out-dir dist",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/scripts/check-repo-fields.js
+++ b/scripts/check-repo-fields.js
@@ -1,0 +1,97 @@
+//@ts-check
+const path = require(`path`)
+const fs = require(`fs`)
+const { getPackages } = require(`@lerna/project`)
+const yargs = require(`yargs`)
+const _ = require(`lodash`)
+
+const GIT_REPO_URL = `https://github.com/gatsbyjs/gatsby`
+const MAIN_PKG_NAME = `gatsby`
+
+// if a key has not been set before, let's try and insert it so
+// that it's not the last key in the package.json which makes merge
+// conflicts more likely
+function insertKeyAvoidMergeConflict(pkgJson, key, value) {
+  if (pkgJson[key]) {
+    pkgJson[key] = value
+    return pkgJson
+  } else {
+    const newPkgJson = {}
+    let inserted = false
+    for (const pkgKey in pkgJson) {
+      if (!inserted && /depend/i.test(pkgKey)) {
+        inserted = true
+        newPkgJson[key] = value
+      }
+      newPkgJson[pkgKey] = pkgJson[pkgKey]
+    }
+    return newPkgJson
+  }
+}
+
+async function main() {
+  let argv = yargs.option(`fix`, {
+    default: false,
+    describe: `Fixes outdated dependencies`,
+  }).argv
+
+  const rootDir = process.cwd()
+
+  const packages = await getPackages(rootDir)
+
+  let warned = false
+
+  await Promise.all(
+    packages.map(async pkg => {
+      // If this is the main gastby package we don't want to override
+      if (pkg.name === MAIN_PKG_NAME || pkg.private) {
+        // eslint complains if we don't consistently return the same type
+        return Promise.resolve()
+      }
+
+      let pkgJson = pkg.toJSON()
+      const relativeLocation = path.relative(rootDir, pkg.location)
+
+      pkgJson = insertKeyAvoidMergeConflict(pkgJson, `repository`, {
+        type: `git`,
+        url: `${GIT_REPO_URL}.git`,
+        directory: relativeLocation,
+      })
+
+      pkgJson = insertKeyAvoidMergeConflict(
+        pkgJson,
+        `homepage`,
+        `${GIT_REPO_URL}/tree/master/${relativeLocation}#readme`
+      )
+
+      if (argv.fix) {
+        return new Promise((resolve, reject) => {
+          fs.writeFile(
+            path.join(relativeLocation, `package.json`),
+            JSON.stringify(pkgJson, null, 2) + `\n`,
+            `utf8`,
+            err => {
+              if (err) reject(err)
+              else resolve()
+            }
+          )
+        })
+      } else {
+        if (!_.isEqual(pkg.toJSON(), pkgJson)) {
+          warned = true
+          console.error(
+            `[${pkg.name}]` +
+              ` repository and/or homepage field in package.json are out of date.` +
+              `Run "yarn run check-repo-fields -- --fix" to update.`
+          )
+        }
+        // eslint complains if we don't consistently return the same type
+        return Promise.resolve()
+      }
+    })
+  )
+  if (warned) {
+    process.exit(1)
+  }
+}
+main()

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -11,6 +11,12 @@
     "blog"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "themes/gatsby-theme-blog"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-theme-blog#readme",
   "dependencies": {
     "@emotion/core": "^10.0.14",
     "@mdx-js/mdx": "^1.0.23",

--- a/themes/gatsby-theme-notes/package.json
+++ b/themes/gatsby-theme-notes/package.json
@@ -13,6 +13,12 @@
     "notes",
     "digital-garden"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "themes/gatsby-theme-notes"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-theme-notes#readme",
   "devDependencies": {
     "gatsby": "^2.13.13",
     "react": "^16.8.6",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Looking at some gatsby packages on npm they are missing any link to the github repo source so it was difficult to find where the source code was.

This PR fixes all the `repository` fields for packages and add a script to be able to do this easily again in the future. Or if we want to make a sweeping change can update the script instead of manually updating each package.

Something I'm not sure about: I had to update the lerna config to include the `themes` directory. I think this should be ok but not sure what else this might affect.

## Related Issues

Related: https://github.com/gatsbyjs/gatsby/issues/12755
