### PR TITLE
feat(docs): add docs guide for building themes

### DIFF
--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -2,15 +2,94 @@
 title: Building Themes
 ---
 
-We're working on more comprehensive written documentation to support building themes.
+The quickest way to get up and running with a workspace for building themes is to use the official [`gatsby-starter-theme-workspace`](https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-starter-theme-workspace) starter.
 
-In the meantime, check out these resources:
+To get started, run:
 
-## Gatsby Themes Authoring (Video course)
+```shell
+gatsby new my-theme gatsbyjs/gatsby-starter-theme-workspace
+```
+
+This will generate a new project for you. The file tree will look like this:
+
+```text
+.
+├── example
+│   ├── src
+│   │   └── pages
+│   │       └── index.js
+│   ├── gatsby-config.js
+│   ├── package.json
+│   └── README.md
+├── gatsby-theme-minimal
+│   ├── gatsby-config.js
+│   ├── index.js
+│   ├── package.json
+│   └── README.md
+├── .gitignore
+├── package.json
+├── README.md
+└── yarn.lock
+```
+
+Yarn workspaces are a great way to set up a project for theme development because they support housing multiple packages in a single parent directory and link them together.
+
+For Gatsby theme development, that means you can keep multiple themes and example sites together in a single project, and develop them locally.
+
+> 💡 If you prefer, using `yarn link` or `npm link` are viable alternatives. In general, we prefer the yarn workspaces approach, and that's what the starter and this guide will reflect.
+
+> 💡 The starter takes care of all of the configuration for developing a theme using yarn workspaces. If you're interested in more detail on this setup, check out [this blog post](/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/).
+
+### `package.json`
+
+The `package.json` in the root of the new project is primarily responsible for setting up the yarn workspaces. In this case, there are two workspaces, `gatsby-theme-minimal` and `example`.
+
+```json:title=my-theme/gatsby-config.js
+{
+  "name": "gatsby-starter-theme-workspace",
+  "private": true,
+  "version": "0.0.1",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "yarn workspace example build"
+  },
+  // highlight-start
+  "workspaces": ["gatsby-theme-minimal", "example"]
+  // highlight-end
+}
+```
+
+### `/gatsby-theme-minimal`
+
+The `/gatsby-theme-minimal` directory is the starting point of the new theme you'll develop.
+
+Inside it you'll find:
+
+- `gatsby-config.js`: An empty gatsby-config that you can use as a starting point for building functionality into your theme.
+- `index.js`: Since themes also function as plugins, this is an empty file that Gatsby requires in order to use this theme as a plugin.
+- `package.json`: The dependencies that your theme will pull in when people install it. Gatsby should be a peer dependency.
+
+### `/example`
+
+The `/example` directory is an example Gatsby site that installs and uses the local theme, `gatsby-theme-minimal`.
+
+Inside it you'll find:
+
+- `gatsby-config.js`: Specifies which theme to use and any other one-off config a site might need.
+- `/src`: Contains source code such as one-off pages or components that might live in a user's site.
+
+## Further resources
+
+### Gatsby Theme Authoring (Video course)
 
 Watch the new [Egghead course on Authoring Gatsby Themes](https://egghead.io/courses/gatsby-theme-authoring).
 
-## Read through source code
+### Building a Gatsby Theme (Tutorial)
+
+Check out the [tutorial for building a Gatsby theme](/tutorial/building-a-theme). The tutorial goes into much more detail than this g This is written as a companion to the [Egghead theme authoring course](https://egghead.io/courses/gatsby-theme-authoring), so they can be used together!
+
+### Read through source code
 
 Check out how some existing themes are built:
 

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -87,7 +87,7 @@ Watch the new [Egghead course on Authoring Gatsby Themes](https://egghead.io/cou
 
 ### Building a Gatsby Theme (Tutorial)
 
-Check out the [tutorial for building a Gatsby theme](/tutorial/building-a-theme). The tutorial goes into much more detail than this g This is written as a companion to the [Egghead theme authoring course](https://egghead.io/courses/gatsby-theme-authoring), so they can be used together!
+Check out the [tutorial for building a Gatsby theme](/tutorial/building-a-theme). The step-by-step tutorial goes into much more detail than this docs guide. It was written as a companion to the [Egghead theme authoring course](https://egghead.io/courses/gatsby-theme-authoring), so they can be used together!
 
 ### Read through source code
 

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -77,7 +77,7 @@ The `/example` directory is an example Gatsby site that installs and uses the lo
 Inside it you'll find:
 
 - `gatsby-config.js`: Specifies which theme to use and any other one-off configuration a site might need.
-- `/src`: Contains source code such as one-off pages or components that might live in a user's site.
+- `/src`: Contains source code such as custom pages or components that might live in a user's site.
 
 ## Further resources
 

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -76,7 +76,7 @@ The `/example` directory is an example Gatsby site that installs and uses the lo
 
 Inside it you'll find:
 
-- `gatsby-config.js`: Specifies which theme to use and any other one-off config a site might need.
+- `gatsby-config.js`: Specifies which theme to use and any other one-off configuration a site might need.
 - `/src`: Contains source code such as one-off pages or components that might live in a user's site.
 
 ## Further resources

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -36,7 +36,7 @@ Yarn workspaces are a great way to set up a project for theme development becaus
 
 For Gatsby theme development, that means you can keep multiple themes and example sites together in a single project, and develop them locally.
 
-> 💡 If you prefer, using `yarn link` or `npm link` are viable alternatives. In general, we prefer the yarn workspaces approach, and that's what the starter and this guide will reflect.
+> 💡 If you prefer, using `yarn link` or `npm link` are viable alternatives. In general, Gatsby recommends the yarn workspaces approach for building themes, and that's what the starter and this guide will reflect.
 
 > 💡 The starter takes care of all of the configuration for developing a theme using yarn workspaces. If you're interested in more detail on this setup, check out [this blog post](/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/).
 

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -68,7 +68,7 @@ Inside it you'll find:
 
 - `gatsby-config.js`: An empty gatsby-config that you can use as a starting point for building functionality into your theme.
 - `index.js`: Since themes also function as plugins, this is an empty file that Gatsby requires in order to use this theme as a plugin.
-- `package.json`: The dependencies that your theme will pull in when people install it. Gatsby should be a peer dependency.
+- `package.json`: A file listing the dependencies that your theme will pull in when people install it. Gatsby should be a peer dependency.
 
 ### `/example`
 


### PR DESCRIPTION
## Description

Introduces a docs guide for building themes, oriented around using the workspace starter.

## Notes

- This references the fuller tutorial -- that PR (#15668) should be merged first.

## Related Issues

Closes #15641.

Related to #15668.
