### PR TITLE
chore: add deploy step to nightly CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,20 @@ jobs:
           paths:
             - ~/project/www/.cache
 
+  deploy_www:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - restore_cache:
+          key: www_public_dir_1
+      - run:
+          command: yarn global add netlify-cli
+          working_directory: ~/project/www
+      - run:
+          command: netlify deploy --dir=public --auth="$NETLIFY_ACCESS_TOKEN" --site="$NETLIFY_SITE_ID" --message "Nightly build deployed from job $CIRCLE_BUILD_URL" # --prod
+          working_directory: ~/project/www
+
 workflows:
   version: 2
   build-test:
@@ -306,4 +320,6 @@ workflows:
     jobs:
       - build_www:
           # Check CircleCI web ui for context details (env vars)
+          context: build_www
+      - deploy_www:
           context: build_www


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Add config to deploy nightly build if it's successful. Still confirming #15790, but adding this in the meantime.

## Related Issues

One of a series: 

- https://github.com/gatsbyjs/gatsby/pull/15766
- https://github.com/gatsbyjs/gatsby/pull/15777
- https://github.com/gatsbyjs/gatsby/pull/15780
- https://github.com/gatsbyjs/gatsby/pull/15782
- https://github.com/gatsbyjs/gatsby/pull/15790