### PR TITLE
fix(gatsby): speed up and lower memory of createPages

### DIFF
--- a/packages/gatsby/src/redux/machines/page-component.js
+++ b/packages/gatsby/src/redux/machines/page-component.js
@@ -105,8 +105,8 @@ module.exports = Machine(
                 queryUtil.runQueuedQueries(event.path)
               }
             }, 0)
-
-            return ctx.pages.concat(event.path)
+            ctx.pages.push(event.path)
+            return ctx.pages
           } else {
             return ctx.pages
           }


### PR DESCRIPTION
## Description

I was noticing very slow createPages times with 75k pages, so I started profiling and found that it was allocating 18GB(!!!) of RAM, and spending a significant amount of time garbage collecting.

I tracked it down to the line modified in this PR, and replaced it with a push rather than a concat. The places it is used don't appear to care if the initial array is modified or not, however whether this is guaranteed I'm unsure.

Tests appear to still work for me, as does the site with 75k pages.

This took RAM from 18GB to 1.5GB, and createPages times from 240-300 to 100-150.

This is one of two sections that use ridiculous amounts of RAM at large page counts. The other is the creation of bundles and HTML pages, however I haven't had a chance to look into this yet. They easily use ~25GB of RAM in 75k pages.