### PR TITLE
fix: correct links in package changelogs

### DIFF
--- a/packages/gatsby-cli/CHANGELOG.md
+++ b/packages/gatsby-cli/CHANGELOG.md
@@ -7,442 +7,442 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.7.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.8...gatsby-cli@2.7.9) (2019-07-10)
+## [2.7.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.8...gatsby-cli@2.7.9) (2019-07-10)
 
 ### Bug Fixes
 
-- don't break joi validation for production bundles webpack… ([#15602](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/15602)) ([4c50024](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/4c50024))
-- don't break joi validation for unhandledRejections & apirunner ([#15600](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/15600)) ([14ba538](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/14ba538))
+- don't break joi validation for production bundles webpack… ([#15602](https://github.com/gatsbyjs/gatsby/issues/15602)) ([4c50024](https://github.com/gatsbyjs/gatsby/commit/4c50024))
+- don't break joi validation for unhandledRejections & apirunner ([#15600](https://github.com/gatsbyjs/gatsby/issues/15600)) ([14ba538](https://github.com/gatsbyjs/gatsby/commit/14ba538))
 
-## [2.7.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.7...gatsby-cli@2.7.8) (2019-07-05)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.7.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.6...gatsby-cli@2.7.7) (2019-06-29)
+## [2.7.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.7...gatsby-cli@2.7.8) (2019-07-05)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.7.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.5...gatsby-cli@2.7.6) (2019-06-28)
+## [2.7.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.6...gatsby-cli@2.7.7) (2019-06-29)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.7.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.5...gatsby-cli@2.7.6) (2019-06-28)
 
 ### Bug Fixes
 
-- **gatsby-cli:** depend upon [@hapi](https://github.com/hapi)/joi ([#15221](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/15221)) ([59a021d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/59a021d))
+- **gatsby-cli:** depend upon [@hapi](https://github.com/hapi)/joi ([#15221](https://github.com/gatsbyjs/gatsby/issues/15221)) ([59a021d](https://github.com/gatsbyjs/gatsby/commit/59a021d))
 
-## [2.7.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.4...gatsby-cli@2.7.5) (2019-06-28)
+## [2.7.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.4...gatsby-cli@2.7.5) (2019-06-28)
 
 ### Features
 
-- **gatsby-cli:** Add error codes and structured errors ([#14904](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14904)) ([d26651e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/d26651e))
+- **gatsby-cli:** Add error codes and structured errors ([#14904](https://github.com/gatsbyjs/gatsby/issues/14904)) ([d26651e](https://github.com/gatsbyjs/gatsby/commit/d26651e))
 
-## [2.7.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.3...gatsby-cli@2.7.4) (2019-06-28)
+## [2.7.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.3...gatsby-cli@2.7.4) (2019-06-28)
 
 ### Bug Fixes
 
-- filter out frames that are not matched to source location ([#15211](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/15211)) ([44e8f76](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/44e8f76))
+- filter out frames that are not matched to source location ([#15211](https://github.com/gatsbyjs/gatsby/issues/15211)) ([44e8f76](https://github.com/gatsbyjs/gatsby/commit/44e8f76))
 
-## [2.7.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.2...gatsby-cli@2.7.3) (2019-06-27)
+## [2.7.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.2...gatsby-cli@2.7.3) (2019-06-27)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.7.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.1...gatsby-cli@2.7.2) (2019-06-24)
+## [2.7.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.1...gatsby-cli@2.7.2) (2019-06-24)
 
 ### Bug Fixes
 
-- **gatsby-cli:** Added better-opn as a dependency ([#15078](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/15078)) ([d855e50](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/d855e50))
+- **gatsby-cli:** Added better-opn as a dependency ([#15078](https://github.com/gatsbyjs/gatsby/issues/15078)) ([d855e50](https://github.com/gatsbyjs/gatsby/commit/d855e50))
 
 ### Features
 
-- **gatsby-cli:** improve version output ([#14924](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14924)) ([6210ec3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/6210ec3))
+- **gatsby-cli:** improve version output ([#14924](https://github.com/gatsbyjs/gatsby/issues/14924)) ([6210ec3](https://github.com/gatsbyjs/gatsby/commit/6210ec3))
 
-## [2.7.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.7.0...gatsby-cli@2.7.1) (2019-06-24)
+## [2.7.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.7.0...gatsby-cli@2.7.1) (2019-06-24)
 
 ### Bug Fixes
 
-- **gatsby:** minor refactor of console functions ([#14956](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14956)) ([7775b3e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/7775b3e))
-- cleanup stack traces for html build errors ([#15050](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/15050)) ([d029f7b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/d029f7b))
+- **gatsby:** minor refactor of console functions ([#14956](https://github.com/gatsbyjs/gatsby/issues/14956)) ([7775b3e](https://github.com/gatsbyjs/gatsby/commit/7775b3e))
+- cleanup stack traces for html build errors ([#15050](https://github.com/gatsbyjs/gatsby/issues/15050)) ([d029f7b](https://github.com/gatsbyjs/gatsby/commit/d029f7b))
 
 ### Features
 
-- **gatsby-cli:** Prompt user for options (no args with gatsby new) ([#14097](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14097)) ([99fb7b4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/99fb7b4))
+- **gatsby-cli:** Prompt user for options (no args with gatsby new) ([#14097](https://github.com/gatsbyjs/gatsby/issues/14097)) ([99fb7b4](https://github.com/gatsbyjs/gatsby/commit/99fb7b4))
 
-# [2.7.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.13...gatsby-cli@2.7.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.6.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.12...gatsby-cli@2.6.13) (2019-06-19)
-
-### Bug Fixes
-
-- **gatsby-cli:** add missing node-fetch dependency ([#14908](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14908)) ([b7da1e4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/b7da1e4))
-
-## [2.6.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.9...gatsby-cli@2.6.12) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/2594623))
-
-## [2.6.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.10...gatsby-cli@2.6.11) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/2594623))
-
-## [2.6.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.9...gatsby-cli@2.6.10) (2019-06-18)
+# [2.7.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.13...gatsby-cli@2.7.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.6.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.8...gatsby-cli@2.6.9) (2019-06-18)
+## [2.6.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.12...gatsby-cli@2.6.13) (2019-06-19)
+
+### Bug Fixes
+
+- **gatsby-cli:** add missing node-fetch dependency ([#14908](https://github.com/gatsbyjs/gatsby/issues/14908)) ([b7da1e4](https://github.com/gatsbyjs/gatsby/commit/b7da1e4))
+
+## [2.6.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.9...gatsby-cli@2.6.12) (2019-06-19)
+
+### Bug Fixes
+
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
+
+## [2.6.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.10...gatsby-cli@2.6.11) (2019-06-19)
+
+### Bug Fixes
+
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
+
+## [2.6.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.9...gatsby-cli@2.6.10) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.6.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.7...gatsby-cli@2.6.8) (2019-06-18)
+## [2.6.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.8...gatsby-cli@2.6.9) (2019-06-18)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.6.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.7...gatsby-cli@2.6.8) (2019-06-18)
 
 ### Features
 
-- **gatsby-cli:** move progressbar into ink ([#14220](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14220)) ([967597c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/967597c))
+- **gatsby-cli:** move progressbar into ink ([#14220](https://github.com/gatsbyjs/gatsby/issues/14220)) ([967597c](https://github.com/gatsbyjs/gatsby/commit/967597c))
 
-## [2.6.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.5...gatsby-cli@2.6.7) (2019-06-12)
-
-### Bug Fixes
-
-- **gatsby-cli:** create spawnWithArgs to be able to call spawn with command containing spaces ([#14698](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14698)) ([7b3efe7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/7b3efe7))
-
-## [2.6.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.5...gatsby-cli@2.6.6) (2019-06-12)
+## [2.6.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.5...gatsby-cli@2.6.7) (2019-06-12)
 
 ### Bug Fixes
 
-- **gatsby-cli:** create spawnWithArgs to be able to call spawn with command containing spaces ([#14698](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14698)) ([7b3efe7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/7b3efe7))
+- **gatsby-cli:** create spawnWithArgs to be able to call spawn with command containing spaces ([#14698](https://github.com/gatsbyjs/gatsby/issues/14698)) ([7b3efe7](https://github.com/gatsbyjs/gatsby/commit/7b3efe7))
 
-## [2.6.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.4...gatsby-cli@2.6.5) (2019-06-05)
+## [2.6.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.5...gatsby-cli@2.6.6) (2019-06-12)
+
+### Bug Fixes
+
+- **gatsby-cli:** create spawnWithArgs to be able to call spawn with command containing spaces ([#14698](https://github.com/gatsbyjs/gatsby/issues/14698)) ([7b3efe7](https://github.com/gatsbyjs/gatsby/commit/7b3efe7))
+
+## [2.6.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.4...gatsby-cli@2.6.5) (2019-06-05)
 
 ### Features
 
-- **gatsby-cli:** Add a plugin authoring help in gatsby-cli ([#13450](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13450)) ([41c0166](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/41c0166))
+- **gatsby-cli:** Add a plugin authoring help in gatsby-cli ([#13450](https://github.com/gatsbyjs/gatsby/issues/13450)) ([41c0166](https://github.com/gatsbyjs/gatsby/commit/41c0166))
 
-## [2.6.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.3...gatsby-cli@2.6.4) (2019-05-31)
+## [2.6.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.3...gatsby-cli@2.6.4) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.6.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.2...gatsby-cli@2.6.3) (2019-05-29)
+## [2.6.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.2...gatsby-cli@2.6.3) (2019-05-29)
 
 ### Bug Fixes
 
-- **gatsby-cli:** build successfully without optional dependencies ([#14383](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14383)) ([e5db077](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/e5db077))
+- **gatsby-cli:** build successfully without optional dependencies ([#14383](https://github.com/gatsbyjs/gatsby/issues/14383)) ([e5db077](https://github.com/gatsbyjs/gatsby/commit/e5db077))
 
-## [2.6.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.1...gatsby-cli@2.6.2) (2019-05-22)
+## [2.6.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.1...gatsby-cli@2.6.2) (2019-05-22)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.6.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.6.0...gatsby-cli@2.6.1) (2019-05-22)
+## [2.6.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.6.0...gatsby-cli@2.6.1) (2019-05-22)
 
 ### Bug Fixes
 
-- **gatsby-cli:** make ink an optional dependency ([#14233](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/14233)) ([10638f8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/10638f8))
+- **gatsby-cli:** make ink an optional dependency ([#14233](https://github.com/gatsbyjs/gatsby/issues/14233)) ([10638f8](https://github.com/gatsbyjs/gatsby/commit/10638f8))
 
-# [2.6.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.15...gatsby-cli@2.6.0) (2019-05-21)
+# [2.6.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.15...gatsby-cli@2.6.0) (2019-05-21)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.5.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.14...gatsby-cli@2.5.15) (2019-05-18)
+## [2.5.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.14...gatsby-cli@2.5.15) (2019-05-18)
 
 ### Bug Fixes
 
-- **gatsby-cli:** log correct version ([#13920](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13920)) ([649f6d8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/649f6d8))
+- **gatsby-cli:** log correct version ([#13920](https://github.com/gatsbyjs/gatsby/issues/13920)) ([649f6d8](https://github.com/gatsbyjs/gatsby/commit/649f6d8))
 
-## [2.5.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.13...gatsby-cli@2.5.14) (2019-05-14)
-
-### Bug Fixes
-
-- **gatsby-cli:** Only init git repository if no git repository exists ([#13096](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13096)) ([7ca32c2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/7ca32c2))
-
-## [2.5.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.12...gatsby-cli@2.5.13) (2019-05-09)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.11...gatsby-cli@2.5.12) (2019-04-25)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.10...gatsby-cli@2.5.11) (2019-04-24)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.9...gatsby-cli@2.5.10) (2019-04-24)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.8...gatsby-cli@2.5.9) (2019-04-17)
+## [2.5.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.13...gatsby-cli@2.5.14) (2019-05-14)
 
 ### Bug Fixes
 
-- **gatsby-cli:** Fix --clipboard on Windows ([#13212](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13212)) ([a7383c5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/a7383c5))
+- **gatsby-cli:** Only init git repository if no git repository exists ([#13096](https://github.com/gatsbyjs/gatsby/issues/13096)) ([7ca32c2](https://github.com/gatsbyjs/gatsby/commit/7ca32c2))
 
-## [2.5.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.7...gatsby-cli@2.5.8) (2019-04-15)
+## [2.5.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.12...gatsby-cli@2.5.13) (2019-05-09)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.11...gatsby-cli@2.5.12) (2019-04-25)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.10...gatsby-cli@2.5.11) (2019-04-24)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.9...gatsby-cli@2.5.10) (2019-04-24)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.8...gatsby-cli@2.5.9) (2019-04-17)
+
+### Bug Fixes
+
+- **gatsby-cli:** Fix --clipboard on Windows ([#13212](https://github.com/gatsbyjs/gatsby/issues/13212)) ([a7383c5](https://github.com/gatsbyjs/gatsby/commit/a7383c5))
+
+## [2.5.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.7...gatsby-cli@2.5.8) (2019-04-15)
 
 ### Features
 
-- **gatsby-cli:** validate rootPath to follow naming conventions as required ([#13158](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13158)) ([68ac45f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/68ac45f)), closes [#13153](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13153)
+- **gatsby-cli:** validate rootPath to follow naming conventions as required ([#13158](https://github.com/gatsbyjs/gatsby/issues/13158)) ([68ac45f](https://github.com/gatsbyjs/gatsby/commit/68ac45f)), closes [#13153](https://github.com/gatsbyjs/gatsby/issues/13153)
 
-## [2.5.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.6...gatsby-cli@2.5.7) (2019-04-11)
-
-### Bug Fixes
-
-- add tty helper to not ask for prompt in non tty/ci env ([#13290](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13290)) ([efae20e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/efae20e))
-
-### Features
-
-- **gatsby-cli:** Remove one of package-lock.json and yarn.lock on gatsby new ([#13225](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13225)) ([3510a46](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/3510a46)), closes [#13210](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/13210)
-
-## [2.5.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.5...gatsby-cli@2.5.6) (2019-04-09)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.4...gatsby-cli@2.5.5) (2019-04-04)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.3...gatsby-cli@2.5.4) (2019-03-28)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.2...gatsby-cli@2.5.3) (2019-03-27)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.1...gatsby-cli@2.5.2) (2019-03-26)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.5.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.5.0...gatsby-cli@2.5.1) (2019-03-26)
-
-**Note:** Version bump only for package gatsby-cli
-
-# [2.5.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.17...gatsby-cli@2.5.0) (2019-03-26)
-
-### Features
-
-- **gatsby:** add anonymous telemetry instrumentation to gatsby ([#12758](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/12758)) ([da8ded9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/da8ded9))
-
-## [2.4.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.16...gatsby-cli@2.4.17) (2019-03-21)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.4.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.15...gatsby-cli@2.4.16) (2019-03-14)
+## [2.5.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.6...gatsby-cli@2.5.7) (2019-04-11)
 
 ### Bug Fixes
 
-- **gatsby:** properly support --no-color for pretty-error ([#12531](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/12531)) ([e493538](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/e493538))
+- add tty helper to not ask for prompt in non tty/ci env ([#13290](https://github.com/gatsbyjs/gatsby/issues/13290)) ([efae20e](https://github.com/gatsbyjs/gatsby/commit/efae20e))
 
-## [2.4.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.14...gatsby-cli@2.4.15) (2019-03-11)
+### Features
+
+- **gatsby-cli:** Remove one of package-lock.json and yarn.lock on gatsby new ([#13225](https://github.com/gatsbyjs/gatsby/issues/13225)) ([3510a46](https://github.com/gatsbyjs/gatsby/commit/3510a46)), closes [#13210](https://github.com/gatsbyjs/gatsby/issues/13210)
+
+## [2.5.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.5...gatsby-cli@2.5.6) (2019-04-09)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.4.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.13...gatsby-cli@2.4.14) (2019-03-08)
+## [2.5.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.4...gatsby-cli@2.5.5) (2019-04-04)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.3...gatsby-cli@2.5.4) (2019-03-28)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.2...gatsby-cli@2.5.3) (2019-03-27)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.1...gatsby-cli@2.5.2) (2019-03-26)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.5.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.5.0...gatsby-cli@2.5.1) (2019-03-26)
+
+**Note:** Version bump only for package gatsby-cli
+
+# [2.5.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.17...gatsby-cli@2.5.0) (2019-03-26)
+
+### Features
+
+- **gatsby:** add anonymous telemetry instrumentation to gatsby ([#12758](https://github.com/gatsbyjs/gatsby/issues/12758)) ([da8ded9](https://github.com/gatsbyjs/gatsby/commit/da8ded9))
+
+## [2.4.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.16...gatsby-cli@2.4.17) (2019-03-21)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.4.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.15...gatsby-cli@2.4.16) (2019-03-14)
 
 ### Bug Fixes
 
-- **gatsby-cli:** Fixed incorrect scriptname in gatsby-cli ([#12186](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/12186)) ([3b116f6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/3b116f6))
+- **gatsby:** properly support --no-color for pretty-error ([#12531](https://github.com/gatsbyjs/gatsby/issues/12531)) ([e493538](https://github.com/gatsbyjs/gatsby/commit/e493538))
 
-## [2.4.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.12...gatsby-cli@2.4.13) (2019-03-05)
-
-**Note:** Version bump only for package gatsby-cli
-
-## [2.4.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.11...gatsby-cli@2.4.12) (2019-02-28)
+## [2.4.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.14...gatsby-cli@2.4.15) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-cli
 
-## [2.4.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.10...gatsby-cli@2.4.11) (2019-02-19)
+## [2.4.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.13...gatsby-cli@2.4.14) (2019-03-08)
+
+### Bug Fixes
+
+- **gatsby-cli:** Fixed incorrect scriptname in gatsby-cli ([#12186](https://github.com/gatsbyjs/gatsby/issues/12186)) ([3b116f6](https://github.com/gatsbyjs/gatsby/commit/3b116f6))
+
+## [2.4.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.12...gatsby-cli@2.4.13) (2019-03-05)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.4.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.11...gatsby-cli@2.4.12) (2019-02-28)
+
+**Note:** Version bump only for package gatsby-cli
+
+## [2.4.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.10...gatsby-cli@2.4.11) (2019-02-19)
 
 ### Features
 
-- **gatsby-cli:** add a clean command to wipe out local dirs ([#9126](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/9126)) ([5807936](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/5807936))
+- **gatsby-cli:** add a clean command to wipe out local dirs ([#9126](https://github.com/gatsbyjs/gatsby/issues/9126)) ([5807936](https://github.com/gatsbyjs/gatsby/commit/5807936))
 
-## [2.4.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.9...gatsby-cli@2.4.10) (2019-02-12)
+## [2.4.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.9...gatsby-cli@2.4.10) (2019-02-12)
 
 ### Features
 
-- **gatsby-cli:** Initialize the newly cloned repository as git ([#10868](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/10868)) ([ccd9dcd](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/ccd9dcd))
+- **gatsby-cli:** Initialize the newly cloned repository as git ([#10868](https://github.com/gatsbyjs/gatsby/issues/10868)) ([ccd9dcd](https://github.com/gatsbyjs/gatsby/commit/ccd9dcd))
 
-## [2.4.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.8...gatsby-cli@2.4.9) (2019-02-04)
+## [2.4.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.8...gatsby-cli@2.4.9) (2019-02-04)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.4.8"></a>
 
-## [2.4.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.7...gatsby-cli@2.4.8) (2018-12-27)
+## [2.4.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.7...gatsby-cli@2.4.8) (2018-12-27)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.4.7"></a>
 
-## [2.4.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.6...gatsby-cli@2.4.7) (2018-12-18)
+## [2.4.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.6...gatsby-cli@2.4.7) (2018-12-18)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.4.6"></a>
 
-## [2.4.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.5...gatsby-cli@2.4.6) (2018-11-29)
+## [2.4.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.5...gatsby-cli@2.4.6) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.4.5"></a>
 
-## [2.4.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.4...gatsby-cli@2.4.5) (2018-11-08)
+## [2.4.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.4...gatsby-cli@2.4.5) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.4.4"></a>
 
-## [2.4.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.3...gatsby-cli@2.4.4) (2018-10-29)
+## [2.4.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.3...gatsby-cli@2.4.4) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.4.3"></a>
 
-## [2.4.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.2...gatsby-cli@2.4.3) (2018-10-09)
+## [2.4.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.2...gatsby-cli@2.4.3) (2018-10-09)
 
 ### Features
 
-- add error message with filename on Markdown error, fix bug in panicOnBuild ([#8866](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/8866)) ([bbff3be](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/bbff3be))
+- add error message with filename on Markdown error, fix bug in panicOnBuild ([#8866](https://github.com/gatsbyjs/gatsby/issues/8866)) ([bbff3be](https://github.com/gatsbyjs/gatsby/commit/bbff3be))
 
 <a name="2.4.2"></a>
 
-## [2.4.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.1...gatsby-cli@2.4.2) (2018-09-27)
+## [2.4.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.1...gatsby-cli@2.4.2) (2018-09-27)
 
 ### Bug Fixes
 
-- add compat fix for gatsby-cli v2 with gatsby v1 ([#8581](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/8581)) ([279ea76](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/279ea76))
+- add compat fix for gatsby-cli v2 with gatsby v1 ([#8581](https://github.com/gatsbyjs/gatsby/issues/8581)) ([279ea76](https://github.com/gatsbyjs/gatsby/commit/279ea76))
 
 <a name="2.4.1"></a>
 
-## [2.4.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.4.0...gatsby-cli@2.4.1) (2018-09-18)
+## [2.4.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.4.0...gatsby-cli@2.4.1) (2018-09-18)
 
 ### Features
 
-- add --prefix-paths option to gatsby serve cli ([#8060](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/issues/8060)) ([98c8e91](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/commit/98c8e91))
+- add --prefix-paths option to gatsby serve cli ([#8060](https://github.com/gatsbyjs/gatsby/issues/8060)) ([98c8e91](https://github.com/gatsbyjs/gatsby/commit/98c8e91))
 
 <a name="2.4.0"></a>
 
-# [2.4.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-rc.6...gatsby-cli@2.4.0) (2018-09-17)
+# [2.4.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-rc.6...gatsby-cli@2.4.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-rc.5...gatsby-cli@2.0.0-rc.6) (2018-09-17)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-rc.5...gatsby-cli@2.0.0-rc.6) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-rc.4...gatsby-cli@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-rc.4...gatsby-cli@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-rc.3...gatsby-cli@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-rc.3...gatsby-cli@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-rc.2...gatsby-cli@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-rc.2...gatsby-cli@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-rc.1...gatsby-cli@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-rc.1...gatsby-cli@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-rc.0...gatsby-cli@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-rc.0...gatsby-cli@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.14...gatsby-cli@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.14...gatsby-cli@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.14"></a>
 
-# [2.0.0-beta.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.13...gatsby-cli@2.0.0-beta.14) (2018-08-16)
+# [2.0.0-beta.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.13...gatsby-cli@2.0.0-beta.14) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.13"></a>
 
-# [2.0.0-beta.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.12...gatsby-cli@2.0.0-beta.13) (2018-08-10)
+# [2.0.0-beta.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.12...gatsby-cli@2.0.0-beta.13) (2018-08-10)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.12"></a>
 
-# [2.0.0-beta.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.10...gatsby-cli@2.0.0-beta.12) (2018-08-07)
+# [2.0.0-beta.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.10...gatsby-cli@2.0.0-beta.12) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.10"></a>
 
-# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.8...gatsby-cli@2.0.0-beta.10) (2018-08-07)
+# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.8...gatsby-cli@2.0.0-beta.10) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.7...gatsby-cli@2.0.0-beta.8) (2018-08-07)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.7...gatsby-cli@2.0.0-beta.8) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.6...gatsby-cli@2.0.0-beta.7) (2018-07-21)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.6...gatsby-cli@2.0.0-beta.7) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.5...gatsby-cli@2.0.0-beta.6) (2018-07-13)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.5...gatsby-cli@2.0.0-beta.6) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.4...gatsby-cli@2.0.0-beta.5) (2018-07-11)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.4...gatsby-cli@2.0.0-beta.5) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.3...gatsby-cli@2.0.0-beta.4) (2018-07-11)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.3...gatsby-cli@2.0.0-beta.4) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.2...gatsby-cli@2.0.0-beta.3) (2018-06-29)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.2...gatsby-cli@2.0.0-beta.3) (2018-06-29)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.1...gatsby-cli@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.1...gatsby-cli@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@2.0.0-beta.0...gatsby-cli@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@2.0.0-beta.0...gatsby-cli@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-cli
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli/compare/gatsby-cli@1.1.58...gatsby-cli@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-cli@1.1.58...gatsby-cli@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-cli

--- a/packages/gatsby-codemods/CHANGELOG.md
+++ b/packages/gatsby-codemods/CHANGELOG.md
@@ -7,11 +7,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-codemods
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-codemods/compare/gatsby-codemods@1.0.11...gatsby-codemods@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-codemods@1.0.11...gatsby-codemods@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-codemods
 
-## [1.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-codemods/compare/gatsby-codemods@1.0.10...gatsby-codemods@1.0.11) (2019-04-23)
+## [1.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-codemods@1.0.10...gatsby-codemods@1.0.11) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-codemods
 

--- a/packages/gatsby-cypress/CHANGELOG.md
+++ b/packages/gatsby-cypress/CHANGELOG.md
@@ -7,33 +7,33 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-cypress
 
-# [0.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress/compare/gatsby-cypress@0.1.9...gatsby-cypress@0.2.0) (2019-06-20)
+# [0.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.9...gatsby-cypress@0.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-cypress
 
-## [0.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress/compare/gatsby-cypress@0.1.8...gatsby-cypress@0.1.9) (2019-04-24)
+## [0.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.8...gatsby-cypress@0.1.9) (2019-04-24)
 
 **Note:** Version bump only for package gatsby-cypress
 
-## [0.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress/compare/gatsby-cypress@0.1.7...gatsby-cypress@0.1.8) (2019-04-18)
+## [0.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.7...gatsby-cypress@0.1.8) (2019-04-18)
 
 ### Bug Fixes
 
-- **gatsby-cypress:** use correct links in package json ([#13458](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress/issues/13458)) ([f55cf46](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress/commit/f55cf46)), closes [#13457](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress/issues/13457)
+- **gatsby-cypress:** use correct links in package json ([#13458](https://github.com/gatsbyjs/gatsby/issues/13458)) ([f55cf46](https://github.com/gatsbyjs/gatsby/commit/f55cf46)), closes [#13457](https://github.com/gatsbyjs/gatsby/issues/13457)
 
-## [0.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/compare/gatsby-cypress@0.1.6...gatsby-cypress@0.1.7) (2019-03-18)
-
-**Note:** Version bump only for package gatsby-cypress
-
-## [0.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/compare/gatsby-cypress@0.1.5...gatsby-cypress@0.1.6) (2019-03-11)
+## [0.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.6...gatsby-cypress@0.1.7) (2019-03-18)
 
 **Note:** Version bump only for package gatsby-cypress
 
-## [0.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/compare/gatsby-cypress@0.1.4...gatsby-cypress@0.1.5) (2019-03-08)
+## [0.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.5...gatsby-cypress@0.1.6) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-cypress
+
+## [0.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.4...gatsby-cypress@0.1.5) (2019-03-08)
 
 ### Bug Fixes
 
-- **gatsby-cypress:** Run files through babel ([#12400](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/issues/12400)) ([bf7fe7f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/commit/bf7fe7f))
+- **gatsby-cypress:** Run files through babel ([#12400](https://github.com/gatsbyjs/gatsby/issues/12400)) ([bf7fe7f](https://github.com/gatsbyjs/gatsby/commit/bf7fe7f))
 
 ## 0.1.4 (2019-03-04)
 
@@ -41,27 +41,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="0.1.3"></a>
 
-## [0.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/compare/gatsby-cypress@0.1.2...gatsby-cypress@0.1.3) (2018-12-24)
+## [0.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.2...gatsby-cypress@0.1.3) (2018-12-24)
 
 ### Bug Fixes
 
-- **gatsby:** handle missing pages metadata chunk ([#10507](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/issues/10507)) ([b9411d8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/commit/b9411d8))
+- **gatsby:** handle missing pages metadata chunk ([#10507](https://github.com/gatsbyjs/gatsby/issues/10507)) ([b9411d8](https://github.com/gatsbyjs/gatsby/commit/b9411d8))
 
 <a name="0.1.2"></a>
 
-## [0.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/compare/gatsby-cypress@0.1.1...gatsby-cypress@0.1.2) (2018-10-02)
+## [0.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.1...gatsby-cypress@0.1.2) (2018-10-02)
 
 **Note:** Version bump only for package gatsby-cypress
 
 <a name="0.1.1"></a>
 
-## [0.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/compare/gatsby-cypress@0.1.1-rc.1...gatsby-cypress@0.1.1) (2018-09-17)
+## [0.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.1-rc.1...gatsby-cypress@0.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-cypress
 
 <a name="0.1.1-rc.1"></a>
 
-## [0.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cypress-commands/compare/gatsby-cypress@0.1.1-rc.0...gatsby-cypress@0.1.1-rc.1) (2018-09-17)
+## [0.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-cypress@0.1.1-rc.0...gatsby-cypress@0.1.1-rc.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-cypress
 

--- a/packages/gatsby-dev-cli/CHANGELOG.md
+++ b/packages/gatsby-dev-cli/CHANGELOG.md
@@ -7,208 +7,208 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-dev-cli
 
-## [2.5.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.5.0...gatsby-dev-cli@2.5.1) (2019-07-02)
+## [2.5.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.5.0...gatsby-dev-cli@2.5.1) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
-# [2.5.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.19...gatsby-dev-cli@2.5.0) (2019-06-20)
+# [2.5.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.19...gatsby-dev-cli@2.5.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
-## [2.4.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.18...gatsby-dev-cli@2.4.19) (2019-06-04)
+## [2.4.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.18...gatsby-dev-cli@2.4.19) (2019-06-04)
 
 ### Bug Fixes
 
-- **gatsby-dev-cli:** add missing awaits and other various fixes ([#14510](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/14510)) ([a2c55a7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/a2c55a7))
+- **gatsby-dev-cli:** add missing awaits and other various fixes ([#14510](https://github.com/gatsbyjs/gatsby/issues/14510)) ([a2c55a7](https://github.com/gatsbyjs/gatsby/commit/a2c55a7))
 
-## [2.4.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.17...gatsby-dev-cli@2.4.18) (2019-05-31)
-
-**Note:** Version bump only for package gatsby-dev-cli
-
-## [2.4.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.16...gatsby-dev-cli@2.4.17) (2019-05-31)
+## [2.4.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.17...gatsby-dev-cli@2.4.18) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
-## [2.4.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.15...gatsby-dev-cli@2.4.16) (2019-05-31)
+## [2.4.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.16...gatsby-dev-cli@2.4.17) (2019-05-31)
+
+**Note:** Version bump only for package gatsby-dev-cli
+
+## [2.4.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.15...gatsby-dev-cli@2.4.16) (2019-05-31)
 
 ### Bug Fixes
 
-- **gatsby-dev-cli:** refactor, wait for package installation before copying files, handle packages that are not direct deps of local project ([#14347](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/14347)) ([d399dc9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/d399dc9))
+- **gatsby-dev-cli:** refactor, wait for package installation before copying files, handle packages that are not direct deps of local project ([#14347](https://github.com/gatsbyjs/gatsby/issues/14347)) ([d399dc9](https://github.com/gatsbyjs/gatsby/commit/d399dc9))
 
-## [2.4.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.14...gatsby-dev-cli@2.4.15) (2019-04-09)
+## [2.4.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.14...gatsby-dev-cli@2.4.15) (2019-04-09)
 
 ### Bug Fixes
 
-- **gatsby-dev-cli:** Persist verdaccio stuff in os.tmpdir ([#13251](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/13251)) ([d00ead5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/d00ead5))
+- **gatsby-dev-cli:** Persist verdaccio stuff in os.tmpdir ([#13251](https://github.com/gatsbyjs/gatsby/issues/13251)) ([d00ead5](https://github.com/gatsbyjs/gatsby/commit/d00ead5))
 
-## [2.4.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.13...gatsby-dev-cli@2.4.14) (2019-04-02)
+## [2.4.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.13...gatsby-dev-cli@2.4.14) (2019-04-02)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
-## [2.4.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.12...gatsby-dev-cli@2.4.13) (2019-04-02)
+## [2.4.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.12...gatsby-dev-cli@2.4.13) (2019-04-02)
 
 ### Features
 
-- **gatsby-dev-cli:** add verdaccio support ([#11525](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/11525)) ([a4f7e77](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/a4f7e77))
+- **gatsby-dev-cli:** add verdaccio support ([#11525](https://github.com/gatsbyjs/gatsby/issues/11525)) ([a4f7e77](https://github.com/gatsbyjs/gatsby/commit/a4f7e77))
 
-## [2.4.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.11...gatsby-dev-cli@2.4.12) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-dev-cli
-
-## [2.4.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.10...gatsby-dev-cli@2.4.11) (2019-03-11)
+## [2.4.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.11...gatsby-dev-cli@2.4.12) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
-## [2.4.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.9...gatsby-dev-cli@2.4.10) (2019-02-19)
+## [2.4.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.10...gatsby-dev-cli@2.4.11) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
-## [2.4.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.8...gatsby-dev-cli@2.4.9) (2019-02-06)
+## [2.4.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.9...gatsby-dev-cli@2.4.10) (2019-02-19)
+
+**Note:** Version bump only for package gatsby-dev-cli
+
+## [2.4.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.8...gatsby-dev-cli@2.4.9) (2019-02-06)
 
 ### Bug Fixes
 
-- **gatsby-dev-cli:** move package.json file check after pathToRepo handling ([#11565](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/11565)) ([da0cbab](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/da0cbab))
+- **gatsby-dev-cli:** move package.json file check after pathToRepo handling ([#11565](https://github.com/gatsbyjs/gatsby/issues/11565)) ([da0cbab](https://github.com/gatsbyjs/gatsby/commit/da0cbab))
 
 <a name="2.4.8"></a>
 
-## [2.4.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.7...gatsby-dev-cli@2.4.8) (2018-11-29)
+## [2.4.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.7...gatsby-dev-cli@2.4.8) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.4.7"></a>
 
-## [2.4.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.6...gatsby-dev-cli@2.4.7) (2018-11-08)
+## [2.4.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.6...gatsby-dev-cli@2.4.7) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.4.6"></a>
 
-## [2.4.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.5...gatsby-dev-cli@2.4.6) (2018-10-29)
+## [2.4.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.5...gatsby-dev-cli@2.4.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.4.5"></a>
 
-## [2.4.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.4...gatsby-dev-cli@2.4.5) (2018-10-05)
+## [2.4.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.4...gatsby-dev-cli@2.4.5) (2018-10-05)
 
 ### Bug Fixes
 
-- check for for both unix and win32 path separators ([#8837](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/8837)) ([57cd191](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/57cd191))
+- check for for both unix and win32 path separators ([#8837](https://github.com/gatsbyjs/gatsby/issues/8837)) ([57cd191](https://github.com/gatsbyjs/gatsby/commit/57cd191))
 
 <a name="2.4.4"></a>
 
-## [2.4.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.3...gatsby-dev-cli@2.4.4) (2018-10-02)
+## [2.4.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.3...gatsby-dev-cli@2.4.4) (2018-10-02)
 
 ### Bug Fixes
 
-- **gatsby-dev-cli:** infer correct prefix from package path ([#8683](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/8683)) ([30b68e2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/30b68e2))
+- **gatsby-dev-cli:** infer correct prefix from package path ([#8683](https://github.com/gatsbyjs/gatsby/issues/8683)) ([30b68e2](https://github.com/gatsbyjs/gatsby/commit/30b68e2))
 
 <a name="2.4.3"></a>
 
-## [2.4.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.2...gatsby-dev-cli@2.4.3) (2018-09-28)
+## [2.4.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.2...gatsby-dev-cli@2.4.3) (2018-09-28)
 
 ### Bug Fixes
 
-- use correct path argument ([#8628](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/8628)) ([acb5293](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/acb5293))
+- use correct path argument ([#8628](https://github.com/gatsbyjs/gatsby/issues/8628)) ([acb5293](https://github.com/gatsbyjs/gatsby/commit/acb5293))
 
 <a name="2.4.2"></a>
 
-## [2.4.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.1...gatsby-dev-cli@2.4.2) (2018-09-28)
+## [2.4.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.1...gatsby-dev-cli@2.4.2) (2018-09-28)
 
 ### Bug Fixes
 
-- **gatsby-dev-cli:** wait for files to be copied before exiting ([#8387](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/8387)) ([576f78a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/576f78a))
+- **gatsby-dev-cli:** wait for files to be copied before exiting ([#8387](https://github.com/gatsbyjs/gatsby/issues/8387)) ([576f78a](https://github.com/gatsbyjs/gatsby/commit/576f78a))
 
 <a name="2.4.1"></a>
 
-## [2.4.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.4.0...gatsby-dev-cli@2.4.1) (2018-09-19)
+## [2.4.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.4.0...gatsby-dev-cli@2.4.1) (2018-09-19)
 
 ### Bug Fixes
 
-- get gatsby-dev-cli working with tilde/home shortcut ([#8337](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/8337)) ([ae51353](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/ae51353))
+- get gatsby-dev-cli working with tilde/home shortcut ([#8337](https://github.com/gatsbyjs/gatsby/issues/8337)) ([ae51353](https://github.com/gatsbyjs/gatsby/commit/ae51353))
 
 <a name="2.4.0"></a>
 
-# [2.4.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-rc.6...gatsby-dev-cli@2.4.0) (2018-09-17)
+# [2.4.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-rc.6...gatsby-dev-cli@2.4.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-rc.5...gatsby-dev-cli@2.0.0-rc.6) (2018-09-12)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-rc.5...gatsby-dev-cli@2.0.0-rc.6) (2018-09-12)
 
 ### Features
 
-- add a copy-all script to gatsby-dev-cli ([#8066](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/issues/8066)) ([1baa523](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/commit/1baa523))
+- add a copy-all script to gatsby-dev-cli ([#8066](https://github.com/gatsbyjs/gatsby/issues/8066)) ([1baa523](https://github.com/gatsbyjs/gatsby/commit/1baa523))
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-rc.4...gatsby-dev-cli@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-rc.4...gatsby-dev-cli@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-rc.3...gatsby-dev-cli@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-rc.3...gatsby-dev-cli@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-rc.2...gatsby-dev-cli@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-rc.2...gatsby-dev-cli@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-rc.1...gatsby-dev-cli@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-rc.1...gatsby-dev-cli@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-rc.0...gatsby-dev-cli@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-rc.0...gatsby-dev-cli@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-beta.5...gatsby-dev-cli@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-beta.5...gatsby-dev-cli@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-beta.4...gatsby-dev-cli@2.0.0-beta.5) (2018-08-04)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-beta.4...gatsby-dev-cli@2.0.0-beta.5) (2018-08-04)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-beta.3...gatsby-dev-cli@2.0.0-beta.4) (2018-07-27)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-beta.3...gatsby-dev-cli@2.0.0-beta.4) (2018-07-27)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-beta.2...gatsby-dev-cli@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-beta.2...gatsby-dev-cli@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-beta.1...gatsby-dev-cli@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-beta.1...gatsby-dev-cli@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@2.0.0-beta.0...gatsby-dev-cli@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@2.0.0-beta.0...gatsby-dev-cli@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-dev-cli
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli/compare/gatsby-dev-cli@1.2.12...gatsby-dev-cli@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-dev-cli@1.2.12...gatsby-dev-cli@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-dev-cli

--- a/packages/gatsby-image/CHANGELOG.md
+++ b/packages/gatsby-image/CHANGELOG.md
@@ -7,370 +7,370 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.2.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.2.3...gatsby-image@2.2.4) (2019-07-02)
+## [2.2.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.2.3...gatsby-image@2.2.4) (2019-07-02)
 
 ### Bug Fixes
 
-- **gatsby-image:** Update TypeScript types ([#15313](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/15313)) ([88e5766](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/88e5766))
+- **gatsby-image:** Update TypeScript types ([#15313](https://github.com/gatsbyjs/gatsby/issues/15313)) ([88e5766](https://github.com/gatsbyjs/gatsby/commit/88e5766))
 
-## [2.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.2.2...gatsby-image@2.2.3) (2019-06-24)
-
-**Note:** Version bump only for package gatsby-image
-
-## [2.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.2.1...gatsby-image@2.2.2) (2019-06-24)
+## [2.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.2.2...gatsby-image@2.2.3) (2019-06-24)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.2.0...gatsby-image@2.2.1) (2019-06-21)
+## [2.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.2.1...gatsby-image@2.2.2) (2019-06-24)
+
+**Note:** Version bump only for package gatsby-image
+
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.2.0...gatsby-image@2.2.1) (2019-06-21)
 
 ### Features
 
-- **gatsby-image:** Add art direction ([#13395](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/13395)) ([02edcdc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/02edcdc))
+- **gatsby-image:** Add art direction ([#13395](https://github.com/gatsbyjs/gatsby/issues/13395)) ([02edcdc](https://github.com/gatsbyjs/gatsby/commit/02edcdc))
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.1.4...gatsby-image@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.1.4...gatsby-image@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.1.3...gatsby-image@2.1.4) (2019-06-12)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.1.3...gatsby-image@2.1.4) (2019-06-12)
 
 ### Bug Fixes
 
-- **docs:** improve image docs from workflow evaluation ([#14697](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/14697)) ([16f0baf](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/16f0baf))
+- **docs:** improve image docs from workflow evaluation ([#14697](https://github.com/gatsbyjs/gatsby/issues/14697)) ([16f0baf](https://github.com/gatsbyjs/gatsby/commit/16f0baf))
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.1.2...gatsby-image@2.1.3) (2019-06-10)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.1.2...gatsby-image@2.1.3) (2019-06-10)
 
 ### Features
 
-- **gatsby-image:** add types for gatsby-image/withIEPolyfill to fix [#14592](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/14592) ([#14641](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/14641)) ([39b1c6e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/39b1c6e))
+- **gatsby-image:** add types for gatsby-image/withIEPolyfill to fix [#14592](https://github.com/gatsbyjs/gatsby/issues/14592) ([#14641](https://github.com/gatsbyjs/gatsby/issues/14641)) ([39b1c6e](https://github.com/gatsbyjs/gatsby/commit/39b1c6e))
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.1.1...gatsby-image@2.1.2) (2019-05-29)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.1.1...gatsby-image@2.1.2) (2019-05-29)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.1.0...gatsby-image@2.1.1) (2019-05-24)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.1.0...gatsby-image@2.1.1) (2019-05-24)
 
 ### Features
 
-- **gatsby-image:** export TS interfaces of gatsby-image object types ([#14284](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/14284)) ([b3e306c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/b3e306c))
+- **gatsby-image:** export TS interfaces of gatsby-image object types ([#14284](https://github.com/gatsbyjs/gatsby/issues/14284)) ([b3e306c](https://github.com/gatsbyjs/gatsby/commit/b3e306c))
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.41...gatsby-image@2.1.0) (2019-05-16)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.41...gatsby-image@2.1.0) (2019-05-16)
 
 ### Features
 
-- **gatsby-image:** Add support for native lazy loading ([#13217](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/13217)) ([3c0eb1e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/3c0eb1e))
+- **gatsby-image:** Add support for native lazy loading ([#13217](https://github.com/gatsbyjs/gatsby/issues/13217)) ([3c0eb1e](https://github.com/gatsbyjs/gatsby/commit/3c0eb1e))
 
-## [2.0.41](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.40...gatsby-image@2.0.41) (2019-04-30)
+## [2.0.41](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.40...gatsby-image@2.0.41) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.0.40](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.39...gatsby-image@2.0.40) (2019-04-23)
+## [2.0.40](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.39...gatsby-image@2.0.40) (2019-04-23)
 
 ### Features
 
-- **gatsby-image:** Add durationFadeIn ([#13566](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/13566)) ([6f46aac](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/6f46aac))
+- **gatsby-image:** Add durationFadeIn ([#13566](https://github.com/gatsbyjs/gatsby/issues/13566)) ([6f46aac](https://github.com/gatsbyjs/gatsby/commit/6f46aac))
 
-## [2.0.39](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.38...gatsby-image@2.0.39) (2019-04-15)
+## [2.0.39](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.38...gatsby-image@2.0.39) (2019-04-15)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.0.38](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.37...gatsby-image@2.0.38) (2019-04-11)
+## [2.0.38](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.37...gatsby-image@2.0.38) (2019-04-11)
 
 ### Bug Fixes
 
-- **gatsby-image:** ensure that currentSrc exists ([#13287](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/13287)) ([6059bce](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/6059bce))
+- **gatsby-image:** ensure that currentSrc exists ([#13287](https://github.com/gatsbyjs/gatsby/issues/13287)) ([6059bce](https://github.com/gatsbyjs/gatsby/commit/6059bce))
 
-## [2.0.37](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.36...gatsby-image@2.0.37) (2019-04-02)
+## [2.0.37](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.36...gatsby-image@2.0.37) (2019-04-02)
 
 ### Features
 
-- **gatsby-image:** don't fadein image when already loaded "browser-cache" ([#12468](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/12468)) ([8646aa4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/8646aa4)), closes [#12254](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/12254)
+- **gatsby-image:** don't fadein image when already loaded "browser-cache" ([#12468](https://github.com/gatsbyjs/gatsby/issues/12468)) ([8646aa4](https://github.com/gatsbyjs/gatsby/commit/8646aa4)), closes [#12254](https://github.com/gatsbyjs/gatsby/issues/12254)
 
-## [2.0.36](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.35...gatsby-image@2.0.36) (2019-04-01)
+## [2.0.36](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.35...gatsby-image@2.0.36) (2019-04-01)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.0.35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.34...gatsby-image@2.0.35) (2019-03-26)
+## [2.0.35](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.34...gatsby-image@2.0.35) (2019-03-26)
 
 ### Features
 
-- **gatsby-image:** Add gatsby-image/withIEPolyfill export with object-fit/position support ([#12681](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/12681)) ([4b9b6a1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/4b9b6a1)), closes [#4021](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/4021)
+- **gatsby-image:** Add gatsby-image/withIEPolyfill export with object-fit/position support ([#12681](https://github.com/gatsbyjs/gatsby/issues/12681)) ([4b9b6a1](https://github.com/gatsbyjs/gatsby/commit/4b9b6a1)), closes [#4021](https://github.com/gatsbyjs/gatsby/issues/4021)
 
-## [2.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.33...gatsby-image@2.0.34) (2019-03-15)
+## [2.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.33...gatsby-image@2.0.34) (2019-03-15)
 
 ### Bug Fixes
 
-- **gatsby-image:** fix memory leak and use more appropriate data structures for cache and listeners ([#10278](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/10278)) ([9298fa3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/9298fa3))
+- **gatsby-image:** fix memory leak and use more appropriate data structures for cache and listeners ([#10278](https://github.com/gatsbyjs/gatsby/issues/10278)) ([9298fa3](https://github.com/gatsbyjs/gatsby/commit/9298fa3))
 
 ### Features
 
-- **gatsby-image:** Whitelist `crossorigin` prop for pass through to `img` tag ([#9758](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/9758)) ([7684b4f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/7684b4f))
+- **gatsby-image:** Whitelist `crossorigin` prop for pass through to `img` tag ([#9758](https://github.com/gatsbyjs/gatsby/issues/9758)) ([7684b4f](https://github.com/gatsbyjs/gatsby/commit/7684b4f))
 
-## [2.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.32...gatsby-image@2.0.33) (2019-03-12)
+## [2.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.32...gatsby-image@2.0.33) (2019-03-12)
 
 ### Features
 
-- **gatsby-image:** Placeholder Improvements ([#10944](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/10944)) ([44491ef](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/44491ef))
+- **gatsby-image:** Placeholder Improvements ([#10944](https://github.com/gatsbyjs/gatsby/issues/10944)) ([44491ef](https://github.com/gatsbyjs/gatsby/commit/44491ef))
 
-## [2.0.32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.31...gatsby-image@2.0.32) (2019-03-11)
+## [2.0.32](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.31...gatsby-image@2.0.32) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.0.31](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.30...gatsby-image@2.0.31) (2019-03-04)
+## [2.0.31](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.30...gatsby-image@2.0.31) (2019-03-04)
 
 **Note:** Version bump only for package gatsby-image
 
-## [2.0.30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.29...gatsby-image@2.0.30) (2019-02-25)
+## [2.0.30](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.29...gatsby-image@2.0.30) (2019-02-25)
 
 ### Bug Fixes
 
-- **gatsby-image:** Safari Downloading multiple resolutions ([#11920](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/11920)) ([29e572e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/29e572e))
+- **gatsby-image:** Safari Downloading multiple resolutions ([#11920](https://github.com/gatsbyjs/gatsby/issues/11920)) ([29e572e](https://github.com/gatsbyjs/gatsby/commit/29e572e))
 
-## [2.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.28...gatsby-image@2.0.29) (2019-01-28)
+## [2.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.28...gatsby-image@2.0.29) (2019-01-28)
 
 ### Bug Fixes
 
-- **gatsby-image:** use the cache to tell if the image was already loaded ([#11303](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/11303)) ([1d5ccff](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/1d5ccff))
+- **gatsby-image:** use the cache to tell if the image was already loaded ([#11303](https://github.com/gatsbyjs/gatsby/issues/11303)) ([1d5ccff](https://github.com/gatsbyjs/gatsby/commit/1d5ccff))
 
 ### Features
 
-- **gatsby-image:** add itemProp prop ([#11296](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/11296)) ([76b9827](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/76b9827))
+- **gatsby-image:** add itemProp prop ([#11296](https://github.com/gatsbyjs/gatsby/issues/11296)) ([76b9827](https://github.com/gatsbyjs/gatsby/commit/76b9827))
 
-## [2.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.27...gatsby-image@2.0.28) (2019-01-25)
+## [2.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.27...gatsby-image@2.0.28) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.27"></a>
 
-## [2.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.26...gatsby-image@2.0.27) (2019-01-23)
+## [2.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.26...gatsby-image@2.0.27) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.26"></a>
 
-## [2.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.25...gatsby-image@2.0.26) (2019-01-10)
+## [2.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.25...gatsby-image@2.0.26) (2019-01-10)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.25"></a>
 
-## [2.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.24...gatsby-image@2.0.25) (2018-12-13)
+## [2.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.24...gatsby-image@2.0.25) (2018-12-13)
 
 ### Bug Fixes
 
-- **gatsby-image:** update TypeScript definitions - properly mark fields as optional ([#10419](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/10419)) ([f2b1821](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/f2b1821))
+- **gatsby-image:** update TypeScript definitions - properly mark fields as optional ([#10419](https://github.com/gatsbyjs/gatsby/issues/10419)) ([f2b1821](https://github.com/gatsbyjs/gatsby/commit/f2b1821))
 
 <a name="2.0.24"></a>
 
-## [2.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.23...gatsby-image@2.0.24) (2018-12-12)
+## [2.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.23...gatsby-image@2.0.24) (2018-12-12)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.23"></a>
 
-## [2.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.22...gatsby-image@2.0.23) (2018-12-11)
+## [2.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.22...gatsby-image@2.0.23) (2018-12-11)
 
 ### Features
 
-- **gatsby-image:** add onStartLoad prop ([#6702](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/6702)) ([1d25a95](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/1d25a95))
+- **gatsby-image:** add onStartLoad prop ([#6702](https://github.com/gatsbyjs/gatsby/issues/6702)) ([1d25a95](https://github.com/gatsbyjs/gatsby/commit/1d25a95))
 
 <a name="2.0.22"></a>
 
-## [2.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.21...gatsby-image@2.0.22) (2018-11-29)
+## [2.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.21...gatsby-image@2.0.22) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.21"></a>
 
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.20...gatsby-image@2.0.21) (2018-11-27)
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.20...gatsby-image@2.0.21) (2018-11-27)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.20"></a>
 
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.19...gatsby-image@2.0.20) (2018-11-08)
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.19...gatsby-image@2.0.20) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.19"></a>
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.18...gatsby-image@2.0.19) (2018-10-30)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.18...gatsby-image@2.0.19) (2018-10-30)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.18"></a>
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.17...gatsby-image@2.0.18) (2018-10-29)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.17...gatsby-image@2.0.18) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.17"></a>
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.16...gatsby-image@2.0.17) (2018-10-24)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.16...gatsby-image@2.0.17) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.16"></a>
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.15...gatsby-image@2.0.16) (2018-10-23)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.15...gatsby-image@2.0.16) (2018-10-23)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.15"></a>
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.14...gatsby-image@2.0.15) (2018-10-15)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.14...gatsby-image@2.0.15) (2018-10-15)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.14"></a>
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.13...gatsby-image@2.0.14) (2018-10-12)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.13...gatsby-image@2.0.14) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.13"></a>
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.12...gatsby-image@2.0.13) (2018-10-01)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.12...gatsby-image@2.0.13) (2018-10-01)
 
 ### Bug Fixes
 
-- Address [#8579](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/8579) Don't display double alt text. ([#8671](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/8671)) ([cb0adee](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/cb0adee))
+- Address [#8579](https://github.com/gatsbyjs/gatsby/issues/8579) Don't display double alt text. ([#8671](https://github.com/gatsbyjs/gatsby/issues/8671)) ([cb0adee](https://github.com/gatsbyjs/gatsby/commit/cb0adee))
 
 <a name="2.0.12"></a>
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.11...gatsby-image@2.0.12) (2018-09-28)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.11...gatsby-image@2.0.12) (2018-09-28)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.10...gatsby-image@2.0.11) (2018-09-28)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.10...gatsby-image@2.0.11) (2018-09-28)
 
 ### Bug Fixes
 
-- add missing GatsbyImageProps to TS defs ([#8606](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/8606)) ([b6f0d62](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/commit/b6f0d62)), closes [/github.com/gatsbyjs/gatsby/blob/76c50aa00653d988043333ceefec7abb34078fca/packages/gatsby-image/src/index.js#L457-L474](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/issues/L457-L474)
+- add missing GatsbyImageProps to TS defs ([#8606](https://github.com/gatsbyjs/gatsby/issues/8606)) ([b6f0d62](https://github.com/gatsbyjs/gatsby/commit/b6f0d62)), closes [/github.com/gatsbyjs/gatsby/blob/76c50aa00653d988043333ceefec7abb34078fca/packages/gatsby-image/src/index.js#L457-L474](https://github.com/gatsbyjs/gatsby/issues/L457-L474)
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.9...gatsby-image@2.0.10) (2018-09-26)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.9...gatsby-image@2.0.10) (2018-09-26)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.8...gatsby-image@2.0.9) (2018-09-24)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.8...gatsby-image@2.0.9) (2018-09-24)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.7...gatsby-image@2.0.8) (2018-09-21)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.7...gatsby-image@2.0.8) (2018-09-21)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.6...gatsby-image@2.0.7) (2018-09-20)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.6...gatsby-image@2.0.7) (2018-09-20)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.5...gatsby-image@2.0.6) (2018-09-19)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.5...gatsby-image@2.0.6) (2018-09-19)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-rc.4...gatsby-image@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-rc.4...gatsby-image@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-rc.3...gatsby-image@2.0.0-rc.4) (2018-09-17)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-rc.3...gatsby-image@2.0.0-rc.4) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-rc.2...gatsby-image@2.0.0-rc.3) (2018-09-17)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-rc.2...gatsby-image@2.0.0-rc.3) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-rc.1...gatsby-image@2.0.0-rc.2) (2018-09-12)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-rc.1...gatsby-image@2.0.0-rc.2) (2018-09-12)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-rc.0...gatsby-image@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-rc.0...gatsby-image@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.9...gatsby-image@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.9...gatsby-image@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.8...gatsby-image@2.0.0-beta.9) (2018-08-20)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.8...gatsby-image@2.0.0-beta.9) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.7...gatsby-image@2.0.0-beta.8) (2018-08-15)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.7...gatsby-image@2.0.0-beta.8) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.6...gatsby-image@2.0.0-beta.7) (2018-07-21)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.6...gatsby-image@2.0.0-beta.7) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.5...gatsby-image@2.0.0-beta.6) (2018-07-12)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.5...gatsby-image@2.0.0-beta.6) (2018-07-12)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.4...gatsby-image@2.0.0-beta.5) (2018-07-09)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.4...gatsby-image@2.0.0-beta.5) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.3...gatsby-image@2.0.0-beta.4) (2018-07-02)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.3...gatsby-image@2.0.0-beta.4) (2018-07-02)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.2...gatsby-image@2.0.0-beta.3) (2018-06-29)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.2...gatsby-image@2.0.0-beta.3) (2018-06-29)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.1...gatsby-image@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.1...gatsby-image@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@2.0.0-beta.0...gatsby-image@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@2.0.0-beta.0...gatsby-image@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-image
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image/compare/gatsby-image@1.0.54...gatsby-image@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-image@1.0.54...gatsby-image@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-image

--- a/packages/gatsby-link/CHANGELOG.md
+++ b/packages/gatsby-link/CHANGELOG.md
@@ -7,271 +7,271 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-link
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.1.1...gatsby-link@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.1.1...gatsby-link@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-link
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.1.0...gatsby-link@2.1.1) (2019-05-03)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.1.0...gatsby-link@2.1.1) (2019-05-03)
 
 ### Bug Fixes
 
-- **gatsby-link:** provide fallback for **BASE_PATH** being missing ([#13839](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/13839)) ([dc554bf](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/dc554bf))
+- **gatsby-link:** provide fallback for **BASE_PATH** being missing ([#13839](https://github.com/gatsbyjs/gatsby/issues/13839)) ([dc554bf](https://github.com/gatsbyjs/gatsby/commit/dc554bf))
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.17...gatsby-link@2.1.0) (2019-05-02)
-
-### Features
-
-- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/8291044))
-
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.16...gatsby-link@2.0.17) (2019-04-30)
-
-**Note:** Version bump only for package gatsby-link
-
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.15...gatsby-link@2.0.16) (2019-03-12)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.17...gatsby-link@2.1.0) (2019-05-02)
 
 ### Features
 
-- **gatsby-link:** adds support for partiallyActive=true to Link ([#12495](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/12495)) ([e0db681](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/e0db681))
+- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/commit/8291044))
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.14...gatsby-link@2.0.15) (2019-03-11)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.16...gatsby-link@2.0.17) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-link
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.13...gatsby-link@2.0.14) (2019-03-04)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.15...gatsby-link@2.0.16) (2019-03-12)
 
 ### Features
 
-- **gatsby-link:** support RefObject ([#12174](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/12174)) ([5ab7a87](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/5ab7a87)), closes [#12014](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/12014)
+- **gatsby-link:** adds support for partiallyActive=true to Link ([#12495](https://github.com/gatsbyjs/gatsby/issues/12495)) ([e0db681](https://github.com/gatsbyjs/gatsby/commit/e0db681))
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.12...gatsby-link@2.0.13) (2019-02-28)
-
-**Note:** Version bump only for package gatsby-link
-
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.11...gatsby-link@2.0.12) (2019-02-22)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.14...gatsby-link@2.0.15) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-link
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.10...gatsby-link@2.0.11) (2019-02-19)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.13...gatsby-link@2.0.14) (2019-03-04)
+
+### Features
+
+- **gatsby-link:** support RefObject ([#12174](https://github.com/gatsbyjs/gatsby/issues/12174)) ([5ab7a87](https://github.com/gatsbyjs/gatsby/commit/5ab7a87)), closes [#12014](https://github.com/gatsbyjs/gatsby/issues/12014)
+
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.12...gatsby-link@2.0.13) (2019-02-28)
 
 **Note:** Version bump only for package gatsby-link
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.9...gatsby-link@2.0.10) (2019-02-01)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.11...gatsby-link@2.0.12) (2019-02-22)
+
+**Note:** Version bump only for package gatsby-link
+
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.10...gatsby-link@2.0.11) (2019-02-19)
+
+**Note:** Version bump only for package gatsby-link
+
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.9...gatsby-link@2.0.10) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.8...gatsby-link@2.0.9) (2019-01-23)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.8...gatsby-link@2.0.9) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.7...gatsby-link@2.0.8) (2019-01-10)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.7...gatsby-link@2.0.8) (2019-01-10)
 
 ### Bug Fixes
 
-- enable ref forwarding with forwardRef ([#9892](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/9892)) ([b6d9775](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/b6d9775))
+- enable ref forwarding with forwardRef ([#9892](https://github.com/gatsbyjs/gatsby/issues/9892)) ([b6d9775](https://github.com/gatsbyjs/gatsby/commit/b6d9775))
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.6...gatsby-link@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.6...gatsby-link@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.5...gatsby-link@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.5...gatsby-link@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.4...gatsby-link@2.0.5) (2018-10-24)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.4...gatsby-link@2.0.5) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.3...gatsby-link@2.0.4) (2018-10-03)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.3...gatsby-link@2.0.4) (2018-10-03)
 
 ### Bug Fixes
 
-- navigateTo deprecation message ([#8745](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/8745)) ([3c824f3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/3c824f3))
+- navigateTo deprecation message ([#8745](https://github.com/gatsbyjs/gatsby/issues/8745)) ([3c824f3](https://github.com/gatsbyjs/gatsby/commit/3c824f3))
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.2...gatsby-link@2.0.3) (2018-10-01)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.2...gatsby-link@2.0.3) (2018-10-01)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.1...gatsby-link@2.0.2) (2018-09-26)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.1...gatsby-link@2.0.2) (2018-09-26)
 
 ### Bug Fixes
 
-- **gatsby-link:** use path prefix in navigate/replace/push calls ([#8289](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/8289)) ([df3ac18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/df3ac18)), closes [#8155](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/8155)
-- scroll behaviour when navigating back to anchor on the same page ([#8061](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/issues/8061)) ([ef44cff](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/commit/ef44cff))
+- **gatsby-link:** use path prefix in navigate/replace/push calls ([#8289](https://github.com/gatsbyjs/gatsby/issues/8289)) ([df3ac18](https://github.com/gatsbyjs/gatsby/commit/df3ac18)), closes [#8155](https://github.com/gatsbyjs/gatsby/issues/8155)
+- scroll behaviour when navigating back to anchor on the same page ([#8061](https://github.com/gatsbyjs/gatsby/issues/8061)) ([ef44cff](https://github.com/gatsbyjs/gatsby/commit/ef44cff))
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-rc.4...gatsby-link@2.0.1) (2018-09-17)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-rc.4...gatsby-link@2.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-rc.3...gatsby-link@2.0.0-rc.4) (2018-09-17)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-rc.3...gatsby-link@2.0.0-rc.4) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-rc.2...gatsby-link@2.0.0-rc.3) (2018-09-13)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-rc.2...gatsby-link@2.0.0-rc.3) (2018-09-13)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-rc.1...gatsby-link@2.0.0-rc.2) (2018-08-29)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-rc.1...gatsby-link@2.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-rc.0...gatsby-link@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-rc.0...gatsby-link@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.22...gatsby-link@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.22...gatsby-link@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.22"></a>
 
-# [2.0.0-beta.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.21...gatsby-link@2.0.0-beta.22) (2018-08-15)
+# [2.0.0-beta.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.21...gatsby-link@2.0.0-beta.22) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.21"></a>
 
-# [2.0.0-beta.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.20...gatsby-link@2.0.0-beta.21) (2018-08-15)
+# [2.0.0-beta.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.20...gatsby-link@2.0.0-beta.21) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.20"></a>
 
-# [2.0.0-beta.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.19...gatsby-link@2.0.0-beta.20) (2018-08-10)
+# [2.0.0-beta.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.19...gatsby-link@2.0.0-beta.20) (2018-08-10)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.19"></a>
 
-# [2.0.0-beta.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.18...gatsby-link@2.0.0-beta.19) (2018-08-09)
+# [2.0.0-beta.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.18...gatsby-link@2.0.0-beta.19) (2018-08-09)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.18"></a>
 
-# [2.0.0-beta.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.17...gatsby-link@2.0.0-beta.18) (2018-08-09)
+# [2.0.0-beta.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.17...gatsby-link@2.0.0-beta.18) (2018-08-09)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.17"></a>
 
-# [2.0.0-beta.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.15...gatsby-link@2.0.0-beta.17) (2018-08-07)
+# [2.0.0-beta.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.15...gatsby-link@2.0.0-beta.17) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.15"></a>
 
-# [2.0.0-beta.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.14...gatsby-link@2.0.0-beta.15) (2018-08-07)
+# [2.0.0-beta.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.14...gatsby-link@2.0.0-beta.15) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.14"></a>
 
-# [2.0.0-beta.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.12...gatsby-link@2.0.0-beta.14) (2018-08-07)
+# [2.0.0-beta.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.12...gatsby-link@2.0.0-beta.14) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.12"></a>
 
-# [2.0.0-beta.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.11...gatsby-link@2.0.0-beta.12) (2018-08-07)
+# [2.0.0-beta.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.11...gatsby-link@2.0.0-beta.12) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.11"></a>
 
-# [2.0.0-beta.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.10...gatsby-link@2.0.0-beta.11) (2018-08-07)
+# [2.0.0-beta.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.10...gatsby-link@2.0.0-beta.11) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.10"></a>
 
-# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.9...gatsby-link@2.0.0-beta.10) (2018-08-07)
+# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.9...gatsby-link@2.0.0-beta.10) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.8...gatsby-link@2.0.0-beta.9) (2018-08-07)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.8...gatsby-link@2.0.0-beta.9) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.7...gatsby-link@2.0.0-beta.8) (2018-08-07)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.7...gatsby-link@2.0.0-beta.8) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.6...gatsby-link@2.0.0-beta.7) (2018-08-06)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.6...gatsby-link@2.0.0-beta.7) (2018-08-06)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.5...gatsby-link@2.0.0-beta.6) (2018-08-01)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.5...gatsby-link@2.0.0-beta.6) (2018-08-01)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.4...gatsby-link@2.0.0-beta.5) (2018-07-21)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.4...gatsby-link@2.0.0-beta.5) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.3...gatsby-link@2.0.0-beta.4) (2018-07-03)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.3...gatsby-link@2.0.0-beta.4) (2018-07-03)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.2...gatsby-link@2.0.0-beta.3) (2018-06-25)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.2...gatsby-link@2.0.0-beta.3) (2018-06-25)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.1...gatsby-link@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.1...gatsby-link@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@2.0.0-beta.0...gatsby-link@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@2.0.0-beta.0...gatsby-link@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-link
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link/compare/gatsby-link@1.6.44...gatsby-link@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-link@1.6.44...gatsby-link@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-link

--- a/packages/gatsby-page-utils/CHANGELOG.md
+++ b/packages/gatsby-page-utils/CHANGELOG.md
@@ -11,8 +11,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **gatsby-page-utils:** check-version-mismatch ([d0fabd3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-page-utils/commit/d0fabd3))
+- **gatsby-page-utils:** check-version-mismatch ([d0fabd3](https://github.com/gatsbyjs/gatsby/commit/d0fabd3))
 
 ### Features
 
-- **gatsby-page-utils:** extract logic for watching a directory from gatsby-page-creator so can reuse for custom page creation ([#14051](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-page-utils/issues/14051)) ([68d9d6f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-page-utils/commit/68d9d6f))
+- **gatsby-page-utils:** extract logic for watching a directory from gatsby-page-creator so can reuse for custom page creation ([#14051](https://github.com/gatsbyjs/gatsby/issues/14051)) ([68d9d6f](https://github.com/gatsbyjs/gatsby/commit/68d9d6f))

--- a/packages/gatsby-plugin-canonical-urls/CHANGELOG.md
+++ b/packages/gatsby-plugin-canonical-urls/CHANGELOG.md
@@ -7,96 +7,96 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.13...gatsby-plugin-canonical-urls@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.13...gatsby-plugin-canonical-urls@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.12...gatsby-plugin-canonical-urls@2.0.13) (2019-05-16)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.12...gatsby-plugin-canonical-urls@2.0.13) (2019-05-16)
 
 ### Features
 
-- **gatsby-plugin-canonical-urls:** add option to strip query string ([#13339](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/issues/13339)) ([c903fed](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/commit/c903fed))
+- **gatsby-plugin-canonical-urls:** add option to strip query string ([#13339](https://github.com/gatsbyjs/gatsby/issues/13339)) ([c903fed](https://github.com/gatsbyjs/gatsby/commit/c903fed))
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.11...gatsby-plugin-canonical-urls@2.0.12) (2019-03-11)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.11...gatsby-plugin-canonical-urls@2.0.12) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.10...gatsby-plugin-canonical-urls@2.0.11) (2019-03-11)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.10...gatsby-plugin-canonical-urls@2.0.11) (2019-03-11)
 
 ### Bug Fixes
 
-- **gatsby-plugin-canonical-urls:** fix typo in "How to use" section (http -> https) ([#12366](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/issues/12366)) ([56f7c2c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/commit/56f7c2c))
+- **gatsby-plugin-canonical-urls:** fix typo in "How to use" section (http -> https) ([#12366](https://github.com/gatsbyjs/gatsby/issues/12366)) ([56f7c2c](https://github.com/gatsbyjs/gatsby/commit/56f7c2c))
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.9...gatsby-plugin-canonical-urls@2.0.10) (2019-02-01)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.9...gatsby-plugin-canonical-urls@2.0.10) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.8...gatsby-plugin-canonical-urls@2.0.9) (2019-01-28)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.8...gatsby-plugin-canonical-urls@2.0.9) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.7...gatsby-plugin-canonical-urls@2.0.8) (2018-11-29)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.7...gatsby-plugin-canonical-urls@2.0.8) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.6...gatsby-plugin-canonical-urls@2.0.7) (2018-10-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.6...gatsby-plugin-canonical-urls@2.0.7) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.5...gatsby-plugin-canonical-urls@2.0.6) (2018-10-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.5...gatsby-plugin-canonical-urls@2.0.6) (2018-10-01)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.0-rc.2...gatsby-plugin-canonical-urls@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.0-rc.2...gatsby-plugin-canonical-urls@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.0-rc.1...gatsby-plugin-canonical-urls@2.0.0-rc.2) (2018-09-17)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.0-rc.1...gatsby-plugin-canonical-urls@2.0.0-rc.2) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.0-rc.0...gatsby-plugin-canonical-urls@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.0-rc.0...gatsby-plugin-canonical-urls@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.0-beta.3...gatsby-plugin-canonical-urls@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.0-beta.3...gatsby-plugin-canonical-urls@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.0-beta.2...gatsby-plugin-canonical-urls@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.0-beta.2...gatsby-plugin-canonical-urls@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.0-beta.1...gatsby-plugin-canonical-urls@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.0-beta.1...gatsby-plugin-canonical-urls@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@2.0.0-beta.0...gatsby-plugin-canonical-urls@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@2.0.0-beta.0...gatsby-plugin-canonical-urls@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls/compare/gatsby-plugin-canonical-urls@1.0.18...gatsby-plugin-canonical-urls@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-canonical-urls@1.0.18...gatsby-plugin-canonical-urls@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-canonical-urls

--- a/packages/gatsby-plugin-catch-links/CHANGELOG.md
+++ b/packages/gatsby-plugin-catch-links/CHANGELOG.md
@@ -7,23 +7,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.15...gatsby-plugin-catch-links@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.15...gatsby-plugin-catch-links@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.14...gatsby-plugin-catch-links@2.0.15) (2019-05-22)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.14...gatsby-plugin-catch-links@2.0.15) (2019-05-22)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.13...gatsby-plugin-catch-links@2.0.14) (2019-05-14)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.13...gatsby-plugin-catch-links@2.0.14) (2019-05-14)
 
 ### Bug Fixes
 
-- **gatsby-plugin-catch-links:** Fall back to default browser link handling when resources fail to fetch ([#13904](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/13904)) ([d4b60f2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/d4b60f2))
+- **gatsby-plugin-catch-links:** Fall back to default browser link handling when resources fail to fetch ([#13904](https://github.com/gatsbyjs/gatsby/issues/13904)) ([d4b60f2](https://github.com/gatsbyjs/gatsby/commit/d4b60f2))
 
 ### Features
 
-- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/8291044))
+- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/commit/8291044))
 
 ### BREAKING CHANGES
 
@@ -102,164 +102,164 @@ Note: this very well may fail
 
 - chore: fix @pieh nit before he finds it
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.12...gatsby-plugin-catch-links@2.0.13) (2019-03-11)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.12...gatsby-plugin-catch-links@2.0.13) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.11...gatsby-plugin-catch-links@2.0.12) (2019-02-28)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.11...gatsby-plugin-catch-links@2.0.12) (2019-02-28)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.10...gatsby-plugin-catch-links@2.0.11) (2019-02-12)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.10...gatsby-plugin-catch-links@2.0.11) (2019-02-12)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.9...gatsby-plugin-catch-links@2.0.10) (2019-02-01)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.9...gatsby-plugin-catch-links@2.0.10) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.8...gatsby-plugin-catch-links@2.0.9) (2018-11-29)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.8...gatsby-plugin-catch-links@2.0.9) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.7...gatsby-plugin-catch-links@2.0.8) (2018-11-09)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.7...gatsby-plugin-catch-links@2.0.8) (2018-11-09)
 
 ### Bug Fixes
 
-- **gatsby-plugin-catch-links:** handle SVGAnimatedString href values ([#9829](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/9829)) ([4538ff3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/4538ff3)), closes [#9816](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/9816)
+- **gatsby-plugin-catch-links:** handle SVGAnimatedString href values ([#9829](https://github.com/gatsbyjs/gatsby/issues/9829)) ([4538ff3](https://github.com/gatsbyjs/gatsby/commit/4538ff3)), closes [#9816](https://github.com/gatsbyjs/gatsby/issues/9816)
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.6...gatsby-plugin-catch-links@2.0.7) (2018-11-08)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.6...gatsby-plugin-catch-links@2.0.7) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.5...gatsby-plugin-catch-links@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.5...gatsby-plugin-catch-links@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.4...gatsby-plugin-catch-links@2.0.5) (2018-10-16)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.4...gatsby-plugin-catch-links@2.0.5) (2018-10-16)
 
 ### Bug Fixes
 
-- **plugin-catch-links:** handle pathPrefix ([#9000](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/9000)) ([6fed3e5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/6fed3e5))
+- **plugin-catch-links:** handle pathPrefix ([#9000](https://github.com/gatsbyjs/gatsby/issues/9000)) ([6fed3e5](https://github.com/gatsbyjs/gatsby/commit/6fed3e5))
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.3...gatsby-plugin-catch-links@2.0.4) (2018-10-05)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.3...gatsby-plugin-catch-links@2.0.4) (2018-10-05)
 
 ### Bug Fixes
 
-- handle more edge cases and fix IE ([#8646](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/8646)) ([4383a57](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/4383a57)), closes [#8685](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/8685)
+- handle more edge cases and fix IE ([#8646](https://github.com/gatsbyjs/gatsby/issues/8646)) ([4383a57](https://github.com/gatsbyjs/gatsby/commit/4383a57)), closes [#8685](https://github.com/gatsbyjs/gatsby/issues/8685)
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-rc.1...gatsby-plugin-catch-links@2.0.3) (2018-09-24)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-rc.1...gatsby-plugin-catch-links@2.0.3) (2018-09-24)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-rc.1...gatsby-plugin-catch-links@2.0.2) (2018-09-17)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-rc.1...gatsby-plugin-catch-links@2.0.2) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-rc.1"></a>
 
-## [2.0.2-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-rc.0...gatsby-plugin-catch-links@2.0.2-rc.1) (2018-08-29)
+## [2.0.2-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-rc.0...gatsby-plugin-catch-links@2.0.2-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-rc.0"></a>
 
-## [2.0.2-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.11...gatsby-plugin-catch-links@2.0.2-rc.0) (2018-08-21)
+## [2.0.2-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.11...gatsby-plugin-catch-links@2.0.2-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.11"></a>
 
-## [2.0.2-beta.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.10...gatsby-plugin-catch-links@2.0.2-beta.11) (2018-08-20)
+## [2.0.2-beta.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.10...gatsby-plugin-catch-links@2.0.2-beta.11) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.10"></a>
 
-## [2.0.2-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.9...gatsby-plugin-catch-links@2.0.2-beta.10) (2018-08-17)
+## [2.0.2-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.9...gatsby-plugin-catch-links@2.0.2-beta.10) (2018-08-17)
 
 ### Bug Fixes
 
-- **gatsby-plugin-catch-links:** update old react-router api to new reach-router ([#7408](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/7408)) ([bedc6f0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/bedc6f0))
+- **gatsby-plugin-catch-links:** update old react-router api to new reach-router ([#7408](https://github.com/gatsbyjs/gatsby/issues/7408)) ([bedc6f0](https://github.com/gatsbyjs/gatsby/commit/bedc6f0))
 
 <a name="2.0.2-beta.9"></a>
 
-## [2.0.2-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.8...gatsby-plugin-catch-links@2.0.2-beta.9) (2018-08-15)
+## [2.0.2-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.8...gatsby-plugin-catch-links@2.0.2-beta.9) (2018-08-15)
 
 ### Bug Fixes
 
-- update docs to remove `gatsby-link` reference ([#7315](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/7315)) ([a285e1c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/a285e1c))
+- update docs to remove `gatsby-link` reference ([#7315](https://github.com/gatsbyjs/gatsby/issues/7315)) ([a285e1c](https://github.com/gatsbyjs/gatsby/commit/a285e1c))
 
 <a name="2.0.2-beta.8"></a>
 
-## [2.0.2-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.7...gatsby-plugin-catch-links@2.0.2-beta.8) (2018-08-14)
+## [2.0.2-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.7...gatsby-plugin-catch-links@2.0.2-beta.8) (2018-08-14)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.7"></a>
 
-## [2.0.2-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.6...gatsby-plugin-catch-links@2.0.2-beta.7) (2018-08-04)
+## [2.0.2-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.6...gatsby-plugin-catch-links@2.0.2-beta.7) (2018-08-04)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.6"></a>
 
-## [2.0.2-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.5...gatsby-plugin-catch-links@2.0.2-beta.6) (2018-08-03)
+## [2.0.2-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.5...gatsby-plugin-catch-links@2.0.2-beta.6) (2018-08-03)
 
 ### Bug Fixes
 
-- refs 6990 plugin-catch-links URL wrong parameter ([#6993](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/6993)) ([fea0f6a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/fea0f6a))
+- refs 6990 plugin-catch-links URL wrong parameter ([#6993](https://github.com/gatsbyjs/gatsby/issues/6993)) ([fea0f6a](https://github.com/gatsbyjs/gatsby/commit/fea0f6a))
 
 <a name="2.0.2-beta.5"></a>
 
-## [2.0.2-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.4...gatsby-plugin-catch-links@2.0.2-beta.5) (2018-08-01)
+## [2.0.2-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.4...gatsby-plugin-catch-links@2.0.2-beta.5) (2018-08-01)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.4"></a>
 
-## [2.0.2-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.3...gatsby-plugin-catch-links@2.0.2-beta.4) (2018-07-21)
+## [2.0.2-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.3...gatsby-plugin-catch-links@2.0.2-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.3"></a>
 
-## [2.0.2-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.2...gatsby-plugin-catch-links@2.0.2-beta.3) (2018-07-17)
+## [2.0.2-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.2...gatsby-plugin-catch-links@2.0.2-beta.3) (2018-07-17)
 
 ### Bug Fixes
 
-- catch-links should use gatsby for push ([#6477](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/issues/6477)) ([a3b5b2d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/commit/a3b5b2d))
+- catch-links should use gatsby for push ([#6477](https://github.com/gatsbyjs/gatsby/issues/6477)) ([a3b5b2d](https://github.com/gatsbyjs/gatsby/commit/a3b5b2d))
 
 <a name="2.0.2-beta.2"></a>
 
-## [2.0.2-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.1...gatsby-plugin-catch-links@2.0.2-beta.2) (2018-06-20)
+## [2.0.2-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.1...gatsby-plugin-catch-links@2.0.2-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.1"></a>
 
-## [2.0.2-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@2.0.2-beta.0...gatsby-plugin-catch-links@2.0.2-beta.1) (2018-06-17)
+## [2.0.2-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@2.0.2-beta.0...gatsby-plugin-catch-links@2.0.2-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links
 
 <a name="2.0.2-beta.0"></a>
 
-## [2.0.2-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links/compare/gatsby-plugin-catch-links@1.0.24...gatsby-plugin-catch-links@2.0.2-beta.0) (2018-06-17)
+## [2.0.2-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-catch-links@1.0.24...gatsby-plugin-catch-links@2.0.2-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-catch-links

--- a/packages/gatsby-plugin-coffeescript/CHANGELOG.md
+++ b/packages/gatsby-plugin-coffeescript/CHANGELOG.md
@@ -7,68 +7,68 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.9...gatsby-plugin-coffeescript@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.9...gatsby-plugin-coffeescript@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.8...gatsby-plugin-coffeescript@2.0.9) (2019-03-11)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.8...gatsby-plugin-coffeescript@2.0.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.7...gatsby-plugin-coffeescript@2.0.8) (2019-02-01)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.7...gatsby-plugin-coffeescript@2.0.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.6...gatsby-plugin-coffeescript@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.6...gatsby-plugin-coffeescript@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.5...gatsby-plugin-coffeescript@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.5...gatsby-plugin-coffeescript@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.0-rc.1...gatsby-plugin-coffeescript@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.0-rc.1...gatsby-plugin-coffeescript@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.0-rc.0...gatsby-plugin-coffeescript@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.0-rc.0...gatsby-plugin-coffeescript@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.0-beta.3...gatsby-plugin-coffeescript@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.0-beta.3...gatsby-plugin-coffeescript@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.0-beta.2...gatsby-plugin-coffeescript@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.0-beta.2...gatsby-plugin-coffeescript@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.0-beta.1...gatsby-plugin-coffeescript@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.0-beta.1...gatsby-plugin-coffeescript@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@2.0.0-beta.0...gatsby-plugin-coffeescript@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@2.0.0-beta.0...gatsby-plugin-coffeescript@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript/compare/gatsby-plugin-coffeescript@1.4.14...gatsby-plugin-coffeescript@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-coffeescript@1.4.14...gatsby-plugin-coffeescript@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-coffeescript

--- a/packages/gatsby-plugin-create-client-paths/CHANGELOG.md
+++ b/packages/gatsby-plugin-create-client-paths/CHANGELOG.md
@@ -7,88 +7,88 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.1.0...gatsby-plugin-create-client-paths@2.1.1) (2019-06-21)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.1.0...gatsby-plugin-create-client-paths@2.1.1) (2019-06-21)
 
 ### Bug Fixes
 
-- **gatsby-plugin-create-client-paths:** set matchPath correctly ([#15014](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/issues/15014)) ([e69800b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/commit/e69800b))
+- **gatsby-plugin-create-client-paths:** set matchPath correctly ([#15014](https://github.com/gatsbyjs/gatsby/issues/15014)) ([e69800b](https://github.com/gatsbyjs/gatsby/commit/e69800b))
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.5...gatsby-plugin-create-client-paths@2.1.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-plugin-create-client-paths
-
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.4...gatsby-plugin-create-client-paths@2.0.5) (2019-03-11)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.5...gatsby-plugin-create-client-paths@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.3...gatsby-plugin-create-client-paths@2.0.4) (2019-02-01)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.4...gatsby-plugin-create-client-paths@2.0.5) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-plugin-create-client-paths
+
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.3...gatsby-plugin-create-client-paths@2.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.2...gatsby-plugin-create-client-paths@2.0.3) (2018-11-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.2...gatsby-plugin-create-client-paths@2.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.1...gatsby-plugin-create-client-paths@2.0.2) (2018-10-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.1...gatsby-plugin-create-client-paths@2.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-rc.1...gatsby-plugin-create-client-paths@2.0.1) (2018-10-18)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-rc.1...gatsby-plugin-create-client-paths@2.0.1) (2018-10-18)
 
 ### Bug Fixes
 
-- **gatsby-plugin-create-client-paths:** don't process pages that already use matchPath ([#9220](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/issues/9220)) ([6951db0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/commit/6951db0))
+- **gatsby-plugin-create-client-paths:** don't process pages that already use matchPath ([#9220](https://github.com/gatsbyjs/gatsby/issues/9220)) ([6951db0](https://github.com/gatsbyjs/gatsby/commit/6951db0))
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-rc.1...gatsby-plugin-create-client-paths@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-rc.1...gatsby-plugin-create-client-paths@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-rc.0...gatsby-plugin-create-client-paths@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-rc.0...gatsby-plugin-create-client-paths@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-beta.4...gatsby-plugin-create-client-paths@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-beta.4...gatsby-plugin-create-client-paths@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-beta.3...gatsby-plugin-create-client-paths@2.0.0-beta.4) (2018-08-06)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-beta.3...gatsby-plugin-create-client-paths@2.0.0-beta.4) (2018-08-06)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-beta.2...gatsby-plugin-create-client-paths@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-beta.2...gatsby-plugin-create-client-paths@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-beta.1...gatsby-plugin-create-client-paths@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-beta.1...gatsby-plugin-create-client-paths@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@2.0.0-beta.0...gatsby-plugin-create-client-paths@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@2.0.0-beta.0...gatsby-plugin-create-client-paths@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths/compare/gatsby-plugin-create-client-paths@1.0.8...gatsby-plugin-create-client-paths@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-create-client-paths@1.0.8...gatsby-plugin-create-client-paths@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-create-client-paths

--- a/packages/gatsby-plugin-cxs/CHANGELOG.md
+++ b/packages/gatsby-plugin-cxs/CHANGELOG.md
@@ -7,47 +7,47 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.8...gatsby-plugin-cxs@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.8...gatsby-plugin-cxs@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.7...gatsby-plugin-cxs@2.0.8) (2019-03-11)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.7...gatsby-plugin-cxs@2.0.8) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.6...gatsby-plugin-cxs@2.0.7) (2019-03-11)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.6...gatsby-plugin-cxs@2.0.7) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.5...gatsby-plugin-cxs@2.0.6) (2019-02-19)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.5...gatsby-plugin-cxs@2.0.6) (2019-02-19)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.4...gatsby-plugin-cxs@2.0.5) (2019-02-19)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.4...gatsby-plugin-cxs@2.0.5) (2019-02-19)
 
 ### Bug Fixes
 
-- **gatsby-plugin-cxs:** Publish plugin files properly ([#11902](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/issues/11902)) ([db2f010](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/commit/db2f010)), closes [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/issues/1234)
+- **gatsby-plugin-cxs:** Publish plugin files properly ([#11902](https://github.com/gatsbyjs/gatsby/issues/11902)) ([db2f010](https://github.com/gatsbyjs/gatsby/commit/db2f010)), closes [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234)
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.3...gatsby-plugin-cxs@2.0.4) (2019-02-01)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.3...gatsby-plugin-cxs@2.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.2...gatsby-plugin-cxs@2.0.3) (2018-11-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.2...gatsby-plugin-cxs@2.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@2.0.1...gatsby-plugin-cxs@2.0.2) (2018-11-08)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@2.0.1...gatsby-plugin-cxs@2.0.2) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs/compare/gatsby-plugin-cxs@1.0.1...gatsby-plugin-cxs@2.0.1) (2018-11-02)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-cxs@1.0.1...gatsby-plugin-cxs@2.0.1) (2018-11-02)
 
 **Note:** Version bump only for package gatsby-plugin-cxs
 

--- a/packages/gatsby-plugin-emotion/CHANGELOG.md
+++ b/packages/gatsby-plugin-emotion/CHANGELOG.md
@@ -7,144 +7,144 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
-# [4.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.7...gatsby-plugin-emotion@4.1.0) (2019-06-20)
+# [4.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.7...gatsby-plugin-emotion@4.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
-## [4.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.6...gatsby-plugin-emotion@4.0.7) (2019-05-24)
+## [4.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.6...gatsby-plugin-emotion@4.0.7) (2019-05-24)
 
 ### Bug Fixes
 
-- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/commit/5e54afe))
+- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/commit/5e54afe))
 
-## [4.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.5...gatsby-plugin-emotion@4.0.6) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-emotion
-
-## [4.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.4...gatsby-plugin-emotion@4.0.5) (2019-03-11)
+## [4.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.5...gatsby-plugin-emotion@4.0.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
-## [4.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.3...gatsby-plugin-emotion@4.0.4) (2019-02-20)
+## [4.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.4...gatsby-plugin-emotion@4.0.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
-## [4.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.2...gatsby-plugin-emotion@4.0.3) (2019-02-01)
+## [4.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.3...gatsby-plugin-emotion@4.0.4) (2019-02-20)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
-## [4.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.1...gatsby-plugin-emotion@4.0.2) (2019-02-01)
+## [4.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.2...gatsby-plugin-emotion@4.0.3) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-plugin-emotion
+
+## [4.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.1...gatsby-plugin-emotion@4.0.2) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="4.0.1"></a>
 
-## [4.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@4.0.0...gatsby-plugin-emotion@4.0.1) (2018-12-19)
+## [4.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@4.0.0...gatsby-plugin-emotion@4.0.1) (2018-12-19)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="4.0.0"></a>
 
-# [4.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@3.0.1...gatsby-plugin-emotion@4.0.0) (2018-12-19)
+# [4.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@3.0.1...gatsby-plugin-emotion@4.0.0) (2018-12-19)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@3.0.0...gatsby-plugin-emotion@3.0.1) (2018-12-05)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@3.0.0...gatsby-plugin-emotion@3.0.1) (2018-12-05)
 
 ### Bug Fixes
 
-- **gatsby-plugin-emotion:** allow for React.Fragment shorthand syntax ([#10291](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/issues/10291)) ([3c902fc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/commit/3c902fc))
+- **gatsby-plugin-emotion:** allow for React.Fragment shorthand syntax ([#10291](https://github.com/gatsbyjs/gatsby/issues/10291)) ([3c902fc](https://github.com/gatsbyjs/gatsby/commit/3c902fc))
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.7...gatsby-plugin-emotion@3.0.0) (2018-12-04)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.7...gatsby-plugin-emotion@3.0.0) (2018-12-04)
 
 ### Features
 
-- **gatsby-plugin-emotion:** update plugin for emotion v10 ([#10226](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/issues/10226)) ([5754c2c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/commit/5754c2c))
+- **gatsby-plugin-emotion:** update plugin for emotion v10 ([#10226](https://github.com/gatsbyjs/gatsby/issues/10226)) ([5754c2c](https://github.com/gatsbyjs/gatsby/commit/5754c2c))
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.6...gatsby-plugin-emotion@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.6...gatsby-plugin-emotion@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.5...gatsby-plugin-emotion@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.5...gatsby-plugin-emotion@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-rc.5...gatsby-plugin-emotion@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-rc.5...gatsby-plugin-emotion@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-rc.4...gatsby-plugin-emotion@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-rc.4...gatsby-plugin-emotion@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-rc.3...gatsby-plugin-emotion@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-rc.3...gatsby-plugin-emotion@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-rc.2...gatsby-plugin-emotion@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-rc.2...gatsby-plugin-emotion@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-rc.1...gatsby-plugin-emotion@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-rc.1...gatsby-plugin-emotion@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-rc.0...gatsby-plugin-emotion@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-rc.0...gatsby-plugin-emotion@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-beta.4...gatsby-plugin-emotion@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-beta.4...gatsby-plugin-emotion@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-beta.3...gatsby-plugin-emotion@2.0.0-beta.4) (2018-08-20)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-beta.3...gatsby-plugin-emotion@2.0.0-beta.4) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-beta.2...gatsby-plugin-emotion@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-beta.2...gatsby-plugin-emotion@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-beta.1...gatsby-plugin-emotion@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-beta.1...gatsby-plugin-emotion@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@2.0.0-beta.0...gatsby-plugin-emotion@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@2.0.0-beta.0...gatsby-plugin-emotion@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-emotion
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion/compare/gatsby-plugin-emotion@1.1.17...gatsby-plugin-emotion@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-emotion@1.1.17...gatsby-plugin-emotion@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-emotion

--- a/packages/gatsby-plugin-facebook-analytics/CHANGELOG.md
+++ b/packages/gatsby-plugin-facebook-analytics/CHANGELOG.md
@@ -7,21 +7,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-facebook-analytics
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics/compare/gatsby-plugin-facebook-analytics@2.1.1...gatsby-plugin-facebook-analytics@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-facebook-analytics@2.1.1...gatsby-plugin-facebook-analytics@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-facebook-analytics
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics/compare/gatsby-plugin-facebook-analytics@2.1.0...gatsby-plugin-facebook-analytics@2.1.1) (2019-05-30)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-facebook-analytics@2.1.0...gatsby-plugin-facebook-analytics@2.1.1) (2019-05-30)
 
 **Note:** Version bump only for package gatsby-plugin-facebook-analytics
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics/compare/gatsby-plugin-facebook-analytics@2.0.5...gatsby-plugin-facebook-analytics@2.1.0) (2019-05-24)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-facebook-analytics@2.0.5...gatsby-plugin-facebook-analytics@2.1.0) (2019-05-24)
 
 ### Features
 
-- **gatsby-plugin-facebook-analytics:** Add version, cookie and xfbml config options ([#14311](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics/issues/14311)) ([a42e08f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics/commit/a42e08f))
+- **gatsby-plugin-facebook-analytics:** Add version, cookie and xfbml config options ([#14311](https://github.com/gatsbyjs/gatsby/issues/14311)) ([a42e08f](https://github.com/gatsbyjs/gatsby/commit/a42e08f))
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics/compare/gatsby-plugin-facebook-analytics@2.0.4...gatsby-plugin-facebook-analytics@2.0.5) (2019-04-23)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-facebook-analytics@2.0.4...gatsby-plugin-facebook-analytics@2.0.5) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-facebook-analytics
 

--- a/packages/gatsby-plugin-feed/CHANGELOG.md
+++ b/packages/gatsby-plugin-feed/CHANGELOG.md
@@ -7,156 +7,156 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-## [2.3.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.3.1...gatsby-plugin-feed@2.3.2) (2019-07-03)
+## [2.3.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.3.1...gatsby-plugin-feed@2.3.2) (2019-07-03)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-## [2.3.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.3.0...gatsby-plugin-feed@2.3.1) (2019-06-24)
+## [2.3.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.3.0...gatsby-plugin-feed@2.3.1) (2019-06-24)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-# [2.3.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.2.3...gatsby-plugin-feed@2.3.0) (2019-06-20)
+# [2.3.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.2.3...gatsby-plugin-feed@2.3.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-## [2.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.2.2...gatsby-plugin-feed@2.2.3) (2019-06-07)
+## [2.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.2.2...gatsby-plugin-feed@2.2.3) (2019-06-07)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-## [2.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.2.1...gatsby-plugin-feed@2.2.2) (2019-05-31)
+## [2.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.2.1...gatsby-plugin-feed@2.2.2) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.2.0...gatsby-plugin-feed@2.2.1) (2019-05-22)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.2.0...gatsby-plugin-feed@2.2.1) (2019-05-22)
 
 ### Features
 
-- **gatsby-plugin-feed:** add match plugin option ([#13827](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/issues/13827)) ([b827fd2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/commit/b827fd2))
+- **gatsby-plugin-feed:** add match plugin option ([#13827](https://github.com/gatsbyjs/gatsby/issues/13827)) ([b827fd2](https://github.com/gatsbyjs/gatsby/commit/b827fd2))
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.1.2...gatsby-plugin-feed@2.2.0) (2019-05-02)
-
-### Features
-
-- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/commit/8291044))
-
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.1.1...gatsby-plugin-feed@2.1.2) (2019-04-30)
-
-**Note:** Version bump only for package gatsby-plugin-feed
-
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.1.0...gatsby-plugin-feed@2.1.1) (2019-04-17)
-
-**Note:** Version bump only for package gatsby-plugin-feed
-
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.15...gatsby-plugin-feed@2.1.0) (2019-03-21)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.1.2...gatsby-plugin-feed@2.2.0) (2019-05-02)
 
 ### Features
 
-- **gatsby-plugin-feed:** warn for deprecations, validate options ([#12085](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/issues/12085)) ([626cab4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/commit/626cab4))
+- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/commit/8291044))
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.14...gatsby-plugin-feed@2.0.15) (2019-03-11)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.1.1...gatsby-plugin-feed@2.1.2) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.13...gatsby-plugin-feed@2.0.14) (2019-02-25)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.1.0...gatsby-plugin-feed@2.1.1) (2019-04-17)
+
+**Note:** Version bump only for package gatsby-plugin-feed
+
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.15...gatsby-plugin-feed@2.1.0) (2019-03-21)
 
 ### Features
 
-- **docs:** adding an RSS Feed ([#11941](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/issues/11941)) ([0d7449d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/commit/0d7449d))
+- **gatsby-plugin-feed:** warn for deprecations, validate options ([#12085](https://github.com/gatsbyjs/gatsby/issues/12085)) ([626cab4](https://github.com/gatsbyjs/gatsby/commit/626cab4))
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.12...gatsby-plugin-feed@2.0.13) (2019-02-01)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.14...gatsby-plugin-feed@2.0.15) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.11...gatsby-plugin-feed@2.0.12) (2019-01-28)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.13...gatsby-plugin-feed@2.0.14) (2019-02-25)
+
+### Features
+
+- **docs:** adding an RSS Feed ([#11941](https://github.com/gatsbyjs/gatsby/issues/11941)) ([0d7449d](https://github.com/gatsbyjs/gatsby/commit/0d7449d))
+
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.12...gatsby-plugin-feed@2.0.13) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-plugin-feed
+
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.11...gatsby-plugin-feed@2.0.12) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.10...gatsby-plugin-feed@2.0.11) (2018-12-01)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.10...gatsby-plugin-feed@2.0.11) (2018-12-01)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.9...gatsby-plugin-feed@2.0.10) (2018-11-29)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.9...gatsby-plugin-feed@2.0.10) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.8...gatsby-plugin-feed@2.0.9) (2018-10-29)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.8...gatsby-plugin-feed@2.0.9) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.7...gatsby-plugin-feed@2.0.8) (2018-10-09)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.7...gatsby-plugin-feed@2.0.8) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.6...gatsby-plugin-feed@2.0.7) (2018-10-05)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.6...gatsby-plugin-feed@2.0.7) (2018-10-05)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.5...gatsby-plugin-feed@2.0.6) (2018-10-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.5...gatsby-plugin-feed@2.0.6) (2018-10-01)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-rc.2...gatsby-plugin-feed@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-rc.2...gatsby-plugin-feed@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-rc.1...gatsby-plugin-feed@2.0.0-rc.2) (2018-08-29)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-rc.1...gatsby-plugin-feed@2.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-rc.0...gatsby-plugin-feed@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-rc.0...gatsby-plugin-feed@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-beta.4...gatsby-plugin-feed@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-beta.4...gatsby-plugin-feed@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-beta.3...gatsby-plugin-feed@2.0.0-beta.4) (2018-07-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-beta.3...gatsby-plugin-feed@2.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-beta.2...gatsby-plugin-feed@2.0.0-beta.3) (2018-06-25)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-beta.2...gatsby-plugin-feed@2.0.0-beta.3) (2018-06-25)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-beta.1...gatsby-plugin-feed@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-beta.1...gatsby-plugin-feed@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@2.0.0-beta.0...gatsby-plugin-feed@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@2.0.0-beta.0...gatsby-plugin-feed@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-feed
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed/compare/gatsby-plugin-feed@1.3.25...gatsby-plugin-feed@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-feed@1.3.25...gatsby-plugin-feed@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-feed

--- a/packages/gatsby-plugin-flow/CHANGELOG.md
+++ b/packages/gatsby-plugin-flow/CHANGELOG.md
@@ -7,17 +7,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-flow
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-flow/compare/gatsby-plugin-flow@1.0.6...gatsby-plugin-flow@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-flow@1.0.6...gatsby-plugin-flow@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-flow
 
-## [1.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-flow/compare/gatsby-plugin-flow@1.0.5...gatsby-plugin-flow@1.0.6) (2019-05-24)
+## [1.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-flow@1.0.5...gatsby-plugin-flow@1.0.6) (2019-05-24)
 
 ### Bug Fixes
 
-- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-flow/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-flow/commit/5e54afe))
+- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/commit/5e54afe))
 
-## [1.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-flow/compare/gatsby-plugin-flow@1.0.4...gatsby-plugin-flow@1.0.5) (2019-04-23)
+## [1.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-flow@1.0.4...gatsby-plugin-flow@1.0.5) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-flow
 

--- a/packages/gatsby-plugin-fullstory/CHANGELOG.md
+++ b/packages/gatsby-plugin-fullstory/CHANGELOG.md
@@ -7,11 +7,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-fullstory
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-fullstory/compare/gatsby-plugin-fullstory@2.0.5...gatsby-plugin-fullstory@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-fullstory@2.0.5...gatsby-plugin-fullstory@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-fullstory
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-fullstory/compare/gatsby-plugin-fullstory@2.0.4...gatsby-plugin-fullstory@2.0.5) (2019-04-23)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-fullstory@2.0.4...gatsby-plugin-fullstory@2.0.5) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-fullstory
 

--- a/packages/gatsby-plugin-glamor/CHANGELOG.md
+++ b/packages/gatsby-plugin-glamor/CHANGELOG.md
@@ -7,78 +7,78 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.1.0...gatsby-plugin-glamor@2.1.1) (2019-07-02)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.1.0...gatsby-plugin-glamor@2.1.1) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.10...gatsby-plugin-glamor@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.10...gatsby-plugin-glamor@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.9...gatsby-plugin-glamor@2.0.10) (2019-05-24)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.9...gatsby-plugin-glamor@2.0.10) (2019-05-24)
 
 ### Bug Fixes
 
-- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/commit/5e54afe))
+- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/commit/5e54afe))
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.8...gatsby-plugin-glamor@2.0.9) (2019-03-11)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.8...gatsby-plugin-glamor@2.0.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.7...gatsby-plugin-glamor@2.0.8) (2019-02-01)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.7...gatsby-plugin-glamor@2.0.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.6...gatsby-plugin-glamor@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.6...gatsby-plugin-glamor@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.5...gatsby-plugin-glamor@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.5...gatsby-plugin-glamor@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.0-rc.1...gatsby-plugin-glamor@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.0-rc.1...gatsby-plugin-glamor@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.0-rc.0...gatsby-plugin-glamor@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.0-rc.0...gatsby-plugin-glamor@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.0-beta.3...gatsby-plugin-glamor@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.0-beta.3...gatsby-plugin-glamor@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.0-beta.2...gatsby-plugin-glamor@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.0-beta.2...gatsby-plugin-glamor@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.0-beta.1...gatsby-plugin-glamor@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.0-beta.1...gatsby-plugin-glamor@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@2.0.0-beta.0...gatsby-plugin-glamor@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@2.0.0-beta.0...gatsby-plugin-glamor@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-glamor
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor/compare/gatsby-plugin-glamor@1.6.13...gatsby-plugin-glamor@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-glamor@1.6.13...gatsby-plugin-glamor@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-glamor

--- a/packages/gatsby-plugin-google-analytics/CHANGELOG.md
+++ b/packages/gatsby-plugin-google-analytics/CHANGELOG.md
@@ -7,156 +7,156 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.1.0...gatsby-plugin-google-analytics@2.1.1) (2019-06-27)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.1.0...gatsby-plugin-google-analytics@2.1.1) (2019-06-27)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.21...gatsby-plugin-google-analytics@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.21...gatsby-plugin-google-analytics@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.20...gatsby-plugin-google-analytics@2.0.21) (2019-06-10)
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.20...gatsby-plugin-google-analytics@2.0.21) (2019-06-10)
 
 ### Bug Fixes
 
-- **gatsby-plugin-google-analytics:** Refactor gatsby-plugin-google-analytics gatsby-browser.js ([#14572](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/14572)) ([9f2c0c9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/commit/9f2c0c9))
+- **gatsby-plugin-google-analytics:** Refactor gatsby-plugin-google-analytics gatsby-browser.js ([#14572](https://github.com/gatsbyjs/gatsby/issues/14572)) ([9f2c0c9](https://github.com/gatsbyjs/gatsby/commit/9f2c0c9))
 
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.19...gatsby-plugin-google-analytics@2.0.20) (2019-05-14)
-
-**Note:** Version bump only for package gatsby-plugin-google-analytics
-
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.18...gatsby-plugin-google-analytics@2.0.19) (2019-04-30)
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.19...gatsby-plugin-google-analytics@2.0.20) (2019-05-14)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.17...gatsby-plugin-google-analytics@2.0.18) (2019-03-26)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.18...gatsby-plugin-google-analytics@2.0.19) (2019-04-30)
+
+**Note:** Version bump only for package gatsby-plugin-google-analytics
+
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.17...gatsby-plugin-google-analytics@2.0.18) (2019-03-26)
 
 ### Features
 
-- **gatsby-plugin-google-analytics:** Add preconnect and dns-prefetch ([#12826](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/12826)) ([0640104](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/commit/0640104))
+- **gatsby-plugin-google-analytics:** Add preconnect and dns-prefetch ([#12826](https://github.com/gatsbyjs/gatsby/issues/12826)) ([0640104](https://github.com/gatsbyjs/gatsby/commit/0640104))
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.16...gatsby-plugin-google-analytics@2.0.17) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-google-analytics
-
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.15...gatsby-plugin-google-analytics@2.0.16) (2019-03-04)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.16...gatsby-plugin-google-analytics@2.0.17) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.14...gatsby-plugin-google-analytics@2.0.15) (2019-02-28)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.15...gatsby-plugin-google-analytics@2.0.16) (2019-03-04)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.13...gatsby-plugin-google-analytics@2.0.14) (2019-02-15)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.14...gatsby-plugin-google-analytics@2.0.15) (2019-02-28)
+
+**Note:** Version bump only for package gatsby-plugin-google-analytics
+
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.13...gatsby-plugin-google-analytics@2.0.14) (2019-02-15)
 
 ### Bug Fixes
 
-- **google-analytics:** fix pageview timing issue by delaying it ([#10917](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/10917)) ([42f509e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/commit/42f509e)), closes [#9139](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/9139) [#2478](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/2478) [#3362](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/3362)
+- **google-analytics:** fix pageview timing issue by delaying it ([#10917](https://github.com/gatsbyjs/gatsby/issues/10917)) ([42f509e](https://github.com/gatsbyjs/gatsby/commit/42f509e)), closes [#9139](https://github.com/gatsbyjs/gatsby/issues/9139) [#2478](https://github.com/gatsbyjs/gatsby/issues/2478) [#3362](https://github.com/gatsbyjs/gatsby/issues/3362)
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.12...gatsby-plugin-google-analytics@2.0.13) (2019-02-01)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.12...gatsby-plugin-google-analytics@2.0.13) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.11...gatsby-plugin-google-analytics@2.0.12) (2019-01-28)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.11...gatsby-plugin-google-analytics@2.0.12) (2019-01-28)
 
 ### Features
 
-- **gatsby-plugin-google-analytics:** add TS typings for OutboundLink component ([#10215](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/10215)) ([7fee096](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/commit/7fee096))
+- **gatsby-plugin-google-analytics:** add TS typings for OutboundLink component ([#10215](https://github.com/gatsbyjs/gatsby/issues/10215)) ([7fee096](https://github.com/gatsbyjs/gatsby/commit/7fee096))
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.10...gatsby-plugin-google-analytics@2.0.11) (2019-01-28)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.10...gatsby-plugin-google-analytics@2.0.11) (2019-01-28)
 
 ### Features
 
-- **gatsby-plugin-google-analytics:** Pass event object to the user's onClick callback in OutboundLink ([#11340](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/11340)) ([e81b246](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/commit/e81b246))
+- **gatsby-plugin-google-analytics:** Pass event object to the user's onClick callback in OutboundLink ([#11340](https://github.com/gatsbyjs/gatsby/issues/11340)) ([e81b246](https://github.com/gatsbyjs/gatsby/commit/e81b246))
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.9...gatsby-plugin-google-analytics@2.0.10) (2019-01-23)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.9...gatsby-plugin-google-analytics@2.0.10) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.8...gatsby-plugin-google-analytics@2.0.9) (2019-01-08)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.8...gatsby-plugin-google-analytics@2.0.9) (2019-01-08)
 
 ### Features
 
-- **gatsby-plugin-google-analytics:** add support for google optimize experiment and variation id ([#10903](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/issues/10903)) ([45ec012](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/commit/45ec012))
+- **gatsby-plugin-google-analytics:** add support for google optimize experiment and variation id ([#10903](https://github.com/gatsbyjs/gatsby/issues/10903)) ([45ec012](https://github.com/gatsbyjs/gatsby/commit/45ec012))
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.7...gatsby-plugin-google-analytics@2.0.8) (2018-11-29)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.7...gatsby-plugin-google-analytics@2.0.8) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.6...gatsby-plugin-google-analytics@2.0.7) (2018-10-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.6...gatsby-plugin-google-analytics@2.0.7) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.5...gatsby-plugin-google-analytics@2.0.6) (2018-09-18)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.5...gatsby-plugin-google-analytics@2.0.6) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-rc.2...gatsby-plugin-google-analytics@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-rc.2...gatsby-plugin-google-analytics@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-rc.1...gatsby-plugin-google-analytics@2.0.0-rc.2) (2018-09-07)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-rc.1...gatsby-plugin-google-analytics@2.0.0-rc.2) (2018-09-07)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-rc.0...gatsby-plugin-google-analytics@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-rc.0...gatsby-plugin-google-analytics@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-beta.5...gatsby-plugin-google-analytics@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-beta.5...gatsby-plugin-google-analytics@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-beta.4...gatsby-plugin-google-analytics@2.0.0-beta.5) (2018-08-08)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-beta.4...gatsby-plugin-google-analytics@2.0.0-beta.5) (2018-08-08)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-beta.3...gatsby-plugin-google-analytics@2.0.0-beta.4) (2018-08-06)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-beta.3...gatsby-plugin-google-analytics@2.0.0-beta.4) (2018-08-06)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-beta.2...gatsby-plugin-google-analytics@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-beta.2...gatsby-plugin-google-analytics@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-beta.1...gatsby-plugin-google-analytics@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-beta.1...gatsby-plugin-google-analytics@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@2.0.0-beta.0...gatsby-plugin-google-analytics@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@2.0.0-beta.0...gatsby-plugin-google-analytics@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics/compare/gatsby-plugin-google-analytics@1.0.31...gatsby-plugin-google-analytics@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-analytics@1.0.31...gatsby-plugin-google-analytics@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-google-analytics

--- a/packages/gatsby-plugin-google-gtag/CHANGELOG.md
+++ b/packages/gatsby-plugin-google-gtag/CHANGELOG.md
@@ -7,115 +7,115 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
-## [1.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.1.0...gatsby-plugin-google-gtag@1.1.1) (2019-07-02)
+## [1.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.1.0...gatsby-plugin-google-gtag@1.1.1) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.17...gatsby-plugin-google-gtag@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.17...gatsby-plugin-google-gtag@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
-## [1.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.16...gatsby-plugin-google-gtag@1.0.17) (2019-04-30)
+## [1.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.16...gatsby-plugin-google-gtag@1.0.17) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
-## [1.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.15...gatsby-plugin-google-gtag@1.0.16) (2019-03-16)
+## [1.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.15...gatsby-plugin-google-gtag@1.0.16) (2019-03-16)
 
 ### Features
 
-- **gatsby-plugin-google-gtag:** add TS types for OutboundLink ([#12606](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/12606)) ([bc72163](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/bc72163)), closes [/github.com/gatsbyjs/gatsby/blob/3834b2bce5edc60cd5386561498ca29f028c1d30/packages/gatsby-plugin-google-analytics/src/index.js#L10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/L10)
+- **gatsby-plugin-google-gtag:** add TS types for OutboundLink ([#12606](https://github.com/gatsbyjs/gatsby/issues/12606)) ([bc72163](https://github.com/gatsbyjs/gatsby/commit/bc72163)), closes [/github.com/gatsbyjs/gatsby/blob/3834b2bce5edc60cd5386561498ca29f028c1d30/packages/gatsby-plugin-google-analytics/src/index.js#L10](https://github.com/gatsbyjs/gatsby/issues/L10)
 
-## [1.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.14...gatsby-plugin-google-gtag@1.0.15) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-google-gtag
-
-## [1.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.13...gatsby-plugin-google-gtag@1.0.14) (2019-02-25)
-
-### Bug Fixes
-
-- **gatsby-plugin-google-gtag:** page view and title mismatch ([#12033](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/12033)) ([b95ae69](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/b95ae69))
-
-## [1.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.12...gatsby-plugin-google-gtag@1.0.13) (2019-02-04)
-
-### Bug Fixes
-
-- **gatsby-plugin-google-grag:** add additional check to prevent crash in Safari ([#11431](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/11431)) ([#11503](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/11503)) ([c79bc6d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/c79bc6d))
-
-## [1.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.11...gatsby-plugin-google-gtag@1.0.12) (2019-02-01)
+## [1.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.14...gatsby-plugin-google-gtag@1.0.15) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
-## [1.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.10...gatsby-plugin-google-gtag@1.0.11) (2019-02-01)
+## [1.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.13...gatsby-plugin-google-gtag@1.0.14) (2019-02-25)
 
 ### Bug Fixes
 
-- **plugin-google-gtag:** make pluginConfig optional ([#11112](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/11112)) ([fa8b1b7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/fa8b1b7)), closes [#11217](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/11217)
+- **gatsby-plugin-google-gtag:** page view and title mismatch ([#12033](https://github.com/gatsbyjs/gatsby/issues/12033)) ([b95ae69](https://github.com/gatsbyjs/gatsby/commit/b95ae69))
 
-## [1.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.9...gatsby-plugin-google-gtag@1.0.10) (2019-01-28)
+## [1.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.12...gatsby-plugin-google-gtag@1.0.13) (2019-02-04)
+
+### Bug Fixes
+
+- **gatsby-plugin-google-grag:** add additional check to prevent crash in Safari ([#11431](https://github.com/gatsbyjs/gatsby/issues/11431)) ([#11503](https://github.com/gatsbyjs/gatsby/issues/11503)) ([c79bc6d](https://github.com/gatsbyjs/gatsby/commit/c79bc6d))
+
+## [1.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.11...gatsby-plugin-google-gtag@1.0.12) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
-## [1.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.8...gatsby-plugin-google-gtag@1.0.9) (2019-01-28)
+## [1.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.10...gatsby-plugin-google-gtag@1.0.11) (2019-02-01)
 
 ### Bug Fixes
 
-- **plugin-google-gtag:** make respectDNT option use the right path ([#11217](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/11217)) ([a0eb2dd](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/a0eb2dd))
+- **plugin-google-gtag:** make pluginConfig optional ([#11112](https://github.com/gatsbyjs/gatsby/issues/11112)) ([fa8b1b7](https://github.com/gatsbyjs/gatsby/commit/fa8b1b7)), closes [#11217](https://github.com/gatsbyjs/gatsby/issues/11217)
+
+## [1.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.9...gatsby-plugin-google-gtag@1.0.10) (2019-01-28)
+
+**Note:** Version bump only for package gatsby-plugin-google-gtag
+
+## [1.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.8...gatsby-plugin-google-gtag@1.0.9) (2019-01-28)
+
+### Bug Fixes
+
+- **plugin-google-gtag:** make respectDNT option use the right path ([#11217](https://github.com/gatsbyjs/gatsby/issues/11217)) ([a0eb2dd](https://github.com/gatsbyjs/gatsby/commit/a0eb2dd))
 
 <a name="1.0.8"></a>
 
-## [1.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.7...gatsby-plugin-google-gtag@1.0.8) (2018-11-29)
+## [1.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.7...gatsby-plugin-google-gtag@1.0.8) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
 <a name="1.0.7"></a>
 
-## [1.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.6...gatsby-plugin-google-gtag@1.0.7) (2018-11-16)
+## [1.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.6...gatsby-plugin-google-gtag@1.0.7) (2018-11-16)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
 <a name="1.0.6"></a>
 
-## [1.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.5...gatsby-plugin-google-gtag@1.0.6) (2018-11-15)
+## [1.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.5...gatsby-plugin-google-gtag@1.0.6) (2018-11-15)
 
 ### Bug Fixes
 
-- **gatsby-plugin-google-gtag:** disable default pageview tracking ([#9842](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/9842)) ([1e8f665](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/1e8f665))
+- **gatsby-plugin-google-gtag:** disable default pageview tracking ([#9842](https://github.com/gatsbyjs/gatsby/issues/9842)) ([1e8f665](https://github.com/gatsbyjs/gatsby/commit/1e8f665))
 
 ### Features
 
-- **starters:** Filter v2 by default ([#9739](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/9739)) ([4064e35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/4064e35)), closes [#7900](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/7900)
+- **starters:** Filter v2 by default ([#9739](https://github.com/gatsbyjs/gatsby/issues/9739)) ([4064e35](https://github.com/gatsbyjs/gatsby/commit/4064e35)), closes [#7900](https://github.com/gatsbyjs/gatsby/issues/7900)
 
 <a name="1.0.5"></a>
 
-## [1.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.4...gatsby-plugin-google-gtag@1.0.5) (2018-11-08)
+## [1.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.4...gatsby-plugin-google-gtag@1.0.5) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
 <a name="1.0.4"></a>
 
-## [1.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.3...gatsby-plugin-google-gtag@1.0.4) (2018-11-08)
+## [1.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.3...gatsby-plugin-google-gtag@1.0.4) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
 <a name="1.0.3"></a>
 
-## [1.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.2...gatsby-plugin-google-gtag@1.0.3) (2018-11-01)
+## [1.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.2...gatsby-plugin-google-gtag@1.0.3) (2018-11-01)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
 <a name="1.0.2"></a>
 
-## [1.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.1...gatsby-plugin-google-gtag@1.0.2) (2018-10-29)
+## [1.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.1...gatsby-plugin-google-gtag@1.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-gtag
 
 <a name="1.0.1"></a>
 
-## [1.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/compare/gatsby-plugin-google-gtag@1.0.0...gatsby-plugin-google-gtag@1.0.1) (2018-10-19)
+## [1.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-gtag@1.0.0...gatsby-plugin-google-gtag@1.0.1) (2018-10-19)
 
 ### Bug Fixes
 
-- **gatsby-plugin-google-gtag:** use CommonJS instead of ES modules ([#9224](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/9224)) ([b05bed5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/commit/b05bed5)), closes [#9218](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag/issues/9218)
+- **gatsby-plugin-google-gtag:** use CommonJS instead of ES modules ([#9224](https://github.com/gatsbyjs/gatsby/issues/9224)) ([b05bed5](https://github.com/gatsbyjs/gatsby/commit/b05bed5)), closes [#9218](https://github.com/gatsbyjs/gatsby/issues/9218)
 
 <a name="1.0.0"></a>
 

--- a/packages/gatsby-plugin-google-tagmanager/CHANGELOG.md
+++ b/packages/gatsby-plugin-google-tagmanager/CHANGELOG.md
@@ -7,118 +7,118 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.1.1...gatsby-plugin-google-tagmanager@2.1.2) (2019-07-09)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.1.1...gatsby-plugin-google-tagmanager@2.1.2) (2019-07-09)
 
 ### Features
 
-- **gatsby-plugin-google-tagmanager:** defaultDataLayer ([#11379](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/issues/11379)) ([3e26eeb](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/commit/3e26eeb))
+- **gatsby-plugin-google-tagmanager:** defaultDataLayer ([#11379](https://github.com/gatsbyjs/gatsby/issues/11379)) ([3e26eeb](https://github.com/gatsbyjs/gatsby/commit/3e26eeb))
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.1.0...gatsby-plugin-google-tagmanager@2.1.1) (2019-07-02)
-
-**Note:** Version bump only for package gatsby-plugin-google-tagmanager
-
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.15...gatsby-plugin-google-tagmanager@2.1.0) (2019-06-20)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.1.0...gatsby-plugin-google-tagmanager@2.1.1) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.14...gatsby-plugin-google-tagmanager@2.0.15) (2019-05-30)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.15...gatsby-plugin-google-tagmanager@2.1.0) (2019-06-20)
+
+**Note:** Version bump only for package gatsby-plugin-google-tagmanager
+
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.14...gatsby-plugin-google-tagmanager@2.0.15) (2019-05-30)
 
 ### Bug Fixes
 
-- **gatsby-plugin-google-tagmanager:** guard against dataLayer being undefined in development ([#14437](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/issues/14437)) ([ecb5d7b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/commit/ecb5d7b)), closes [#14424](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/issues/14424)
+- **gatsby-plugin-google-tagmanager:** guard against dataLayer being undefined in development ([#14437](https://github.com/gatsbyjs/gatsby/issues/14437)) ([ecb5d7b](https://github.com/gatsbyjs/gatsby/commit/ecb5d7b)), closes [#14424](https://github.com/gatsbyjs/gatsby/issues/14424)
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.13...gatsby-plugin-google-tagmanager@2.0.14) (2019-05-29)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.13...gatsby-plugin-google-tagmanager@2.0.14) (2019-05-29)
 
 ### Bug Fixes
 
-- **gatsby-plugin-google-tagmanager:** Properly communicate site title with GTM services ([#14384](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/issues/14384)) ([f9bb78a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/commit/f9bb78a))
+- **gatsby-plugin-google-tagmanager:** Properly communicate site title with GTM services ([#14384](https://github.com/gatsbyjs/gatsby/issues/14384)) ([f9bb78a](https://github.com/gatsbyjs/gatsby/commit/f9bb78a))
 
 ### Features
 
-- **gatsby-plugin-google-tagmanager:** Allow to place the GTM script … ([#13424](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/issues/13424)) ([0b56c3b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/commit/0b56c3b))
+- **gatsby-plugin-google-tagmanager:** Allow to place the GTM script … ([#13424](https://github.com/gatsbyjs/gatsby/issues/13424)) ([0b56c3b](https://github.com/gatsbyjs/gatsby/commit/0b56c3b))
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.12...gatsby-plugin-google-tagmanager@2.0.13) (2019-04-11)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.12...gatsby-plugin-google-tagmanager@2.0.13) (2019-04-11)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.11...gatsby-plugin-google-tagmanager@2.0.12) (2019-03-28)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.11...gatsby-plugin-google-tagmanager@2.0.12) (2019-03-28)
 
 ### Bug Fixes
 
-- **gatsby-plugin-google-tagmanager:** update dataLayer to be camelCased ([#12920](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/issues/12920)) ([057dc9a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/commit/057dc9a))
+- **gatsby-plugin-google-tagmanager:** update dataLayer to be camelCased ([#12920](https://github.com/gatsbyjs/gatsby/issues/12920)) ([057dc9a](https://github.com/gatsbyjs/gatsby/commit/057dc9a))
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.10...gatsby-plugin-google-tagmanager@2.0.11) (2019-03-25)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.10...gatsby-plugin-google-tagmanager@2.0.11) (2019-03-25)
 
 ### Features
 
 - **gatsby-plugin-google-tagmanager:** Add plugin option for custom dataLayer name ([#12783](https://github.com/gatsbyjs/gatsby/issues/12783)) ([4a149c](https://github.com/gatsbyjs/gatsby/commit/4a149c))
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.9...gatsby-plugin-google-tagmanager@2.0.10) (2019-03-11)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.9...gatsby-plugin-google-tagmanager@2.0.10) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.8...gatsby-plugin-google-tagmanager@2.0.9) (2019-02-01)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.8...gatsby-plugin-google-tagmanager@2.0.9) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.7...gatsby-plugin-google-tagmanager@2.0.8) (2019-01-24)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.7...gatsby-plugin-google-tagmanager@2.0.8) (2019-01-24)
 
 ### Bug Fixes
 
-- **gatsby-plugin-google-tagmanager:** handle line breaks ([#11169](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/issues/11169)) ([d974f80](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/commit/d974f80))
+- **gatsby-plugin-google-tagmanager:** handle line breaks ([#11169](https://github.com/gatsbyjs/gatsby/issues/11169)) ([d974f80](https://github.com/gatsbyjs/gatsby/commit/d974f80))
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.6...gatsby-plugin-google-tagmanager@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.6...gatsby-plugin-google-tagmanager@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.5...gatsby-plugin-google-tagmanager@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.5...gatsby-plugin-google-tagmanager@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.0-rc.1...gatsby-plugin-google-tagmanager@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.0-rc.1...gatsby-plugin-google-tagmanager@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.0-rc.0...gatsby-plugin-google-tagmanager@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.0-rc.0...gatsby-plugin-google-tagmanager@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.3...gatsby-plugin-google-tagmanager@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.3...gatsby-plugin-google-tagmanager@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.2...gatsby-plugin-google-tagmanager@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.2...gatsby-plugin-google-tagmanager@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.1...gatsby-plugin-google-tagmanager@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.1...gatsby-plugin-google-tagmanager@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.0...gatsby-plugin-google-tagmanager@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@2.0.0-beta.0...gatsby-plugin-google-tagmanager@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager/compare/gatsby-plugin-google-tagmanager@1.0.19...gatsby-plugin-google-tagmanager@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-google-tagmanager@1.0.19...gatsby-plugin-google-tagmanager@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-google-tagmanager

--- a/packages/gatsby-plugin-guess-js/CHANGELOG.md
+++ b/packages/gatsby-plugin-guess-js/CHANGELOG.md
@@ -7,15 +7,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-guess-js
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-guess-js/compare/gatsby-plugin-guess-js@1.0.7...gatsby-plugin-guess-js@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-guess-js@1.0.7...gatsby-plugin-guess-js@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-guess-js
 
-## [1.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-guess-js/compare/gatsby-plugin-guess-js@1.0.6...gatsby-plugin-guess-js@1.0.7) (2019-06-11)
+## [1.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-guess-js@1.0.6...gatsby-plugin-guess-js@1.0.7) (2019-06-11)
 
 **Note:** Version bump only for package gatsby-plugin-guess-js
 
-## [1.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-guess-js/compare/gatsby-plugin-guess-js@1.0.5...gatsby-plugin-guess-js@1.0.6) (2019-04-23)
+## [1.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-guess-js@1.0.5...gatsby-plugin-guess-js@1.0.6) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-guess-js
 

--- a/packages/gatsby-plugin-jss/CHANGELOG.md
+++ b/packages/gatsby-plugin-jss/CHANGELOG.md
@@ -7,98 +7,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.1.0...gatsby-plugin-jss@2.1.1) (2019-06-24)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.1.0...gatsby-plugin-jss@2.1.1) (2019-06-24)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.9...gatsby-plugin-jss@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.9...gatsby-plugin-jss@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.8...gatsby-plugin-jss@2.0.9) (2019-03-11)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.8...gatsby-plugin-jss@2.0.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.7...gatsby-plugin-jss@2.0.8) (2019-02-19)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.7...gatsby-plugin-jss@2.0.8) (2019-02-19)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.6...gatsby-plugin-jss@2.0.7) (2019-02-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.6...gatsby-plugin-jss@2.0.7) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.5...gatsby-plugin-jss@2.0.6) (2019-01-23)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.5...gatsby-plugin-jss@2.0.6) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.4...gatsby-plugin-jss@2.0.5) (2018-11-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.4...gatsby-plugin-jss@2.0.5) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.3...gatsby-plugin-jss@2.0.4) (2018-11-20)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.3...gatsby-plugin-jss@2.0.4) (2018-11-20)
 
 ### Bug Fixes
 
-- update peerDependency, plugins rely on extra arg being passed in API hooks ([#10045](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/issues/10045)) ([83b7a18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/commit/83b7a18)), closes [/github.com/gatsbyjs/gatsby/pull/9943#issuecomment-440152666](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/issues/issuecomment-440152666)
+- update peerDependency, plugins rely on extra arg being passed in API hooks ([#10045](https://github.com/gatsbyjs/gatsby/issues/10045)) ([83b7a18](https://github.com/gatsbyjs/gatsby/commit/83b7a18)), closes [/github.com/gatsbyjs/gatsby/pull/9943#issuecomment-440152666](https://github.com/gatsbyjs/gatsby/issues/issuecomment-440152666)
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2...gatsby-plugin-jss@2.0.3) (2018-10-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2...gatsby-plugin-jss@2.0.3) (2018-10-29)
 
 ### Bug Fixes
 
-- **gatsby-plugin-jss:** use separate SheetsRegistry for each page ([#9401](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/issues/9401)) ([15375c8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/commit/15375c8)), closes [#7716](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/issues/7716)
+- **gatsby-plugin-jss:** use separate SheetsRegistry for each page ([#9401](https://github.com/gatsbyjs/gatsby/issues/9401)) ([15375c8](https://github.com/gatsbyjs/gatsby/commit/15375c8)), closes [#7716](https://github.com/gatsbyjs/gatsby/issues/7716)
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2-rc.1...gatsby-plugin-jss@2.0.2) (2018-09-17)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2-rc.1...gatsby-plugin-jss@2.0.2) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.2-rc.1"></a>
 
-## [2.0.2-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2-rc.0...gatsby-plugin-jss@2.0.2-rc.1) (2018-08-29)
+## [2.0.2-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2-rc.0...gatsby-plugin-jss@2.0.2-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.2-rc.0"></a>
 
-## [2.0.2-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2-beta.4...gatsby-plugin-jss@2.0.2-rc.0) (2018-08-21)
+## [2.0.2-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2-beta.4...gatsby-plugin-jss@2.0.2-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.2-beta.4"></a>
 
-## [2.0.2-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2-beta.3...gatsby-plugin-jss@2.0.2-beta.4) (2018-08-16)
+## [2.0.2-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2-beta.3...gatsby-plugin-jss@2.0.2-beta.4) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.2-beta.3"></a>
 
-## [2.0.2-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2-beta.2...gatsby-plugin-jss@2.0.2-beta.3) (2018-07-21)
+## [2.0.2-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2-beta.2...gatsby-plugin-jss@2.0.2-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.2-beta.2"></a>
 
-## [2.0.2-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2-beta.1...gatsby-plugin-jss@2.0.2-beta.2) (2018-06-20)
+## [2.0.2-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2-beta.1...gatsby-plugin-jss@2.0.2-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.2-beta.1"></a>
 
-## [2.0.2-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@2.0.2-beta.0...gatsby-plugin-jss@2.0.2-beta.1) (2018-06-17)
+## [2.0.2-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@2.0.2-beta.0...gatsby-plugin-jss@2.0.2-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-jss
 
 <a name="2.0.2-beta.0"></a>
 
-## [2.0.2-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss/compare/gatsby-plugin-jss@1.5.14...gatsby-plugin-jss@2.0.2-beta.0) (2018-06-17)
+## [2.0.2-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-jss@1.5.14...gatsby-plugin-jss@2.0.2-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-jss

--- a/packages/gatsby-plugin-layout/CHANGELOG.md
+++ b/packages/gatsby-plugin-layout/CHANGELOG.md
@@ -7,11 +7,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-layout
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-layout/compare/gatsby-plugin-layout@1.0.15...gatsby-plugin-layout@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-layout@1.0.15...gatsby-plugin-layout@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-layout
 
-## [1.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-layout/compare/gatsby-plugin-layout@1.0.14...gatsby-plugin-layout@1.0.15) (2019-04-23)
+## [1.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-layout@1.0.14...gatsby-plugin-layout@1.0.15) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-layout
 

--- a/packages/gatsby-plugin-less/CHANGELOG.md
+++ b/packages/gatsby-plugin-less/CHANGELOG.md
@@ -7,112 +7,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-less
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.13...gatsby-plugin-less@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.13...gatsby-plugin-less@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.12...gatsby-plugin-less@2.0.13) (2019-05-14)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.12...gatsby-plugin-less@2.0.13) (2019-05-14)
 
 ### Features
 
-- **gatsby-plugin-less:** allow passing less plugins ([#12898](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/issues/12898)) ([8933ca9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/commit/8933ca9))
+- **gatsby-plugin-less:** allow passing less plugins ([#12898](https://github.com/gatsbyjs/gatsby/issues/12898)) ([8933ca9](https://github.com/gatsbyjs/gatsby/commit/8933ca9))
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.11...gatsby-plugin-less@2.0.12) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-less
-
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.10...gatsby-plugin-less@2.0.11) (2019-02-01)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.11...gatsby-plugin-less@2.0.12) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.9...gatsby-plugin-less@2.0.10) (2019-02-01)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.10...gatsby-plugin-less@2.0.11) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-plugin-less
+
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.9...gatsby-plugin-less@2.0.10) (2019-02-01)
 
 ### Bug Fixes
 
-- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/commit/97c98e9))
+- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/commit/97c98e9))
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.8...gatsby-plugin-less@2.0.9) (2019-01-28)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.8...gatsby-plugin-less@2.0.9) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.7...gatsby-plugin-less@2.0.8) (2018-11-29)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.7...gatsby-plugin-less@2.0.8) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.6...gatsby-plugin-less@2.0.7) (2018-10-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.6...gatsby-plugin-less@2.0.7) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.5...gatsby-plugin-less@2.0.6) (2018-10-23)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.5...gatsby-plugin-less@2.0.6) (2018-10-23)
 
 ### Features
 
-- **gatsby-plugin-less:** add support for overriding the default options of `css-loader` ([#9237](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/issues/9237)) ([ba82bc4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/commit/ba82bc4)), closes [#9142](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/issues/9142)
+- **gatsby-plugin-less:** add support for overriding the default options of `css-loader` ([#9237](https://github.com/gatsbyjs/gatsby/issues/9237)) ([ba82bc4](https://github.com/gatsbyjs/gatsby/commit/ba82bc4)), closes [#9142](https://github.com/gatsbyjs/gatsby/issues/9142)
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-rc.2...gatsby-plugin-less@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-rc.2...gatsby-plugin-less@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-rc.1...gatsby-plugin-less@2.0.0-rc.2) (2018-09-17)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-rc.1...gatsby-plugin-less@2.0.0-rc.2) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-rc.0...gatsby-plugin-less@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-rc.0...gatsby-plugin-less@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-beta.5...gatsby-plugin-less@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-beta.5...gatsby-plugin-less@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-beta.4...gatsby-plugin-less@2.0.0-beta.5) (2018-07-21)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-beta.4...gatsby-plugin-less@2.0.0-beta.5) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-beta.3...gatsby-plugin-less@2.0.0-beta.4) (2018-07-09)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-beta.3...gatsby-plugin-less@2.0.0-beta.4) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-beta.2...gatsby-plugin-less@2.0.0-beta.3) (2018-06-27)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-beta.2...gatsby-plugin-less@2.0.0-beta.3) (2018-06-27)
 
 ### Bug Fixes
 
-- use the language loader for imports not postcss ([#6173](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/issues/6173)) ([7190fe1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/commit/7190fe1))
+- use the language loader for imports not postcss ([#6173](https://github.com/gatsbyjs/gatsby/issues/6173)) ([7190fe1](https://github.com/gatsbyjs/gatsby/commit/7190fe1))
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-beta.1...gatsby-plugin-less@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-beta.1...gatsby-plugin-less@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@2.0.0-beta.0...gatsby-plugin-less@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@2.0.0-beta.0...gatsby-plugin-less@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-less
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less/compare/gatsby-plugin-less@1.1.8...gatsby-plugin-less@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-less@1.1.8...gatsby-plugin-less@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-less

--- a/packages/gatsby-plugin-lodash/CHANGELOG.md
+++ b/packages/gatsby-plugin-lodash/CHANGELOG.md
@@ -7,68 +7,68 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.5...gatsby-plugin-lodash@3.1.0) (2019-06-20)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.5...gatsby-plugin-lodash@3.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.4...gatsby-plugin-lodash@3.0.5) (2019-03-11)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.4...gatsby-plugin-lodash@3.0.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.3...gatsby-plugin-lodash@3.0.4) (2019-02-01)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.3...gatsby-plugin-lodash@3.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.2...gatsby-plugin-lodash@3.0.3) (2018-11-29)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.2...gatsby-plugin-lodash@3.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.1...gatsby-plugin-lodash@3.0.2) (2018-10-29)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.1...gatsby-plugin-lodash@3.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.1-rc.1...gatsby-plugin-lodash@3.0.1) (2018-09-17)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.1-rc.1...gatsby-plugin-lodash@3.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.1-rc.1"></a>
 
-## [3.0.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.1-rc.0...gatsby-plugin-lodash@3.0.1-rc.1) (2018-08-29)
+## [3.0.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.1-rc.0...gatsby-plugin-lodash@3.0.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.1-rc.0"></a>
 
-## [3.0.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.1-beta.3...gatsby-plugin-lodash@3.0.1-rc.0) (2018-08-21)
+## [3.0.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.1-beta.3...gatsby-plugin-lodash@3.0.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.1-beta.3"></a>
 
-## [3.0.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.1-beta.2...gatsby-plugin-lodash@3.0.1-beta.3) (2018-07-21)
+## [3.0.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.1-beta.2...gatsby-plugin-lodash@3.0.1-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.1-beta.2"></a>
 
-## [3.0.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.1-beta.1...gatsby-plugin-lodash@3.0.1-beta.2) (2018-06-20)
+## [3.0.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.1-beta.1...gatsby-plugin-lodash@3.0.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.1-beta.1"></a>
 
-## [3.0.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@3.0.1-beta.0...gatsby-plugin-lodash@3.0.1-beta.1) (2018-06-17)
+## [3.0.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@3.0.1-beta.0...gatsby-plugin-lodash@3.0.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-lodash
 
 <a name="3.0.1-beta.0"></a>
 
-## [3.0.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash/compare/gatsby-plugin-lodash@1.0.11...gatsby-plugin-lodash@3.0.1-beta.0) (2018-06-17)
+## [3.0.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-lodash@1.0.11...gatsby-plugin-lodash@3.0.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-lodash

--- a/packages/gatsby-plugin-manifest/CHANGELOG.md
+++ b/packages/gatsby-plugin-manifest/CHANGELOG.md
@@ -7,252 +7,252 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.2.0...gatsby-plugin-manifest@2.2.1) (2019-07-02)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.2.0...gatsby-plugin-manifest@2.2.1) (2019-07-02)
 
 ### Features
 
-- **gatsby-plugin-manifest:** add i18n, localization ([#13471](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/13471)) ([d93e478](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/d93e478)), closes [/github.com/gatsbyjs/gatsby/pull/13471#issuecomment-486056407](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/issuecomment-486056407) [/github.com/gatsbyjs/gatsby/pull/13471#discussion_r277955596](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/discussion_r277955596)
+- **gatsby-plugin-manifest:** add i18n, localization ([#13471](https://github.com/gatsbyjs/gatsby/issues/13471)) ([d93e478](https://github.com/gatsbyjs/gatsby/commit/d93e478)), closes [/github.com/gatsbyjs/gatsby/pull/13471#issuecomment-486056407](https://github.com/gatsbyjs/gatsby/issues/issuecomment-486056407) [/github.com/gatsbyjs/gatsby/pull/13471#discussion_r277955596](https://github.com/gatsbyjs/gatsby/issues/discussion_r277955596)
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.1.1...gatsby-plugin-manifest@2.2.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-plugin-manifest
-
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.1.0...gatsby-plugin-manifest@2.1.1) (2019-05-03)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.1.1...gatsby-plugin-manifest@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.29...gatsby-plugin-manifest@2.1.0) (2019-05-02)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.1.0...gatsby-plugin-manifest@2.1.1) (2019-05-03)
+
+**Note:** Version bump only for package gatsby-plugin-manifest
+
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.29...gatsby-plugin-manifest@2.1.0) (2019-05-02)
 
 ### Features
 
-- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/8291044))
+- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/commit/8291044))
 
-## [2.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.28...gatsby-plugin-manifest@2.0.29) (2019-04-10)
-
-### Bug Fixes
-
-- **gatsby-plugin-manifest:** fix regression with sharp failing to load ([#13271](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/13271)) ([c264a85](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/c264a85)), closes [#13055](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/13264)
-
-## [2.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.27...gatsby-plugin-manifest@2.0.28) (2019-04-09)
+## [2.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.28...gatsby-plugin-manifest@2.0.29) (2019-04-10)
 
 ### Bug Fixes
 
-- **gatsby-plugin-manifest:** allow multiple icon paths ([#13059](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/13059)) ([5dcde0d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/5dcde0d)), closes [#13055](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/13055)
+- **gatsby-plugin-manifest:** fix regression with sharp failing to load ([#13271](https://github.com/gatsbyjs/gatsby/issues/13271)) ([c264a85](https://github.com/gatsbyjs/gatsby/commit/c264a85)), closes [#13055](https://github.com/gatsbyjs/gatsby/issues/13264)
 
-## [2.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.26...gatsby-plugin-manifest@2.0.27) (2019-04-08)
+## [2.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.27...gatsby-plugin-manifest@2.0.28) (2019-04-09)
+
+### Bug Fixes
+
+- **gatsby-plugin-manifest:** allow multiple icon paths ([#13059](https://github.com/gatsbyjs/gatsby/issues/13059)) ([5dcde0d](https://github.com/gatsbyjs/gatsby/commit/5dcde0d)), closes [#13055](https://github.com/gatsbyjs/gatsby/issues/13055)
+
+## [2.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.26...gatsby-plugin-manifest@2.0.27) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
-## [2.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.25...gatsby-plugin-manifest@2.0.26) (2019-03-29)
+## [2.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.25...gatsby-plugin-manifest@2.0.26) (2019-03-29)
 
 ### Bug Fixes
 
-- **gatsby-plugin-manifest:** ensure icon_options is stripped ([#12907](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12907)) ([201a4f5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/201a4f5))
+- **gatsby-plugin-manifest:** ensure icon_options is stripped ([#12907](https://github.com/gatsbyjs/gatsby/issues/12907)) ([201a4f5](https://github.com/gatsbyjs/gatsby/commit/201a4f5))
 
-## [2.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.24...gatsby-plugin-manifest@2.0.25) (2019-03-27)
+## [2.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.24...gatsby-plugin-manifest@2.0.25) (2019-03-27)
 
 ### Bug Fixes
 
-- **gatsby-plugin-manifest:** Fix incorrect favicons size bug ([#12081](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12081)) ([366980b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/366980b)), closes [#12051](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12051) [#12051](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12051)
+- **gatsby-plugin-manifest:** Fix incorrect favicons size bug ([#12081](https://github.com/gatsbyjs/gatsby/issues/12081)) ([366980b](https://github.com/gatsbyjs/gatsby/commit/366980b)), closes [#12051](https://github.com/gatsbyjs/gatsby/issues/12051) [#12051](https://github.com/gatsbyjs/gatsby/issues/12051)
 
 ### Features
 
-- **gatsby-plugin-manifest:** add icon_options as an option to support the purpose property ([#12794](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12794)) ([127f232](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/127f232)), closes [#12793](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12793)
+- **gatsby-plugin-manifest:** add icon_options as an option to support the purpose property ([#12794](https://github.com/gatsbyjs/gatsby/issues/12794)) ([127f232](https://github.com/gatsbyjs/gatsby/commit/127f232)), closes [#12793](https://github.com/gatsbyjs/gatsby/issues/12793)
 
-## [2.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.23...gatsby-plugin-manifest@2.0.24) (2019-03-12)
+## [2.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.23...gatsby-plugin-manifest@2.0.24) (2019-03-12)
 
 ### Features
 
-- **gatsby-plugin-manifest:** add cache busting to icon url ([#8343](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/8343)) ([5f656f8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/5f656f8))
+- **gatsby-plugin-manifest:** add cache busting to icon url ([#8343](https://github.com/gatsbyjs/gatsby/issues/8343)) ([5f656f8](https://github.com/gatsbyjs/gatsby/commit/5f656f8))
 
-## [2.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.22...gatsby-plugin-manifest@2.0.23) (2019-03-11)
+## [2.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.22...gatsby-plugin-manifest@2.0.23) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
-## [2.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.21...gatsby-plugin-manifest@2.0.22) (2019-03-05)
+## [2.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.21...gatsby-plugin-manifest@2.0.22) (2019-03-05)
 
 ### Bug Fixes
 
-- don't crash if cpu-core-count is not available ([#12332](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/12332)) ([412217d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/412217d))
+- don't crash if cpu-core-count is not available ([#12332](https://github.com/gatsbyjs/gatsby/issues/12332)) ([412217d](https://github.com/gatsbyjs/gatsby/commit/412217d))
 
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.20...gatsby-plugin-manifest@2.0.21) (2019-03-04)
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.20...gatsby-plugin-manifest@2.0.21) (2019-03-04)
 
 ### Features
 
-- **gatsby:** configure physical cores, logical_cores or fixed number ([#10257](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/10257)) ([c51440e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/c51440e))
+- **gatsby:** configure physical cores, logical_cores or fixed number ([#10257](https://github.com/gatsbyjs/gatsby/issues/10257)) ([c51440e](https://github.com/gatsbyjs/gatsby/commit/c51440e))
 
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.19...gatsby-plugin-manifest@2.0.20) (2019-02-28)
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.19...gatsby-plugin-manifest@2.0.20) (2019-02-28)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.18...gatsby-plugin-manifest@2.0.19) (2019-02-22)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.18...gatsby-plugin-manifest@2.0.19) (2019-02-22)
 
 ### Features
 
-- **gatsby-plugin-manifest:** add option for crossorigin in manifest ([#11953](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/11953)) ([1a16600](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/1a16600))
+- **gatsby-plugin-manifest:** add option for crossorigin in manifest ([#11953](https://github.com/gatsbyjs/gatsby/issues/11953)) ([1a16600](https://github.com/gatsbyjs/gatsby/commit/1a16600))
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.17...gatsby-plugin-manifest@2.0.18) (2019-02-19)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.17...gatsby-plugin-manifest@2.0.18) (2019-02-19)
 
 ### Bug Fixes
 
-- **gatsby-plugin-manifest:** improve SVG->PNG fidelity ([#11608](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/11608)) ([e9345cd](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/e9345cd))
+- **gatsby-plugin-manifest:** improve SVG->PNG fidelity ([#11608](https://github.com/gatsbyjs/gatsby/issues/11608)) ([e9345cd](https://github.com/gatsbyjs/gatsby/commit/e9345cd))
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.16...gatsby-plugin-manifest@2.0.17) (2019-02-01)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.16...gatsby-plugin-manifest@2.0.17) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.15...gatsby-plugin-manifest@2.0.16) (2019-01-31)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.15...gatsby-plugin-manifest@2.0.16) (2019-01-31)
 
 ### Features
 
-- **gatsby-plugin-manifest:** make favicon link tag optional ([#11414](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/11414)) ([1af42bc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/1af42bc))
+- **gatsby-plugin-manifest:** make favicon link tag optional ([#11414](https://github.com/gatsbyjs/gatsby/issues/11414)) ([1af42bc](https://github.com/gatsbyjs/gatsby/commit/1af42bc))
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.14...gatsby-plugin-manifest@2.0.15) (2019-01-29)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.14...gatsby-plugin-manifest@2.0.15) (2019-01-29)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.13...gatsby-plugin-manifest@2.0.14) (2019-01-28)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.13...gatsby-plugin-manifest@2.0.14) (2019-01-28)
 
 ### Bug Fixes
 
-- **gatsby-plugin-manifest:** Legacy default to true ([#11203](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/11203)) ([7e84613](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/7e84613))
+- **gatsby-plugin-manifest:** Legacy default to true ([#11203](https://github.com/gatsbyjs/gatsby/issues/11203)) ([7e84613](https://github.com/gatsbyjs/gatsby/commit/7e84613))
 
 <a name="2.0.13"></a>
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.12...gatsby-plugin-manifest@2.0.13) (2018-12-29)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.12...gatsby-plugin-manifest@2.0.13) (2018-12-29)
 
 ### Features
 
-- **gatsby-plugin-manifest:** add option to remove the "theme color" meta tag ([#10440](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/10440)) ([129c5d8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/129c5d8))
+- **gatsby-plugin-manifest:** add option to remove the "theme color" meta tag ([#10440](https://github.com/gatsbyjs/gatsby/issues/10440)) ([129c5d8](https://github.com/gatsbyjs/gatsby/commit/129c5d8))
 
 <a name="2.0.12"></a>
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.11...gatsby-plugin-manifest@2.0.12) (2018-12-11)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.11...gatsby-plugin-manifest@2.0.12) (2018-12-11)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.10...gatsby-plugin-manifest@2.0.11) (2018-11-29)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.10...gatsby-plugin-manifest@2.0.11) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.9...gatsby-plugin-manifest@2.0.10) (2018-11-21)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.9...gatsby-plugin-manifest@2.0.10) (2018-11-21)
 
 ### Features
 
-- **gatsby-plugin-manifest:** don't output `theme-color` meta tag if it's not defiened ([#10069](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/10069)) ([7802470](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/7802470))
+- **gatsby-plugin-manifest:** don't output `theme-color` meta tag if it's not defiened ([#10069](https://github.com/gatsbyjs/gatsby/issues/10069)) ([7802470](https://github.com/gatsbyjs/gatsby/commit/7802470))
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.8...gatsby-plugin-manifest@2.0.9) (2018-11-12)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.8...gatsby-plugin-manifest@2.0.9) (2018-11-12)
 
 ### Features
 
-- **gatsby-plugin-manifest:** add option to generate apple-touch-icons links ([#7256](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/7256)) ([0b9d656](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/0b9d656)), closes [#5887](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/5887)
+- **gatsby-plugin-manifest:** add option to generate apple-touch-icons links ([#7256](https://github.com/gatsbyjs/gatsby/issues/7256)) ([0b9d656](https://github.com/gatsbyjs/gatsby/commit/0b9d656)), closes [#5887](https://github.com/gatsbyjs/gatsby/issues/5887)
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.7...gatsby-plugin-manifest@2.0.8) (2018-11-08)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.7...gatsby-plugin-manifest@2.0.8) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.6...gatsby-plugin-manifest@2.0.7) (2018-10-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.6...gatsby-plugin-manifest@2.0.7) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.5...gatsby-plugin-manifest@2.0.6) (2018-10-24)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.5...gatsby-plugin-manifest@2.0.6) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.4...gatsby-plugin-manifest@2.0.5) (2018-10-09)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.4...gatsby-plugin-manifest@2.0.5) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.3...gatsby-plugin-manifest@2.0.4) (2018-09-26)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.3...gatsby-plugin-manifest@2.0.4) (2018-09-26)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-rc.1...gatsby-plugin-manifest@2.0.3) (2018-09-24)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-rc.1...gatsby-plugin-manifest@2.0.3) (2018-09-24)
 
 ### Bug Fixes
 
-- **gatsby-plugin-manifest:** favicon path respects hybrid mode ([#8315](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/issues/8315)) ([05e7ccd](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/commit/05e7ccd))
+- **gatsby-plugin-manifest:** favicon path respects hybrid mode ([#8315](https://github.com/gatsbyjs/gatsby/issues/8315)) ([05e7ccd](https://github.com/gatsbyjs/gatsby/commit/05e7ccd))
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-rc.1...gatsby-plugin-manifest@2.0.2) (2018-09-17)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-rc.1...gatsby-plugin-manifest@2.0.2) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-rc.1"></a>
 
-## [2.0.2-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-rc.0...gatsby-plugin-manifest@2.0.2-rc.1) (2018-08-29)
+## [2.0.2-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-rc.0...gatsby-plugin-manifest@2.0.2-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-rc.0"></a>
 
-## [2.0.2-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.7...gatsby-plugin-manifest@2.0.2-rc.0) (2018-08-21)
+## [2.0.2-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.7...gatsby-plugin-manifest@2.0.2-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.7"></a>
 
-## [2.0.2-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.6...gatsby-plugin-manifest@2.0.2-beta.7) (2018-08-20)
+## [2.0.2-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.6...gatsby-plugin-manifest@2.0.2-beta.7) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.6"></a>
 
-## [2.0.2-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.5...gatsby-plugin-manifest@2.0.2-beta.6) (2018-08-15)
+## [2.0.2-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.5...gatsby-plugin-manifest@2.0.2-beta.6) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.5"></a>
 
-## [2.0.2-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.4...gatsby-plugin-manifest@2.0.2-beta.5) (2018-08-10)
+## [2.0.2-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.4...gatsby-plugin-manifest@2.0.2-beta.5) (2018-08-10)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.4"></a>
 
-## [2.0.2-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.3...gatsby-plugin-manifest@2.0.2-beta.4) (2018-08-07)
+## [2.0.2-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.3...gatsby-plugin-manifest@2.0.2-beta.4) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.3"></a>
 
-## [2.0.2-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.2...gatsby-plugin-manifest@2.0.2-beta.3) (2018-07-21)
+## [2.0.2-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.2...gatsby-plugin-manifest@2.0.2-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.2"></a>
 
-## [2.0.2-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.1...gatsby-plugin-manifest@2.0.2-beta.2) (2018-06-20)
+## [2.0.2-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.1...gatsby-plugin-manifest@2.0.2-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.1"></a>
 
-## [2.0.2-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@2.0.2-beta.0...gatsby-plugin-manifest@2.0.2-beta.1) (2018-06-17)
+## [2.0.2-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@2.0.2-beta.0...gatsby-plugin-manifest@2.0.2-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-manifest
 
 <a name="2.0.2-beta.0"></a>
 
-## [2.0.2-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest/compare/gatsby-plugin-manifest@1.0.27...gatsby-plugin-manifest@2.0.2-beta.0) (2018-06-17)
+## [2.0.2-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-manifest@1.0.27...gatsby-plugin-manifest@2.0.2-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-manifest

--- a/packages/gatsby-plugin-netlify-cms/CHANGELOG.md
+++ b/packages/gatsby-plugin-netlify-cms/CHANGELOG.md
@@ -7,272 +7,272 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
-## [4.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@4.1.1...gatsby-plugin-netlify-cms@4.1.2) (2019-07-10)
+## [4.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@4.1.1...gatsby-plugin-netlify-cms@4.1.2) (2019-07-10)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** remove dependency rule from custom compilation ([#15591](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/15591)) ([5886544](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/5886544))
+- **gatsby-plugin-netlify-cms:** remove dependency rule from custom compilation ([#15591](https://github.com/gatsbyjs/gatsby/issues/15591)) ([5886544](https://github.com/gatsbyjs/gatsby/commit/5886544))
 
 ### Features
 
-- **gatsby-plugin-netlify-cms:** add deprecation message for netlify-cms ([#15588](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/15588)) ([7932414](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/7932414))
+- **gatsby-plugin-netlify-cms:** add deprecation message for netlify-cms ([#15588](https://github.com/gatsbyjs/gatsby/issues/15588)) ([7932414](https://github.com/gatsbyjs/gatsby/commit/7932414))
 
-## [4.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@4.1.0...gatsby-plugin-netlify-cms@4.1.1) (2019-07-01)
+## [4.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@4.1.0...gatsby-plugin-netlify-cms@4.1.1) (2019-07-01)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** exclude node_modules from cms ([#15191](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/15191)) ([a767854](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/a767854))
+- **gatsby-plugin-netlify-cms:** exclude node_modules from cms ([#15191](https://github.com/gatsbyjs/gatsby/issues/15191)) ([a767854](https://github.com/gatsbyjs/gatsby/commit/a767854))
 
-# [4.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@4.0.3...gatsby-plugin-netlify-cms@4.1.0) (2019-06-20)
+# [4.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@4.0.3...gatsby-plugin-netlify-cms@4.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
-## [4.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@4.0.2...gatsby-plugin-netlify-cms@4.0.3) (2019-06-18)
+## [4.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@4.0.2...gatsby-plugin-netlify-cms@4.0.3) (2019-06-18)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** fix minimizer settings ([#14795](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/14795)) ([7973165](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/7973165))
+- **gatsby-plugin-netlify-cms:** fix minimizer settings ([#14795](https://github.com/gatsbyjs/gatsby/issues/14795)) ([7973165](https://github.com/gatsbyjs/gatsby/commit/7973165))
 
-## [4.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@4.0.1...gatsby-plugin-netlify-cms@4.0.2) (2019-06-14)
+## [4.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@4.0.1...gatsby-plugin-netlify-cms@4.0.2) (2019-06-14)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** Fix minimizer for production builds with gatsby-plugins-netlify-cms ([#14783](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/14783)) ([1520e4a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/1520e4a))
+- **gatsby-plugin-netlify-cms:** Fix minimizer for production builds with gatsby-plugins-netlify-cms ([#14783](https://github.com/gatsbyjs/gatsby/issues/14783)) ([1520e4a](https://github.com/gatsbyjs/gatsby/commit/1520e4a))
 
-## [4.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@4.0.0...gatsby-plugin-netlify-cms@4.0.1) (2019-05-09)
+## [4.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@4.0.0...gatsby-plugin-netlify-cms@4.0.1) (2019-05-09)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
-# [4.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.18...gatsby-plugin-netlify-cms@4.0.0) (2019-05-03)
+# [4.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.18...gatsby-plugin-netlify-cms@4.0.0) (2019-05-03)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
-## [3.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.17...gatsby-plugin-netlify-cms@3.0.18) (2019-04-15)
+## [3.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.17...gatsby-plugin-netlify-cms@3.0.18) (2019-04-15)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** fix hardcoded admin path for localhost ([#13324](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/13324)) ([1096514](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/1096514)), closes [#13291](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/13291)
+- **gatsby-plugin-netlify-cms:** fix hardcoded admin path for localhost ([#13324](https://github.com/gatsbyjs/gatsby/issues/13324)) ([1096514](https://github.com/gatsbyjs/gatsby/commit/1096514)), closes [#13291](https://github.com/gatsbyjs/gatsby/issues/13291)
 
-## [3.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.16...gatsby-plugin-netlify-cms@3.0.17) (2019-03-26)
+## [3.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.16...gatsby-plugin-netlify-cms@3.0.17) (2019-03-26)
 
 ### Features
 
-- **gatsby-plugin-netlify-cms:** support multiple cms module paths ([#12672](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/12672)) ([a17df90](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/a17df90))
+- **gatsby-plugin-netlify-cms:** support multiple cms module paths ([#12672](https://github.com/gatsbyjs/gatsby/issues/12672)) ([a17df90](https://github.com/gatsbyjs/gatsby/commit/a17df90))
 
-## [3.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.15...gatsby-plugin-netlify-cms@3.0.16) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-plugin-netlify-cms
-
-## [3.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.14...gatsby-plugin-netlify-cms@3.0.15) (2019-03-14)
-
-### Bug Fixes
-
-- **gatsby:** properly support --no-color for pretty-error ([#12531](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/12531)) ([e493538](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/e493538))
-
-## [3.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.13...gatsby-plugin-netlify-cms@3.0.14) (2019-03-11)
+## [3.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.15...gatsby-plugin-netlify-cms@3.0.16) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
-## [3.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.12...gatsby-plugin-netlify-cms@3.0.13) (2019-03-11)
+## [3.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.14...gatsby-plugin-netlify-cms@3.0.15) (2019-03-14)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** Add listener for /admin ([#12474](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/12474)) ([617df24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/617df24))
+- **gatsby:** properly support --no-color for pretty-error ([#12531](https://github.com/gatsbyjs/gatsby/issues/12531)) ([e493538](https://github.com/gatsbyjs/gatsby/commit/e493538))
 
-## [3.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.11...gatsby-plugin-netlify-cms@3.0.12) (2019-01-31)
+## [3.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.13...gatsby-plugin-netlify-cms@3.0.14) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
-## [3.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.10...gatsby-plugin-netlify-cms@3.0.11) (2019-01-28)
+## [3.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.12...gatsby-plugin-netlify-cms@3.0.13) (2019-03-11)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** exclude gatsby-webpack-stats-extractor from being called ([#11288](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/11288)) ([658e6d5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/658e6d5))
+- **gatsby-plugin-netlify-cms:** Add listener for /admin ([#12474](https://github.com/gatsbyjs/gatsby/issues/12474)) ([617df24](https://github.com/gatsbyjs/gatsby/commit/617df24))
+
+## [3.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.11...gatsby-plugin-netlify-cms@3.0.12) (2019-01-31)
+
+**Note:** Version bump only for package gatsby-plugin-netlify-cms
+
+## [3.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.10...gatsby-plugin-netlify-cms@3.0.11) (2019-01-28)
+
+### Bug Fixes
+
+- **gatsby-plugin-netlify-cms:** exclude gatsby-webpack-stats-extractor from being called ([#11288](https://github.com/gatsbyjs/gatsby/issues/11288)) ([658e6d5](https://github.com/gatsbyjs/gatsby/commit/658e6d5))
 
 <a name="3.0.10"></a>
 
-## [3.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.9...gatsby-plugin-netlify-cms@3.0.10) (2019-01-23)
+## [3.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.9...gatsby-plugin-netlify-cms@3.0.10) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.9"></a>
 
-## [3.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.8...gatsby-plugin-netlify-cms@3.0.9) (2018-11-29)
+## [3.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.8...gatsby-plugin-netlify-cms@3.0.9) (2018-11-29)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** dynamically import netlify-identity-widget ([#9565](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/9565)) ([49100e9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/49100e9))
+- **gatsby-plugin-netlify-cms:** dynamically import netlify-identity-widget ([#9565](https://github.com/gatsbyjs/gatsby/issues/9565)) ([49100e9](https://github.com/gatsbyjs/gatsby/commit/49100e9))
 
 <a name="3.0.8"></a>
 
-## [3.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.7...gatsby-plugin-netlify-cms@3.0.8) (2018-11-27)
+## [3.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.7...gatsby-plugin-netlify-cms@3.0.8) (2018-11-27)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** fix uglify webpack plugin check ([#10150](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/10150)) ([b1101f5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/b1101f5)), closes [#10067](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/10067) [#10149](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/10149)
+- **gatsby-plugin-netlify-cms:** fix uglify webpack plugin check ([#10150](https://github.com/gatsbyjs/gatsby/issues/10150)) ([b1101f5](https://github.com/gatsbyjs/gatsby/commit/b1101f5)), closes [#10067](https://github.com/gatsbyjs/gatsby/issues/10067) [#10149](https://github.com/gatsbyjs/gatsby/issues/10149)
 
 <a name="3.0.7"></a>
 
-## [3.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.6...gatsby-plugin-netlify-cms@3.0.7) (2018-11-08)
+## [3.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.6...gatsby-plugin-netlify-cms@3.0.7) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.6"></a>
 
-## [3.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.5...gatsby-plugin-netlify-cms@3.0.6) (2018-11-06)
+## [3.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.5...gatsby-plugin-netlify-cms@3.0.6) (2018-11-06)
 
 ### Bug Fixes
 
-- revert admin redirect ([#9728](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/9728)) ([88a671a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/88a671a))
+- revert admin redirect ([#9728](https://github.com/gatsbyjs/gatsby/issues/9728)) ([88a671a](https://github.com/gatsbyjs/gatsby/commit/88a671a))
 
 <a name="3.0.5"></a>
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.4...gatsby-plugin-netlify-cms@3.0.5) (2018-10-29)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.4...gatsby-plugin-netlify-cms@3.0.5) (2018-10-29)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** automatic redirect ([#9269](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/9269)) ([c6dce1c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/c6dce1c))
+- **gatsby-plugin-netlify-cms:** automatic redirect ([#9269](https://github.com/gatsbyjs/gatsby/issues/9269)) ([c6dce1c](https://github.com/gatsbyjs/gatsby/commit/c6dce1c))
 
 <a name="3.0.4"></a>
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.3...gatsby-plugin-netlify-cms@3.0.4) (2018-10-18)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.3...gatsby-plugin-netlify-cms@3.0.4) (2018-10-18)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.2...gatsby-plugin-netlify-cms@3.0.3) (2018-09-24)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.2...gatsby-plugin-netlify-cms@3.0.3) (2018-09-24)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify-cms:** ensure login listener is added after logout ([9b1a2e7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/9b1a2e7))
+- **gatsby-plugin-netlify-cms:** ensure login listener is added after logout ([9b1a2e7](https://github.com/gatsbyjs/gatsby/commit/9b1a2e7))
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.1...gatsby-plugin-netlify-cms@3.0.2) (2018-09-18)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.1...gatsby-plugin-netlify-cms@3.0.2) (2018-09-18)
 
 ### Bug Fixes
 
-- **netlify-cms:** redirect after git gateway login ([#8286](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/8286)) ([535b4a7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/535b4a7))
+- **netlify-cms:** redirect after git gateway login ([#8286](https://github.com/gatsbyjs/gatsby/issues/8286)) ([535b4a7](https://github.com/gatsbyjs/gatsby/commit/535b4a7))
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0...gatsby-plugin-netlify-cms@3.0.1) (2018-09-18)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0...gatsby-plugin-netlify-cms@3.0.1) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-rc.5...gatsby-plugin-netlify-cms@3.0.0) (2018-09-17)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-rc.5...gatsby-plugin-netlify-cms@3.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-rc.5"></a>
 
-# [3.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-rc.4...gatsby-plugin-netlify-cms@3.0.0-rc.5) (2018-09-11)
+# [3.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-rc.4...gatsby-plugin-netlify-cms@3.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-rc.4"></a>
 
-# [3.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-rc.3...gatsby-plugin-netlify-cms@3.0.0-rc.4) (2018-09-11)
+# [3.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-rc.3...gatsby-plugin-netlify-cms@3.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-rc.3"></a>
 
-# [3.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-rc.2...gatsby-plugin-netlify-cms@3.0.0-rc.3) (2018-09-11)
+# [3.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-rc.2...gatsby-plugin-netlify-cms@3.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-rc.2"></a>
 
-# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-rc.1...gatsby-plugin-netlify-cms@3.0.0-rc.2) (2018-09-11)
+# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-rc.1...gatsby-plugin-netlify-cms@3.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-rc.1"></a>
 
-# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-rc.0...gatsby-plugin-netlify-cms@3.0.0-rc.1) (2018-08-29)
+# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-rc.0...gatsby-plugin-netlify-cms@3.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-rc.0"></a>
 
-# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-beta.4...gatsby-plugin-netlify-cms@3.0.0-rc.0) (2018-08-21)
+# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-beta.4...gatsby-plugin-netlify-cms@3.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-beta.4"></a>
 
-# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-beta.3...gatsby-plugin-netlify-cms@3.0.0-beta.4) (2018-08-08)
+# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-beta.3...gatsby-plugin-netlify-cms@3.0.0-beta.4) (2018-08-08)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-beta.3"></a>
 
-# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-beta.2...gatsby-plugin-netlify-cms@3.0.0-beta.3) (2018-08-04)
+# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-beta.2...gatsby-plugin-netlify-cms@3.0.0-beta.3) (2018-08-04)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-beta.2"></a>
 
-# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@3.0.0-beta.1...gatsby-plugin-netlify-cms@3.0.0-beta.2) (2018-08-01)
+# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@3.0.0-beta.1...gatsby-plugin-netlify-cms@3.0.0-beta.2) (2018-08-01)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="3.0.0-beta.1"></a>
 
-# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.7...gatsby-plugin-netlify-cms@3.0.0-beta.1) (2018-07-31)
+# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.7...gatsby-plugin-netlify-cms@3.0.0-beta.1) (2018-07-31)
 
 ### Bug Fixes
 
-- **netlify-cms:** fix identity default, auto register styles ([#6871](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/issues/6871)) ([fba1b59](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/commit/fba1b59))
+- **netlify-cms:** fix identity default, auto register styles ([#6871](https://github.com/gatsbyjs/gatsby/issues/6871)) ([fba1b59](https://github.com/gatsbyjs/gatsby/commit/fba1b59))
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.6...gatsby-plugin-netlify-cms@2.0.0-beta.7) (2018-07-21)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.6...gatsby-plugin-netlify-cms@2.0.0-beta.7) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.5...gatsby-plugin-netlify-cms@2.0.0-beta.6) (2018-07-17)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.5...gatsby-plugin-netlify-cms@2.0.0-beta.6) (2018-07-17)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.4...gatsby-plugin-netlify-cms@2.0.0-beta.5) (2018-07-09)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.4...gatsby-plugin-netlify-cms@2.0.0-beta.5) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.3...gatsby-plugin-netlify-cms@2.0.0-beta.4) (2018-07-06)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.3...gatsby-plugin-netlify-cms@2.0.0-beta.4) (2018-07-06)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.2...gatsby-plugin-netlify-cms@2.0.0-beta.3) (2018-06-20)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.2...gatsby-plugin-netlify-cms@2.0.0-beta.3) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.1...gatsby-plugin-netlify-cms@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.1...gatsby-plugin-netlify-cms@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.0-beta.0...gatsby-plugin-netlify-cms@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.0-beta.0...gatsby-plugin-netlify-cms@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify-cms/compare/gatsby-plugin-netlify-cms@2.0.1...gatsby-plugin-netlify-cms@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify-cms@2.0.1...gatsby-plugin-netlify-cms@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-netlify-cms

--- a/packages/gatsby-plugin-netlify/CHANGELOG.md
+++ b/packages/gatsby-plugin-netlify/CHANGELOG.md
@@ -7,190 +7,190 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.17...gatsby-plugin-netlify@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.17...gatsby-plugin-netlify@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.16...gatsby-plugin-netlify@2.0.17) (2019-05-14)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.16...gatsby-plugin-netlify@2.0.17) (2019-05-14)
 
 ### Features
 
-- **gatsby-plugin-netlify:** Add caching headers for immutable assets ([#14000](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/14000)) ([e5a4c3d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/commit/e5a4c3d))
+- **gatsby-plugin-netlify:** Add caching headers for immutable assets ([#14000](https://github.com/gatsbyjs/gatsby/issues/14000)) ([e5a4c3d](https://github.com/gatsbyjs/gatsby/commit/e5a4c3d))
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.15...gatsby-plugin-netlify@2.0.16) (2019-05-01)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.15...gatsby-plugin-netlify@2.0.16) (2019-05-01)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.14...gatsby-plugin-netlify@2.0.15) (2019-04-23)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.14...gatsby-plugin-netlify@2.0.15) (2019-04-23)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify:** add all .js files from webpack.stats.json to \_headers ([#12521](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/12521)) ([983dbd9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/commit/983dbd9)), closes [#9828](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/9828)
+- **gatsby-plugin-netlify:** add all .js files from webpack.stats.json to \_headers ([#12521](https://github.com/gatsbyjs/gatsby/issues/12521)) ([983dbd9](https://github.com/gatsbyjs/gatsby/commit/983dbd9)), closes [#9828](https://github.com/gatsbyjs/gatsby/issues/9828)
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.13...gatsby-plugin-netlify@2.0.14) (2019-04-18)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.13...gatsby-plugin-netlify@2.0.14) (2019-04-18)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify:** Add Referrer-Policy to security headers ([#13452](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/13452)) ([871923a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/commit/871923a))
+- **gatsby-plugin-netlify:** Add Referrer-Policy to security headers ([#13452](https://github.com/gatsbyjs/gatsby/issues/13452)) ([871923a](https://github.com/gatsbyjs/gatsby/commit/871923a))
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.12...gatsby-plugin-netlify@2.0.13) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-plugin-netlify
-
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.11...gatsby-plugin-netlify@2.0.12) (2019-03-11)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.12...gatsby-plugin-netlify@2.0.13) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.10...gatsby-plugin-netlify@2.0.11) (2019-02-15)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.11...gatsby-plugin-netlify@2.0.12) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.9...gatsby-plugin-netlify@2.0.10) (2019-02-08)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.10...gatsby-plugin-netlify@2.0.11) (2019-02-15)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.8...gatsby-plugin-netlify@2.0.9) (2019-02-06)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.9...gatsby-plugin-netlify@2.0.10) (2019-02-08)
+
+**Note:** Version bump only for package gatsby-plugin-netlify
+
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.8...gatsby-plugin-netlify@2.0.9) (2019-02-06)
 
 ### Features
 
-- **gatsby-plugin-netlify:** Allow status codes in redirects ([#11255](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/11255)) ([#11484](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/11484)) ([024f6f4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/commit/024f6f4))
+- **gatsby-plugin-netlify:** Allow status codes in redirects ([#11255](https://github.com/gatsbyjs/gatsby/issues/11255)) ([#11484](https://github.com/gatsbyjs/gatsby/issues/11484)) ([024f6f4](https://github.com/gatsbyjs/gatsby/commit/024f6f4))
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.7...gatsby-plugin-netlify@2.0.8) (2019-02-01)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.7...gatsby-plugin-netlify@2.0.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.6...gatsby-plugin-netlify@2.0.7) (2019-01-25)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.6...gatsby-plugin-netlify@2.0.7) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.5...gatsby-plugin-netlify@2.0.6) (2018-11-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.5...gatsby-plugin-netlify@2.0.6) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.4...gatsby-plugin-netlify@2.0.5) (2018-11-15)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.4...gatsby-plugin-netlify@2.0.5) (2018-11-15)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify:** do not cache service worker file on Netlify ([#9680](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/9680)) ([9280fd7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/commit/9280fd7)), closes [/www.netlify.com/blog/2018/06/28/5-pro-tips-and-plugins-for-optimizing-your-gatsby---netlify-site/#4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/4)
+- **gatsby-plugin-netlify:** do not cache service worker file on Netlify ([#9680](https://github.com/gatsbyjs/gatsby/issues/9680)) ([9280fd7](https://github.com/gatsbyjs/gatsby/commit/9280fd7)), closes [/www.netlify.com/blog/2018/06/28/5-pro-tips-and-plugins-for-optimizing-your-gatsby---netlify-site/#4](https://github.com/gatsbyjs/gatsby/issues/4)
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.3...gatsby-plugin-netlify@2.0.4) (2018-11-08)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.3...gatsby-plugin-netlify@2.0.4) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.2...gatsby-plugin-netlify@2.0.3) (2018-10-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.2...gatsby-plugin-netlify@2.0.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.1...gatsby-plugin-netlify@2.0.2) (2018-10-23)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.1...gatsby-plugin-netlify@2.0.2) (2018-10-23)
 
 ### Bug Fixes
 
-- **gatsby-plugin-netlify:** Broken links updated ([#9286](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/9286)) ([21830b4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/commit/21830b4))
+- **gatsby-plugin-netlify:** Broken links updated ([#9286](https://github.com/gatsbyjs/gatsby/issues/9286)) ([21830b4](https://github.com/gatsbyjs/gatsby/commit/21830b4))
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0...gatsby-plugin-netlify@2.0.1) (2018-10-02)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0...gatsby-plugin-netlify@2.0.1) (2018-10-02)
 
 ### Features
 
-- **gatsby-plugin-netlify:** add force option to createRedirect ([#8521](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/issues/8521)) ([e1d354e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/commit/e1d354e))
+- **gatsby-plugin-netlify:** add force option to createRedirect ([#8521](https://github.com/gatsbyjs/gatsby/issues/8521)) ([e1d354e](https://github.com/gatsbyjs/gatsby/commit/e1d354e))
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-rc.6...gatsby-plugin-netlify@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-rc.6...gatsby-plugin-netlify@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-rc.5...gatsby-plugin-netlify@2.0.0-rc.6) (2018-09-11)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-rc.5...gatsby-plugin-netlify@2.0.0-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-rc.4...gatsby-plugin-netlify@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-rc.4...gatsby-plugin-netlify@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-rc.3...gatsby-plugin-netlify@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-rc.3...gatsby-plugin-netlify@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-rc.2...gatsby-plugin-netlify@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-rc.2...gatsby-plugin-netlify@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-rc.1...gatsby-plugin-netlify@2.0.0-rc.2) (2018-09-05)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-rc.1...gatsby-plugin-netlify@2.0.0-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-rc.0...gatsby-plugin-netlify@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-rc.0...gatsby-plugin-netlify@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-beta.6...gatsby-plugin-netlify@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-beta.6...gatsby-plugin-netlify@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-beta.5...gatsby-plugin-netlify@2.0.0-beta.6) (2018-08-08)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-beta.5...gatsby-plugin-netlify@2.0.0-beta.6) (2018-08-08)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-beta.4...gatsby-plugin-netlify@2.0.0-beta.5) (2018-08-02)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-beta.4...gatsby-plugin-netlify@2.0.0-beta.5) (2018-08-02)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-beta.3...gatsby-plugin-netlify@2.0.0-beta.4) (2018-07-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-beta.3...gatsby-plugin-netlify@2.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-beta.2...gatsby-plugin-netlify@2.0.0-beta.3) (2018-07-11)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-beta.2...gatsby-plugin-netlify@2.0.0-beta.3) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-beta.1...gatsby-plugin-netlify@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-beta.1...gatsby-plugin-netlify@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@2.0.0-beta.0...gatsby-plugin-netlify@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@2.0.0-beta.0...gatsby-plugin-netlify@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-netlify
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify/compare/gatsby-plugin-netlify@1.0.21...gatsby-plugin-netlify@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-netlify@1.0.21...gatsby-plugin-netlify@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-netlify

--- a/packages/gatsby-plugin-no-sourcemaps/CHANGELOG.md
+++ b/packages/gatsby-plugin-no-sourcemaps/CHANGELOG.md
@@ -7,46 +7,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@2.0.2...gatsby-plugin-no-sourcemaps@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@2.0.2...gatsby-plugin-no-sourcemaps@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@2.0.1...gatsby-plugin-no-sourcemaps@2.0.2) (2019-02-01)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@2.0.1...gatsby-plugin-no-sourcemaps@2.0.2) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@2.0.0...gatsby-plugin-no-sourcemaps@2.0.1) (2018-10-12)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@2.0.0...gatsby-plugin-no-sourcemaps@2.0.1) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@2.0.0-rc.0...gatsby-plugin-no-sourcemaps@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@2.0.0-rc.0...gatsby-plugin-no-sourcemaps@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@2.0.0-beta.2...gatsby-plugin-no-sourcemaps@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@2.0.0-beta.2...gatsby-plugin-no-sourcemaps@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@2.0.0-beta.1...gatsby-plugin-no-sourcemaps@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@2.0.0-beta.1...gatsby-plugin-no-sourcemaps@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@2.0.0-beta.0...gatsby-plugin-no-sourcemaps@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@2.0.0-beta.0...gatsby-plugin-no-sourcemaps@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-no-sourcemaps/compare/gatsby-plugin-no-sourcemaps@1.0.5...gatsby-plugin-no-sourcemaps@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-no-sourcemaps@1.0.5...gatsby-plugin-no-sourcemaps@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-no-sourcemaps

--- a/packages/gatsby-plugin-nprogress/CHANGELOG.md
+++ b/packages/gatsby-plugin-nprogress/CHANGELOG.md
@@ -7,78 +7,78 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.10...gatsby-plugin-nprogress@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.10...gatsby-plugin-nprogress@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.9...gatsby-plugin-nprogress@2.0.10) (2019-03-11)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.9...gatsby-plugin-nprogress@2.0.10) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.8...gatsby-plugin-nprogress@2.0.9) (2019-03-05)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.8...gatsby-plugin-nprogress@2.0.9) (2019-03-05)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.7...gatsby-plugin-nprogress@2.0.8) (2019-02-01)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.7...gatsby-plugin-nprogress@2.0.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.6...gatsby-plugin-nprogress@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.6...gatsby-plugin-nprogress@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.5...gatsby-plugin-nprogress@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.5...gatsby-plugin-nprogress@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.0-rc.1...gatsby-plugin-nprogress@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.0-rc.1...gatsby-plugin-nprogress@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.0-rc.0...gatsby-plugin-nprogress@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.0-rc.0...gatsby-plugin-nprogress@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.0-beta.4...gatsby-plugin-nprogress@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.0-beta.4...gatsby-plugin-nprogress@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.0-beta.3...gatsby-plugin-nprogress@2.0.0-beta.4) (2018-07-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.0-beta.3...gatsby-plugin-nprogress@2.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.0-beta.2...gatsby-plugin-nprogress@2.0.0-beta.3) (2018-06-26)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.0-beta.2...gatsby-plugin-nprogress@2.0.0-beta.3) (2018-06-26)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.0-beta.1...gatsby-plugin-nprogress@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.0-beta.1...gatsby-plugin-nprogress@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@2.0.0-beta.0...gatsby-plugin-nprogress@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@2.0.0-beta.0...gatsby-plugin-nprogress@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress/compare/gatsby-plugin-nprogress@1.0.14...gatsby-plugin-nprogress@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-nprogress@1.0.14...gatsby-plugin-nprogress@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-nprogress

--- a/packages/gatsby-plugin-offline/CHANGELOG.md
+++ b/packages/gatsby-plugin-offline/CHANGELOG.md
@@ -7,298 +7,298 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.2.0...gatsby-plugin-offline@2.2.1) (2019-07-04)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.2.0...gatsby-plugin-offline@2.2.1) (2019-07-04)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.1.3...gatsby-plugin-offline@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.1.3...gatsby-plugin-offline@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.1.2...gatsby-plugin-offline@2.1.3) (2019-06-13)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.1.2...gatsby-plugin-offline@2.1.3) (2019-06-13)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.1.1...gatsby-plugin-offline@2.1.2) (2019-06-12)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.1.1...gatsby-plugin-offline@2.1.2) (2019-06-12)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** use networkFirst caching for page-data.json files ([#14720](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/14720)) ([5352411](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/5352411))
+- **gatsby-plugin-offline:** use networkFirst caching for page-data.json files ([#14720](https://github.com/gatsbyjs/gatsby/issues/14720)) ([5352411](https://github.com/gatsbyjs/gatsby/commit/5352411))
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.1.0...gatsby-plugin-offline@2.1.1) (2019-05-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.1.0...gatsby-plugin-offline@2.1.1) (2019-05-17)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** Drop preload link for json from offline shell ([#13935](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/13935)) ([d1f0ae6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/d1f0ae6))
+- **gatsby-plugin-offline:** Drop preload link for json from offline shell ([#13935](https://github.com/gatsbyjs/gatsby/issues/13935)) ([d1f0ae6](https://github.com/gatsbyjs/gatsby/commit/d1f0ae6))
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.25...gatsby-plugin-offline@2.1.0) (2019-05-02)
-
-### Features
-
-- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/8291044))
-
-## [2.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.24...gatsby-plugin-offline@2.0.25) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-offline
-
-## [2.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.23...gatsby-plugin-offline@2.0.24) (2019-02-19)
-
-**Note:** Version bump only for package gatsby-plugin-offline
-
-## [2.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.22...gatsby-plugin-offline@2.0.23) (2019-02-07)
-
-**Note:** Version bump only for package gatsby-plugin-offline
-
-## [2.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.21...gatsby-plugin-offline@2.0.22) (2019-01-28)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.25...gatsby-plugin-offline@2.1.0) (2019-05-02)
 
 ### Features
 
-- **gatsby-plugin-offline:** reload when missing resources and SW was updated + add "onServiceWorkerUpdateReady" API ([#10432](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/10432)) ([4a01c6d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/4a01c6d))
+- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/commit/8291044))
+
+## [2.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.24...gatsby-plugin-offline@2.0.25) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-plugin-offline
+
+## [2.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.23...gatsby-plugin-offline@2.0.24) (2019-02-19)
+
+**Note:** Version bump only for package gatsby-plugin-offline
+
+## [2.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.22...gatsby-plugin-offline@2.0.23) (2019-02-07)
+
+**Note:** Version bump only for package gatsby-plugin-offline
+
+## [2.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.21...gatsby-plugin-offline@2.0.22) (2019-01-28)
+
+### Features
+
+- **gatsby-plugin-offline:** reload when missing resources and SW was updated + add "onServiceWorkerUpdateReady" API ([#10432](https://github.com/gatsbyjs/gatsby/issues/10432)) ([4a01c6d](https://github.com/gatsbyjs/gatsby/commit/4a01c6d))
 
 <a name="2.0.21"></a>
 
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.20...gatsby-plugin-offline@2.0.21) (2019-01-06)
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.20...gatsby-plugin-offline@2.0.21) (2019-01-06)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.20"></a>
 
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.19...gatsby-plugin-offline@2.0.20) (2018-12-17)
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.19...gatsby-plugin-offline@2.0.20) (2018-12-17)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** prevent incorrect revisioning of static file by workbox ([#10416](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/10416)) ([008b5db](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/008b5db))
+- **gatsby-plugin-offline:** prevent incorrect revisioning of static file by workbox ([#10416](https://github.com/gatsbyjs/gatsby/issues/10416)) ([008b5db](https://github.com/gatsbyjs/gatsby/commit/008b5db))
 
 <a name="2.0.19"></a>
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.18...gatsby-plugin-offline@2.0.19) (2018-12-07)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.18...gatsby-plugin-offline@2.0.19) (2018-12-07)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** gracefully degrade if appshell isn't precached ([#10329](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/10329)) ([19e9f3e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/19e9f3e))
+- **gatsby-plugin-offline:** gracefully degrade if appshell isn't precached ([#10329](https://github.com/gatsbyjs/gatsby/issues/10329)) ([19e9f3e](https://github.com/gatsbyjs/gatsby/commit/19e9f3e))
 
 <a name="2.0.18"></a>
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.17...gatsby-plugin-offline@2.0.18) (2018-11-29)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.17...gatsby-plugin-offline@2.0.18) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.17"></a>
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.16...gatsby-plugin-offline@2.0.17) (2018-11-21)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.16...gatsby-plugin-offline@2.0.17) (2018-11-21)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.16"></a>
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.15...gatsby-plugin-offline@2.0.16) (2018-11-20)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.15...gatsby-plugin-offline@2.0.16) (2018-11-20)
 
 ### Features
 
-- **gatsby-plugin-offline:** replace no-cache detection with dynamic path whitelist ([#9907](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9907)) ([8d3af3f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/8d3af3f))
+- **gatsby-plugin-offline:** replace no-cache detection with dynamic path whitelist ([#9907](https://github.com/gatsbyjs/gatsby/issues/9907)) ([8d3af3f](https://github.com/gatsbyjs/gatsby/commit/8d3af3f))
 
 <a name="2.0.15"></a>
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.14...gatsby-plugin-offline@2.0.15) (2018-11-14)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.14...gatsby-plugin-offline@2.0.15) (2018-11-14)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** fix certain resources being cached excessively ([#9923](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9923)) ([7c826a1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/7c826a1)), closes [#9415](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9415)
+- **gatsby-plugin-offline:** fix certain resources being cached excessively ([#9923](https://github.com/gatsbyjs/gatsby/issues/9923)) ([7c826a1](https://github.com/gatsbyjs/gatsby/commit/7c826a1)), closes [#9415](https://github.com/gatsbyjs/gatsby/issues/9415)
 
 <a name="2.0.14"></a>
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.13...gatsby-plugin-offline@2.0.14) (2018-11-13)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.13...gatsby-plugin-offline@2.0.14) (2018-11-13)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** Sync docs with actual defaults being used ([#9903](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9903)) ([8cd7432](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/8cd7432))
+- **gatsby-plugin-offline:** Sync docs with actual defaults being used ([#9903](https://github.com/gatsbyjs/gatsby/issues/9903)) ([8cd7432](https://github.com/gatsbyjs/gatsby/commit/8cd7432))
 
 <a name="2.0.13"></a>
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.12...gatsby-plugin-offline@2.0.13) (2018-11-08)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.12...gatsby-plugin-offline@2.0.13) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.12"></a>
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.11...gatsby-plugin-offline@2.0.12) (2018-11-05)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.11...gatsby-plugin-offline@2.0.12) (2018-11-05)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** Serve the offline shell for short URLs + use no-cors for external resources ([#9679](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9679)) ([430e8f1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/430e8f1)), closes [#8145](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/8145)
+- **gatsby-plugin-offline:** Serve the offline shell for short URLs + use no-cors for external resources ([#9679](https://github.com/gatsbyjs/gatsby/issues/9679)) ([430e8f1](https://github.com/gatsbyjs/gatsby/commit/430e8f1)), closes [#8145](https://github.com/gatsbyjs/gatsby/issues/8145)
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.10...gatsby-plugin-offline@2.0.11) (2018-11-01)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.10...gatsby-plugin-offline@2.0.11) (2018-11-01)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** don't precache the index page ([#9603](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9603)) ([00284e0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/00284e0)), closes [#7997](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/7997)
+- **gatsby-plugin-offline:** don't precache the index page ([#9603](https://github.com/gatsbyjs/gatsby/issues/9603)) ([00284e0](https://github.com/gatsbyjs/gatsby/commit/00284e0)), closes [#7997](https://github.com/gatsbyjs/gatsby/issues/7997)
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.9...gatsby-plugin-offline@2.0.10) (2018-10-29)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.9...gatsby-plugin-offline@2.0.10) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.8...gatsby-plugin-offline@2.0.9) (2018-10-24)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.8...gatsby-plugin-offline@2.0.9) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.7...gatsby-plugin-offline@2.0.8) (2018-10-23)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.7...gatsby-plugin-offline@2.0.8) (2018-10-23)
 
 ### Features
 
-- update Workbox to 3.6.3 ([#9294](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9294)) ([f53d457](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/f53d457))
+- update Workbox to 3.6.3 ([#9294](https://github.com/gatsbyjs/gatsby/issues/9294)) ([f53d457](https://github.com/gatsbyjs/gatsby/commit/f53d457))
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.6...gatsby-plugin-offline@2.0.7) (2018-10-16)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.6...gatsby-plugin-offline@2.0.7) (2018-10-16)
 
 ### Bug Fixes
 
-- update gatsby peerDep version ([#9150](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/9150)) ([f5c5556](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/f5c5556))
+- update gatsby peerDep version ([#9150](https://github.com/gatsbyjs/gatsby/issues/9150)) ([f5c5556](https://github.com/gatsbyjs/gatsby/commit/f5c5556))
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.5...gatsby-plugin-offline@2.0.6) (2018-10-09)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.5...gatsby-plugin-offline@2.0.6) (2018-10-09)
 
 ### Bug Fixes
 
-- **gatsby-plugin-offline:** delay adding resources for paths until we have urls ([#8613](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/issues/8613)) ([2605aa0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/commit/2605aa0))
+- **gatsby-plugin-offline:** delay adding resources for paths until we have urls ([#8613](https://github.com/gatsbyjs/gatsby/issues/8613)) ([2605aa0](https://github.com/gatsbyjs/gatsby/commit/2605aa0))
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.9...gatsby-plugin-offline@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.9...gatsby-plugin-offline@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.9"></a>
 
-# [2.0.0-rc.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.8...gatsby-plugin-offline@2.0.0-rc.9) (2018-09-17)
+# [2.0.0-rc.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.8...gatsby-plugin-offline@2.0.0-rc.9) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.8"></a>
 
-# [2.0.0-rc.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.7...gatsby-plugin-offline@2.0.0-rc.8) (2018-09-14)
+# [2.0.0-rc.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.7...gatsby-plugin-offline@2.0.0-rc.8) (2018-09-14)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.7"></a>
 
-# [2.0.0-rc.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.6...gatsby-plugin-offline@2.0.0-rc.7) (2018-09-12)
+# [2.0.0-rc.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.6...gatsby-plugin-offline@2.0.0-rc.7) (2018-09-12)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.5...gatsby-plugin-offline@2.0.0-rc.6) (2018-09-08)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.5...gatsby-plugin-offline@2.0.0-rc.6) (2018-09-08)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.4...gatsby-plugin-offline@2.0.0-rc.5) (2018-09-07)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.4...gatsby-plugin-offline@2.0.0-rc.5) (2018-09-07)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.3...gatsby-plugin-offline@2.0.0-rc.4) (2018-09-05)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.3...gatsby-plugin-offline@2.0.0-rc.4) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.2...gatsby-plugin-offline@2.0.0-rc.3) (2018-09-05)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.2...gatsby-plugin-offline@2.0.0-rc.3) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.1...gatsby-plugin-offline@2.0.0-rc.2) (2018-08-31)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.1...gatsby-plugin-offline@2.0.0-rc.2) (2018-08-31)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-rc.0...gatsby-plugin-offline@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-rc.0...gatsby-plugin-offline@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.10...gatsby-plugin-offline@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.10...gatsby-plugin-offline@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.10"></a>
 
-# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.9...gatsby-plugin-offline@2.0.0-beta.10) (2018-08-21)
+# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.9...gatsby-plugin-offline@2.0.0-beta.10) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.8...gatsby-plugin-offline@2.0.0-beta.9) (2018-08-07)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.8...gatsby-plugin-offline@2.0.0-beta.9) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.7...gatsby-plugin-offline@2.0.0-beta.8) (2018-08-07)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.7...gatsby-plugin-offline@2.0.0-beta.8) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.6...gatsby-plugin-offline@2.0.0-beta.7) (2018-08-07)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.6...gatsby-plugin-offline@2.0.0-beta.7) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.5...gatsby-plugin-offline@2.0.0-beta.6) (2018-08-02)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.5...gatsby-plugin-offline@2.0.0-beta.6) (2018-08-02)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.4...gatsby-plugin-offline@2.0.0-beta.5) (2018-07-24)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.4...gatsby-plugin-offline@2.0.0-beta.5) (2018-07-24)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.3...gatsby-plugin-offline@2.0.0-beta.4) (2018-07-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.3...gatsby-plugin-offline@2.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.2...gatsby-plugin-offline@2.0.0-beta.3) (2018-07-06)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.2...gatsby-plugin-offline@2.0.0-beta.3) (2018-07-06)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.1...gatsby-plugin-offline@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.1...gatsby-plugin-offline@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@2.0.0-beta.0...gatsby-plugin-offline@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@2.0.0-beta.0...gatsby-plugin-offline@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-offline
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline/compare/gatsby-plugin-offline@1.0.18...gatsby-plugin-offline@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-offline@1.0.18...gatsby-plugin-offline@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-offline

--- a/packages/gatsby-plugin-page-creator/CHANGELOG.md
+++ b/packages/gatsby-plugin-page-creator/CHANGELOG.md
@@ -7,41 +7,41 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-page-creator
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.1.1...gatsby-plugin-page-creator@2.1.2) (2019-07-01)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.1.1...gatsby-plugin-page-creator@2.1.2) (2019-07-01)
 
 **Note:** Version bump only for package gatsby-plugin-page-creator
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.1.0...gatsby-plugin-page-creator@2.1.1) (2019-06-24)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.1.0...gatsby-plugin-page-creator@2.1.1) (2019-06-24)
 
 ### Features
 
-- **gatsby-page-utils:** extract logic for watching a directory from gatsby-page-creator so can reuse for custom page creation ([#14051](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/issues/14051)) ([68d9d6f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/commit/68d9d6f))
+- **gatsby-page-utils:** extract logic for watching a directory from gatsby-page-creator so can reuse for custom page creation ([#14051](https://github.com/gatsbyjs/gatsby/issues/14051)) ([68d9d6f](https://github.com/gatsbyjs/gatsby/commit/68d9d6f))
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.0.13...gatsby-plugin-page-creator@2.1.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-plugin-page-creator
-
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.0.12...gatsby-plugin-page-creator@2.0.13) (2019-05-14)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.0.13...gatsby-plugin-page-creator@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-page-creator
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.0.11...gatsby-plugin-page-creator@2.0.12) (2019-03-26)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.0.12...gatsby-plugin-page-creator@2.0.13) (2019-05-14)
+
+**Note:** Version bump only for package gatsby-plugin-page-creator
+
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.0.11...gatsby-plugin-page-creator@2.0.12) (2019-03-26)
 
 ### Features
 
-- **gatsby-plugin-page-creator:** add ignore support via plugin options, fix test file ignores on Windows ([#11304](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/issues/11304)) ([9fdc223](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/commit/9fdc223)), closes [/github.com/gatsbyjs/gatsby/blob/026d2a956296cb01936bcf45d2be1066dd844d00/packages/gatsby-plugin-page-creator/src/gatsby-node.js#L51-L66](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/issues/L51-L66) [/github.com/gatsbyjs/gatsby/blob/026d2a956296cb01936bcf45d2be1066dd844d00/packages/gatsby-plugin-page-creator/src/validate-path.js#L11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/issues/L11) [#11168](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/issues/11168)
+- **gatsby-plugin-page-creator:** add ignore support via plugin options, fix test file ignores on Windows ([#11304](https://github.com/gatsbyjs/gatsby/issues/11304)) ([9fdc223](https://github.com/gatsbyjs/gatsby/commit/9fdc223)), closes [/github.com/gatsbyjs/gatsby/blob/026d2a956296cb01936bcf45d2be1066dd844d00/packages/gatsby-plugin-page-creator/src/gatsby-node.js#L51-L66](https://github.com/gatsbyjs/gatsby/issues/L51-L66) [/github.com/gatsbyjs/gatsby/blob/026d2a956296cb01936bcf45d2be1066dd844d00/packages/gatsby-plugin-page-creator/src/validate-path.js#L11](https://github.com/gatsbyjs/gatsby/issues/L11) [#11168](https://github.com/gatsbyjs/gatsby/issues/11168)
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.0.10...gatsby-plugin-page-creator@2.0.11) (2019-03-22)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.0.10...gatsby-plugin-page-creator@2.0.11) (2019-03-22)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** pin chokidar@2.1.2 to fix unix issues ([#12759](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/issues/12759)) ([0ea1505](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/commit/0ea1505))
+- **gatsby-source-filesystem:** pin chokidar@2.1.2 to fix unix issues ([#12759](https://github.com/gatsbyjs/gatsby/issues/12759)) ([0ea1505](https://github.com/gatsbyjs/gatsby/commit/0ea1505))
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.0.9...gatsby-plugin-page-creator@2.0.10) (2019-03-11)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.0.9...gatsby-plugin-page-creator@2.0.10) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-page-creator
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator/compare/gatsby-plugin-page-creator@2.0.8...gatsby-plugin-page-creator@2.0.9) (2019-03-05)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-page-creator@2.0.8...gatsby-plugin-page-creator@2.0.9) (2019-03-05)
 
 **Note:** Version bump only for package gatsby-plugin-page-creator
 

--- a/packages/gatsby-plugin-postcss/CHANGELOG.md
+++ b/packages/gatsby-plugin-postcss/CHANGELOG.md
@@ -7,85 +7,85 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.7...gatsby-plugin-postcss@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.7...gatsby-plugin-postcss@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.6...gatsby-plugin-postcss@2.0.7) (2019-03-15)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.6...gatsby-plugin-postcss@2.0.7) (2019-03-15)
 
 ### Features
 
-- **gatsby-plugin-postcss:** added css-loader options ([#10861](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/issues/10861)) ([88b3158](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/commit/88b3158))
+- **gatsby-plugin-postcss:** added css-loader options ([#10861](https://github.com/gatsbyjs/gatsby/issues/10861)) ([88b3158](https://github.com/gatsbyjs/gatsby/commit/88b3158))
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.5...gatsby-plugin-postcss@2.0.6) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-postcss
-
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.4...gatsby-plugin-postcss@2.0.5) (2019-02-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.5...gatsby-plugin-postcss@2.0.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.3...gatsby-plugin-postcss@2.0.4) (2019-02-01)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.4...gatsby-plugin-postcss@2.0.5) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-plugin-postcss
+
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.3...gatsby-plugin-postcss@2.0.4) (2019-02-01)
 
 ### Bug Fixes
 
-- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/commit/97c98e9))
+- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/commit/97c98e9))
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.2...gatsby-plugin-postcss@2.0.3) (2019-01-28)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.2...gatsby-plugin-postcss@2.0.3) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.1...gatsby-plugin-postcss@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.1...gatsby-plugin-postcss@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0...gatsby-plugin-postcss@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0...gatsby-plugin-postcss@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0-rc.5...gatsby-plugin-postcss@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0-rc.5...gatsby-plugin-postcss@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0-rc.3...gatsby-plugin-postcss@2.0.0-rc.5) (2018-09-17)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0-rc.3...gatsby-plugin-postcss@2.0.0-rc.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0-rc.2...gatsby-plugin-postcss@2.0.0-rc.3) (2018-09-17)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0-rc.2...gatsby-plugin-postcss@2.0.0-rc.3) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0-rc.1...gatsby-plugin-postcss@2.0.0-rc.2) (2018-09-07)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0-rc.1...gatsby-plugin-postcss@2.0.0-rc.2) (2018-09-07)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0-rc.0...gatsby-plugin-postcss@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0-rc.0...gatsby-plugin-postcss@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0-beta.3...gatsby-plugin-postcss@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0-beta.3...gatsby-plugin-postcss@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss/compare/gatsby-plugin-postcss@2.0.0-beta.2...gatsby-plugin-postcss@2.0.0-beta.3) (2018-08-10)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-postcss@2.0.0-beta.2...gatsby-plugin-postcss@2.0.0-beta.3) (2018-08-10)
 
 **Note:** Version bump only for package gatsby-plugin-postcss
 

--- a/packages/gatsby-plugin-preact/CHANGELOG.md
+++ b/packages/gatsby-plugin-preact/CHANGELOG.md
@@ -7,92 +7,92 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
-## [3.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@3.1.1...gatsby-plugin-preact@3.1.2) (2019-06-27)
+## [3.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@3.1.1...gatsby-plugin-preact@3.1.2) (2019-06-27)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
-## [3.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@3.1.0...gatsby-plugin-preact@3.1.1) (2019-06-24)
+## [3.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@3.1.0...gatsby-plugin-preact@3.1.1) (2019-06-24)
 
 ### Bug Fixes
 
-- **gatsby-plugin-preact:** Make preact/compat server render HTML ([#15013](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/issues/15013)) ([36ef955](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/commit/36ef955))
+- **gatsby-plugin-preact:** Make preact/compat server render HTML ([#15013](https://github.com/gatsbyjs/gatsby/issues/15013)) ([36ef955](https://github.com/gatsbyjs/gatsby/commit/36ef955))
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@3.0.0...gatsby-plugin-preact@3.1.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-plugin-preact
-
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.11...gatsby-plugin-preact@3.0.0) (2019-05-17)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@3.0.0...gatsby-plugin-preact@3.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.10...gatsby-plugin-preact@2.0.11) (2019-03-11)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.11...gatsby-plugin-preact@3.0.0) (2019-05-17)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.9...gatsby-plugin-preact@2.0.10) (2019-03-05)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.10...gatsby-plugin-preact@2.0.11) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.8...gatsby-plugin-preact@2.0.9) (2019-02-01)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.9...gatsby-plugin-preact@2.0.10) (2019-03-05)
+
+**Note:** Version bump only for package gatsby-plugin-preact
+
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.8...gatsby-plugin-preact@2.0.9) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.7...gatsby-plugin-preact@2.0.8) (2018-11-29)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.7...gatsby-plugin-preact@2.0.8) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.6...gatsby-plugin-preact@2.0.7) (2018-10-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.6...gatsby-plugin-preact@2.0.7) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.5...gatsby-plugin-preact@2.0.6) (2018-10-12)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.5...gatsby-plugin-preact@2.0.6) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.0-rc.1...gatsby-plugin-preact@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.0-rc.1...gatsby-plugin-preact@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.0-rc.0...gatsby-plugin-preact@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.0-rc.0...gatsby-plugin-preact@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.0-beta.3...gatsby-plugin-preact@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.0-beta.3...gatsby-plugin-preact@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.0-beta.2...gatsby-plugin-preact@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.0-beta.2...gatsby-plugin-preact@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.0-beta.1...gatsby-plugin-preact@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.0-beta.1...gatsby-plugin-preact@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@2.0.0-beta.0...gatsby-plugin-preact@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@2.0.0-beta.0...gatsby-plugin-preact@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-preact
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact/compare/gatsby-plugin-preact@1.0.17...gatsby-plugin-preact@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-preact@1.0.17...gatsby-plugin-preact@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-preact

--- a/packages/gatsby-plugin-react-css-modules/CHANGELOG.md
+++ b/packages/gatsby-plugin-react-css-modules/CHANGELOG.md
@@ -7,134 +7,134 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.9...gatsby-plugin-react-css-modules@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.9...gatsby-plugin-react-css-modules@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.8...gatsby-plugin-react-css-modules@2.0.9) (2019-03-15)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.8...gatsby-plugin-react-css-modules@2.0.9) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.7...gatsby-plugin-react-css-modules@2.0.8) (2019-03-11)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.7...gatsby-plugin-react-css-modules@2.0.8) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.6...gatsby-plugin-react-css-modules@2.0.7) (2019-02-04)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.6...gatsby-plugin-react-css-modules@2.0.7) (2019-02-04)
 
 ### Bug Fixes
 
-- **gatsby-plugin-react-css-modules:** fix generateScopedName in production ([#11483](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/issues/11483)) ([1d9f02f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/commit/1d9f02f))
+- **gatsby-plugin-react-css-modules:** fix generateScopedName in production ([#11483](https://github.com/gatsbyjs/gatsby/issues/11483)) ([1d9f02f](https://github.com/gatsbyjs/gatsby/commit/1d9f02f))
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.5...gatsby-plugin-react-css-modules@2.0.6) (2019-02-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.5...gatsby-plugin-react-css-modules@2.0.6) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.4...gatsby-plugin-react-css-modules@2.0.5) (2019-01-23)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.4...gatsby-plugin-react-css-modules@2.0.5) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.3...gatsby-plugin-react-css-modules@2.0.4) (2018-11-29)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.3...gatsby-plugin-react-css-modules@2.0.4) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.2...gatsby-plugin-react-css-modules@2.0.3) (2018-10-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.2...gatsby-plugin-react-css-modules@2.0.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.1...gatsby-plugin-react-css-modules@2.0.2) (2018-10-12)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.1...gatsby-plugin-react-css-modules@2.0.2) (2018-10-12)
 
 ### Bug Fixes
 
-- fix "additionalProperties" error with gatsby-plugin-react-css-modules ([#8994](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/issues/8994)) ([688e112](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/commit/688e112))
+- fix "additionalProperties" error with gatsby-plugin-react-css-modules ([#8994](https://github.com/gatsbyjs/gatsby/issues/8994)) ([688e112](https://github.com/gatsbyjs/gatsby/commit/688e112))
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0...gatsby-plugin-react-css-modules@2.0.1) (2018-09-26)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0...gatsby-plugin-react-css-modules@2.0.1) (2018-09-26)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-rc.5...gatsby-plugin-react-css-modules@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-rc.5...gatsby-plugin-react-css-modules@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-rc.4...gatsby-plugin-react-css-modules@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-rc.4...gatsby-plugin-react-css-modules@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-rc.3...gatsby-plugin-react-css-modules@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-rc.3...gatsby-plugin-react-css-modules@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-rc.2...gatsby-plugin-react-css-modules@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-rc.2...gatsby-plugin-react-css-modules@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-rc.1...gatsby-plugin-react-css-modules@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-rc.1...gatsby-plugin-react-css-modules@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-rc.0...gatsby-plugin-react-css-modules@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-rc.0...gatsby-plugin-react-css-modules@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-beta.5...gatsby-plugin-react-css-modules@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-beta.5...gatsby-plugin-react-css-modules@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-beta.4...gatsby-plugin-react-css-modules@2.0.0-beta.5) (2018-08-03)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-beta.4...gatsby-plugin-react-css-modules@2.0.0-beta.5) (2018-08-03)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-beta.3...gatsby-plugin-react-css-modules@2.0.0-beta.4) (2018-07-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-beta.3...gatsby-plugin-react-css-modules@2.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-beta.2...gatsby-plugin-react-css-modules@2.0.0-beta.3) (2018-06-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-beta.2...gatsby-plugin-react-css-modules@2.0.0-beta.3) (2018-06-21)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-beta.1...gatsby-plugin-react-css-modules@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-beta.1...gatsby-plugin-react-css-modules@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@2.0.0-beta.0...gatsby-plugin-react-css-modules@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@2.0.0-beta.0...gatsby-plugin-react-css-modules@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules/compare/gatsby-plugin-react-css-modules@1.0.15...gatsby-plugin-react-css-modules@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-css-modules@1.0.15...gatsby-plugin-react-css-modules@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-react-css-modules

--- a/packages/gatsby-plugin-react-helmet/CHANGELOG.md
+++ b/packages/gatsby-plugin-react-helmet/CHANGELOG.md
@@ -7,112 +7,112 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.12...gatsby-plugin-react-helmet@3.1.0) (2019-06-20)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.12...gatsby-plugin-react-helmet@3.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-## [3.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.11...gatsby-plugin-react-helmet@3.0.12) (2019-04-04)
+## [3.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.11...gatsby-plugin-react-helmet@3.0.12) (2019-04-04)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-## [3.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.10...gatsby-plugin-react-helmet@3.0.11) (2019-03-25)
+## [3.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.10...gatsby-plugin-react-helmet@3.0.11) (2019-03-25)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-## [3.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.9...gatsby-plugin-react-helmet@3.0.10) (2019-03-16)
+## [3.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.9...gatsby-plugin-react-helmet@3.0.10) (2019-03-16)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-## [3.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.8...gatsby-plugin-react-helmet@3.0.9) (2019-03-11)
+## [3.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.8...gatsby-plugin-react-helmet@3.0.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-## [3.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.7...gatsby-plugin-react-helmet@3.0.8) (2019-03-05)
+## [3.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.7...gatsby-plugin-react-helmet@3.0.8) (2019-03-05)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-## [3.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.6...gatsby-plugin-react-helmet@3.0.7) (2019-02-25)
+## [3.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.6...gatsby-plugin-react-helmet@3.0.7) (2019-02-25)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
-## [3.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.5...gatsby-plugin-react-helmet@3.0.6) (2019-02-01)
+## [3.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.5...gatsby-plugin-react-helmet@3.0.6) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.5"></a>
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.4...gatsby-plugin-react-helmet@3.0.5) (2018-12-21)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.4...gatsby-plugin-react-helmet@3.0.5) (2018-12-21)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.4"></a>
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.3...gatsby-plugin-react-helmet@3.0.4) (2018-12-01)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.3...gatsby-plugin-react-helmet@3.0.4) (2018-12-01)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.2...gatsby-plugin-react-helmet@3.0.3) (2018-11-29)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.2...gatsby-plugin-react-helmet@3.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.1...gatsby-plugin-react-helmet@3.0.2) (2018-11-12)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.1...gatsby-plugin-react-helmet@3.0.2) (2018-11-12)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0...gatsby-plugin-react-helmet@3.0.1) (2018-10-29)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0...gatsby-plugin-react-helmet@3.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0-rc.1...gatsby-plugin-react-helmet@3.0.0) (2018-09-17)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0-rc.1...gatsby-plugin-react-helmet@3.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0-rc.1"></a>
 
-# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0-rc.0...gatsby-plugin-react-helmet@3.0.0-rc.1) (2018-08-29)
+# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0-rc.0...gatsby-plugin-react-helmet@3.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0-rc.0"></a>
 
-# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0-beta.4...gatsby-plugin-react-helmet@3.0.0-rc.0) (2018-08-21)
+# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0-beta.4...gatsby-plugin-react-helmet@3.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0-beta.4"></a>
 
-# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0-beta.3...gatsby-plugin-react-helmet@3.0.0-beta.4) (2018-07-21)
+# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0-beta.3...gatsby-plugin-react-helmet@3.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0-beta.3"></a>
 
-# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0-beta.2...gatsby-plugin-react-helmet@3.0.0-beta.3) (2018-06-27)
+# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0-beta.2...gatsby-plugin-react-helmet@3.0.0-beta.3) (2018-06-27)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0-beta.2"></a>
 
-# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0-beta.1...gatsby-plugin-react-helmet@3.0.0-beta.2) (2018-06-20)
+# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0-beta.1...gatsby-plugin-react-helmet@3.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0-beta.1"></a>
 
-# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@3.0.0-beta.0...gatsby-plugin-react-helmet@3.0.0-beta.1) (2018-06-17)
+# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@3.0.0-beta.0...gatsby-plugin-react-helmet@3.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet
 
 <a name="3.0.0-beta.0"></a>
 
-# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet/compare/gatsby-plugin-react-helmet@2.0.11...gatsby-plugin-react-helmet@3.0.0-beta.0) (2018-06-17)
+# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-react-helmet@2.0.11...gatsby-plugin-react-helmet@3.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-react-helmet

--- a/packages/gatsby-plugin-remove-trailing-slashes/CHANGELOG.md
+++ b/packages/gatsby-plugin-remove-trailing-slashes/CHANGELOG.md
@@ -7,104 +7,104 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.11...gatsby-plugin-remove-trailing-slashes@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.11...gatsby-plugin-remove-trailing-slashes@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.10...gatsby-plugin-remove-trailing-slashes@2.0.11) (2019-04-23)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.10...gatsby-plugin-remove-trailing-slashes@2.0.11) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.9...gatsby-plugin-remove-trailing-slashes@2.0.10) (2019-03-11)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.9...gatsby-plugin-remove-trailing-slashes@2.0.10) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.8...gatsby-plugin-remove-trailing-slashes@2.0.9) (2019-02-28)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.8...gatsby-plugin-remove-trailing-slashes@2.0.9) (2019-02-28)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.7...gatsby-plugin-remove-trailing-slashes@2.0.8) (2019-02-25)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.7...gatsby-plugin-remove-trailing-slashes@2.0.8) (2019-02-25)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.6...gatsby-plugin-remove-trailing-slashes@2.0.7) (2019-02-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.6...gatsby-plugin-remove-trailing-slashes@2.0.7) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.5...gatsby-plugin-remove-trailing-slashes@2.0.6) (2018-11-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.5...gatsby-plugin-remove-trailing-slashes@2.0.6) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.4...gatsby-plugin-remove-trailing-slashes@2.0.5) (2018-11-08)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.4...gatsby-plugin-remove-trailing-slashes@2.0.5) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.3...gatsby-plugin-remove-trailing-slashes@2.0.4) (2018-10-29)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.3...gatsby-plugin-remove-trailing-slashes@2.0.4) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.2...gatsby-plugin-remove-trailing-slashes@2.0.3) (2018-10-03)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.2...gatsby-plugin-remove-trailing-slashes@2.0.3) (2018-10-03)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.1...gatsby-plugin-remove-trailing-slashes@2.0.2) (2018-10-01)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.1...gatsby-plugin-remove-trailing-slashes@2.0.2) (2018-10-01)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-rc.1...gatsby-plugin-remove-trailing-slashes@2.0.1) (2018-10-01)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-rc.1...gatsby-plugin-remove-trailing-slashes@2.0.1) (2018-10-01)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-rc.1...gatsby-plugin-remove-trailing-slashes@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-rc.1...gatsby-plugin-remove-trailing-slashes@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-rc.0...gatsby-plugin-remove-trailing-slashes@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-rc.0...gatsby-plugin-remove-trailing-slashes@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.3...gatsby-plugin-remove-trailing-slashes@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.3...gatsby-plugin-remove-trailing-slashes@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.2...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.2...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.1...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.1...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.0...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@2.0.0-beta.0...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes/compare/gatsby-plugin-remove-trailing-slashes@1.0.9...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-remove-trailing-slashes@1.0.9...gatsby-plugin-remove-trailing-slashes@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-remove-trailing-slashes

--- a/packages/gatsby-plugin-sass/CHANGELOG.md
+++ b/packages/gatsby-plugin-sass/CHANGELOG.md
@@ -7,164 +7,164 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.13...gatsby-plugin-sass@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.13...gatsby-plugin-sass@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.11...gatsby-plugin-sass@2.0.13) (2019-06-19)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.11...gatsby-plugin-sass@2.0.13) (2019-06-19)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.11...gatsby-plugin-sass@2.0.12) (2019-06-19)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.11...gatsby-plugin-sass@2.0.12) (2019-06-19)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.10...gatsby-plugin-sass@2.0.11) (2019-03-11)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.10...gatsby-plugin-sass@2.0.11) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.9...gatsby-plugin-sass@2.0.10) (2019-02-01)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.9...gatsby-plugin-sass@2.0.10) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.8...gatsby-plugin-sass@2.0.9) (2019-02-01)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.8...gatsby-plugin-sass@2.0.9) (2019-02-01)
 
 ### Bug Fixes
 
-- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/commit/97c98e9))
+- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/commit/97c98e9))
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.7...gatsby-plugin-sass@2.0.8) (2019-01-28)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.7...gatsby-plugin-sass@2.0.8) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.6...gatsby-plugin-sass@2.0.7) (2018-12-06)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.6...gatsby-plugin-sass@2.0.7) (2018-12-06)
 
 ### Features
 
-- **gatsby-plugin-sass:** Support Dart SASS ([#10159](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/issues/10159)) ([a48843e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/commit/a48843e))
+- **gatsby-plugin-sass:** Support Dart SASS ([#10159](https://github.com/gatsbyjs/gatsby/issues/10159)) ([a48843e](https://github.com/gatsbyjs/gatsby/commit/a48843e))
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.5...gatsby-plugin-sass@2.0.6) (2018-12-05)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.5...gatsby-plugin-sass@2.0.6) (2018-12-05)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.4...gatsby-plugin-sass@2.0.5) (2018-11-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.4...gatsby-plugin-sass@2.0.5) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.3...gatsby-plugin-sass@2.0.4) (2018-11-08)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.3...gatsby-plugin-sass@2.0.4) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.2...gatsby-plugin-sass@2.0.3) (2018-11-01)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.2...gatsby-plugin-sass@2.0.3) (2018-11-01)
 
 ### Features
 
-- **gatsby-plugin-sass:** Accept css-loader options ([#9462](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/issues/9462)) ([a55bc13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/commit/a55bc13))
+- **gatsby-plugin-sass:** Accept css-loader options ([#9462](https://github.com/gatsbyjs/gatsby/issues/9462)) ([a55bc13](https://github.com/gatsbyjs/gatsby/commit/a55bc13))
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.1...gatsby-plugin-sass@2.0.2) (2018-10-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.1...gatsby-plugin-sass@2.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-rc.3...gatsby-plugin-sass@2.0.1) (2018-09-17)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-rc.3...gatsby-plugin-sass@2.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-rc.2...gatsby-plugin-sass@2.0.0-rc.3) (2018-09-17)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-rc.2...gatsby-plugin-sass@2.0.0-rc.3) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-rc.1...gatsby-plugin-sass@2.0.0-rc.2) (2018-09-04)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-rc.1...gatsby-plugin-sass@2.0.0-rc.2) (2018-09-04)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-rc.0...gatsby-plugin-sass@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-rc.0...gatsby-plugin-sass@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.10...gatsby-plugin-sass@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.10...gatsby-plugin-sass@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.10"></a>
 
-# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.9...gatsby-plugin-sass@2.0.0-beta.10) (2018-08-08)
+# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.9...gatsby-plugin-sass@2.0.0-beta.10) (2018-08-08)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.7...gatsby-plugin-sass@2.0.0-beta.9) (2018-08-07)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.7...gatsby-plugin-sass@2.0.0-beta.9) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.6...gatsby-plugin-sass@2.0.0-beta.7) (2018-08-07)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.6...gatsby-plugin-sass@2.0.0-beta.7) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.5...gatsby-plugin-sass@2.0.0-beta.6) (2018-07-21)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.5...gatsby-plugin-sass@2.0.0-beta.6) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.4...gatsby-plugin-sass@2.0.0-beta.5) (2018-07-10)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.4...gatsby-plugin-sass@2.0.0-beta.5) (2018-07-10)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.3...gatsby-plugin-sass@2.0.0-beta.4) (2018-07-09)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.3...gatsby-plugin-sass@2.0.0-beta.4) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.2...gatsby-plugin-sass@2.0.0-beta.3) (2018-06-27)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.2...gatsby-plugin-sass@2.0.0-beta.3) (2018-06-27)
 
 ### Bug Fixes
 
-- use the language loader for imports not postcss ([#6173](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/issues/6173)) ([7190fe1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/commit/7190fe1))
+- use the language loader for imports not postcss ([#6173](https://github.com/gatsbyjs/gatsby/issues/6173)) ([7190fe1](https://github.com/gatsbyjs/gatsby/commit/7190fe1))
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.1...gatsby-plugin-sass@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.1...gatsby-plugin-sass@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@2.0.0-beta.0...gatsby-plugin-sass@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@2.0.0-beta.0...gatsby-plugin-sass@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-sass
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass/compare/gatsby-plugin-sass@1.0.26...gatsby-plugin-sass@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sass@1.0.26...gatsby-plugin-sass@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-sass

--- a/packages/gatsby-plugin-sharp/CHANGELOG.md
+++ b/packages/gatsby-plugin-sharp/CHANGELOG.md
@@ -7,387 +7,387 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-## [2.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.2.2...gatsby-plugin-sharp@2.2.3) (2019-07-06)
+## [2.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.2.2...gatsby-plugin-sharp@2.2.3) (2019-07-06)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** sort nested options ([#15459](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/15459)) ([6ea8c29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/6ea8c29))
+- **gatsby-plugin-sharp:** sort nested options ([#15459](https://github.com/gatsbyjs/gatsby/issues/15459)) ([6ea8c29](https://github.com/gatsbyjs/gatsby/commit/6ea8c29))
 
-## [2.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.2.1...gatsby-plugin-sharp@2.2.2) (2019-07-02)
+## [2.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.2.1...gatsby-plugin-sharp@2.2.2) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.2.0...gatsby-plugin-sharp@2.2.1) (2019-06-21)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.2.0...gatsby-plugin-sharp@2.2.1) (2019-06-21)
 
 ### Features
 
-- **gatsby-image:** Add art direction ([#13395](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/13395)) ([02edcdc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/02edcdc))
+- **gatsby-image:** Add art direction ([#13395](https://github.com/gatsbyjs/gatsby/issues/13395)) ([02edcdc](https://github.com/gatsbyjs/gatsby/commit/02edcdc))
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.9...gatsby-plugin-sharp@2.2.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-plugin-sharp
-
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.6...gatsby-plugin-sharp@2.1.9) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/2594623))
-
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.7...gatsby-plugin-sharp@2.1.8) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/2594623))
-
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.6...gatsby-plugin-sharp@2.1.7) (2019-06-18)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.9...gatsby-plugin-sharp@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.5...gatsby-plugin-sharp@2.1.6) (2019-06-18)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.6...gatsby-plugin-sharp@2.1.9) (2019-06-19)
+
+### Bug Fixes
+
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
+
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.7...gatsby-plugin-sharp@2.1.8) (2019-06-19)
+
+### Bug Fixes
+
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
+
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.6...gatsby-plugin-sharp@2.1.7) (2019-06-18)
+
+**Note:** Version bump only for package gatsby-plugin-sharp
+
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.5...gatsby-plugin-sharp@2.1.6) (2019-06-18)
 
 ### Features
 
-- **gatsby-cli:** move progressbar into ink ([#14220](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14220)) ([967597c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/967597c))
+- **gatsby-cli:** move progressbar into ink ([#14220](https://github.com/gatsbyjs/gatsby/issues/14220)) ([967597c](https://github.com/gatsbyjs/gatsby/commit/967597c))
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.3...gatsby-plugin-sharp@2.1.5) (2019-06-12)
-
-### Bug Fixes
-
-- **gatsby-plugin-sharp:** create job before async-queue processing ([#14731](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14731)) ([f566210](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/f566210))
-
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.3...gatsby-plugin-sharp@2.1.4) (2019-06-12)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.3...gatsby-plugin-sharp@2.1.5) (2019-06-12)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** create job before async-queue processing ([#14731](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14731)) ([f566210](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/f566210))
+- **gatsby-plugin-sharp:** create job before async-queue processing ([#14731](https://github.com/gatsbyjs/gatsby/issues/14731)) ([f566210](https://github.com/gatsbyjs/gatsby/commit/f566210))
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.2...gatsby-plugin-sharp@2.1.3) (2019-05-31)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.3...gatsby-plugin-sharp@2.1.4) (2019-06-12)
+
+### Bug Fixes
+
+- **gatsby-plugin-sharp:** create job before async-queue processing ([#14731](https://github.com/gatsbyjs/gatsby/issues/14731)) ([f566210](https://github.com/gatsbyjs/gatsby/commit/f566210))
+
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.2...gatsby-plugin-sharp@2.1.3) (2019-05-31)
 
 ### Features
 
-- **image-sharp:** add trim option ([#14137](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14137)) ([cf0e77b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/cf0e77b))
+- **image-sharp:** add trim option ([#14137](https://github.com/gatsbyjs/gatsby/issues/14137)) ([cf0e77b](https://github.com/gatsbyjs/gatsby/commit/cf0e77b))
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.1...gatsby-plugin-sharp@2.1.2) (2019-05-29)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.1...gatsby-plugin-sharp@2.1.2) (2019-05-29)
 
 ### Bug Fixes
 
-- cache tracedSVG calculations when cache is present ([#12044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/12044)) ([c40bc4b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/c40bc4b))
-- **gatsby-plugin-sharp:** Image rotation ([#14302](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14302)) ([5e4bf34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/5e4bf34))
+- cache tracedSVG calculations when cache is present ([#12044](https://github.com/gatsbyjs/gatsby/issues/12044)) ([c40bc4b](https://github.com/gatsbyjs/gatsby/commit/c40bc4b))
+- **gatsby-plugin-sharp:** Image rotation ([#14302](https://github.com/gatsbyjs/gatsby/issues/14302)) ([5e4bf34](https://github.com/gatsbyjs/gatsby/commit/5e4bf34))
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.1.0...gatsby-plugin-sharp@2.1.1) (2019-05-24)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.1.0...gatsby-plugin-sharp@2.1.1) (2019-05-24)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.37...gatsby-plugin-sharp@2.1.0) (2019-05-23)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.37...gatsby-plugin-sharp@2.1.0) (2019-05-23)
 
 ### Features
 
-- **gatsby-plugin-sharp:** remove 3x DPi resolutions ([#14201](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/14201)) ([d821f0e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/d821f0e))
+- **gatsby-plugin-sharp:** remove 3x DPi resolutions ([#14201](https://github.com/gatsbyjs/gatsby/issues/14201)) ([d821f0e](https://github.com/gatsbyjs/gatsby/commit/d821f0e))
 
-## [2.0.37](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.36...gatsby-plugin-sharp@2.0.37) (2019-05-09)
+## [2.0.37](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.36...gatsby-plugin-sharp@2.0.37) (2019-05-09)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** ignore sizeByPixelDensity option and add deprecation warning ([#13852](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/13852)) ([4131a09](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/4131a09)), closes [#12743](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/12743)
+- **gatsby-plugin-sharp:** ignore sizeByPixelDensity option and add deprecation warning ([#13852](https://github.com/gatsbyjs/gatsby/issues/13852)) ([4131a09](https://github.com/gatsbyjs/gatsby/commit/4131a09)), closes [#12743](https://github.com/gatsbyjs/gatsby/issues/12743)
 
-## [2.0.36](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.35...gatsby-plugin-sharp@2.0.36) (2019-05-03)
+## [2.0.36](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.35...gatsby-plugin-sharp@2.0.36) (2019-05-03)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-## [2.0.35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.34...gatsby-plugin-sharp@2.0.35) (2019-04-17)
+## [2.0.35](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.34...gatsby-plugin-sharp@2.0.35) (2019-04-17)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** tracedSVG for `fluid` images should respect forced aspect ratio ([#9337](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9337)) ([2fed2c7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/2fed2c7)), closes [#9204](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9204)
+- **gatsby-plugin-sharp:** tracedSVG for `fluid` images should respect forced aspect ratio ([#9337](https://github.com/gatsbyjs/gatsby/issues/9337)) ([2fed2c7](https://github.com/gatsbyjs/gatsby/commit/2fed2c7)), closes [#9204](https://github.com/gatsbyjs/gatsby/issues/9204)
 
-## [2.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.33...gatsby-plugin-sharp@2.0.34) (2019-04-11)
+## [2.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.33...gatsby-plugin-sharp@2.0.34) (2019-04-11)
 
 ### Features
 
-- add options fit and background to image sharp ([#13078](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/13078)) ([494ad07](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/494ad07)), closes [#12972](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/12972)
+- add options fit and background to image sharp ([#13078](https://github.com/gatsbyjs/gatsby/issues/13078)) ([494ad07](https://github.com/gatsbyjs/gatsby/commit/494ad07)), closes [#12972](https://github.com/gatsbyjs/gatsby/issues/12972)
 
-## [2.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.32...gatsby-plugin-sharp@2.0.33) (2019-04-09)
-
-### Bug Fixes
-
-- **gatsby-plugin-sharp:** don't write to same temporary time multiple times at a same time ([#12927](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/12927)) ([5e254e2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/5e254e2)), closes [#8301](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/8301)
-
-## [2.0.32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.31...gatsby-plugin-sharp@2.0.32) (2019-03-27)
+## [2.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.32...gatsby-plugin-sharp@2.0.33) (2019-04-09)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** strip non related args when hashing resizing args ([#12129](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/12129)) ([da0b622](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/da0b622))
+- **gatsby-plugin-sharp:** don't write to same temporary time multiple times at a same time ([#12927](https://github.com/gatsbyjs/gatsby/issues/12927)) ([5e254e2](https://github.com/gatsbyjs/gatsby/commit/5e254e2)), closes [#8301](https://github.com/gatsbyjs/gatsby/issues/8301)
 
-## [2.0.31](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.30...gatsby-plugin-sharp@2.0.31) (2019-03-25)
-
-**Note:** Version bump only for package gatsby-plugin-sharp
-
-## [2.0.30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.29...gatsby-plugin-sharp@2.0.30) (2019-03-20)
+## [2.0.32](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.31...gatsby-plugin-sharp@2.0.32) (2019-03-27)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** bail early if sharp isn't working ([#10677](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/10677)) ([2104a9f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/2104a9f))
+- **gatsby-plugin-sharp:** strip non related args when hashing resizing args ([#12129](https://github.com/gatsbyjs/gatsby/issues/12129)) ([da0b622](https://github.com/gatsbyjs/gatsby/commit/da0b622))
 
-## [2.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.28...gatsby-plugin-sharp@2.0.29) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-plugin-sharp
-
-## [2.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.27...gatsby-plugin-sharp@2.0.28) (2019-03-12)
-
-### Features
-
-- **gatsby-image:** Placeholder Improvements ([#10944](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/10944)) ([44491ef](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/44491ef))
-
-## [2.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.26...gatsby-plugin-sharp@2.0.27) (2019-03-11)
+## [2.0.31](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.30...gatsby-plugin-sharp@2.0.31) (2019-03-25)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-## [2.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.25...gatsby-plugin-sharp@2.0.26) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-sharp
-
-## [2.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.24...gatsby-plugin-sharp@2.0.25) (2019-03-05)
+## [2.0.30](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.29...gatsby-plugin-sharp@2.0.30) (2019-03-20)
 
 ### Bug Fixes
 
-- don't crash if cpu-core-count is not available ([#12332](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/12332)) ([412217d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/412217d))
+- **gatsby-plugin-sharp:** bail early if sharp isn't working ([#10677](https://github.com/gatsbyjs/gatsby/issues/10677)) ([2104a9f](https://github.com/gatsbyjs/gatsby/commit/2104a9f))
 
-## [2.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.23...gatsby-plugin-sharp@2.0.24) (2019-03-04)
-
-### Features
-
-- **gatsby:** configure physical cores, logical_cores or fixed number ([#10257](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/10257)) ([c51440e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/c51440e))
-
-## [2.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.22...gatsby-plugin-sharp@2.0.23) (2019-02-28)
+## [2.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.28...gatsby-plugin-sharp@2.0.29) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-## [2.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.21...gatsby-plugin-sharp@2.0.22) (2019-02-22)
+## [2.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.27...gatsby-plugin-sharp@2.0.28) (2019-03-12)
 
 ### Features
 
-- **gatsby-plugin-sharp:** Add tracedSVG option in fluid and fixed processors ([#11981](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/11981)) ([8aaaa85](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/8aaaa85)), closes [#11912](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/11912)
+- **gatsby-image:** Placeholder Improvements ([#10944](https://github.com/gatsbyjs/gatsby/issues/10944)) ([44491ef](https://github.com/gatsbyjs/gatsby/commit/44491ef))
 
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.20...gatsby-plugin-sharp@2.0.21) (2019-02-19)
-
-### Features
-
-- **gatsby-plugin-sharp:** add defaultQuality option ([8af9826](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/8af9826))
-
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.19...gatsby-plugin-sharp@2.0.20) (2019-02-01)
+## [2.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.26...gatsby-plugin-sharp@2.0.27) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.18...gatsby-plugin-sharp@2.0.19) (2019-01-29)
+## [2.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.25...gatsby-plugin-sharp@2.0.26) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-plugin-sharp
+
+## [2.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.24...gatsby-plugin-sharp@2.0.25) (2019-03-05)
+
+### Bug Fixes
+
+- don't crash if cpu-core-count is not available ([#12332](https://github.com/gatsbyjs/gatsby/issues/12332)) ([412217d](https://github.com/gatsbyjs/gatsby/commit/412217d))
+
+## [2.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.23...gatsby-plugin-sharp@2.0.24) (2019-03-04)
+
+### Features
+
+- **gatsby:** configure physical cores, logical_cores or fixed number ([#10257](https://github.com/gatsbyjs/gatsby/issues/10257)) ([c51440e](https://github.com/gatsbyjs/gatsby/commit/c51440e))
+
+## [2.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.22...gatsby-plugin-sharp@2.0.23) (2019-02-28)
+
+**Note:** Version bump only for package gatsby-plugin-sharp
+
+## [2.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.21...gatsby-plugin-sharp@2.0.22) (2019-02-22)
+
+### Features
+
+- **gatsby-plugin-sharp:** Add tracedSVG option in fluid and fixed processors ([#11981](https://github.com/gatsbyjs/gatsby/issues/11981)) ([8aaaa85](https://github.com/gatsbyjs/gatsby/commit/8aaaa85)), closes [#11912](https://github.com/gatsbyjs/gatsby/issues/11912)
+
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.20...gatsby-plugin-sharp@2.0.21) (2019-02-19)
+
+### Features
+
+- **gatsby-plugin-sharp:** add defaultQuality option ([8af9826](https://github.com/gatsbyjs/gatsby/commit/8af9826))
+
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.19...gatsby-plugin-sharp@2.0.20) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-plugin-sharp
+
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.18...gatsby-plugin-sharp@2.0.19) (2019-01-29)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.18"></a>
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.17...gatsby-plugin-sharp@2.0.18) (2019-01-23)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.17...gatsby-plugin-sharp@2.0.18) (2019-01-23)
 
 ### Features
 
-- **gatsby-plugin-sharp:** Add support for pngquant speed option ([#9563](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9563)) ([b789689](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/b789689))
+- **gatsby-plugin-sharp:** Add support for pngquant speed option ([#9563](https://github.com/gatsbyjs/gatsby/issues/9563)) ([b789689](https://github.com/gatsbyjs/gatsby/commit/b789689))
 
 <a name="2.0.17"></a>
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.16...gatsby-plugin-sharp@2.0.17) (2018-12-27)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.16...gatsby-plugin-sharp@2.0.17) (2018-12-27)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** url encode file names ([#10650](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/10650)) ([4685bcb](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/4685bcb))
+- **gatsby-plugin-sharp:** url encode file names ([#10650](https://github.com/gatsbyjs/gatsby/issues/10650)) ([4685bcb](https://github.com/gatsbyjs/gatsby/commit/4685bcb))
 
 <a name="2.0.16"></a>
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.15...gatsby-plugin-sharp@2.0.16) (2018-12-21)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.15...gatsby-plugin-sharp@2.0.16) (2018-12-21)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.15"></a>
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.14...gatsby-plugin-sharp@2.0.15) (2018-12-07)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.14...gatsby-plugin-sharp@2.0.15) (2018-12-07)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.14"></a>
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.13...gatsby-plugin-sharp@2.0.14) (2018-11-29)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.13...gatsby-plugin-sharp@2.0.14) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.13"></a>
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.12...gatsby-plugin-sharp@2.0.13) (2018-11-21)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.12...gatsby-plugin-sharp@2.0.13) (2018-11-21)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sharp:** use actions provided, don't assume Gatsby module location. ([#9986](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9986)) ([54f6a85](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/54f6a85)), closes [#9984](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9984)
+- **gatsby-plugin-sharp:** use actions provided, don't assume Gatsby module location. ([#9986](https://github.com/gatsbyjs/gatsby/issues/9986)) ([54f6a85](https://github.com/gatsbyjs/gatsby/commit/54f6a85)), closes [#9984](https://github.com/gatsbyjs/gatsby/issues/9984)
 
 <a name="2.0.12"></a>
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.11...gatsby-plugin-sharp@2.0.12) (2018-11-06)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.11...gatsby-plugin-sharp@2.0.12) (2018-11-06)
 
 ### Features
 
-- **gatsby-plugin-sharp:** cache base64 if possible ([#9059](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9059)) ([5dc9346](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/5dc9346)), closes [#6999](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/6999)
+- **gatsby-plugin-sharp:** cache base64 if possible ([#9059](https://github.com/gatsbyjs/gatsby/issues/9059)) ([5dc9346](https://github.com/gatsbyjs/gatsby/commit/5dc9346)), closes [#6999](https://github.com/gatsbyjs/gatsby/issues/6999)
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.10...gatsby-plugin-sharp@2.0.11) (2018-11-01)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.10...gatsby-plugin-sharp@2.0.11) (2018-11-01)
 
 ### Features
 
-- **gatsby:** Move connection out of sift ([#9508](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9508)) ([8c7a745](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/8c7a745)), closes [#9416](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9416) [#9338](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/9338)
+- **gatsby:** Move connection out of sift ([#9508](https://github.com/gatsbyjs/gatsby/issues/9508)) ([8c7a745](https://github.com/gatsbyjs/gatsby/commit/8c7a745)), closes [#9416](https://github.com/gatsbyjs/gatsby/issues/9416) [#9338](https://github.com/gatsbyjs/gatsby/issues/9338)
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.9...gatsby-plugin-sharp@2.0.10) (2018-10-29)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.9...gatsby-plugin-sharp@2.0.10) (2018-10-29)
 
 ### Features
 
-- use hashed folder names instead of filenames. closes [#6232](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/6232) ([#8808](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/8808)) ([2a66958](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/2a66958))
+- use hashed folder names instead of filenames. closes [#6232](https://github.com/gatsbyjs/gatsby/issues/6232) ([#8808](https://github.com/gatsbyjs/gatsby/issues/8808)) ([2a66958](https://github.com/gatsbyjs/gatsby/commit/2a66958))
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.8...gatsby-plugin-sharp@2.0.9) (2018-10-29)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.8...gatsby-plugin-sharp@2.0.9) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.7...gatsby-plugin-sharp@2.0.8) (2018-10-24)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.7...gatsby-plugin-sharp@2.0.8) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.6...gatsby-plugin-sharp@2.0.7) (2018-10-16)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.6...gatsby-plugin-sharp@2.0.7) (2018-10-16)
 
 ### Features
 
-- add custom sizes for fluid images ([#8825](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/8825)) ([6cb4ee6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/6cb4ee6)), closes [#8621](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/8621)
+- add custom sizes for fluid images ([#8825](https://github.com/gatsbyjs/gatsby/issues/8825)) ([6cb4ee6](https://github.com/gatsbyjs/gatsby/commit/6cb4ee6)), closes [#8621](https://github.com/gatsbyjs/gatsby/issues/8621)
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.5...gatsby-plugin-sharp@2.0.6) (2018-10-03)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.5...gatsby-plugin-sharp@2.0.6) (2018-10-03)
 
 ### Features
 
-- add option to use mozjpeg ([#8621](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/8621)) ([10bc679](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/10bc679))
+- add option to use mozjpeg ([#8621](https://github.com/gatsbyjs/gatsby/issues/8621)) ([10bc679](https://github.com/gatsbyjs/gatsby/commit/10bc679))
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.7...gatsby-plugin-sharp@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.7...gatsby-plugin-sharp@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.7"></a>
 
-# [2.0.0-rc.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.6...gatsby-plugin-sharp@2.0.0-rc.7) (2018-09-11)
+# [2.0.0-rc.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.6...gatsby-plugin-sharp@2.0.0-rc.7) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.5...gatsby-plugin-sharp@2.0.0-rc.6) (2018-09-11)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.5...gatsby-plugin-sharp@2.0.0-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.4...gatsby-plugin-sharp@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.4...gatsby-plugin-sharp@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.3...gatsby-plugin-sharp@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.3...gatsby-plugin-sharp@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.2...gatsby-plugin-sharp@2.0.0-rc.3) (2018-08-31)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.2...gatsby-plugin-sharp@2.0.0-rc.3) (2018-08-31)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.1...gatsby-plugin-sharp@2.0.0-rc.2) (2018-08-29)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.1...gatsby-plugin-sharp@2.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-rc.0...gatsby-plugin-sharp@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-rc.0...gatsby-plugin-sharp@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.9...gatsby-plugin-sharp@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.9...gatsby-plugin-sharp@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.8...gatsby-plugin-sharp@2.0.0-beta.9) (2018-08-16)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.8...gatsby-plugin-sharp@2.0.0-beta.9) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.7...gatsby-plugin-sharp@2.0.0-beta.8) (2018-08-16)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.7...gatsby-plugin-sharp@2.0.0-beta.8) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.6...gatsby-plugin-sharp@2.0.0-beta.7) (2018-07-21)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.6...gatsby-plugin-sharp@2.0.0-beta.7) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.5...gatsby-plugin-sharp@2.0.0-beta.6) (2018-07-20)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.5...gatsby-plugin-sharp@2.0.0-beta.6) (2018-07-20)
 
 ### Features
 
-- **remark-images:** Added support for WebP versions in addition to fallbacks. ([#6495](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/issues/6495)) ([65e3a78](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/commit/65e3a78))
+- **remark-images:** Added support for WebP versions in addition to fallbacks. ([#6495](https://github.com/gatsbyjs/gatsby/issues/6495)) ([65e3a78](https://github.com/gatsbyjs/gatsby/commit/65e3a78))
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.4...gatsby-plugin-sharp@2.0.0-beta.5) (2018-07-13)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.4...gatsby-plugin-sharp@2.0.0-beta.5) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.3...gatsby-plugin-sharp@2.0.0-beta.4) (2018-07-13)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.3...gatsby-plugin-sharp@2.0.0-beta.4) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.2...gatsby-plugin-sharp@2.0.0-beta.3) (2018-07-11)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.2...gatsby-plugin-sharp@2.0.0-beta.3) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.1...gatsby-plugin-sharp@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.1...gatsby-plugin-sharp@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@2.0.0-beta.0...gatsby-plugin-sharp@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@2.0.0-beta.0...gatsby-plugin-sharp@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-sharp
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp/compare/gatsby-plugin-sharp@1.6.48...gatsby-plugin-sharp@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sharp@1.6.48...gatsby-plugin-sharp@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-sharp

--- a/packages/gatsby-plugin-sitemap/CHANGELOG.md
+++ b/packages/gatsby-plugin-sitemap/CHANGELOG.md
@@ -7,132 +7,132 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.2.0...gatsby-plugin-sitemap@2.2.1) (2019-06-29)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.2.0...gatsby-plugin-sitemap@2.2.1) (2019-06-29)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.1.0...gatsby-plugin-sitemap@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.1.0...gatsby-plugin-sitemap@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.12...gatsby-plugin-sitemap@2.1.0) (2019-05-02)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.12...gatsby-plugin-sitemap@2.1.0) (2019-05-02)
 
 ### Features
 
-- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/commit/8291044))
+- **gatsby:** add assetPrefix to support deploying assets separate from html ([#12128](https://github.com/gatsbyjs/gatsby/issues/12128)) ([8291044](https://github.com/gatsbyjs/gatsby/commit/8291044))
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.11...gatsby-plugin-sitemap@2.0.12) (2019-04-08)
-
-### Bug Fixes
-
-- **gatsby-plugin-sitemap:** add meaningful error when siteUrl is missing ([#13123](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/13123)) ([65693d3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/commit/65693d3)), closes [#12912](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/12912)
-
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.10...gatsby-plugin-sitemap@2.0.11) (2019-03-28)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.11...gatsby-plugin-sitemap@2.0.12) (2019-04-08)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sitemap:** use pathPrefix when building sitemap index ([#12852](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/12852)) ([1d7e6c7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/commit/1d7e6c7))
+- **gatsby-plugin-sitemap:** add meaningful error when siteUrl is missing ([#13123](https://github.com/gatsbyjs/gatsby/issues/13123)) ([65693d3](https://github.com/gatsbyjs/gatsby/commit/65693d3)), closes [#12912](https://github.com/gatsbyjs/gatsby/issues/12912)
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.9...gatsby-plugin-sitemap@2.0.10) (2019-03-16)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.10...gatsby-plugin-sitemap@2.0.11) (2019-03-28)
+
+### Bug Fixes
+
+- **gatsby-plugin-sitemap:** use pathPrefix when building sitemap index ([#12852](https://github.com/gatsbyjs/gatsby/issues/12852)) ([1d7e6c7](https://github.com/gatsbyjs/gatsby/commit/1d7e6c7))
+
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.9...gatsby-plugin-sitemap@2.0.10) (2019-03-16)
 
 ### Features
 
-- **gatsby-plugin-sitemap:** sanitize siteUrl ([#12613](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/12613)) ([41bd265](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/commit/41bd265))
+- **gatsby-plugin-sitemap:** sanitize siteUrl ([#12613](https://github.com/gatsbyjs/gatsby/issues/12613)) ([41bd265](https://github.com/gatsbyjs/gatsby/commit/41bd265))
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.8...gatsby-plugin-sitemap@2.0.9) (2019-03-12)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.8...gatsby-plugin-sitemap@2.0.9) (2019-03-12)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sitemap:** fix typo in comment ([#12512](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/12512)) ([3bc5f4d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/commit/3bc5f4d))
+- **gatsby-plugin-sitemap:** fix typo in comment ([#12512](https://github.com/gatsbyjs/gatsby/issues/12512)) ([3bc5f4d](https://github.com/gatsbyjs/gatsby/commit/3bc5f4d))
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.7...gatsby-plugin-sitemap@2.0.8) (2019-03-12)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.7...gatsby-plugin-sitemap@2.0.8) (2019-03-12)
 
 ### Features
 
-- **gatsby-plugin-sitemap:** create sitemap index ([#12239](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/12239)) ([55baf48](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/commit/55baf48))
+- **gatsby-plugin-sitemap:** create sitemap index ([#12239](https://github.com/gatsbyjs/gatsby/issues/12239)) ([55baf48](https://github.com/gatsbyjs/gatsby/commit/55baf48))
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.6...gatsby-plugin-sitemap@2.0.7) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-sitemap
-
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.5...gatsby-plugin-sitemap@2.0.6) (2019-02-22)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.6...gatsby-plugin-sitemap@2.0.7) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.4...gatsby-plugin-sitemap@2.0.5) (2019-02-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.5...gatsby-plugin-sitemap@2.0.6) (2019-02-22)
+
+**Note:** Version bump only for package gatsby-plugin-sitemap
+
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.4...gatsby-plugin-sitemap@2.0.5) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.3...gatsby-plugin-sitemap@2.0.4) (2018-12-27)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.3...gatsby-plugin-sitemap@2.0.4) (2018-12-27)
 
 ### Bug Fixes
 
-- **gatsby-plugin-sitemap:** add missing dependency pify and minimatch ([#10605](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/issues/10605)) ([726d5ab](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/commit/726d5ab))
+- **gatsby-plugin-sitemap:** add missing dependency pify and minimatch ([#10605](https://github.com/gatsbyjs/gatsby/issues/10605)) ([726d5ab](https://github.com/gatsbyjs/gatsby/commit/726d5ab))
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.2...gatsby-plugin-sitemap@2.0.3) (2018-11-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.2...gatsby-plugin-sitemap@2.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.1...gatsby-plugin-sitemap@2.0.2) (2018-10-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.1...gatsby-plugin-sitemap@2.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-rc.2...gatsby-plugin-sitemap@2.0.1) (2018-09-17)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-rc.2...gatsby-plugin-sitemap@2.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-rc.1...gatsby-plugin-sitemap@2.0.0-rc.2) (2018-09-13)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-rc.1...gatsby-plugin-sitemap@2.0.0-rc.2) (2018-09-13)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-rc.0...gatsby-plugin-sitemap@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-rc.0...gatsby-plugin-sitemap@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-beta.4...gatsby-plugin-sitemap@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-beta.4...gatsby-plugin-sitemap@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-beta.3...gatsby-plugin-sitemap@2.0.0-beta.4) (2018-08-14)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-beta.3...gatsby-plugin-sitemap@2.0.0-beta.4) (2018-08-14)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-beta.2...gatsby-plugin-sitemap@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-beta.2...gatsby-plugin-sitemap@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-beta.1...gatsby-plugin-sitemap@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-beta.1...gatsby-plugin-sitemap@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@2.0.0-beta.0...gatsby-plugin-sitemap@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@2.0.0-beta.0...gatsby-plugin-sitemap@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap/compare/gatsby-plugin-sitemap@1.2.25...gatsby-plugin-sitemap@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-sitemap@1.2.25...gatsby-plugin-sitemap@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-sitemap

--- a/packages/gatsby-plugin-styled-components/CHANGELOG.md
+++ b/packages/gatsby-plugin-styled-components/CHANGELOG.md
@@ -7,118 +7,118 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.7...gatsby-plugin-styled-components@3.1.0) (2019-06-20)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.7...gatsby-plugin-styled-components@3.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
-## [3.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.6...gatsby-plugin-styled-components@3.0.7) (2019-03-11)
+## [3.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.6...gatsby-plugin-styled-components@3.0.7) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
-## [3.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.5...gatsby-plugin-styled-components@3.0.6) (2019-02-19)
+## [3.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.5...gatsby-plugin-styled-components@3.0.6) (2019-02-19)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.4...gatsby-plugin-styled-components@3.0.5) (2019-02-01)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.4...gatsby-plugin-styled-components@3.0.5) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.4"></a>
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.3...gatsby-plugin-styled-components@3.0.4) (2018-11-29)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.3...gatsby-plugin-styled-components@3.0.4) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.2...gatsby-plugin-styled-components@3.0.3) (2018-11-20)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.2...gatsby-plugin-styled-components@3.0.3) (2018-11-20)
 
 ### Bug Fixes
 
-- update peerDependency, plugins rely on extra arg being passed in API hooks ([#10045](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/issues/10045)) ([83b7a18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/commit/83b7a18)), closes [/github.com/gatsbyjs/gatsby/pull/9943#issuecomment-440152666](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/issues/issuecomment-440152666)
+- update peerDependency, plugins rely on extra arg being passed in API hooks ([#10045](https://github.com/gatsbyjs/gatsby/issues/10045)) ([83b7a18](https://github.com/gatsbyjs/gatsby/commit/83b7a18)), closes [/github.com/gatsbyjs/gatsby/pull/9943#issuecomment-440152666](https://github.com/gatsbyjs/gatsby/issues/issuecomment-440152666)
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.1...gatsby-plugin-styled-components@3.0.2) (2018-11-15)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.1...gatsby-plugin-styled-components@3.0.2) (2018-11-15)
 
 ### Bug Fixes
 
-- **gatsby-plugin-styled-components:** fix global styles pollution ([#9943](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/issues/9943)) ([a75c641](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/commit/a75c641)), closes [#9922](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/issues/9922)
+- **gatsby-plugin-styled-components:** fix global styles pollution ([#9943](https://github.com/gatsbyjs/gatsby/issues/9943)) ([a75c641](https://github.com/gatsbyjs/gatsby/commit/a75c641)), closes [#9922](https://github.com/gatsbyjs/gatsby/issues/9922)
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0...gatsby-plugin-styled-components@3.0.1) (2018-10-29)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0...gatsby-plugin-styled-components@3.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-rc.5...gatsby-plugin-styled-components@3.0.0) (2018-09-17)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-rc.5...gatsby-plugin-styled-components@3.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-rc.5"></a>
 
-# [3.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-rc.4...gatsby-plugin-styled-components@3.0.0-rc.5) (2018-09-11)
+# [3.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-rc.4...gatsby-plugin-styled-components@3.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-rc.4"></a>
 
-# [3.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-rc.3...gatsby-plugin-styled-components@3.0.0-rc.4) (2018-09-11)
+# [3.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-rc.3...gatsby-plugin-styled-components@3.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-rc.3"></a>
 
-# [3.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-rc.2...gatsby-plugin-styled-components@3.0.0-rc.3) (2018-09-11)
+# [3.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-rc.2...gatsby-plugin-styled-components@3.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-rc.2"></a>
 
-# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-rc.1...gatsby-plugin-styled-components@3.0.0-rc.2) (2018-09-11)
+# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-rc.1...gatsby-plugin-styled-components@3.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-rc.1"></a>
 
-# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-rc.0...gatsby-plugin-styled-components@3.0.0-rc.1) (2018-08-29)
+# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-rc.0...gatsby-plugin-styled-components@3.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-rc.0"></a>
 
-# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-beta.4...gatsby-plugin-styled-components@3.0.0-rc.0) (2018-08-21)
+# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-beta.4...gatsby-plugin-styled-components@3.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-beta.4"></a>
 
-# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-beta.3...gatsby-plugin-styled-components@3.0.0-beta.4) (2018-08-16)
+# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-beta.3...gatsby-plugin-styled-components@3.0.0-beta.4) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-beta.3"></a>
 
-# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-beta.2...gatsby-plugin-styled-components@3.0.0-beta.3) (2018-07-21)
+# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-beta.2...gatsby-plugin-styled-components@3.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-beta.2"></a>
 
-# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-beta.1...gatsby-plugin-styled-components@3.0.0-beta.2) (2018-06-20)
+# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-beta.1...gatsby-plugin-styled-components@3.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-beta.1"></a>
 
-# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@3.0.0-beta.0...gatsby-plugin-styled-components@3.0.0-beta.1) (2018-06-17)
+# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@3.0.0-beta.0...gatsby-plugin-styled-components@3.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components
 
 <a name="3.0.0-beta.0"></a>
 
-# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components/compare/gatsby-plugin-styled-components@2.0.11...gatsby-plugin-styled-components@3.0.0-beta.0) (2018-06-17)
+# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-components@2.0.11...gatsby-plugin-styled-components@3.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-styled-components

--- a/packages/gatsby-plugin-styled-jsx/CHANGELOG.md
+++ b/packages/gatsby-plugin-styled-jsx/CHANGELOG.md
@@ -7,86 +7,86 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.5...gatsby-plugin-styled-jsx@3.1.0) (2019-06-20)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.5...gatsby-plugin-styled-jsx@3.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.4...gatsby-plugin-styled-jsx@3.0.5) (2019-03-11)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.4...gatsby-plugin-styled-jsx@3.0.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.3...gatsby-plugin-styled-jsx@3.0.4) (2019-02-01)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.3...gatsby-plugin-styled-jsx@3.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.2...gatsby-plugin-styled-jsx@3.0.3) (2018-11-29)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.2...gatsby-plugin-styled-jsx@3.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1...gatsby-plugin-styled-jsx@3.0.2) (2018-10-29)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1...gatsby-plugin-styled-jsx@3.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-rc.4...gatsby-plugin-styled-jsx@3.0.1) (2018-09-17)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-rc.4...gatsby-plugin-styled-jsx@3.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-rc.4"></a>
 
-## [3.0.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-rc.3...gatsby-plugin-styled-jsx@3.0.1-rc.4) (2018-09-12)
+## [3.0.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-rc.3...gatsby-plugin-styled-jsx@3.0.1-rc.4) (2018-09-12)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-rc.3"></a>
 
-## [3.0.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-rc.2...gatsby-plugin-styled-jsx@3.0.1-rc.3) (2018-09-05)
+## [3.0.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-rc.2...gatsby-plugin-styled-jsx@3.0.1-rc.3) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-rc.2"></a>
 
-## [3.0.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-rc.1...gatsby-plugin-styled-jsx@3.0.1-rc.2) (2018-09-03)
+## [3.0.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-rc.1...gatsby-plugin-styled-jsx@3.0.1-rc.2) (2018-09-03)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-rc.1"></a>
 
-## [3.0.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-rc.0...gatsby-plugin-styled-jsx@3.0.1-rc.1) (2018-08-29)
+## [3.0.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-rc.0...gatsby-plugin-styled-jsx@3.0.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-rc.0"></a>
 
-## [3.0.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-beta.3...gatsby-plugin-styled-jsx@3.0.1-rc.0) (2018-08-21)
+## [3.0.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-beta.3...gatsby-plugin-styled-jsx@3.0.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-beta.3"></a>
 
-## [3.0.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-beta.2...gatsby-plugin-styled-jsx@3.0.1-beta.3) (2018-07-21)
+## [3.0.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-beta.2...gatsby-plugin-styled-jsx@3.0.1-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-beta.2"></a>
 
-## [3.0.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-beta.1...gatsby-plugin-styled-jsx@3.0.1-beta.2) (2018-06-20)
+## [3.0.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-beta.1...gatsby-plugin-styled-jsx@3.0.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-beta.1"></a>
 
-## [3.0.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@3.0.1-beta.0...gatsby-plugin-styled-jsx@3.0.1-beta.1) (2018-06-17)
+## [3.0.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@3.0.1-beta.0...gatsby-plugin-styled-jsx@3.0.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx
 
 <a name="3.0.1-beta.0"></a>
 
-## [3.0.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx/compare/gatsby-plugin-styled-jsx@2.0.6...gatsby-plugin-styled-jsx@3.0.1-beta.0) (2018-06-17)
+## [3.0.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styled-jsx@2.0.6...gatsby-plugin-styled-jsx@3.0.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-styled-jsx

--- a/packages/gatsby-plugin-styletron/CHANGELOG.md
+++ b/packages/gatsby-plugin-styletron/CHANGELOG.md
@@ -7,15 +7,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
-# [4.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@4.0.0...gatsby-plugin-styletron@4.1.0) (2019-06-20)
+# [4.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@4.0.0...gatsby-plugin-styletron@4.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
-# [4.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.5...gatsby-plugin-styletron@4.0.0) (2019-05-16)
+# [4.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.5...gatsby-plugin-styletron@4.0.0) (2019-05-16)
 
 ### Features
 
-- **gatsby-plugin-styletron:** update to v5, debug mode, useStyletron ([#13955](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/issues/13955)) ([7a80d1a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/commit/7a80d1a))
+- **gatsby-plugin-styletron:** update to v5, debug mode, useStyletron ([#13955](https://github.com/gatsbyjs/gatsby/issues/13955)) ([7a80d1a](https://github.com/gatsbyjs/gatsby/commit/7a80d1a))
 
 ### BREAKING CHANGES
 
@@ -25,76 +25,76 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - feat(gatsby-plugin-styletron): add note about styletron-react v5 support
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.4...gatsby-plugin-styletron@3.0.5) (2019-03-11)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.4...gatsby-plugin-styletron@3.0.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.3...gatsby-plugin-styletron@3.0.4) (2019-02-01)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.3...gatsby-plugin-styletron@3.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.2...gatsby-plugin-styletron@3.0.3) (2018-11-29)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.2...gatsby-plugin-styletron@3.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.1...gatsby-plugin-styletron@3.0.2) (2018-10-29)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.1...gatsby-plugin-styletron@3.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0...gatsby-plugin-styletron@3.0.1) (2018-09-26)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0...gatsby-plugin-styletron@3.0.1) (2018-09-26)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0-rc.1...gatsby-plugin-styletron@3.0.0) (2018-09-17)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0-rc.1...gatsby-plugin-styletron@3.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0-rc.1"></a>
 
-# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0-rc.0...gatsby-plugin-styletron@3.0.0-rc.1) (2018-08-29)
+# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0-rc.0...gatsby-plugin-styletron@3.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0-rc.0"></a>
 
-# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0-beta.4...gatsby-plugin-styletron@3.0.0-rc.0) (2018-08-21)
+# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0-beta.4...gatsby-plugin-styletron@3.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0-beta.4"></a>
 
-# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0-beta.3...gatsby-plugin-styletron@3.0.0-beta.4) (2018-08-16)
+# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0-beta.3...gatsby-plugin-styletron@3.0.0-beta.4) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0-beta.3"></a>
 
-# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0-beta.2...gatsby-plugin-styletron@3.0.0-beta.3) (2018-07-21)
+# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0-beta.2...gatsby-plugin-styletron@3.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0-beta.2"></a>
 
-# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0-beta.1...gatsby-plugin-styletron@3.0.0-beta.2) (2018-06-20)
+# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0-beta.1...gatsby-plugin-styletron@3.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0-beta.1"></a>
 
-# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@3.0.0-beta.0...gatsby-plugin-styletron@3.0.0-beta.1) (2018-06-17)
+# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@3.0.0-beta.0...gatsby-plugin-styletron@3.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-styletron
 
 <a name="3.0.0-beta.0"></a>
 
-# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styletron/compare/gatsby-plugin-styletron@2.0.9...gatsby-plugin-styletron@3.0.0-beta.0) (2018-06-17)
+# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-styletron@2.0.9...gatsby-plugin-styletron@3.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-styletron

--- a/packages/gatsby-plugin-stylus/CHANGELOG.md
+++ b/packages/gatsby-plugin-stylus/CHANGELOG.md
@@ -7,104 +7,104 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.7...gatsby-plugin-stylus@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.7...gatsby-plugin-stylus@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.6...gatsby-plugin-stylus@2.0.7) (2019-03-11)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.6...gatsby-plugin-stylus@2.0.7) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.5...gatsby-plugin-stylus@2.0.6) (2019-02-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.5...gatsby-plugin-stylus@2.0.6) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.4...gatsby-plugin-stylus@2.0.5) (2019-02-01)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.4...gatsby-plugin-stylus@2.0.5) (2019-02-01)
 
 ### Bug Fixes
 
-- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/commit/97c98e9))
+- **core:** Disable HMR for CSS modules ([#11032](https://github.com/gatsbyjs/gatsby/issues/11032)) ([97c98e9](https://github.com/gatsbyjs/gatsby/commit/97c98e9))
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.3...gatsby-plugin-stylus@2.0.4) (2019-01-28)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.3...gatsby-plugin-stylus@2.0.4) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.2...gatsby-plugin-stylus@2.0.3) (2018-11-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.2...gatsby-plugin-stylus@2.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.1...gatsby-plugin-stylus@2.0.2) (2018-10-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.1...gatsby-plugin-stylus@2.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-rc.2...gatsby-plugin-stylus@2.0.1) (2018-09-17)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-rc.2...gatsby-plugin-stylus@2.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-rc.1...gatsby-plugin-stylus@2.0.0-rc.2) (2018-09-17)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-rc.1...gatsby-plugin-stylus@2.0.0-rc.2) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-rc.0...gatsby-plugin-stylus@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-rc.0...gatsby-plugin-stylus@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-beta.6...gatsby-plugin-stylus@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-beta.6...gatsby-plugin-stylus@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-beta.5...gatsby-plugin-stylus@2.0.0-beta.6) (2018-08-02)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-beta.5...gatsby-plugin-stylus@2.0.0-beta.6) (2018-08-02)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-beta.4...gatsby-plugin-stylus@2.0.0-beta.5) (2018-07-21)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-beta.4...gatsby-plugin-stylus@2.0.0-beta.5) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-beta.3...gatsby-plugin-stylus@2.0.0-beta.4) (2018-07-09)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-beta.3...gatsby-plugin-stylus@2.0.0-beta.4) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-beta.2...gatsby-plugin-stylus@2.0.0-beta.3) (2018-06-27)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-beta.2...gatsby-plugin-stylus@2.0.0-beta.3) (2018-06-27)
 
 ### Bug Fixes
 
-- use the language loader for imports not postcss ([#6173](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/issues/6173)) ([7190fe1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/commit/7190fe1))
+- use the language loader for imports not postcss ([#6173](https://github.com/gatsbyjs/gatsby/issues/6173)) ([7190fe1](https://github.com/gatsbyjs/gatsby/commit/7190fe1))
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-beta.1...gatsby-plugin-stylus@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-beta.1...gatsby-plugin-stylus@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@2.0.0-beta.0...gatsby-plugin-stylus@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@2.0.0-beta.0...gatsby-plugin-stylus@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-stylus
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus/compare/gatsby-plugin-stylus@1.1.21...gatsby-plugin-stylus@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-stylus@1.1.21...gatsby-plugin-stylus@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-stylus

--- a/packages/gatsby-plugin-subfont/CHANGELOG.md
+++ b/packages/gatsby-plugin-subfont/CHANGELOG.md
@@ -7,11 +7,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-subfont
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-subfont/compare/gatsby-plugin-subfont@1.0.6...gatsby-plugin-subfont@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-subfont@1.0.6...gatsby-plugin-subfont@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-subfont
 
-## [1.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-subfont/compare/gatsby-plugin-subfont@1.0.5...gatsby-plugin-subfont@1.0.6) (2019-04-23)
+## [1.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-subfont@1.0.5...gatsby-plugin-subfont@1.0.6) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-subfont
 

--- a/packages/gatsby-plugin-twitter/CHANGELOG.md
+++ b/packages/gatsby-plugin-twitter/CHANGELOG.md
@@ -7,96 +7,96 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.13...gatsby-plugin-twitter@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.13...gatsby-plugin-twitter@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.12...gatsby-plugin-twitter@2.0.13) (2019-03-16)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.12...gatsby-plugin-twitter@2.0.13) (2019-03-16)
 
 ### Features
 
-- **gatsby-plugin-twitter:** load widget for all Twitter embeds ([#12607](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/issues/12607)) ([bb5d62d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/commit/bb5d62d))
+- **gatsby-plugin-twitter:** load widget for all Twitter embeds ([#12607](https://github.com/gatsbyjs/gatsby/issues/12607)) ([bb5d62d](https://github.com/gatsbyjs/gatsby/commit/bb5d62d))
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.11...gatsby-plugin-twitter@2.0.12) (2019-03-11)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.11...gatsby-plugin-twitter@2.0.12) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.10...gatsby-plugin-twitter@2.0.11) (2019-03-05)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.10...gatsby-plugin-twitter@2.0.11) (2019-03-05)
 
 ### Bug Fixes
 
-- **gatsby-plugin-twitter:** add back semi-colons to injected script ([#12296](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/issues/12296)) ([b939b8b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/commit/b939b8b)), closes [#12193](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/issues/12193) [/github.com/gatsbyjs/gatsby/pull/12193#issuecomment-469418343](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/issues/issuecomment-469418343)
+- **gatsby-plugin-twitter:** add back semi-colons to injected script ([#12296](https://github.com/gatsbyjs/gatsby/issues/12296)) ([b939b8b](https://github.com/gatsbyjs/gatsby/commit/b939b8b)), closes [#12193](https://github.com/gatsbyjs/gatsby/issues/12193) [/github.com/gatsbyjs/gatsby/pull/12193#issuecomment-469418343](https://github.com/gatsbyjs/gatsby/issues/issuecomment-469418343)
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.9...gatsby-plugin-twitter@2.0.10) (2019-03-04)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.9...gatsby-plugin-twitter@2.0.10) (2019-03-04)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.8...gatsby-plugin-twitter@2.0.9) (2019-02-01)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.8...gatsby-plugin-twitter@2.0.9) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.7...gatsby-plugin-twitter@2.0.8) (2018-11-29)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.7...gatsby-plugin-twitter@2.0.8) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.6...gatsby-plugin-twitter@2.0.7) (2018-10-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.6...gatsby-plugin-twitter@2.0.7) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.5...gatsby-plugin-twitter@2.0.6) (2018-10-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.5...gatsby-plugin-twitter@2.0.6) (2018-10-01)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.0-rc.2...gatsby-plugin-twitter@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.0-rc.2...gatsby-plugin-twitter@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.0-rc.1...gatsby-plugin-twitter@2.0.0-rc.2) (2018-09-05)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.0-rc.1...gatsby-plugin-twitter@2.0.0-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.0-rc.0...gatsby-plugin-twitter@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.0-rc.0...gatsby-plugin-twitter@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.0-beta.3...gatsby-plugin-twitter@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.0-beta.3...gatsby-plugin-twitter@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.0-beta.2...gatsby-plugin-twitter@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.0-beta.2...gatsby-plugin-twitter@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.0-beta.1...gatsby-plugin-twitter@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.0-beta.1...gatsby-plugin-twitter@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@2.0.0-beta.0...gatsby-plugin-twitter@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@2.0.0-beta.0...gatsby-plugin-twitter@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-twitter
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter/compare/gatsby-plugin-twitter@1.0.20...gatsby-plugin-twitter@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-twitter@1.0.20...gatsby-plugin-twitter@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-twitter

--- a/packages/gatsby-plugin-typescript/CHANGELOG.md
+++ b/packages/gatsby-plugin-typescript/CHANGELOG.md
@@ -7,190 +7,190 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.15...gatsby-plugin-typescript@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.15...gatsby-plugin-typescript@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.14...gatsby-plugin-typescript@2.0.15) (2019-05-24)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.14...gatsby-plugin-typescript@2.0.15) (2019-05-24)
 
 ### Bug Fixes
 
-- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/commit/5e54afe))
+- **PnP:** use `require.resolve` on `setBabelPreset` ([#14288](https://github.com/gatsbyjs/gatsby/issues/14288)) ([5e54afe](https://github.com/gatsbyjs/gatsby/commit/5e54afe))
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.13...gatsby-plugin-typescript@2.0.14) (2019-05-16)
-
-**Note:** Version bump only for package gatsby-plugin-typescript
-
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.12...gatsby-plugin-typescript@2.0.13) (2019-04-23)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.13...gatsby-plugin-typescript@2.0.14) (2019-05-16)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.11...gatsby-plugin-typescript@2.0.12) (2019-04-02)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.12...gatsby-plugin-typescript@2.0.13) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.10...gatsby-plugin-typescript@2.0.11) (2019-03-11)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.11...gatsby-plugin-typescript@2.0.12) (2019-04-02)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.9...gatsby-plugin-typescript@2.0.10) (2019-03-04)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.10...gatsby-plugin-typescript@2.0.11) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.8...gatsby-plugin-typescript@2.0.9) (2019-02-22)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.9...gatsby-plugin-typescript@2.0.10) (2019-03-04)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.7...gatsby-plugin-typescript@2.0.8) (2019-02-13)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.8...gatsby-plugin-typescript@2.0.9) (2019-02-22)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.6...gatsby-plugin-typescript@2.0.7) (2019-02-04)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.7...gatsby-plugin-typescript@2.0.8) (2019-02-13)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.5...gatsby-plugin-typescript@2.0.6) (2019-02-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.6...gatsby-plugin-typescript@2.0.7) (2019-02-04)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.4...gatsby-plugin-typescript@2.0.5) (2019-02-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.5...gatsby-plugin-typescript@2.0.6) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.3...gatsby-plugin-typescript@2.0.4) (2019-01-28)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.4...gatsby-plugin-typescript@2.0.5) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-plugin-typescript
+
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.3...gatsby-plugin-typescript@2.0.4) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.2...gatsby-plugin-typescript@2.0.3) (2018-12-05)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.2...gatsby-plugin-typescript@2.0.3) (2018-12-05)
 
 ### Features
 
-- **gatsby-plugin-typescript:** allow specifying babel preset options ([#10248](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/issues/10248)) ([f106241](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/commit/f106241))
+- **gatsby-plugin-typescript:** allow specifying babel preset options ([#10248](https://github.com/gatsbyjs/gatsby/issues/10248)) ([f106241](https://github.com/gatsbyjs/gatsby/commit/f106241))
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.1...gatsby-plugin-typescript@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.1...gatsby-plugin-typescript@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0...gatsby-plugin-typescript@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0...gatsby-plugin-typescript@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-rc.6...gatsby-plugin-typescript@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-rc.6...gatsby-plugin-typescript@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-rc.5...gatsby-plugin-typescript@2.0.0-rc.6) (2018-09-13)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-rc.5...gatsby-plugin-typescript@2.0.0-rc.6) (2018-09-13)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-rc.4...gatsby-plugin-typescript@2.0.0-rc.5) (2018-09-08)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-rc.4...gatsby-plugin-typescript@2.0.0-rc.5) (2018-09-08)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-rc.3...gatsby-plugin-typescript@2.0.0-rc.4) (2018-09-05)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-rc.3...gatsby-plugin-typescript@2.0.0-rc.4) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-rc.2...gatsby-plugin-typescript@2.0.0-rc.3) (2018-08-29)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-rc.2...gatsby-plugin-typescript@2.0.0-rc.3) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-rc.1...gatsby-plugin-typescript@2.0.0-rc.2) (2018-08-29)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-rc.1...gatsby-plugin-typescript@2.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-rc.0...gatsby-plugin-typescript@2.0.0-rc.1) (2018-08-21)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-rc.0...gatsby-plugin-typescript@2.0.0-rc.1) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.10...gatsby-plugin-typescript@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.10...gatsby-plugin-typescript@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.10"></a>
 
-# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.9...gatsby-plugin-typescript@2.0.0-beta.10) (2018-08-20)
+# [2.0.0-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.9...gatsby-plugin-typescript@2.0.0-beta.10) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.8...gatsby-plugin-typescript@2.0.0-beta.9) (2018-07-31)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.8...gatsby-plugin-typescript@2.0.0-beta.9) (2018-07-31)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.7...gatsby-plugin-typescript@2.0.0-beta.8) (2018-07-31)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.7...gatsby-plugin-typescript@2.0.0-beta.8) (2018-07-31)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.6...gatsby-plugin-typescript@2.0.0-beta.7) (2018-07-21)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.6...gatsby-plugin-typescript@2.0.0-beta.7) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.5...gatsby-plugin-typescript@2.0.0-beta.6) (2018-07-18)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.5...gatsby-plugin-typescript@2.0.0-beta.6) (2018-07-18)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.4...gatsby-plugin-typescript@2.0.0-beta.5) (2018-07-02)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.4...gatsby-plugin-typescript@2.0.0-beta.5) (2018-07-02)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.3...gatsby-plugin-typescript@2.0.0-beta.4) (2018-06-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.3...gatsby-plugin-typescript@2.0.0-beta.4) (2018-06-21)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.2...gatsby-plugin-typescript@2.0.0-beta.3) (2018-06-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.2...gatsby-plugin-typescript@2.0.0-beta.3) (2018-06-21)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.1...gatsby-plugin-typescript@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.1...gatsby-plugin-typescript@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@2.0.0-beta.0...gatsby-plugin-typescript@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@2.0.0-beta.0...gatsby-plugin-typescript@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-typescript
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript/compare/gatsby-plugin-typescript@1.4.20...gatsby-plugin-typescript@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typescript@1.4.20...gatsby-plugin-typescript@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-typescript

--- a/packages/gatsby-plugin-typography/CHANGELOG.md
+++ b/packages/gatsby-plugin-typography/CHANGELOG.md
@@ -7,132 +7,132 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
-# [2.3.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.13...gatsby-plugin-typography@2.3.0) (2019-06-20)
+# [2.3.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.13...gatsby-plugin-typography@2.3.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
-## [2.2.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.12...gatsby-plugin-typography@2.2.13) (2019-04-12)
+## [2.2.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.12...gatsby-plugin-typography@2.2.13) (2019-04-12)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
-## [2.2.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.11...gatsby-plugin-typography@2.2.12) (2019-04-09)
+## [2.2.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.11...gatsby-plugin-typography@2.2.12) (2019-04-09)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
-## [2.2.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.10...gatsby-plugin-typography@2.2.11) (2019-04-08)
+## [2.2.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.10...gatsby-plugin-typography@2.2.11) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
-## [2.2.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.9...gatsby-plugin-typography@2.2.10) (2019-03-13)
+## [2.2.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.9...gatsby-plugin-typography@2.2.10) (2019-03-13)
 
 ### Bug Fixes
 
-- **gatsby-pugin-typography:** headerComponents is now tolerant to null values ([#12551](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/issues/12551)) ([a02ef30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/commit/a02ef30)), closes [#12549](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/issues/12549)
+- **gatsby-pugin-typography:** headerComponents is now tolerant to null values ([#12551](https://github.com/gatsbyjs/gatsby/issues/12551)) ([a02ef30](https://github.com/gatsbyjs/gatsby/commit/a02ef30)), closes [#12549](https://github.com/gatsbyjs/gatsby/issues/12549)
 
-## [2.2.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.8...gatsby-plugin-typography@2.2.9) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-plugin-typography
-
-## [2.2.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.7...gatsby-plugin-typography@2.2.8) (2019-03-05)
-
-### Bug Fixes
-
-- **gatsby-plugin-typography:** sort typography style tag first to avoid overwriting issues ([#12295](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/issues/12295)) ([5caf95e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/commit/5caf95e))
-
-## [2.2.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.6...gatsby-plugin-typography@2.2.7) (2019-02-01)
+## [2.2.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.8...gatsby-plugin-typography@2.2.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
-## [2.2.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.5...gatsby-plugin-typography@2.2.6) (2019-01-28)
+## [2.2.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.7...gatsby-plugin-typography@2.2.8) (2019-03-05)
 
 ### Bug Fixes
 
-- **gatsby-plugin-typography:** omitGoogleFont in "develop" ([#11226](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/issues/11226)) ([7dc7c5f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/commit/7dc7c5f))
+- **gatsby-plugin-typography:** sort typography style tag first to avoid overwriting issues ([#12295](https://github.com/gatsbyjs/gatsby/issues/12295)) ([5caf95e](https://github.com/gatsbyjs/gatsby/commit/5caf95e))
+
+## [2.2.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.6...gatsby-plugin-typography@2.2.7) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-plugin-typography
+
+## [2.2.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.5...gatsby-plugin-typography@2.2.6) (2019-01-28)
+
+### Bug Fixes
+
+- **gatsby-plugin-typography:** omitGoogleFont in "develop" ([#11226](https://github.com/gatsbyjs/gatsby/issues/11226)) ([7dc7c5f](https://github.com/gatsbyjs/gatsby/commit/7dc7c5f))
 
 <a name="2.2.5"></a>
 
-## [2.2.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.4...gatsby-plugin-typography@2.2.5) (2019-01-06)
+## [2.2.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.4...gatsby-plugin-typography@2.2.5) (2019-01-06)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.4"></a>
 
-## [2.2.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.3...gatsby-plugin-typography@2.2.4) (2018-12-21)
+## [2.2.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.3...gatsby-plugin-typography@2.2.4) (2018-12-21)
 
 ### Bug Fixes
 
-- support cjs modules when loading typography config ([#10610](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/issues/10610)) ([2f7303d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/commit/2f7303d))
+- support cjs modules when loading typography config ([#10610](https://github.com/gatsbyjs/gatsby/issues/10610)) ([2f7303d](https://github.com/gatsbyjs/gatsby/commit/2f7303d))
 
 <a name="2.2.3"></a>
 
-## [2.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.2...gatsby-plugin-typography@2.2.3) (2018-12-21)
+## [2.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.2...gatsby-plugin-typography@2.2.3) (2018-12-21)
 
 ### Features
 
-- **gatsby-plugin-typography:** hot reloading for styles and Google Fonts ([#10545](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/issues/10545)) ([7fbbd60](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/commit/7fbbd60))
+- **gatsby-plugin-typography:** hot reloading for styles and Google Fonts ([#10545](https://github.com/gatsbyjs/gatsby/issues/10545)) ([7fbbd60](https://github.com/gatsbyjs/gatsby/commit/7fbbd60))
 
 <a name="2.2.2"></a>
 
-## [2.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.1...gatsby-plugin-typography@2.2.2) (2018-11-29)
+## [2.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.1...gatsby-plugin-typography@2.2.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.1"></a>
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0...gatsby-plugin-typography@2.2.1) (2018-10-29)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0...gatsby-plugin-typography@2.2.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0"></a>
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-rc.3...gatsby-plugin-typography@2.2.0) (2018-09-17)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-rc.3...gatsby-plugin-typography@2.2.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-rc.3"></a>
 
-# [2.2.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-rc.2...gatsby-plugin-typography@2.2.0-rc.3) (2018-09-01)
+# [2.2.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-rc.2...gatsby-plugin-typography@2.2.0-rc.3) (2018-09-01)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-rc.2"></a>
 
-# [2.2.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-rc.1...gatsby-plugin-typography@2.2.0-rc.2) (2018-08-29)
+# [2.2.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-rc.1...gatsby-plugin-typography@2.2.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-rc.1"></a>
 
-# [2.2.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-rc.0...gatsby-plugin-typography@2.2.0-rc.1) (2018-08-29)
+# [2.2.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-rc.0...gatsby-plugin-typography@2.2.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-rc.0"></a>
 
-# [2.2.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-beta.3...gatsby-plugin-typography@2.2.0-rc.0) (2018-08-21)
+# [2.2.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-beta.3...gatsby-plugin-typography@2.2.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-beta.3"></a>
 
-# [2.2.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-beta.2...gatsby-plugin-typography@2.2.0-beta.3) (2018-07-21)
+# [2.2.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-beta.2...gatsby-plugin-typography@2.2.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-beta.2"></a>
 
-# [2.2.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-beta.1...gatsby-plugin-typography@2.2.0-beta.2) (2018-06-20)
+# [2.2.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-beta.1...gatsby-plugin-typography@2.2.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-beta.1"></a>
 
-# [2.2.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@2.2.0-beta.0...gatsby-plugin-typography@2.2.0-beta.1) (2018-06-17)
+# [2.2.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@2.2.0-beta.0...gatsby-plugin-typography@2.2.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-typography
 
 <a name="2.2.0-beta.0"></a>
 
-# [2.2.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typography/compare/gatsby-plugin-typography@1.7.19...gatsby-plugin-typography@2.2.0-beta.0) (2018-06-17)
+# [2.2.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-plugin-typography@1.7.19...gatsby-plugin-typography@2.2.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-plugin-typography

--- a/packages/gatsby-react-router-scroll/CHANGELOG.md
+++ b/packages/gatsby-react-router-scroll/CHANGELOG.md
@@ -7,128 +7,128 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.1.0...gatsby-react-router-scroll@2.1.1) (2019-07-02)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.1.0...gatsby-react-router-scroll@2.1.1) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.7...gatsby-react-router-scroll@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.7...gatsby-react-router-scroll@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.6...gatsby-react-router-scroll@2.0.7) (2019-03-28)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.6...gatsby-react-router-scroll@2.0.7) (2019-03-28)
 
 ### Bug Fixes
 
-- **scroll:** use location.key for scroll behaviours ([#12403](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/issues/12403)) ([853ceb9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/commit/853ceb9)), closes [/github.com/taion/scroll-behavior/issues/135#issuecomment-468962628](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/issues/issuecomment-468962628) [#12390](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/issues/12390)
+- **scroll:** use location.key for scroll behaviours ([#12403](https://github.com/gatsbyjs/gatsby/issues/12403)) ([853ceb9](https://github.com/gatsbyjs/gatsby/commit/853ceb9)), closes [/github.com/taion/scroll-behavior/issues/135#issuecomment-468962628](https://github.com/gatsbyjs/gatsby/issues/issuecomment-468962628) [#12390](https://github.com/gatsbyjs/gatsby/issues/12390)
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.5...gatsby-react-router-scroll@2.0.6) (2019-03-16)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.5...gatsby-react-router-scroll@2.0.6) (2019-03-16)
 
 ### Bug Fixes
 
-- **gatsby-react-router-scroll:** hide sessionStorage warnings in production ([#12593](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/issues/12593)) ([365be0a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/commit/365be0a)), closes [#12577](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/issues/12577)
+- **gatsby-react-router-scroll:** hide sessionStorage warnings in production ([#12593](https://github.com/gatsbyjs/gatsby/issues/12593)) ([365be0a](https://github.com/gatsbyjs/gatsby/commit/365be0a)), closes [#12577](https://github.com/gatsbyjs/gatsby/issues/12577)
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.4...gatsby-react-router-scroll@2.0.5) (2019-03-11)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.4...gatsby-react-router-scroll@2.0.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.3...gatsby-react-router-scroll@2.0.4) (2019-02-01)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.3...gatsby-react-router-scroll@2.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.2...gatsby-react-router-scroll@2.0.3) (2019-01-24)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.2...gatsby-react-router-scroll@2.0.3) (2019-01-24)
 
 ### Bug Fixes
 
-- **gatsby-react-router-scroll:** keep scroll positions in tact on reload ([#11224](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/issues/11224)) ([3cbaade](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/commit/3cbaade))
+- **gatsby-react-router-scroll:** keep scroll positions in tact on reload ([#11224](https://github.com/gatsbyjs/gatsby/issues/11224)) ([3cbaade](https://github.com/gatsbyjs/gatsby/commit/3cbaade))
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.1...gatsby-react-router-scroll@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.1...gatsby-react-router-scroll@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0...gatsby-react-router-scroll@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0...gatsby-react-router-scroll@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-rc.2...gatsby-react-router-scroll@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-rc.2...gatsby-react-router-scroll@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-rc.1...gatsby-react-router-scroll@2.0.0-rc.2) (2018-08-31)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-rc.1...gatsby-react-router-scroll@2.0.0-rc.2) (2018-08-31)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-rc.0...gatsby-react-router-scroll@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-rc.0...gatsby-react-router-scroll@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.9...gatsby-react-router-scroll@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.9...gatsby-react-router-scroll@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.8...gatsby-react-router-scroll@2.0.0-beta.9) (2018-08-21)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.8...gatsby-react-router-scroll@2.0.0-beta.9) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.6...gatsby-react-router-scroll@2.0.0-beta.8) (2018-08-07)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.6...gatsby-react-router-scroll@2.0.0-beta.8) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.4...gatsby-react-router-scroll@2.0.0-beta.6) (2018-08-07)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.4...gatsby-react-router-scroll@2.0.0-beta.6) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.4...gatsby-react-router-scroll@2.0.0-beta.5) (2018-08-07)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.4...gatsby-react-router-scroll@2.0.0-beta.5) (2018-08-07)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.3...gatsby-react-router-scroll@2.0.0-beta.4) (2018-08-06)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.3...gatsby-react-router-scroll@2.0.0-beta.4) (2018-08-06)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.2...gatsby-react-router-scroll@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.2...gatsby-react-router-scroll@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.1...gatsby-react-router-scroll@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.1...gatsby-react-router-scroll@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@2.0.0-beta.0...gatsby-react-router-scroll@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@2.0.0-beta.0...gatsby-react-router-scroll@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-react-router-scroll
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll/compare/gatsby-react-router-scroll@1.0.17...gatsby-react-router-scroll@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-react-router-scroll@1.0.17...gatsby-react-router-scroll@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-react-router-scroll

--- a/packages/gatsby-remark-autolink-headers/CHANGELOG.md
+++ b/packages/gatsby-remark-autolink-headers/CHANGELOG.md
@@ -7,144 +7,144 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.18...gatsby-remark-autolink-headers@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.18...gatsby-remark-autolink-headers@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.16...gatsby-remark-autolink-headers@2.0.18) (2019-06-14)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.16...gatsby-remark-autolink-headers@2.0.18) (2019-06-14)
 
 ### Features
 
-- **gatsby-remark-autolink-headers:** Support {#custom-id} header syntax ([#14253](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/issues/14253)) ([63dd87b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/commit/63dd87b))
+- **gatsby-remark-autolink-headers:** Support {#custom-id} header syntax ([#14253](https://github.com/gatsbyjs/gatsby/issues/14253)) ([63dd87b](https://github.com/gatsbyjs/gatsby/commit/63dd87b))
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.16...gatsby-remark-autolink-headers@2.0.17) (2019-06-14)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.16...gatsby-remark-autolink-headers@2.0.17) (2019-06-14)
 
 ### Features
 
-- **gatsby-remark-autolink-headers:** Support {#custom-id} header syntax ([#14253](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/issues/14253)) ([63dd87b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/commit/63dd87b))
+- **gatsby-remark-autolink-headers:** Support {#custom-id} header syntax ([#14253](https://github.com/gatsbyjs/gatsby/issues/14253)) ([63dd87b](https://github.com/gatsbyjs/gatsby/commit/63dd87b))
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.15...gatsby-remark-autolink-headers@2.0.16) (2019-03-11)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.15...gatsby-remark-autolink-headers@2.0.16) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.14...gatsby-remark-autolink-headers@2.0.15) (2019-02-28)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.14...gatsby-remark-autolink-headers@2.0.15) (2019-02-28)
 
 ### Features
 
-- **gatsby-remark-autolink-headers:** add removeAccents option ([#11575](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/issues/11575)) ([b6b3045](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/commit/b6b3045))
+- **gatsby-remark-autolink-headers:** add removeAccents option ([#11575](https://github.com/gatsbyjs/gatsby/issues/11575)) ([b6b3045](https://github.com/gatsbyjs/gatsby/commit/b6b3045))
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.13...gatsby-remark-autolink-headers@2.0.14) (2019-02-07)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.13...gatsby-remark-autolink-headers@2.0.14) (2019-02-07)
 
 ### Bug Fixes
 
-- **gatsby-remark-autolink-headers:** improve accessibility of generated links ([#11635](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/issues/11635)) ([2059424](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/commit/2059424))
+- **gatsby-remark-autolink-headers:** improve accessibility of generated links ([#11635](https://github.com/gatsbyjs/gatsby/issues/11635)) ([2059424](https://github.com/gatsbyjs/gatsby/commit/2059424))
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.12...gatsby-remark-autolink-headers@2.0.13) (2019-02-01)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.12...gatsby-remark-autolink-headers@2.0.13) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.12"></a>
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.11...gatsby-remark-autolink-headers@2.0.12) (2018-11-29)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.11...gatsby-remark-autolink-headers@2.0.12) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.10...gatsby-remark-autolink-headers@2.0.11) (2018-11-08)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.10...gatsby-remark-autolink-headers@2.0.11) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.9...gatsby-remark-autolink-headers@2.0.10) (2018-11-02)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.9...gatsby-remark-autolink-headers@2.0.10) (2018-11-02)
 
 ### Bug Fixes
 
-- **gatsby-remark-autolink-headers:** use shouldUpdateScroll api and not onRouteUpdate ([#9657](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/issues/9657)) ([390803c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/commit/390803c))
+- **gatsby-remark-autolink-headers:** use shouldUpdateScroll api and not onRouteUpdate ([#9657](https://github.com/gatsbyjs/gatsby/issues/9657)) ([390803c](https://github.com/gatsbyjs/gatsby/commit/390803c))
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.8...gatsby-remark-autolink-headers@2.0.9) (2018-10-29)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.8...gatsby-remark-autolink-headers@2.0.9) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.7...gatsby-remark-autolink-headers@2.0.8) (2018-10-23)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.7...gatsby-remark-autolink-headers@2.0.8) (2018-10-23)
 
 ### Features
 
-- **gatsby-remark-autolink-headers:** add option to maintain case ([#9313](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/issues/9313)) ([4265ff3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/commit/4265ff3))
+- **gatsby-remark-autolink-headers:** add option to maintain case ([#9313](https://github.com/gatsbyjs/gatsby/issues/9313)) ([4265ff3](https://github.com/gatsbyjs/gatsby/commit/4265ff3))
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.6...gatsby-remark-autolink-headers@2.0.7) (2018-10-15)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.6...gatsby-remark-autolink-headers@2.0.7) (2018-10-15)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.5...gatsby-remark-autolink-headers@2.0.6) (2018-09-19)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.5...gatsby-remark-autolink-headers@2.0.6) (2018-09-19)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-rc.2...gatsby-remark-autolink-headers@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-rc.2...gatsby-remark-autolink-headers@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-rc.1...gatsby-remark-autolink-headers@2.0.0-rc.2) (2018-09-14)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-rc.1...gatsby-remark-autolink-headers@2.0.0-rc.2) (2018-09-14)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-rc.0...gatsby-remark-autolink-headers@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-rc.0...gatsby-remark-autolink-headers@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-beta.5...gatsby-remark-autolink-headers@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-beta.5...gatsby-remark-autolink-headers@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-beta.4...gatsby-remark-autolink-headers@2.0.0-beta.5) (2018-07-31)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-beta.4...gatsby-remark-autolink-headers@2.0.0-beta.5) (2018-07-31)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-beta.3...gatsby-remark-autolink-headers@2.0.0-beta.4) (2018-07-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-beta.3...gatsby-remark-autolink-headers@2.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-beta.2...gatsby-remark-autolink-headers@2.0.0-beta.3) (2018-06-20)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-beta.2...gatsby-remark-autolink-headers@2.0.0-beta.3) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-beta.1...gatsby-remark-autolink-headers@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-beta.1...gatsby-remark-autolink-headers@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@2.0.0-beta.0...gatsby-remark-autolink-headers@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@2.0.0-beta.0...gatsby-remark-autolink-headers@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers/compare/gatsby-remark-autolink-headers@1.4.19...gatsby-remark-autolink-headers@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-autolink-headers@1.4.19...gatsby-remark-autolink-headers@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-autolink-headers

--- a/packages/gatsby-remark-code-repls/CHANGELOG.md
+++ b/packages/gatsby-remark-code-repls/CHANGELOG.md
@@ -7,104 +7,104 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.2.0...gatsby-remark-code-repls@3.0.0) (2019-06-25)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.2.0...gatsby-remark-code-repls@3.0.0) (2019-06-25)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.1.0...gatsby-remark-code-repls@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.1.0...gatsby-remark-code-repls@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.8...gatsby-remark-code-repls@2.1.0) (2019-04-12)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.8...gatsby-remark-code-repls@2.1.0) (2019-04-12)
 
 ### Features
 
-- **gatsby-remark-code-repls:** include matching css option (CodePen) ([#12110](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/issues/12110)) ([1b8d93e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/commit/1b8d93e)), closes [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/issues/1234)
+- **gatsby-remark-code-repls:** include matching css option (CodePen) ([#12110](https://github.com/gatsbyjs/gatsby/issues/12110)) ([1b8d93e](https://github.com/gatsbyjs/gatsby/commit/1b8d93e)), closes [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234)
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.7...gatsby-remark-code-repls@2.0.8) (2019-03-27)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.7...gatsby-remark-code-repls@2.0.8) (2019-03-27)
 
 ### Bug Fixes
 
-- **gatsby-remark-code-repls:** handle scoped packages in dependencies ([#12347](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/issues/12347)) ([bc7d472](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/commit/bc7d472)), closes [#12327](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/issues/12327)
+- **gatsby-remark-code-repls:** handle scoped packages in dependencies ([#12347](https://github.com/gatsbyjs/gatsby/issues/12347)) ([bc7d472](https://github.com/gatsbyjs/gatsby/commit/bc7d472)), closes [#12327](https://github.com/gatsbyjs/gatsby/issues/12327)
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.6...gatsby-remark-code-repls@2.0.7) (2019-03-13)
-
-**Note:** Version bump only for package gatsby-remark-code-repls
-
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.5...gatsby-remark-code-repls@2.0.6) (2019-03-11)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.6...gatsby-remark-code-repls@2.0.7) (2019-03-13)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.4...gatsby-remark-code-repls@2.0.5) (2019-02-01)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.5...gatsby-remark-code-repls@2.0.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.3...gatsby-remark-code-repls@2.0.4) (2019-01-25)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.4...gatsby-remark-code-repls@2.0.5) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-remark-code-repls
+
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.3...gatsby-remark-code-repls@2.0.4) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.2...gatsby-remark-code-repls@2.0.3) (2018-12-11)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.2...gatsby-remark-code-repls@2.0.3) (2018-12-11)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.1...gatsby-remark-code-repls@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.1...gatsby-remark-code-repls@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0...gatsby-remark-code-repls@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0...gatsby-remark-code-repls@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0-rc.1...gatsby-remark-code-repls@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0-rc.1...gatsby-remark-code-repls@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0-rc.0...gatsby-remark-code-repls@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0-rc.0...gatsby-remark-code-repls@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0-beta.4...gatsby-remark-code-repls@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0-beta.4...gatsby-remark-code-repls@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0-beta.3...gatsby-remark-code-repls@2.0.0-beta.4) (2018-07-25)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0-beta.3...gatsby-remark-code-repls@2.0.0-beta.4) (2018-07-25)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0-beta.2...gatsby-remark-code-repls@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0-beta.2...gatsby-remark-code-repls@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0-beta.1...gatsby-remark-code-repls@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0-beta.1...gatsby-remark-code-repls@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@2.0.0-beta.0...gatsby-remark-code-repls@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@2.0.0-beta.0...gatsby-remark-code-repls@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-code-repls
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls/compare/gatsby-remark-code-repls@1.0.11...gatsby-remark-code-repls@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-code-repls@1.0.11...gatsby-remark-code-repls@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-code-repls

--- a/packages/gatsby-remark-copy-linked-files/CHANGELOG.md
+++ b/packages/gatsby-remark-copy-linked-files/CHANGELOG.md
@@ -7,116 +7,116 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.13...gatsby-remark-copy-linked-files@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.13...gatsby-remark-copy-linked-files@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.12...gatsby-remark-copy-linked-files@2.0.13) (2019-05-29)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.12...gatsby-remark-copy-linked-files@2.0.13) (2019-05-29)
 
 ### Features
 
-- **gatsby-remark-copy-linked-files:** handle flash object tags ([#14381](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/issues/14381)) ([ef173e2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/commit/ef173e2))
+- **gatsby-remark-copy-linked-files:** handle flash object tags ([#14381](https://github.com/gatsbyjs/gatsby/issues/14381)) ([ef173e2](https://github.com/gatsbyjs/gatsby/commit/ef173e2))
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.11...gatsby-remark-copy-linked-files@2.0.12) (2019-04-23)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.11...gatsby-remark-copy-linked-files@2.0.12) (2019-04-23)
 
 ### Bug Fixes
 
-- **gatsby-remark-copy-linked-files:** Support MDX by visiting JSX nodes ([#13552](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/issues/13552)) ([0b1c9f2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/commit/0b1c9f2))
+- **gatsby-remark-copy-linked-files:** Support MDX by visiting JSX nodes ([#13552](https://github.com/gatsbyjs/gatsby/issues/13552)) ([0b1c9f2](https://github.com/gatsbyjs/gatsby/commit/0b1c9f2))
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.10...gatsby-remark-copy-linked-files@2.0.11) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-remark-copy-linked-files
-
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.9...gatsby-remark-copy-linked-files@2.0.10) (2019-03-11)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.10...gatsby-remark-copy-linked-files@2.0.11) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.8...gatsby-remark-copy-linked-files@2.0.9) (2019-02-01)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.9...gatsby-remark-copy-linked-files@2.0.10) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-remark-copy-linked-files
+
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.8...gatsby-remark-copy-linked-files@2.0.9) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.7...gatsby-remark-copy-linked-files@2.0.8) (2018-12-17)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.7...gatsby-remark-copy-linked-files@2.0.8) (2018-12-17)
 
 ### Features
 
-- **gatsby-remark-copy-linked-files:** add support for video elements with `src` attribute ([#10395](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/issues/10395)) ([4ceb0f8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/commit/4ceb0f8))
+- **gatsby-remark-copy-linked-files:** add support for video elements with `src` attribute ([#10395](https://github.com/gatsbyjs/gatsby/issues/10395)) ([4ceb0f8](https://github.com/gatsbyjs/gatsby/commit/4ceb0f8))
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.6...gatsby-remark-copy-linked-files@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.6...gatsby-remark-copy-linked-files@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.5...gatsby-remark-copy-linked-files@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.5...gatsby-remark-copy-linked-files@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-rc.5...gatsby-remark-copy-linked-files@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-rc.5...gatsby-remark-copy-linked-files@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-rc.4...gatsby-remark-copy-linked-files@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-rc.4...gatsby-remark-copy-linked-files@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-rc.3...gatsby-remark-copy-linked-files@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-rc.3...gatsby-remark-copy-linked-files@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-rc.2...gatsby-remark-copy-linked-files@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-rc.2...gatsby-remark-copy-linked-files@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-rc.1...gatsby-remark-copy-linked-files@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-rc.1...gatsby-remark-copy-linked-files@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-rc.0...gatsby-remark-copy-linked-files@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-rc.0...gatsby-remark-copy-linked-files@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-beta.3...gatsby-remark-copy-linked-files@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-beta.3...gatsby-remark-copy-linked-files@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-beta.2...gatsby-remark-copy-linked-files@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-beta.2...gatsby-remark-copy-linked-files@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-beta.1...gatsby-remark-copy-linked-files@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-beta.1...gatsby-remark-copy-linked-files@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@2.0.0-beta.0...gatsby-remark-copy-linked-files@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@2.0.0-beta.0...gatsby-remark-copy-linked-files@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files/compare/gatsby-remark-copy-linked-files@1.5.37...gatsby-remark-copy-linked-files@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-copy-linked-files@1.5.37...gatsby-remark-copy-linked-files@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-copy-linked-files

--- a/packages/gatsby-remark-custom-blocks/CHANGELOG.md
+++ b/packages/gatsby-remark-custom-blocks/CHANGELOG.md
@@ -7,100 +7,100 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.7...gatsby-remark-custom-blocks@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.7...gatsby-remark-custom-blocks@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.6...gatsby-remark-custom-blocks@2.0.7) (2019-03-15)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.6...gatsby-remark-custom-blocks@2.0.7) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.5...gatsby-remark-custom-blocks@2.0.6) (2019-03-11)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.5...gatsby-remark-custom-blocks@2.0.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.4...gatsby-remark-custom-blocks@2.0.5) (2019-02-01)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.4...gatsby-remark-custom-blocks@2.0.5) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.3...gatsby-remark-custom-blocks@2.0.4) (2019-01-25)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.3...gatsby-remark-custom-blocks@2.0.4) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.2...gatsby-remark-custom-blocks@2.0.3) (2018-12-27)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.2...gatsby-remark-custom-blocks@2.0.3) (2018-12-27)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.1...gatsby-remark-custom-blocks@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.1...gatsby-remark-custom-blocks@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0...gatsby-remark-custom-blocks@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0...gatsby-remark-custom-blocks@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-rc.1...gatsby-remark-custom-blocks@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-rc.1...gatsby-remark-custom-blocks@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-rc.0...gatsby-remark-custom-blocks@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-rc.0...gatsby-remark-custom-blocks@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-beta.6...gatsby-remark-custom-blocks@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-beta.6...gatsby-remark-custom-blocks@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-beta.5...gatsby-remark-custom-blocks@2.0.0-beta.6) (2018-07-21)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-beta.5...gatsby-remark-custom-blocks@2.0.0-beta.6) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-beta.4...gatsby-remark-custom-blocks@2.0.0-beta.5) (2018-07-13)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-beta.4...gatsby-remark-custom-blocks@2.0.0-beta.5) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-beta.3...gatsby-remark-custom-blocks@2.0.0-beta.4) (2018-07-13)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-beta.3...gatsby-remark-custom-blocks@2.0.0-beta.4) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-beta.2...gatsby-remark-custom-blocks@2.0.0-beta.3) (2018-06-20)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-beta.2...gatsby-remark-custom-blocks@2.0.0-beta.3) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-beta.1...gatsby-remark-custom-blocks@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-beta.1...gatsby-remark-custom-blocks@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@2.0.0-beta.0...gatsby-remark-custom-blocks@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@2.0.0-beta.0...gatsby-remark-custom-blocks@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-custom-blocks/compare/gatsby-remark-custom-blocks@1.0.4...gatsby-remark-custom-blocks@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-custom-blocks@1.0.4...gatsby-remark-custom-blocks@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-custom-blocks

--- a/packages/gatsby-remark-embed-snippet/CHANGELOG.md
+++ b/packages/gatsby-remark-embed-snippet/CHANGELOG.md
@@ -7,130 +7,130 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
-# [4.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@4.0.0...gatsby-remark-embed-snippet@4.1.0) (2019-06-20)
+# [4.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@4.0.0...gatsby-remark-embed-snippet@4.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
-# [4.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.2.4...gatsby-remark-embed-snippet@4.0.0) (2019-06-14)
+# [4.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.2.4...gatsby-remark-embed-snippet@4.0.0) (2019-06-14)
 
 ### Features
 
-- **gatsby-remark-embed-snippet:** apply gatsby-remark-prismjs configuration to embedded snippets ([#13973](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/issues/13973)) ([c43c4c8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/commit/c43c4c8))
+- **gatsby-remark-embed-snippet:** apply gatsby-remark-prismjs configuration to embedded snippets ([#13973](https://github.com/gatsbyjs/gatsby/issues/13973)) ([c43c4c8](https://github.com/gatsbyjs/gatsby/commit/c43c4c8))
 
 ### BREAKING CHANGES
 
 - **gatsby-remark-embed-snippet:** Configuration of `gatsby-remark-prismjs` is used to generate markup for code snippets. `classPrefix` option has been removed from `gatsby-remark-embed-snippet` (same option in `gatsby-remark-prismjs` will be used instead).
 
-## [3.2.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.2.3...gatsby-remark-embed-snippet@3.2.4) (2019-03-11)
+## [3.2.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.2.3...gatsby-remark-embed-snippet@3.2.4) (2019-03-11)
 
 ### Features
 
-- **gatsby-remark-embed-snippet:** Add rb support ([#12416](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/issues/12416)) ([ec8f60b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/commit/ec8f60b))
+- **gatsby-remark-embed-snippet:** Add rb support ([#12416](https://github.com/gatsbyjs/gatsby/issues/12416)) ([ec8f60b](https://github.com/gatsbyjs/gatsby/commit/ec8f60b))
 
-## [3.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.2.2...gatsby-remark-embed-snippet@3.2.3) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-remark-embed-snippet
-
-## [3.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.2.1...gatsby-remark-embed-snippet@3.2.2) (2019-02-01)
+## [3.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.2.2...gatsby-remark-embed-snippet@3.2.3) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
-## [3.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.2.0...gatsby-remark-embed-snippet@3.2.1) (2019-01-25)
+## [3.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.2.1...gatsby-remark-embed-snippet@3.2.2) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-remark-embed-snippet
+
+## [3.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.2.0...gatsby-remark-embed-snippet@3.2.1) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.2.0"></a>
 
-# [3.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.1.2...gatsby-remark-embed-snippet@3.2.0) (2018-12-31)
+# [3.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.1.2...gatsby-remark-embed-snippet@3.2.0) (2018-12-31)
 
 ### Features
 
-- Support hide lines in remark-embed-snippet ([#6084](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/issues/6084)) ([dad0628](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/commit/dad0628))
+- Support hide lines in remark-embed-snippet ([#6084](https://github.com/gatsbyjs/gatsby/issues/6084)) ([dad0628](https://github.com/gatsbyjs/gatsby/commit/dad0628))
 
 <a name="3.1.2"></a>
 
-## [3.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.1.1...gatsby-remark-embed-snippet@3.1.2) (2018-11-30)
+## [3.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.1.1...gatsby-remark-embed-snippet@3.1.2) (2018-11-30)
 
 ### Bug Fixes
 
-- **gatsby-remark-prismjs:** prevent additional blank line from appearing ([#10209](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/issues/10209)) ([71d7f23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/commit/71d7f23))
+- **gatsby-remark-prismjs:** prevent additional blank line from appearing ([#10209](https://github.com/gatsbyjs/gatsby/issues/10209)) ([71d7f23](https://github.com/gatsbyjs/gatsby/commit/71d7f23))
 
 <a name="3.1.1"></a>
 
-## [3.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.1.0...gatsby-remark-embed-snippet@3.1.1) (2018-11-29)
+## [3.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.1.0...gatsby-remark-embed-snippet@3.1.1) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.1.0"></a>
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.3...gatsby-remark-embed-snippet@3.1.0) (2018-11-26)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.3...gatsby-remark-embed-snippet@3.1.0) (2018-11-26)
 
 ### Features
 
-- **gatsby-remark-prismjs:** add in ability to use comments to specify line highlighting ([#9696](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/issues/9696)) ([11e1834](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/commit/11e1834))
+- **gatsby-remark-prismjs:** add in ability to use comments to specify line highlighting ([#9696](https://github.com/gatsbyjs/gatsby/issues/9696)) ([11e1834](https://github.com/gatsbyjs/gatsby/commit/11e1834))
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.2...gatsby-remark-embed-snippet@3.0.3) (2018-11-05)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.2...gatsby-remark-embed-snippet@3.0.3) (2018-11-05)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.1...gatsby-remark-embed-snippet@3.0.2) (2018-10-29)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.1...gatsby-remark-embed-snippet@3.0.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0...gatsby-remark-embed-snippet@3.0.1) (2018-10-12)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0...gatsby-remark-embed-snippet@3.0.1) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0-rc.1...gatsby-remark-embed-snippet@3.0.0) (2018-09-17)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0-rc.1...gatsby-remark-embed-snippet@3.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0-rc.1"></a>
 
-# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0-rc.0...gatsby-remark-embed-snippet@3.0.0-rc.1) (2018-08-29)
+# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0-rc.0...gatsby-remark-embed-snippet@3.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0-rc.0"></a>
 
-# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0-beta.4...gatsby-remark-embed-snippet@3.0.0-rc.0) (2018-08-21)
+# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0-beta.4...gatsby-remark-embed-snippet@3.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0-beta.4"></a>
 
-# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0-beta.3...gatsby-remark-embed-snippet@3.0.0-beta.4) (2018-08-15)
+# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0-beta.3...gatsby-remark-embed-snippet@3.0.0-beta.4) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0-beta.3"></a>
 
-# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0-beta.2...gatsby-remark-embed-snippet@3.0.0-beta.3) (2018-07-21)
+# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0-beta.2...gatsby-remark-embed-snippet@3.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0-beta.2"></a>
 
-# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0-beta.1...gatsby-remark-embed-snippet@3.0.0-beta.2) (2018-06-20)
+# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0-beta.1...gatsby-remark-embed-snippet@3.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0-beta.1"></a>
 
-# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@3.0.0-beta.0...gatsby-remark-embed-snippet@3.0.0-beta.1) (2018-06-17)
+# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@3.0.0-beta.0...gatsby-remark-embed-snippet@3.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet
 
 <a name="3.0.0-beta.0"></a>
 
-# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet/compare/gatsby-remark-embed-snippet@2.0.2...gatsby-remark-embed-snippet@3.0.0-beta.0) (2018-06-17)
+# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-embed-snippet@2.0.2...gatsby-remark-embed-snippet@3.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-embed-snippet

--- a/packages/gatsby-remark-graphviz/CHANGELOG.md
+++ b/packages/gatsby-remark-graphviz/CHANGELOG.md
@@ -7,133 +7,133 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.13...gatsby-remark-graphviz@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.13...gatsby-remark-graphviz@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
-## [1.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.12...gatsby-remark-graphviz@1.0.13) (2019-06-19)
+## [1.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.12...gatsby-remark-graphviz@1.0.13) (2019-06-19)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
-## [1.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.11...gatsby-remark-graphviz@1.0.12) (2019-06-18)
+## [1.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.11...gatsby-remark-graphviz@1.0.12) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
-## [1.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.10...gatsby-remark-graphviz@1.0.11) (2019-06-10)
+## [1.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.10...gatsby-remark-graphviz@1.0.11) (2019-06-10)
 
 ### Bug Fixes
 
-- **gatsby-remark-graphviz:** fix graphviz on node < 10 ([#14691](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/issues/14691)) ([728a63d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/commit/728a63d))
+- **gatsby-remark-graphviz:** fix graphviz on node < 10 ([#14691](https://github.com/gatsbyjs/gatsby/issues/14691)) ([728a63d](https://github.com/gatsbyjs/gatsby/commit/728a63d))
 
-## [1.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.9...gatsby-remark-graphviz@1.0.10) (2019-06-04)
+## [1.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.9...gatsby-remark-graphviz@1.0.10) (2019-06-04)
 
 ### Features
 
-- **gatsby-remark-graphviz:** custom SVG attributes and default styling ([#11624](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/issues/11624)) ([e64ac14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/commit/e64ac14))
+- **gatsby-remark-graphviz:** custom SVG attributes and default styling ([#11624](https://github.com/gatsbyjs/gatsby/issues/11624)) ([e64ac14](https://github.com/gatsbyjs/gatsby/commit/e64ac14))
 
-## [1.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.8...gatsby-remark-graphviz@1.0.9) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-remark-graphviz
-
-## [1.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.7...gatsby-remark-graphviz@1.0.8) (2019-03-11)
+## [1.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.8...gatsby-remark-graphviz@1.0.9) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
-## [1.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.6...gatsby-remark-graphviz@1.0.7) (2019-02-20)
+## [1.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.7...gatsby-remark-graphviz@1.0.8) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
-## [1.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.5...gatsby-remark-graphviz@1.0.6) (2019-02-01)
+## [1.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.6...gatsby-remark-graphviz@1.0.7) (2019-02-20)
+
+**Note:** Version bump only for package gatsby-remark-graphviz
+
+## [1.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.5...gatsby-remark-graphviz@1.0.6) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.5"></a>
 
-## [1.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.4...gatsby-remark-graphviz@1.0.5) (2018-12-19)
+## [1.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.4...gatsby-remark-graphviz@1.0.5) (2018-12-19)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.4"></a>
 
-## [1.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.3...gatsby-remark-graphviz@1.0.4) (2018-11-29)
+## [1.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.3...gatsby-remark-graphviz@1.0.4) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.3"></a>
 
-## [1.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.2...gatsby-remark-graphviz@1.0.3) (2018-10-29)
+## [1.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.2...gatsby-remark-graphviz@1.0.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.2"></a>
 
-## [1.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.1...gatsby-remark-graphviz@1.0.2) (2018-10-23)
+## [1.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.1...gatsby-remark-graphviz@1.0.2) (2018-10-23)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.1"></a>
 
-## [1.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0...gatsby-remark-graphviz@1.0.1) (2018-10-12)
+## [1.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0...gatsby-remark-graphviz@1.0.1) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0"></a>
 
-# [1.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-rc.5...gatsby-remark-graphviz@1.0.0) (2018-09-17)
+# [1.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-rc.5...gatsby-remark-graphviz@1.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-rc.5"></a>
 
-# [1.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-rc.4...gatsby-remark-graphviz@1.0.0-rc.5) (2018-09-11)
+# [1.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-rc.4...gatsby-remark-graphviz@1.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-rc.4"></a>
 
-# [1.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-rc.3...gatsby-remark-graphviz@1.0.0-rc.4) (2018-09-11)
+# [1.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-rc.3...gatsby-remark-graphviz@1.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-rc.3"></a>
 
-# [1.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-rc.2...gatsby-remark-graphviz@1.0.0-rc.3) (2018-09-11)
+# [1.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-rc.2...gatsby-remark-graphviz@1.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-rc.2"></a>
 
-# [1.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-rc.1...gatsby-remark-graphviz@1.0.0-rc.2) (2018-09-11)
+# [1.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-rc.1...gatsby-remark-graphviz@1.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-rc.1"></a>
 
-# [1.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-rc.0...gatsby-remark-graphviz@1.0.0-rc.1) (2018-08-29)
+# [1.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-rc.0...gatsby-remark-graphviz@1.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-rc.0"></a>
 
-# [1.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-beta.3...gatsby-remark-graphviz@1.0.0-rc.0) (2018-08-21)
+# [1.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-beta.3...gatsby-remark-graphviz@1.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-beta.3"></a>
 
-# [1.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-beta.2...gatsby-remark-graphviz@1.0.0-beta.3) (2018-08-20)
+# [1.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-beta.2...gatsby-remark-graphviz@1.0.0-beta.3) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-beta.2"></a>
 
-# [1.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-beta.1...gatsby-remark-graphviz@1.0.0-beta.2) (2018-08-16)
+# [1.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-beta.1...gatsby-remark-graphviz@1.0.0-beta.2) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 
 <a name="1.0.0-beta.1"></a>
 
-# [1.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz/compare/gatsby-remark-graphviz@1.0.0-beta.0...gatsby-remark-graphviz@1.0.0-beta.1) (2018-08-16)
+# [1.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-graphviz@1.0.0-beta.0...gatsby-remark-graphviz@1.0.0-beta.1) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-remark-graphviz
 

--- a/packages/gatsby-remark-images/CHANGELOG.md
+++ b/packages/gatsby-remark-images/CHANGELOG.md
@@ -7,121 +7,121 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-images
 
-## [3.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.1.2...gatsby-remark-images@3.1.3) (2019-07-05)
+## [3.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.1.2...gatsby-remark-images@3.1.3) (2019-07-05)
 
 **Note:** Version bump only for package gatsby-remark-images
 
-## [3.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.1.1...gatsby-remark-images@3.1.2) (2019-06-25)
+## [3.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.1.1...gatsby-remark-images@3.1.2) (2019-06-25)
 
 ### Bug Fixes
 
-- **gatsby-remark-images:** Escape HTML characters for image caption ([#14496](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/14496)) ([9fb78f8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/9fb78f8))
+- **gatsby-remark-images:** Escape HTML characters for image caption ([#14496](https://github.com/gatsbyjs/gatsby/issues/14496)) ([9fb78f8](https://github.com/gatsbyjs/gatsby/commit/9fb78f8))
 
-## [3.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.1.0...gatsby-remark-images@3.1.1) (2019-06-25)
+## [3.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.1.0...gatsby-remark-images@3.1.1) (2019-06-25)
 
 ### Bug Fixes
 
-- **gatsby-remark-images:** remove clickable whitespace around image when linking ([#11528](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/11528)) ([8b398f4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/8b398f4))
+- **gatsby-remark-images:** remove clickable whitespace around image when linking ([#11528](https://github.com/gatsbyjs/gatsby/issues/11528)) ([8b398f4](https://github.com/gatsbyjs/gatsby/commit/8b398f4))
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.16...gatsby-remark-images@3.1.0) (2019-06-20)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.16...gatsby-remark-images@3.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-images
 
-## [3.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.14...gatsby-remark-images@3.0.16) (2019-06-14)
+## [3.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.14...gatsby-remark-images@3.0.16) (2019-06-14)
 
 ### Features
 
-- **gatsby-remark-images:** add option to use alt text as caption fallback ([#14379](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/14379)) ([e5171f1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/e5171f1))
+- **gatsby-remark-images:** add option to use alt text as caption fallback ([#14379](https://github.com/gatsbyjs/gatsby/issues/14379)) ([e5171f1](https://github.com/gatsbyjs/gatsby/commit/e5171f1))
 
-## [3.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.14...gatsby-remark-images@3.0.15) (2019-06-14)
-
-### Features
-
-- **gatsby-remark-images:** add option to use alt text as caption fallback ([#14379](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/14379)) ([e5171f1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/e5171f1))
-
-## [3.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.13...gatsby-remark-images@3.0.14) (2019-05-29)
-
-### Bug Fixes
-
-- cache tracedSVG calculations when cache is present ([#12044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/12044)) ([c40bc4b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/c40bc4b))
-
-## [3.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.12...gatsby-remark-images@3.0.13) (2019-05-26)
+## [3.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.14...gatsby-remark-images@3.0.15) (2019-06-14)
 
 ### Features
 
-- **gatsby-remark-images:** enable relative images in jsx content ([#14314](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/14314)) ([1ccc3c2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/1ccc3c2))
+- **gatsby-remark-images:** add option to use alt text as caption fallback ([#14379](https://github.com/gatsbyjs/gatsby/issues/14379)) ([e5171f1](https://github.com/gatsbyjs/gatsby/commit/e5171f1))
 
-## [3.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.11...gatsby-remark-images@3.0.12) (2019-05-23)
-
-### Bug Fixes
-
-- **gatsby-remark-images:** captions do not show fallback based on filename ([#14219](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/14219)) ([167df1a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/167df1a))
-
-## [3.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.10...gatsby-remark-images@3.0.11) (2019-04-23)
+## [3.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.13...gatsby-remark-images@3.0.14) (2019-05-29)
 
 ### Bug Fixes
 
-- **gatsby-remark-images:** update to accept alt as title when no title present ([#13489](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/13489)) ([80c7023](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/80c7023)), closes [#13448](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/13448)
+- cache tracedSVG calculations when cache is present ([#12044](https://github.com/gatsbyjs/gatsby/issues/12044)) ([c40bc4b](https://github.com/gatsbyjs/gatsby/commit/c40bc4b))
 
-## [3.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.9...gatsby-remark-images@3.0.10) (2019-03-15)
+## [3.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.12...gatsby-remark-images@3.0.13) (2019-05-26)
+
+### Features
+
+- **gatsby-remark-images:** enable relative images in jsx content ([#14314](https://github.com/gatsbyjs/gatsby/issues/14314)) ([1ccc3c2](https://github.com/gatsbyjs/gatsby/commit/1ccc3c2))
+
+## [3.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.11...gatsby-remark-images@3.0.12) (2019-05-23)
+
+### Bug Fixes
+
+- **gatsby-remark-images:** captions do not show fallback based on filename ([#14219](https://github.com/gatsbyjs/gatsby/issues/14219)) ([167df1a](https://github.com/gatsbyjs/gatsby/commit/167df1a))
+
+## [3.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.10...gatsby-remark-images@3.0.11) (2019-04-23)
+
+### Bug Fixes
+
+- **gatsby-remark-images:** update to accept alt as title when no title present ([#13489](https://github.com/gatsbyjs/gatsby/issues/13489)) ([80c7023](https://github.com/gatsbyjs/gatsby/commit/80c7023)), closes [#13448](https://github.com/gatsbyjs/gatsby/issues/13448)
+
+## [3.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.9...gatsby-remark-images@3.0.10) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-remark-images
 
-## [3.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.8...gatsby-remark-images@3.0.9) (2019-03-12)
+## [3.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.8...gatsby-remark-images@3.0.9) (2019-03-12)
 
 ### Bug Fixes
 
-- **gatsby-remark-images:** override all default styling with wrapperStyle ([#12200](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/12200)) ([27e4a6a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/27e4a6a)), closes [gatsbyjs#12199](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/12199)
+- **gatsby-remark-images:** override all default styling with wrapperStyle ([#12200](https://github.com/gatsbyjs/gatsby/issues/12200)) ([27e4a6a](https://github.com/gatsbyjs/gatsby/commit/27e4a6a)), closes [gatsbyjs#12199](https://github.com/gatsbyjs/gatsby/issues/12199)
 
-## [3.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.7...gatsby-remark-images@3.0.8) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-remark-images
-
-## [3.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.6...gatsby-remark-images@3.0.7) (2019-03-11)
-
-### Features
-
-- **gatsby-remark-images:** set wrapperStyle as a function to enable dynamic css ([#12060](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/12060)) ([d83f212](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/d83f212))
-
-## [3.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.5...gatsby-remark-images@3.0.6) (2019-03-04)
+## [3.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.7...gatsby-remark-images@3.0.8) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-images
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.4...gatsby-remark-images@3.0.5) (2019-02-22)
+## [3.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.6...gatsby-remark-images@3.0.7) (2019-03-11)
 
 ### Features
 
-- **gatsby-remark-images:** Add option to use tracedSVG instead of blur up effect ([#9490](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/9490)) ([072bcdd](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/072bcdd))
+- **gatsby-remark-images:** set wrapperStyle as a function to enable dynamic css ([#12060](https://github.com/gatsbyjs/gatsby/issues/12060)) ([d83f212](https://github.com/gatsbyjs/gatsby/commit/d83f212))
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.3...gatsby-remark-images@3.0.4) (2019-02-15)
+## [3.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.5...gatsby-remark-images@3.0.6) (2019-03-04)
+
+**Note:** Version bump only for package gatsby-remark-images
+
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.4...gatsby-remark-images@3.0.5) (2019-02-22)
+
+### Features
+
+- **gatsby-remark-images:** Add option to use tracedSVG instead of blur up effect ([#9490](https://github.com/gatsbyjs/gatsby/issues/9490)) ([072bcdd](https://github.com/gatsbyjs/gatsby/commit/072bcdd))
+
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.3...gatsby-remark-images@3.0.4) (2019-02-15)
 
 ### Bug Fixes
 
-- **gatsby-remark-images:** ensure query string is ignored when detecting images ([#11743](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/11743)) ([37cc21f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/37cc21f))
+- **gatsby-remark-images:** ensure query string is ignored when detecting images ([#11743](https://github.com/gatsbyjs/gatsby/issues/11743)) ([37cc21f](https://github.com/gatsbyjs/gatsby/commit/37cc21f))
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.2...gatsby-remark-images@3.0.3) (2019-02-01)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.2...gatsby-remark-images@3.0.3) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-images
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.1...gatsby-remark-images@3.0.2) (2019-01-31)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.1...gatsby-remark-images@3.0.2) (2019-01-31)
 
 ### Features
 
-- **gatsby-remark-images:** handle image references ([#11086](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/11086)) ([9ee6b4a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/9ee6b4a))
+- **gatsby-remark-images:** handle image references ([#11086](https://github.com/gatsbyjs/gatsby/issues/11086)) ([9ee6b4a](https://github.com/gatsbyjs/gatsby/commit/9ee6b4a))
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@3.0.0...gatsby-remark-images@3.0.1) (2018-11-29)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@3.0.0...gatsby-remark-images@3.0.1) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.6...gatsby-remark-images@3.0.0) (2018-11-21)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.6...gatsby-remark-images@3.0.0) (2018-11-21)
 
 ### Features
 
-- **gatsby-remark-images:** make images blur up ([#7800](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/7800)) ([5a5254e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/5a5254e))
+- **gatsby-remark-images:** make images blur up ([#7800](https://github.com/gatsbyjs/gatsby/issues/7800)) ([5a5254e](https://github.com/gatsbyjs/gatsby/commit/5a5254e))
 
 ### BREAKING CHANGES
 
@@ -129,160 +129,160 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.5...gatsby-remark-images@2.0.6) (2018-11-06)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.5...gatsby-remark-images@2.0.6) (2018-11-06)
 
 ### Features
 
-- **gatsby-plugin-sharp:** cache base64 if possible ([#9059](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/9059)) ([5dc9346](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/5dc9346)), closes [#6999](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/6999)
+- **gatsby-plugin-sharp:** cache base64 if possible ([#9059](https://github.com/gatsbyjs/gatsby/issues/9059)) ([5dc9346](https://github.com/gatsbyjs/gatsby/commit/5dc9346)), closes [#6999](https://github.com/gatsbyjs/gatsby/issues/6999)
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.4...gatsby-remark-images@2.0.5) (2018-10-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.4...gatsby-remark-images@2.0.5) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.3...gatsby-remark-images@2.0.4) (2018-10-09)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.3...gatsby-remark-images@2.0.4) (2018-10-09)
 
 ### Bug Fixes
 
-- don't add extra semicolon after wrapperStyle ([#8864](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/8864)) ([9944450](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/9944450))
+- don't add extra semicolon after wrapperStyle ([#8864](https://github.com/gatsbyjs/gatsby/issues/8864)) ([9944450](https://github.com/gatsbyjs/gatsby/commit/9944450))
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.2...gatsby-remark-images@2.0.3) (2018-09-26)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.2...gatsby-remark-images@2.0.3) (2018-09-26)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-rc.5...gatsby-remark-images@2.0.2) (2018-09-24)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-rc.5...gatsby-remark-images@2.0.2) (2018-09-24)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-rc.5...gatsby-remark-images@2.0.1) (2018-09-17)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-rc.5...gatsby-remark-images@2.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-rc.5"></a>
 
-## [2.0.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-rc.4...gatsby-remark-images@2.0.1-rc.5) (2018-09-11)
+## [2.0.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-rc.4...gatsby-remark-images@2.0.1-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-rc.4"></a>
 
-## [2.0.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-rc.3...gatsby-remark-images@2.0.1-rc.4) (2018-09-11)
+## [2.0.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-rc.3...gatsby-remark-images@2.0.1-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-rc.3"></a>
 
-## [2.0.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-rc.2...gatsby-remark-images@2.0.1-rc.3) (2018-09-11)
+## [2.0.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-rc.2...gatsby-remark-images@2.0.1-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-rc.2"></a>
 
-## [2.0.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-rc.1...gatsby-remark-images@2.0.1-rc.2) (2018-09-11)
+## [2.0.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-rc.1...gatsby-remark-images@2.0.1-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-rc.1"></a>
 
-## [2.0.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-rc.0...gatsby-remark-images@2.0.1-rc.1) (2018-08-29)
+## [2.0.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-rc.0...gatsby-remark-images@2.0.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-rc.0"></a>
 
-## [2.0.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.12...gatsby-remark-images@2.0.1-rc.0) (2018-08-21)
+## [2.0.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.12...gatsby-remark-images@2.0.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.12"></a>
 
-## [2.0.1-beta.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.11...gatsby-remark-images@2.0.1-beta.12) (2018-08-20)
+## [2.0.1-beta.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.11...gatsby-remark-images@2.0.1-beta.12) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.11"></a>
 
-## [2.0.1-beta.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.10...gatsby-remark-images@2.0.1-beta.11) (2018-08-16)
+## [2.0.1-beta.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.10...gatsby-remark-images@2.0.1-beta.11) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.10"></a>
 
-## [2.0.1-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.9...gatsby-remark-images@2.0.1-beta.10) (2018-08-06)
+## [2.0.1-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.9...gatsby-remark-images@2.0.1-beta.10) (2018-08-06)
 
 ### Bug Fixes
 
-- **gatsby-remark-images:** don’t add links if image is already linked ([#6982](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/6982)) ([0146fc6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/0146fc6)), closes [#6980](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/6980)
+- **gatsby-remark-images:** don’t add links if image is already linked ([#6982](https://github.com/gatsbyjs/gatsby/issues/6982)) ([0146fc6](https://github.com/gatsbyjs/gatsby/commit/0146fc6)), closes [#6980](https://github.com/gatsbyjs/gatsby/issues/6980)
 
 <a name="2.0.1-beta.9"></a>
 
-## [2.0.1-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.8...gatsby-remark-images@2.0.1-beta.9) (2018-07-21)
+## [2.0.1-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.8...gatsby-remark-images@2.0.1-beta.9) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.8"></a>
 
-## [2.0.1-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.7...gatsby-remark-images@2.0.1-beta.8) (2018-07-20)
+## [2.0.1-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.7...gatsby-remark-images@2.0.1-beta.8) (2018-07-20)
 
 ### Features
 
-- **remark-images:** Added support for WebP versions in addition to fallbacks. ([#6495](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/6495)) ([65e3a78](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/65e3a78))
+- **remark-images:** Added support for WebP versions in addition to fallbacks. ([#6495](https://github.com/gatsbyjs/gatsby/issues/6495)) ([65e3a78](https://github.com/gatsbyjs/gatsby/commit/65e3a78))
 
 <a name="2.0.1-beta.7"></a>
 
-## [2.0.1-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.6...gatsby-remark-images@2.0.1-beta.7) (2018-07-16)
+## [2.0.1-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.6...gatsby-remark-images@2.0.1-beta.7) (2018-07-16)
 
 ### Features
 
-- **sharp:** move gatsby-plugin-sharp to peerDependencies ([#6487](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/issues/6487)) ([4cdd3bf](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/commit/4cdd3bf))
+- **sharp:** move gatsby-plugin-sharp to peerDependencies ([#6487](https://github.com/gatsbyjs/gatsby/issues/6487)) ([4cdd3bf](https://github.com/gatsbyjs/gatsby/commit/4cdd3bf))
 
 <a name="2.0.1-beta.6"></a>
 
-## [2.0.1-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.5...gatsby-remark-images@2.0.1-beta.6) (2018-07-13)
+## [2.0.1-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.5...gatsby-remark-images@2.0.1-beta.6) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.5"></a>
 
-## [2.0.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.4...gatsby-remark-images@2.0.1-beta.5) (2018-07-13)
+## [2.0.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.4...gatsby-remark-images@2.0.1-beta.5) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.4"></a>
 
-## [2.0.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.3...gatsby-remark-images@2.0.1-beta.4) (2018-07-11)
+## [2.0.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.3...gatsby-remark-images@2.0.1-beta.4) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.3"></a>
 
-## [2.0.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.2...gatsby-remark-images@2.0.1-beta.3) (2018-06-20)
+## [2.0.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.2...gatsby-remark-images@2.0.1-beta.3) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.2"></a>
 
-## [2.0.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.1...gatsby-remark-images@2.0.1-beta.2) (2018-06-20)
+## [2.0.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.1...gatsby-remark-images@2.0.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.1"></a>
 
-## [2.0.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@2.0.1-beta.0...gatsby-remark-images@2.0.1-beta.1) (2018-06-17)
+## [2.0.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@2.0.1-beta.0...gatsby-remark-images@2.0.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-images
 
 <a name="2.0.1-beta.0"></a>
 
-## [2.0.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images/compare/gatsby-remark-images@1.5.67...gatsby-remark-images@2.0.1-beta.0) (2018-06-17)
+## [2.0.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-images@1.5.67...gatsby-remark-images@2.0.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-images

--- a/packages/gatsby-remark-katex/CHANGELOG.md
+++ b/packages/gatsby-remark-katex/CHANGELOG.md
@@ -7,80 +7,80 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-katex
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@3.0.4...gatsby-remark-katex@3.1.0) (2019-06-20)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@3.0.4...gatsby-remark-katex@3.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@3.0.3...gatsby-remark-katex@3.0.4) (2019-03-11)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@3.0.3...gatsby-remark-katex@3.0.4) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@3.0.2...gatsby-remark-katex@3.0.3) (2019-02-01)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@3.0.2...gatsby-remark-katex@3.0.3) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@3.0.1...gatsby-remark-katex@3.0.2) (2019-01-31)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@3.0.1...gatsby-remark-katex@3.0.2) (2019-01-31)
 
 ### Features
 
-- **gatsby-remark-katex:** support katex options ([#11402](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/issues/11402)) ([5547e84](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/commit/5547e84))
+- **gatsby-remark-katex:** support katex options ([#11402](https://github.com/gatsbyjs/gatsby/issues/11402)) ([5547e84](https://github.com/gatsbyjs/gatsby/commit/5547e84))
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@3.0.0...gatsby-remark-katex@3.0.1) (2018-11-29)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@3.0.0...gatsby-remark-katex@3.0.1) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.6...gatsby-remark-katex@3.0.0) (2018-11-15)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.6...gatsby-remark-katex@3.0.0) (2018-11-15)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.5...gatsby-remark-katex@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.5...gatsby-remark-katex@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.0-rc.1...gatsby-remark-katex@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.0-rc.1...gatsby-remark-katex@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.0-rc.0...gatsby-remark-katex@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.0-rc.0...gatsby-remark-katex@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.0-beta.3...gatsby-remark-katex@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.0-beta.3...gatsby-remark-katex@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.0-beta.2...gatsby-remark-katex@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.0-beta.2...gatsby-remark-katex@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.0-beta.1...gatsby-remark-katex@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.0-beta.1...gatsby-remark-katex@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@2.0.0-beta.0...gatsby-remark-katex@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@2.0.0-beta.0...gatsby-remark-katex@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-katex
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex/compare/gatsby-remark-katex@1.0.14...gatsby-remark-katex@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-katex@1.0.14...gatsby-remark-katex@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-katex

--- a/packages/gatsby-remark-prismjs/CHANGELOG.md
+++ b/packages/gatsby-remark-prismjs/CHANGELOG.md
@@ -7,208 +7,208 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
-## [3.3.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.3.0...gatsby-remark-prismjs@3.3.1) (2019-07-02)
+## [3.3.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.3.0...gatsby-remark-prismjs@3.3.1) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
-# [3.3.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.11...gatsby-remark-prismjs@3.3.0) (2019-06-20)
+# [3.3.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.11...gatsby-remark-prismjs@3.3.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
-## [3.2.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.10...gatsby-remark-prismjs@3.2.11) (2019-06-07)
+## [3.2.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.10...gatsby-remark-prismjs@3.2.11) (2019-06-07)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
-## [3.2.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.9...gatsby-remark-prismjs@3.2.10) (2019-06-05)
+## [3.2.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.9...gatsby-remark-prismjs@3.2.10) (2019-06-05)
 
 ### Features
 
-- **gatsby-remark-prismjs:** add support for language extensions ([#11932](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/11932)) ([a20afb1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/a20afb1))
+- **gatsby-remark-prismjs:** add support for language extensions ([#11932](https://github.com/gatsbyjs/gatsby/issues/11932)) ([a20afb1](https://github.com/gatsbyjs/gatsby/commit/a20afb1))
 
-## [3.2.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.8...gatsby-remark-prismjs@3.2.9) (2019-05-02)
+## [3.2.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.8...gatsby-remark-prismjs@3.2.9) (2019-05-02)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
-## [3.2.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.7...gatsby-remark-prismjs@3.2.8) (2019-04-09)
+## [3.2.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.7...gatsby-remark-prismjs@3.2.8) (2019-04-09)
 
 ### Bug Fixes
 
-- **gatsby-remark-prismjs:** Update warnings to handle missing language ([#13159](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/13159)) ([422f91d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/422f91d))
+- **gatsby-remark-prismjs:** Update warnings to handle missing language ([#13159](https://github.com/gatsbyjs/gatsby/issues/13159)) ([422f91d](https://github.com/gatsbyjs/gatsby/commit/422f91d))
 
-## [3.2.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.6...gatsby-remark-prismjs@3.2.7) (2019-04-04)
+## [3.2.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.6...gatsby-remark-prismjs@3.2.7) (2019-04-04)
 
 ### Features
 
-- **gatsby-remark-prismjs:** load languages when referred to by an alias ([#13127](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/13127)) ([de8f99b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/de8f99b))
+- **gatsby-remark-prismjs:** load languages when referred to by an alias ([#13127](https://github.com/gatsbyjs/gatsby/issues/13127)) ([de8f99b](https://github.com/gatsbyjs/gatsby/commit/de8f99b))
 
-## [3.2.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.5...gatsby-remark-prismjs@3.2.6) (2019-03-18)
-
-**Note:** Version bump only for package gatsby-remark-prismjs
-
-## [3.2.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.4...gatsby-remark-prismjs@3.2.5) (2019-03-11)
+## [3.2.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.5...gatsby-remark-prismjs@3.2.6) (2019-03-18)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
-## [3.2.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.3...gatsby-remark-prismjs@3.2.4) (2019-02-01)
+## [3.2.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.4...gatsby-remark-prismjs@3.2.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
-## [3.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.2...gatsby-remark-prismjs@3.2.3) (2019-01-29)
+## [3.2.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.3...gatsby-remark-prismjs@3.2.4) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-remark-prismjs
+
+## [3.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.2...gatsby-remark-prismjs@3.2.3) (2019-01-29)
 
 ### Bug Fixes
 
-- **gatsby-remark-prismjs:** use aliased name for highlighters ([#11038](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/11038)) ([d2eba72](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/d2eba72))
+- **gatsby-remark-prismjs:** use aliased name for highlighters ([#11038](https://github.com/gatsbyjs/gatsby/issues/11038)) ([d2eba72](https://github.com/gatsbyjs/gatsby/commit/d2eba72))
 
-## [3.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.1...gatsby-remark-prismjs@3.2.2) (2019-01-24)
+## [3.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.1...gatsby-remark-prismjs@3.2.2) (2019-01-24)
 
 ### Features
 
-- **gatsby-remark-prismjs:** Add class when using highlighted lines ([#11218](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/11218)) ([e1d6622](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/e1d6622))
+- **gatsby-remark-prismjs:** Add class when using highlighted lines ([#11218](https://github.com/gatsbyjs/gatsby/issues/11218)) ([e1d6622](https://github.com/gatsbyjs/gatsby/commit/e1d6622))
 
 <a name="3.2.1"></a>
 
-## [3.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.2.0...gatsby-remark-prismjs@3.2.1) (2019-01-23)
+## [3.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.2.0...gatsby-remark-prismjs@3.2.1) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.2.0"></a>
 
-# [3.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.1.4...gatsby-remark-prismjs@3.2.0) (2018-12-31)
+# [3.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.1.4...gatsby-remark-prismjs@3.2.0) (2018-12-31)
 
 ### Features
 
-- Support hide lines in remark-embed-snippet ([#6084](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/6084)) ([dad0628](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/dad0628))
+- Support hide lines in remark-embed-snippet ([#6084](https://github.com/gatsbyjs/gatsby/issues/6084)) ([dad0628](https://github.com/gatsbyjs/gatsby/commit/dad0628))
 
 <a name="3.1.4"></a>
 
-## [3.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.1.3...gatsby-remark-prismjs@3.1.4) (2018-12-06)
+## [3.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.1.3...gatsby-remark-prismjs@3.1.4) (2018-12-06)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.1.3"></a>
 
-## [3.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.1.2...gatsby-remark-prismjs@3.1.3) (2018-12-03)
+## [3.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.1.2...gatsby-remark-prismjs@3.1.3) (2018-12-03)
 
 ### Features
 
-- **gatsby-remark-prismjs:** Allow global line number config ([#10076](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/10076)) ([2efec7a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/2efec7a))
+- **gatsby-remark-prismjs:** Allow global line number config ([#10076](https://github.com/gatsbyjs/gatsby/issues/10076)) ([2efec7a](https://github.com/gatsbyjs/gatsby/commit/2efec7a))
 
 <a name="3.1.2"></a>
 
-## [3.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.1.1...gatsby-remark-prismjs@3.1.2) (2018-11-30)
+## [3.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.1.1...gatsby-remark-prismjs@3.1.2) (2018-11-30)
 
 ### Bug Fixes
 
-- **gatsby-remark-prismjs:** prevent additional blank line from appearing ([#10209](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/10209)) ([71d7f23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/71d7f23))
+- **gatsby-remark-prismjs:** prevent additional blank line from appearing ([#10209](https://github.com/gatsbyjs/gatsby/issues/10209)) ([71d7f23](https://github.com/gatsbyjs/gatsby/commit/71d7f23))
 
 <a name="3.1.1"></a>
 
-## [3.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.1.0...gatsby-remark-prismjs@3.1.1) (2018-11-29)
+## [3.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.1.0...gatsby-remark-prismjs@3.1.1) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.1.0"></a>
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.3...gatsby-remark-prismjs@3.1.0) (2018-11-26)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.3...gatsby-remark-prismjs@3.1.0) (2018-11-26)
 
 ### Features
 
-- **gatsby-remark-prismjs:** add in ability to use comments to specify line highlighting ([#9696](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/9696)) ([11e1834](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/11e1834))
+- **gatsby-remark-prismjs:** add in ability to use comments to specify line highlighting ([#9696](https://github.com/gatsbyjs/gatsby/issues/9696)) ([11e1834](https://github.com/gatsbyjs/gatsby/commit/11e1834))
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.2...gatsby-remark-prismjs@3.0.3) (2018-10-29)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.2...gatsby-remark-prismjs@3.0.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.1...gatsby-remark-prismjs@3.0.2) (2018-10-12)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.1...gatsby-remark-prismjs@3.0.2) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0...gatsby-remark-prismjs@3.0.1) (2018-09-26)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0...gatsby-remark-prismjs@3.0.1) (2018-09-26)
 
 ### Features
 
-- add noInlineHighlight option ([#7554](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/issues/7554)) ([f7c07f7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/commit/f7c07f7))
+- add noInlineHighlight option ([#7554](https://github.com/gatsbyjs/gatsby/issues/7554)) ([f7c07f7](https://github.com/gatsbyjs/gatsby/commit/f7c07f7))
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-rc.2...gatsby-remark-prismjs@3.0.0) (2018-09-17)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-rc.2...gatsby-remark-prismjs@3.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-rc.2"></a>
 
-# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-rc.1...gatsby-remark-prismjs@3.0.0-rc.2) (2018-08-29)
+# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-rc.1...gatsby-remark-prismjs@3.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-rc.1"></a>
 
-# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-rc.0...gatsby-remark-prismjs@3.0.0-rc.1) (2018-08-29)
+# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-rc.0...gatsby-remark-prismjs@3.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-rc.0"></a>
 
-# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.8...gatsby-remark-prismjs@3.0.0-rc.0) (2018-08-21)
+# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.8...gatsby-remark-prismjs@3.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.8"></a>
 
-# [3.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.7...gatsby-remark-prismjs@3.0.0-beta.8) (2018-08-20)
+# [3.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.7...gatsby-remark-prismjs@3.0.0-beta.8) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.7"></a>
 
-# [3.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.6...gatsby-remark-prismjs@3.0.0-beta.7) (2018-08-15)
+# [3.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.6...gatsby-remark-prismjs@3.0.0-beta.7) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.6"></a>
 
-# [3.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.5...gatsby-remark-prismjs@3.0.0-beta.6) (2018-08-15)
+# [3.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.5...gatsby-remark-prismjs@3.0.0-beta.6) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.5"></a>
 
-# [3.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.4...gatsby-remark-prismjs@3.0.0-beta.5) (2018-07-27)
+# [3.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.4...gatsby-remark-prismjs@3.0.0-beta.5) (2018-07-27)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.4"></a>
 
-# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.3...gatsby-remark-prismjs@3.0.0-beta.4) (2018-07-21)
+# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.3...gatsby-remark-prismjs@3.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.3"></a>
 
-# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.2...gatsby-remark-prismjs@3.0.0-beta.3) (2018-06-27)
+# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.2...gatsby-remark-prismjs@3.0.0-beta.3) (2018-06-27)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.2"></a>
 
-# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.1...gatsby-remark-prismjs@3.0.0-beta.2) (2018-06-20)
+# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.1...gatsby-remark-prismjs@3.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.1"></a>
 
-# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@3.0.0-beta.0...gatsby-remark-prismjs@3.0.0-beta.1) (2018-06-17)
+# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@3.0.0-beta.0...gatsby-remark-prismjs@3.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-prismjs
 
 <a name="3.0.0-beta.0"></a>
 
-# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs/compare/gatsby-remark-prismjs@2.0.4...gatsby-remark-prismjs@3.0.0-beta.0) (2018-06-17)
+# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-prismjs@2.0.4...gatsby-remark-prismjs@3.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-prismjs

--- a/packages/gatsby-remark-responsive-iframe/CHANGELOG.md
+++ b/packages/gatsby-remark-responsive-iframe/CHANGELOG.md
@@ -7,114 +7,114 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.2.0...gatsby-remark-responsive-iframe@2.2.1) (2019-06-25)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.2.0...gatsby-remark-responsive-iframe@2.2.1) (2019-06-25)
 
 ### Bug Fixes
 
-- **gatsby-remark-responsive-iframe:** Support MDX by visiting JSX nodes ([#13913](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/issues/13913)) ([8da38c0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/commit/8da38c0)), closes [#13552](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/issues/13552)
+- **gatsby-remark-responsive-iframe:** Support MDX by visiting JSX nodes ([#13913](https://github.com/gatsbyjs/gatsby/issues/13913)) ([8da38c0](https://github.com/gatsbyjs/gatsby/commit/8da38c0)), closes [#13552](https://github.com/gatsbyjs/gatsby/issues/13552)
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.1.1...gatsby-remark-responsive-iframe@2.2.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-remark-responsive-iframe
-
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.1.0...gatsby-remark-responsive-iframe@2.1.1) (2019-03-15)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.1.1...gatsby-remark-responsive-iframe@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.10...gatsby-remark-responsive-iframe@2.1.0) (2019-03-14)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.1.0...gatsby-remark-responsive-iframe@2.1.1) (2019-03-15)
+
+**Note:** Version bump only for package gatsby-remark-responsive-iframe
+
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.10...gatsby-remark-responsive-iframe@2.1.0) (2019-03-14)
 
 ### Bug Fixes
 
-- **gatsby-remark-responsive-iframe:** use html node rather than unknown node type ([#12543](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/issues/12543)) ([bb46905](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/commit/bb46905)), closes [/github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-transformer-remark/src/extend-node-type.js#L489-L492](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/issues/L489-L492)
+- **gatsby-remark-responsive-iframe:** use html node rather than unknown node type ([#12543](https://github.com/gatsbyjs/gatsby/issues/12543)) ([bb46905](https://github.com/gatsbyjs/gatsby/commit/bb46905)), closes [/github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-transformer-remark/src/extend-node-type.js#L489-L492](https://github.com/gatsbyjs/gatsby/issues/L489-L492)
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.9...gatsby-remark-responsive-iframe@2.0.10) (2019-03-11)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.9...gatsby-remark-responsive-iframe@2.0.10) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.8...gatsby-remark-responsive-iframe@2.0.9) (2019-02-01)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.8...gatsby-remark-responsive-iframe@2.0.9) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.7...gatsby-remark-responsive-iframe@2.0.8) (2018-12-21)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.7...gatsby-remark-responsive-iframe@2.0.8) (2018-12-21)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.6...gatsby-remark-responsive-iframe@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.6...gatsby-remark-responsive-iframe@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.5...gatsby-remark-responsive-iframe@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.5...gatsby-remark-responsive-iframe@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-rc.5...gatsby-remark-responsive-iframe@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-rc.5...gatsby-remark-responsive-iframe@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-rc.4...gatsby-remark-responsive-iframe@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-rc.4...gatsby-remark-responsive-iframe@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-rc.3...gatsby-remark-responsive-iframe@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-rc.3...gatsby-remark-responsive-iframe@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-rc.2...gatsby-remark-responsive-iframe@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-rc.2...gatsby-remark-responsive-iframe@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-rc.1...gatsby-remark-responsive-iframe@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-rc.1...gatsby-remark-responsive-iframe@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-rc.0...gatsby-remark-responsive-iframe@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-rc.0...gatsby-remark-responsive-iframe@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-beta.3...gatsby-remark-responsive-iframe@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-beta.3...gatsby-remark-responsive-iframe@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-beta.2...gatsby-remark-responsive-iframe@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-beta.2...gatsby-remark-responsive-iframe@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-beta.1...gatsby-remark-responsive-iframe@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-beta.1...gatsby-remark-responsive-iframe@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@2.0.0-beta.0...gatsby-remark-responsive-iframe@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@2.0.0-beta.0...gatsby-remark-responsive-iframe@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-responsive-iframe/compare/gatsby-remark-responsive-iframe@1.4.20...gatsby-remark-responsive-iframe@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-responsive-iframe@1.4.20...gatsby-remark-responsive-iframe@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-responsive-iframe

--- a/packages/gatsby-remark-smartypants/CHANGELOG.md
+++ b/packages/gatsby-remark-smartypants/CHANGELOG.md
@@ -7,68 +7,68 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.9...gatsby-remark-smartypants@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.9...gatsby-remark-smartypants@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.8...gatsby-remark-smartypants@2.0.9) (2019-03-11)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.8...gatsby-remark-smartypants@2.0.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.7...gatsby-remark-smartypants@2.0.8) (2019-02-01)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.7...gatsby-remark-smartypants@2.0.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.6...gatsby-remark-smartypants@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.6...gatsby-remark-smartypants@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.5...gatsby-remark-smartypants@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.5...gatsby-remark-smartypants@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.0-rc.1...gatsby-remark-smartypants@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.0-rc.1...gatsby-remark-smartypants@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.0-rc.0...gatsby-remark-smartypants@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.0-rc.0...gatsby-remark-smartypants@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.0-beta.3...gatsby-remark-smartypants@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.0-beta.3...gatsby-remark-smartypants@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.0-beta.2...gatsby-remark-smartypants@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.0-beta.2...gatsby-remark-smartypants@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.0-beta.1...gatsby-remark-smartypants@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.0-beta.1...gatsby-remark-smartypants@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@2.0.0-beta.0...gatsby-remark-smartypants@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@2.0.0-beta.0...gatsby-remark-smartypants@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-smartypants
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants/compare/gatsby-remark-smartypants@1.4.12...gatsby-remark-smartypants@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-remark-smartypants@1.4.12...gatsby-remark-smartypants@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-remark-smartypants

--- a/packages/gatsby-source-contentful/CHANGELOG.md
+++ b/packages/gatsby-source-contentful/CHANGELOG.md
@@ -7,614 +7,614 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.8...gatsby-source-contentful@2.1.9) (2019-07-10)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.8...gatsby-source-contentful@2.1.9) (2019-07-10)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.7...gatsby-source-contentful@2.1.8) (2019-07-06)
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.7...gatsby-source-contentful@2.1.8) (2019-07-06)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.6...gatsby-source-contentful@2.1.7) (2019-07-05)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.6...gatsby-source-contentful@2.1.7) (2019-07-05)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** include locale in asset cache key ([#14994](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/14994)) ([e6fb93a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/e6fb93a))
+- **gatsby-source-contentful:** include locale in asset cache key ([#14994](https://github.com/gatsbyjs/gatsby/issues/14994)) ([e6fb93a](https://github.com/gatsbyjs/gatsby/commit/e6fb93a))
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.5...gatsby-source-contentful@2.1.6) (2019-07-03)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.4...gatsby-source-contentful@2.1.5) (2019-07-02)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.5...gatsby-source-contentful@2.1.6) (2019-07-03)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.3...gatsby-source-contentful@2.1.4) (2019-07-01)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.4...gatsby-source-contentful@2.1.5) (2019-07-02)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.3...gatsby-source-contentful@2.1.4) (2019-07-01)
 
 ### Features
 
-- **gatsby-source-contentful:** Add option to not use sync tokens ([#15203](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/15203)) ([251f9a8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/251f9a8))
+- **gatsby-source-contentful:** Add option to not use sync tokens ([#15203](https://github.com/gatsbyjs/gatsby/issues/15203)) ([251f9a8](https://github.com/gatsbyjs/gatsby/commit/251f9a8))
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.2...gatsby-source-contentful@2.1.3) (2019-06-25)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.1...gatsby-source-contentful@2.1.2) (2019-06-24)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.2...gatsby-source-contentful@2.1.3) (2019-06-25)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.1.0...gatsby-source-contentful@2.1.1) (2019-06-21)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.1...gatsby-source-contentful@2.1.2) (2019-06-24)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.75...gatsby-source-contentful@2.1.0) (2019-06-20)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.1.0...gatsby-source-contentful@2.1.1) (2019-06-21)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.75](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.72...gatsby-source-contentful@2.0.75) (2019-06-19)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.75...gatsby-source-contentful@2.1.0) (2019-06-20)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.75](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.72...gatsby-source-contentful@2.0.75) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [2.0.74](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.73...gatsby-source-contentful@2.0.74) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/2594623))
-
-## [2.0.73](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.72...gatsby-source-contentful@2.0.73) (2019-06-18)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.72](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.71...gatsby-source-contentful@2.0.72) (2019-06-18)
+## [2.0.74](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.73...gatsby-source-contentful@2.0.74) (2019-06-19)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** Restricts images to 4000 max image width/height ([#14760](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/14760)) ([177d35c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/177d35c))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [2.0.71](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.69...gatsby-source-contentful@2.0.71) (2019-06-12)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.70](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.69...gatsby-source-contentful@2.0.70) (2019-06-12)
+## [2.0.73](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.72...gatsby-source-contentful@2.0.73) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.69](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.68...gatsby-source-contentful@2.0.69) (2019-06-10)
+## [2.0.72](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.71...gatsby-source-contentful@2.0.72) (2019-06-18)
+
+### Bug Fixes
+
+- **gatsby-source-contentful:** Restricts images to 4000 max image width/height ([#14760](https://github.com/gatsbyjs/gatsby/issues/14760)) ([177d35c](https://github.com/gatsbyjs/gatsby/commit/177d35c))
+
+## [2.0.71](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.69...gatsby-source-contentful@2.0.71) (2019-06-12)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.70](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.69...gatsby-source-contentful@2.0.70) (2019-06-12)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.69](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.68...gatsby-source-contentful@2.0.69) (2019-06-10)
 
 ### Features
 
-- **gatsby-source-contentful:** Remove default image transform width ([#14159](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/14159)) ([d24e22f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/d24e22f))
+- **gatsby-source-contentful:** Remove default image transform width ([#14159](https://github.com/gatsbyjs/gatsby/issues/14159)) ([d24e22f](https://github.com/gatsbyjs/gatsby/commit/d24e22f))
 
-## [2.0.68](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.67...gatsby-source-contentful@2.0.68) (2019-06-10)
+## [2.0.68](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.67...gatsby-source-contentful@2.0.68) (2019-06-10)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.67](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.66...gatsby-source-contentful@2.0.67) (2019-05-31)
+## [2.0.67](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.66...gatsby-source-contentful@2.0.67) (2019-05-31)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** add query to the subsequent api call ([#14449](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/14449)) ([45fcefb](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/45fcefb))
+- **gatsby-source-contentful:** add query to the subsequent api call ([#14449](https://github.com/gatsbyjs/gatsby/issues/14449)) ([45fcefb](https://github.com/gatsbyjs/gatsby/commit/45fcefb))
 
-## [2.0.66](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.65...gatsby-source-contentful@2.0.66) (2019-05-31)
+## [2.0.66](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.65...gatsby-source-contentful@2.0.66) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.65](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.64...gatsby-source-contentful@2.0.65) (2019-05-29)
+## [2.0.65](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.64...gatsby-source-contentful@2.0.65) (2019-05-29)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** Don't set default widths ([#14361](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/14361)) ([ee83270](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/ee83270))
+- **gatsby-source-contentful:** Don't set default widths ([#14361](https://github.com/gatsbyjs/gatsby/issues/14361)) ([ee83270](https://github.com/gatsbyjs/gatsby/commit/ee83270))
 
-## [2.0.64](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.63...gatsby-source-contentful@2.0.64) (2019-05-29)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.63](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.62...gatsby-source-contentful@2.0.63) (2019-05-24)
+## [2.0.64](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.63...gatsby-source-contentful@2.0.64) (2019-05-29)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.62](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.61...gatsby-source-contentful@2.0.62) (2019-05-23)
+## [2.0.63](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.62...gatsby-source-contentful@2.0.63) (2019-05-24)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.61](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.60...gatsby-source-contentful@2.0.61) (2019-05-20)
+## [2.0.62](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.61...gatsby-source-contentful@2.0.62) (2019-05-23)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.60](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.59...gatsby-source-contentful@2.0.60) (2019-05-18)
+## [2.0.61](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.60...gatsby-source-contentful@2.0.61) (2019-05-20)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.60](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.59...gatsby-source-contentful@2.0.60) (2019-05-18)
 
 ### Features
 
-- **gatsby-source-contentful:** add options validation and more detailed error messages ([#9231](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/9231)) ([68cb1a5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/68cb1a5))
+- **gatsby-source-contentful:** add options validation and more detailed error messages ([#9231](https://github.com/gatsbyjs/gatsby/issues/9231)) ([68cb1a5](https://github.com/gatsbyjs/gatsby/commit/68cb1a5))
 
-## [2.0.59](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.58...gatsby-source-contentful@2.0.59) (2019-05-16)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.58](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.57...gatsby-source-contentful@2.0.58) (2019-05-15)
+## [2.0.59](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.58...gatsby-source-contentful@2.0.59) (2019-05-16)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.57](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.56...gatsby-source-contentful@2.0.57) (2019-05-14)
+## [2.0.58](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.57...gatsby-source-contentful@2.0.58) (2019-05-15)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.56](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.55...gatsby-source-contentful@2.0.56) (2019-05-09)
+## [2.0.57](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.56...gatsby-source-contentful@2.0.57) (2019-05-14)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.55](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.54...gatsby-source-contentful@2.0.55) (2019-05-03)
+## [2.0.56](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.55...gatsby-source-contentful@2.0.56) (2019-05-09)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.54](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.53...gatsby-source-contentful@2.0.54) (2019-04-30)
+## [2.0.55](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.54...gatsby-source-contentful@2.0.55) (2019-05-03)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.53](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.52...gatsby-source-contentful@2.0.53) (2019-04-24)
+## [2.0.54](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.53...gatsby-source-contentful@2.0.54) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.52](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.51...gatsby-source-contentful@2.0.52) (2019-04-23)
+## [2.0.53](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.52...gatsby-source-contentful@2.0.53) (2019-04-24)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.51](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.50...gatsby-source-contentful@2.0.51) (2019-04-23)
+## [2.0.52](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.51...gatsby-source-contentful@2.0.52) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.50](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.49...gatsby-source-contentful@2.0.50) (2019-04-17)
+## [2.0.51](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.50...gatsby-source-contentful@2.0.51) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.50](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.49...gatsby-source-contentful@2.0.50) (2019-04-17)
 
 ### Features
 
-- **gatsby-source-contentful:** add locale filter ([#12939](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/12939)) ([6421c5b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/6421c5b))
+- **gatsby-source-contentful:** add locale filter ([#12939](https://github.com/gatsbyjs/gatsby/issues/12939)) ([6421c5b](https://github.com/gatsbyjs/gatsby/commit/6421c5b))
 
-## [2.0.49](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.48...gatsby-source-contentful@2.0.49) (2019-04-15)
-
-### Bug Fixes
-
-- **gatsby-source-contentful:** add missing "face" crop focus option ([#13364](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/13364)) ([68340bf](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/68340bf))
-
-## [2.0.48](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.47...gatsby-source-contentful@2.0.48) (2019-04-11)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.47](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.46...gatsby-source-contentful@2.0.47) (2019-04-09)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.46](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.45...gatsby-source-contentful@2.0.46) (2019-04-08)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.45](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.44...gatsby-source-contentful@2.0.45) (2019-03-27)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.44](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.43...gatsby-source-contentful@2.0.44) (2019-03-25)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.43](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.42...gatsby-source-contentful@2.0.43) (2019-03-25)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.42](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.41...gatsby-source-contentful@2.0.42) (2019-03-22)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.41](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.40...gatsby-source-contentful@2.0.41) (2019-03-20)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.40](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.39...gatsby-source-contentful@2.0.40) (2019-03-18)
+## [2.0.49](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.48...gatsby-source-contentful@2.0.49) (2019-04-15)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** Add gatsby-source-filesystem as dependency ([#12612](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/12612)) ([0e6d7a1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/0e6d7a1))
+- **gatsby-source-contentful:** add missing "face" crop focus option ([#13364](https://github.com/gatsbyjs/gatsby/issues/13364)) ([68340bf](https://github.com/gatsbyjs/gatsby/commit/68340bf))
 
-## [2.0.39](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.38...gatsby-source-contentful@2.0.39) (2019-03-15)
+## [2.0.48](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.47...gatsby-source-contentful@2.0.48) (2019-04-11)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.47](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.46...gatsby-source-contentful@2.0.47) (2019-04-09)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.46](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.45...gatsby-source-contentful@2.0.46) (2019-04-08)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.45](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.44...gatsby-source-contentful@2.0.45) (2019-03-27)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.44](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.43...gatsby-source-contentful@2.0.44) (2019-03-25)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.43](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.42...gatsby-source-contentful@2.0.43) (2019-03-25)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.42](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.41...gatsby-source-contentful@2.0.42) (2019-03-22)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.41](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.40...gatsby-source-contentful@2.0.41) (2019-03-20)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.40](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.39...gatsby-source-contentful@2.0.40) (2019-03-18)
+
+### Bug Fixes
+
+- **gatsby-source-contentful:** Add gatsby-source-filesystem as dependency ([#12612](https://github.com/gatsbyjs/gatsby/issues/12612)) ([0e6d7a1](https://github.com/gatsbyjs/gatsby/commit/0e6d7a1))
+
+## [2.0.39](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.38...gatsby-source-contentful@2.0.39) (2019-03-15)
 
 ### Features
 
-- **gatsby-source-contentful:** Support storing assets locally ([#10682](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/10682)) ([6d7bd76](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/6d7bd76))
+- **gatsby-source-contentful:** Support storing assets locally ([#10682](https://github.com/gatsbyjs/gatsby/issues/10682)) ([6d7bd76](https://github.com/gatsbyjs/gatsby/commit/6d7bd76))
 
-## [2.0.38](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.37...gatsby-source-contentful@2.0.38) (2019-03-12)
-
-**Note:** Version bump only for package gatsby-source-contentful
-
-## [2.0.37](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.36...gatsby-source-contentful@2.0.37) (2019-03-11)
+## [2.0.38](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.37...gatsby-source-contentful@2.0.38) (2019-03-12)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.36](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.35...gatsby-source-contentful@2.0.36) (2019-03-11)
+## [2.0.37](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.36...gatsby-source-contentful@2.0.37) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.34...gatsby-source-contentful@2.0.35) (2019-03-05)
+## [2.0.36](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.35...gatsby-source-contentful@2.0.36) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.33...gatsby-source-contentful@2.0.34) (2019-03-04)
+## [2.0.35](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.34...gatsby-source-contentful@2.0.35) (2019-03-05)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.32...gatsby-source-contentful@2.0.33) (2019-02-28)
+## [2.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.33...gatsby-source-contentful@2.0.34) (2019-03-04)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.31...gatsby-source-contentful@2.0.32) (2019-02-22)
+## [2.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.32...gatsby-source-contentful@2.0.33) (2019-02-28)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.31](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.30...gatsby-source-contentful@2.0.31) (2019-02-22)
+## [2.0.32](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.31...gatsby-source-contentful@2.0.32) (2019-02-22)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.29...gatsby-source-contentful@2.0.30) (2019-02-19)
+## [2.0.31](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.30...gatsby-source-contentful@2.0.31) (2019-02-22)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.28...gatsby-source-contentful@2.0.29) (2019-02-01)
+## [2.0.30](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.29...gatsby-source-contentful@2.0.30) (2019-02-19)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
-## [2.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.27...gatsby-source-contentful@2.0.28) (2019-01-29)
+## [2.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.28...gatsby-source-contentful@2.0.29) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-source-contentful
+
+## [2.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.27...gatsby-source-contentful@2.0.28) (2019-01-29)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.27"></a>
 
-## [2.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.26...gatsby-source-contentful@2.0.27) (2019-01-23)
+## [2.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.26...gatsby-source-contentful@2.0.27) (2019-01-23)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** checking if entryItemFieldValue[0] exists ([#11087](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/11087)) ([a11f79a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/a11f79a))
+- **gatsby-source-contentful:** checking if entryItemFieldValue[0] exists ([#11087](https://github.com/gatsbyjs/gatsby/issues/11087)) ([a11f79a](https://github.com/gatsbyjs/gatsby/commit/a11f79a))
 
 <a name="2.0.26"></a>
 
-## [2.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.24...gatsby-source-contentful@2.0.26) (2019-01-11)
+## [2.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.24...gatsby-source-contentful@2.0.26) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.24"></a>
 
-## [2.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.23...gatsby-source-contentful@2.0.24) (2019-01-11)
+## [2.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.23...gatsby-source-contentful@2.0.24) (2019-01-11)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** Fix check for fluid and fixed size fliters ([#11009](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/11009)) ([aeb2bbd](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/aeb2bbd))
+- **gatsby-source-contentful:** Fix check for fluid and fixed size fliters ([#11009](https://github.com/gatsbyjs/gatsby/issues/11009)) ([aeb2bbd](https://github.com/gatsbyjs/gatsby/commit/aeb2bbd))
 
 <a name="2.0.23"></a>
 
-## [2.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.22...gatsby-source-contentful@2.0.23) (2019-01-09)
+## [2.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.22...gatsby-source-contentful@2.0.23) (2019-01-09)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.22"></a>
 
-## [2.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.21...gatsby-source-contentful@2.0.22) (2018-12-27)
+## [2.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.21...gatsby-source-contentful@2.0.22) (2018-12-27)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.21"></a>
 
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.20...gatsby-source-contentful@2.0.21) (2018-12-21)
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.20...gatsby-source-contentful@2.0.21) (2018-12-21)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.20"></a>
 
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.19...gatsby-source-contentful@2.0.20) (2018-12-11)
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.19...gatsby-source-contentful@2.0.20) (2018-12-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.19"></a>
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.18...gatsby-source-contentful@2.0.19) (2018-12-07)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.18...gatsby-source-contentful@2.0.19) (2018-12-07)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.18"></a>
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.17...gatsby-source-contentful@2.0.18) (2018-12-05)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.17...gatsby-source-contentful@2.0.18) (2018-12-05)
 
 ### Features
 
-- **gatsby-source-contentful:** enable RichText for all users ([#10301](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/10301)) ([ce65534](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/ce65534))
+- **gatsby-source-contentful:** enable RichText for all users ([#10301](https://github.com/gatsbyjs/gatsby/issues/10301)) ([ce65534](https://github.com/gatsbyjs/gatsby/commit/ce65534))
 
 <a name="2.0.17"></a>
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.16...gatsby-source-contentful@2.0.17) (2018-12-03)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.16...gatsby-source-contentful@2.0.17) (2018-12-03)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** use safe stringification for Rich Text fields ([#10228](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/10228)) ([2d2ac7c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/2d2ac7c))
+- **gatsby-source-contentful:** use safe stringification for Rich Text fields ([#10228](https://github.com/gatsbyjs/gatsby/issues/10228)) ([2d2ac7c](https://github.com/gatsbyjs/gatsby/commit/2d2ac7c))
 
 <a name="2.0.16"></a>
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.15...gatsby-source-contentful@2.0.16) (2018-11-29)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.15...gatsby-source-contentful@2.0.16) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.15"></a>
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.14...gatsby-source-contentful@2.0.15) (2018-11-21)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.14...gatsby-source-contentful@2.0.15) (2018-11-21)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.14"></a>
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.13...gatsby-source-contentful@2.0.14) (2018-11-12)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.13...gatsby-source-contentful@2.0.14) (2018-11-12)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** Remove unused argument ([#9866](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/9866)) ([88fffb5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/88fffb5))
+- **gatsby-source-contentful:** Remove unused argument ([#9866](https://github.com/gatsbyjs/gatsby/issues/9866)) ([88fffb5](https://github.com/gatsbyjs/gatsby/commit/88fffb5))
 
 <a name="2.0.13"></a>
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.12...gatsby-source-contentful@2.0.13) (2018-11-08)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.12...gatsby-source-contentful@2.0.13) (2018-11-08)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** fix structured content fields ([#9768](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/9768)) ([b7992fb](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/b7992fb))
+- **gatsby-source-contentful:** fix structured content fields ([#9768](https://github.com/gatsbyjs/gatsby/issues/9768)) ([b7992fb](https://github.com/gatsbyjs/gatsby/commit/b7992fb))
 
 <a name="2.0.12"></a>
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.11...gatsby-source-contentful@2.0.12) (2018-11-06)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.11...gatsby-source-contentful@2.0.12) (2018-11-06)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.10...gatsby-source-contentful@2.0.11) (2018-11-05)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.10...gatsby-source-contentful@2.0.11) (2018-11-05)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.9...gatsby-source-contentful@2.0.10) (2018-11-01)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.9...gatsby-source-contentful@2.0.10) (2018-11-01)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.8...gatsby-source-contentful@2.0.9) (2018-10-29)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.8...gatsby-source-contentful@2.0.9) (2018-10-29)
 
 ### Features
 
-- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/9338)
+- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/issues/9338)
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.7...gatsby-source-contentful@2.0.8) (2018-10-29)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.7...gatsby-source-contentful@2.0.8) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.6...gatsby-source-contentful@2.0.7) (2018-10-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.6...gatsby-source-contentful@2.0.7) (2018-10-29)
 
 ### Features
 
-- **gatsby-source-contentful:** adds CENTER option to ImageCropFocusType ([#9473](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/9473)) ([cc8c60d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/cc8c60d))
+- **gatsby-source-contentful:** adds CENTER option to ImageCropFocusType ([#9473](https://github.com/gatsbyjs/gatsby/issues/9473)) ([cc8c60d](https://github.com/gatsbyjs/gatsby/commit/cc8c60d))
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.5...gatsby-source-contentful@2.0.6) (2018-10-24)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.5...gatsby-source-contentful@2.0.6) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.4...gatsby-source-contentful@2.0.5) (2018-10-23)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.4...gatsby-source-contentful@2.0.5) (2018-10-23)
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** fix missing linked assets when editing unrelated fields ([#9303](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/9303)) ([3969a94](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/3969a94))
+- **gatsby-source-contentful:** fix missing linked assets when editing unrelated fields ([#9303](https://github.com/gatsbyjs/gatsby/issues/9303)) ([3969a94](https://github.com/gatsbyjs/gatsby/commit/3969a94))
 
 ### Features
 
-- **gatsby-source-contentful:** add structured text node type ([#8214](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/8214)) ([57f48ef](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/57f48ef))
+- **gatsby-source-contentful:** add structured text node type ([#8214](https://github.com/gatsbyjs/gatsby/issues/8214)) ([57f48ef](https://github.com/gatsbyjs/gatsby/commit/57f48ef))
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.3...gatsby-source-contentful@2.0.4) (2018-10-16)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.3...gatsby-source-contentful@2.0.4) (2018-10-16)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.2...gatsby-source-contentful@2.0.3) (2018-10-10)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.2...gatsby-source-contentful@2.0.3) (2018-10-10)
 
 ### Features
 
-- store sync token for contentful preview ([#8814](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/issues/8814)) ([365942b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/commit/365942b))
+- store sync token for contentful preview ([#8814](https://github.com/gatsbyjs/gatsby/issues/8814)) ([365942b](https://github.com/gatsbyjs/gatsby/commit/365942b))
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1...gatsby-source-contentful@2.0.2) (2018-10-03)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1...gatsby-source-contentful@2.0.2) (2018-10-03)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.9...gatsby-source-contentful@2.0.1) (2018-09-17)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.9...gatsby-source-contentful@2.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.9"></a>
 
-## [2.0.1-rc.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.8...gatsby-source-contentful@2.0.1-rc.9) (2018-09-11)
+## [2.0.1-rc.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.8...gatsby-source-contentful@2.0.1-rc.9) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.8"></a>
 
-## [2.0.1-rc.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.7...gatsby-source-contentful@2.0.1-rc.8) (2018-09-11)
+## [2.0.1-rc.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.7...gatsby-source-contentful@2.0.1-rc.8) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.7"></a>
 
-## [2.0.1-rc.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.6...gatsby-source-contentful@2.0.1-rc.7) (2018-09-11)
+## [2.0.1-rc.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.6...gatsby-source-contentful@2.0.1-rc.7) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.6"></a>
 
-## [2.0.1-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.5...gatsby-source-contentful@2.0.1-rc.6) (2018-09-11)
+## [2.0.1-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.5...gatsby-source-contentful@2.0.1-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.5"></a>
 
-## [2.0.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.4...gatsby-source-contentful@2.0.1-rc.5) (2018-09-07)
+## [2.0.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.4...gatsby-source-contentful@2.0.1-rc.5) (2018-09-07)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.4"></a>
 
-## [2.0.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.3...gatsby-source-contentful@2.0.1-rc.4) (2018-09-05)
+## [2.0.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.3...gatsby-source-contentful@2.0.1-rc.4) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.3"></a>
 
-## [2.0.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.2...gatsby-source-contentful@2.0.1-rc.3) (2018-08-31)
+## [2.0.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.2...gatsby-source-contentful@2.0.1-rc.3) (2018-08-31)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.2"></a>
 
-## [2.0.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.1...gatsby-source-contentful@2.0.1-rc.2) (2018-08-29)
+## [2.0.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.1...gatsby-source-contentful@2.0.1-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.1"></a>
 
-## [2.0.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-rc.0...gatsby-source-contentful@2.0.1-rc.1) (2018-08-29)
+## [2.0.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-rc.0...gatsby-source-contentful@2.0.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-rc.0"></a>
 
-## [2.0.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.18...gatsby-source-contentful@2.0.1-rc.0) (2018-08-21)
+## [2.0.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.18...gatsby-source-contentful@2.0.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.18"></a>
 
-## [2.0.1-beta.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.17...gatsby-source-contentful@2.0.1-beta.18) (2018-08-16)
+## [2.0.1-beta.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.17...gatsby-source-contentful@2.0.1-beta.18) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.17"></a>
 
-## [2.0.1-beta.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.16...gatsby-source-contentful@2.0.1-beta.17) (2018-08-16)
+## [2.0.1-beta.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.16...gatsby-source-contentful@2.0.1-beta.17) (2018-08-16)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.16"></a>
 
-## [2.0.1-beta.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.15...gatsby-source-contentful@2.0.1-beta.16) (2018-08-14)
+## [2.0.1-beta.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.15...gatsby-source-contentful@2.0.1-beta.16) (2018-08-14)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.15"></a>
 
-## [2.0.1-beta.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.14...gatsby-source-contentful@2.0.1-beta.15) (2018-07-21)
+## [2.0.1-beta.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.14...gatsby-source-contentful@2.0.1-beta.15) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.14"></a>
 
-## [2.0.1-beta.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.13...gatsby-source-contentful@2.0.1-beta.14) (2018-07-20)
+## [2.0.1-beta.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.13...gatsby-source-contentful@2.0.1-beta.14) (2018-07-20)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.13"></a>
 
-## [2.0.1-beta.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.12...gatsby-source-contentful@2.0.1-beta.13) (2018-07-13)
+## [2.0.1-beta.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.12...gatsby-source-contentful@2.0.1-beta.13) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.12"></a>
 
-## [2.0.1-beta.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.11...gatsby-source-contentful@2.0.1-beta.12) (2018-07-13)
+## [2.0.1-beta.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.11...gatsby-source-contentful@2.0.1-beta.12) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.11"></a>
 
-## [2.0.1-beta.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.10...gatsby-source-contentful@2.0.1-beta.11) (2018-07-11)
+## [2.0.1-beta.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.10...gatsby-source-contentful@2.0.1-beta.11) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.10"></a>
 
-## [2.0.1-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.9...gatsby-source-contentful@2.0.1-beta.10) (2018-07-09)
+## [2.0.1-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.9...gatsby-source-contentful@2.0.1-beta.10) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.9"></a>
 
-## [2.0.1-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.8...gatsby-source-contentful@2.0.1-beta.9) (2018-07-06)
+## [2.0.1-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.8...gatsby-source-contentful@2.0.1-beta.9) (2018-07-06)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.8"></a>
 
-## [2.0.1-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.7...gatsby-source-contentful@2.0.1-beta.8) (2018-06-25)
+## [2.0.1-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.7...gatsby-source-contentful@2.0.1-beta.8) (2018-06-25)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.7"></a>
 
-## [2.0.1-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.6...gatsby-source-contentful@2.0.1-beta.7) (2018-06-25)
+## [2.0.1-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.6...gatsby-source-contentful@2.0.1-beta.7) (2018-06-25)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.6"></a>
 
-## [2.0.1-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.5...gatsby-source-contentful@2.0.1-beta.6) (2018-06-23)
+## [2.0.1-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.5...gatsby-source-contentful@2.0.1-beta.6) (2018-06-23)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.5"></a>
 
-## [2.0.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.4...gatsby-source-contentful@2.0.1-beta.5) (2018-06-21)
+## [2.0.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.4...gatsby-source-contentful@2.0.1-beta.5) (2018-06-21)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.4"></a>
 
-## [2.0.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.3...gatsby-source-contentful@2.0.1-beta.4) (2018-06-20)
+## [2.0.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.3...gatsby-source-contentful@2.0.1-beta.4) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.3"></a>
 
-## [2.0.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.2...gatsby-source-contentful@2.0.1-beta.3) (2018-06-20)
+## [2.0.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.2...gatsby-source-contentful@2.0.1-beta.3) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.2"></a>
 
-## [2.0.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.1...gatsby-source-contentful@2.0.1-beta.2) (2018-06-19)
+## [2.0.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.1...gatsby-source-contentful@2.0.1-beta.2) (2018-06-19)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.1"></a>
 
-## [2.0.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@2.0.1-beta.0...gatsby-source-contentful@2.0.1-beta.1) (2018-06-17)
+## [2.0.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@2.0.1-beta.0...gatsby-source-contentful@2.0.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-contentful
 
 <a name="2.0.1-beta.0"></a>
 
-## [2.0.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful/compare/gatsby-source-contentful@1.3.54...gatsby-source-contentful@2.0.1-beta.0) (2018-06-17)
+## [2.0.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-contentful@1.3.54...gatsby-source-contentful@2.0.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-contentful

--- a/packages/gatsby-source-drupal/CHANGELOG.md
+++ b/packages/gatsby-source-drupal/CHANGELOG.md
@@ -7,422 +7,422 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.2.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.2.3...gatsby-source-drupal@3.2.4) (2019-07-10)
+## [3.2.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.2.3...gatsby-source-drupal@3.2.4) (2019-07-10)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.2.2...gatsby-source-drupal@3.2.3) (2019-07-08)
+## [3.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.2.2...gatsby-source-drupal@3.2.3) (2019-07-08)
 
 ### Features
 
-- **gatsby-source-drupal:** added preview feature ([#14630](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/14630)) ([a045a32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/a045a32))
+- **gatsby-source-drupal:** added preview feature ([#14630](https://github.com/gatsbyjs/gatsby/issues/14630)) ([a045a32](https://github.com/gatsbyjs/gatsby/commit/a045a32))
 
-## [3.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.2.1...gatsby-source-drupal@3.2.2) (2019-07-02)
-
-**Note:** Version bump only for package gatsby-source-drupal
-
-## [3.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.2.0...gatsby-source-drupal@3.2.1) (2019-06-25)
+## [3.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.2.1...gatsby-source-drupal@3.2.2) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-# [3.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.16...gatsby-source-drupal@3.2.0) (2019-06-20)
+## [3.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.2.0...gatsby-source-drupal@3.2.1) (2019-06-25)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.13...gatsby-source-drupal@3.1.16) (2019-06-19)
+# [3.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.16...gatsby-source-drupal@3.2.0) (2019-06-20)
+
+**Note:** Version bump only for package gatsby-source-drupal
+
+## [3.1.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.13...gatsby-source-drupal@3.1.16) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [3.1.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.14...gatsby-source-drupal@3.1.15) (2019-06-19)
+## [3.1.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.14...gatsby-source-drupal@3.1.15) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [3.1.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.13...gatsby-source-drupal@3.1.14) (2019-06-18)
-
-**Note:** Version bump only for package gatsby-source-drupal
-
-## [3.1.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.12...gatsby-source-drupal@3.1.13) (2019-06-18)
+## [3.1.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.13...gatsby-source-drupal@3.1.14) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.11...gatsby-source-drupal@3.1.12) (2019-06-14)
+## [3.1.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.12...gatsby-source-drupal@3.1.13) (2019-06-18)
+
+**Note:** Version bump only for package gatsby-source-drupal
+
+## [3.1.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.11...gatsby-source-drupal@3.1.12) (2019-06-14)
 
 ### Features
 
-- **gatsby-source-drupal:** Copy relationship meta (if any) to a node's field ([#14562](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/14562)) ([83e2ee3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/83e2ee3))
+- **gatsby-source-drupal:** Copy relationship meta (if any) to a node's field ([#14562](https://github.com/gatsbyjs/gatsby/issues/14562)) ([83e2ee3](https://github.com/gatsbyjs/gatsby/commit/83e2ee3))
 
-## [3.1.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.10...gatsby-source-drupal@3.1.11) (2019-06-10)
-
-**Note:** Version bump only for package gatsby-source-drupal
-
-## [3.1.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.9...gatsby-source-drupal@3.1.10) (2019-05-31)
+## [3.1.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.10...gatsby-source-drupal@3.1.11) (2019-06-10)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.8...gatsby-source-drupal@3.1.9) (2019-05-20)
+## [3.1.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.9...gatsby-source-drupal@3.1.10) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.7...gatsby-source-drupal@3.1.8) (2019-05-16)
+## [3.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.8...gatsby-source-drupal@3.1.9) (2019-05-20)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.6...gatsby-source-drupal@3.1.7) (2019-05-15)
+## [3.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.7...gatsby-source-drupal@3.1.8) (2019-05-16)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.5...gatsby-source-drupal@3.1.6) (2019-05-14)
+## [3.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.6...gatsby-source-drupal@3.1.7) (2019-05-15)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.4...gatsby-source-drupal@3.1.5) (2019-05-14)
+## [3.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.5...gatsby-source-drupal@3.1.6) (2019-05-14)
+
+**Note:** Version bump only for package gatsby-source-drupal
+
+## [3.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.4...gatsby-source-drupal@3.1.5) (2019-05-14)
 
 ### Bug Fixes
 
-- **gatsby-source-drupal:** limit concurrentFileRequests while downloading remote images ([#13943](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/13943)) ([1f0e0f4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/1f0e0f4))
+- **gatsby-source-drupal:** limit concurrentFileRequests while downloading remote images ([#13943](https://github.com/gatsbyjs/gatsby/issues/13943)) ([1f0e0f4](https://github.com/gatsbyjs/gatsby/commit/1f0e0f4))
 
-## [3.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.3...gatsby-source-drupal@3.1.4) (2019-04-30)
-
-**Note:** Version bump only for package gatsby-source-drupal
-
-## [3.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.2...gatsby-source-drupal@3.1.3) (2019-04-24)
+## [3.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.3...gatsby-source-drupal@3.1.4) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.1...gatsby-source-drupal@3.1.2) (2019-04-23)
+## [3.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.2...gatsby-source-drupal@3.1.3) (2019-04-24)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.1.0...gatsby-source-drupal@3.1.1) (2019-04-23)
+## [3.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.1...gatsby-source-drupal@3.1.2) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.34...gatsby-source-drupal@3.1.0) (2019-04-09)
+## [3.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.1.0...gatsby-source-drupal@3.1.1) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-source-drupal
+
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.34...gatsby-source-drupal@3.1.0) (2019-04-09)
 
 ### Features
 
-- **gatsby-source-drupal:** added Request Headers and GET Request Params options ([#12180](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/12180)) ([239101e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/239101e))
+- **gatsby-source-drupal:** added Request Headers and GET Request Params options ([#12180](https://github.com/gatsbyjs/gatsby/issues/12180)) ([239101e](https://github.com/gatsbyjs/gatsby/commit/239101e))
 
-## [3.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.33...gatsby-source-drupal@3.0.34) (2019-04-08)
-
-**Note:** Version bump only for package gatsby-source-drupal
-
-## [3.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.32...gatsby-source-drupal@3.0.33) (2019-04-02)
+## [3.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.33...gatsby-source-drupal@3.0.34) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.31...gatsby-source-drupal@3.0.32) (2019-03-22)
+## [3.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.32...gatsby-source-drupal@3.0.33) (2019-04-02)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.31](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.30...gatsby-source-drupal@3.0.31) (2019-03-15)
+## [3.0.32](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.31...gatsby-source-drupal@3.0.32) (2019-03-22)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.29...gatsby-source-drupal@3.0.30) (2019-03-14)
+## [3.0.31](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.30...gatsby-source-drupal@3.0.31) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.28...gatsby-source-drupal@3.0.29) (2019-03-13)
+## [3.0.30](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.29...gatsby-source-drupal@3.0.30) (2019-03-14)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.27...gatsby-source-drupal@3.0.28) (2019-03-12)
+## [3.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.28...gatsby-source-drupal@3.0.29) (2019-03-13)
+
+**Note:** Version bump only for package gatsby-source-drupal
+
+## [3.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.27...gatsby-source-drupal@3.0.28) (2019-03-12)
 
 ### Features
 
-- **gatsby-source-drupal:** Add ability to use JSON API filters when querying. ([#12508](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/12508)) ([a226769](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/a226769))
+- **gatsby-source-drupal:** Add ability to use JSON API filters when querying. ([#12508](https://github.com/gatsbyjs/gatsby/issues/12508)) ([a226769](https://github.com/gatsbyjs/gatsby/commit/a226769))
 
-## [3.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.26...gatsby-source-drupal@3.0.27) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-source-drupal
-
-## [3.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.25...gatsby-source-drupal@3.0.26) (2019-02-25)
+## [3.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.26...gatsby-source-drupal@3.0.27) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.24...gatsby-source-drupal@3.0.25) (2019-02-22)
+## [3.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.25...gatsby-source-drupal@3.0.26) (2019-02-25)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.23...gatsby-source-drupal@3.0.24) (2019-02-20)
+## [3.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.24...gatsby-source-drupal@3.0.25) (2019-02-22)
+
+**Note:** Version bump only for package gatsby-source-drupal
+
+## [3.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.23...gatsby-source-drupal@3.0.24) (2019-02-20)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/5a3c1fc))
+- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/commit/5a3c1fc))
 
-## [3.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.22...gatsby-source-drupal@3.0.23) (2019-02-01)
-
-**Note:** Version bump only for package gatsby-source-drupal
-
-## [3.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.21...gatsby-source-drupal@3.0.22) (2019-01-31)
+## [3.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.22...gatsby-source-drupal@3.0.23) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
-## [3.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.20...gatsby-source-drupal@3.0.21) (2019-01-28)
+## [3.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.21...gatsby-source-drupal@3.0.22) (2019-01-31)
+
+**Note:** Version bump only for package gatsby-source-drupal
+
+## [3.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.20...gatsby-source-drupal@3.0.21) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.20"></a>
 
-## [3.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.19...gatsby-source-drupal@3.0.20) (2019-01-23)
+## [3.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.19...gatsby-source-drupal@3.0.20) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.19"></a>
 
-## [3.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.18...gatsby-source-drupal@3.0.19) (2019-01-23)
+## [3.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.18...gatsby-source-drupal@3.0.19) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.18"></a>
 
-## [3.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.16...gatsby-source-drupal@3.0.18) (2019-01-11)
+## [3.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.16...gatsby-source-drupal@3.0.18) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.16"></a>
 
-## [3.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.15...gatsby-source-drupal@3.0.16) (2019-01-11)
+## [3.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.15...gatsby-source-drupal@3.0.16) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.15"></a>
 
-## [3.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.14...gatsby-source-drupal@3.0.15) (2019-01-08)
+## [3.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.14...gatsby-source-drupal@3.0.15) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.14"></a>
 
-## [3.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.13...gatsby-source-drupal@3.0.14) (2018-12-11)
+## [3.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.13...gatsby-source-drupal@3.0.14) (2018-12-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.13"></a>
 
-## [3.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.12...gatsby-source-drupal@3.0.13) (2018-12-06)
+## [3.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.12...gatsby-source-drupal@3.0.13) (2018-12-06)
 
 ### Bug Fixes
 
-- **gatsby-source-drupal:** use basic auth credentials to fetch remote files as well. ([#10302](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/10302)) ([747943c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/747943c))
+- **gatsby-source-drupal:** use basic auth credentials to fetch remote files as well. ([#10302](https://github.com/gatsbyjs/gatsby/issues/10302)) ([747943c](https://github.com/gatsbyjs/gatsby/commit/747943c))
 
 <a name="3.0.12"></a>
 
-## [3.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.11...gatsby-source-drupal@3.0.12) (2018-11-29)
+## [3.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.11...gatsby-source-drupal@3.0.12) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.11"></a>
 
-## [3.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.10...gatsby-source-drupal@3.0.11) (2018-11-26)
+## [3.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.10...gatsby-source-drupal@3.0.11) (2018-11-26)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.10"></a>
 
-## [3.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.9...gatsby-source-drupal@3.0.10) (2018-11-16)
+## [3.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.9...gatsby-source-drupal@3.0.10) (2018-11-16)
 
 ### Features
 
-- **gatsby-source-drupal:** add basicauth support ([#9848](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/9848)) ([e208134](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/e208134))
+- **gatsby-source-drupal:** add basicauth support ([#9848](https://github.com/gatsbyjs/gatsby/issues/9848)) ([e208134](https://github.com/gatsbyjs/gatsby/commit/e208134))
 
 <a name="3.0.9"></a>
 
-## [3.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.8...gatsby-source-drupal@3.0.9) (2018-11-14)
+## [3.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.8...gatsby-source-drupal@3.0.9) (2018-11-14)
 
 ### Features
 
-- **gatsby-source-drupal:** add support for Drupal JSON API 2.x File URI format ([#9835](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/9835)) ([e86d141](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/e86d141))
+- **gatsby-source-drupal:** add support for Drupal JSON API 2.x File URI format ([#9835](https://github.com/gatsbyjs/gatsby/issues/9835)) ([e86d141](https://github.com/gatsbyjs/gatsby/commit/e86d141))
 
 <a name="3.0.8"></a>
 
-## [3.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.7...gatsby-source-drupal@3.0.8) (2018-11-08)
+## [3.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.7...gatsby-source-drupal@3.0.8) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.7"></a>
 
-## [3.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.6...gatsby-source-drupal@3.0.7) (2018-11-01)
+## [3.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.6...gatsby-source-drupal@3.0.7) (2018-11-01)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.6"></a>
 
-## [3.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.5...gatsby-source-drupal@3.0.6) (2018-10-29)
+## [3.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.5...gatsby-source-drupal@3.0.6) (2018-10-29)
 
 ### Bug Fixes
 
-- **gatsby-source-drupal:** handle links outputted as objects in REST responses ([#9356](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/issues/9356)) ([2add021](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/commit/2add021))
+- **gatsby-source-drupal:** handle links outputted as objects in REST responses ([#9356](https://github.com/gatsbyjs/gatsby/issues/9356)) ([2add021](https://github.com/gatsbyjs/gatsby/commit/2add021))
 
 <a name="3.0.5"></a>
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.4...gatsby-source-drupal@3.0.5) (2018-10-19)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.4...gatsby-source-drupal@3.0.5) (2018-10-19)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.4"></a>
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.3...gatsby-source-drupal@3.0.4) (2018-10-15)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.3...gatsby-source-drupal@3.0.4) (2018-10-15)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.2...gatsby-source-drupal@3.0.3) (2018-10-09)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.2...gatsby-source-drupal@3.0.3) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@3.0.1...gatsby-source-drupal@3.0.2) (2018-10-05)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@3.0.1...gatsby-source-drupal@3.0.2) (2018-10-05)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0...gatsby-source-drupal@3.0.1) (2018-09-26)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0...gatsby-source-drupal@3.0.1) (2018-09-26)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0"></a>
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-rc.6...gatsby-source-drupal@2.2.0) (2018-09-17)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-rc.6...gatsby-source-drupal@2.2.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-rc.6"></a>
 
-# [2.2.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-rc.5...gatsby-source-drupal@2.2.0-rc.6) (2018-09-11)
+# [2.2.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-rc.5...gatsby-source-drupal@2.2.0-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-rc.5"></a>
 
-# [2.2.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-rc.4...gatsby-source-drupal@2.2.0-rc.5) (2018-09-11)
+# [2.2.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-rc.4...gatsby-source-drupal@2.2.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-rc.4"></a>
 
-# [2.2.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-rc.3...gatsby-source-drupal@2.2.0-rc.4) (2018-09-11)
+# [2.2.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-rc.3...gatsby-source-drupal@2.2.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-rc.3"></a>
 
-# [2.2.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-rc.2...gatsby-source-drupal@2.2.0-rc.3) (2018-09-11)
+# [2.2.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-rc.2...gatsby-source-drupal@2.2.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-rc.2"></a>
 
-# [2.2.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-rc.1...gatsby-source-drupal@2.2.0-rc.2) (2018-09-07)
+# [2.2.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-rc.1...gatsby-source-drupal@2.2.0-rc.2) (2018-09-07)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-rc.1"></a>
 
-# [2.2.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-rc.0...gatsby-source-drupal@2.2.0-rc.1) (2018-08-29)
+# [2.2.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-rc.0...gatsby-source-drupal@2.2.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-rc.0"></a>
 
-# [2.2.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.14...gatsby-source-drupal@2.2.0-rc.0) (2018-08-21)
+# [2.2.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.14...gatsby-source-drupal@2.2.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.14"></a>
 
-# [2.2.0-beta.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.13...gatsby-source-drupal@2.2.0-beta.14) (2018-08-21)
+# [2.2.0-beta.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.13...gatsby-source-drupal@2.2.0-beta.14) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.13"></a>
 
-# [2.2.0-beta.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.12...gatsby-source-drupal@2.2.0-beta.13) (2018-08-15)
+# [2.2.0-beta.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.12...gatsby-source-drupal@2.2.0-beta.13) (2018-08-15)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.12"></a>
 
-# [2.2.0-beta.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.11...gatsby-source-drupal@2.2.0-beta.12) (2018-07-24)
+# [2.2.0-beta.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.11...gatsby-source-drupal@2.2.0-beta.12) (2018-07-24)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.11"></a>
 
-# [2.2.0-beta.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.10...gatsby-source-drupal@2.2.0-beta.11) (2018-07-21)
+# [2.2.0-beta.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.10...gatsby-source-drupal@2.2.0-beta.11) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.10"></a>
 
-# [2.2.0-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.9...gatsby-source-drupal@2.2.0-beta.10) (2018-07-20)
+# [2.2.0-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.9...gatsby-source-drupal@2.2.0-beta.10) (2018-07-20)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.9"></a>
 
-# [2.2.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.8...gatsby-source-drupal@2.2.0-beta.9) (2018-07-19)
+# [2.2.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.8...gatsby-source-drupal@2.2.0-beta.9) (2018-07-19)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.8"></a>
 
-# [2.2.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.7...gatsby-source-drupal@2.2.0-beta.8) (2018-07-19)
+# [2.2.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.7...gatsby-source-drupal@2.2.0-beta.8) (2018-07-19)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.7"></a>
 
-# [2.2.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.6...gatsby-source-drupal@2.2.0-beta.7) (2018-07-18)
+# [2.2.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.6...gatsby-source-drupal@2.2.0-beta.7) (2018-07-18)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.6"></a>
 
-# [2.2.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.5...gatsby-source-drupal@2.2.0-beta.6) (2018-07-14)
+# [2.2.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.5...gatsby-source-drupal@2.2.0-beta.6) (2018-07-14)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.5"></a>
 
-# [2.2.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.4...gatsby-source-drupal@2.2.0-beta.5) (2018-07-13)
+# [2.2.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.4...gatsby-source-drupal@2.2.0-beta.5) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.4"></a>
 
-# [2.2.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.3...gatsby-source-drupal@2.2.0-beta.4) (2018-06-21)
+# [2.2.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.3...gatsby-source-drupal@2.2.0-beta.4) (2018-06-21)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.3"></a>
 
-# [2.2.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.2...gatsby-source-drupal@2.2.0-beta.3) (2018-06-20)
+# [2.2.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.2...gatsby-source-drupal@2.2.0-beta.3) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.2"></a>
 
-# [2.2.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.1...gatsby-source-drupal@2.2.0-beta.2) (2018-06-20)
+# [2.2.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.1...gatsby-source-drupal@2.2.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.1"></a>
 
-# [2.2.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.2.0-beta.0...gatsby-source-drupal@2.2.0-beta.1) (2018-06-17)
+# [2.2.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.2.0-beta.0...gatsby-source-drupal@2.2.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-drupal
 
 <a name="2.2.0-beta.0"></a>
 
-# [2.2.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal/compare/gatsby-source-drupal@2.0.41...gatsby-source-drupal@2.2.0-beta.0) (2018-06-17)
+# [2.2.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-drupal@2.0.41...gatsby-source-drupal@2.2.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-drupal

--- a/packages/gatsby-source-faker/CHANGELOG.md
+++ b/packages/gatsby-source-faker/CHANGELOG.md
@@ -7,80 +7,80 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-faker
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.6...gatsby-source-faker@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.6...gatsby-source-faker@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-faker
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.5...gatsby-source-faker@2.0.6) (2019-03-11)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.5...gatsby-source-faker@2.0.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-faker
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.4...gatsby-source-faker@2.0.5) (2019-01-31)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.4...gatsby-source-faker@2.0.5) (2019-01-31)
 
 **Note:** Version bump only for package gatsby-source-faker
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.3...gatsby-source-faker@2.0.4) (2019-01-25)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.3...gatsby-source-faker@2.0.4) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.2...gatsby-source-faker@2.0.3) (2018-11-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.2...gatsby-source-faker@2.0.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.1...gatsby-source-faker@2.0.2) (2018-11-21)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.1...gatsby-source-faker@2.0.2) (2018-11-21)
 
 ### Features
 
-- **gatsby-plugin-manifest:** don't output `theme-color` meta tag if it's not defiened ([#10069](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/issues/10069)) ([7802470](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/commit/7802470))
+- **gatsby-plugin-manifest:** don't output `theme-color` meta tag if it's not defiened ([#10069](https://github.com/gatsbyjs/gatsby/issues/10069)) ([7802470](https://github.com/gatsbyjs/gatsby/commit/7802470))
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.0...gatsby-source-faker@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.0...gatsby-source-faker@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.0-rc.1...gatsby-source-faker@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.0-rc.1...gatsby-source-faker@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.0-rc.0...gatsby-source-faker@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.0-rc.0...gatsby-source-faker@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.0-beta.3...gatsby-source-faker@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.0-beta.3...gatsby-source-faker@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.0-beta.2...gatsby-source-faker@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.0-beta.2...gatsby-source-faker@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.0-beta.1...gatsby-source-faker@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.0-beta.1...gatsby-source-faker@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@2.0.0-beta.0...gatsby-source-faker@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@2.0.0-beta.0...gatsby-source-faker@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-faker
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker/compare/gatsby-source-faker@1.0.9...gatsby-source-faker@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-faker@1.0.9...gatsby-source-faker@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-faker

--- a/packages/gatsby-source-filesystem/CHANGELOG.md
+++ b/packages/gatsby-source-filesystem/CHANGELOG.md
@@ -7,384 +7,384 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.1.2...gatsby-source-filesystem@2.1.3) (2019-07-10)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.1.2...gatsby-source-filesystem@2.1.3) (2019-07-10)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.1.1...gatsby-source-filesystem@2.1.2) (2019-07-02)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.1.1...gatsby-source-filesystem@2.1.2) (2019-07-02)
 
 ### Bug Fixes
 
-- **gatsby:** various Typescript definitions ([#15268](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/15268)) ([b8f3ed5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/b8f3ed5))
+- **gatsby:** various Typescript definitions ([#15268](https://github.com/gatsbyjs/gatsby/issues/15268)) ([b8f3ed5](https://github.com/gatsbyjs/gatsby/commit/b8f3ed5))
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.1.0...gatsby-source-filesystem@2.1.1) (2019-06-25)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.1.0...gatsby-source-filesystem@2.1.1) (2019-06-25)
 
 ### Features
 
-- **gatsby-source-filesystem:** add createFileNodeFromBuffer ([#14576](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/14576)) ([aa21755](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/aa21755))
+- **gatsby-source-filesystem:** add createFileNodeFromBuffer ([#14576](https://github.com/gatsbyjs/gatsby/issues/14576)) ([aa21755](https://github.com/gatsbyjs/gatsby/commit/aa21755))
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.43...gatsby-source-filesystem@2.1.0) (2019-06-20)
-
-**Note:** Version bump only for package gatsby-source-filesystem
-
-## [2.0.43](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.40...gatsby-source-filesystem@2.0.43) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/2594623))
-
-## [2.0.42](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.41...gatsby-source-filesystem@2.0.42) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/2594623))
-
-## [2.0.41](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.40...gatsby-source-filesystem@2.0.41) (2019-06-18)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.43...gatsby-source-filesystem@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
-## [2.0.40](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.39...gatsby-source-filesystem@2.0.40) (2019-06-18)
+## [2.0.43](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.40...gatsby-source-filesystem@2.0.43) (2019-06-19)
+
+### Bug Fixes
+
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
+
+## [2.0.42](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.41...gatsby-source-filesystem@2.0.42) (2019-06-19)
+
+### Bug Fixes
+
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
+
+## [2.0.41](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.40...gatsby-source-filesystem@2.0.41) (2019-06-18)
+
+**Note:** Version bump only for package gatsby-source-filesystem
+
+## [2.0.40](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.39...gatsby-source-filesystem@2.0.40) (2019-06-18)
 
 ### Features
 
-- **gatsby-cli:** move progressbar into ink ([#14220](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/14220)) ([967597c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/967597c))
+- **gatsby-cli:** move progressbar into ink ([#14220](https://github.com/gatsbyjs/gatsby/issues/14220)) ([967597c](https://github.com/gatsbyjs/gatsby/commit/967597c))
 
-## [2.0.39](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.38...gatsby-source-filesystem@2.0.39) (2019-06-10)
-
-### Features
-
-- **gatsby-source-filesystem:** remove slash ([#14372](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/14372)) ([1d9ba86](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/1d9ba86))
-
-## [2.0.38](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.37...gatsby-source-filesystem@2.0.38) (2019-05-31)
+## [2.0.39](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.38...gatsby-source-filesystem@2.0.39) (2019-06-10)
 
 ### Features
 
-- **gatsby-source-filesystem:** add an environment variable to control concurrent queue size ([#13110](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/13110)) ([90aa247](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/90aa247))
+- **gatsby-source-filesystem:** remove slash ([#14372](https://github.com/gatsbyjs/gatsby/issues/14372)) ([1d9ba86](https://github.com/gatsbyjs/gatsby/commit/1d9ba86))
 
-## [2.0.37](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.36...gatsby-source-filesystem@2.0.37) (2019-05-20)
-
-### Bug Fixes
-
-- **gatsby-source-filesystem:** fix unhandled rejection by returning promise chain ([#14180](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/14180)) ([53c91b5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/53c91b5))
-
-## [2.0.36](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.35...gatsby-source-filesystem@2.0.36) (2019-05-16)
-
-### Bug Fixes
-
-- **gatsby-source-filesystem:** fix createRemoteFileNode ts types ([#14086](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/14086)) ([e47da77](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/e47da77))
-
-## [2.0.35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.34...gatsby-source-filesystem@2.0.35) (2019-05-15)
-
-### Bug Fixes
-
-- **gatsby-source-filesystem:** createRemoteFileNode rejects promise instead resolving on failure ([#12348](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/12348)) ([c2c5cea](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/c2c5cea))
-
-## [2.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.33...gatsby-source-filesystem@2.0.34) (2019-05-14)
+## [2.0.38](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.37...gatsby-source-filesystem@2.0.38) (2019-05-31)
 
 ### Features
 
-- **gatsby:** allow awaiting API run triggered by createNode action ([#12748](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/12748)) ([17a67a5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/17a67a5))
+- **gatsby-source-filesystem:** add an environment variable to control concurrent queue size ([#13110](https://github.com/gatsbyjs/gatsby/issues/13110)) ([90aa247](https://github.com/gatsbyjs/gatsby/commit/90aa247))
 
-## [2.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.32...gatsby-source-filesystem@2.0.33) (2019-04-30)
-
-**Note:** Version bump only for package gatsby-source-filesystem
-
-## [2.0.32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.31...gatsby-source-filesystem@2.0.32) (2019-04-24)
+## [2.0.37](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.36...gatsby-source-filesystem@2.0.37) (2019-05-20)
 
 ### Bug Fixes
 
-- Add fallback for createContentDigest ([#13584](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/13584)) ([093f1f2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/093f1f2))
+- **gatsby-source-filesystem:** fix unhandled rejection by returning promise chain ([#14180](https://github.com/gatsbyjs/gatsby/issues/14180)) ([53c91b5](https://github.com/gatsbyjs/gatsby/commit/53c91b5))
 
-## [2.0.31](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.30...gatsby-source-filesystem@2.0.31) (2019-04-23)
+## [2.0.36](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.35...gatsby-source-filesystem@2.0.36) (2019-05-16)
 
-**Note:** Version bump only for package gatsby-source-filesystem
+### Bug Fixes
 
-## [2.0.30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.29...gatsby-source-filesystem@2.0.30) (2019-04-23)
+- **gatsby-source-filesystem:** fix createRemoteFileNode ts types ([#14086](https://github.com/gatsbyjs/gatsby/issues/14086)) ([e47da77](https://github.com/gatsbyjs/gatsby/commit/e47da77))
 
-**Note:** Version bump only for package gatsby-source-filesystem
+## [2.0.35](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.34...gatsby-source-filesystem@2.0.35) (2019-05-15)
 
-## [2.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.28...gatsby-source-filesystem@2.0.29) (2019-04-08)
+### Bug Fixes
+
+- **gatsby-source-filesystem:** createRemoteFileNode rejects promise instead resolving on failure ([#12348](https://github.com/gatsbyjs/gatsby/issues/12348)) ([c2c5cea](https://github.com/gatsbyjs/gatsby/commit/c2c5cea))
+
+## [2.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.33...gatsby-source-filesystem@2.0.34) (2019-05-14)
 
 ### Features
 
-- **createRemoteFileNode:** allow passing headers to request ([#11682](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/11682)) ([7a8e41a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/7a8e41a))
+- **gatsby:** allow awaiting API run triggered by createNode action ([#12748](https://github.com/gatsbyjs/gatsby/issues/12748)) ([17a67a5](https://github.com/gatsbyjs/gatsby/commit/17a67a5))
 
-## [2.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.27...gatsby-source-filesystem@2.0.28) (2019-03-22)
-
-### Bug Fixes
-
-- **gatsby-source-filesystem:** pin chokidar@2.1.2 to fix unix issues ([#12759](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/12759)) ([0ea1505](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/0ea1505))
-
-## [2.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.26...gatsby-source-filesystem@2.0.27) (2019-03-15)
+## [2.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.32...gatsby-source-filesystem@2.0.33) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
-## [2.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.25...gatsby-source-filesystem@2.0.26) (2019-03-14)
+## [2.0.32](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.31...gatsby-source-filesystem@2.0.32) (2019-04-24)
+
+### Bug Fixes
+
+- Add fallback for createContentDigest ([#13584](https://github.com/gatsbyjs/gatsby/issues/13584)) ([093f1f2](https://github.com/gatsbyjs/gatsby/commit/093f1f2))
+
+## [2.0.31](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.30...gatsby-source-filesystem@2.0.31) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-source-filesystem
+
+## [2.0.30](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.29...gatsby-source-filesystem@2.0.30) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-source-filesystem
+
+## [2.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.28...gatsby-source-filesystem@2.0.29) (2019-04-08)
 
 ### Features
 
-- **create-remote-file-node:** add `url` field to downloaded file nodes ([#12582](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/12582)) ([cac37a9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/cac37a9)), closes [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/1234)
+- **createRemoteFileNode:** allow passing headers to request ([#11682](https://github.com/gatsbyjs/gatsby/issues/11682)) ([7a8e41a](https://github.com/gatsbyjs/gatsby/commit/7a8e41a))
 
-## [2.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.24...gatsby-source-filesystem@2.0.25) (2019-03-13)
-
-**Note:** Version bump only for package gatsby-source-filesystem
-
-## [2.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.23...gatsby-source-filesystem@2.0.24) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-source-filesystem
-
-## [2.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.22...gatsby-source-filesystem@2.0.23) (2019-02-25)
+## [2.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.27...gatsby-source-filesystem@2.0.28) (2019-03-22)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** Do not re-download cached files from createRemoteFileNode ([#12054](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/12054)) ([a358239](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/a358239))
+- **gatsby-source-filesystem:** pin chokidar@2.1.2 to fix unix issues ([#12759](https://github.com/gatsbyjs/gatsby/issues/12759)) ([0ea1505](https://github.com/gatsbyjs/gatsby/commit/0ea1505))
 
-## [2.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.21...gatsby-source-filesystem@2.0.22) (2019-02-22)
-
-**Note:** Version bump only for package gatsby-source-filesystem
-
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.20...gatsby-source-filesystem@2.0.21) (2019-02-20)
-
-### Bug Fixes
-
-- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/5a3c1fc))
-
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.19...gatsby-source-filesystem@2.0.20) (2019-02-01)
+## [2.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.26...gatsby-source-filesystem@2.0.27) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.18...gatsby-source-filesystem@2.0.19) (2019-01-31)
+## [2.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.25...gatsby-source-filesystem@2.0.26) (2019-03-14)
+
+### Features
+
+- **create-remote-file-node:** add `url` field to downloaded file nodes ([#12582](https://github.com/gatsbyjs/gatsby/issues/12582)) ([cac37a9](https://github.com/gatsbyjs/gatsby/commit/cac37a9)), closes [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234)
+
+## [2.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.24...gatsby-source-filesystem@2.0.25) (2019-03-13)
+
+**Note:** Version bump only for package gatsby-source-filesystem
+
+## [2.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.23...gatsby-source-filesystem@2.0.24) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-source-filesystem
+
+## [2.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.22...gatsby-source-filesystem@2.0.23) (2019-02-25)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** report when downloading fails ([#10980](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/10980)) ([eff2cf4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/eff2cf4))
+- **gatsby-source-filesystem:** Do not re-download cached files from createRemoteFileNode ([#12054](https://github.com/gatsbyjs/gatsby/issues/12054)) ([a358239](https://github.com/gatsbyjs/gatsby/commit/a358239))
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.17...gatsby-source-filesystem@2.0.18) (2019-01-28)
+## [2.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.21...gatsby-source-filesystem@2.0.22) (2019-02-22)
+
+**Note:** Version bump only for package gatsby-source-filesystem
+
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.20...gatsby-source-filesystem@2.0.21) (2019-02-20)
+
+### Bug Fixes
+
+- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/commit/5a3c1fc))
+
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.19...gatsby-source-filesystem@2.0.20) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-source-filesystem
+
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.18...gatsby-source-filesystem@2.0.19) (2019-01-31)
+
+### Bug Fixes
+
+- **gatsby-source-filesystem:** report when downloading fails ([#10980](https://github.com/gatsbyjs/gatsby/issues/10980)) ([eff2cf4](https://github.com/gatsbyjs/gatsby/commit/eff2cf4))
+
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.17...gatsby-source-filesystem@2.0.18) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.17"></a>
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.16...gatsby-source-filesystem@2.0.17) (2019-01-23)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.16...gatsby-source-filesystem@2.0.17) (2019-01-23)
 
 ### Features
 
-- **gatsby-source-filesystem:** add optional name parameter to createRemoteFileNode ([#11054](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/11054)) ([8105be6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/8105be6)), closes [#11037](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/11037) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/1234)
+- **gatsby-source-filesystem:** add optional name parameter to createRemoteFileNode ([#11054](https://github.com/gatsbyjs/gatsby/issues/11054)) ([8105be6](https://github.com/gatsbyjs/gatsby/commit/8105be6)), closes [#11037](https://github.com/gatsbyjs/gatsby/issues/11037) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234)
 
 <a name="2.0.16"></a>
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.14...gatsby-source-filesystem@2.0.16) (2019-01-11)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.14...gatsby-source-filesystem@2.0.16) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.14"></a>
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.13...gatsby-source-filesystem@2.0.14) (2019-01-11)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.13...gatsby-source-filesystem@2.0.14) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.13"></a>
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.12...gatsby-source-filesystem@2.0.13) (2019-01-08)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.12...gatsby-source-filesystem@2.0.13) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.12"></a>
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.11...gatsby-source-filesystem@2.0.12) (2018-12-11)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.11...gatsby-source-filesystem@2.0.12) (2018-12-11)
 
 ### Features
 
-- **gatsby-source-filesystem:** keep original name of remote files ([#9777](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/9777)) ([dfc069d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/dfc069d))
+- **gatsby-source-filesystem:** keep original name of remote files ([#9777](https://github.com/gatsbyjs/gatsby/issues/9777)) ([dfc069d](https://github.com/gatsbyjs/gatsby/commit/dfc069d))
 
 <a name="2.0.11"></a>
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.10...gatsby-source-filesystem@2.0.11) (2018-12-06)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.10...gatsby-source-filesystem@2.0.11) (2018-12-06)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** allow empty password for basic auth in createRemoteFileNode ([#10280](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/10280)) ([1d4e057](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/1d4e057))
+- **gatsby-source-filesystem:** allow empty password for basic auth in createRemoteFileNode ([#10280](https://github.com/gatsbyjs/gatsby/issues/10280)) ([1d4e057](https://github.com/gatsbyjs/gatsby/commit/1d4e057))
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.9...gatsby-source-filesystem@2.0.10) (2018-11-29)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.9...gatsby-source-filesystem@2.0.10) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.8...gatsby-source-filesystem@2.0.9) (2018-11-26)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.8...gatsby-source-filesystem@2.0.9) (2018-11-26)
 
 ### Bug Fixes
 
-- **gatsby-plugin-filesystem:** throw meaningful errors on bad inputs ([#10123](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/10123)) ([21ebf2c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/21ebf2c)), closes [#6643](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/6643)
+- **gatsby-plugin-filesystem:** throw meaningful errors on bad inputs ([#10123](https://github.com/gatsbyjs/gatsby/issues/10123)) ([21ebf2c](https://github.com/gatsbyjs/gatsby/commit/21ebf2c)), closes [#6643](https://github.com/gatsbyjs/gatsby/issues/6643)
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.7...gatsby-source-filesystem@2.0.8) (2018-11-08)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.7...gatsby-source-filesystem@2.0.8) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.6...gatsby-source-filesystem@2.0.7) (2018-11-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.6...gatsby-source-filesystem@2.0.7) (2018-11-01)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.5...gatsby-source-filesystem@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.5...gatsby-source-filesystem@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.4...gatsby-source-filesystem@2.0.5) (2018-10-19)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.4...gatsby-source-filesystem@2.0.5) (2018-10-19)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.3...gatsby-source-filesystem@2.0.4) (2018-10-15)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.3...gatsby-source-filesystem@2.0.4) (2018-10-15)
 
 ### Bug Fixes
 
-- first parse url and then path to retrieve extension ([#9011](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/9011)) ([eb7648c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/eb7648c))
+- first parse url and then path to retrieve extension ([#9011](https://github.com/gatsbyjs/gatsby/issues/9011)) ([eb7648c](https://github.com/gatsbyjs/gatsby/commit/eb7648c))
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.2...gatsby-source-filesystem@2.0.3) (2018-10-09)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.2...gatsby-source-filesystem@2.0.3) (2018-10-09)
 
 ### Bug Fixes
 
-- more work to prevent queries from running when there's in-progress node processing ([#8859](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/8859)) ([00eeef0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/00eeef0))
+- more work to prevent queries from running when there's in-progress node processing ([#8859](https://github.com/gatsbyjs/gatsby/issues/8859)) ([00eeef0](https://github.com/gatsbyjs/gatsby/commit/00eeef0))
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.6...gatsby-source-filesystem@2.0.2) (2018-10-05)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.6...gatsby-source-filesystem@2.0.2) (2018-10-05)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.6...gatsby-source-filesystem@2.0.1) (2018-09-17)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.6...gatsby-source-filesystem@2.0.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-rc.6"></a>
 
-## [2.0.1-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.5...gatsby-source-filesystem@2.0.1-rc.6) (2018-09-11)
+## [2.0.1-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.5...gatsby-source-filesystem@2.0.1-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-rc.5"></a>
 
-## [2.0.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.4...gatsby-source-filesystem@2.0.1-rc.5) (2018-09-11)
+## [2.0.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.4...gatsby-source-filesystem@2.0.1-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-rc.4"></a>
 
-## [2.0.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.3...gatsby-source-filesystem@2.0.1-rc.4) (2018-09-11)
+## [2.0.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.3...gatsby-source-filesystem@2.0.1-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-rc.3"></a>
 
-## [2.0.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.2...gatsby-source-filesystem@2.0.1-rc.3) (2018-09-11)
+## [2.0.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.2...gatsby-source-filesystem@2.0.1-rc.3) (2018-09-11)
 
 ### Features
 
-- **gatsby-source-filesystem:** Added an 'ignore' property to the options to ignore more files. ([#8016](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/8016)) ([3f67a2f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/3f67a2f))
+- **gatsby-source-filesystem:** Added an 'ignore' property to the options to ignore more files. ([#8016](https://github.com/gatsbyjs/gatsby/issues/8016)) ([3f67a2f](https://github.com/gatsbyjs/gatsby/commit/3f67a2f))
 
 <a name="2.0.1-rc.2"></a>
 
-## [2.0.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.1...gatsby-source-filesystem@2.0.1-rc.2) (2018-09-07)
+## [2.0.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.1...gatsby-source-filesystem@2.0.1-rc.2) (2018-09-07)
 
 ### Bug Fixes
 
-- remove some warnings on promises ([#7922](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/issues/7922)) ([e069f27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/commit/e069f27))
+- remove some warnings on promises ([#7922](https://github.com/gatsbyjs/gatsby/issues/7922)) ([e069f27](https://github.com/gatsbyjs/gatsby/commit/e069f27))
 
 <a name="2.0.1-rc.1"></a>
 
-## [2.0.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-rc.0...gatsby-source-filesystem@2.0.1-rc.1) (2018-08-29)
+## [2.0.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-rc.0...gatsby-source-filesystem@2.0.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-rc.0"></a>
 
-## [2.0.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.11...gatsby-source-filesystem@2.0.1-rc.0) (2018-08-21)
+## [2.0.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.11...gatsby-source-filesystem@2.0.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.11"></a>
 
-## [2.0.1-beta.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.10...gatsby-source-filesystem@2.0.1-beta.11) (2018-08-21)
+## [2.0.1-beta.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.10...gatsby-source-filesystem@2.0.1-beta.11) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.10"></a>
 
-## [2.0.1-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.9...gatsby-source-filesystem@2.0.1-beta.10) (2018-07-24)
+## [2.0.1-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.9...gatsby-source-filesystem@2.0.1-beta.10) (2018-07-24)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.9"></a>
 
-## [2.0.1-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.8...gatsby-source-filesystem@2.0.1-beta.9) (2018-07-21)
+## [2.0.1-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.8...gatsby-source-filesystem@2.0.1-beta.9) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.8"></a>
 
-## [2.0.1-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.7...gatsby-source-filesystem@2.0.1-beta.8) (2018-07-19)
+## [2.0.1-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.7...gatsby-source-filesystem@2.0.1-beta.8) (2018-07-19)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.7"></a>
 
-## [2.0.1-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.6...gatsby-source-filesystem@2.0.1-beta.7) (2018-07-19)
+## [2.0.1-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.6...gatsby-source-filesystem@2.0.1-beta.7) (2018-07-19)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.6"></a>
 
-## [2.0.1-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.5...gatsby-source-filesystem@2.0.1-beta.6) (2018-07-18)
+## [2.0.1-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.5...gatsby-source-filesystem@2.0.1-beta.6) (2018-07-18)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.5"></a>
 
-## [2.0.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.4...gatsby-source-filesystem@2.0.1-beta.5) (2018-07-14)
+## [2.0.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.4...gatsby-source-filesystem@2.0.1-beta.5) (2018-07-14)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.4"></a>
 
-## [2.0.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.3...gatsby-source-filesystem@2.0.1-beta.4) (2018-07-13)
+## [2.0.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.3...gatsby-source-filesystem@2.0.1-beta.4) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.3"></a>
 
-## [2.0.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.2...gatsby-source-filesystem@2.0.1-beta.3) (2018-06-21)
+## [2.0.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.2...gatsby-source-filesystem@2.0.1-beta.3) (2018-06-21)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.2"></a>
 
-## [2.0.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.1...gatsby-source-filesystem@2.0.1-beta.2) (2018-06-20)
+## [2.0.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.1...gatsby-source-filesystem@2.0.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.1"></a>
 
-## [2.0.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@2.0.1-beta.0...gatsby-source-filesystem@2.0.1-beta.1) (2018-06-17)
+## [2.0.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@2.0.1-beta.0...gatsby-source-filesystem@2.0.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-filesystem
 
 <a name="2.0.1-beta.0"></a>
 
-## [2.0.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem/compare/gatsby-source-filesystem@1.5.39...gatsby-source-filesystem@2.0.1-beta.0) (2018-06-17)
+## [2.0.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-filesystem@1.5.39...gatsby-source-filesystem@2.0.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-filesystem

--- a/packages/gatsby-source-graphql/CHANGELOG.md
+++ b/packages/gatsby-source-graphql/CHANGELOG.md
@@ -7,161 +7,161 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-graphql
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.19...gatsby-source-graphql@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.19...gatsby-source-graphql@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.18...gatsby-source-graphql@2.0.19) (2019-06-10)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.18...gatsby-source-graphql@2.0.19) (2019-06-10)
 
 ### Bug Fixes
 
-- **gatsby:** Dont use createPageDependency from actions ([#14665](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/issues/14665)) ([73ac41a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/commit/73ac41a))
+- **gatsby:** Dont use createPageDependency from actions ([#14665](https://github.com/gatsbyjs/gatsby/issues/14665)) ([73ac41a](https://github.com/gatsbyjs/gatsby/commit/73ac41a))
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.17...gatsby-source-graphql@2.0.18) (2019-04-12)
-
-### Bug Fixes
-
-- **gatsby-source-graphql:** fix data refetching ([#13280](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/issues/13280)) ([a61d002](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/commit/a61d002))
-
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.16...gatsby-source-graphql@2.0.17) (2019-04-08)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.17...gatsby-source-graphql@2.0.18) (2019-04-12)
 
 ### Bug Fixes
 
-- **gatsby-source-graphql:** Destructure createContentDigest from first parameter ([#13214](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/issues/13214)) ([382fbe1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/commit/382fbe1))
+- **gatsby-source-graphql:** fix data refetching ([#13280](https://github.com/gatsbyjs/gatsby/issues/13280)) ([a61d002](https://github.com/gatsbyjs/gatsby/commit/a61d002))
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.15...gatsby-source-graphql@2.0.16) (2019-04-08)
-
-**Note:** Version bump only for package gatsby-source-graphql
-
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.14...gatsby-source-graphql@2.0.15) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-source-graphql
-
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.13...gatsby-source-graphql@2.0.14) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-source-graphql
-
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.12...gatsby-source-graphql@2.0.13) (2019-03-08)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.16...gatsby-source-graphql@2.0.17) (2019-04-08)
 
 ### Bug Fixes
 
-- **gatsby): Revert "chore(gatsby:** Update more dependencies to support graphql@14" ([#12408](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/issues/12408)) ([b040b44](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/commit/b040b44)), closes [gatsbyjs/gatsby#11512](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/issues/11512)
+- **gatsby-source-graphql:** Destructure createContentDigest from first parameter ([#13214](https://github.com/gatsbyjs/gatsby/issues/13214)) ([382fbe1](https://github.com/gatsbyjs/gatsby/commit/382fbe1))
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.11...gatsby-source-graphql@2.0.12) (2019-03-08)
-
-**Note:** Version bump only for package gatsby-source-graphql
-
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.10...gatsby-source-graphql@2.0.11) (2019-02-28)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.15...gatsby-source-graphql@2.0.16) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.9...gatsby-source-graphql@2.0.10) (2019-02-01)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.14...gatsby-source-graphql@2.0.15) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.8...gatsby-source-graphql@2.0.9) (2019-02-01)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.13...gatsby-source-graphql@2.0.14) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-source-graphql
+
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.12...gatsby-source-graphql@2.0.13) (2019-03-08)
+
+### Bug Fixes
+
+- **gatsby): Revert "chore(gatsby:** Update more dependencies to support graphql@14" ([#12408](https://github.com/gatsbyjs/gatsby/issues/12408)) ([b040b44](https://github.com/gatsbyjs/gatsby/commit/b040b44)), closes [gatsbyjs/gatsby#11512](https://github.com/gatsbyjs/gatsby/issues/11512)
+
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.11...gatsby-source-graphql@2.0.12) (2019-03-08)
+
+**Note:** Version bump only for package gatsby-source-graphql
+
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.10...gatsby-source-graphql@2.0.11) (2019-02-28)
+
+**Note:** Version bump only for package gatsby-source-graphql
+
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.9...gatsby-source-graphql@2.0.10) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-source-graphql
+
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.8...gatsby-source-graphql@2.0.9) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.7...gatsby-source-graphql@2.0.8) (2018-12-29)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.7...gatsby-source-graphql@2.0.8) (2018-12-29)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.6...gatsby-source-graphql@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.6...gatsby-source-graphql@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.5...gatsby-source-graphql@2.0.6) (2018-11-05)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.5...gatsby-source-graphql@2.0.6) (2018-11-05)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.4...gatsby-source-graphql@2.0.5) (2018-10-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.4...gatsby-source-graphql@2.0.5) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.3...gatsby-source-graphql@2.0.4) (2018-10-09)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.3...gatsby-source-graphql@2.0.4) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.2...gatsby-source-graphql@2.0.3) (2018-09-27)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.2...gatsby-source-graphql@2.0.3) (2018-09-27)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.1...gatsby-source-graphql@2.0.2) (2018-09-18)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.1...gatsby-source-graphql@2.0.2) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0...gatsby-source-graphql@2.0.1) (2018-09-18)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0...gatsby-source-graphql@2.0.1) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-rc.6...gatsby-source-graphql@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-rc.6...gatsby-source-graphql@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-rc.5...gatsby-source-graphql@2.0.0-rc.6) (2018-09-11)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-rc.5...gatsby-source-graphql@2.0.0-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-rc.4...gatsby-source-graphql@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-rc.4...gatsby-source-graphql@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-rc.3...gatsby-source-graphql@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-rc.3...gatsby-source-graphql@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-rc.2...gatsby-source-graphql@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-rc.2...gatsby-source-graphql@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-rc.1...gatsby-source-graphql@2.0.0-rc.2) (2018-08-29)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-rc.1...gatsby-source-graphql@2.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-rc.0...gatsby-source-graphql@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-rc.0...gatsby-source-graphql@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-beta.2...gatsby-source-graphql@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-beta.2...gatsby-source-graphql@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-graphql
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql/compare/gatsby-source-graphql@2.0.0-beta.1...gatsby-source-graphql@2.0.0-beta.2) (2018-08-10)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-graphql@2.0.0-beta.1...gatsby-source-graphql@2.0.0-beta.2) (2018-08-10)
 
 **Note:** Version bump only for package gatsby-source-graphql
 

--- a/packages/gatsby-source-hacker-news/CHANGELOG.md
+++ b/packages/gatsby-source-hacker-news/CHANGELOG.md
@@ -7,116 +7,116 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.12...gatsby-source-hacker-news@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.12...gatsby-source-hacker-news@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.11...gatsby-source-hacker-news@2.0.12) (2019-05-31)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.11...gatsby-source-hacker-news@2.0.12) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.10...gatsby-source-hacker-news@2.0.11) (2019-04-08)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.10...gatsby-source-hacker-news@2.0.11) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.9...gatsby-source-hacker-news@2.0.10) (2019-03-15)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.9...gatsby-source-hacker-news@2.0.10) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.8...gatsby-source-hacker-news@2.0.9) (2019-03-11)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.8...gatsby-source-hacker-news@2.0.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.7...gatsby-source-hacker-news@2.0.8) (2019-02-01)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.7...gatsby-source-hacker-news@2.0.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.6...gatsby-source-hacker-news@2.0.7) (2018-11-29)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.6...gatsby-source-hacker-news@2.0.7) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.5...gatsby-source-hacker-news@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.5...gatsby-source-hacker-news@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-rc.5...gatsby-source-hacker-news@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-rc.5...gatsby-source-hacker-news@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-rc.4...gatsby-source-hacker-news@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-rc.4...gatsby-source-hacker-news@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-rc.3...gatsby-source-hacker-news@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-rc.3...gatsby-source-hacker-news@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-rc.2...gatsby-source-hacker-news@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-rc.2...gatsby-source-hacker-news@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-rc.1...gatsby-source-hacker-news@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-rc.1...gatsby-source-hacker-news@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-rc.0...gatsby-source-hacker-news@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-rc.0...gatsby-source-hacker-news@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-beta.5...gatsby-source-hacker-news@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-beta.5...gatsby-source-hacker-news@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-beta.4...gatsby-source-hacker-news@2.0.0-beta.5) (2018-07-21)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-beta.4...gatsby-source-hacker-news@2.0.0-beta.5) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-beta.3...gatsby-source-hacker-news@2.0.0-beta.4) (2018-07-12)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-beta.3...gatsby-source-hacker-news@2.0.0-beta.4) (2018-07-12)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-beta.2...gatsby-source-hacker-news@2.0.0-beta.3) (2018-06-29)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-beta.2...gatsby-source-hacker-news@2.0.0-beta.3) (2018-06-29)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-beta.1...gatsby-source-hacker-news@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-beta.1...gatsby-source-hacker-news@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@2.0.0-beta.0...gatsby-source-hacker-news@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@2.0.0-beta.0...gatsby-source-hacker-news@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-hacker-news
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news/compare/gatsby-source-hacker-news@1.0.11...gatsby-source-hacker-news@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-hacker-news@1.0.11...gatsby-source-hacker-news@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-hacker-news

--- a/packages/gatsby-source-lever/CHANGELOG.md
+++ b/packages/gatsby-source-lever/CHANGELOG.md
@@ -7,118 +7,118 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-lever
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.9...gatsby-source-lever@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.9...gatsby-source-lever@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-lever
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.8...gatsby-source-lever@2.0.9) (2019-05-31)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.8...gatsby-source-lever@2.0.9) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-source-lever
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.7...gatsby-source-lever@2.0.8) (2019-04-08)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.7...gatsby-source-lever@2.0.8) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-source-lever
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.6...gatsby-source-lever@2.0.7) (2019-03-15)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.6...gatsby-source-lever@2.0.7) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-lever
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.5...gatsby-source-lever@2.0.6) (2019-03-11)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.5...gatsby-source-lever@2.0.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-lever
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.4...gatsby-source-lever@2.0.5) (2019-02-08)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.4...gatsby-source-lever@2.0.5) (2019-02-08)
 
 **Note:** Version bump only for package gatsby-source-lever
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.3...gatsby-source-lever@2.0.4) (2019-02-01)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.3...gatsby-source-lever@2.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-source-lever
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.2...gatsby-source-lever@2.0.3) (2019-01-25)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.2...gatsby-source-lever@2.0.3) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.1...gatsby-source-lever@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.1...gatsby-source-lever@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0...gatsby-source-lever@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0...gatsby-source-lever@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-rc.5...gatsby-source-lever@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-rc.5...gatsby-source-lever@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-rc.4...gatsby-source-lever@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-rc.4...gatsby-source-lever@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-rc.3...gatsby-source-lever@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-rc.3...gatsby-source-lever@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-rc.2...gatsby-source-lever@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-rc.2...gatsby-source-lever@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-rc.1...gatsby-source-lever@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-rc.1...gatsby-source-lever@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-rc.0...gatsby-source-lever@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-rc.0...gatsby-source-lever@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-beta.4...gatsby-source-lever@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-beta.4...gatsby-source-lever@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-beta.3...gatsby-source-lever@2.0.0-beta.4) (2018-08-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-beta.3...gatsby-source-lever@2.0.0-beta.4) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-beta.2...gatsby-source-lever@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-beta.2...gatsby-source-lever@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-beta.1...gatsby-source-lever@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-beta.1...gatsby-source-lever@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@2.0.0-beta.0...gatsby-source-lever@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@2.0.0-beta.0...gatsby-source-lever@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-lever
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever/compare/gatsby-source-lever@1.0.11...gatsby-source-lever@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-lever@1.0.11...gatsby-source-lever@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-lever

--- a/packages/gatsby-source-medium/CHANGELOG.md
+++ b/packages/gatsby-source-medium/CHANGELOG.md
@@ -7,126 +7,126 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-medium
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.8...gatsby-source-medium@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.8...gatsby-source-medium@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-medium
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.7...gatsby-source-medium@2.0.8) (2019-05-31)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.7...gatsby-source-medium@2.0.8) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-source-medium
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.6...gatsby-source-medium@2.0.7) (2019-04-02)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.6...gatsby-source-medium@2.0.7) (2019-04-02)
 
 **Note:** Version bump only for package gatsby-source-medium
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.5...gatsby-source-medium@2.0.6) (2019-03-15)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.5...gatsby-source-medium@2.0.6) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-medium
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.4...gatsby-source-medium@2.0.5) (2019-03-11)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.4...gatsby-source-medium@2.0.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-medium
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.3...gatsby-source-medium@2.0.4) (2019-02-01)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.3...gatsby-source-medium@2.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-source-medium
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.2...gatsby-source-medium@2.0.3) (2019-01-25)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.2...gatsby-source-medium@2.0.3) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.1...gatsby-source-medium@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.1...gatsby-source-medium@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0...gatsby-source-medium@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0...gatsby-source-medium@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-rc.6...gatsby-source-medium@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-rc.6...gatsby-source-medium@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-rc.5...gatsby-source-medium@2.0.0-rc.6) (2018-09-11)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-rc.5...gatsby-source-medium@2.0.0-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-rc.4...gatsby-source-medium@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-rc.4...gatsby-source-medium@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-rc.3...gatsby-source-medium@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-rc.3...gatsby-source-medium@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-rc.2...gatsby-source-medium@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-rc.2...gatsby-source-medium@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-rc.1...gatsby-source-medium@2.0.0-rc.2) (2018-09-05)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-rc.1...gatsby-source-medium@2.0.0-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-rc.0...gatsby-source-medium@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-rc.0...gatsby-source-medium@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-beta.5...gatsby-source-medium@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-beta.5...gatsby-source-medium@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-beta.4...gatsby-source-medium@2.0.0-beta.5) (2018-07-21)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-beta.4...gatsby-source-medium@2.0.0-beta.5) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-beta.3...gatsby-source-medium@2.0.0-beta.4) (2018-07-12)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-beta.3...gatsby-source-medium@2.0.0-beta.4) (2018-07-12)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-beta.2...gatsby-source-medium@2.0.0-beta.3) (2018-06-29)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-beta.2...gatsby-source-medium@2.0.0-beta.3) (2018-06-29)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-beta.1...gatsby-source-medium@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-beta.1...gatsby-source-medium@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@2.0.0-beta.0...gatsby-source-medium@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@2.0.0-beta.0...gatsby-source-medium@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-medium
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium/compare/gatsby-source-medium@1.0.14...gatsby-source-medium@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-medium@1.0.14...gatsby-source-medium@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-medium

--- a/packages/gatsby-source-mongodb/CHANGELOG.md
+++ b/packages/gatsby-source-mongodb/CHANGELOG.md
@@ -7,188 +7,188 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.1.0...gatsby-source-mongodb@2.1.1) (2019-07-02)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.1.0...gatsby-source-mongodb@2.1.1) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.20...gatsby-source-mongodb@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.20...gatsby-source-mongodb@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.19...gatsby-source-mongodb@2.0.20) (2019-06-10)
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.19...gatsby-source-mongodb@2.0.20) (2019-06-10)
 
 ### Bug Fixes
 
-- **gatsby-source-mongodb:** fix mapping function signature ([#14402](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/14402)) ([48dbfd7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/commit/48dbfd7))
+- **gatsby-source-mongodb:** fix mapping function signature ([#14402](https://github.com/gatsbyjs/gatsby/issues/14402)) ([48dbfd7](https://github.com/gatsbyjs/gatsby/commit/48dbfd7))
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.18...gatsby-source-mongodb@2.0.19) (2019-05-29)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.18...gatsby-source-mongodb@2.0.19) (2019-05-29)
 
 ### Bug Fixes
 
-- **gatsby-source-mongodb:** fix null values ([#14356](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/14356)) ([c6bbe4b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/commit/c6bbe4b))
+- **gatsby-source-mongodb:** fix null values ([#14356](https://github.com/gatsbyjs/gatsby/issues/14356)) ([c6bbe4b](https://github.com/gatsbyjs/gatsby/commit/c6bbe4b))
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.17...gatsby-source-mongodb@2.0.18) (2019-04-18)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.17...gatsby-source-mongodb@2.0.18) (2019-04-18)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.16...gatsby-source-mongodb@2.0.17) (2019-04-08)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.16...gatsby-source-mongodb@2.0.17) (2019-04-08)
 
 ### Features
 
-- **gatsby-source-mongodb:** accommodate relationships with MongoDB collections ([#12774](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/12774)) ([a9c1507](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/commit/a9c1507))
+- **gatsby-source-mongodb:** accommodate relationships with MongoDB collections ([#12774](https://github.com/gatsbyjs/gatsby/issues/12774)) ([a9c1507](https://github.com/gatsbyjs/gatsby/commit/a9c1507))
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.15...gatsby-source-mongodb@2.0.16) (2019-03-22)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.15...gatsby-source-mongodb@2.0.16) (2019-03-22)
 
 ### Features
 
-- **gatsby-source-mongodb:** mongodb to ver 3, added ability to pass entire connection string ([#11698](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/11698)) ([f61e437](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/commit/f61e437))
+- **gatsby-source-mongodb:** mongodb to ver 3, added ability to pass entire connection string ([#11698](https://github.com/gatsbyjs/gatsby/issues/11698)) ([f61e437](https://github.com/gatsbyjs/gatsby/commit/f61e437))
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.14...gatsby-source-mongodb@2.0.15) (2019-03-15)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.14...gatsby-source-mongodb@2.0.15) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.13...gatsby-source-mongodb@2.0.14) (2019-03-12)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.13...gatsby-source-mongodb@2.0.14) (2019-03-12)
 
 ### Bug Fixes
 
-- **gatsby-source-mongodb:** sanitize name correctly ([#11294](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/11294)) ([731dd60](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/commit/731dd60)), closes [#11277](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/11277) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/1234)
+- **gatsby-source-mongodb:** sanitize name correctly ([#11294](https://github.com/gatsbyjs/gatsby/issues/11294)) ([731dd60](https://github.com/gatsbyjs/gatsby/commit/731dd60)), closes [#11277](https://github.com/gatsbyjs/gatsby/issues/11277) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234) [#1234](https://github.com/gatsbyjs/gatsby/issues/1234)
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.12...gatsby-source-mongodb@2.0.13) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-source-mongodb
-
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.11...gatsby-source-mongodb@2.0.12) (2019-02-01)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.12...gatsby-source-mongodb@2.0.13) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.10...gatsby-source-mongodb@2.0.11) (2019-01-31)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.11...gatsby-source-mongodb@2.0.12) (2019-02-01)
+
+**Note:** Version bump only for package gatsby-source-mongodb
+
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.10...gatsby-source-mongodb@2.0.11) (2019-01-31)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.9...gatsby-source-mongodb@2.0.10) (2018-12-11)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.9...gatsby-source-mongodb@2.0.10) (2018-12-11)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.8...gatsby-source-mongodb@2.0.9) (2018-11-29)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.8...gatsby-source-mongodb@2.0.9) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.7...gatsby-source-mongodb@2.0.8) (2018-11-08)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.7...gatsby-source-mongodb@2.0.8) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.6...gatsby-source-mongodb@2.0.7) (2018-11-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.6...gatsby-source-mongodb@2.0.7) (2018-11-01)
 
 ### Bug Fixes
 
-- **gatsby-source-mongodb:** sanitize type of nodes to only contain alphanumeric chars and underscores ([#7246](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/7246)) ([47a800c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/commit/47a800c)), closes [#7218](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/7218) [/github.com/graphql/graphql-js/blob/5fe39262a308df944a87cc85b225228e7556aaa4/src/utilities/assertValidName.js#L14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/issues/L14)
+- **gatsby-source-mongodb:** sanitize type of nodes to only contain alphanumeric chars and underscores ([#7246](https://github.com/gatsbyjs/gatsby/issues/7246)) ([47a800c](https://github.com/gatsbyjs/gatsby/commit/47a800c)), closes [#7218](https://github.com/gatsbyjs/gatsby/issues/7218) [/github.com/graphql/graphql-js/blob/5fe39262a308df944a87cc85b225228e7556aaa4/src/utilities/assertValidName.js#L14](https://github.com/gatsbyjs/gatsby/issues/L14)
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.5...gatsby-source-mongodb@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.5...gatsby-source-mongodb@2.0.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-rc.5...gatsby-source-mongodb@2.0.5) (2018-09-17)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-rc.5...gatsby-source-mongodb@2.0.5) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-rc.4...gatsby-source-mongodb@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-rc.4...gatsby-source-mongodb@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-rc.3...gatsby-source-mongodb@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-rc.3...gatsby-source-mongodb@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-rc.2...gatsby-source-mongodb@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-rc.2...gatsby-source-mongodb@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-rc.1...gatsby-source-mongodb@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-rc.1...gatsby-source-mongodb@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-rc.0...gatsby-source-mongodb@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-rc.0...gatsby-source-mongodb@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.9...gatsby-source-mongodb@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.9...gatsby-source-mongodb@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.9"></a>
 
-# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.8...gatsby-source-mongodb@2.0.0-beta.9) (2018-08-20)
+# [2.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.8...gatsby-source-mongodb@2.0.0-beta.9) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.8"></a>
 
-# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.6...gatsby-source-mongodb@2.0.0-beta.8) (2018-08-13)
+# [2.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.6...gatsby-source-mongodb@2.0.0-beta.8) (2018-08-13)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.5...gatsby-source-mongodb@2.0.0-beta.6) (2018-07-21)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.5...gatsby-source-mongodb@2.0.0-beta.6) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.4...gatsby-source-mongodb@2.0.0-beta.5) (2018-07-12)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.4...gatsby-source-mongodb@2.0.0-beta.5) (2018-07-12)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.3...gatsby-source-mongodb@2.0.0-beta.4) (2018-07-09)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.3...gatsby-source-mongodb@2.0.0-beta.4) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.2...gatsby-source-mongodb@2.0.0-beta.3) (2018-06-25)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.2...gatsby-source-mongodb@2.0.0-beta.3) (2018-06-25)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.1...gatsby-source-mongodb@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.1...gatsby-source-mongodb@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@2.0.0-beta.0...gatsby-source-mongodb@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@2.0.0-beta.0...gatsby-source-mongodb@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-mongodb
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb/compare/gatsby-source-mongodb@1.5.21...gatsby-source-mongodb@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-mongodb@1.5.21...gatsby-source-mongodb@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-mongodb

--- a/packages/gatsby-source-shopify/CHANGELOG.md
+++ b/packages/gatsby-source-shopify/CHANGELOG.md
@@ -7,201 +7,201 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.1.3...gatsby-source-shopify@2.1.4) (2019-07-10)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.1.3...gatsby-source-shopify@2.1.4) (2019-07-10)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.1.2...gatsby-source-shopify@2.1.3) (2019-07-02)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.1.2...gatsby-source-shopify@2.1.3) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.1.1...gatsby-source-shopify@2.1.2) (2019-06-25)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.1.1...gatsby-source-shopify@2.1.2) (2019-06-25)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.1.0...gatsby-source-shopify@2.1.1) (2019-06-24)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.1.0...gatsby-source-shopify@2.1.1) (2019-06-24)
 
 ### Bug Fixes
 
-- **gatsby-source-shopify:** fix pages query path ([#14604](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/14604)) ([5013f27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/5013f27))
+- **gatsby-source-shopify:** fix pages query path ([#14604](https://github.com/gatsbyjs/gatsby/issues/14604)) ([5013f27](https://github.com/gatsbyjs/gatsby/commit/5013f27))
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.41...gatsby-source-shopify@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.41...gatsby-source-shopify@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.41](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.38...gatsby-source-shopify@2.0.41) (2019-06-19)
+## [2.0.41](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.38...gatsby-source-shopify@2.0.41) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [2.0.40](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.39...gatsby-source-shopify@2.0.40) (2019-06-19)
+## [2.0.40](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.39...gatsby-source-shopify@2.0.40) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [2.0.39](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.38...gatsby-source-shopify@2.0.39) (2019-06-18)
-
-**Note:** Version bump only for package gatsby-source-shopify
-
-## [2.0.38](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.37...gatsby-source-shopify@2.0.38) (2019-06-18)
+## [2.0.39](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.38...gatsby-source-shopify@2.0.39) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.37](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.36...gatsby-source-shopify@2.0.37) (2019-06-10)
+## [2.0.38](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.37...gatsby-source-shopify@2.0.38) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.36](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.35...gatsby-source-shopify@2.0.36) (2019-06-04)
+## [2.0.37](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.36...gatsby-source-shopify@2.0.37) (2019-06-10)
+
+**Note:** Version bump only for package gatsby-source-shopify
+
+## [2.0.36](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.35...gatsby-source-shopify@2.0.36) (2019-06-04)
 
 ### Features
 
-- **gatsby-source-shopify:** add configurable 'paginationSize' parameter ([#14470](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/14470)) ([b07dcc0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/b07dcc0))
+- **gatsby-source-shopify:** add configurable 'paginationSize' parameter ([#14470](https://github.com/gatsbyjs/gatsby/issues/14470)) ([b07dcc0](https://github.com/gatsbyjs/gatsby/commit/b07dcc0))
 
-## [2.0.35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.34...gatsby-source-shopify@2.0.35) (2019-05-31)
+## [2.0.35](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.34...gatsby-source-shopify@2.0.35) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.33...gatsby-source-shopify@2.0.34) (2019-05-31)
+## [2.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.33...gatsby-source-shopify@2.0.34) (2019-05-31)
 
 ### Bug Fixes
 
-- **gatsby-source-shopify:** Fix empty result error ([#14457](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/14457)) ([b34f6d0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/b34f6d0))
+- **gatsby-source-shopify:** Fix empty result error ([#14457](https://github.com/gatsbyjs/gatsby/issues/14457)) ([b34f6d0](https://github.com/gatsbyjs/gatsby/commit/b34f6d0))
 
-## [2.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.32...gatsby-source-shopify@2.0.33) (2019-05-29)
+## [2.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.32...gatsby-source-shopify@2.0.33) (2019-05-29)
 
 ### Features
 
-- **gatsby-source-shopify:** Add support for Shopify Pages ([#13183](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/13183)) ([cae067c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/cae067c))
+- **gatsby-source-shopify:** Add support for Shopify Pages ([#13183](https://github.com/gatsbyjs/gatsby/issues/13183)) ([cae067c](https://github.com/gatsbyjs/gatsby/commit/cae067c))
 
-## [2.0.32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.31...gatsby-source-shopify@2.0.32) (2019-05-20)
-
-**Note:** Version bump only for package gatsby-source-shopify
-
-## [2.0.31](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.30...gatsby-source-shopify@2.0.31) (2019-05-16)
+## [2.0.32](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.31...gatsby-source-shopify@2.0.32) (2019-05-20)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.29...gatsby-source-shopify@2.0.30) (2019-05-15)
+## [2.0.31](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.30...gatsby-source-shopify@2.0.31) (2019-05-16)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.28...gatsby-source-shopify@2.0.29) (2019-05-14)
+## [2.0.30](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.29...gatsby-source-shopify@2.0.30) (2019-05-15)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.27...gatsby-source-shopify@2.0.28) (2019-04-30)
+## [2.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.28...gatsby-source-shopify@2.0.29) (2019-05-14)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.26...gatsby-source-shopify@2.0.27) (2019-04-24)
+## [2.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.27...gatsby-source-shopify@2.0.28) (2019-04-30)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.25...gatsby-source-shopify@2.0.26) (2019-04-23)
+## [2.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.26...gatsby-source-shopify@2.0.27) (2019-04-24)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.24...gatsby-source-shopify@2.0.25) (2019-04-23)
+## [2.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.25...gatsby-source-shopify@2.0.26) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.24](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.23...gatsby-source-shopify@2.0.24) (2019-04-08)
+## [2.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.24...gatsby-source-shopify@2.0.25) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.22...gatsby-source-shopify@2.0.23) (2019-04-02)
+## [2.0.24](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.23...gatsby-source-shopify@2.0.24) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.21...gatsby-source-shopify@2.0.22) (2019-03-22)
+## [2.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.22...gatsby-source-shopify@2.0.23) (2019-04-02)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.20...gatsby-source-shopify@2.0.21) (2019-03-15)
+## [2.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.21...gatsby-source-shopify@2.0.22) (2019-03-22)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.19...gatsby-source-shopify@2.0.20) (2019-03-14)
+## [2.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.20...gatsby-source-shopify@2.0.21) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.18...gatsby-source-shopify@2.0.19) (2019-03-13)
+## [2.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.19...gatsby-source-shopify@2.0.20) (2019-03-14)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.17...gatsby-source-shopify@2.0.18) (2019-03-11)
+## [2.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.18...gatsby-source-shopify@2.0.19) (2019-03-13)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.16...gatsby-source-shopify@2.0.17) (2019-02-25)
+## [2.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.17...gatsby-source-shopify@2.0.18) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.15...gatsby-source-shopify@2.0.16) (2019-02-22)
+## [2.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.16...gatsby-source-shopify@2.0.17) (2019-02-25)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.14...gatsby-source-shopify@2.0.15) (2019-02-20)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.15...gatsby-source-shopify@2.0.16) (2019-02-22)
+
+**Note:** Version bump only for package gatsby-source-shopify
+
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.14...gatsby-source-shopify@2.0.15) (2019-02-20)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/5a3c1fc))
+- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/commit/5a3c1fc))
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.13...gatsby-source-shopify@2.0.14) (2019-02-19)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.13...gatsby-source-shopify@2.0.14) (2019-02-19)
 
 ### Bug Fixes
 
-- **gatsby-source-shopify:** fix query pagination ([#11752](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/11752)) ([a82682c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/a82682c))
+- **gatsby-source-shopify:** fix query pagination ([#11752](https://github.com/gatsbyjs/gatsby/issues/11752)) ([a82682c](https://github.com/gatsbyjs/gatsby/commit/a82682c))
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.12...gatsby-source-shopify@2.0.13) (2019-02-01)
-
-**Note:** Version bump only for package gatsby-source-shopify
-
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.11...gatsby-source-shopify@2.0.12) (2019-01-31)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.12...gatsby-source-shopify@2.0.13) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.10...gatsby-source-shopify@2.0.11) (2019-01-28)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.11...gatsby-source-shopify@2.0.12) (2019-01-31)
+
+**Note:** Version bump only for package gatsby-source-shopify
+
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.10...gatsby-source-shopify@2.0.11) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.9...gatsby-source-shopify@2.0.10) (2019-01-23)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.9...gatsby-source-shopify@2.0.10) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.8...gatsby-source-shopify@2.0.9) (2019-01-23)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.8...gatsby-source-shopify@2.0.9) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.6...gatsby-source-shopify@2.0.8) (2019-01-11)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.6...gatsby-source-shopify@2.0.8) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.5...gatsby-source-shopify@2.0.6) (2019-01-11)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.5...gatsby-source-shopify@2.0.6) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-shopify
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.4...gatsby-source-shopify@2.0.5) (2019-01-09)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.4...gatsby-source-shopify@2.0.5) (2019-01-09)
 
 ### Bug Fixes
 
-- update calls to sourceNodes ([#10955](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/issues/10955)) ([38c0b8d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/commit/38c0b8d))
+- update calls to sourceNodes ([#10955](https://github.com/gatsbyjs/gatsby/issues/10955)) ([38c0b8d](https://github.com/gatsbyjs/gatsby/commit/38c0b8d))
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify/compare/gatsby-source-shopify@2.0.3...gatsby-source-shopify@2.0.4) (2019-01-08)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-shopify@2.0.3...gatsby-source-shopify@2.0.4) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-source-shopify
 

--- a/packages/gatsby-source-wikipedia/CHANGELOG.md
+++ b/packages/gatsby-source-wikipedia/CHANGELOG.md
@@ -7,15 +7,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-wikipedia
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wikipedia/compare/gatsby-source-wikipedia@2.0.8...gatsby-source-wikipedia@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wikipedia@2.0.8...gatsby-source-wikipedia@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-source-wikipedia
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wikipedia/compare/gatsby-source-wikipedia@2.0.7...gatsby-source-wikipedia@2.0.8) (2019-05-31)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wikipedia@2.0.7...gatsby-source-wikipedia@2.0.8) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-source-wikipedia
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wikipedia/compare/gatsby-source-wikipedia@2.0.6...gatsby-source-wikipedia@2.0.7) (2019-04-23)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wikipedia@2.0.6...gatsby-source-wikipedia@2.0.7) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-source-wikipedia
 

--- a/packages/gatsby-source-wordpress/CHANGELOG.md
+++ b/packages/gatsby-source-wordpress/CHANGELOG.md
@@ -7,604 +7,604 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.1.4...gatsby-source-wordpress@3.1.5) (2019-07-10)
+## [3.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.1.4...gatsby-source-wordpress@3.1.5) (2019-07-10)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.1.3...gatsby-source-wordpress@3.1.4) (2019-07-04)
+## [3.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.1.3...gatsby-source-wordpress@3.1.4) (2019-07-04)
 
 ### Features
 
-- **gatsby-source-wordpress:** add option to send cookies ([#15361](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/15361)) ([2b08ae5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/2b08ae5))
+- **gatsby-source-wordpress:** add option to send cookies ([#15361](https://github.com/gatsbyjs/gatsby/issues/15361)) ([2b08ae5](https://github.com/gatsbyjs/gatsby/commit/2b08ae5))
 
-## [3.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.1.2...gatsby-source-wordpress@3.1.3) (2019-07-02)
+## [3.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.1.2...gatsby-source-wordpress@3.1.3) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.1.1...gatsby-source-wordpress@3.1.2) (2019-06-26)
+## [3.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.1.1...gatsby-source-wordpress@3.1.2) (2019-06-26)
 
 ### Features
 
-- **gatsby-source-wordpress:** Add support for WP-REST-API V2… ([#13343](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/13343)) ([e2c8402](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/e2c8402))
+- **gatsby-source-wordpress:** Add support for WP-REST-API V2… ([#13343](https://github.com/gatsbyjs/gatsby/issues/13343)) ([e2c8402](https://github.com/gatsbyjs/gatsby/commit/e2c8402))
 
-## [3.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.1.0...gatsby-source-wordpress@3.1.1) (2019-06-25)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-# [3.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.69...gatsby-source-wordpress@3.1.0) (2019-06-20)
+## [3.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.1.0...gatsby-source-wordpress@3.1.1) (2019-06-25)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.69](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.66...gatsby-source-wordpress@3.0.69) (2019-06-19)
+# [3.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.69...gatsby-source-wordpress@3.1.0) (2019-06-20)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.69](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.66...gatsby-source-wordpress@3.0.69) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [3.0.68](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.67...gatsby-source-wordpress@3.0.68) (2019-06-19)
-
-### Bug Fixes
-
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/2594623))
-
-## [3.0.67](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.66...gatsby-source-wordpress@3.0.67) (2019-06-18)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.66](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.65...gatsby-source-wordpress@3.0.66) (2019-06-18)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.65](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.64...gatsby-source-wordpress@3.0.65) (2019-06-10)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.64](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.63...gatsby-source-wordpress@3.0.64) (2019-05-31)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.63](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.62...gatsby-source-wordpress@3.0.63) (2019-05-31)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.62](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.61...gatsby-source-wordpress@3.0.62) (2019-05-20)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.61](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.60...gatsby-source-wordpress@3.0.61) (2019-05-16)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.60](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.59...gatsby-source-wordpress@3.0.60) (2019-05-15)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.59](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.58...gatsby-source-wordpress@3.0.59) (2019-05-14)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.58](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.57...gatsby-source-wordpress@3.0.58) (2019-04-30)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.57](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.56...gatsby-source-wordpress@3.0.57) (2019-04-24)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.56](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.55...gatsby-source-wordpress@3.0.56) (2019-04-23)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.55](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.54...gatsby-source-wordpress@3.0.55) (2019-04-23)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.54](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.53...gatsby-source-wordpress@3.0.54) (2019-04-15)
+## [3.0.68](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.67...gatsby-source-wordpress@3.0.68) (2019-06-19)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** fix WP-API-MENUS when reported endpoint url doesn't match base url ([#12859](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/12859)) ([a430202](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/a430202))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [3.0.53](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.52...gatsby-source-wordpress@3.0.53) (2019-04-08)
+## [3.0.67](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.66...gatsby-source-wordpress@3.0.67) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.52](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.51...gatsby-source-wordpress@3.0.52) (2019-04-05)
+## [3.0.66](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.65...gatsby-source-wordpress@3.0.66) (2019-06-18)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.65](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.64...gatsby-source-wordpress@3.0.65) (2019-06-10)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.64](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.63...gatsby-source-wordpress@3.0.64) (2019-05-31)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.63](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.62...gatsby-source-wordpress@3.0.63) (2019-05-31)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.62](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.61...gatsby-source-wordpress@3.0.62) (2019-05-20)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.61](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.60...gatsby-source-wordpress@3.0.61) (2019-05-16)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.60](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.59...gatsby-source-wordpress@3.0.60) (2019-05-15)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.59](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.58...gatsby-source-wordpress@3.0.59) (2019-05-14)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.58](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.57...gatsby-source-wordpress@3.0.58) (2019-04-30)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.57](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.56...gatsby-source-wordpress@3.0.57) (2019-04-24)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.56](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.55...gatsby-source-wordpress@3.0.56) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.55](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.54...gatsby-source-wordpress@3.0.55) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.54](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.53...gatsby-source-wordpress@3.0.54) (2019-04-15)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** fix local files being nulles after unpublishing and republishing posts ([#13140](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/13140)) ([378f863](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/378f863))
+- **gatsby-source-wordpress:** fix WP-API-MENUS when reported endpoint url doesn't match base url ([#12859](https://github.com/gatsbyjs/gatsby/issues/12859)) ([a430202](https://github.com/gatsbyjs/gatsby/commit/a430202))
+
+## [3.0.53](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.52...gatsby-source-wordpress@3.0.53) (2019-04-08)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.52](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.51...gatsby-source-wordpress@3.0.52) (2019-04-05)
+
+### Bug Fixes
+
+- **gatsby-source-wordpress:** fix local files being nulles after unpublishing and republishing posts ([#13140](https://github.com/gatsbyjs/gatsby/issues/13140)) ([378f863](https://github.com/gatsbyjs/gatsby/commit/378f863))
 
 ### Features
 
-- **gatsby-source-wordpress:** Add yoast premium redirects support ([#11595](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11595)) ([e01f080](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/e01f080))
+- **gatsby-source-wordpress:** Add yoast premium redirects support ([#11595](https://github.com/gatsbyjs/gatsby/issues/11595)) ([e01f080](https://github.com/gatsbyjs/gatsby/commit/e01f080))
 
-## [3.0.51](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.50...gatsby-source-wordpress@3.0.51) (2019-03-28)
+## [3.0.51](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.50...gatsby-source-wordpress@3.0.51) (2019-03-28)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.50](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.49...gatsby-source-wordpress@3.0.50) (2019-03-27)
+## [3.0.50](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.49...gatsby-source-wordpress@3.0.50) (2019-03-27)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** adjust how endpoint urls are constructed to fix fetching for wordpress.com hosted sites and proxied urls ([#10624](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/10624)) ([85b8749](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/85b8749)), closes [#10427](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/10427) [#10427](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/10427)
+- **gatsby-source-wordpress:** adjust how endpoint urls are constructed to fix fetching for wordpress.com hosted sites and proxied urls ([#10624](https://github.com/gatsbyjs/gatsby/issues/10624)) ([85b8749](https://github.com/gatsbyjs/gatsby/commit/85b8749)), closes [#10427](https://github.com/gatsbyjs/gatsby/issues/10427) [#10427](https://github.com/gatsbyjs/gatsby/issues/10427)
 
-## [3.0.49](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.48...gatsby-source-wordpress@3.0.49) (2019-03-22)
+## [3.0.49](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.48...gatsby-source-wordpress@3.0.49) (2019-03-22)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.48](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.47...gatsby-source-wordpress@3.0.48) (2019-03-19)
+## [3.0.48](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.47...gatsby-source-wordpress@3.0.48) (2019-03-19)
 
 ### Features
 
-- **gatsby-source-wordpress:** use unique multi-site node id's ([#12683](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/12683)) ([925a655](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/925a655))
+- **gatsby-source-wordpress:** use unique multi-site node id's ([#12683](https://github.com/gatsbyjs/gatsby/issues/12683)) ([925a655](https://github.com/gatsbyjs/gatsby/commit/925a655))
 
-## [3.0.47](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.46...gatsby-source-wordpress@3.0.47) (2019-03-15)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.46](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.45...gatsby-source-wordpress@3.0.46) (2019-03-14)
+## [3.0.47](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.46...gatsby-source-wordpress@3.0.47) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.45](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.44...gatsby-source-wordpress@3.0.45) (2019-03-13)
+## [3.0.46](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.45...gatsby-source-wordpress@3.0.46) (2019-03-14)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.44](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.43...gatsby-source-wordpress@3.0.44) (2019-03-11)
+## [3.0.45](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.44...gatsby-source-wordpress@3.0.45) (2019-03-13)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.43](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.42...gatsby-source-wordpress@3.0.43) (2019-03-05)
+## [3.0.44](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.43...gatsby-source-wordpress@3.0.44) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.42](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.41...gatsby-source-wordpress@3.0.42) (2019-03-04)
+## [3.0.43](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.42...gatsby-source-wordpress@3.0.43) (2019-03-05)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.42](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.41...gatsby-source-wordpress@3.0.42) (2019-03-04)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** Sync sample w/docs ([#11868](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11868)) ([337d98e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/337d98e)), closes [#11739](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11739)
+- **gatsby-source-wordpress:** Sync sample w/docs ([#11868](https://github.com/gatsbyjs/gatsby/issues/11868)) ([337d98e](https://github.com/gatsbyjs/gatsby/commit/337d98e)), closes [#11739](https://github.com/gatsbyjs/gatsby/issues/11739)
 
-## [3.0.41](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.40...gatsby-source-wordpress@3.0.41) (2019-02-28)
+## [3.0.41](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.40...gatsby-source-wordpress@3.0.41) (2019-02-28)
 
 ### Features
 
-- **gatsby-source-wordpress:** Add "path" field to post/page/custom post type entities ([#11775](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11775)) ([0b39498](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/0b39498))
+- **gatsby-source-wordpress:** Add "path" field to post/page/custom post type entities ([#11775](https://github.com/gatsbyjs/gatsby/issues/11775)) ([0b39498](https://github.com/gatsbyjs/gatsby/commit/0b39498))
 
-## [3.0.40](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.39...gatsby-source-wordpress@3.0.40) (2019-02-25)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.39](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.38...gatsby-source-wordpress@3.0.39) (2019-02-25)
+## [3.0.40](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.39...gatsby-source-wordpress@3.0.40) (2019-02-25)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.38](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.37...gatsby-source-wordpress@3.0.38) (2019-02-22)
+## [3.0.39](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.38...gatsby-source-wordpress@3.0.39) (2019-02-25)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.37](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.36...gatsby-source-wordpress@3.0.37) (2019-02-20)
+## [3.0.38](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.37...gatsby-source-wordpress@3.0.38) (2019-02-22)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.37](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.36...gatsby-source-wordpress@3.0.37) (2019-02-20)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/5a3c1fc))
+- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/commit/5a3c1fc))
 
-## [3.0.36](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.35...gatsby-source-wordpress@3.0.36) (2019-02-19)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.34...gatsby-source-wordpress@3.0.35) (2019-02-15)
+## [3.0.36](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.35...gatsby-source-wordpress@3.0.36) (2019-02-19)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.33...gatsby-source-wordpress@3.0.34) (2019-02-12)
+## [3.0.35](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.34...gatsby-source-wordpress@3.0.35) (2019-02-15)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.32...gatsby-source-wordpress@3.0.33) (2019-02-04)
+## [3.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.33...gatsby-source-wordpress@3.0.34) (2019-02-12)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.32...gatsby-source-wordpress@3.0.33) (2019-02-04)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** handle woocommerce categories and tags ([#11527](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11527)) ([afa4dad](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/afa4dad))
+- **gatsby-source-wordpress:** handle woocommerce categories and tags ([#11527](https://github.com/gatsbyjs/gatsby/issues/11527)) ([afa4dad](https://github.com/gatsbyjs/gatsby/commit/afa4dad))
 
-## [3.0.32](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.31...gatsby-source-wordpress@3.0.32) (2019-02-01)
+## [3.0.32](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.31...gatsby-source-wordpress@3.0.32) (2019-02-01)
 
 ### Features
 
-- **gatsby-source-wordpress:** add jwt_base_path option ([#11425](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11425)) ([8bcd19b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/8bcd19b))
+- **gatsby-source-wordpress:** add jwt_base_path option ([#11425](https://github.com/gatsbyjs/gatsby/issues/11425)) ([8bcd19b](https://github.com/gatsbyjs/gatsby/commit/8bcd19b))
 
-## [3.0.31](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.30...gatsby-source-wordpress@3.0.31) (2019-02-01)
-
-**Note:** Version bump only for package gatsby-source-wordpress
-
-## [3.0.30](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.29...gatsby-source-wordpress@3.0.30) (2019-01-31)
+## [3.0.31](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.30...gatsby-source-wordpress@3.0.31) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
-## [3.0.29](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.28...gatsby-source-wordpress@3.0.29) (2019-01-28)
+## [3.0.30](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.29...gatsby-source-wordpress@3.0.30) (2019-01-31)
+
+**Note:** Version bump only for package gatsby-source-wordpress
+
+## [3.0.29](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.28...gatsby-source-wordpress@3.0.29) (2019-01-28)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** check response exists before accessing property ([#11349](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/11349)) ([3beb891](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/3beb891))
+- **gatsby-source-wordpress:** check response exists before accessing property ([#11349](https://github.com/gatsbyjs/gatsby/issues/11349)) ([3beb891](https://github.com/gatsbyjs/gatsby/commit/3beb891))
 
-## [3.0.28](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.27...gatsby-source-wordpress@3.0.28) (2019-01-25)
+## [3.0.28](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.27...gatsby-source-wordpress@3.0.28) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.27"></a>
 
-## [3.0.27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.26...gatsby-source-wordpress@3.0.27) (2019-01-23)
+## [3.0.27](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.26...gatsby-source-wordpress@3.0.27) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.26"></a>
 
-## [3.0.26](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.25...gatsby-source-wordpress@3.0.26) (2019-01-23)
+## [3.0.26](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.25...gatsby-source-wordpress@3.0.26) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.25"></a>
 
-## [3.0.25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.23...gatsby-source-wordpress@3.0.25) (2019-01-11)
+## [3.0.25](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.23...gatsby-source-wordpress@3.0.25) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.23"></a>
 
-## [3.0.23](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.22...gatsby-source-wordpress@3.0.23) (2019-01-11)
+## [3.0.23](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.22...gatsby-source-wordpress@3.0.23) (2019-01-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.22"></a>
 
-## [3.0.22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.21...gatsby-source-wordpress@3.0.22) (2019-01-08)
+## [3.0.22](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.21...gatsby-source-wordpress@3.0.22) (2019-01-08)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** add a check for namespaces in response from wp ([#10891](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/10891)) ([d96016c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/d96016c))
-- **gatsby-source-wordpress:** use correct glob pattern paths for routes ([#10887](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/10887)) ([c793419](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/c793419))
+- **gatsby-source-wordpress:** add a check for namespaces in response from wp ([#10891](https://github.com/gatsbyjs/gatsby/issues/10891)) ([d96016c](https://github.com/gatsbyjs/gatsby/commit/d96016c))
+- **gatsby-source-wordpress:** use correct glob pattern paths for routes ([#10887](https://github.com/gatsbyjs/gatsby/issues/10887)) ([c793419](https://github.com/gatsbyjs/gatsby/commit/c793419))
 
 <a name="3.0.21"></a>
 
-## [3.0.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.20...gatsby-source-wordpress@3.0.21) (2018-12-18)
+## [3.0.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.20...gatsby-source-wordpress@3.0.21) (2018-12-18)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.20"></a>
 
-## [3.0.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.19...gatsby-source-wordpress@3.0.20) (2018-12-11)
+## [3.0.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.19...gatsby-source-wordpress@3.0.20) (2018-12-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.19"></a>
 
-## [3.0.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.18...gatsby-source-wordpress@3.0.19) (2018-12-06)
+## [3.0.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.18...gatsby-source-wordpress@3.0.19) (2018-12-06)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.18"></a>
 
-## [3.0.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.17...gatsby-source-wordpress@3.0.18) (2018-12-03)
+## [3.0.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.17...gatsby-source-wordpress@3.0.18) (2018-12-03)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.17"></a>
 
-## [3.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.16...gatsby-source-wordpress@3.0.17) (2018-12-01)
+## [3.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.16...gatsby-source-wordpress@3.0.17) (2018-12-01)
 
 ### Bug Fixes
 
-- **gatsby-source-wordpress:** add undefined check to avoid taxonomy mapping error ([#10216](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/10216)) ([24c7dfc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/24c7dfc))
+- **gatsby-source-wordpress:** add undefined check to avoid taxonomy mapping error ([#10216](https://github.com/gatsbyjs/gatsby/issues/10216)) ([24c7dfc](https://github.com/gatsbyjs/gatsby/commit/24c7dfc))
 
 <a name="3.0.16"></a>
 
-## [3.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.15...gatsby-source-wordpress@3.0.16) (2018-11-29)
+## [3.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.15...gatsby-source-wordpress@3.0.16) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.15"></a>
 
-## [3.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.14...gatsby-source-wordpress@3.0.15) (2018-11-26)
+## [3.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.14...gatsby-source-wordpress@3.0.15) (2018-11-26)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.14"></a>
 
-## [3.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.13...gatsby-source-wordpress@3.0.14) (2018-11-14)
+## [3.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.13...gatsby-source-wordpress@3.0.14) (2018-11-14)
 
 ### Bug Fixes
 
-- **docs:** update broken links with working links ([#9912](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9912)) ([e9f2a6f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/e9f2a6f))
+- **docs:** update broken links with working links ([#9912](https://github.com/gatsbyjs/gatsby/issues/9912)) ([e9f2a6f](https://github.com/gatsbyjs/gatsby/commit/e9f2a6f))
 
 <a name="3.0.13"></a>
 
-## [3.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.12...gatsby-source-wordpress@3.0.13) (2018-11-08)
+## [3.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.12...gatsby-source-wordpress@3.0.13) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.12"></a>
 
-## [3.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.11...gatsby-source-wordpress@3.0.12) (2018-11-05)
+## [3.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.11...gatsby-source-wordpress@3.0.12) (2018-11-05)
 
 ### Features
 
-- **gatsby-source-wordpress:** allow users to obtain JWT Token to make authenticated requests ([#9509](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9509)) ([9177fc6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/9177fc6)), closes [#6879](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/6879)
+- **gatsby-source-wordpress:** allow users to obtain JWT Token to make authenticated requests ([#9509](https://github.com/gatsbyjs/gatsby/issues/9509)) ([9177fc6](https://github.com/gatsbyjs/gatsby/commit/9177fc6)), closes [#6879](https://github.com/gatsbyjs/gatsby/issues/6879)
 
 <a name="3.0.11"></a>
 
-## [3.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.10...gatsby-source-wordpress@3.0.11) (2018-11-01)
+## [3.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.10...gatsby-source-wordpress@3.0.11) (2018-11-01)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.10"></a>
 
-## [3.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.9...gatsby-source-wordpress@3.0.10) (2018-10-29)
+## [3.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.9...gatsby-source-wordpress@3.0.10) (2018-10-29)
 
 ### Features
 
-- **gatsby-source-wordpress:** normalize baseUrl ([#9386](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9386)) ([2235bf9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/2235bf9))
+- **gatsby-source-wordpress:** normalize baseUrl ([#9386](https://github.com/gatsbyjs/gatsby/issues/9386)) ([2235bf9](https://github.com/gatsbyjs/gatsby/commit/2235bf9))
 
 <a name="3.0.9"></a>
 
-## [3.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.8...gatsby-source-wordpress@3.0.9) (2018-10-24)
+## [3.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.8...gatsby-source-wordpress@3.0.9) (2018-10-24)
 
 ### Features
 
-- **gatsby-source-wordpress:** create site metadata node ([#9329](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9329)) ([2103e87](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/2103e87)), closes [#8051](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/8051)
+- **gatsby-source-wordpress:** create site metadata node ([#9329](https://github.com/gatsbyjs/gatsby/issues/9329)) ([2103e87](https://github.com/gatsbyjs/gatsby/commit/2103e87)), closes [#8051](https://github.com/gatsbyjs/gatsby/issues/8051)
 
 <a name="3.0.8"></a>
 
-## [3.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.7...gatsby-source-wordpress@3.0.8) (2018-10-23)
+## [3.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.7...gatsby-source-wordpress@3.0.8) (2018-10-23)
 
 ### Bug Fixes
 
-- throw error instead of string ([#9284](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9284)) ([bcdd834](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/bcdd834)), closes [#9283](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9283)
+- throw error instead of string ([#9284](https://github.com/gatsbyjs/gatsby/issues/9284)) ([bcdd834](https://github.com/gatsbyjs/gatsby/commit/bcdd834)), closes [#9283](https://github.com/gatsbyjs/gatsby/issues/9283)
 
 <a name="3.0.7"></a>
 
-## [3.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.6...gatsby-source-wordpress@3.0.7) (2018-10-19)
+## [3.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.6...gatsby-source-wordpress@3.0.7) (2018-10-19)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.6"></a>
 
-## [3.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.5...gatsby-source-wordpress@3.0.6) (2018-10-15)
+## [3.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.5...gatsby-source-wordpress@3.0.6) (2018-10-15)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.5"></a>
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.4...gatsby-source-wordpress@3.0.5) (2018-10-12)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.4...gatsby-source-wordpress@3.0.5) (2018-10-12)
 
 ### Bug Fixes
 
-- id generation for nested acf flexible content fields ([#9006](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9006)) ([f458faf](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/f458faf)), closes [#8910](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/8910) [#8910](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/8910)
+- id generation for nested acf flexible content fields ([#9006](https://github.com/gatsbyjs/gatsby/issues/9006)) ([f458faf](https://github.com/gatsbyjs/gatsby/commit/f458faf)), closes [#8910](https://github.com/gatsbyjs/gatsby/issues/8910) [#8910](https://github.com/gatsbyjs/gatsby/issues/8910)
 
 ### Features
 
-- **gatsby-source-wordpress:** add newline to error log message ([#9033](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/9033)) ([57b57e1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/57b57e1))
-- **gatsby-source-wordpress:** add support for route whitelist to complement route blacklist option ([#6036](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/6036)) ([a088b51](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/a088b51)), closes [#6556](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/6556)
+- **gatsby-source-wordpress:** add newline to error log message ([#9033](https://github.com/gatsbyjs/gatsby/issues/9033)) ([57b57e1](https://github.com/gatsbyjs/gatsby/commit/57b57e1))
+- **gatsby-source-wordpress:** add support for route whitelist to complement route blacklist option ([#6036](https://github.com/gatsbyjs/gatsby/issues/6036)) ([a088b51](https://github.com/gatsbyjs/gatsby/commit/a088b51)), closes [#6556](https://github.com/gatsbyjs/gatsby/issues/6556)
 
 <a name="3.0.4"></a>
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.3...gatsby-source-wordpress@3.0.4) (2018-10-10)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.3...gatsby-source-wordpress@3.0.4) (2018-10-10)
 
 ### Features
 
-- **gatsby-source-wordpress:** improve error logging for wordpress API requests ([#8967](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/8967)) ([3bac0c4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/commit/3bac0c4)), closes [#8928](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/issues/8928)
+- **gatsby-source-wordpress:** improve error logging for wordpress API requests ([#8967](https://github.com/gatsbyjs/gatsby/issues/8967)) ([3bac0c4](https://github.com/gatsbyjs/gatsby/commit/3bac0c4)), closes [#8928](https://github.com/gatsbyjs/gatsby/issues/8928)
 
 <a name="3.0.3"></a>
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.2...gatsby-source-wordpress@3.0.3) (2018-10-09)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.2...gatsby-source-wordpress@3.0.3) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.2"></a>
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.1...gatsby-source-wordpress@3.0.2) (2018-10-05)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.1...gatsby-source-wordpress@3.0.2) (2018-10-05)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0...gatsby-source-wordpress@3.0.1) (2018-09-18)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0...gatsby-source-wordpress@3.0.1) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.9...gatsby-source-wordpress@3.0.0) (2018-09-17)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.9...gatsby-source-wordpress@3.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.9"></a>
 
-# [3.0.0-rc.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.8...gatsby-source-wordpress@3.0.0-rc.9) (2018-09-13)
+# [3.0.0-rc.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.8...gatsby-source-wordpress@3.0.0-rc.9) (2018-09-13)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.8"></a>
 
-# [3.0.0-rc.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.7...gatsby-source-wordpress@3.0.0-rc.8) (2018-09-13)
+# [3.0.0-rc.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.7...gatsby-source-wordpress@3.0.0-rc.8) (2018-09-13)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.7"></a>
 
-# [3.0.0-rc.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.6...gatsby-source-wordpress@3.0.0-rc.7) (2018-09-12)
+# [3.0.0-rc.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.6...gatsby-source-wordpress@3.0.0-rc.7) (2018-09-12)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.6"></a>
 
-# [3.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.5...gatsby-source-wordpress@3.0.0-rc.6) (2018-09-11)
+# [3.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.5...gatsby-source-wordpress@3.0.0-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.5"></a>
 
-# [3.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.4...gatsby-source-wordpress@3.0.0-rc.5) (2018-09-11)
+# [3.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.4...gatsby-source-wordpress@3.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.4"></a>
 
-# [3.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.3...gatsby-source-wordpress@3.0.0-rc.4) (2018-09-11)
+# [3.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.3...gatsby-source-wordpress@3.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.3"></a>
 
-# [3.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.2...gatsby-source-wordpress@3.0.0-rc.3) (2018-09-11)
+# [3.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.2...gatsby-source-wordpress@3.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.2"></a>
 
-# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.1...gatsby-source-wordpress@3.0.0-rc.2) (2018-09-07)
+# [3.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.1...gatsby-source-wordpress@3.0.0-rc.2) (2018-09-07)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.1"></a>
 
-# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-rc.0...gatsby-source-wordpress@3.0.0-rc.1) (2018-08-29)
+# [3.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-rc.0...gatsby-source-wordpress@3.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-rc.0"></a>
 
-# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.21...gatsby-source-wordpress@3.0.0-rc.0) (2018-08-21)
+# [3.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.21...gatsby-source-wordpress@3.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.21"></a>
 
-# [3.0.0-beta.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.20...gatsby-source-wordpress@3.0.0-beta.21) (2018-08-21)
+# [3.0.0-beta.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.20...gatsby-source-wordpress@3.0.0-beta.21) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.20"></a>
 
-# [3.0.0-beta.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.19...gatsby-source-wordpress@3.0.0-beta.20) (2018-08-20)
+# [3.0.0-beta.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.19...gatsby-source-wordpress@3.0.0-beta.20) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.19"></a>
 
-# [3.0.0-beta.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.18...gatsby-source-wordpress@3.0.0-beta.19) (2018-08-13)
+# [3.0.0-beta.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.18...gatsby-source-wordpress@3.0.0-beta.19) (2018-08-13)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.18"></a>
 
-# [3.0.0-beta.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.17...gatsby-source-wordpress@3.0.0-beta.18) (2018-08-08)
+# [3.0.0-beta.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.17...gatsby-source-wordpress@3.0.0-beta.18) (2018-08-08)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.17"></a>
 
-# [3.0.0-beta.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.16...gatsby-source-wordpress@3.0.0-beta.17) (2018-08-04)
+# [3.0.0-beta.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.16...gatsby-source-wordpress@3.0.0-beta.17) (2018-08-04)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.16"></a>
 
-# [3.0.0-beta.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.15...gatsby-source-wordpress@3.0.0-beta.16) (2018-07-31)
+# [3.0.0-beta.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.15...gatsby-source-wordpress@3.0.0-beta.16) (2018-07-31)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.15"></a>
 
-# [3.0.0-beta.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.14...gatsby-source-wordpress@3.0.0-beta.15) (2018-07-27)
+# [3.0.0-beta.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.14...gatsby-source-wordpress@3.0.0-beta.15) (2018-07-27)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.14"></a>
 
-# [3.0.0-beta.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.13...gatsby-source-wordpress@3.0.0-beta.14) (2018-07-24)
+# [3.0.0-beta.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.13...gatsby-source-wordpress@3.0.0-beta.14) (2018-07-24)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.13"></a>
 
-# [3.0.0-beta.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.12...gatsby-source-wordpress@3.0.0-beta.13) (2018-07-21)
+# [3.0.0-beta.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.12...gatsby-source-wordpress@3.0.0-beta.13) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.12"></a>
 
-# [3.0.0-beta.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.11...gatsby-source-wordpress@3.0.0-beta.12) (2018-07-20)
+# [3.0.0-beta.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.11...gatsby-source-wordpress@3.0.0-beta.12) (2018-07-20)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.11"></a>
 
-# [3.0.0-beta.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.10...gatsby-source-wordpress@3.0.0-beta.11) (2018-07-19)
+# [3.0.0-beta.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.10...gatsby-source-wordpress@3.0.0-beta.11) (2018-07-19)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.10"></a>
 
-# [3.0.0-beta.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.9...gatsby-source-wordpress@3.0.0-beta.10) (2018-07-19)
+# [3.0.0-beta.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.9...gatsby-source-wordpress@3.0.0-beta.10) (2018-07-19)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.9"></a>
 
-# [3.0.0-beta.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.8...gatsby-source-wordpress@3.0.0-beta.9) (2018-07-18)
+# [3.0.0-beta.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.8...gatsby-source-wordpress@3.0.0-beta.9) (2018-07-18)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.8"></a>
 
-# [3.0.0-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.7...gatsby-source-wordpress@3.0.0-beta.8) (2018-07-18)
+# [3.0.0-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.7...gatsby-source-wordpress@3.0.0-beta.8) (2018-07-18)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.7"></a>
 
-# [3.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.6...gatsby-source-wordpress@3.0.0-beta.7) (2018-07-14)
+# [3.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.6...gatsby-source-wordpress@3.0.0-beta.7) (2018-07-14)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.6"></a>
 
-# [3.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.5...gatsby-source-wordpress@3.0.0-beta.6) (2018-07-13)
+# [3.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.5...gatsby-source-wordpress@3.0.0-beta.6) (2018-07-13)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.5"></a>
 
-# [3.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.4...gatsby-source-wordpress@3.0.0-beta.5) (2018-07-09)
+# [3.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.4...gatsby-source-wordpress@3.0.0-beta.5) (2018-07-09)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.4"></a>
 
-# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.3...gatsby-source-wordpress@3.0.0-beta.4) (2018-06-21)
+# [3.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.3...gatsby-source-wordpress@3.0.0-beta.4) (2018-06-21)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.3"></a>
 
-# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.2...gatsby-source-wordpress@3.0.0-beta.3) (2018-06-20)
+# [3.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.2...gatsby-source-wordpress@3.0.0-beta.3) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.2"></a>
 
-# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.1...gatsby-source-wordpress@3.0.0-beta.2) (2018-06-20)
+# [3.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.1...gatsby-source-wordpress@3.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.1"></a>
 
-# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@3.0.0-beta.0...gatsby-source-wordpress@3.0.0-beta.1) (2018-06-17)
+# [3.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@3.0.0-beta.0...gatsby-source-wordpress@3.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-wordpress
 
 <a name="3.0.0-beta.0"></a>
 
-# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress/compare/gatsby-source-wordpress@2.0.92...gatsby-source-wordpress@3.0.0-beta.0) (2018-06-17)
+# [3.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-source-wordpress@2.0.92...gatsby-source-wordpress@3.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-source-wordpress

--- a/packages/gatsby-telemetry/CHANGELOG.md
+++ b/packages/gatsby-telemetry/CHANGELOG.md
@@ -7,102 +7,102 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-telemetry
 
-## [1.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.1.2...gatsby-telemetry@1.1.3) (2019-07-05)
+## [1.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.1.2...gatsby-telemetry@1.1.3) (2019-07-05)
 
 ### Features
 
-- **gatsby-telemetry:** Use v4 instead of v1 uuids ([#15431](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/15431)) ([b310822](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/b310822))
+- **gatsby-telemetry:** Use v4 instead of v1 uuids ([#15431](https://github.com/gatsbyjs/gatsby/issues/15431)) ([b310822](https://github.com/gatsbyjs/gatsby/commit/b310822))
 
-## [1.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.1.1...gatsby-telemetry@1.1.2) (2019-06-28)
+## [1.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.1.1...gatsby-telemetry@1.1.2) (2019-06-28)
 
 ### Features
 
-- **gatsby-cli:** Add error codes and structured errors ([#14904](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/14904)) ([d26651e](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/d26651e))
+- **gatsby-cli:** Add error codes and structured errors ([#14904](https://github.com/gatsbyjs/gatsby/issues/14904)) ([d26651e](https://github.com/gatsbyjs/gatsby/commit/d26651e))
 
-## [1.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.1.0...gatsby-telemetry@1.1.1) (2019-06-27)
+## [1.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.1.0...gatsby-telemetry@1.1.1) (2019-06-27)
 
 **Note:** Version bump only for package gatsby-telemetry
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.12...gatsby-telemetry@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.12...gatsby-telemetry@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-telemetry
 
-## [1.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.11...gatsby-telemetry@1.0.12) (2019-06-18)
+## [1.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.11...gatsby-telemetry@1.0.12) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-telemetry
 
-## [1.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.10...gatsby-telemetry@1.0.11) (2019-05-31)
+## [1.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.10...gatsby-telemetry@1.0.11) (2019-05-31)
 
 ### Bug Fixes
 
-- **telemetry:** Ensure we strip paths with additional layer of `\` escaping ([#14461](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/14461)) ([ae1fcc2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/ae1fcc2))
+- **telemetry:** Ensure we strip paths with additional layer of `\` escaping ([#14461](https://github.com/gatsbyjs/gatsby/issues/14461)) ([ae1fcc2](https://github.com/gatsbyjs/gatsby/commit/ae1fcc2))
 
-## [1.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.9...gatsby-telemetry@1.0.10) (2019-05-22)
-
-### Bug Fixes
-
-- **gatsby-telemetry:** enable CI name for unsupported CI & fixed cpu count ([#14238](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/14238)) ([7d3d3e4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/7d3d3e4))
-
-## [1.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.8...gatsby-telemetry@1.0.9) (2019-04-24)
+## [1.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.9...gatsby-telemetry@1.0.10) (2019-05-22)
 
 ### Bug Fixes
 
-- **gatsby-telemetry:** Fix postinstall script ([#13605](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/13605)) ([ab41206](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/ab41206))
+- **gatsby-telemetry:** enable CI name for unsupported CI & fixed cpu count ([#14238](https://github.com/gatsbyjs/gatsby/issues/14238)) ([7d3d3e4](https://github.com/gatsbyjs/gatsby/commit/7d3d3e4))
 
-## [1.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.7...gatsby-telemetry@1.0.8) (2019-04-24)
+## [1.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.8...gatsby-telemetry@1.0.9) (2019-04-24)
+
+### Bug Fixes
+
+- **gatsby-telemetry:** Fix postinstall script ([#13605](https://github.com/gatsbyjs/gatsby/issues/13605)) ([ab41206](https://github.com/gatsbyjs/gatsby/commit/ab41206))
+
+## [1.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.7...gatsby-telemetry@1.0.8) (2019-04-24)
 
 ### Features
 
-- **gatsby-telemetry:** Clearer notice through `boxen` ([#13597](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/13597)) ([d740583](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/d740583))
+- **gatsby-telemetry:** Clearer notice through `boxen` ([#13597](https://github.com/gatsbyjs/gatsby/issues/13597)) ([d740583](https://github.com/gatsbyjs/gatsby/commit/d740583))
 
-## [1.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.6...gatsby-telemetry@1.0.7) (2019-04-11)
+## [1.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.6...gatsby-telemetry@1.0.7) (2019-04-11)
 
 ### Bug Fixes
 
-- **gatsby-telemetry:** Ensure we capture cli version even with older gatsby-cli ([#13087](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/13087)) ([b978db6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/b978db6))
+- **gatsby-telemetry:** Ensure we capture cli version even with older gatsby-cli ([#13087](https://github.com/gatsbyjs/gatsby/issues/13087)) ([b978db6](https://github.com/gatsbyjs/gatsby/commit/b978db6))
 
 ### Features
 
-- **gatsby-cli:** Remove one of package-lock.json and yarn.lock on gatsby new ([#13225](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/13225)) ([3510a46](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/3510a46)), closes [#13210](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/13210)
+- **gatsby-cli:** Remove one of package-lock.json and yarn.lock on gatsby new ([#13225](https://github.com/gatsbyjs/gatsby/issues/13225)) ([3510a46](https://github.com/gatsbyjs/gatsby/commit/3510a46)), closes [#13210](https://github.com/gatsbyjs/gatsby/issues/13210)
 
-## [1.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.5...gatsby-telemetry@1.0.6) (2019-04-09)
+## [1.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.5...gatsby-telemetry@1.0.6) (2019-04-09)
 
 ### Features
 
-- **gatsby-telemetry:** Include a boolean flag to telemetry data whether gatsby is running in docker or not. ([#13246](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/13246)) ([f07147a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/f07147a)), closes [1#discussion-57-comment-1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/discussion-57-comment-1)
+- **gatsby-telemetry:** Include a boolean flag to telemetry data whether gatsby is running in docker or not. ([#13246](https://github.com/gatsbyjs/gatsby/issues/13246)) ([f07147a](https://github.com/gatsbyjs/gatsby/commit/f07147a)), closes [1#discussion-57-comment-1](https://github.com/gatsbyjs/gatsby/issues/discussion-57-comment-1)
 
-## [1.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.4...gatsby-telemetry@1.0.5) (2019-04-04)
+## [1.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.4...gatsby-telemetry@1.0.5) (2019-04-04)
 
 **Note:** Version bump only for package gatsby-telemetry
 
-## [1.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.3...gatsby-telemetry@1.0.4) (2019-03-28)
+## [1.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.3...gatsby-telemetry@1.0.4) (2019-03-28)
 
 ### Bug Fixes
 
-- **gatsby-telemetry:** add the missing fs-extra dependency ([#12899](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/12899)) ([798d232](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/798d232)), closes [/github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/store.js#L10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/L10)
+- **gatsby-telemetry:** add the missing fs-extra dependency ([#12899](https://github.com/gatsbyjs/gatsby/issues/12899)) ([798d232](https://github.com/gatsbyjs/gatsby/commit/798d232)), closes [/github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/store.js#L10](https://github.com/gatsbyjs/gatsby/issues/L10)
 
-## [1.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.2...gatsby-telemetry@1.0.3) (2019-03-27)
-
-### Bug Fixes
-
-- **gatsby-telemetry:** Ensure quickly running commands exit freely ([#12888](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/12888)) ([e30d264](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/e30d264))
-
-## [1.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.1...gatsby-telemetry@1.0.2) (2019-03-26)
+## [1.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.2...gatsby-telemetry@1.0.3) (2019-03-27)
 
 ### Bug Fixes
 
-- **gatsby-telemetry:** don't inherit args from main process ([#12875](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/12875)) ([880f322](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/880f322))
+- **gatsby-telemetry:** Ensure quickly running commands exit freely ([#12888](https://github.com/gatsbyjs/gatsby/issues/12888)) ([e30d264](https://github.com/gatsbyjs/gatsby/commit/e30d264))
 
-## [1.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/compare/gatsby-telemetry@1.0.0...gatsby-telemetry@1.0.1) (2019-03-26)
+## [1.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.1...gatsby-telemetry@1.0.2) (2019-03-26)
 
 ### Bug Fixes
 
-- **gatsby-telemetry:** Ensure all new installs will see the telemetry message at least once ([#12867](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/12867)) ([ddde1ee](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/ddde1ee)), closes [/github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/telemetry.js#L110](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/L110)
+- **gatsby-telemetry:** don't inherit args from main process ([#12875](https://github.com/gatsbyjs/gatsby/issues/12875)) ([880f322](https://github.com/gatsbyjs/gatsby/commit/880f322))
+
+## [1.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-telemetry@1.0.0...gatsby-telemetry@1.0.1) (2019-03-26)
+
+### Bug Fixes
+
+- **gatsby-telemetry:** Ensure all new installs will see the telemetry message at least once ([#12867](https://github.com/gatsbyjs/gatsby/issues/12867)) ([ddde1ee](https://github.com/gatsbyjs/gatsby/commit/ddde1ee)), closes [/github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-telemetry/src/telemetry.js#L110](https://github.com/gatsbyjs/gatsby/issues/L110)
 
 # 1.0.0 (2019-03-26)
 
 ### Features
 
-- **gatsby:** add anonymous telemetry instrumentation to gatsby ([#12758](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/issues/12758)) ([da8ded9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry/commit/da8ded9))
+- **gatsby:** add anonymous telemetry instrumentation to gatsby ([#12758](https://github.com/gatsbyjs/gatsby/issues/12758)) ([da8ded9](https://github.com/gatsbyjs/gatsby/commit/da8ded9))
 
 # Change Log

--- a/packages/gatsby-transformer-asciidoc/CHANGELOG.md
+++ b/packages/gatsby-transformer-asciidoc/CHANGELOG.md
@@ -7,37 +7,37 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-asciidoc
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/compare/gatsby-transformer-asciidoc@1.0.5...gatsby-transformer-asciidoc@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-asciidoc@1.0.5...gatsby-transformer-asciidoc@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-asciidoc
 
-## [1.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/compare/gatsby-transformer-asciidoc@1.0.4...gatsby-transformer-asciidoc@1.0.5) (2019-04-17)
+## [1.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-asciidoc@1.0.4...gatsby-transformer-asciidoc@1.0.5) (2019-04-17)
 
 ### Bug Fixes
 
-- usage of pluginOptions leads to TypeError: Cannot read property 'imagesdir' of undefined ([#13418](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/13418)) ([cfb7af5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/commit/cfb7af5))
+- usage of pluginOptions leads to TypeError: Cannot read property 'imagesdir' of undefined ([#13418](https://github.com/gatsbyjs/gatsby/issues/13418)) ([cfb7af5](https://github.com/gatsbyjs/gatsby/commit/cfb7af5))
 
-## [1.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/compare/gatsby-transformer-asciidoc@1.0.3...gatsby-transformer-asciidoc@1.0.4) (2019-04-17)
+## [1.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-asciidoc@1.0.3...gatsby-transformer-asciidoc@1.0.4) (2019-04-17)
 
 ### Features
 
-- **gatsby-transformer-asciidoc:** add pathPrefix handling for images, define supported file extensions and add "page-\*" attributes from asciidoc file to AsciiDoc node ([#13357](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/13357)) ([9e547c8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/commit/9e547c8))
+- **gatsby-transformer-asciidoc:** add pathPrefix handling for images, define supported file extensions and add "page-\*" attributes from asciidoc file to AsciiDoc node ([#13357](https://github.com/gatsbyjs/gatsby/issues/13357)) ([9e547c8](https://github.com/gatsbyjs/gatsby/commit/9e547c8))
 
-## [1.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/compare/gatsby-transformer-asciidoc@1.0.2...gatsby-transformer-asciidoc@1.0.3) (2019-04-15)
+## [1.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-asciidoc@1.0.2...gatsby-transformer-asciidoc@1.0.3) (2019-04-15)
 
 ### Bug Fixes
 
-- **gatsby-transformer-asciidoc:** fix opal-runtime modifying fundamental prototypes ([#13368](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/13368)) ([a7ff441](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/commit/a7ff441)), closes [/github.com/asciidoctor/asciidoctor.js/issues/651#issuecomment-483008364](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/issuecomment-483008364) [#13087](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/13087) [#13097](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/13097)
+- **gatsby-transformer-asciidoc:** fix opal-runtime modifying fundamental prototypes ([#13368](https://github.com/gatsbyjs/gatsby/issues/13368)) ([a7ff441](https://github.com/gatsbyjs/gatsby/commit/a7ff441)), closes [/github.com/asciidoctor/asciidoctor.js/issues/651#issuecomment-483008364](https://github.com/gatsbyjs/gatsby/issues/issuecomment-483008364) [#13087](https://github.com/gatsbyjs/gatsby/issues/13087) [#13097](https://github.com/gatsbyjs/gatsby/issues/13097)
 
-## [1.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/compare/gatsby-transformer-asciidoc@1.0.1...gatsby-transformer-asciidoc@1.0.2) (2019-03-11)
+## [1.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-asciidoc@1.0.1...gatsby-transformer-asciidoc@1.0.2) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-asciidoc
 
-## [1.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/compare/gatsby-transformer-asciidoc@1.0.0...gatsby-transformer-asciidoc@1.0.1) (2019-02-05)
+## [1.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-asciidoc@1.0.0...gatsby-transformer-asciidoc@1.0.1) (2019-02-05)
 
 ### Bug Fixes
 
-- **gatsby-transformer-asciidoc:** abstract the source of asciidoc transformer ([#11531](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/11531)) ([7728d25](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/commit/7728d25))
+- **gatsby-transformer-asciidoc:** abstract the source of asciidoc transformer ([#11531](https://github.com/gatsbyjs/gatsby/issues/11531)) ([7728d25](https://github.com/gatsbyjs/gatsby/commit/7728d25))
 
 <a name="1.0.0"></a>
 
@@ -45,4 +45,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- initial version of gatsby-transformer-asciidoc plugin ([#8885](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/issues/8885)) ([1873fc4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc/commit/1873fc4))
+- initial version of gatsby-transformer-asciidoc plugin ([#8885](https://github.com/gatsbyjs/gatsby/issues/8885)) ([1873fc4](https://github.com/gatsbyjs/gatsby/commit/1873fc4))

--- a/packages/gatsby-transformer-csv/CHANGELOG.md
+++ b/packages/gatsby-transformer-csv/CHANGELOG.md
@@ -7,98 +7,98 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.8...gatsby-transformer-csv@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.8...gatsby-transformer-csv@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.7...gatsby-transformer-csv@2.0.8) (2019-03-11)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.7...gatsby-transformer-csv@2.0.8) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.6...gatsby-transformer-csv@2.0.7) (2019-02-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.6...gatsby-transformer-csv@2.0.7) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.5...gatsby-transformer-csv@2.0.6) (2019-01-08)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.5...gatsby-transformer-csv@2.0.6) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.4...gatsby-transformer-csv@2.0.5) (2018-11-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.4...gatsby-transformer-csv@2.0.5) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.3...gatsby-transformer-csv@2.0.4) (2018-11-08)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.3...gatsby-transformer-csv@2.0.4) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.2...gatsby-transformer-csv@2.0.3) (2018-10-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.2...gatsby-transformer-csv@2.0.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.1...gatsby-transformer-csv@2.0.2) (2018-10-04)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.1...gatsby-transformer-csv@2.0.2) (2018-10-04)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0...gatsby-transformer-csv@2.0.1) (2018-10-02)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0...gatsby-transformer-csv@2.0.1) (2018-10-02)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0-rc.2...gatsby-transformer-csv@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0-rc.2...gatsby-transformer-csv@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0-rc.1...gatsby-transformer-csv@2.0.0-rc.2) (2018-09-05)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0-rc.1...gatsby-transformer-csv@2.0.0-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0-rc.0...gatsby-transformer-csv@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0-rc.0...gatsby-transformer-csv@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0-beta.3...gatsby-transformer-csv@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0-beta.3...gatsby-transformer-csv@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0-beta.2...gatsby-transformer-csv@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0-beta.2...gatsby-transformer-csv@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0-beta.1...gatsby-transformer-csv@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0-beta.1...gatsby-transformer-csv@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@2.0.0-beta.0...gatsby-transformer-csv@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@2.0.0-beta.0...gatsby-transformer-csv@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-csv
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv/compare/gatsby-transformer-csv@1.3.11...gatsby-transformer-csv@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-csv@1.3.11...gatsby-transformer-csv@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-csv

--- a/packages/gatsby-transformer-documentationjs/CHANGELOG.md
+++ b/packages/gatsby-transformer-documentationjs/CHANGELOG.md
@@ -7,130 +7,130 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
-# [4.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@4.0.3...gatsby-transformer-documentationjs@4.1.0) (2019-06-20)
+# [4.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@4.0.3...gatsby-transformer-documentationjs@4.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
-## [4.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@4.0.2...gatsby-transformer-documentationjs@4.0.3) (2019-06-07)
+## [4.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@4.0.2...gatsby-transformer-documentationjs@4.0.3) (2019-06-07)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
-## [4.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@4.0.1...gatsby-transformer-documentationjs@4.0.2) (2019-05-17)
+## [4.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@4.0.1...gatsby-transformer-documentationjs@4.0.2) (2019-05-17)
 
 ### Bug Fixes
 
-- **gatsby-transformer-documentationjs:** re-add ability to get typeDef field from nested type field ([#13768](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/issues/13768)) ([d6714c1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/commit/d6714c1))
+- **gatsby-transformer-documentationjs:** re-add ability to get typeDef field from nested type field ([#13768](https://github.com/gatsbyjs/gatsby/issues/13768)) ([d6714c1](https://github.com/gatsbyjs/gatsby/commit/d6714c1))
 
-## [4.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@4.0.0...gatsby-transformer-documentationjs@4.0.1) (2019-05-01)
+## [4.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@4.0.0...gatsby-transformer-documentationjs@4.0.1) (2019-05-01)
 
 ### Bug Fixes
 
-- **gatsby-transformer-documentationjs:** bump documentationjs to get TypeScript support ([#13751](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/issues/13751)) ([e5f9a22](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/commit/e5f9a22)), closes [#13692](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/issues/13692)
+- **gatsby-transformer-documentationjs:** bump documentationjs to get TypeScript support ([#13751](https://github.com/gatsbyjs/gatsby/issues/13751)) ([e5f9a22](https://github.com/gatsbyjs/gatsby/commit/e5f9a22)), closes [#13692](https://github.com/gatsbyjs/gatsby/issues/13692)
 
-# [4.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@3.0.1...gatsby-transformer-documentationjs@4.0.0) (2019-04-30)
+# [4.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@3.0.1...gatsby-transformer-documentationjs@4.0.0) (2019-04-30)
 
 ### Features
 
-- **gatsby-plugin-documentationjs:** Ensure a consistent schema for gatsby-plugin-documentationjs and add TypeScript support ([#13692](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/issues/13692)) ([950b9d6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/commit/950b9d6))
+- **gatsby-plugin-documentationjs:** Ensure a consistent schema for gatsby-plugin-documentationjs and add TypeScript support ([#13692](https://github.com/gatsbyjs/gatsby/issues/13692)) ([950b9d6](https://github.com/gatsbyjs/gatsby/commit/950b9d6))
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@3.0.0...gatsby-transformer-documentationjs@3.0.1) (2019-04-04)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@3.0.0...gatsby-transformer-documentationjs@3.0.1) (2019-04-04)
 
 ### Bug Fixes
 
-- **gatsby-transformer-documentationjs:** handle free floating jsdocs ([#13058](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/issues/13058)) ([ca3a712](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/commit/ca3a712))
+- **gatsby-transformer-documentationjs:** handle free floating jsdocs ([#13058](https://github.com/gatsbyjs/gatsby/issues/13058)) ([ca3a712](https://github.com/gatsbyjs/gatsby/commit/ca3a712))
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.5...gatsby-transformer-documentationjs@3.0.0) (2019-03-13)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.5...gatsby-transformer-documentationjs@3.0.0) (2019-03-13)
 
 ### Features
 
-- **gatsby-transformer-documentationjs:** support linking typedefs ([#11597](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/issues/11597)) ([16b7d0d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/commit/16b7d0d))
+- **gatsby-transformer-documentationjs:** support linking typedefs ([#11597](https://github.com/gatsbyjs/gatsby/issues/11597)) ([16b7d0d](https://github.com/gatsbyjs/gatsby/commit/16b7d0d))
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.4...gatsby-transformer-documentationjs@2.0.5) (2019-03-11)
-
-**Note:** Version bump only for package gatsby-transformer-documentationjs
-
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.3...gatsby-transformer-documentationjs@2.0.4) (2019-02-06)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.4...gatsby-transformer-documentationjs@2.0.5) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.2...gatsby-transformer-documentationjs@2.0.3) (2019-02-01)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.3...gatsby-transformer-documentationjs@2.0.4) (2019-02-06)
+
+**Note:** Version bump only for package gatsby-transformer-documentationjs
+
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.2...gatsby-transformer-documentationjs@2.0.3) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.1...gatsby-transformer-documentationjs@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.1...gatsby-transformer-documentationjs@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0...gatsby-transformer-documentationjs@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0...gatsby-transformer-documentationjs@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-rc.5...gatsby-transformer-documentationjs@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-rc.5...gatsby-transformer-documentationjs@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-rc.4...gatsby-transformer-documentationjs@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-rc.4...gatsby-transformer-documentationjs@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-rc.3...gatsby-transformer-documentationjs@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-rc.3...gatsby-transformer-documentationjs@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-rc.2...gatsby-transformer-documentationjs@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-rc.2...gatsby-transformer-documentationjs@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-rc.1...gatsby-transformer-documentationjs@2.0.0-rc.2) (2018-09-11)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-rc.1...gatsby-transformer-documentationjs@2.0.0-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-rc.0...gatsby-transformer-documentationjs@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-rc.0...gatsby-transformer-documentationjs@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-beta.3...gatsby-transformer-documentationjs@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-beta.3...gatsby-transformer-documentationjs@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-beta.2...gatsby-transformer-documentationjs@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-beta.2...gatsby-transformer-documentationjs@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-beta.1...gatsby-transformer-documentationjs@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-beta.1...gatsby-transformer-documentationjs@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@2.0.0-beta.0...gatsby-transformer-documentationjs@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@2.0.0-beta.0...gatsby-transformer-documentationjs@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs/compare/gatsby-transformer-documentationjs@1.4.10...gatsby-transformer-documentationjs@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-documentationjs@1.4.10...gatsby-transformer-documentationjs@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-documentationjs

--- a/packages/gatsby-transformer-excel/CHANGELOG.md
+++ b/packages/gatsby-transformer-excel/CHANGELOG.md
@@ -7,136 +7,136 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.11...gatsby-transformer-excel@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.11...gatsby-transformer-excel@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
-## [2.1.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.10...gatsby-transformer-excel@2.1.11) (2019-04-08)
+## [2.1.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.10...gatsby-transformer-excel@2.1.11) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
-## [2.1.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.9...gatsby-transformer-excel@2.1.10) (2019-03-15)
+## [2.1.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.9...gatsby-transformer-excel@2.1.10) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.8...gatsby-transformer-excel@2.1.9) (2019-03-11)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.8...gatsby-transformer-excel@2.1.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.7...gatsby-transformer-excel@2.1.8) (2019-02-28)
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.7...gatsby-transformer-excel@2.1.8) (2019-02-28)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.6...gatsby-transformer-excel@2.1.7) (2019-02-01)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.6...gatsby-transformer-excel@2.1.7) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.6"></a>
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.5...gatsby-transformer-excel@2.1.6) (2019-01-08)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.5...gatsby-transformer-excel@2.1.6) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.5"></a>
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.4...gatsby-transformer-excel@2.1.5) (2018-12-29)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.4...gatsby-transformer-excel@2.1.5) (2018-12-29)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.3...gatsby-transformer-excel@2.1.4) (2018-11-29)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.3...gatsby-transformer-excel@2.1.4) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.2...gatsby-transformer-excel@2.1.3) (2018-10-29)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.2...gatsby-transformer-excel@2.1.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.7...gatsby-transformer-excel@2.1.2) (2018-10-15)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.7...gatsby-transformer-excel@2.1.2) (2018-10-15)
 
 ### Features
 
-- added option to support 'defval' option ([#8980](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/issues/8980)) ([95c1eac](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/commit/95c1eac))
+- added option to support 'defval' option ([#8980](https://github.com/gatsbyjs/gatsby/issues/8980)) ([95c1eac](https://github.com/gatsbyjs/gatsby/commit/95c1eac))
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.7...gatsby-transformer-excel@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.7...gatsby-transformer-excel@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.7"></a>
 
-## [2.1.1-rc.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.6...gatsby-transformer-excel@2.1.1-rc.7) (2018-09-11)
+## [2.1.1-rc.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.6...gatsby-transformer-excel@2.1.1-rc.7) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.6"></a>
 
-## [2.1.1-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.5...gatsby-transformer-excel@2.1.1-rc.6) (2018-09-11)
+## [2.1.1-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.5...gatsby-transformer-excel@2.1.1-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.5"></a>
 
-## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.4...gatsby-transformer-excel@2.1.1-rc.5) (2018-09-11)
+## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.4...gatsby-transformer-excel@2.1.1-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.4"></a>
 
-## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.3...gatsby-transformer-excel@2.1.1-rc.4) (2018-09-11)
+## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.3...gatsby-transformer-excel@2.1.1-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.3"></a>
 
-## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.2...gatsby-transformer-excel@2.1.1-rc.3) (2018-09-03)
+## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.2...gatsby-transformer-excel@2.1.1-rc.3) (2018-09-03)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.1...gatsby-transformer-excel@2.1.1-rc.2) (2018-09-01)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.1...gatsby-transformer-excel@2.1.1-rc.2) (2018-09-01)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-rc.0...gatsby-transformer-excel@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-rc.0...gatsby-transformer-excel@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-beta.3...gatsby-transformer-excel@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-beta.3...gatsby-transformer-excel@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-beta.2...gatsby-transformer-excel@2.1.1-beta.3) (2018-07-21)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-beta.2...gatsby-transformer-excel@2.1.1-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-beta.1...gatsby-transformer-excel@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-beta.1...gatsby-transformer-excel@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@2.1.1-beta.0...gatsby-transformer-excel@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@2.1.1-beta.0...gatsby-transformer-excel@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-excel
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel/compare/gatsby-transformer-excel@1.0.9...gatsby-transformer-excel@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-excel@1.0.9...gatsby-transformer-excel@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-excel

--- a/packages/gatsby-transformer-hjson/CHANGELOG.md
+++ b/packages/gatsby-transformer-hjson/CHANGELOG.md
@@ -7,82 +7,82 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.8...gatsby-transformer-hjson@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.8...gatsby-transformer-hjson@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.7...gatsby-transformer-hjson@2.1.8) (2019-04-08)
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.7...gatsby-transformer-hjson@2.1.8) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.6...gatsby-transformer-hjson@2.1.7) (2019-03-11)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.6...gatsby-transformer-hjson@2.1.7) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.5...gatsby-transformer-hjson@2.1.6) (2019-03-11)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.5...gatsby-transformer-hjson@2.1.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.4...gatsby-transformer-hjson@2.1.5) (2019-02-01)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.4...gatsby-transformer-hjson@2.1.5) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.3...gatsby-transformer-hjson@2.1.4) (2019-01-08)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.3...gatsby-transformer-hjson@2.1.4) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.2...gatsby-transformer-hjson@2.1.3) (2018-11-29)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.2...gatsby-transformer-hjson@2.1.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.1...gatsby-transformer-hjson@2.1.2) (2018-10-29)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.1...gatsby-transformer-hjson@2.1.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.1-rc.1...gatsby-transformer-hjson@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.1-rc.1...gatsby-transformer-hjson@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.1-rc.0...gatsby-transformer-hjson@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.1-rc.0...gatsby-transformer-hjson@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.1-beta.3...gatsby-transformer-hjson@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.1-beta.3...gatsby-transformer-hjson@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.1-beta.2...gatsby-transformer-hjson@2.1.1-beta.3) (2018-07-21)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.1-beta.2...gatsby-transformer-hjson@2.1.1-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.1-beta.1...gatsby-transformer-hjson@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.1-beta.1...gatsby-transformer-hjson@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@2.1.1-beta.0...gatsby-transformer-hjson@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@2.1.1-beta.0...gatsby-transformer-hjson@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-hjson
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson/compare/gatsby-transformer-hjson@1.0.4...gatsby-transformer-hjson@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-hjson@1.0.4...gatsby-transformer-hjson@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-hjson

--- a/packages/gatsby-transformer-javascript-frontmatter/CHANGELOG.md
+++ b/packages/gatsby-transformer-javascript-frontmatter/CHANGELOG.md
@@ -7,110 +7,110 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.10...gatsby-transformer-javascript-frontmatter@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.10...gatsby-transformer-javascript-frontmatter@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.9...gatsby-transformer-javascript-frontmatter@2.0.10) (2019-04-08)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.9...gatsby-transformer-javascript-frontmatter@2.0.10) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.8...gatsby-transformer-javascript-frontmatter@2.0.9) (2019-03-11)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.8...gatsby-transformer-javascript-frontmatter@2.0.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.7...gatsby-transformer-javascript-frontmatter@2.0.8) (2019-02-04)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.7...gatsby-transformer-javascript-frontmatter@2.0.8) (2019-02-04)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.6...gatsby-transformer-javascript-frontmatter@2.0.7) (2019-02-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.6...gatsby-transformer-javascript-frontmatter@2.0.7) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.5...gatsby-transformer-javascript-frontmatter@2.0.6) (2019-01-28)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.5...gatsby-transformer-javascript-frontmatter@2.0.6) (2019-01-28)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.4...gatsby-transformer-javascript-frontmatter@2.0.5) (2018-11-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.4...gatsby-transformer-javascript-frontmatter@2.0.5) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.3...gatsby-transformer-javascript-frontmatter@2.0.4) (2018-11-08)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.3...gatsby-transformer-javascript-frontmatter@2.0.4) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.2...gatsby-transformer-javascript-frontmatter@2.0.3) (2018-10-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.2...gatsby-transformer-javascript-frontmatter@2.0.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.1...gatsby-transformer-javascript-frontmatter@2.0.2) (2018-10-15)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.1...gatsby-transformer-javascript-frontmatter@2.0.2) (2018-10-15)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0...gatsby-transformer-javascript-frontmatter@2.0.1) (2018-10-12)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0...gatsby-transformer-javascript-frontmatter@2.0.1) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.3...gatsby-transformer-javascript-frontmatter@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.3...gatsby-transformer-javascript-frontmatter@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.2...gatsby-transformer-javascript-frontmatter@2.0.0-rc.3) (2018-09-05)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.2...gatsby-transformer-javascript-frontmatter@2.0.0-rc.3) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.1...gatsby-transformer-javascript-frontmatter@2.0.0-rc.2) (2018-08-29)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.1...gatsby-transformer-javascript-frontmatter@2.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.0...gatsby-transformer-javascript-frontmatter@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-rc.0...gatsby-transformer-javascript-frontmatter@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.3...gatsby-transformer-javascript-frontmatter@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.3...gatsby-transformer-javascript-frontmatter@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.2...gatsby-transformer-javascript-frontmatter@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.2...gatsby-transformer-javascript-frontmatter@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.1...gatsby-transformer-javascript-frontmatter@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.1...gatsby-transformer-javascript-frontmatter@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.0...gatsby-transformer-javascript-frontmatter@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@2.0.0-beta.0...gatsby-transformer-javascript-frontmatter@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-frontmatter/compare/gatsby-transformer-javascript-frontmatter@1.0.10...gatsby-transformer-javascript-frontmatter@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-frontmatter@1.0.10...gatsby-transformer-javascript-frontmatter@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-frontmatter

--- a/packages/gatsby-transformer-javascript-static-exports/CHANGELOG.md
+++ b/packages/gatsby-transformer-javascript-static-exports/CHANGELOG.md
@@ -7,84 +7,84 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.7...gatsby-transformer-javascript-static-exports@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.7...gatsby-transformer-javascript-static-exports@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.6...gatsby-transformer-javascript-static-exports@2.1.7) (2019-04-08)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.6...gatsby-transformer-javascript-static-exports@2.1.7) (2019-04-08)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.5...gatsby-transformer-javascript-static-exports@2.1.6) (2019-03-11)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.5...gatsby-transformer-javascript-static-exports@2.1.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.4...gatsby-transformer-javascript-static-exports@2.1.5) (2019-02-01)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.4...gatsby-transformer-javascript-static-exports@2.1.5) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.3...gatsby-transformer-javascript-static-exports@2.1.4) (2018-11-29)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.3...gatsby-transformer-javascript-static-exports@2.1.4) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.2...gatsby-transformer-javascript-static-exports@2.1.3) (2018-10-29)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.2...gatsby-transformer-javascript-static-exports@2.1.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1...gatsby-transformer-javascript-static-exports@2.1.2) (2018-10-12)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1...gatsby-transformer-javascript-static-exports@2.1.2) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1-rc.2...gatsby-transformer-javascript-static-exports@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1-rc.2...gatsby-transformer-javascript-static-exports@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1-rc.1...gatsby-transformer-javascript-static-exports@2.1.1-rc.2) (2018-08-29)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1-rc.1...gatsby-transformer-javascript-static-exports@2.1.1-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1-rc.0...gatsby-transformer-javascript-static-exports@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1-rc.0...gatsby-transformer-javascript-static-exports@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.3...gatsby-transformer-javascript-static-exports@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.3...gatsby-transformer-javascript-static-exports@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.2...gatsby-transformer-javascript-static-exports@2.1.1-beta.3) (2018-07-21)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.2...gatsby-transformer-javascript-static-exports@2.1.1-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.1...gatsby-transformer-javascript-static-exports@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.1...gatsby-transformer-javascript-static-exports@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.0...gatsby-transformer-javascript-static-exports@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@2.1.1-beta.0...gatsby-transformer-javascript-static-exports@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports/compare/gatsby-transformer-javascript-static-exports@1.3.11...gatsby-transformer-javascript-static-exports@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-javascript-static-exports@1.3.11...gatsby-transformer-javascript-static-exports@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-javascript-static-exports

--- a/packages/gatsby-transformer-json/CHANGELOG.md
+++ b/packages/gatsby-transformer-json/CHANGELOG.md
@@ -7,144 +7,144 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-json
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.11...gatsby-transformer-json@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.11...gatsby-transformer-json@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
-## [2.1.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.10...gatsby-transformer-json@2.1.11) (2019-03-15)
+## [2.1.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.10...gatsby-transformer-json@2.1.11) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
-## [2.1.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.9...gatsby-transformer-json@2.1.10) (2019-03-11)
+## [2.1.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.9...gatsby-transformer-json@2.1.10) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.8...gatsby-transformer-json@2.1.9) (2019-03-11)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.8...gatsby-transformer-json@2.1.9) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.7...gatsby-transformer-json@2.1.8) (2019-02-01)
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.7...gatsby-transformer-json@2.1.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.7"></a>
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.6...gatsby-transformer-json@2.1.7) (2019-01-08)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.6...gatsby-transformer-json@2.1.7) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.6"></a>
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.5...gatsby-transformer-json@2.1.6) (2018-11-29)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.5...gatsby-transformer-json@2.1.6) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.5"></a>
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.4...gatsby-transformer-json@2.1.5) (2018-10-29)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.4...gatsby-transformer-json@2.1.5) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.3...gatsby-transformer-json@2.1.4) (2018-10-04)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.3...gatsby-transformer-json@2.1.4) (2018-10-04)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.2...gatsby-transformer-json@2.1.3) (2018-10-02)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.2...gatsby-transformer-json@2.1.3) (2018-10-02)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1...gatsby-transformer-json@2.1.2) (2018-09-27)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1...gatsby-transformer-json@2.1.2) (2018-09-27)
 
 ### Bug Fixes
 
-- don't expect `application/json` type nodes to be files ([#8544](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/issues/8544)) ([cd780aa](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/commit/cd780aa))
+- don't expect `application/json` type nodes to be files ([#8544](https://github.com/gatsbyjs/gatsby/issues/8544)) ([cd780aa](https://github.com/gatsbyjs/gatsby/commit/cd780aa))
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-rc.6...gatsby-transformer-json@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-rc.6...gatsby-transformer-json@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-rc.6"></a>
 
-## [2.1.1-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-rc.5...gatsby-transformer-json@2.1.1-rc.6) (2018-09-11)
+## [2.1.1-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-rc.5...gatsby-transformer-json@2.1.1-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-rc.5"></a>
 
-## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-rc.4...gatsby-transformer-json@2.1.1-rc.5) (2018-09-11)
+## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-rc.4...gatsby-transformer-json@2.1.1-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-rc.4"></a>
 
-## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-rc.3...gatsby-transformer-json@2.1.1-rc.4) (2018-09-11)
+## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-rc.3...gatsby-transformer-json@2.1.1-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-rc.3"></a>
 
-## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-rc.2...gatsby-transformer-json@2.1.1-rc.3) (2018-09-11)
+## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-rc.2...gatsby-transformer-json@2.1.1-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-rc.1...gatsby-transformer-json@2.1.1-rc.2) (2018-09-05)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-rc.1...gatsby-transformer-json@2.1.1-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-rc.0...gatsby-transformer-json@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-rc.0...gatsby-transformer-json@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-beta.5...gatsby-transformer-json@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-beta.5...gatsby-transformer-json@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-beta.5"></a>
 
-## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-beta.4...gatsby-transformer-json@2.1.1-beta.5) (2018-08-04)
+## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-beta.4...gatsby-transformer-json@2.1.1-beta.5) (2018-08-04)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-beta.4"></a>
 
-## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-beta.3...gatsby-transformer-json@2.1.1-beta.4) (2018-07-27)
+## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-beta.3...gatsby-transformer-json@2.1.1-beta.4) (2018-07-27)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-beta.2...gatsby-transformer-json@2.1.1-beta.3) (2018-07-21)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-beta.2...gatsby-transformer-json@2.1.1-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-beta.1...gatsby-transformer-json@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-beta.1...gatsby-transformer-json@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@2.1.1-beta.0...gatsby-transformer-json@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@2.1.1-beta.0...gatsby-transformer-json@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-json
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json/compare/gatsby-transformer-json@1.0.20...gatsby-transformer-json@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-json@1.0.20...gatsby-transformer-json@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-json

--- a/packages/gatsby-transformer-pdf/CHANGELOG.md
+++ b/packages/gatsby-transformer-pdf/CHANGELOG.md
@@ -7,47 +7,47 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 
-# [1.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.17...gatsby-transformer-pdf@1.1.0) (2019-06-20)
+# [1.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.17...gatsby-transformer-pdf@1.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 
-## [1.0.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.16...gatsby-transformer-pdf@1.0.17) (2019-03-11)
+## [1.0.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.16...gatsby-transformer-pdf@1.0.17) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 
-## [1.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.15...gatsby-transformer-pdf@1.0.16) (2019-02-01)
+## [1.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.15...gatsby-transformer-pdf@1.0.16) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 
 <a name="1.0.15"></a>
 
-## [1.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.14...gatsby-transformer-pdf@1.0.15) (2018-11-29)
+## [1.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.14...gatsby-transformer-pdf@1.0.15) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 
 <a name="1.0.14"></a>
 
-## [1.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.13...gatsby-transformer-pdf@1.0.14) (2018-11-08)
+## [1.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.13...gatsby-transformer-pdf@1.0.14) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 
 <a name="1.0.13"></a>
 
-## [1.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.12...gatsby-transformer-pdf@1.0.13) (2018-10-29)
+## [1.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.12...gatsby-transformer-pdf@1.0.13) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 
 <a name="1.0.12"></a>
 
-## [1.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.11...gatsby-transformer-pdf@1.0.12) (2018-10-12)
+## [1.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.11...gatsby-transformer-pdf@1.0.12) (2018-10-12)
 
 ### Bug Fixes
 
-- **docs:** fix link in gatsby-transformer-pdf/README ([#9053](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/issues/9053)) ([aba189a](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/commit/aba189a))
+- **docs:** fix link in gatsby-transformer-pdf/README ([#9053](https://github.com/gatsbyjs/gatsby/issues/9053)) ([aba189a](https://github.com/gatsbyjs/gatsby/commit/aba189a))
 
 <a name="1.0.11"></a>
 
-## [1.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf/compare/gatsby-transformer-pdf@1.0.10...gatsby-transformer-pdf@1.0.11) (2018-10-09)
+## [1.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-pdf@1.0.10...gatsby-transformer-pdf@1.0.11) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-transformer-pdf
 

--- a/packages/gatsby-transformer-react-docgen/CHANGELOG.md
+++ b/packages/gatsby-transformer-react-docgen/CHANGELOG.md
@@ -7,35 +7,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
-# [4.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@4.0.4...gatsby-transformer-react-docgen@4.1.0) (2019-06-20)
+# [4.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@4.0.4...gatsby-transformer-react-docgen@4.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
-## [4.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@4.0.2...gatsby-transformer-react-docgen@4.0.4) (2019-06-19)
+## [4.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@4.0.2...gatsby-transformer-react-docgen@4.0.4) (2019-06-19)
 
 ### Bug Fixes
 
-- **gatsby-transformer-react-docgen:** always create description nodes ([#14876](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/issues/14876)) ([48a9e10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/commit/48a9e10))
+- **gatsby-transformer-react-docgen:** always create description nodes ([#14876](https://github.com/gatsbyjs/gatsby/issues/14876)) ([48a9e10](https://github.com/gatsbyjs/gatsby/commit/48a9e10))
 
-## [4.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@4.0.2...gatsby-transformer-react-docgen@4.0.3) (2019-06-19)
+## [4.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@4.0.2...gatsby-transformer-react-docgen@4.0.3) (2019-06-19)
 
 ### Bug Fixes
 
-- **gatsby-transformer-react-docgen:** always create description nodes ([#14876](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/issues/14876)) ([48a9e10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/commit/48a9e10))
+- **gatsby-transformer-react-docgen:** always create description nodes ([#14876](https://github.com/gatsbyjs/gatsby/issues/14876)) ([48a9e10](https://github.com/gatsbyjs/gatsby/commit/48a9e10))
 
-## [4.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@4.0.1...gatsby-transformer-react-docgen@4.0.2) (2019-05-30)
-
-**Note:** Version bump only for package gatsby-transformer-react-docgen
-
-## [4.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@4.0.0...gatsby-transformer-react-docgen@4.0.1) (2019-04-08)
+## [4.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@4.0.1...gatsby-transformer-react-docgen@4.0.2) (2019-05-30)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
-# [4.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.7...gatsby-transformer-react-docgen@4.0.0) (2019-04-02)
+## [4.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@4.0.0...gatsby-transformer-react-docgen@4.0.1) (2019-04-08)
+
+**Note:** Version bump only for package gatsby-transformer-react-docgen
+
+# [4.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.7...gatsby-transformer-react-docgen@4.0.0) (2019-04-02)
 
 ### Features
 
-- **gatsby-transformer-react-docgen:** use local babel config for react-docgen ([#12001](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/issues/12001)) ([4a2680b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/commit/4a2680b))
+- **gatsby-transformer-react-docgen:** use local babel config for react-docgen ([#12001](https://github.com/gatsbyjs/gatsby/issues/12001)) ([4a2680b](https://github.com/gatsbyjs/gatsby/commit/4a2680b))
 
 ### BREAKING CHANGES
 
@@ -43,45 +43,45 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - Update README.md
 
-## [3.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.6...gatsby-transformer-react-docgen@3.0.7) (2019-03-15)
+## [3.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.6...gatsby-transformer-react-docgen@3.0.7) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
-## [3.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.5...gatsby-transformer-react-docgen@3.0.6) (2019-03-11)
+## [3.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.5...gatsby-transformer-react-docgen@3.0.6) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
-## [3.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.4...gatsby-transformer-react-docgen@3.0.5) (2019-02-06)
+## [3.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.4...gatsby-transformer-react-docgen@3.0.5) (2019-02-06)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
-## [3.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.3...gatsby-transformer-react-docgen@3.0.4) (2019-02-01)
+## [3.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.3...gatsby-transformer-react-docgen@3.0.4) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
-## [3.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.2...gatsby-transformer-react-docgen@3.0.3) (2019-01-29)
+## [3.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.2...gatsby-transformer-react-docgen@3.0.3) (2019-01-29)
 
 ### Features
 
-- **gatsby-transformer-react-docgen:** allow parsing TypeScript files ([#11265](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/issues/11265)) ([c9a8991](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/commit/c9a8991))
+- **gatsby-transformer-react-docgen:** allow parsing TypeScript files ([#11265](https://github.com/gatsbyjs/gatsby/issues/11265)) ([c9a8991](https://github.com/gatsbyjs/gatsby/commit/c9a8991))
 
-## [3.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.1...gatsby-transformer-react-docgen@3.0.2) (2019-01-25)
+## [3.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.1...gatsby-transformer-react-docgen@3.0.2) (2019-01-25)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="3.0.1"></a>
 
-## [3.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@3.0.0...gatsby-transformer-react-docgen@3.0.1) (2019-01-23)
+## [3.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@3.0.0...gatsby-transformer-react-docgen@3.0.1) (2019-01-23)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.3...gatsby-transformer-react-docgen@3.0.0) (2018-12-31)
+# [3.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.3...gatsby-transformer-react-docgen@3.0.0) (2018-12-31)
 
 ### Features
 
-- **gatsby-transformer-react-docgen:** support multiple doclets of same tag ([#10342](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/issues/10342)) ([c5c84a0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/commit/c5c84a0))
+- **gatsby-transformer-react-docgen:** support multiple doclets of same tag ([#10342](https://github.com/gatsbyjs/gatsby/issues/10342)) ([c5c84a0](https://github.com/gatsbyjs/gatsby/commit/c5c84a0))
 
 ### BREAKING CHANGES
 
@@ -112,90 +112,90 @@ gatsby-transformer-react-docgen@^3.0.0:
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.2...gatsby-transformer-react-docgen@2.1.3) (2018-11-29)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.2...gatsby-transformer-react-docgen@2.1.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1...gatsby-transformer-react-docgen@2.1.2) (2018-10-29)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1...gatsby-transformer-react-docgen@2.1.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-rc.5...gatsby-transformer-react-docgen@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-rc.5...gatsby-transformer-react-docgen@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-rc.5"></a>
 
-## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-rc.4...gatsby-transformer-react-docgen@2.1.1-rc.5) (2018-09-11)
+## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-rc.4...gatsby-transformer-react-docgen@2.1.1-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-rc.4"></a>
 
-## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-rc.3...gatsby-transformer-react-docgen@2.1.1-rc.4) (2018-09-11)
+## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-rc.3...gatsby-transformer-react-docgen@2.1.1-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-rc.3"></a>
 
-## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-rc.2...gatsby-transformer-react-docgen@2.1.1-rc.3) (2018-09-11)
+## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-rc.2...gatsby-transformer-react-docgen@2.1.1-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-rc.1...gatsby-transformer-react-docgen@2.1.1-rc.2) (2018-09-11)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-rc.1...gatsby-transformer-react-docgen@2.1.1-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-rc.0...gatsby-transformer-react-docgen@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-rc.0...gatsby-transformer-react-docgen@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-beta.5...gatsby-transformer-react-docgen@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-beta.5...gatsby-transformer-react-docgen@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-beta.5"></a>
 
-## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-beta.4...gatsby-transformer-react-docgen@2.1.1-beta.5) (2018-08-08)
+## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-beta.4...gatsby-transformer-react-docgen@2.1.1-beta.5) (2018-08-08)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-beta.4"></a>
 
-## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-beta.3...gatsby-transformer-react-docgen@2.1.1-beta.4) (2018-07-21)
+## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-beta.3...gatsby-transformer-react-docgen@2.1.1-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-beta.2...gatsby-transformer-react-docgen@2.1.1-beta.3) (2018-06-23)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-beta.2...gatsby-transformer-react-docgen@2.1.1-beta.3) (2018-06-23)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-beta.1...gatsby-transformer-react-docgen@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-beta.1...gatsby-transformer-react-docgen@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@2.1.1-beta.0...gatsby-transformer-react-docgen@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@2.1.1-beta.0...gatsby-transformer-react-docgen@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen/compare/gatsby-transformer-react-docgen@1.0.17...gatsby-transformer-react-docgen@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-react-docgen@1.0.17...gatsby-transformer-react-docgen@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-react-docgen

--- a/packages/gatsby-transformer-remark/CHANGELOG.md
+++ b/packages/gatsby-transformer-remark/CHANGELOG.md
@@ -7,368 +7,368 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
-## [2.6.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.6.1...gatsby-transformer-remark@2.6.2) (2019-07-10)
+## [2.6.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.6.1...gatsby-transformer-remark@2.6.2) (2019-07-10)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** Fix transformer-remark when using assetPrefix ([#15518](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/15518)) ([44f7550](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/44f7550))
+- **gatsby-transformer-remark:** Fix transformer-remark when using assetPrefix ([#15518](https://github.com/gatsbyjs/gatsby/issues/15518)) ([44f7550](https://github.com/gatsbyjs/gatsby/commit/44f7550))
 
-## [2.6.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.6.0...gatsby-transformer-remark@2.6.1) (2019-07-06)
+## [2.6.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.6.0...gatsby-transformer-remark@2.6.1) (2019-07-06)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** fix spaces between text-bearing block-level elements in plain text excerpts ([#15040](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/15040)) ([84ec96d](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/84ec96d))
+- **gatsby-transformer-remark:** fix spaces between text-bearing block-level elements in plain text excerpts ([#15040](https://github.com/gatsbyjs/gatsby/issues/15040)) ([84ec96d](https://github.com/gatsbyjs/gatsby/commit/84ec96d))
 
-# [2.6.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.5.0...gatsby-transformer-remark@2.6.0) (2019-07-04)
+# [2.6.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.5.0...gatsby-transformer-remark@2.6.0) (2019-07-04)
 
 ### Features
 
-- **gatsby-transformer-remark:** add meta support to code block ([#15348](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/15348)) ([13f0c27](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/13f0c27))
+- **gatsby-transformer-remark:** add meta support to code block ([#15348](https://github.com/gatsbyjs/gatsby/issues/15348)) ([13f0c27](https://github.com/gatsbyjs/gatsby/commit/13f0c27))
 
-# [2.5.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.4.0...gatsby-transformer-remark@2.5.0) (2019-06-20)
+# [2.5.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.4.0...gatsby-transformer-remark@2.5.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
-# [2.4.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.12...gatsby-transformer-remark@2.4.0) (2019-06-14)
+# [2.4.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.12...gatsby-transformer-remark@2.4.0) (2019-06-14)
 
 ### Features
 
-- **gatsby-transformer-remark:** change excerpt behavior ([#14723](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/14723)) ([4f72687](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/4f72687))
+- **gatsby-transformer-remark:** change excerpt behavior ([#14723](https://github.com/gatsbyjs/gatsby/issues/14723)) ([4f72687](https://github.com/gatsbyjs/gatsby/commit/4f72687))
 
-## [2.3.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.11...gatsby-transformer-remark@2.3.12) (2019-04-25)
-
-### Bug Fixes
-
-- **gatsby-transformer-remark:** fix excerpt generation - strip excessive white spaces, extract alt from images ([#12878](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/12878)) ([ceb0d72](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/ceb0d72))
-
-## [2.3.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.10...gatsby-transformer-remark@2.3.11) (2019-04-24)
+## [2.3.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.11...gatsby-transformer-remark@2.3.12) (2019-04-25)
 
 ### Bug Fixes
 
-- Add fallback for createContentDigest ([#13584](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/13584)) ([093f1f2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/093f1f2))
+- **gatsby-transformer-remark:** fix excerpt generation - strip excessive white spaces, extract alt from images ([#12878](https://github.com/gatsbyjs/gatsby/issues/12878)) ([ceb0d72](https://github.com/gatsbyjs/gatsby/commit/ceb0d72))
 
-## [2.3.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.9...gatsby-transformer-remark@2.3.10) (2019-04-23)
-
-**Note:** Version bump only for package gatsby-transformer-remark
-
-## [2.3.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.8...gatsby-transformer-remark@2.3.9) (2019-04-23)
-
-**Note:** Version bump only for package gatsby-transformer-remark
-
-## [2.3.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.7...gatsby-transformer-remark@2.3.8) (2019-03-21)
-
-**Note:** Version bump only for package gatsby-transformer-remark
-
-## [2.3.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.6...gatsby-transformer-remark@2.3.7) (2019-03-19)
+## [2.3.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.10...gatsby-transformer-remark@2.3.11) (2019-04-24)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** always include the root node of AST ([#12647](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/12647)) ([f480a35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/f480a35)), closes [#11237](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/11237)
+- Add fallback for createContentDigest ([#13584](https://github.com/gatsbyjs/gatsby/issues/13584)) ([093f1f2](https://github.com/gatsbyjs/gatsby/commit/093f1f2))
 
-## [2.3.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.5...gatsby-transformer-remark@2.3.6) (2019-03-19)
+## [2.3.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.9...gatsby-transformer-remark@2.3.10) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-transformer-remark
+
+## [2.3.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.8...gatsby-transformer-remark@2.3.9) (2019-04-23)
+
+**Note:** Version bump only for package gatsby-transformer-remark
+
+## [2.3.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.7...gatsby-transformer-remark@2.3.8) (2019-03-21)
+
+**Note:** Version bump only for package gatsby-transformer-remark
+
+## [2.3.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.6...gatsby-transformer-remark@2.3.7) (2019-03-19)
+
+### Bug Fixes
+
+- **gatsby-transformer-remark:** always include the root node of AST ([#12647](https://github.com/gatsbyjs/gatsby/issues/12647)) ([f480a35](https://github.com/gatsbyjs/gatsby/commit/f480a35)), closes [#11237](https://github.com/gatsbyjs/gatsby/issues/11237)
+
+## [2.3.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.5...gatsby-transformer-remark@2.3.6) (2019-03-19)
 
 ### Features
 
-- **gatsby:** allow schema customization ([#11480](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/11480)) ([07e69be](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/07e69be))
+- **gatsby:** allow schema customization ([#11480](https://github.com/gatsbyjs/gatsby/issues/11480)) ([07e69be](https://github.com/gatsbyjs/gatsby/commit/07e69be))
 
-## [2.3.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.4...gatsby-transformer-remark@2.3.5) (2019-03-18)
-
-### Bug Fixes
-
-- **gatsby-transformer-remark:** Revert/remark sources from different sources ([#12639](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/12639)) ([e28dd81](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/e28dd81)), closes [#7512](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/7512)
-
-## [2.3.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.3...gatsby-transformer-remark@2.3.4) (2019-03-14)
+## [2.3.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.4...gatsby-transformer-remark@2.3.5) (2019-03-18)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** wait for async subplugins ([#12578](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/12578)) ([af87e96](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/af87e96))
+- **gatsby-transformer-remark:** Revert/remark sources from different sources ([#12639](https://github.com/gatsbyjs/gatsby/issues/12639)) ([e28dd81](https://github.com/gatsbyjs/gatsby/commit/e28dd81)), closes [#7512](https://github.com/gatsbyjs/gatsby/issues/7512)
 
-## [2.3.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.2...gatsby-transformer-remark@2.3.3) (2019-03-13)
+## [2.3.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.3...gatsby-transformer-remark@2.3.4) (2019-03-14)
+
+### Bug Fixes
+
+- **gatsby-transformer-remark:** wait for async subplugins ([#12578](https://github.com/gatsbyjs/gatsby/issues/12578)) ([af87e96](https://github.com/gatsbyjs/gatsby/commit/af87e96))
+
+## [2.3.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.2...gatsby-transformer-remark@2.3.3) (2019-03-13)
 
 ### Features
 
-- **gatsby-transformer-remark:** Allow for multiple different remark sources ([#7512](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/7512)) ([95155e0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/95155e0))
+- **gatsby-transformer-remark:** Allow for multiple different remark sources ([#7512](https://github.com/gatsbyjs/gatsby/issues/7512)) ([95155e0](https://github.com/gatsbyjs/gatsby/commit/95155e0))
 
-## [2.3.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.1...gatsby-transformer-remark@2.3.2) (2019-03-11)
+## [2.3.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.1...gatsby-transformer-remark@2.3.2) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
-## [2.3.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.3.0...gatsby-transformer-remark@2.3.1) (2019-03-05)
+## [2.3.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.3.0...gatsby-transformer-remark@2.3.1) (2019-03-05)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** Fix unreturned Promise warning ([#12303](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/12303)) ([6f8f2c3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/6f8f2c3))
+- **gatsby-transformer-remark:** Fix unreturned Promise warning ([#12303](https://github.com/gatsbyjs/gatsby/issues/12303)) ([6f8f2c3](https://github.com/gatsbyjs/gatsby/commit/6f8f2c3))
 
-# [2.3.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.2.6...gatsby-transformer-remark@2.3.0) (2019-02-25)
+# [2.3.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.2.6...gatsby-transformer-remark@2.3.0) (2019-02-25)
 
 ### Features
 
-- **gatsby-transformer-remark:** add excerptAst to be exported as a GraphQL field ([#11237](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/11237)) ([e59d4ca](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/e59d4ca))
+- **gatsby-transformer-remark:** add excerptAst to be exported as a GraphQL field ([#11237](https://github.com/gatsbyjs/gatsby/issues/11237)) ([e59d4ca](https://github.com/gatsbyjs/gatsby/commit/e59d4ca))
 
-## [2.2.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.2.5...gatsby-transformer-remark@2.2.6) (2019-02-22)
-
-### Bug Fixes
-
-- **gatsby-transformer-remark:** Handle headings with nested text ([#11881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/11881)) ([4c0c5c0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/4c0c5c0)), closes [#11879](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/11879) [#11879](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/11879)
-
-## [2.2.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.2.4...gatsby-transformer-remark@2.2.5) (2019-02-12)
+## [2.2.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.2.5...gatsby-transformer-remark@2.2.6) (2019-02-22)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** restore behavior of serializing date-like fields to string ([#11716](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/11716)) ([29dee3f](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/29dee3f))
+- **gatsby-transformer-remark:** Handle headings with nested text ([#11881](https://github.com/gatsbyjs/gatsby/issues/11881)) ([4c0c5c0](https://github.com/gatsbyjs/gatsby/commit/4c0c5c0)), closes [#11879](https://github.com/gatsbyjs/gatsby/issues/11879) [#11879](https://github.com/gatsbyjs/gatsby/issues/11879)
 
-## [2.2.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.2.3...gatsby-transformer-remark@2.2.4) (2019-02-04)
+## [2.2.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.2.4...gatsby-transformer-remark@2.2.5) (2019-02-12)
+
+### Bug Fixes
+
+- **gatsby-transformer-remark:** restore behavior of serializing date-like fields to string ([#11716](https://github.com/gatsbyjs/gatsby/issues/11716)) ([29dee3f](https://github.com/gatsbyjs/gatsby/commit/29dee3f))
+
+## [2.2.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.2.3...gatsby-transformer-remark@2.2.4) (2019-02-04)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
-## [2.2.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.2.2...gatsby-transformer-remark@2.2.3) (2019-02-01)
+## [2.2.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.2.2...gatsby-transformer-remark@2.2.3) (2019-02-01)
 
 ### Features
 
-- **gatsby-transformer-remark:** add options for tableOfContents ([#9814](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/9814)) ([8290dfe](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/8290dfe))
+- **gatsby-transformer-remark:** add options for tableOfContents ([#9814](https://github.com/gatsbyjs/gatsby/issues/9814)) ([8290dfe](https://github.com/gatsbyjs/gatsby/commit/8290dfe))
 
-## [2.2.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.2.1...gatsby-transformer-remark@2.2.2) (2019-01-29)
+## [2.2.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.2.1...gatsby-transformer-remark@2.2.2) (2019-01-29)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.2.0...gatsby-transformer-remark@2.2.1) (2019-01-28)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.2.0...gatsby-transformer-remark@2.2.1) (2019-01-28)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** don't convert Date objects ([#10924](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/10924)) ([4463f52](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/4463f52))
+- **gatsby-transformer-remark:** don't convert Date objects ([#10924](https://github.com/gatsbyjs/gatsby/issues/10924)) ([4463f52](https://github.com/gatsbyjs/gatsby/commit/4463f52))
 
 <a name="2.2.0"></a>
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.20...gatsby-transformer-remark@2.2.0) (2019-01-08)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.20...gatsby-transformer-remark@2.2.0) (2019-01-08)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** correctly pass cache to sub plugins ([#10892](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/10892)) ([8ea9a52](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/8ea9a52))
+- **gatsby-transformer-remark:** correctly pass cache to sub plugins ([#10892](https://github.com/gatsbyjs/gatsby/issues/10892)) ([8ea9a52](https://github.com/gatsbyjs/gatsby/commit/8ea9a52))
 
 <a name="2.1.20"></a>
 
-## [2.1.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.19...gatsby-transformer-remark@2.1.20) (2019-01-08)
+## [2.1.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.19...gatsby-transformer-remark@2.1.20) (2019-01-08)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** remove unused \_PARENT field from frontmatter ([#10919](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/10919)) ([e831b42](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/e831b42))
+- **gatsby-transformer-remark:** remove unused \_PARENT field from frontmatter ([#10919](https://github.com/gatsbyjs/gatsby/issues/10919)) ([e831b42](https://github.com/gatsbyjs/gatsby/commit/e831b42))
 
 <a name="2.1.19"></a>
 
-## [2.1.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.18...gatsby-transformer-remark@2.1.19) (2019-01-01)
+## [2.1.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.18...gatsby-transformer-remark@2.1.19) (2019-01-01)
 
 ### Features
 
-- **gatsby-transformer-remark:** support raw HTML in markdown excerpts ([#10499](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/10499)) ([29a8c5c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/29a8c5c)), closes [#10498](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/10498)
+- **gatsby-transformer-remark:** support raw HTML in markdown excerpts ([#10499](https://github.com/gatsbyjs/gatsby/issues/10499)) ([29a8c5c](https://github.com/gatsbyjs/gatsby/commit/29a8c5c)), closes [#10498](https://github.com/gatsbyjs/gatsby/issues/10498)
 
 <a name="2.1.18"></a>
 
-## [2.1.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.17...gatsby-transformer-remark@2.1.18) (2018-12-31)
+## [2.1.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.17...gatsby-transformer-remark@2.1.18) (2018-12-31)
 
 ### Features
 
-- **gatsby-transformer-remark:** Note about gray-matter ([#10718](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/10718)) ([0e84ff3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/0e84ff3))
+- **gatsby-transformer-remark:** Note about gray-matter ([#10718](https://github.com/gatsbyjs/gatsby/issues/10718)) ([0e84ff3](https://github.com/gatsbyjs/gatsby/commit/0e84ff3))
 
 <a name="2.1.17"></a>
 
-## [2.1.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.16...gatsby-transformer-remark@2.1.17) (2018-12-17)
+## [2.1.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.16...gatsby-transformer-remark@2.1.17) (2018-12-17)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.16"></a>
 
-## [2.1.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.15...gatsby-transformer-remark@2.1.16) (2018-12-17)
+## [2.1.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.15...gatsby-transformer-remark@2.1.16) (2018-12-17)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.15"></a>
 
-## [2.1.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.14...gatsby-transformer-remark@2.1.15) (2018-11-30)
+## [2.1.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.14...gatsby-transformer-remark@2.1.15) (2018-11-30)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** render html attributes in html excerpt ([#10196](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/10196)) ([2483aef](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/2483aef))
+- **gatsby-transformer-remark:** render html attributes in html excerpt ([#10196](https://github.com/gatsbyjs/gatsby/issues/10196)) ([2483aef](https://github.com/gatsbyjs/gatsby/commit/2483aef))
 
 <a name="2.1.14"></a>
 
-## [2.1.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.13...gatsby-transformer-remark@2.1.14) (2018-11-29)
+## [2.1.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.13...gatsby-transformer-remark@2.1.14) (2018-11-29)
 
 ### Bug Fixes
 
-- **gatsby-transformer-remark:** properly bubble up errors thrown in subplugins ([#9972](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/9972)) ([b7d4656](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/b7d4656))
+- **gatsby-transformer-remark:** properly bubble up errors thrown in subplugins ([#9972](https://github.com/gatsbyjs/gatsby/issues/9972)) ([b7d4656](https://github.com/gatsbyjs/gatsby/commit/b7d4656))
 
 <a name="2.1.13"></a>
 
-## [2.1.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.12...gatsby-transformer-remark@2.1.13) (2018-11-27)
+## [2.1.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.12...gatsby-transformer-remark@2.1.13) (2018-11-27)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.12"></a>
 
-## [2.1.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.11...gatsby-transformer-remark@2.1.12) (2018-11-08)
+## [2.1.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.11...gatsby-transformer-remark@2.1.12) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.11"></a>
 
-## [2.1.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.10...gatsby-transformer-remark@2.1.11) (2018-10-29)
+## [2.1.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.10...gatsby-transformer-remark@2.1.11) (2018-10-29)
 
 ### Features
 
-- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/9338)
+- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/issues/9338)
 
 <a name="2.1.10"></a>
 
-## [2.1.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.9...gatsby-transformer-remark@2.1.10) (2018-10-29)
+## [2.1.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.9...gatsby-transformer-remark@2.1.10) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.9"></a>
 
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.8...gatsby-transformer-remark@2.1.9) (2018-10-24)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.8...gatsby-transformer-remark@2.1.9) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.8"></a>
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.7...gatsby-transformer-remark@2.1.8) (2018-10-18)
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.7...gatsby-transformer-remark@2.1.8) (2018-10-18)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.7"></a>
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.6...gatsby-transformer-remark@2.1.7) (2018-10-09)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.6...gatsby-transformer-remark@2.1.7) (2018-10-09)
 
 ### Features
 
-- add error message with filename on Markdown error, fix bug in panicOnBuild ([#8866](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/8866)) ([bbff3be](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/bbff3be))
+- add error message with filename on Markdown error, fix bug in panicOnBuild ([#8866](https://github.com/gatsbyjs/gatsby/issues/8866)) ([bbff3be](https://github.com/gatsbyjs/gatsby/commit/bbff3be))
 
 <a name="2.1.6"></a>
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.5...gatsby-transformer-remark@2.1.6) (2018-10-02)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.5...gatsby-transformer-remark@2.1.6) (2018-10-02)
 
 ### Bug Fixes
 
-- support path-prefix for reference links in Markdown files ([#8607](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/8607)) ([fb43fda](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/fb43fda)), closes [#8588](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/8588)
+- support path-prefix for reference links in Markdown files ([#8607](https://github.com/gatsbyjs/gatsby/issues/8607)) ([fb43fda](https://github.com/gatsbyjs/gatsby/commit/fb43fda)), closes [#8588](https://github.com/gatsbyjs/gatsby/issues/8588)
 
 <a name="2.1.5"></a>
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.4...gatsby-transformer-remark@2.1.5) (2018-10-01)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.4...gatsby-transformer-remark@2.1.5) (2018-10-01)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.3...gatsby-transformer-remark@2.1.4) (2018-09-26)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.3...gatsby-transformer-remark@2.1.4) (2018-09-26)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.2...gatsby-transformer-remark@2.1.3) (2018-09-18)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.2...gatsby-transformer-remark@2.1.3) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1...gatsby-transformer-remark@2.1.2) (2018-09-18)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1...gatsby-transformer-remark@2.1.2) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-rc.5...gatsby-transformer-remark@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-rc.5...gatsby-transformer-remark@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-rc.5"></a>
 
-## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-rc.4...gatsby-transformer-remark@2.1.1-rc.5) (2018-09-11)
+## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-rc.4...gatsby-transformer-remark@2.1.1-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-rc.4"></a>
 
-## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-rc.3...gatsby-transformer-remark@2.1.1-rc.4) (2018-09-11)
+## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-rc.3...gatsby-transformer-remark@2.1.1-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-rc.3"></a>
 
-## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-rc.2...gatsby-transformer-remark@2.1.1-rc.3) (2018-09-11)
+## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-rc.2...gatsby-transformer-remark@2.1.1-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-rc.1...gatsby-transformer-remark@2.1.1-rc.2) (2018-09-11)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-rc.1...gatsby-transformer-remark@2.1.1-rc.2) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-rc.0...gatsby-transformer-remark@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-rc.0...gatsby-transformer-remark@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.8...gatsby-transformer-remark@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.8...gatsby-transformer-remark@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.8"></a>
 
-## [2.1.1-beta.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.7...gatsby-transformer-remark@2.1.1-beta.8) (2018-08-20)
+## [2.1.1-beta.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.7...gatsby-transformer-remark@2.1.1-beta.8) (2018-08-20)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.7"></a>
 
-## [2.1.1-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.6...gatsby-transformer-remark@2.1.1-beta.7) (2018-08-17)
+## [2.1.1-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.6...gatsby-transformer-remark@2.1.1-beta.7) (2018-08-17)
 
 ### Bug Fixes
 
-- remark excerpt add halfChop option ([#6992](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/issues/6992)) ([4386750](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/commit/4386750))
+- remark excerpt add halfChop option ([#6992](https://github.com/gatsbyjs/gatsby/issues/6992)) ([4386750](https://github.com/gatsbyjs/gatsby/commit/4386750))
 
 <a name="2.1.1-beta.6"></a>
 
-## [2.1.1-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.5...gatsby-transformer-remark@2.1.1-beta.6) (2018-08-06)
+## [2.1.1-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.5...gatsby-transformer-remark@2.1.1-beta.6) (2018-08-06)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.5"></a>
 
-## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.4...gatsby-transformer-remark@2.1.1-beta.5) (2018-07-27)
+## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.4...gatsby-transformer-remark@2.1.1-beta.5) (2018-07-27)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.4"></a>
 
-## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.3...gatsby-transformer-remark@2.1.1-beta.4) (2018-07-21)
+## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.3...gatsby-transformer-remark@2.1.1-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.2...gatsby-transformer-remark@2.1.1-beta.3) (2018-07-11)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.2...gatsby-transformer-remark@2.1.1-beta.3) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.1...gatsby-transformer-remark@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.1...gatsby-transformer-remark@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@2.1.1-beta.0...gatsby-transformer-remark@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@2.1.1-beta.0...gatsby-transformer-remark@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-remark
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark/compare/gatsby-transformer-remark@1.7.44...gatsby-transformer-remark@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-remark@1.7.44...gatsby-transformer-remark@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-remark

--- a/packages/gatsby-transformer-screenshot/CHANGELOG.md
+++ b/packages/gatsby-transformer-screenshot/CHANGELOG.md
@@ -7,168 +7,168 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.16...gatsby-transformer-screenshot@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.16...gatsby-transformer-screenshot@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
-## [2.0.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.14...gatsby-transformer-screenshot@2.0.16) (2019-06-19)
+## [2.0.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.14...gatsby-transformer-screenshot@2.0.16) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [2.0.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.14...gatsby-transformer-screenshot@2.0.15) (2019-06-19)
+## [2.0.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.14...gatsby-transformer-screenshot@2.0.15) (2019-06-19)
 
 ### Bug Fixes
 
-- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/commit/2594623))
+- fix gatsby-cli dep in source-filesystem & plugin-sharp ([#14881](https://github.com/gatsbyjs/gatsby/issues/14881)) ([2594623](https://github.com/gatsbyjs/gatsby/commit/2594623))
 
-## [2.0.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.13...gatsby-transformer-screenshot@2.0.14) (2019-05-31)
+## [2.0.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.13...gatsby-transformer-screenshot@2.0.14) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
-## [2.0.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.12...gatsby-transformer-screenshot@2.0.13) (2019-03-11)
+## [2.0.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.12...gatsby-transformer-screenshot@2.0.13) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
-## [2.0.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.11...gatsby-transformer-screenshot@2.0.12) (2019-02-20)
+## [2.0.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.11...gatsby-transformer-screenshot@2.0.12) (2019-02-20)
 
 ### Bug Fixes
 
-- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/commit/5a3c1fc))
+- **gatsby-source-filesystem:** Let plugins set parent when creating File nodes with createRemoteFileNode ([#11795](https://github.com/gatsbyjs/gatsby/issues/11795)) ([5a3c1fc](https://github.com/gatsbyjs/gatsby/commit/5a3c1fc))
 
-## [2.0.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.10...gatsby-transformer-screenshot@2.0.11) (2019-02-12)
+## [2.0.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.10...gatsby-transformer-screenshot@2.0.11) (2019-02-12)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.10"></a>
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.9...gatsby-transformer-screenshot@2.0.10) (2018-12-18)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.9...gatsby-transformer-screenshot@2.0.10) (2018-12-18)
 
 ### Features
 
-- **gatsby-transformer-screenshot:** Added fullpage option for puppeteer API call ([#10517](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/10517)) ([51a8c98](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/commit/51a8c98)), closes [#10483](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/10483)
+- **gatsby-transformer-screenshot:** Added fullpage option for puppeteer API call ([#10517](https://github.com/gatsbyjs/gatsby/issues/10517)) ([51a8c98](https://github.com/gatsbyjs/gatsby/commit/51a8c98)), closes [#10483](https://github.com/gatsbyjs/gatsby/issues/10483)
 
 <a name="2.0.9"></a>
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.8...gatsby-transformer-screenshot@2.0.9) (2018-11-29)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.8...gatsby-transformer-screenshot@2.0.9) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.8"></a>
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.7...gatsby-transformer-screenshot@2.0.8) (2018-11-09)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.7...gatsby-transformer-screenshot@2.0.8) (2018-11-09)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.7"></a>
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.6...gatsby-transformer-screenshot@2.0.7) (2018-11-08)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.6...gatsby-transformer-screenshot@2.0.7) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.5...gatsby-transformer-screenshot@2.0.6) (2018-10-29)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.5...gatsby-transformer-screenshot@2.0.6) (2018-10-29)
 
 ### Features
 
-- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/9338)
+- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/issues/9338)
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.4...gatsby-transformer-screenshot@2.0.5) (2018-10-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.4...gatsby-transformer-screenshot@2.0.5) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.3...gatsby-transformer-screenshot@2.0.4) (2018-10-16)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.3...gatsby-transformer-screenshot@2.0.4) (2018-10-16)
 
 ### Features
 
-- **gatsby-transformer-sharp:** allow screenshot placeholder ([#9100](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/issues/9100)) ([c82670c](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/commit/c82670c))
+- **gatsby-transformer-sharp:** allow screenshot placeholder ([#9100](https://github.com/gatsbyjs/gatsby/issues/9100)) ([c82670c](https://github.com/gatsbyjs/gatsby/commit/c82670c))
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.2...gatsby-transformer-screenshot@2.0.3) (2018-10-12)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.2...gatsby-transformer-screenshot@2.0.3) (2018-10-12)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.1...gatsby-transformer-screenshot@2.0.2) (2018-09-19)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.1...gatsby-transformer-screenshot@2.0.2) (2018-09-19)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0...gatsby-transformer-screenshot@2.0.1) (2018-09-18)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0...gatsby-transformer-screenshot@2.0.1) (2018-09-18)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-rc.1...gatsby-transformer-screenshot@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-rc.1...gatsby-transformer-screenshot@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-rc.0...gatsby-transformer-screenshot@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-rc.0...gatsby-transformer-screenshot@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.7...gatsby-transformer-screenshot@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.7...gatsby-transformer-screenshot@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.7"></a>
 
-# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.6...gatsby-transformer-screenshot@2.0.0-beta.7) (2018-07-28)
+# [2.0.0-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.6...gatsby-transformer-screenshot@2.0.0-beta.7) (2018-07-28)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.6"></a>
 
-# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.5...gatsby-transformer-screenshot@2.0.0-beta.6) (2018-07-28)
+# [2.0.0-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.5...gatsby-transformer-screenshot@2.0.0-beta.6) (2018-07-28)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.5"></a>
 
-# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.4...gatsby-transformer-screenshot@2.0.0-beta.5) (2018-07-27)
+# [2.0.0-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.4...gatsby-transformer-screenshot@2.0.0-beta.5) (2018-07-27)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.4"></a>
 
-# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.3...gatsby-transformer-screenshot@2.0.0-beta.4) (2018-07-21)
+# [2.0.0-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.3...gatsby-transformer-screenshot@2.0.0-beta.4) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.2...gatsby-transformer-screenshot@2.0.0-beta.3) (2018-07-11)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.2...gatsby-transformer-screenshot@2.0.0-beta.3) (2018-07-11)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.1...gatsby-transformer-screenshot@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.1...gatsby-transformer-screenshot@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@2.0.0-beta.0...gatsby-transformer-screenshot@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@2.0.0-beta.0...gatsby-transformer-screenshot@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot/compare/gatsby-transformer-screenshot@1.0.7...gatsby-transformer-screenshot@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-screenshot@1.0.7...gatsby-transformer-screenshot@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-screenshot

--- a/packages/gatsby-transformer-sharp/CHANGELOG.md
+++ b/packages/gatsby-transformer-sharp/CHANGELOG.md
@@ -7,218 +7,218 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
-## [2.2.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.2.0...gatsby-transformer-sharp@2.2.1) (2019-07-02)
+## [2.2.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.2.0...gatsby-transformer-sharp@2.2.1) (2019-07-02)
 
 ### Features
 
-- **gatsby-transformer-sharp:** Add default types for ImageSha… ([#15285](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/15285)) ([44580c6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/44580c6))
+- **gatsby-transformer-sharp:** Add default types for ImageSha… ([#15285](https://github.com/gatsbyjs/gatsby/issues/15285)) ([44580c6](https://github.com/gatsbyjs/gatsby/commit/44580c6))
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.21...gatsby-transformer-sharp@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.21...gatsby-transformer-sharp@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
-## [2.1.21](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.20...gatsby-transformer-sharp@2.1.21) (2019-05-31)
+## [2.1.21](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.20...gatsby-transformer-sharp@2.1.21) (2019-05-31)
 
 ### Features
 
-- **image-sharp:** add trim option ([#14137](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/14137)) ([cf0e77b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/cf0e77b))
+- **image-sharp:** add trim option ([#14137](https://github.com/gatsbyjs/gatsby/issues/14137)) ([cf0e77b](https://github.com/gatsbyjs/gatsby/commit/cf0e77b))
 
-## [2.1.20](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.19...gatsby-transformer-sharp@2.1.20) (2019-05-29)
+## [2.1.20](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.19...gatsby-transformer-sharp@2.1.20) (2019-05-29)
 
 ### Bug Fixes
 
-- cache tracedSVG calculations when cache is present ([#12044](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/12044)) ([c40bc4b](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/c40bc4b))
+- cache tracedSVG calculations when cache is present ([#12044](https://github.com/gatsbyjs/gatsby/issues/12044)) ([c40bc4b](https://github.com/gatsbyjs/gatsby/commit/c40bc4b))
 
-## [2.1.19](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.18...gatsby-transformer-sharp@2.1.19) (2019-05-03)
-
-**Note:** Version bump only for package gatsby-transformer-sharp
-
-## [2.1.18](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.17...gatsby-transformer-sharp@2.1.18) (2019-04-11)
-
-### Features
-
-- add options fit and background to image sharp ([#13078](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/13078)) ([494ad07](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/494ad07)), closes [#12972](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/12972)
-
-## [2.1.17](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.16...gatsby-transformer-sharp@2.1.17) (2019-03-12)
-
-### Features
-
-- **gatsby-image:** Placeholder Improvements ([#10944](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/10944)) ([44491ef](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/44491ef))
-
-## [2.1.16](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.15...gatsby-transformer-sharp@2.1.16) (2019-03-11)
+## [2.1.19](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.18...gatsby-transformer-sharp@2.1.19) (2019-05-03)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
-## [2.1.15](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.14...gatsby-transformer-sharp@2.1.15) (2019-02-28)
-
-**Note:** Version bump only for package gatsby-transformer-sharp
-
-## [2.1.14](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.13...gatsby-transformer-sharp@2.1.14) (2019-02-19)
+## [2.1.18](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.17...gatsby-transformer-sharp@2.1.18) (2019-04-11)
 
 ### Features
 
-- **gatsby-plugin-sharp:** add defaultQuality option ([8af9826](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/8af9826))
+- add options fit and background to image sharp ([#13078](https://github.com/gatsbyjs/gatsby/issues/13078)) ([494ad07](https://github.com/gatsbyjs/gatsby/commit/494ad07)), closes [#12972](https://github.com/gatsbyjs/gatsby/issues/12972)
 
-## [2.1.13](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.12...gatsby-transformer-sharp@2.1.13) (2019-01-29)
+## [2.1.17](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.16...gatsby-transformer-sharp@2.1.17) (2019-03-12)
+
+### Features
+
+- **gatsby-image:** Placeholder Improvements ([#10944](https://github.com/gatsbyjs/gatsby/issues/10944)) ([44491ef](https://github.com/gatsbyjs/gatsby/commit/44491ef))
+
+## [2.1.16](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.15...gatsby-transformer-sharp@2.1.16) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-transformer-sharp
+
+## [2.1.15](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.14...gatsby-transformer-sharp@2.1.15) (2019-02-28)
+
+**Note:** Version bump only for package gatsby-transformer-sharp
+
+## [2.1.14](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.13...gatsby-transformer-sharp@2.1.14) (2019-02-19)
+
+### Features
+
+- **gatsby-plugin-sharp:** add defaultQuality option ([8af9826](https://github.com/gatsbyjs/gatsby/commit/8af9826))
+
+## [2.1.13](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.12...gatsby-transformer-sharp@2.1.13) (2019-01-29)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.12"></a>
 
-## [2.1.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.11...gatsby-transformer-sharp@2.1.12) (2019-01-24)
+## [2.1.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.11...gatsby-transformer-sharp@2.1.12) (2019-01-24)
 
 ### Bug Fixes
 
-- **gatsby-transformer-sharp:** Pick extension from file prop ([#11166](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/11166)) ([0a8b189](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/0a8b189))
+- **gatsby-transformer-sharp:** Pick extension from file prop ([#11166](https://github.com/gatsbyjs/gatsby/issues/11166)) ([0a8b189](https://github.com/gatsbyjs/gatsby/commit/0a8b189))
 
 <a name="2.1.11"></a>
 
-## [2.1.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.10...gatsby-transformer-sharp@2.1.11) (2019-01-23)
+## [2.1.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.10...gatsby-transformer-sharp@2.1.11) (2019-01-23)
 
 ### Features
 
-- **gatsby-plugin-sharp:** Add support for pngquant speed option ([#9563](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/9563)) ([b789689](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/b789689))
+- **gatsby-plugin-sharp:** Add support for pngquant speed option ([#9563](https://github.com/gatsbyjs/gatsby/issues/9563)) ([b789689](https://github.com/gatsbyjs/gatsby/commit/b789689))
 
 <a name="2.1.10"></a>
 
-## [2.1.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.9...gatsby-transformer-sharp@2.1.10) (2018-12-31)
+## [2.1.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.9...gatsby-transformer-sharp@2.1.10) (2018-12-31)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.9"></a>
 
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.8...gatsby-transformer-sharp@2.1.9) (2018-11-29)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.8...gatsby-transformer-sharp@2.1.9) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.8"></a>
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.7...gatsby-transformer-sharp@2.1.8) (2018-11-06)
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.7...gatsby-transformer-sharp@2.1.8) (2018-11-06)
 
 ### Features
 
-- **gatsby-plugin-sharp:** cache base64 if possible ([#9059](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/9059)) ([5dc9346](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/5dc9346)), closes [#6999](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/6999)
+- **gatsby-plugin-sharp:** cache base64 if possible ([#9059](https://github.com/gatsbyjs/gatsby/issues/9059)) ([5dc9346](https://github.com/gatsbyjs/gatsby/commit/5dc9346)), closes [#6999](https://github.com/gatsbyjs/gatsby/issues/6999)
 
 <a name="2.1.7"></a>
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.6...gatsby-transformer-sharp@2.1.7) (2018-10-29)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.6...gatsby-transformer-sharp@2.1.7) (2018-10-29)
 
 ### Features
 
-- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/9338)
+- **gatsby:** Add nodes db module ([#9416](https://github.com/gatsbyjs/gatsby/issues/9416)) ([7d31fe7](https://github.com/gatsbyjs/gatsby/commit/7d31fe7)), closes [#9338](https://github.com/gatsbyjs/gatsby/issues/9338)
 
 <a name="2.1.6"></a>
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.5...gatsby-transformer-sharp@2.1.6) (2018-10-29)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.5...gatsby-transformer-sharp@2.1.6) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.5"></a>
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.4...gatsby-transformer-sharp@2.1.5) (2018-10-24)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.4...gatsby-transformer-sharp@2.1.5) (2018-10-24)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.3...gatsby-transformer-sharp@2.1.4) (2018-10-16)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.3...gatsby-transformer-sharp@2.1.4) (2018-10-16)
 
 ### Features
 
-- add custom sizes for fluid images ([#8825](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/8825)) ([6cb4ee6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/6cb4ee6)), closes [#8621](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/8621)
+- add custom sizes for fluid images ([#8825](https://github.com/gatsbyjs/gatsby/issues/8825)) ([6cb4ee6](https://github.com/gatsbyjs/gatsby/commit/6cb4ee6)), closes [#8621](https://github.com/gatsbyjs/gatsby/issues/8621)
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.2...gatsby-transformer-sharp@2.1.3) (2018-09-28)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.2...gatsby-transformer-sharp@2.1.3) (2018-09-28)
 
 ### Features
 
-- provide fragments without gatsby-image ([#8459](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/8459)) ([3389b89](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/3389b89))
+- provide fragments without gatsby-image ([#8459](https://github.com/gatsbyjs/gatsby/issues/8459)) ([3389b89](https://github.com/gatsbyjs/gatsby/commit/3389b89))
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-rc.3...gatsby-transformer-sharp@2.1.2) (2018-09-24)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-rc.3...gatsby-transformer-sharp@2.1.2) (2018-09-24)
 
 ### Features
 
-- **gatsby-transformer-sharp:** expose sizes argument for fluid query ([#8466](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/8466)) ([efe95a4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/efe95a4))
+- **gatsby-transformer-sharp:** expose sizes argument for fluid query ([#8466](https://github.com/gatsbyjs/gatsby/issues/8466)) ([efe95a4](https://github.com/gatsbyjs/gatsby/commit/efe95a4))
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-rc.3...gatsby-transformer-sharp@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-rc.3...gatsby-transformer-sharp@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-rc.3"></a>
 
-## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-rc.2...gatsby-transformer-sharp@2.1.1-rc.3) (2018-09-07)
+## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-rc.2...gatsby-transformer-sharp@2.1.1-rc.3) (2018-09-07)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-rc.1...gatsby-transformer-sharp@2.1.1-rc.2) (2018-08-29)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-rc.1...gatsby-transformer-sharp@2.1.1-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-rc.0...gatsby-transformer-sharp@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-rc.0...gatsby-transformer-sharp@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.7...gatsby-transformer-sharp@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.7...gatsby-transformer-sharp@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-beta.7"></a>
 
-## [2.1.1-beta.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.6...gatsby-transformer-sharp@2.1.1-beta.7) (2018-08-13)
+## [2.1.1-beta.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.6...gatsby-transformer-sharp@2.1.1-beta.7) (2018-08-13)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-beta.6"></a>
 
-## [2.1.1-beta.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.5...gatsby-transformer-sharp@2.1.1-beta.6) (2018-07-21)
+## [2.1.1-beta.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.5...gatsby-transformer-sharp@2.1.1-beta.6) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-beta.5"></a>
 
-## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.4...gatsby-transformer-sharp@2.1.1-beta.5) (2018-07-17)
+## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.4...gatsby-transformer-sharp@2.1.1-beta.5) (2018-07-17)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-beta.4"></a>
 
-## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.3...gatsby-transformer-sharp@2.1.1-beta.4) (2018-07-16)
+## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.3...gatsby-transformer-sharp@2.1.1-beta.4) (2018-07-16)
 
 ### Features
 
-- **sharp:** move gatsby-plugin-sharp to peerDependencies ([#6487](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/issues/6487)) ([4cdd3bf](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/commit/4cdd3bf))
+- **sharp:** move gatsby-plugin-sharp to peerDependencies ([#6487](https://github.com/gatsbyjs/gatsby/issues/6487)) ([4cdd3bf](https://github.com/gatsbyjs/gatsby/commit/4cdd3bf))
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.2...gatsby-transformer-sharp@2.1.1-beta.3) (2018-06-26)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.2...gatsby-transformer-sharp@2.1.1-beta.3) (2018-06-26)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.1...gatsby-transformer-sharp@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.1...gatsby-transformer-sharp@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@2.1.1-beta.0...gatsby-transformer-sharp@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@2.1.1-beta.0...gatsby-transformer-sharp@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-sharp
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp/compare/gatsby-transformer-sharp@1.6.27...gatsby-transformer-sharp@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sharp@1.6.27...gatsby-transformer-sharp@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-sharp

--- a/packages/gatsby-transformer-sqip/CHANGELOG.md
+++ b/packages/gatsby-transformer-sqip/CHANGELOG.md
@@ -7,87 +7,87 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.1.4...gatsby-transformer-sqip@2.1.5) (2019-07-06)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.1.4...gatsby-transformer-sqip@2.1.5) (2019-07-06)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.1.3...gatsby-transformer-sqip@2.1.4) (2019-07-02)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.1.3...gatsby-transformer-sqip@2.1.4) (2019-07-02)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.1.2...gatsby-transformer-sqip@2.1.3) (2019-07-01)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.1.2...gatsby-transformer-sqip@2.1.3) (2019-07-01)
 
 ### Bug Fixes
 
-- **gatsby-transformer-sqip:** remove more leftovers from broken merge ([#15219](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/issues/15219)) ([de04318](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/commit/de04318))
+- **gatsby-transformer-sqip:** remove more leftovers from broken merge ([#15219](https://github.com/gatsbyjs/gatsby/issues/15219)) ([de04318](https://github.com/gatsbyjs/gatsby/commit/de04318))
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.1.1...gatsby-transformer-sqip@2.1.2) (2019-06-24)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.1.1...gatsby-transformer-sqip@2.1.2) (2019-06-24)
 
 ### Bug Fixes
 
-- **gatsby-transformer-sqip:** make it work again ([#14996](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/issues/14996)) ([7ab0c62](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/commit/7ab0c62))
+- **gatsby-transformer-sqip:** make it work again ([#14996](https://github.com/gatsbyjs/gatsby/issues/14996)) ([7ab0c62](https://github.com/gatsbyjs/gatsby/commit/7ab0c62))
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.1.0...gatsby-transformer-sqip@2.1.1) (2019-06-21)
-
-**Note:** Version bump only for package gatsby-transformer-sqip
-
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.46...gatsby-transformer-sqip@2.1.0) (2019-06-20)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.1.0...gatsby-transformer-sqip@2.1.1) (2019-06-21)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.46](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.43...gatsby-transformer-sqip@2.0.46) (2019-06-19)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.46...gatsby-transformer-sqip@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.45](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.44...gatsby-transformer-sqip@2.0.45) (2019-06-19)
+## [2.0.46](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.43...gatsby-transformer-sqip@2.0.46) (2019-06-19)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.44](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.43...gatsby-transformer-sqip@2.0.44) (2019-06-18)
+## [2.0.45](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.44...gatsby-transformer-sqip@2.0.45) (2019-06-19)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.43](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.42...gatsby-transformer-sqip@2.0.43) (2019-06-18)
+## [2.0.44](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.43...gatsby-transformer-sqip@2.0.44) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.42](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.40...gatsby-transformer-sqip@2.0.42) (2019-06-12)
+## [2.0.43](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.42...gatsby-transformer-sqip@2.0.43) (2019-06-18)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.41](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.40...gatsby-transformer-sqip@2.0.41) (2019-06-12)
+## [2.0.42](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.40...gatsby-transformer-sqip@2.0.42) (2019-06-12)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.40](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.39...gatsby-transformer-sqip@2.0.40) (2019-05-31)
+## [2.0.41](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.40...gatsby-transformer-sqip@2.0.41) (2019-06-12)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.39](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.38...gatsby-transformer-sqip@2.0.39) (2019-05-31)
+## [2.0.40](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.39...gatsby-transformer-sqip@2.0.40) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.38](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.37...gatsby-transformer-sqip@2.0.38) (2019-05-29)
+## [2.0.39](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.38...gatsby-transformer-sqip@2.0.39) (2019-05-31)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.37](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.36...gatsby-transformer-sqip@2.0.37) (2019-05-24)
+## [2.0.38](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.37...gatsby-transformer-sqip@2.0.38) (2019-05-29)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.36](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.35...gatsby-transformer-sqip@2.0.36) (2019-05-23)
+## [2.0.37](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.36...gatsby-transformer-sqip@2.0.37) (2019-05-24)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.35](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.34...gatsby-transformer-sqip@2.0.35) (2019-05-09)
+## [2.0.36](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.35...gatsby-transformer-sqip@2.0.36) (2019-05-23)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.34](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.33...gatsby-transformer-sqip@2.0.34) (2019-05-03)
+## [2.0.35](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.34...gatsby-transformer-sqip@2.0.35) (2019-05-09)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 
-## [2.0.33](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip/compare/gatsby-transformer-sqip@2.0.32...gatsby-transformer-sqip@2.0.33) (2019-04-23)
+## [2.0.34](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.33...gatsby-transformer-sqip@2.0.34) (2019-05-03)
+
+**Note:** Version bump only for package gatsby-transformer-sqip
+
+## [2.0.33](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-sqip@2.0.32...gatsby-transformer-sqip@2.0.33) (2019-04-23)
 
 **Note:** Version bump only for package gatsby-transformer-sqip
 

--- a/packages/gatsby-transformer-toml/CHANGELOG.md
+++ b/packages/gatsby-transformer-toml/CHANGELOG.md
@@ -7,106 +7,106 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.9...gatsby-transformer-toml@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.9...gatsby-transformer-toml@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.8...gatsby-transformer-toml@2.1.9) (2019-04-04)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.8...gatsby-transformer-toml@2.1.9) (2019-04-04)
 
 ### Bug Fixes
 
-- **gatsby-transformer-toml:** Fix createContentDigest usage ([#13118](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/issues/13118)) ([506d7c3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/commit/506d7c3)), closes [#13112](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/issues/13112)
+- **gatsby-transformer-toml:** Fix createContentDigest usage ([#13118](https://github.com/gatsbyjs/gatsby/issues/13118)) ([506d7c3](https://github.com/gatsbyjs/gatsby/commit/506d7c3)), closes [#13112](https://github.com/gatsbyjs/gatsby/issues/13112)
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.7...gatsby-transformer-toml@2.1.8) (2019-04-02)
-
-**Note:** Version bump only for package gatsby-transformer-toml
-
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.6...gatsby-transformer-toml@2.1.7) (2019-03-11)
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.7...gatsby-transformer-toml@2.1.8) (2019-04-02)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.5...gatsby-transformer-toml@2.1.6) (2019-03-11)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.6...gatsby-transformer-toml@2.1.7) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.4...gatsby-transformer-toml@2.1.5) (2019-02-01)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.5...gatsby-transformer-toml@2.1.6) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-transformer-toml
+
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.4...gatsby-transformer-toml@2.1.5) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.3...gatsby-transformer-toml@2.1.4) (2019-01-08)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.3...gatsby-transformer-toml@2.1.4) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.2...gatsby-transformer-toml@2.1.3) (2018-11-29)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.2...gatsby-transformer-toml@2.1.3) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1...gatsby-transformer-toml@2.1.2) (2018-10-29)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1...gatsby-transformer-toml@2.1.2) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-rc.2...gatsby-transformer-toml@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-rc.2...gatsby-transformer-toml@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-rc.1...gatsby-transformer-toml@2.1.1-rc.2) (2018-09-05)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-rc.1...gatsby-transformer-toml@2.1.1-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-rc.0...gatsby-transformer-toml@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-rc.0...gatsby-transformer-toml@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-beta.5...gatsby-transformer-toml@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-beta.5...gatsby-transformer-toml@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-beta.5"></a>
 
-## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-beta.4...gatsby-transformer-toml@2.1.1-beta.5) (2018-07-21)
+## [2.1.1-beta.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-beta.4...gatsby-transformer-toml@2.1.1-beta.5) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-beta.4"></a>
 
-## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-beta.3...gatsby-transformer-toml@2.1.1-beta.4) (2018-07-18)
+## [2.1.1-beta.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-beta.3...gatsby-transformer-toml@2.1.1-beta.4) (2018-07-18)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-beta.2...gatsby-transformer-toml@2.1.1-beta.3) (2018-07-12)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-beta.2...gatsby-transformer-toml@2.1.1-beta.3) (2018-07-12)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-beta.1...gatsby-transformer-toml@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-beta.1...gatsby-transformer-toml@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@2.1.1-beta.0...gatsby-transformer-toml@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@2.1.1-beta.0...gatsby-transformer-toml@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-toml
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml/compare/gatsby-transformer-toml@1.1.9...gatsby-transformer-toml@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-toml@1.1.9...gatsby-transformer-toml@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-toml

--- a/packages/gatsby-transformer-xml/CHANGELOG.md
+++ b/packages/gatsby-transformer-xml/CHANGELOG.md
@@ -7,130 +7,130 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.10...gatsby-transformer-xml@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.10...gatsby-transformer-xml@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
-## [2.0.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.9...gatsby-transformer-xml@2.0.10) (2019-05-09)
+## [2.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.9...gatsby-transformer-xml@2.0.10) (2019-05-09)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
-## [2.0.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.8...gatsby-transformer-xml@2.0.9) (2019-03-15)
+## [2.0.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.8...gatsby-transformer-xml@2.0.9) (2019-03-15)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
-## [2.0.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.7...gatsby-transformer-xml@2.0.8) (2019-03-11)
+## [2.0.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.7...gatsby-transformer-xml@2.0.8) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
-## [2.0.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.6...gatsby-transformer-xml@2.0.7) (2019-02-01)
+## [2.0.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.6...gatsby-transformer-xml@2.0.7) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.6"></a>
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.5...gatsby-transformer-xml@2.0.6) (2019-01-08)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.5...gatsby-transformer-xml@2.0.6) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.5"></a>
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.4...gatsby-transformer-xml@2.0.5) (2018-11-29)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.4...gatsby-transformer-xml@2.0.5) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.3...gatsby-transformer-xml@2.0.4) (2018-11-08)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.3...gatsby-transformer-xml@2.0.4) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.2...gatsby-transformer-xml@2.0.3) (2018-10-29)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.2...gatsby-transformer-xml@2.0.3) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.1...gatsby-transformer-xml@2.0.2) (2018-10-04)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.1...gatsby-transformer-xml@2.0.2) (2018-10-04)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0...gatsby-transformer-xml@2.0.1) (2018-10-02)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0...gatsby-transformer-xml@2.0.1) (2018-10-02)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-rc.6...gatsby-transformer-xml@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-rc.6...gatsby-transformer-xml@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-rc.6"></a>
 
-# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-rc.5...gatsby-transformer-xml@2.0.0-rc.6) (2018-09-11)
+# [2.0.0-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-rc.5...gatsby-transformer-xml@2.0.0-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-rc.5"></a>
 
-# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-rc.4...gatsby-transformer-xml@2.0.0-rc.5) (2018-09-11)
+# [2.0.0-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-rc.4...gatsby-transformer-xml@2.0.0-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-rc.4"></a>
 
-# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-rc.3...gatsby-transformer-xml@2.0.0-rc.4) (2018-09-11)
+# [2.0.0-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-rc.3...gatsby-transformer-xml@2.0.0-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-rc.2...gatsby-transformer-xml@2.0.0-rc.3) (2018-09-11)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-rc.2...gatsby-transformer-xml@2.0.0-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-rc.1...gatsby-transformer-xml@2.0.0-rc.2) (2018-09-05)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-rc.1...gatsby-transformer-xml@2.0.0-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-rc.0...gatsby-transformer-xml@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-rc.0...gatsby-transformer-xml@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-beta.3...gatsby-transformer-xml@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-beta.3...gatsby-transformer-xml@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-beta.2...gatsby-transformer-xml@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-beta.2...gatsby-transformer-xml@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-beta.1...gatsby-transformer-xml@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-beta.1...gatsby-transformer-xml@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@2.0.0-beta.0...gatsby-transformer-xml@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@2.0.0-beta.0...gatsby-transformer-xml@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-xml
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml/compare/gatsby-transformer-xml@1.0.15...gatsby-transformer-xml@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-xml@1.0.15...gatsby-transformer-xml@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-xml

--- a/packages/gatsby-transformer-yaml/CHANGELOG.md
+++ b/packages/gatsby-transformer-yaml/CHANGELOG.md
@@ -7,136 +7,136 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
-# [2.2.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.12...gatsby-transformer-yaml@2.2.0) (2019-06-20)
+# [2.2.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.12...gatsby-transformer-yaml@2.2.0) (2019-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
-## [2.1.12](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.11...gatsby-transformer-yaml@2.1.12) (2019-04-24)
+## [2.1.12](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.11...gatsby-transformer-yaml@2.1.12) (2019-04-24)
 
 ### Features
 
-- **gatsby-transformer-yaml:** support typeName ([#13563](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/issues/13563)) ([80c07e6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/commit/80c07e6))
+- **gatsby-transformer-yaml:** support typeName ([#13563](https://github.com/gatsbyjs/gatsby/issues/13563)) ([80c07e6](https://github.com/gatsbyjs/gatsby/commit/80c07e6))
 
-## [2.1.11](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.10...gatsby-transformer-yaml@2.1.11) (2019-03-25)
-
-**Note:** Version bump only for package gatsby-transformer-yaml
-
-## [2.1.10](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.9...gatsby-transformer-yaml@2.1.10) (2019-03-11)
+## [2.1.11](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.10...gatsby-transformer-yaml@2.1.11) (2019-03-25)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
-## [2.1.9](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.8...gatsby-transformer-yaml@2.1.9) (2019-03-11)
+## [2.1.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.9...gatsby-transformer-yaml@2.1.10) (2019-03-11)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
-## [2.1.8](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.7...gatsby-transformer-yaml@2.1.8) (2019-02-01)
+## [2.1.9](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.8...gatsby-transformer-yaml@2.1.9) (2019-03-11)
+
+**Note:** Version bump only for package gatsby-transformer-yaml
+
+## [2.1.8](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.7...gatsby-transformer-yaml@2.1.8) (2019-02-01)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.7"></a>
 
-## [2.1.7](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.6...gatsby-transformer-yaml@2.1.7) (2019-01-08)
+## [2.1.7](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.6...gatsby-transformer-yaml@2.1.7) (2019-01-08)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.6"></a>
 
-## [2.1.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.5...gatsby-transformer-yaml@2.1.6) (2018-11-29)
+## [2.1.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.5...gatsby-transformer-yaml@2.1.6) (2018-11-29)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.5"></a>
 
-## [2.1.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.4...gatsby-transformer-yaml@2.1.5) (2018-11-08)
+## [2.1.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.4...gatsby-transformer-yaml@2.1.5) (2018-11-08)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.4"></a>
 
-## [2.1.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.3...gatsby-transformer-yaml@2.1.4) (2018-10-29)
+## [2.1.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.3...gatsby-transformer-yaml@2.1.4) (2018-10-29)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.3"></a>
 
-## [2.1.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.2...gatsby-transformer-yaml@2.1.3) (2018-10-09)
+## [2.1.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.2...gatsby-transformer-yaml@2.1.3) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.2"></a>
 
-## [2.1.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1...gatsby-transformer-yaml@2.1.2) (2018-10-09)
+## [2.1.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1...gatsby-transformer-yaml@2.1.2) (2018-10-09)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1"></a>
 
-## [2.1.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-rc.6...gatsby-transformer-yaml@2.1.1) (2018-09-17)
+## [2.1.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-rc.6...gatsby-transformer-yaml@2.1.1) (2018-09-17)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-rc.6"></a>
 
-## [2.1.1-rc.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-rc.5...gatsby-transformer-yaml@2.1.1-rc.6) (2018-09-11)
+## [2.1.1-rc.6](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-rc.5...gatsby-transformer-yaml@2.1.1-rc.6) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-rc.5"></a>
 
-## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-rc.4...gatsby-transformer-yaml@2.1.1-rc.5) (2018-09-11)
+## [2.1.1-rc.5](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-rc.4...gatsby-transformer-yaml@2.1.1-rc.5) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-rc.4"></a>
 
-## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-rc.3...gatsby-transformer-yaml@2.1.1-rc.4) (2018-09-11)
+## [2.1.1-rc.4](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-rc.3...gatsby-transformer-yaml@2.1.1-rc.4) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-rc.3"></a>
 
-## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-rc.2...gatsby-transformer-yaml@2.1.1-rc.3) (2018-09-11)
+## [2.1.1-rc.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-rc.2...gatsby-transformer-yaml@2.1.1-rc.3) (2018-09-11)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-rc.2"></a>
 
-## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-rc.1...gatsby-transformer-yaml@2.1.1-rc.2) (2018-09-05)
+## [2.1.1-rc.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-rc.1...gatsby-transformer-yaml@2.1.1-rc.2) (2018-09-05)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-rc.1"></a>
 
-## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-rc.0...gatsby-transformer-yaml@2.1.1-rc.1) (2018-08-29)
+## [2.1.1-rc.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-rc.0...gatsby-transformer-yaml@2.1.1-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-rc.0"></a>
 
-## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-beta.3...gatsby-transformer-yaml@2.1.1-rc.0) (2018-08-21)
+## [2.1.1-rc.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-beta.3...gatsby-transformer-yaml@2.1.1-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-beta.3"></a>
 
-## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-beta.2...gatsby-transformer-yaml@2.1.1-beta.3) (2018-07-21)
+## [2.1.1-beta.3](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-beta.2...gatsby-transformer-yaml@2.1.1-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-beta.2"></a>
 
-## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-beta.1...gatsby-transformer-yaml@2.1.1-beta.2) (2018-06-20)
+## [2.1.1-beta.2](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-beta.1...gatsby-transformer-yaml@2.1.1-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-beta.1"></a>
 
-## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@2.1.1-beta.0...gatsby-transformer-yaml@2.1.1-beta.1) (2018-06-17)
+## [2.1.1-beta.1](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@2.1.1-beta.0...gatsby-transformer-yaml@2.1.1-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-yaml
 
 <a name="2.1.1-beta.0"></a>
 
-## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml/compare/gatsby-transformer-yaml@1.5.18...gatsby-transformer-yaml@2.1.1-beta.0) (2018-06-17)
+## [2.1.1-beta.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-transformer-yaml@1.5.18...gatsby-transformer-yaml@2.1.1-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package gatsby-transformer-yaml

--- a/packages/graphql-skip-limit/CHANGELOG.md
+++ b/packages/graphql-skip-limit/CHANGELOG.md
@@ -7,96 +7,96 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package graphql-skip-limit
 
-# [2.1.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.6...graphql-skip-limit@2.1.0) (2019-06-20)
+# [2.1.0](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.6...graphql-skip-limit@2.1.0) (2019-06-20)
 
 **Note:** Version bump only for package graphql-skip-limit
 
-## [2.0.6](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.5...graphql-skip-limit@2.0.6) (2019-03-11)
+## [2.0.6](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.5...graphql-skip-limit@2.0.6) (2019-03-11)
 
 **Note:** Version bump only for package graphql-skip-limit
 
-## [2.0.5](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.4...graphql-skip-limit@2.0.5) (2019-02-01)
+## [2.0.5](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.4...graphql-skip-limit@2.0.5) (2019-02-01)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.4"></a>
 
-## [2.0.4](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.3...graphql-skip-limit@2.0.4) (2018-12-17)
+## [2.0.4](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.3...graphql-skip-limit@2.0.4) (2018-12-17)
 
 ### Bug Fixes
 
-- **graphql-skip-limit:** fix hasNextPage ([#10504](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/issues/10504)) ([ea56c49](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/commit/ea56c49))
+- **graphql-skip-limit:** fix hasNextPage ([#10504](https://github.com/gatsbyjs/gatsby/issues/10504)) ([ea56c49](https://github.com/gatsbyjs/gatsby/commit/ea56c49))
 
 <a name="2.0.3"></a>
 
-## [2.0.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.2...graphql-skip-limit@2.0.3) (2018-12-07)
+## [2.0.3](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.2...graphql-skip-limit@2.0.3) (2018-12-07)
 
 ### Bug Fixes
 
-- **graphql-skip-limit:** declare `graphql` peer dependency ([#10305](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/issues/10305)) ([b62159a](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/commit/b62159a))
+- **graphql-skip-limit:** declare `graphql` peer dependency ([#10305](https://github.com/gatsbyjs/gatsby/issues/10305)) ([b62159a](https://github.com/gatsbyjs/gatsby/commit/b62159a))
 
 <a name="2.0.2"></a>
 
-## [2.0.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.1...graphql-skip-limit@2.0.2) (2018-11-29)
+## [2.0.2](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.1...graphql-skip-limit@2.0.2) (2018-11-29)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0...graphql-skip-limit@2.0.1) (2018-10-29)
+## [2.0.1](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0...graphql-skip-limit@2.0.1) (2018-10-29)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0"></a>
 
-# [2.0.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-rc.3...graphql-skip-limit@2.0.0) (2018-09-17)
+# [2.0.0](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-rc.3...graphql-skip-limit@2.0.0) (2018-09-17)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-rc.3"></a>
 
-# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-rc.2...graphql-skip-limit@2.0.0-rc.3) (2018-08-31)
+# [2.0.0-rc.3](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-rc.2...graphql-skip-limit@2.0.0-rc.3) (2018-08-31)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-rc.2"></a>
 
-# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-rc.1...graphql-skip-limit@2.0.0-rc.2) (2018-08-29)
+# [2.0.0-rc.2](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-rc.1...graphql-skip-limit@2.0.0-rc.2) (2018-08-29)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-rc.1"></a>
 
-# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-rc.0...graphql-skip-limit@2.0.0-rc.1) (2018-08-29)
+# [2.0.0-rc.1](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-rc.0...graphql-skip-limit@2.0.0-rc.1) (2018-08-29)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-rc.0"></a>
 
-# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-beta.3...graphql-skip-limit@2.0.0-rc.0) (2018-08-21)
+# [2.0.0-rc.0](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-beta.3...graphql-skip-limit@2.0.0-rc.0) (2018-08-21)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-beta.3"></a>
 
-# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-beta.2...graphql-skip-limit@2.0.0-beta.3) (2018-07-21)
+# [2.0.0-beta.3](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-beta.2...graphql-skip-limit@2.0.0-beta.3) (2018-07-21)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-beta.2"></a>
 
-# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-beta.1...graphql-skip-limit@2.0.0-beta.2) (2018-06-20)
+# [2.0.0-beta.2](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-beta.1...graphql-skip-limit@2.0.0-beta.2) (2018-06-20)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-beta.1"></a>
 
-# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@2.0.0-beta.0...graphql-skip-limit@2.0.0-beta.1) (2018-06-17)
+# [2.0.0-beta.1](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@2.0.0-beta.0...graphql-skip-limit@2.0.0-beta.1) (2018-06-17)
 
 **Note:** Version bump only for package graphql-skip-limit
 
 <a name="2.0.0-beta.0"></a>
 
-# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit/compare/graphql-skip-limit@1.0.11...graphql-skip-limit@2.0.0-beta.0) (2018-06-17)
+# [2.0.0-beta.0](https://github.com/gatsbyjs/gatsby/compare/graphql-skip-limit@1.0.11...graphql-skip-limit@2.0.0-beta.0) (2018-06-17)
 
 **Note:** Version bump only for package graphql-skip-limit


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
#15477 fixed the cause of broken links in all the package changelogs. This fixes those existing links to work correctly. 

used a regex to capture the ("/tree/master/packages/[a-z,-]+?/") and replaced with "/".

## Related Issues
#15477 
#12755
