### PR TITLE
fix(gatsby-transformer-remark): Fix transformer-remark when using assetPrefix

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -480,6 +480,13 @@ Object {
 }
 `;
 
+exports[`Relative links keep being relative relative links are not prefixed 1`] = `
+Object {
+  "html": "<p>This is <a href=\\"path/to/page1\\">a link</a>.</p>
+<p>This is <a href=\\"./path/to/page2\\">a reference</a></p>",
+}
+`;
+
 exports[`Table of contents is generated correctly from schema correctly generates table of contents 1`] = `
 Object {
   "frontmatter": Object {

--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -473,6 +473,13 @@ Object {
 }
 `;
 
+exports[`Links are correctly prefixed when assetPrefix is used correctly prefixes links 1`] = `
+Object {
+  "html": "<p>This is <a href=\\"/prefix/path/to/page1\\">a link</a>.</p>
+<p>This is <a href=\\"/prefix/path/to/page2\\">a reference</a></p>",
+}
+`;
+
 exports[`Table of contents is generated correctly from schema correctly generates table of contents 1`] = `
 Object {
   "frontmatter": Object {

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -920,6 +920,30 @@ final text`,
   )
 })
 
+describe(`Relative links keep being relative`, () => {
+  const assetPrefix = ``
+  const basePath = `/prefix`
+  const pathPrefix = assetPrefix + basePath
+
+  bootstrapTest(
+    `relative links are not prefixed`,
+    `
+This is [a link](path/to/page1).
+
+This is [a reference]
+
+[a reference]: ./path/to/page2
+`,
+    `html`,
+    node => {
+      expect(node).toMatchSnapshot()
+      expect(node.html).toMatch(`<a href="path/to/page1">`)
+      expect(node.html).toMatch(`<a href="./path/to/page2">`)
+    },
+    { additionalParameters: { pathPrefix: pathPrefix, basePath: basePath } }
+  )
+})
+
 describe(`Links are correctly prefixed`, () => {
   const assetPrefix = ``
   const basePath = `/prefix`

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -921,6 +921,10 @@ final text`,
 })
 
 describe(`Links are correctly prefixed`, () => {
+  const assetPrefix = ``
+  const basePath = `/prefix`
+  const pathPrefix = assetPrefix + basePath
+
   bootstrapTest(
     `correctly prefixes links`,
     `
@@ -936,7 +940,31 @@ This is [a reference]
       expect(node.html).toMatch(`<a href="/prefix/path/to/page1">`)
       expect(node.html).toMatch(`<a href="/prefix/path/to/page2">`)
     },
-    { additionalParameters: { pathPrefix: `/prefix` } }
+    { additionalParameters: { pathPrefix: pathPrefix, basePath: basePath } }
+  )
+})
+
+describe(`Links are correctly prefixed when assetPrefix is used`, () => {
+  const assetPrefix = `https://example.com/assets`
+  const basePath = `/prefix`
+  const pathPrefix = assetPrefix + basePath
+
+  bootstrapTest(
+    `correctly prefixes links`,
+    `
+This is [a link](/path/to/page1).
+
+This is [a reference]
+
+[a reference]: /path/to/page2
+`,
+    `html`,
+    node => {
+      expect(node).toMatchSnapshot()
+      expect(node.html).toMatch(`<a href="/prefix/path/to/page1">`)
+      expect(node.html).toMatch(`<a href="/prefix/path/to/page2">`)
+    },
+    { additionalParameters: { pathPrefix: pathPrefix, basePath: basePath } }
   )
 })
 

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -94,6 +94,7 @@ const SpaceMarkdownNodeTypesSet = new Set([
 module.exports = (
   {
     type,
+    basePath,
     pathPrefix,
     getNode,
     getNodesByType,
@@ -108,7 +109,7 @@ module.exports = (
     return {}
   }
   pluginsCacheStr = pluginOptions.plugins.map(p => p.name).join(``)
-  pathPrefixCacheStr = pathPrefix || ``
+  pathPrefixCacheStr = basePath || ``
 
   const getCache = safeGetCache({ cache, getCache: possibleGetCache })
 
@@ -203,7 +204,7 @@ module.exports = (
       })
       const markdownAST = remark.parse(markdownNode.internal.content)
 
-      if (pathPrefix) {
+      if (basePath) {
         // Ensure relative links include `pathPrefix`
         visit(markdownAST, [`link`, `definition`], node => {
           if (
@@ -211,7 +212,7 @@ module.exports = (
             node.url.startsWith(`/`) &&
             !node.url.startsWith(`//`)
           ) {
-            node.url = withPathPrefix(node.url, pathPrefix)
+            node.url = withPathPrefix(node.url, basePath)
           }
         })
       }
@@ -259,7 +260,7 @@ module.exports = (
               markdownNode,
               getNode,
               files: fileNodes,
-              pathPrefix,
+              basePath,
               reporter,
               cache: getCache(plugin.name),
               getCache,
@@ -322,7 +323,7 @@ module.exports = (
                 return null
               }
               node.url = [
-                pathPrefix,
+                basePath,
                 _.get(markdownNode, appliedTocOptions.pathToSlugField),
                 node.url,
               ]


### PR DESCRIPTION
## Description

Fixed support for `assetPrefix` with `gatsby-transformer-remark`

## Related Issues

Fixes #15514
