### PR TITLE
fix: don't break joi validation for unhandledRejections & apirunner 

### DIFF
--- a/packages/gatsby-cli/src/index.js
+++ b/packages/gatsby-cli/src/index.js
@@ -4,6 +4,7 @@
 // use require() with backtick strings so use the es6 syntax
 import "@babel/polyfill"
 const semver = require(`semver`)
+const util = require(`util`)
 
 const createCli = require(`./create-cli`)
 const report = require(`./reporter`)
@@ -24,10 +25,17 @@ if (!semver.satisfies(process.version, MIN_NODE_VERSION)) {
   )
 }
 
-process.on(`unhandledRejection`, error => {
+process.on(`unhandledRejection`, reason => {
   // This will exit the process in newer Node anyway so lets be consistent
   // across versions and crash
-  report.panic(`UNHANDLED REJECTION`, error)
+
+  // reason can be anything, it can be a message, an object, ANYTHING!
+  // we convert it to an error object so we don't crash on structured error validation
+  if (!(reason instanceof Error)) {
+    reason = new Error(util.format(reason))
+  }
+
+  report.panic(`UNHANDLED REJECTION`, reason)
 })
 
 process.on(`uncaughtException`, error => {

--- a/packages/gatsby-cli/src/structured-errors/error-map.js
+++ b/packages/gatsby-cli/src/structured-errors/error-map.js
@@ -76,6 +76,14 @@ const errorMap = {
     type: `CONFIG`,
     level: `ERROR`,
   },
+  "10126": {
+    text: context =>
+      `${context.pluginName} threw an error while running the ${
+        context.api
+      } lifecycle:\n\n${context.message}`,
+    type: `CONFIG`,
+    level: `ERROR`,
+  },
 }
 
 module.exports = { errorMap, defaultError: errorMap[``] }

--- a/packages/gatsby-cli/src/structured-errors/error-map.js
+++ b/packages/gatsby-cli/src/structured-errors/error-map.js
@@ -78,7 +78,7 @@ const errorMap = {
   },
   "11321": {
     text: context =>
-      `${context.pluginName} threw an error while running the ${
+      `"${context.pluginName}" threw an error while running the ${
         context.api
       } lifecycle:\n\n${context.message}`,
     type: `PLUGIN`,

--- a/packages/gatsby-cli/src/structured-errors/error-map.js
+++ b/packages/gatsby-cli/src/structured-errors/error-map.js
@@ -76,12 +76,12 @@ const errorMap = {
     type: `CONFIG`,
     level: `ERROR`,
   },
-  "10126": {
+  "11321": {
     text: context =>
       `${context.pluginName} threw an error while running the ${
         context.api
       } lifecycle:\n\n${context.message}`,
-    type: `CONFIG`,
+    type: `PLUGIN`,
     level: `ERROR`,
   },
 }

--- a/packages/gatsby-cli/src/structured-errors/error-schema.js
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.js
@@ -10,7 +10,7 @@ const errorSchema = Joi.object().keys({
   text: Joi.string(),
   stack: Joi.array().items(Joi.object({}).unknown()),
   level: Joi.string().valid([`ERROR`, `WARNING`, `INFO`, `DEBUG`]),
-  type: Joi.string().valid([`GRAPHQL`, `CONFIG`]),
+  type: Joi.string().valid([`GRAPHQL`, `CONFIG`, `PLUGIN`]),
   filePath: Joi.string(),
   location: Joi.object({
     start: Position.required(),

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -341,7 +341,7 @@ module.exports = async (api, args = {}, pluginSource) =>
         })
 
         reporter.panicOnBuild({
-          id: `10126`,
+          id: `11321`,
           context: {
             pluginName,
             api,

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -333,7 +333,7 @@ module.exports = async (api, args = {}, pluginSource) =>
       let pluginName =
         plugin.name === `default-site-plugin`
           ? `gatsby-node.js`
-          : `Plugin ${plugin.name}`
+          : `${plugin.name}`
 
       return new Promise(resolve => {
         resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }))
@@ -341,7 +341,24 @@ module.exports = async (api, args = {}, pluginSource) =>
         decorateEvent(`BUILD_PANIC`, {
           pluginName: `${plugin.name}@${plugin.version}`,
         })
-        reporter.panicOnBuild(`${pluginName} returned an error`, err)
+
+        let error = {}
+        if (err instanceof Error) {
+          error = {
+            error: err,
+          }
+        }
+
+        reporter.panicOnBuild({
+          ...error,
+          id: `10126`,
+          context: {
+            pluginName,
+            api,
+            message: err instanceof Error ? err.message : err,
+          },
+        })
+
         return null
       })
     }).then(results => {

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -333,7 +333,7 @@ module.exports = async (api, args = {}, pluginSource) =>
       let pluginName =
         plugin.name === `default-site-plugin`
           ? `gatsby-node.js`
-          : `${plugin.name}`
+          : plugin.name
 
       return new Promise(resolve => {
         resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }))

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -331,9 +331,7 @@ module.exports = async (api, args = {}, pluginSource) =>
       }
 
       let pluginName =
-        plugin.name === `default-site-plugin`
-          ? `gatsby-node.js`
-          : plugin.name
+        plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
 
       return new Promise(resolve => {
         resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }))
@@ -342,21 +340,14 @@ module.exports = async (api, args = {}, pluginSource) =>
           pluginName: `${plugin.name}@${plugin.version}`,
         })
 
-        let error = {}
-        if (err instanceof Error) {
-          error = {
-            error: err,
-          }
-        }
-
         reporter.panicOnBuild({
-          ...error,
           id: `10126`,
           context: {
             pluginName,
             api,
             message: err instanceof Error ? err.message : err,
           },
+          error: err instanceof Error ? err : undefined,
         })
 
         return null


### PR DESCRIPTION
## Description
Structured logging as some flaws in our code. These changes don't fix evertyhing but they fix the ones that are mentioned in the issues.

**unhandledRejection** is a hard event to format into a structured log. The reason why it fails can be anything (ex: `Promise.reject({ errors: ["I don't care"]})`). This PR formats into a string so we at least don't break. UnhandledRejection should only occur on users code and not plugins as we should be guarded against this.

The other fix is that I converted our api runner into a structured error as not every error was compatible. We want plugins to use structured logging themselves but for now, this fixes weird errors thrown in plugins.

## Related Issues
Fixes #15487 
Partially fixes #15242