### PR TITLE
docs(blog): Fixed misquote of phrase sneak peek in blog

### DIFF
--- a/docs/blog/2018-03-07-why-we-created-the-plugin-library/index.md
+++ b/docs/blog/2018-03-07-why-we-created-the-plugin-library/index.md
@@ -83,7 +83,7 @@ Here are some ways you can help make the Gatsby plugin ecosystem great:
 - [Contact me](https://twitter.com/shannonb_ux/status/938551014956732418) here if you have feedback that differs from or provides deeper insight into one of the pain points this article mentions.
 - Follow us on [Twitter](https://twitter.com/gatsbyjs).
 
-## Sneak peak into the next UX project
+## Sneak peek into the next UX project
 
 Our next UX project is designing and building a [Gatsby site showcase](https://github.com/gatsbyjs/gatsby/issues/4392). Please contribute to and subscribe to the issue to help out!
 

--- a/docs/blog/2018-07-20-why-we-built-the-site-showcase/index.md
+++ b/docs/blog/2018-07-20-why-we-built-the-site-showcase/index.md
@@ -78,7 +78,7 @@ Users should be able to:
 
 Here's what's next in [Issue #5927](https://github.com/gatsbyjs/gatsby/issues/5927). Feel free to tackle any part of this project and contribute to it or discuss new possibilities!
 
-## Sneak peak into the next UX project
+## Sneak peek into the next UX project
 
 Our next UX project is finishing up the starter showcase, which will look similar to the site showcase and also have a major functional difference: filter by dependency. Please contribute to these issues to help out!
 

--- a/docs/blog/2018-08-13-using-decoupled-drupal-with-gatsby/index.md
+++ b/docs/blog/2018-08-13-using-decoupled-drupal-with-gatsby/index.md
@@ -7,7 +7,7 @@ tags: ["cms", "drupal"]
 
 ## Why use Drupal + Gatsby together?
 
-Kyle Mathews is presenting on “Gatsby + Drupal” at [Decoupled Drupal Days NYC](https://2018.decoupleddays.com/session/decoupled-drupal-gatsby) this Saturday; for those who can’t make it to his presentation, we wanted to give you a sneak peak of what it will be about.
+Kyle Mathews is presenting on “Gatsby + Drupal” at [Decoupled Drupal Days NYC](https://2018.decoupleddays.com/session/decoupled-drupal-gatsby) this Saturday; for those who can’t make it to his presentation, we wanted to give you a sneak peek of what it will be about.
 
 (Hint: it’s about how nicely Gatsby and Drupal work together!)
 

--- a/www/src/components/guidelines/cards/blog.js
+++ b/www/src/components/guidelines/cards/blog.js
@@ -34,7 +34,7 @@ const BlogCard = ({ ...props }) => (
         <strong>Why use Drupal + Gatsby together?</strong> Kyle Mathews is
         presenting on “Gatsby + Drupal” at Decoupled Drupal Days NYC this
         Saturday; for those who can’t make it to his presentation, we wanted to
-        give you a sneak peak of what it will be about.
+        give you a sneak peek of what it will be about.
       </Text>
 
       <Flex mt={4} alignItems="center">


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Found a possible typo in the blog:
`sneak peak` -> `sneak peek`

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

There is no issue related to this. Seems like a misquote of `sneak peek` (^_^)

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Edit: Originally had fixed in a single blog post. Replaced all the instances of `sneak peak` in c620031
Although both of them are valid phrases however `sneak peak` doesn't seem to fit the context here

![alt text](https://s3.amazonaws.com/theoatmeal-img/comics/sneak_peek/sneak_peek.png)
