### PR TITLE
chore(gatsby-design-tokens): add homepage and stub README

### DIFF
--- a/packages/gatsby-design-tokens/README.md
+++ b/packages/gatsby-design-tokens/README.md
@@ -1,3 +1,3 @@
 # gatsby-design-tokens
 
-_TODO_: document purpose and usage once we hit 1.0.0
+Design tokens for Gatsby products including our brand colours, fonts and other guidelines.

--- a/packages/gatsby-design-tokens/README.md
+++ b/packages/gatsby-design-tokens/README.md
@@ -1,0 +1,3 @@
+# gatsby-design-tokens
+
+_TODO_: document purpose and usage once we hit 1.0.0

--- a/packages/gatsby-design-tokens/package.json
+++ b/packages/gatsby-design-tokens/package.json
@@ -15,6 +15,7 @@
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
   },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-design-tokens#readme",
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Recently added script that makes sure all packages have proper metadata ( https://github.com/gatsbyjs/gatsby/pull/15477 ) is causing failed lint tests after merging https://github.com/gatsbyjs/gatsby/pull/15779. This is quick chore to make sure it passes.

Would be great to have 1 paragraph explanation of what this package is for, but I have no context so just added TODO to readme.