### PR TITLE
docs: fix typo in gatsby-image

### DIFF
--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -76,7 +76,7 @@ export default () => {
       file(relativePath: { eq: "images/default.jpg" }) {
         childImageSharp {
           # Specify a fixed image and fragment.
-          # The default width is 400 pixelss
+          # The default width is 400 pixels
           // highlight-start
           fixed {
             ...GatsbyImageSharpFixed


### PR DESCRIPTION
## Description

Fix typo in Gatsby images docs.

