### PR TITLE
Recommend npx for one-time CLI use

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -28,9 +28,9 @@ Now we have the `develop` script available to be used which will use our package
 
 ## How to use
 
-The Gatsby CLI is available via [npm](https://www.npmjs.com/) and should be installed globally by running `npm install -g gatsby-cli` to use it locally.
+The Gatsby CLI is available via [npm](https://www.npmjs.com/). If you want to run a single command, you can use [npx](https://npm.im/npx), e.g. `npx gatsby-cli new gatsby-site`. If you want to install it globally, run `npm install -g gatsby-cli`.
 
-Run `gatsby --help` for full help.
+Run `npx gatsby-cli --help` or `gatsby --help` for full help.
 
 ### `new`
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -23,9 +23,9 @@ We can now use the `develop` script tied to our app's version of Gatsby, rather 
 
 ## How to use
 
-The Gatsby CLI is available via [npm](https://www.npmjs.com/) and should be installed globally by running `npm install -g gatsby-cli` to use it locally.
+The Gatsby CLI is available via [npm](https://www.npmjs.com/). If you want to run a single command, you can use [npx](https://npm.im/npx), e.g. `npx gatsby-cli new gatsby-site`. If you want to install it globally, run `npm install -g gatsby-cli`.
 
-Run `gatsby --help` for full help.
+Run `npx gatsby-cli --help` or `gatsby --help` for full help.
 
 ## Commands
 


### PR DESCRIPTION
## Description

Update documentation for `gatsby-cli` to recommend using [npx](https://npm.im/npx) for one-time usage of the CLI, particularly when running the `new` command.

## Related Issues

None
