### PR TITLE
feat(gatsby-plugin-netlify-cms): add deprecation message for netlify-cms

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -63,6 +63,17 @@ function replaceRule(value) {
   return value
 }
 
+exports.onPreInit = ({ reporter }) => {
+  try {
+    require.resolve(`netlify-cms`)
+    reporter.warn(
+      `The netlify-cms package is deprecated, please install netlify-cms-app instead. You can do this by running "npm install netlify-cms-app"`
+    )
+  } catch (err) {
+    // carry on
+  }
+}
+
 exports.onCreateDevServer = ({ app, store }, { publicPath = `admin` }) => {
   const { program } = store.getState()
   const publicPathClean = trim(publicPath, `/`)


### PR DESCRIPTION
## Description
`netlify-cms-app` is the successor of `netlify-cms` as it uses es6 modules instead of umd. `Netlify-cms-app` is a peer-dependency of `gatsby-plugin-netlify-cms` whereas `netlify-cms` isn't anymore.

Message looks like this:
```
warn The netlify-cms package is deprecated, please install netlify-cms-app instead. You can do this by running "npm install netlify-cms-app"
```

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/15256#issuecomment-509319390