### PR TITLE
 fix(gatsby): handle `/404/`, `/404`, `404/` or `404` page paths

### DIFF
--- a/docs/docs/add-404-page.md
+++ b/docs/docs/add-404-page.md
@@ -3,7 +3,7 @@ title: "Adding a 404 Page"
 ---
 
 To create a 404 page create a page whose path matches the regex
-`/404*`. Most often you'll want to create a React component page at
+`^\/?404\/?$` (`/404/`, `/404`, `404/` or `404`). Most often you'll want to create a React component page at
 `src/pages/404.js`.
 
 Gatsby ensures that your 404 page is built as `404.html` as many static hosting

--- a/packages/gatsby/src/internal-plugins/prod-404/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/prod-404/gatsby-node.js
@@ -3,7 +3,7 @@ exports.onCreatePage = ({ page, store, actions }) => {
   // Copy /404/ to /404.html as many static site hosts expect
   // site 404 pages to be named this.
   // https://www.gatsbyjs.org/docs/add-404-page/
-  if (!created404 && page.path === `/404/`) {
+  if (!created404 && /^\/?404\/?$/.test(page.path)) {
     actions.createPage({
       ...page,
       path: `/404.html`,


### PR DESCRIPTION
Relax current logic of finding 404 page.

Currently page must be exactly `/404/` - which is what `gatsby-plugin-page-creator` will use when user have `src/pages/404.html`.

With this change `/404/`, `/404`, `404/` or `404` all will be considered 404 page. This is mostly quality of life improvement, so users creating 404 pages don't have to scratch their head and look in documentation (or worse in source code) why it didn't work if path wasn't exactly what Gatsby expects

Related: https://github.com/gatsbyjs/gatsby/issues/15429

Fixes: https://github.com/gatsbyjs/gatsby/issues/13030