### PR TITLE
Add a link to JustComments plugin

### DIFF
--- a/docs/docs/adding-comments.md
+++ b/docs/docs/adding-comments.md
@@ -10,7 +10,7 @@ There are many options out there for adding comment functionality, several of th
 - [Commento](https://commento.io)
 - [Facebook comments](https://www.npmjs.com/package/react-facebook)
 - [Staticman](https://staticman.net)
-- [JustComments](https://just-comments.com)
+- [JustComments](https://just-comments.com) \([official plugin for Gatsby](https://www.gatsbyjs.org/packages/gatsby-plugin-just-comments/)\)
 - [TalkYard](https://www.talkyard.io)
 - [Gitalk](https://gitalk.github.io)
 


### PR DESCRIPTION
I am the maker of JustComments and I created a plugin to make it easier to integrate the widget. I thought it's worth including the link to the plugin.