### PR TITLE
feat(gatsby): Make builtin field extensions wrap resolvers

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -1102,7 +1102,7 @@ describe(`Build schema`, () => {
       const type = schema.getType(`PostFrontmatter`)
       const fields = type.getFields()
       expect(
-        fields[`date`].resolve(
+        await fields[`date`].resolve(
           { date: new Date(2019, 10, 10) },
           { formatString: `YYYY` },
           {},
@@ -1112,7 +1112,7 @@ describe(`Build schema`, () => {
         )
       ).toEqual(`2019`)
       expect(
-        fields[`date`].resolve(
+        await fields[`date`].resolve(
           { date: new Date(2010, 10, 10) },
           { formatString: `YYYY` },
           {},

--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -55,7 +55,7 @@ const builtInFieldExtensions = {
       locale: { type: GraphQLString },
     },
     extend(args, fieldConfig) {
-      return getDateResolver(args)
+      return getDateResolver(args, fieldConfig)
     },
   },
 
@@ -72,8 +72,9 @@ const builtInFieldExtensions = {
       },
     },
     extend(args, fieldConfig) {
+      const originalResolver = fieldConfig.resolve || defaultFieldResolver
       return {
-        resolve: link(args),
+        resolve: link(args, originalResolver),
       }
     },
   },
@@ -87,8 +88,9 @@ const builtInFieldExtensions = {
       },
     },
     extend(args, fieldConfig) {
+      const originalResolver = fieldConfig.resolve || defaultFieldResolver
       return {
-        resolve: fileByPath(args),
+        resolve: fileByPath(args, originalResolver),
       }
     },
   },
@@ -102,10 +104,10 @@ const builtInFieldExtensions = {
       },
     },
     extend({ from }, fieldConfig) {
-      const resolver = fieldConfig.resolve || defaultFieldResolver
+      const originalResolver = fieldConfig.resolve || defaultFieldResolver
       return {
         resolve(source, args, context, info) {
-          return resolver(source, args, context, {
+          return originalResolver(source, args, context, {
             ...info,
             fieldName: from,
           })

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -115,8 +115,16 @@ const paginate = (results = [], { skip = 0, limit }) => {
   }
 }
 
-const link = ({ by = `id`, from }) => async (source, args, context, info) => {
-  const fieldValue = source && source[from || info.fieldName]
+const link = ({ by = `id`, from }, originalResolver) => async (
+  source,
+  args,
+  context,
+  info
+) => {
+  const fieldValue = await originalResolver(source, args, context, {
+    ...info,
+    fieldName: from || info.fieldName,
+  })
 
   if (fieldValue == null || _.isPlainObject(fieldValue)) return fieldValue
   if (
@@ -173,8 +181,16 @@ const link = ({ by = `id`, from }) => async (source, args, context, info) => {
   }
 }
 
-const fileByPath = ({ from }) => (source, args, context, info) => {
-  const fieldValue = source && source[from || info.fieldName]
+const fileByPath = ({ from }, originalResolver) => async (
+  source,
+  args,
+  context,
+  info
+) => {
+  const fieldValue = await originalResolver(source, args, context, {
+    ...info,
+    fieldName: from || info.fieldName,
+  })
 
   if (fieldValue == null || _.isPlainObject(fieldValue)) return fieldValue
   if (

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -113,7 +113,7 @@ const updateSchemaComposer = async ({
     parentSpan,
   })
   await Promise.all(
-    Array.from(schemaComposer.values()).map(typeComposer =>
+    Array.from(new Set(schemaComposer.values())).map(typeComposer =>
       processTypeComposer({
         schemaComposer,
         typeComposer,

--- a/packages/gatsby/src/schema/types/__tests__/date.js
+++ b/packages/gatsby/src/schema/types/__tests__/date.js
@@ -446,7 +446,7 @@ describe(`dateResolver`, () => {
     const schema = await buildTestSchema({})
     const fields = schema.getType(`Test`).getFields()
     expect(
-      fields[`testDate`].resolve(
+      await fields[`testDate`].resolve(
         { date: dateString },
         { formatString: `MMM DD, YYYY` },
         {},
@@ -471,7 +471,7 @@ describe(`dateResolver`, () => {
     const schema = await buildTestSchema({})
     const fields = schema.getType(`Test`).getFields()
     expect(
-      fields[`testDate`].resolve(
+      await fields[`testDate`].resolve(
         { date: dateString },
         { formatString: `MMM DD, YYYY` },
         {},

--- a/packages/gatsby/src/schema/types/date.js
+++ b/packages/gatsby/src/schema/types/date.js
@@ -4,6 +4,7 @@ const {
   GraphQLBoolean,
   GraphQLScalarType,
   Kind,
+  defaultFieldResolver,
 } = require(`graphql`)
 const { oneLine } = require(`common-tags`)
 
@@ -215,10 +216,12 @@ const formatDate = ({
   return normalizedDate
 }
 
-const getDateResolver = defaults => {
+const getDateResolver = (defaults, prevFieldConfig) => {
+  const resolver = prevFieldConfig.resolve || defaultFieldResolver
   const { locale, formatString } = defaults
   return {
     args: {
+      ...prevFieldConfig.args,
       formatString: {
         type: GraphQLString,
         description: oneLine`
@@ -248,8 +251,8 @@ const getDateResolver = defaults => {
         defaultValue: locale,
       },
     },
-    resolve(source, args, context, { fieldName }) {
-      const date = source[fieldName]
+    async resolve(source, args, context, info) {
+      const date = await resolver(source, args, context, info)
       if (date == null) return null
 
       return Array.isArray(date)


### PR DESCRIPTION
Built-in field extensions (`dateformat` etc.) should wrap existing field resolvers (both resolvers provided with `createTypes` and `createResolvers`, as well as resolvers added by other field extensions).

This is useful e.g. to fix issues like #14765, where a source plugin returns `0` instead of `null` on empty Date fields. We want to be able to add a custom resolver to the field that converts zeros to null, but also keep the `dateformat` extension (which until now would replace any pre-existing field resolver)