### PR TITLE
fix(gatsby): bump `react-hot-loader` version to fix regressions in gatsby-plugin-typescript

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -108,7 +108,7 @@
     "raw-loader": "^0.5.1",
     "react-dev-utils": "^4.2.3",
     "react-error-overlay": "^3.0.0",
-    "react-hot-loader": "^4.8.4",
+    "react-hot-loader": "^4.12.5",
     "read-package-tree": "^5.3.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17004,15 +17004,15 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
-react-hot-loader@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.8.4.tgz#357ba342e367fd42d6a870a9c0601c23fa0730c6"
+react-hot-loader@^4.12.5:
+  version "4.12.5"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.5.tgz#ebe5b6a68190b14fce42151fff03d1ad43634e9b"
+  integrity sha512-RH7mi2hSp+74pM/GCwFoQ+nHY6JnFKrzBNbSWnOfT9LJMMnCWf/Eg5CoaeJHMpvqF+x6hdT//T2GoSpqImEzfg==
   dependencies:
     fast-levenshtein "^2.0.6"
     global "^4.3.0"
     hoist-non-react-statics "^3.3.0"
     loader-utils "^1.1.0"
-    lodash "^4.17.11"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"


### PR DESCRIPTION
This is not strictly needed, but it will help with resolving recent issues in `gatsby-plugin-typescript` ( https://github.com/gatsbyjs/gatsby/issues/15423 ) when `react-hot-loader` is pinned with lock file

Related upstream issues:
 - https://github.com/babel/babel/issues/10162
 - https://github.com/gaearon/react-hot-loader/issues/1292

Fixes #15423