### PR TITLE
docs: Add note that createSchemaCustomization is available only in ^2.12

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -169,7 +169,8 @@ Note that the rest of the fields (`name`, `firstName` etc.) don't have to be
 provided, they will still be handled by Gatsby's type inference.
 
 > Actions to customize Gatsby's schema generation are made available in the
-> [`createSchemaCustomization`](/docs/node-apis/#createSchemaCustomization),
+> [`createSchemaCustomization`](/docs/node-apis/#createSchemaCustomization)
+> (available in Gatsby v2.12 and above),
 > and [`sourcesNodes`](/docs/node-apis/#sourceNodes) APIs.
 
 #### Opting out of type inference


### PR DESCRIPTION
 Add note that `createSchemaCustomization` is available only in ^2.12.