### PR TITLE
feat(gatsby): Add nodeInterface extension

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
@@ -31,6 +31,20 @@ Object {
         },
       ],
     },
+    "interface": Object {
+      "nodes": Array [
+        Object {
+          "code": "3lADm0M90E",
+          "id": "1001206739996237060",
+          "image": Object {
+            "childImageSharp": Object {
+              "id": "0b06bdfe-f253-5859-8321-b42b5d737195",
+            },
+          },
+          "time": "06 kesäkuu",
+        },
+      ],
+    },
     "resolveFilter": Object {
       "id": "1601601194425654597",
       "idWithDecoration": "decoration-1601601194425654597",

--- a/packages/gatsby/src/schema/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/__tests__/interfaces.js
@@ -1,0 +1,237 @@
+const { graphql } = require(`graphql`)
+const { build } = require(`..`)
+const withResolverContext = require(`../context`)
+const { store } = require(`../../redux`)
+const { dispatch } = store
+const { actions } = require(`../../redux/actions/restricted`)
+const { createTypes } = actions
+require(`../../db/__tests__/fixtures/ensure-loki`)()
+
+const report = require(`gatsby-cli/lib/reporter`)
+report.panic = jest.fn()
+afterEach(() => {
+  report.panic.mockClear()
+})
+
+describe(`Queryable interfaces`, () => {
+  beforeEach(() => {
+    dispatch({ type: `DELETE_CACHE` })
+    const nodes = [
+      {
+        id: `test1`,
+        internal: { type: `Test` },
+        foo: `foo`,
+        bar: `bar`,
+        date: new Date(`2019-01-01`),
+      },
+      {
+        id: `anothertest1`,
+        internal: { type: `AnotherTest` },
+        foo: `foooo`,
+        baz: `baz`,
+        date: new Date(`2018-01-01`),
+      },
+    ]
+    nodes.forEach(node => {
+      dispatch({ type: `CREATE_NODE`, payload: { ...node } })
+    })
+    dispatch(
+      createTypes(`
+        interface TestInterface @queryable {
+          foo: String
+          date: Date @dateformat
+        }
+        type Test implements Node & TestInterface {
+          foo: String
+          bar: String
+          date: Date @dateformat
+        }
+        type AnotherTest implements Node & TestInterface {
+          foo: String
+          baz: String
+          date: Date @dateformat
+        }
+      `)
+    )
+  })
+
+  it(`adds root query fields for interface with @queryable extension`, async () => {
+    const schema = await buildSchema()
+    const rootQueryFields = schema.getType(`Query`).getFields()
+    expect(rootQueryFields.testInterface).toBeDefined()
+    expect(rootQueryFields.allTestInterface).toBeDefined()
+    expect(rootQueryFields.testInterface.resolve).toBeDefined()
+    expect(rootQueryFields.allTestInterface.resolve).toBeDefined()
+  })
+
+  it(`does not add root query fields for interface without @queryable extension`, async () => {
+    dispatch(
+      createTypes(`
+        interface WrongInterface {
+          foo: String
+        }
+        type Wrong implements Node & WrongInterface {
+          foo: String
+        }
+        type WrongAgain implements Node & WrongInterface {
+          foo: String
+        }
+      `)
+    )
+    const schema = await buildSchema()
+    const rootQueryFields = schema.getType(`Query`).getFields()
+    expect(rootQueryFields.wrongInterface).toBeUndefined()
+    expect(rootQueryFields.allWrongInterface).toBeUndefined()
+  })
+
+  it(`does not add root query fields for interfaces when types don't implement Node interface`, async () => {
+    dispatch(
+      createTypes(`
+          interface WrongInterface @queryable {
+            foo: String
+          }
+          type Wrong implements WrongInterface {
+            foo: String
+          }
+          type WrongAgain implements WrongInterface {
+            foo: String
+          }
+        `)
+    )
+    await buildSchema()
+    expect(report.panic).toBeCalledWith(
+      `Interfaces with the \`queryable\` extension must only be ` +
+        `implemented by types which also implement the \`Node\` ` +
+        `interface. Check the type definition of \`Wrong\`, \`WrongAgain\`.`
+    )
+  })
+
+  it(`returns correct results for query`, async () => {
+    const query = `
+      {
+        allTestInterface {
+          nodes {
+            foo
+            ...on AnotherTest {
+              baz
+            }
+            ...on Node {
+              id
+            }
+          }
+        }
+        testInterface {
+          foo
+          ...on Test {
+            bar
+          }
+          ...on Node {
+            id
+          }
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allTestInterface: {
+        nodes: [
+          {
+            foo: `foo`,
+            id: `test1`,
+          },
+          {
+            foo: `foooo`,
+            baz: `baz`,
+            id: `anothertest1`,
+          },
+        ],
+      },
+      testInterface: {
+        foo: `foo`,
+        bar: `bar`,
+        id: `test1`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`returns correct results for query with args`, async () => {
+    const query = `
+      {
+        allTestInterface(
+          filter: { foo: { eq: "foooo" } }
+        ) {
+          nodes {
+            foo
+          }
+        }
+        testInterface(foo: { eq: "foooo" }) {
+          foo
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allTestInterface: {
+        nodes: [
+          {
+            foo: `foooo`,
+          },
+        ],
+      },
+      testInterface: {
+        foo: `foooo`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`adds input args from extensions to fields`, async () => {
+    const query = `
+      {
+        allTestInterface {
+          nodes {
+            date(formatString: "YYYY")
+          }
+        }
+        testInterface {
+          date(formatString: "MM/DD/YYYY")
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allTestInterface: {
+        nodes: [
+          {
+            date: `2019`,
+          },
+          {
+            date: `2018`,
+          },
+        ],
+      },
+      testInterface: {
+        date: `01/01/2019`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+})
+
+const buildSchema = async () => {
+  await build({})
+  return store.getState().schema
+}
+
+const runQuery = async query => {
+  const schema = await buildSchema({})
+  const results = await graphql(
+    schema,
+    query,
+    undefined,
+    withResolverContext({}, schema)
+  )
+  expect(results.errors).toBeUndefined()
+  return results.data
+}

--- a/packages/gatsby/src/schema/__tests__/kitchen-sink.js
+++ b/packages/gatsby/src/schema/__tests__/kitchen-sink.js
@@ -54,8 +54,12 @@ describe(`Kitchen sink schema test`, () => {
     store.dispatch({
       type: `CREATE_TYPES`,
       payload: `
-        type PostsJson implements Node @infer {
-          id: String!
+        interface Post @nodeInterface {
+          id: ID!
+          code: String
+        }
+        type PostsJson implements Node & Post @infer {
+          id: ID!
           time: Date @dateformat(locale: "fi", formatString: "DD MMMM")
           code: String
           image: File @fileByRelativePath
@@ -76,6 +80,20 @@ describe(`Kitchen sink schema test`, () => {
     expect(
       await runQuery(`
         {
+          interface: allPost(sort: { fields: id }, limit: 1) {
+            nodes {
+              id
+              code
+              ... on PostsJson {
+                time
+                image {
+                  childImageSharp {
+                    id
+                  }
+                }
+              }
+            }
+          }
           sort: allPostsJson(sort: { fields: likes, order: ASC }, limit: 2) {
             edges {
               node {
@@ -105,7 +123,9 @@ describe(`Kitchen sink schema test`, () => {
               }
             }
           }
-          resolveFilter: postsJson(idWithDecoration: { eq: "decoration-1601601194425654597"}) {
+          resolveFilter: postsJson(
+            idWithDecoration: { eq: "decoration-1601601194425654597" }
+          ) {
             id
             idWithDecoration
             likes

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -56,6 +56,7 @@ describe(`Queryable Node interfaces`, () => {
     dispatch(
       createTypes(`
         interface TestInterface @nodeInterface {
+          id: ID!
           foo: String
           date: Date @dateformat
         }
@@ -86,6 +87,7 @@ describe(`Queryable Node interfaces`, () => {
     dispatch(
       createTypes(`
         interface WrongInterface {
+          id: ID!
           foo: String
         }
         type Wrong implements Node & WrongInterface {
@@ -106,6 +108,7 @@ describe(`Queryable Node interfaces`, () => {
     dispatch(
       createTypes(`
         interface WrongInterface @nodeInterface {
+          id: ID!
           foo: String
         }
         type Wrong implements WrongInterface {
@@ -133,6 +136,7 @@ describe(`Queryable Node interfaces`, () => {
             nodeInterface: true,
           },
           fields: {
+            id: `ID!`,
             foo: `String`,
             date: {
               type: `Date`,
@@ -314,6 +318,26 @@ describe(`Queryable Node interfaces`, () => {
       },
     }
     expect(results).toEqual(expected)
+  })
+
+  it(`shows error when interface with @nodeInterface extension does not have id field`, async () => {
+    dispatch(
+      createTypes(`
+        interface NotWrongInterface @nodeInterface {
+          id: ID!
+          foo: String
+        }
+        interface WrongInterface @nodeInterface {
+          foo: String
+        }
+      `)
+    )
+    await buildSchema()
+    expect(report.panic).toBeCalledTimes(1)
+    expect(report.panic).toBeCalledWith(
+      `Interfaces with the \`nodeInterface\` extension must have a field ` +
+        `\`id\` of type \`ID!\`. Check the type definition of \`WrongInterface\`.`
+    )
   })
 })
 

--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -44,10 +44,11 @@ const typeExtensions = {
       },
     },
   },
-  queryable: {
+  nodeInterface: {
     description:
       `Adds root query fields for an interface. All implementing types ` +
       `must also implement the Node interface.`,
+    locations: [DirectiveLocation.INTERFACE],
   },
 }
 
@@ -133,17 +134,21 @@ const reservedExtensionNames = [
   ...Object.keys(builtInFieldExtensions),
 ]
 
-const toDirectives = ({ schemaComposer, extensions, locations }) =>
+const toDirectives = ({
+  schemaComposer,
+  extensions,
+  locations: defaultLocations,
+}) =>
   Object.keys(extensions).map(name => {
     const extension = extensions[name]
-    const { args, description } = extension
+    const { args, description, locations } = extension
     // Support the `graphql-compose` style of directly providing the field type as string
     const normalizedArgs = schemaComposer.typeMapper.convertArgConfigMap(args)
     return new GraphQLDirective({
       name,
       args: normalizedArgs,
       description,
-      locations,
+      locations: locations || defaultLocations,
     })
   })
 

--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -44,6 +44,11 @@ const typeExtensions = {
       },
     },
   },
+  queryable: {
+    description:
+      `Adds root query fields for an interface. All implementing types ` +
+      `must also implement the Node interface.`,
+  },
 }
 
 const builtInFieldExtensions = {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -171,8 +171,8 @@ class LocalNodeModel {
     // We provide nodes in case of abstract types, because `run-sift` should
     // only need to know about node types in the store.
     let nodes
-    const nodeTypeNames = toNodeTypeNames(this.schema, gqlType)
-    if (nodeTypeNames.length > 1) {
+    if (isAbstractType(gqlType)) {
+      const nodeTypeNames = toNodeTypeNames(this.schema, gqlType)
       nodes = nodeTypeNames.reduce(
         (acc, typeName) => acc.concat(this.nodeStore.getNodesByType(typeName)),
         []

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -331,6 +331,16 @@ const addExtensions = ({
           break
         case `nodeInterface`:
           if (typeComposer instanceof InterfaceTypeComposer) {
+            if (
+              !typeComposer.hasField(`id`) ||
+              typeComposer.getFieldType(`id`).toString() !== `ID!`
+            ) {
+              report.panic(
+                `Interfaces with the \`nodeInterface\` extension must have a field ` +
+                  `\`id\` of type \`ID!\`. Check the type definition of ` +
+                  `\`${typeComposer.getTypeName()}\`.`
+              )
+            }
             typeComposer.setExtension(`nodeInterface`, true)
           }
           break

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -153,8 +153,8 @@ const processTypeComposer = async ({
       await addTypeToRootQuery({ schemaComposer, typeComposer, parentSpan })
     }
   } else if (typeComposer instanceof InterfaceTypeComposer) {
-    if (typeComposer.getExtension(`queryable`)) {
-      // We only process field extensions for queryable interfaces, so we get
+    if (typeComposer.getExtension(`nodeInterface`)) {
+      // We only process field extensions for queryable Node interfaces, so we get
       // the input args on the root query type, e.g. `formatString` etc. for `dateformat`
       await processFieldExtensions({
         schemaComposer,
@@ -329,9 +329,9 @@ const addExtensions = ({
             )
           }
           break
-        case `queryable`:
+        case `nodeInterface`:
           if (typeComposer instanceof InterfaceTypeComposer) {
-            typeComposer.setExtension(`queryable`, true)
+            typeComposer.setExtension(`nodeInterface`, true)
           }
           break
         default:
@@ -870,7 +870,7 @@ const checkQueryableInterfaces = ({ schemaComposer }) => {
   schemaComposer.forEach(type => {
     if (
       type instanceof InterfaceTypeComposer &&
-      type.getExtension(`queryable`)
+      type.getExtension(`nodeInterface`)
     ) {
       queryableInterfaces.add(type.getTypeName())
     }
@@ -889,7 +889,7 @@ const checkQueryableInterfaces = ({ schemaComposer }) => {
   })
   if (incorrectTypes.length) {
     report.panic(
-      `Interfaces with the \`queryable\` extension must only be ` +
+      `Interfaces with the \`nodeInterface\` extension must only be ` +
         `implemented by types which also implement the \`Node\` ` +
         `interface. Check the type definition of ` +
         `${incorrectTypes.map(t => `\`${t}\``).join(`, `)}.`

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -123,6 +123,7 @@ const updateSchemaComposer = async ({
       })
     )
   )
+  checkQueryableInterfaces({ schemaComposer })
   await addThirdPartySchemas({ schemaComposer, thirdPartySchemas, parentSpan })
   await addCustomResolveFunctions({ schemaComposer, parentSpan })
 }
@@ -143,11 +144,22 @@ const processTypeComposer = async ({
     })
     if (typeComposer.hasInterface(`Node`)) {
       await addNodeInterfaceFields({ schemaComposer, typeComposer, parentSpan })
-      await addResolvers({ schemaComposer, typeComposer, parentSpan })
       await addConvenienceChildrenFields({
         schemaComposer,
         typeComposer,
         nodeStore,
+        parentSpan,
+      })
+      await addTypeToRootQuery({ schemaComposer, typeComposer, parentSpan })
+    }
+  } else if (typeComposer instanceof InterfaceTypeComposer) {
+    if (typeComposer.getExtension(`queryable`)) {
+      // We only process field extensions for queryable interfaces, so we get
+      // the input args on the root query type, e.g. `formatString` etc. for `dateformat`
+      await processFieldExtensions({
+        schemaComposer,
+        typeComposer,
+        fieldExtensions,
         parentSpan,
       })
       await addTypeToRootQuery({ schemaComposer, typeComposer, parentSpan })
@@ -315,6 +327,11 @@ const addExtensions = ({
               `addDefaultResolvers`,
               !args.noDefaultResolvers
             )
+          }
+          break
+        case `queryable`:
+          if (typeComposer instanceof InterfaceTypeComposer) {
+            typeComposer.setExtension(`queryable`, true)
           }
           break
         default:
@@ -628,47 +645,6 @@ const addCustomResolveFunctions = async ({ schemaComposer, parentSpan }) => {
   })
 }
 
-const addResolvers = ({ schemaComposer, typeComposer }) => {
-  const typeName = typeComposer.getTypeName()
-
-  // TODO: We should have an abstraction for keeping and clearing
-  // related TypeComposers and InputTypeComposers.
-  // Also see the comment on the skipped test in `rebuild-schema`.
-  typeComposer.removeInputTypeComposer()
-
-  const sortInputTC = getSortInput({
-    schemaComposer,
-    typeComposer,
-  })
-  const filterInputTC = getFilterInput({
-    schemaComposer,
-    typeComposer,
-  })
-  const paginationTC = getPagination({
-    schemaComposer,
-    typeComposer,
-  })
-  typeComposer.addResolver({
-    name: `findOne`,
-    type: typeComposer,
-    args: {
-      ...filterInputTC.getFields(),
-    },
-    resolve: findOne(typeName),
-  })
-  typeComposer.addResolver({
-    name: `findManyPaginated`,
-    type: paginationTC,
-    args: {
-      filter: filterInputTC,
-      sort: sortInputTC,
-      skip: `Int`,
-      limit: `Int`,
-    },
-    resolve: findManyPaginated(typeName),
-  })
-}
-
 const addConvenienceChildrenFields = ({
   schemaComposer,
   typeComposer,
@@ -736,13 +712,47 @@ function groupChildNodesByType({ nodeStore, nodes }) {
 }
 
 const addTypeToRootQuery = ({ schemaComposer, typeComposer }) => {
+  // TODO: We should have an abstraction for keeping and clearing
+  // related TypeComposers and InputTypeComposers.
+  // Also see the comment on the skipped test in `rebuild-schema`.
+  typeComposer.removeInputTypeComposer()
+
+  const sortInputTC = getSortInput({
+    schemaComposer,
+    typeComposer,
+  })
+  const filterInputTC = getFilterInput({
+    schemaComposer,
+    typeComposer,
+  })
+  const paginationTC = getPagination({
+    schemaComposer,
+    typeComposer,
+  })
+
   const typeName = typeComposer.getTypeName()
   // not strictly correctly, result is `npmPackage` and `allNpmPackage` from type `NPMPackage`
   const queryName = _.camelCase(typeName)
   const queryNamePlural = _.camelCase(`all ${typeName}`)
+
   schemaComposer.Query.addFields({
-    [queryName]: typeComposer.getResolver(`findOne`),
-    [queryNamePlural]: typeComposer.getResolver(`findManyPaginated`),
+    [queryName]: {
+      type: typeComposer,
+      args: {
+        ...filterInputTC.getFields(),
+      },
+      resolve: findOne(typeName),
+    },
+    [queryNamePlural]: {
+      type: paginationTC,
+      args: {
+        filter: filterInputTC,
+        sort: sortInputTC,
+        skip: `Int`,
+        limit: `Int`,
+      },
+      resolve: findManyPaginated(typeName),
+    },
   })
 }
 
@@ -852,5 +862,37 @@ const validate = (type, value) => {
     return value.map(v => validate(type.ofType, v))
   } else {
     return type.parseValue(value)
+  }
+}
+
+const checkQueryableInterfaces = ({ schemaComposer }) => {
+  const queryableInterfaces = new Set()
+  schemaComposer.forEach(type => {
+    if (
+      type instanceof InterfaceTypeComposer &&
+      type.getExtension(`queryable`)
+    ) {
+      queryableInterfaces.add(type.getTypeName())
+    }
+  })
+  const incorrectTypes = []
+  schemaComposer.forEach(type => {
+    if (type instanceof ObjectTypeComposer) {
+      const interfaces = type.getInterfaces()
+      if (
+        interfaces.some(iface => queryableInterfaces.has(iface.name)) &&
+        !type.hasInterface(`Node`)
+      ) {
+        incorrectTypes.push(type.getTypeName())
+      }
+    }
+  })
+  if (incorrectTypes.length) {
+    report.panic(
+      `Interfaces with the \`queryable\` extension must only be ` +
+        `implemented by types which also implement the \`Node\` ` +
+        `interface. Check the type definition of ` +
+        `${incorrectTypes.map(t => `\`${t}\``).join(`, `)}.`
+    )
   }
 }


### PR DESCRIPTION
The `@nodeInterface` type extension on GraphQL Interfaces will add root query fields for that interface.
All types that implement that interface are required to also implement the `Node` interface.

Example:
```graphql
interface TestInterface @nodeInterface {
  foo: String
  date: Date @dateformat
}
type Test implements Node & TestInterface {
  foo: String
  bar: String
  date: Date @dateformat
}
type AnotherTest implements Node & TestInterface {
  foo: String
  baz: String
  date: Date @dateformat
}
```
The above type definitions will add two additional root query fields: `testInterface` and `allTestInterface`.