### PR TITLE
fix(gatsby): Fix import on cache-dir/gatsby-browser-entry.js

### DIFF
--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -10,7 +10,9 @@ import Link, {
   parsePath,
 } from "gatsby-link"
 import PageRenderer from "./public-page-renderer"
-import { enqueue as prefetchPathname } from "./loader"
+import loader from "./loader"
+
+const prefetchPathname = loader.enqueue
 
 const StaticQueryContext = React.createContext({})
 


### PR DESCRIPTION
## Description

`enqueue` is not exported directly from https://github.com/gatsbyjs/gatsby/blob/2d27d7d42112fcbeb13cd52fa9fe0d46b1764d13/packages/gatsby/cache-dir/loader.js#L355

So it causes the error:

```
"export 'enqueue' (reexported as 'prefetchPathname') was not found in './loader'
```

This PR fixes it.

Fixes https://github.com/gatsbyjs/gatsby/issues/15750