### PR TITLE
[blog] remove duplicate image

### DIFF
--- a/docs/blog/2019-07-11-user-testing-accessible-client-routing/index.md
+++ b/docs/blog/2019-07-11-user-testing-accessible-client-routing/index.md
@@ -1,6 +1,5 @@
 ---
 title: What we learned from user testing of accessible client-side routing techniques with Fable Tech Labs
-image: "./images/magnification-a11y.png"
 author: Marcy Sutton
 date: 2019-07-11
 excerpt: "We conducted 5 user testing sessions for accessibility research with Fable Tech Labs to determine which client-side routing techniques are the most ergonomic and intuitive to users with disabilities, and if any of the techniques presented barriers detracting from their browsing experience."


### PR DESCRIPTION
## Description

I added an image to my blog post thinking it would act as a social sharing image, but I didn't realize it would be duplicating content. This PR removes the image reference from frontmatter and uses the one in the body of the post instead.

## Related Issues

N/A