### PR TITLE
feat(gatsby): Refine typing on createPage

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -777,8 +777,8 @@ export interface Actions {
   deletePage(args: { path: string; component: string }): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createPage */
-  createPage(
-    args: { path: string; component: string; context: Record<string, unknown> },
+  createPage<TContext = Record<string, unknown>>(
+    args: { path: string; component: string; context: TContext },
     plugin?: ActionPlugin,
     option?: ActionOptions
   ): void


### PR DESCRIPTION
## Description

This PR expands the typing on createPage function (the one destructured from actions):
- Accepts `TContext` as type parameter
- Type guards `context` object with `TContext`

Below is example code that will be properly typed with this PR merged.

`gatsby-node.ts`

```ts
import { GatsbyNode } from 'gatsby'
import { PageContext } from '../templates/product'

// interface PageContext {
//   slug: string
// }

export const gatsbyNode: GatsbyNode = {
  createPages: async ({ graphql, actions }) => {
    const { createPage } = actions

    // ... query here

    products.forEach((product) => {
      createPage<PageContext>({
        path: `/product/${product.slug}/`,
        component: resolve(__dirname, '../templates/product.tsx'),
        context: {
          slug: product.slug
        }        
      })
    })
  },
}
```