### PR TITLE
feat(gatsby): Add enum and scalar type builders

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -473,6 +473,12 @@ const createTypeComposerFromGatsbyType = ({
     case GatsbyGraphQLTypeKind.INTERFACE: {
       return InterfaceTypeComposer.createTemp(type.config, schemaComposer)
     }
+    case GatsbyGraphQLTypeKind.ENUM: {
+      return EnumTypeComposer.createTemp(type.config, schemaComposer)
+    }
+    case GatsbyGraphQLTypeKind.SCALAR: {
+      return ScalarTypeComposer.createTemp(type.config, schemaComposer)
+    }
     default: {
       report.warn(`Illegal type definition: ${JSON.stringify(type.config)}`)
       return null

--- a/packages/gatsby/src/schema/types/type-builders.js
+++ b/packages/gatsby/src/schema/types/type-builders.js
@@ -5,6 +5,8 @@ import type {
   ComposeInputObjectTypeConfig,
   ComposeInterfaceTypeConfig,
   ComposeUnionTypeConfig,
+  ComposeEnumTypeConfig,
+  ComposeScalarTypeConfig,
 } from "graphql-compose"
 
 const GatsbyGraphQLTypeKind = {
@@ -12,18 +14,34 @@ const GatsbyGraphQLTypeKind = {
   INPUT_OBJECT: `INPUT_OBJECT`,
   UNION: `UNION`,
   INTERFACE: `INTERFACE`,
+  ENUM: `ENUM`,
+  SCALAR: `SCALAR`,
 }
 
 export type GatsbyGraphQLType =
-  | { kind: GatsbyGraphQLTypeKind.OBJECT, config: ComposeObjectTypeConfig }
+  | {
+      kind: GatsbyGraphQLTypeKind.OBJECT,
+      config: ComposeObjectTypeConfig,
+    }
   | {
       kind: GatsbyGraphQLTypeKind.INPUT_OBJECT,
       config: ComposeInputObjectTypeConfig,
     }
-  | { kind: GatsbyGraphQLTypeKind.UNION, config: ComposeUnionTypeConfig }
+  | {
+      kind: GatsbyGraphQLTypeKind.UNION,
+      config: ComposeUnionTypeConfig,
+    }
   | {
       kind: GatsbyGraphQLTypeKind.INTERFACE,
       config: ComposeInterfaceTypeConfig,
+    }
+  | {
+      kind: GatsbyGraphQLTypeKind.ENUM,
+      config: ComposeEnumTypeConfig,
+    }
+  | {
+      kind: GatsbyGraphQLTypeKind.SCALAR,
+      config: ComposeScalarTypeConfig,
     }
 
 const buildObjectType = config => {
@@ -54,6 +72,20 @@ const buildInputObjectType = config => {
   }
 }
 
+const buildEnumType = config => {
+  return {
+    kind: GatsbyGraphQLTypeKind.ENUM,
+    config,
+  }
+}
+
+const buildScalarType = config => {
+  return {
+    kind: GatsbyGraphQLTypeKind.SCALAR,
+    config,
+  }
+}
+
 const isGatsbyType = something =>
   typeof something === `object` &&
   something.kind &&
@@ -65,5 +97,7 @@ module.exports = {
   buildUnionType,
   buildInterfaceType,
   buildInputObjectType,
+  buildEnumType,
+  buildScalarType,
   isGatsbyType,
 }

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -14,6 +14,8 @@ const {
   buildUnionType,
   buildInterfaceType,
   buildInputObjectType,
+  buildEnumType,
+  buildScalarType,
 } = require(`../schema/types/type-builders`)
 const { emitter } = require(`../redux`)
 const getPublicPath = require(`./get-public-path`)
@@ -188,6 +190,8 @@ const runAPI = (plugin, api, args) => {
           buildUnionType,
           buildInterfaceType,
           buildInputObjectType,
+          buildEnumType,
+          buildScalarType,
         },
       },
       plugin.pluginOptions,


### PR DESCRIPTION
This adds Gatsby Type Builders for enum and scalar types.
Especially enum type builder seems good to have because enums in SDL cannot have custom internal values. 