### PR TITLE
chore(gatsby-plugin-mdx): Remove unused _PARENT frontmatter field

### DIFF
--- a/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
+++ b/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
@@ -28,7 +28,6 @@ module.exports = async ({ id, node, content }) => {
   mdxNode.frontmatter = {
     title: ``, // always include a title
     ...frontmatter,
-    _PARENT: node.id
   };
 
   mdxNode.excerpt = frontmatter.excerpt;


### PR DESCRIPTION
We did remove the same field for `gatsby-transformer-remark` in #10919