### PR TITLE
[docs] Remove extra "prop drilling" words in CRA docs

### DIFF
--- a/docs/docs/porting-from-create-react-app-to-gatsby.md
+++ b/docs/docs/porting-from-create-react-app-to-gatsby.md
@@ -217,7 +217,7 @@ Create React App will require you to eject or rely on another workaround to edit
 
 #### Context providers
 
-React's context API allows you to share state from a higher component and distribute it to components below it in the component tree without having to deal with issues like prop drilling [prop drilling](https://kentcdodds.com/blog/prop-drilling).
+React's context API allows you to share state from a higher component and distribute it to components below it in the component tree without having to deal with issues like [prop drilling](https://kentcdodds.com/blog/prop-drilling).
 
 How do you share state across components like a theme without one top level `App.js` file? Gatsby has a `wrapRootElement` and a `wrapPageElement` API that allow you to wrap the root element or all pages of your Gatsby site with components you want.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I noticed while reading the section *Porting from Create React App* in the Context providers section that the words "prop drilling" appeared twice right next to each other. This PR removes the extra words.

Current [docs](https://www.gatsbyjs.org/docs/porting-from-create-react-app-to-gatsby/#context-providers)
