### PR TITLE
docs(blog): Fix typos in old posts

### DIFF
--- a/docs/blog/2017-10-29-my-search-for-the-perfect-universal-javaScript-framework/index.md
+++ b/docs/blog/2017-10-29-my-search-for-the-perfect-universal-javaScript-framework/index.md
@@ -60,7 +60,7 @@ similar and supports both SSR for dynamic content and exporting to static pages.
 And don't forget [Netlify](https://www.netlify.com) who is doing an amazing job
 at building and hosting static websites.
 
-It is so much easier and fun to code for the web today. I would haved saved a
+It is so much easier and fun to code for the web today. I would have saved a
 lot of development/devops hours at my previous startup just by using Gatsby. And
 the most fun fact about Gatsby is these aren’t modern ideas at all - it's just
 static websites done right.

--- a/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
+++ b/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
@@ -77,7 +77,7 @@ The only work I had to do on the content migration was to reformat the
 [frontmatter](https://gohugo.io/content-management/front-matter/). In Hugo, I
 used TOML, whereas `gatsby-transformer-remark` works only with YAML for the
 moment. Luckily, I still had the Hugo CLI on my system so could make use of its
-[build-in conversion tool](https://gohugo.io/commands/hugo_convert_toyaml/). The
+[built-in conversion tool](https://gohugo.io/commands/hugo_convert_toyaml/). The
 only issue I had was that sometimes titles were longer than 1 line and were not
 parse-able, so I just had to cut some words out where problematic.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I found a couple of possible typo in the blog:
* `haved` -> `have`
* `build-in` -> `built-in`
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

There are no related issue filed toward this. I found this while going through the blog posts (I have been reading up a couple of them everyday)
If this fix isn't necessary please let me know and I'll close the PR (^_^)

:octocat: 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
