### PR TITLE
chore(docs): fix typo in method name in docs blog post

### DIFF
--- a/docs/blog/2019-05-17-improvements-to-schema-customization/index.md
+++ b/docs/blog/2019-05-17-improvements-to-schema-customization/index.md
@@ -126,7 +126,7 @@ exports.sourceNodes = function sourceNodes({ actions }) {
 You can now apply configuration to type builder types through an exposed `extensions` property.
 
 ```js
-schema.createObjectType({
+schema.buildObjectType({
   name: MyType,
   extensions: {
     infer: true,


### PR DESCRIPTION

## Description

`schema.createObjectType` does not exist in the code. This should be `schema.buildObjectType`

## Related Issues

None
