### PR TITLE
fix(gatsby-plugin-netlify-cms): remove dependencies rule

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -33,18 +33,18 @@ function replaceRule(value) {
     return value
   }
 
-  // when javascript we exclude node_modules
+  // remove dependency rule
   if (
     value.type === `javascript/auto` &&
-    value.exclude &&
-    value.exclude instanceof RegExp
+    value.use &&
+    value.use[0] &&
+    value.use[0].options &&
+    value.use[0].options.presets &&
+    /babel-preset-gatsby[/\\]dependencies\.js/.test(
+      value.use[0].options.presets
+    )
   ) {
-    return {
-      ...value,
-      exclude: new RegExp(
-        [value.exclude.source, `node_modules|bower_components`].join(`|`)
-      ),
-    }
+    return null
   }
 
   // Manually swap `style-loader` for `MiniCssExtractPlugin.loader`.
@@ -109,7 +109,7 @@ exports.onCreateWebpackConfig = (
       path: path.join(program.directory, `public`, publicPathClean),
     },
     module: {
-      rules: deepMap(gatsbyConfig.module.rules, replaceRule),
+      rules: deepMap(gatsbyConfig.module.rules, replaceRule).filter(Boolean),
     },
     plugins: [
       // Remove plugins that either attempt to process the core Netlify CMS


### PR DESCRIPTION
## Description
Remove the dependency rule from webpack for netlify-cms-plugin. It may cause out of memory problems. By removing it we also speed up the webpack build by 10-15s on a simple build.

Before:
https://app.netlify.com/sites/kind-saha-4b1cd3/deploys/5d25a0a1a68a8f25ae61bdac
`success Building production JavaScript and CSS bundles — 17.970`

After:
https://app.netlify.com/sites/kind-saha-4b1cd3/deploys/5d25a4a72660500007210224
`Building production JavaScript and CSS bundles — 6.275`

## Related Issues
Fixes https://github.com/gatsbyjs/gatsby/issues/15256
