### PR TITLE
Fix(www): uppercase breadcrumbTitles and change separator to ChevronLeft

### DIFF
--- a/www/src/components/docs-breadcrumb.js
+++ b/www/src/components/docs-breadcrumb.js
@@ -45,7 +45,7 @@ const Breadcrumb = ({ itemList, location }) => {
           {topLevelTitle}
         </BreadcrumbNav>
         <BreadcrumbNav mobile>
-          <Separator character="<" />
+          <Separator character={<ChevronLeft />} />
           <Link to="/">Home</Link>
         </BreadcrumbNav>
       </>

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -77,7 +77,7 @@
               breadcrumbTitle: Babel Plugin Macros
             - title: Adding a Custom Webpack Config
               link: /docs/add-custom-webpack-config/
-              breadcrumbTitle: webpack Config
+              breadcrumbTitle: Webpack Config
             - title: Customizing html.js
               link: /docs/custom-html/
               breadcrumbTitle: html.js
@@ -145,7 +145,7 @@
                   breadcrumbTitle: Netlify CMS
                 - title: Sourcing from WordPress
                   link: /docs/sourcing-from-wordpress/
-                  breadcrumbTitle: Wordpress
+                  breadcrumbTitle: WordPress
                 - title: Sourcing from Prismic
                   link: /docs/sourcing-from-prismic/
                   breadcrumbTitle: Prismic


### PR DESCRIPTION
## Description

Fixes breadcrumb titles and change separator to ChevronLeft

## Related Issues

introduced in #15165
