### PR TITLE
chore(.github): add a personal github token to the PR bot action

### DIFF
--- a/.github/actions/high-priority-prs/src/fetch.js
+++ b/.github/actions/high-priority-prs/src/fetch.js
@@ -65,7 +65,11 @@ query GitHubOpenPullRequestsQuery {
 module.exports = async () => {
   let data
   try {
-    data = await tools.github.graphql(query)
+    data = await tools.github.graphql(query, {
+      headers: {
+        authorization: `token ${process.env.PERSONAL_GITHUB_TOKEN}`,
+      },
+    })
     // const filecontents = tools.getFile(
     //   ".github/actions/high-priority-prs/src/data.json"
     // )

--- a/.github/actions/high-priority-prs/src/process-data.js
+++ b/.github/actions/high-priority-prs/src/process-data.js
@@ -7,6 +7,7 @@ const isBefore = require("date-fns/is_before")
 const differenceInDays = require("date-fns/difference_in_days")
 const tools = new Toolkit({
   secrets: [
+    "PERSONAL_GITHUB_TOKEN",
     "SLACK_TOKEN",
     "SLACK_CORE_CHANNEL_ID",
     "SLACK_LEARNING_CHANNEL_ID",

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -11,6 +11,7 @@ action "high-priority-prs" {
     "SLACK_CHANNEL_ID",
     "SLACK_CORE_CHANNEL_ID",
     "SLACK_LEARNING_CHANNEL_ID",
+    "PERSONAL_GITHUB_TOKEN",
   ]
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Use a personal GitHub token instead of the baked in `GITHUB_TOKEN` like outlined [here](https://gist.github.com/gbaman/b3137e18c739e0cf98539bf4ec4366ad#gistcomment-2561831), and [here](https://github.com/octokit/graphql.js#usage)

The token needs:
`repo`, `read:org`, and `read:discussion` permissions