### PR TITLE
chore(gatsby-plugin-feed): bump lodash.merge min. version to 4.6.2

### DIFF
--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "@hapi/joi": "^15.0.0",
     "fs-extra": "^7.0.1",
-    "lodash.merge": "^4.6.0",
+    "lodash.merge": "^4.6.2",
     "rss": "^1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JS-LODASHMERGE-173732
Prototype Pollution
Affecting lodash.merge package, versions <4.6.2

See closed issues #s 4317, 4273, & 4254 in [Lodash issues](https://github.com/lodash/lodash/issues/)
(not linking individual issues to avoid mention noise)

John-David Dalton updated individual lodash.merge pkg yesterday
https://github.com/lodash/lodash/tree/4.6.2-npm-packages/lodash.merge
https://github.com/lodash/lodash/commit/b59e006377c78d86fc11d73d6e72315e4c53f9f6

...with fixes for vulnerabilities that went into lodash@4.17.11 on Sep 12, 2018.

[This automated PR from GH dependabot](https://github.com/rdela/rdela.com/pull/160) brought my attention to the issue

...so thought we could save people who might have <4.6.2 cached some trouble.