### PR TITLE
fix(www): remove unnecessary quotation mark

### DIFF
--- a/www/src/components/share-menu.js
+++ b/www/src/components/share-menu.js
@@ -98,7 +98,7 @@ class ShareMenu extends React.Component {
                 media: image,
                 description: title,
               })}`}
-              title="Share on Pinterest'"
+              title="Share on Pinterest"
             >
               <FaPinterestP />
             </a>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I was copying this code (😅) and I noticed that there's an unnecessary single quotation mark on title property of the `a` tag.
<!-- Write a brief description of the changes introduced by this PR -->
