### PR TITLE
docs(gatsby-source-wordpress): add note about limitation of pagination in WordPress.com API

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -893,7 +893,7 @@ If you have custom post types or metadata that are not showing up within the sch
 
 - **Custom Meta**
 
-  To retrieve custom post meta in your queries, they first must be registered using WordPress' `register_meta()` function with `show_in_rest` set as `true`. You will then see your registered post meta in your Gatsby GraphQL Schema nested within the `meta` field for associated entities. For more details, see https://developer.wordpress.org/reference/functions/register_meta/.
+  To retrieve custom post meta in your queries, they first must be registered using WordPress' `register_meta()` function with `show_in_rest` set as `true`. You will then see your registered post meta in your Gatsby GraphQL Schema nested within the `meta` field for associated entities. For more details, see <https://developer.wordpress.org/reference/functions/register_meta/>.
 
 - **Custom Post Types**
 
@@ -970,7 +970,7 @@ In order to resolve this, you can manually change the `post_parent` value of the
 
 ### TypeError - `Cannot read property 'id' of undefined` with WordPress.com
 
-While there are other reasons this can occur (see issues), a very specific version of this issue occurs when a particlar tag, category, file (or any other referenced object) is referenced in a post but cannot be mapped to the list of related items to generate the proper node. 
+While there are other reasons this can occur (see issues), a very specific version of this issue occurs when a particlar tag, category, file (or any other referenced object) is referenced in a post but cannot be mapped to the list of related items to generate the proper node.
 
 This problem occurs because WordPress.com's API lacks the `X-WP-Total` and `X-WP-TotalPages` headers, which are used to determine the number of items and number of pages to pull from the API. Because of this, lower WordPress.com plans (Starter, Personal, and Premium) will not traverse the 2,...n pages and **will not be able to work with more than 100 items**.
 
@@ -998,4 +998,3 @@ Please note that you need to add `dotenv`, as mentioned earlier, to expose envir
 
 [dotenv]: https://github.com/motdotla/dotenv
 [envvars]: https://www.gatsbyjs.org/docs/environment-variables
-

--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -188,12 +188,17 @@ plugins.
 
 ## How to use Gatsby with Wordpress.com hosting
 
+### For Blogger, Personal, and Premium Plans
+
 Set `hostingWPCOM: true`.
 
 You will need to provide an [API Key](https://en.support.wordpress.com/api-keys/).
 
-Note : you don't need this for Wordpress.org hosting in which your WordPress
-will behave like a self-hosted instance.
+Note : The WordPress.com API does not have all of the features of the WordPress.org API, specifically with respect to pagination. See ~TypeError - Cannot read property 'id' of undefined with WordPress.com~ in the troubleshooting section for more.
+
+### For Business, and eCommerce Plans
+
+Business and eCommerce plans will run the WordPress.org version, so it is recommended to set `hostingWPCOM: false`.
 
 ## Test your WordPress API
 
@@ -963,6 +968,14 @@ which prevents Gatsby from retrieving it.
 
 In order to resolve this, you can manually change the `post_parent` value of the image record to `0` in the database. The only side effect of this change is that the image will no longer appear in the "Uploaded to this post" filter in the Add Media dialog in the WordPress administration area.
 
+### TypeError - `Cannot read property 'id' of undefined` with WordPress.com
+
+While there are other reasons this can occur (see issues), a very specific version of this issue occurs when a particlar tag, category, file (or any other referenced object) is referenced in a post but cannot be mapped to the list of related items to generate the proper node. 
+
+This problem occurs because WordPress.com's API lacks the `X-WP-Total` and `X-WP-TotalPages` headers, which are used to determine the number of items and number of pages to pull from the API. Because of this, lower WordPress.com plans (Starter, Personal, and Premium) will not traverse the 2,...n pages and **will not be able to work with more than 100 items**.
+
+Note: The plugin is currently using `https://public-api.wordpress.com/wp/v2/sites/[site]/` base endpoint, instead of what is in the WordPress.com documentation (`https://public-api.wordpress.com/rest/v1.1/sites/[site]/`. the `wp/v2` closely resembles the WordPress.org API, whereas the `rest/v1` and `rest/v1.1` enpoints behave differently.
+
 ### ACF Option Pages - Option page data not showing or not updating
 
 This issue occurs when you are trying to pull in data from your ACF Option pages. On certain occasions (initial setup or rebuilding) the data will not appear or won't update to the latest data.
@@ -985,3 +998,4 @@ Please note that you need to add `dotenv`, as mentioned earlier, to expose envir
 
 [dotenv]: https://github.com/motdotla/dotenv
 [envvars]: https://www.gatsbyjs.org/docs/environment-variables
+


### PR DESCRIPTION
## Description

This is just a documentation update for gatsby-source-wordpress. I've added some additional information for WordPress.com users, as well as added some troubleshooting documentation for a common issue.

This does not fix issue https://github.com/gatsbyjs/gatsby/issues/15347 I raised here, but rather provides some WordPress.com users with an alternative.

## Changes

- Add more information for WordPress.com users based on which plan they have
- Add note about limitation for some WordPress.com users in troubleshooting section (I guess it would be removed once the fix has been introduced)


