### PR TITLE
chore: Upgrade lodash for prototype pollution fix 

### DIFF
--- a/.github/actions/high-priority-prs/package.json
+++ b/.github/actions/high-priority-prs/package.json
@@ -11,7 +11,7 @@
     "actions-toolkit": "^2.0.0",
     "array-to-sentence": "^2.0.0",
     "date-fns": "^1.30.1",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "jest": "^24.8.0"

--- a/benchmarks/query/package.json
+++ b/benchmarks/query/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "faker": "^4.1.0",
     "gatsby": "^2.0.118",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/examples/client-only-paths/package.json
+++ b/examples/client-only-paths/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "gatsby": "^2.0.0",
     "gatsby-plugin-typography": "^2.2.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-transition-group": "^2.4.0",

--- a/examples/gatsbygram/package.json
+++ b/examples/gatsbygram/package.json
@@ -19,7 +19,7 @@
     "gatsby-transformer-sharp": "^2.1.1",
     "glamor": "^2.20.40",
     "instagram-screen-scrape": "^2.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "mkdirp": "^0.5.1",
     "mousetrap": "^1.6.0",
     "progress": "^2.0.0",

--- a/examples/hn/package.json
+++ b/examples/hn/package.json
@@ -9,7 +9,7 @@
     "gatsby": "^2.0.0",
     "gatsby-plugin-manifest": "^2.0.2",
     "gatsby-source-hacker-news": "^2.0.5",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "slash": "^2.0.0"

--- a/examples/no-plugins/package.json
+++ b/examples/no-plugins/package.json
@@ -6,7 +6,7 @@
   "author": "Scotty Eckenthal <scott.eckenthal@gmail.com>",
   "dependencies": {
     "gatsby": "^2.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "slash": "^1.0.0"

--- a/examples/no-trailing-slashes/package.json
+++ b/examples/no-trailing-slashes/package.json
@@ -8,7 +8,7 @@
     "gatsby": "^2.0.0",
     "gatsby-plugin-google-analytics": "^2.0.5",
     "gatsby-plugin-offline": "^2.0.5",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "slash": "^1.0.0"

--- a/examples/using-asciidoc/package.json
+++ b/examples/using-asciidoc/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-typography": "^2.2.0",
     "gatsby-source-filesystem": "^2.0.1",
     "gatsby-transformer-asciidoc": "^1.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-typography": "^0.16.13",

--- a/examples/using-contentful/package.json
+++ b/examples/using-contentful/package.json
@@ -12,7 +12,7 @@
     "gatsby-plugin-typography": "^2.2.0",
     "gatsby-source-contentful": "^2.0.1",
     "gatsby-transformer-remark": "^2.1.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-typography": "^0.16.3",

--- a/examples/using-cxs/package.json
+++ b/examples/using-cxs/package.json
@@ -12,7 +12,7 @@
     "gatsby-plugin-offline": "^2.0.25",
     "gatsby-plugin-react-helmet": "^3.0.12",
     "gatsby-plugin-typography": "^2.2.13",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",

--- a/examples/using-drupal/package.json
+++ b/examples/using-drupal/package.json
@@ -16,7 +16,7 @@
     "gatsby-transformer-sharp": "^2.1.1",
     "glamor": "^2.20.40",
     "gray-percentage": "^2.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-icons": "^2.2.7",

--- a/examples/using-emotion-prismjs/package.json
+++ b/examples/using-emotion-prismjs/package.json
@@ -22,7 +22,7 @@
     "gatsby-remark-prismjs": "^3.2.8",
     "gatsby-source-filesystem": "^2.0.29",
     "gatsby-transformer-remark": "^2.3.8",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "prismjs": "^1.16.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/examples/using-glamor/package.json
+++ b/examples/using-glamor/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-typography": "^2.2.0",
     "glamor": "^2.20.40",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-typography": "^0.16.13",

--- a/examples/using-prefetching-preloading-modules/package.json
+++ b/examples/using-prefetching-preloading-modules/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-styled-components": "^3.0.0",
     "gatsby-plugin-typography": "^2.2.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-helmet": "^5.2.0",

--- a/examples/using-remark-copy-linked-files/package.json
+++ b/examples/using-remark-copy-linked-files/package.json
@@ -18,7 +18,7 @@
     "gatsby-source-filesystem": "^2.0.29",
     "gatsby-transformer-remark": "^2.3.8",
     "gatsby-transformer-sharp": "^2.1.18",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "prismjs": "^1.16.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/examples/using-remark/package.json
+++ b/examples/using-remark/package.json
@@ -28,7 +28,7 @@
     "gatsby-transformer-yaml": "^2.1.11",
     "glamor": "^2.20.40",
     "katex": "^0.10.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "lodash-id": "^0.14.0",
     "lodash-webpack-plugin": "^0.11.5",
     "prismjs": "^1.16.0",

--- a/examples/using-styled-components/package.json
+++ b/examples/using-styled-components/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-offline": "^2.0.21",
     "gatsby-plugin-react-helmet": "^3.0.5",
     "gatsby-plugin-styled-components": "^3.0.4",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-helmet": "^5.2.0",

--- a/examples/using-wordpress/package.json
+++ b/examples/using-wordpress/package.json
@@ -14,7 +14,7 @@
     "gatsby-source-wordpress": "^3.0.0",
     "gatsby-transformer-sharp": "^2.1.1",
     "glamor": "^2.20.40",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0",

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -29,7 +29,7 @@
     "gatsby-telemetry": "^1.1.5",
     "hosted-git-info": "^2.6.0",
     "is-valid-path": "^0.1.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "meant": "^1.0.1",
     "node-fetch": "^2.6.0",
     "object.entries": "^1.1.0",

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -18,7 +18,7 @@
     "find-yarn-workspace-root": "^1.2.1",
     "fs-extra": "^4.0.1",
     "is-absolute": "^0.2.6",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "request": "2.88.0",
     "signal-exit": "^3.0.2",
     "verdaccio": "^3.11.1",

--- a/packages/gatsby-page-utils/package.json
+++ b/packages/gatsby-page-utils/package.json
@@ -25,7 +25,7 @@
     "chokidar": "2.1.2",
     "fs-exists-cached": "^1.0.0",
     "glob": "^7.1.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "micromatch": "^3.1.10",
     "slash": "^1.0.0"
   },

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -30,7 +30,7 @@
     "fs-extra": "^7.0.0",
     "gray-matter": "^4.0.1",
     "loader-utils": "^1.2.3",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "mdast-util-to-string": "^1.0.4",
     "mdast-util-toc": "^3.0.0",
     "mime": "^2.3.1",

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -10,7 +10,7 @@
     "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
     "html-webpack-exclude-assets-plugin": "^0.0.7",
     "html-webpack-plugin": "^3.2.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "mini-css-extract-plugin": "^0.4.1",
     "netlify-identity-widget": "^1.4.11",
     "webpack": "^4.16.0"

--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -16,7 +16,7 @@
     "@babel/runtime": "^7.0.0",
     "fs-extra": "^4.0.2",
     "kebab-hash": "^0.1.2",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "webpack-assets-manifest": "^3.0.2"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "cheerio": "^1.0.0-rc.2",
     "idb-keyval": "^3.1.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "slash": "^3.0.0",
     "workbox-build": "^3.6.3"
   },

--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -29,7 +29,7 @@
     "fs-exists-cached": "^1.0.0",
     "gatsby-page-utils": "^0.0.4",
     "glob": "^7.1.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "micromatch": "^3.1.10"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -16,7 +16,7 @@
     "imagemin-mozjpeg": "^8.0.0",
     "imagemin-pngquant": "^6.0.0",
     "imagemin-webp": "^5.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "mini-svg-data-uri": "^1.0.0",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",

--- a/packages/gatsby-remark-autolink-headers/package.json
+++ b/packages/gatsby-remark-autolink-headers/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "github-slugger": "^1.1.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "mdast-util-to-string": "^1.0.2",
     "unist-util-visit": "^1.3.0"
   },

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -11,7 +11,7 @@
     "cheerio": "^1.0.0-rc.2",
     "fs-extra": "^4.0.1",
     "is-relative-url": "^2.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "path-is-inside": "^1.0.2",
     "probe-image-size": "^4.0.0",
     "unist-util-visit": "^1.3.0"

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -19,7 +19,7 @@
     "axios": "^0.19.0",
     "cheerio": "^1.0.0-rc.2",
     "is-relative-url": "^2.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "semver": "^5.6.0",
     "sharp": "^0.22.1",
     "unist-util-select": "^1.5.0"

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "cheerio": "^1.0.0-rc.2",
     "is-relative-url": "^2.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "mdast-util-definitions": "^1.2.0",
     "potrace": "^2.1.1",
     "query-string": "^6.1.0",

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",
     "cheerio": "^1.0.0-rc.2",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "unist-util-visit": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -20,7 +20,7 @@
     "gatsby-source-filesystem": "^2.1.5",
     "is-online": "^7.0.0",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "qs": "^6.4.0"
   },
   "devDependencies": {

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -12,7 +12,7 @@
     "bluebird": "^3.5.0",
     "body-parser": "^1.19.0",
     "gatsby-source-filesystem": "^2.1.5",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "tiny-async-pool": "^1.0.4"
   },
   "devDependencies": {

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "axios": "^0.19.0",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -14,7 +14,7 @@
     "deep-map": "^1.5.0",
     "deep-map-keys": "^1.2.0",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.14"
   },
   "deprecated": false,
   "devDependencies": {

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -38,7 +38,7 @@
     "gatsby-node-helpers": "^0.3.0",
     "gatsby-source-filesystem": "^2.1.5",
     "graphql-request": "^1.6.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.14",
     "p-iteration": "^1.1.7",
     "prettyjson": "^1.2.1"
   },

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -16,7 +16,7 @@
     "deep-map-keys": "^1.2.0",
     "gatsby-source-filesystem": "^2.1.5",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
     "qs": "^6.4.0"
   },

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -17,7 +17,7 @@
     "fs-extra": "^7.0.1",
     "git-up": "4.0.1",
     "is-docker": "1.1.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "node-fetch": "2.3.0",
     "resolve-cwd": "^2.0.0",
     "source-map": "^0.5.7",

--- a/packages/gatsby-transformer-asciidoc/package.json
+++ b/packages/gatsby-transformer-asciidoc/package.json
@@ -15,7 +15,7 @@
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.2.2",
     "cross-env": "^5.1.4",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.14"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc#readme",
   "keywords": [

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -19,7 +19,7 @@
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.2.2",
     "cross-env": "^5.1.4",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.14"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen#readme",
   "keywords": [

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -12,7 +12,7 @@
     "gray-matter": "^4.0.0",
     "hast-util-raw": "^4.0.0",
     "hast-util-to-html": "^4.0.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "mdast-util-to-hast": "^3.0.0",
     "mdast-util-to-string": "^1.0.5",
     "mdast-util-toc": "^2.0.1",

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "xml-parser": "^1.2.1"
   },
   "devDependencies": {

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "js-yaml": "^3.13.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "unist-util-select": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -85,7 +85,7 @@
     "jest-worker": "^23.2.0",
     "json-loader": "^0.5.7",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "md5": "^2.2.1",
     "md5-file": "^3.1.1",
     "micromatch": "^3.1.10",

--- a/scripts/site-up-checker/package.json
+++ b/scripts/site-up-checker/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "discord.js": "^11.1.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "request": "^2.81.0",
     "request-promise": "^4.2.0",
     "webhook-discord": "^2.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13817,6 +13817,11 @@ lodash@^4.11.1, lodash@^4.11.2, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10,
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
+lodash@^4.17.14:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"


### PR DESCRIPTION
## Description

As [reported by Snyk](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/) about the prototype pollution in lodash 4.17.11 and lower version, we should upgrade it to 4.17.14 version (https://github.com/lodash/lodash/issues/4348#issuecomment-509716822) which will fix the issue.

Note: Should I run `yarn-deduplicate` for lodash so that we can keep the dependency flat? (I was taught by @JLHwung about this in https://github.com/babel/babel/pull/10191#discussion_r302025078)

## Related Issues

Related to #15621 