### PR TITLE
feat(gatsby-plugin-google-analytics): Add pageTransitionDelay option

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -24,6 +24,8 @@ module.exports = {
         respectDNT: true,
         // Avoids sending pageview hits from custom paths
         exclude: ["/preview/**", "/do-not-track/me/too/"],
+        // Delays sending pageview hits on route update (in milliseconds)
+        pageTransitionDelay: 0,
         // Enables Google Optimize using your container Id
         optimizeId: "YOUR_GOOGLE_OPTIMIZE_TRACKING_ID",
         // Enables Google Optimize Experiment ID
@@ -101,6 +103,10 @@ If you enable this optional option, Google Analytics will not be loaded at all f
 ### `exclude`
 
 If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array as glob expressions.
+
+### `pageTransitionDelay`
+
+If your site uses any custom transitions on route update (e.g. [`gatsby-plugin-transition-link`](https://www.gatsbyjs.org/blog/2018-12-04-per-link-gatsby-page-transitions-with-transitionlink/)), then you can delay processing the page view event until the new page is mounted.
 
 ### `optimizeId`
 

--- a/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-browser.js
@@ -81,7 +81,7 @@ describe(`gatsby-plugin-google-analytics`, () => {
 
           jest.runAllTimers()
 
-          expect(setTimeout).toHaveBeenCalledTimes(1)
+          expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000)
           expect(window.ga).toHaveBeenCalledTimes(2)
         })
       })

--- a/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-browser.js
@@ -29,9 +29,6 @@ describe(`gatsby-plugin-google-analytics`, () => {
         beforeEach(() => {
           jest.useFakeTimers()
           window.ga = jest.fn()
-          window.requestAnimationFrame = jest.fn(cb => {
-            cb()
-          })
         })
 
         afterEach(() => {
@@ -43,7 +40,9 @@ describe(`gatsby-plugin-google-analytics`, () => {
 
           onRouteUpdate({})
 
-          expect(window.requestAnimationFrame).not.toHaveBeenCalled()
+          jest.runAllTimers()
+
+          expect(setTimeout).not.toHaveBeenCalled()
         })
 
         it(`does not send page view when path is excluded`, () => {
@@ -56,27 +55,29 @@ describe(`gatsby-plugin-google-analytics`, () => {
             },
           })
 
+          jest.runAllTimers()
+
           expect(window.ga).not.toHaveBeenCalled()
         })
 
         it(`sends page view`, () => {
           onRouteUpdate({})
 
+          jest.runAllTimers()
+
           expect(window.ga).toHaveBeenCalledTimes(2)
         })
 
-        it(`uses setTimeout when requestAnimationFrame is undefined`, () => {
-          delete window.requestAnimationFrame
-
+        it(`uses setTimeout with a minimum delay of 32ms`, () => {
           onRouteUpdate({})
 
           jest.runAllTimers()
 
-          expect(setTimeout).toHaveBeenCalledTimes(1)
+          expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 32)
           expect(window.ga).toHaveBeenCalledTimes(2)
         })
 
-        it(`uses setTimeout when pageTransitionDelay is set`, () => {
+        it(`uses setTimeout with the provided pageTransitionDelay value`, () => {
           onRouteUpdate({}, { pageTransitionDelay: 1000 })
 
           jest.runAllTimers()

--- a/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-browser.js
@@ -1,8 +1,6 @@
 import { onRouteUpdate } from "../gatsby-browser"
 import { Minimatch } from "minimatch"
 
-jest.useFakeTimers()
-
 describe(`gatsby-plugin-google-analytics`, () => {
   describe(`gatsby-browser`, () => {
     describe(`onRouteUpdate`, () => {
@@ -29,10 +27,15 @@ describe(`gatsby-plugin-google-analytics`, () => {
         })
 
         beforeEach(() => {
+          jest.useFakeTimers()
           window.ga = jest.fn()
           window.requestAnimationFrame = jest.fn(cb => {
             cb()
           })
+        })
+
+        afterEach(() => {
+          jest.resetAllMocks()
         })
 
         it(`does not send page view when ga is undefined`, () => {
@@ -66,6 +69,15 @@ describe(`gatsby-plugin-google-analytics`, () => {
           delete window.requestAnimationFrame
 
           onRouteUpdate({})
+
+          jest.runAllTimers()
+
+          expect(setTimeout).toHaveBeenCalledTimes(1)
+          expect(window.ga).toHaveBeenCalledTimes(2)
+        })
+
+        it(`uses setTimeout when pageTransitionDelay is set`, () => {
+          onRouteUpdate({}, { pageTransitionDelay: 1000 })
 
           jest.runAllTimers()
 

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -1,4 +1,4 @@
-export const onRouteUpdate = ({ location }) => {
+export const onRouteUpdate = ({ location }, pluginOptions = {}) => {
   if (process.env.NODE_ENV !== `production` || typeof ga !== `function`) {
     return null
   }
@@ -20,13 +20,14 @@ export const onRouteUpdate = ({ location }) => {
     window.ga(`send`, `pageview`)
   }
 
-  if (`requestAnimationFrame` in window) {
+  const delay = pluginOptions.pageTransitionDelay
+  if (delay || !(`requestAnimationFrame` in window)) {
+    // minimum delay to simulate a pair of requestAnimationFrame calls
+    setTimeout(sendPageView, Math.min(32, delay))
+  } else {
     requestAnimationFrame(() => {
       requestAnimationFrame(sendPageView)
     })
-  } else {
-    // simulate 2 rAF calls
-    setTimeout(sendPageView, 32)
   }
 
   return null

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -20,7 +20,8 @@ export const onRouteUpdate = ({ location }, pluginOptions = {}) => {
     window.ga(`send`, `pageview`)
   }
 
-  const delay = pluginOptions.pageTransitionDelay
+  const delay = Math.max(32, pluginOptions.pageTransitionDelay)
+  setTimeout(sendPageView, delay)
   if (delay || !(`requestAnimationFrame` in window)) {
     // minimum delay to simulate a pair of requestAnimationFrame calls
     setTimeout(sendPageView, Math.min(32, delay))

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -11,7 +11,7 @@ export const onRouteUpdate = ({ location }, pluginOptions = {}) => {
   if (pathIsExcluded) return null
 
   // wrap inside a timeout to make sure react-helmet is done with it's changes (https://github.com/gatsbyjs/gatsby/issues/9139)
-  // reactHelmet is using requestAnimationFrame so we should use it too: https://github.com/nfl/react-helmet/blob/5.2.0/src/HelmetUtils.js#L296-L299
+  // reactHelmet is using requestAnimationFrame: https://github.com/nfl/react-helmet/blob/5.2.0/src/HelmetUtils.js#L296-L299
   const sendPageView = () => {
     const pagePath = location
       ? location.pathname + location.search + location.hash
@@ -20,16 +20,9 @@ export const onRouteUpdate = ({ location }, pluginOptions = {}) => {
     window.ga(`send`, `pageview`)
   }
 
-  const delay = Math.max(32, pluginOptions.pageTransitionDelay)
+  // Minimum delay for reactHelmet's requestAnimationFrame
+  const delay = Math.max(32, pluginOptions.pageTransitionDelay || 0)
   setTimeout(sendPageView, delay)
-  if (delay || !(`requestAnimationFrame` in window)) {
-    // minimum delay to simulate a pair of requestAnimationFrame calls
-    setTimeout(sendPageView, Math.min(32, delay))
-  } else {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(sendPageView)
-    })
-  }
 
   return null
 }


### PR DESCRIPTION
## Description

Adds a `pageTransitionDelay` option to `gatsby-plugin-google-analytics` to delay the "Page View" event when necessary for page transitions.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/15504 - contains more context.