### PR TITLE
feat(gatsby-transformer-remark): Allow remark subplugins to modify graphql types owned by parent plugin

### DIFF
--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -43,7 +43,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.88"
+    "gatsby": "^2.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -1,6 +1,7 @@
 const { graphql } = require(`gatsby/graphql`)
 const { onCreateNode } = require(`../gatsby-node`)
 const extendNodeType = require(`../extend-node-type`)
+const { typeDefs } = require(`../create-schema-customization`)
 const { createContentDigest } = require(`gatsby/utils`)
 
 // given a set of nodes and a query, return the result of the query
@@ -39,6 +40,7 @@ async function queryResult(
   const typeName = `MarkdownRemark`
   const sc = createSchemaComposer()
   const tc = sc.createObjectTC(typeName)
+  sc.addTypeDefs(typeDefs)
   addInferredFields({
     schemaComposer: sc,
     typeComposer: tc,
@@ -53,11 +55,11 @@ async function queryResult(
   const result = await graphql(
     schema,
     `query {
-            listNode {
-                ${fragment}
-            }
-          }
-        `
+        listNode {
+            ${fragment}
+        }
+      }
+    `
   )
   return result
 }

--- a/packages/gatsby-transformer-remark/src/create-schema-customization.js
+++ b/packages/gatsby-transformer-remark/src/create-schema-customization.js
@@ -1,0 +1,48 @@
+const typeDefs = `
+  type MarkdownHeading {
+    value: String
+    depth: Int
+  }
+
+  enum MarkdownHeadingLevels {
+    h1
+    h2
+    h3
+    h4
+    h5
+    h6
+  }
+
+  enum MarkdownExcerptFormats {
+    PLAIN
+    HTML
+    MARKDOWN
+  }
+
+  type MarkdownWordCount {
+    paragraphs: Int
+    sentences: Int
+    words: Int
+  }
+`
+
+module.exports = (nodeApiArgs, pluginOptions = {}) => {
+  const { plugins = [] } = pluginOptions
+
+  nodeApiArgs.actions.createTypes(typeDefs)
+
+  // This allows subplugins to use Node APIs bound to `gatsby-transformer-remark`
+  // to customize the GraphQL schema. This makes it possible for subplugins to
+  // modify types owned by `gatsby-transformer-remark`.
+  plugins.forEach(plugin => {
+    const resolvedPlugin = require(plugin.resolve)
+    if (typeof resolvedPlugin.createSchemaCustomization === `function`) {
+      resolvedPlugin.createSchemaCustomization(
+        nodeApiArgs,
+        plugin.pluginOptions
+      )
+    }
+  })
+}
+
+module.exports.typeDefs = typeDefs

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -1,2 +1,3 @@
+exports.createSchemaCustomization = require(`./create-schema-customization`)
 exports.onCreateNode = require(`./on-node-create`)
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)


### PR DESCRIPTION
The schema customization APIs allow modifying existing types only by plugins that own that type, or from a user's `gatsby-node.js`. This is an issue for "subplugins", which should be allowed to modify types owned by the parent plugin, but currently can't. AFAICS `gatsby-transformer-remark` is the only plugin which has subplugins.

The approach in this PR is to forward `gatsby-transformer-remark`'s `createSchemaCustomization` API call to its subplugins, so they have actions bound to `gatsby-transformer-remark` available. This makes it possible for subplugins to modify types owned by `gatsby-transformer-remark`.

We forward to a `createSchemaCustomization` function exported by the subplugin, which maybe is a bit weird because the `exports` object can already be a function (when the subplugin does not use `setParserPlugins` or `mutateSource`, which is most of them I think), but it's "just javascript" (i.e. we just stick it on `module.exports.createSchemaCustomization`).

Also:
* move auxiliary type definitions (for headings, excerpt formats, wordcount) to createTypes, so they are in a central location and have better names that can be targetted by subplugin's `createTypes` calls.
* removed a confusing comment that seems left over from ancient times (but maybe i misunderstood)

Related:  #13972