### PR TITLE
Add support for preloaded global critical styles

### DIFF
--- a/examples/using-preloaded-global-styles/.eslintrc.json
+++ b/examples/using-preloaded-global-styles/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "graphql": false
+  }
+}

--- a/examples/using-preloaded-global-styles/README.md
+++ b/examples/using-preloaded-global-styles/README.md
@@ -1,0 +1,7 @@
+# Using Preloading Global Critical Styles
+
+Demonstrates how to use `webpackPreloaded` to apply a critical style globally.
+
+## References
+
+- [Prefetching/Preloading Modules](https://webpack.js.org/guides/code-splitting/#prefetching-preloading-modules).

--- a/examples/using-preloaded-global-styles/gatsby-browser.js
+++ b/examples/using-preloaded-global-styles/gatsby-browser.js
@@ -1,0 +1,1 @@
+import(/* webpackPreload: true */ `./src/styles/index.sass`)

--- a/examples/using-preloaded-global-styles/gatsby-config.js
+++ b/examples/using-preloaded-global-styles/gatsby-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  siteMetadata: {
+    title: `Gatsby with global style`,
+  },
+  plugins: [`gatsby-plugin-sass`],
+}

--- a/examples/using-preloaded-global-styles/package.json
+++ b/examples/using-preloaded-global-styles/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "gatsby-example-using-preloaded-global-critical-styles",
+  "private": true,
+  "description": "Gatsby example site using preloaded global critical style",
+  "version": "2.0.0",
+  "author": "Julien Cayzac <julien.cayzac@gmail.com>",
+  "dependencies": {
+    "gatsby": "next",
+    "gatsby-plugin-sass": "^2.1.0",
+    "node-sass": "^4.12.0",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "start": "npm run develop"
+  }
+}

--- a/examples/using-preloaded-global-styles/src/pages/index.jsx
+++ b/examples/using-preloaded-global-styles/src/pages/index.jsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+const Index = () => <div>Hello</div>
+
+export default Index

--- a/examples/using-preloaded-global-styles/src/styles/index.sass
+++ b/examples/using-preloaded-global-styles/src/styles/index.sass
@@ -1,0 +1,4 @@
+html
+	background-color: rebeccapurple
+	color: white
+

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -314,10 +314,10 @@ export default (pagePath, callback) => {
     .slice(0)
     .reverse()
     .forEach(style => {
-      // Add <link>s for styles that should be prefetched
+      // Add <link>s for styles that should be prefetched or preloaded
       // otherwise, inline as a <style> tag
 
-      if (style.rel === `prefetch`) {
+      if (style.rel === `prefetch` || style.rel === `preload`) {
         headComponents.push(
           <link
             as="style"


### PR DESCRIPTION
## Description
This allows injecting critical style without inlining (antipattern in HTTP/2).

```js
// gatsby-browser.js
import(/* webpackPreload: true */ `./src/styles/index.sass`)
```

The above generates a `<link as="style" rel="preload" href="/styles.9b011d582aac2f4be01f.css"/>` tag in
each page's `<head>`.

## Related Issues

- https://github.com/gatsbyjs/gatsby/commit/981bc8ca0aa726f9459cef99168c18cc2173740b
- #9828 gatsby-plugin-netlify v2 excludes some link headers
- #12521 PR adding links to `_headers`, for Netlify. Only preloads bundles.
- `from: jc#3330 static-entry.js` search on Discord.

## Caveats

`gatsby-plugin-netlify` doesn't parse `.namedChunkGroups.app.childAssets.preload` in the webpack stats, and simply ignore all assets marked for preloading, so this commit still doesn't enable the expected HTTP/2 behavior on Netlify.
