### PR TITLE
chore(telemetry): normalize starter name

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -270,7 +270,9 @@ module.exports = async (starter: string, options: InitOptions = {}) => {
 
   const hostedInfo = hostedGitInfo.fromUrl(starterPath)
 
-  trackCli(`NEW_PROJECT`, { starterName: starterPath })
+  trackCli(`NEW_PROJECT`, {
+    starterName: hostedInfo.shortcut(),
+  })
   if (hostedInfo) await clone(hostedInfo, rootPath)
   else await copy(starterPath, rootPath)
 }


### PR DESCRIPTION
## Description

Normalize the starter name based on what `gatsby-cli` would actually use instead of providing the raw parameter