### PR TITLE
fix(gatsby-plugin-mdx): Fix Safari 9 `const` syntax error

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-scopes.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-scopes.js
@@ -12,7 +12,7 @@ module.exports = function() {
     files
       .map(
         (file, i) =>
-          `const scope_${i} = require('${slash(
+          `var scope_${i} = require('${slash(
             path.join(abs, file)
           )}').default;`
       )


### PR DESCRIPTION
## Description

Gatsby sites using mdx, break in Safari 9 (possibly other older browsers) because it's using es6 `const`.

`SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.`
<img width="1181" alt="Dashboard" src="https://user-images.githubusercontent.com/1545577/61083487-453c9980-a402-11e9-9881-0dc22bd33060.png">



