### PR TITLE
Remove base path "/app" in client route.

### DIFF
--- a/docs/tutorial/authentication-tutorial.md
+++ b/docs/tutorial/authentication-tutorial.md
@@ -158,8 +158,8 @@ import Login from "../components/login"
 const App = () => (
   <Layout>
     <Router>
-      <Profile path="/app/profile" />
-      <Login path="/app/login" />
+      <Profile path="/profile" />
+      <Login path="/login" />
     </Router>
   </Layout>
 )


### PR DESCRIPTION
The example not work with the path /app/profile or /app/login. 
Now, the path is without "/app" for find the route.

## Related Issues

Related to #15401 
