### PR TITLE
fix(www): Prevent Breadcrumbs from breaking builds 

### DIFF
--- a/www/src/components/docs-breadcrumb.js
+++ b/www/src/components/docs-breadcrumb.js
@@ -29,6 +29,9 @@ const BreadcrumbNav = ({ children, mobile = false }) => (
 )
 
 const Breadcrumb = ({ itemList, location }) => {
+  // provide escape if no itemList is provided so breadcrumb isn't rendered
+  if (itemList === undefined) return null
+
   const activeItem = getActiveItem(itemList.items, location, undefined)
   const activeItemParents = getActiveItemParents(itemList.items, activeItem, [])
   const topLevel = itemList.key

--- a/www/src/pages/docs/index.js
+++ b/www/src/pages/docs/index.js
@@ -23,7 +23,10 @@ class IndexRoute extends React.Component {
                 content="The one stop location for tutorials, guides, and information about building with Gatsby"
               />
             </Helmet>
-            <Breadcrumb itemList={itemListDocs} location={location} />
+            <Breadcrumb
+              itemList={itemListDocs}
+              location={this.props.location}
+            />
             <h1 id="gatsby-documentation" css={{ marginTop: 0 }}>
               Gatsby.js Documentation
             </h1>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Breadcrumbs don't break builds now, hooray! 🎉 
