### PR TITLE
fix(babel-preset-gatsby): add @babel/plugin-transform-spread as dependencies

### DIFF
--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -12,6 +12,7 @@
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
+    "@babel/plugin-transform-spread": "^7.2.2",
     "@babel/preset-env": "^7.4.1",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,7 +1585,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-spread@^7.2.0":
+"@babel/plugin-transform-spread@^7.2.0", "@babel/plugin-transform-spread@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406"
   dependencies:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

#15172 introduced _@babel/plugin-transform-spread_ in _babel-preset-gatsby_, this will cause build errors if using a _custom .babelrc_, since it's not a dependency of babel-preset-gatsby.

We should add @babel/plugin-transform-spread as dependencies of babel-preset-gatsby.

```
[BABEL] /PROJECT-DIR/.cache/production-app.js: Cannot find module '@babel/plugin-transform-spread' (While processing: "/PROJECT-DIR/node_modules/babel-preset-gatsby/index.js")
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
