### PR TITLE
feat(www) : Add starters library to top navigation menu

### DIFF
--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -126,6 +126,7 @@ const Navigation = ({ pathname }) => {
             <NavItem linkTo="/docs/">Docs</NavItem>
             <NavItem linkTo="/tutorial/">Tutorials</NavItem>
             <NavItem linkTo="/plugins/">Plugins</NavItem>
+            <NavItem linkTo="/starters/">Starters</NavItem>
             <NavItem linkTo="/features/">Features</NavItem>
             <NavItem linkTo="/blog/">Blog</NavItem>
             <NavItem linkTo="/showcase/">Showcase</NavItem>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The current navigation menu lacks a link to the starters library, which leads to using the browser's history or searching in google to find the page. This commit would add a link to starters library to make it easier to navigate to the page.
