### PR TITLE
chore: Cache build dirs between workflow runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,12 +228,24 @@ jobs:
     resource_class: xlarge # ++ RAM and CPU
     steps:
       - checkout
+      - restore_cache:
+          key: www_public_dir_1
+      - restore_cache:
+          key: www-cache_dir_1
       - run:
           command: yarn
           working_directory: ~/project/www
       - run:
           command: yarn build
           working_directory: ~/project/www
+      - save_cache:
+          key: www_public_dir_1
+          paths:
+            - ~/project/www/public
+      - save_cache:
+          key: www_cache_dir_1
+          paths:
+            - ~/project/www/.cache
 
 workflows:
   version: 2


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The CI job completed! It took nearly three hours. Add some caching

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
