### PR TITLE
fix(babel-preset-gatsby): Add babel-plugin-dynamic-import-node for tests

### DIFF
--- a/jest-transformer.js
+++ b/jest-transformer.js
@@ -1,5 +1,2 @@
 const babelPreset = require(`babel-preset-gatsby-package`)()
-module.exports = require(`babel-jest`).createTransformer({
-  ...babelPreset,
-  plugins: [...babelPreset.plugins, `babel-plugin-dynamic-import-node`],
-})
+module.exports = require(`babel-jest`).createTransformer(babelPreset)

--- a/jest-transformer.js
+++ b/jest-transformer.js
@@ -1,2 +1,5 @@
 const babelPreset = require(`babel-preset-gatsby-package`)()
-module.exports = require(`babel-jest`).createTransformer(babelPreset)
+module.exports = require(`babel-jest`).createTransformer({
+  ...babelPreset,
+  plugins: [...babelPreset.plugins, `babel-plugin-dynamic-import-node`],
+})

--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -64,6 +64,7 @@ Array [
   "@babel/plugin-proposal-optional-chaining",
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",
+  "babel-plugin-dynamic-import-node",
 ]
 `;
 
@@ -123,6 +124,7 @@ Array [
   "@babel/plugin-proposal-optional-chaining",
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",
+  "babel-plugin-dynamic-import-node",
 ]
 `;
 

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -4,12 +4,13 @@ function preset(context, options = {}) {
   const { browser = false, debug = false, nodeVersion = `8.0` } = options
   const { NODE_ENV, BABEL_ENV } = process.env
 
-  const PRODUCTION = (BABEL_ENV || NODE_ENV) === `production`
+  const IS_PRODUCTION = (BABEL_ENV || NODE_ENV) === `production`
+  const IS_TEST  = (BABEL_ENV || NODE_ENV) === `test`
 
   const browserConfig = {
     useBuiltIns: false,
     targets: {
-      browsers: PRODUCTION
+      browsers: IS_PRODUCTION
         ? [`last 4 versions`, `safari >= 7`, `ie >= 9`]
         : [`last 2 versions`, `not ie <= 11`, `not android 4.4.3`],
     },
@@ -17,7 +18,7 @@ function preset(context, options = {}) {
 
   const nodeConfig = {
     targets: {
-      node: PRODUCTION ? nodeVersion : `current`,
+      node: IS_PRODUCTION ? nodeVersion : `current`,
     },
   }
 
@@ -36,7 +37,7 @@ function preset(context, options = {}) {
           browser ? browserConfig : nodeConfig
         ),
       ],
-      [r(`@babel/preset-react`), { development: !PRODUCTION }],
+      [r(`@babel/preset-react`), { development: !IS_PRODUCTION }],
       r(`@babel/preset-flow`),
     ],
     plugins: [
@@ -44,7 +45,8 @@ function preset(context, options = {}) {
       r(`@babel/plugin-proposal-optional-chaining`),
       r(`@babel/plugin-transform-runtime`),
       r(`@babel/plugin-syntax-dynamic-import`),
-    ],
+      IS_TEST && r(`babel-plugin-dynamic-import-node`)
+    ].filter(Boolean),
   }
 }
 

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -15,7 +15,8 @@
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-flow": "^7.0.0",
-    "@babel/preset-react": "^7.0.0"
+    "@babel/preset-react": "^7.0.0",
+    "babel-plugin-dynamic-import-node": "^1.2.0"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -15,7 +15,8 @@
     "@babel/preset-env": "^7.4.1",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
-    "babel-plugin-macros": "^2.4.2"
+    "babel-plugin-macros": "^2.4.2",
+    "babel-plugin-dynamic-import-node": "^1.2.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"
@@ -29,7 +30,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
-    "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-preset-gatsby-package": "^0.2.1",
     "cross-env": "^5.1.4"
   },

--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
+    "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-preset-gatsby-package": "^0.2.1",
     "cross-env": "^5.1.4"
   },

--- a/packages/babel-preset-gatsby/src/__tests__/index.js
+++ b/packages/babel-preset-gatsby/src/__tests__/index.js
@@ -50,6 +50,7 @@ it(`Specifies proper presets and plugins for test stage`, () => {
         useESModules: false,
       },
     ],
+    expect.stringContaining(`babel-plugin-dynamic-import-node`),
   ])
 })
 
@@ -111,6 +112,7 @@ it(`Specifies proper presets and plugins for build-html stage`, () => {
         useESModules: true,
       },
     ],
+    expect.stringContaining(`babel-plugin-dynamic-import-node`),
   ])
 })
 

--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -2,9 +2,11 @@ const path = require(`path`)
 
 const resolve = m => require.resolve(m)
 
+const IS_TEST = process.env.NODE_ENV === `test`
+
 const loadCachedConfig = () => {
   let pluginBabelConfig = {}
-  if (process.env.NODE_ENV !== `test`) {
+  if (!IS_TEST) {
     try {
       pluginBabelConfig = require(path.join(
         process.cwd(),
@@ -85,6 +87,7 @@ module.exports = function preset(_, options = {}) {
           absoluteRuntimePath,
         },
       ],
-    ],
+      IS_TEST && resolve(`babel-plugin-dynamic-import-node`),
+    ].filter(Boolean),
   }
 }

--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -2,7 +2,7 @@ const path = require(`path`)
 
 const resolve = m => require.resolve(m)
 
-const IS_TEST = process.env.NODE_ENV === `test`
+const IS_TEST = (process.env.BABEL_ENV || process.env.NODE_ENV) === `test`
 
 const loadCachedConfig = () => {
   let pluginBabelConfig = {}


### PR DESCRIPTION
Node 8 (which we still support) doesn't understand dynamic imports. While it's okay to keep these untranspiled (like in `gatsby-image/withIEPolyfill`) because webpack will handle them anyway, this breaks tests run on Node 8 (https://circleci.com/gh/gatsbyjs/gatsby/169116?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). 

To fix this, we need to conditionally transpile these to deferred requires for Node in test environments. This PR does that for this monorepo's jest config and for `babel-preset-gatsby` which we recommend in https://www.gatsbyjs.org/docs/unit-testing/