### PR TITLE
Don’t include example code in API docs that doesn’t work

### DIFF
--- a/packages/gatsby/src/utils/api-browser-docs.js
+++ b/packages/gatsby/src/utils/api-browser-docs.js
@@ -68,14 +68,6 @@ exports.onRouteUpdateDelayed = true
  * exports.onRouteUpdate = ({ location, prevLocation }) => {
  *   console.log('new pathname', location.pathname)
  *   console.log('old pathname', prevLocation ? prevLocation.pathname : null)
- *
- *   // Track pageview with google analytics
- *   window.ga(
- *     `set`,
- *     `page`,
- *     location.pathname + location.search + location.hash,
- *   )
- *   window.ga(`send`, `pageview`)
  * }
  */
 exports.onRouteUpdate = true


### PR DESCRIPTION
Was showing someone how to use `onRouteUpdate` and copied the code and was surprised to see a wall of errors in their browser console.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
