### PR TITLE
fix(docs): add requirement of node-sass

### DIFF
--- a/docs/docs/sass.md
+++ b/docs/docs/sass.md
@@ -12,9 +12,9 @@ Sass will compile `.sass` and `.scss` files to `.css` files for you, so you can 
 
 This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [**Quick Start guide**](/docs), then come back.
 
-1.  Install the Gatsby plugin [**gatsby-plugin-sass**](/packages/gatsby-plugin-sass/).
+1.  Install the Gatsby plugin [**gatsby-plugin-sass**](/packages/gatsby-plugin-sass/) and `node-sass`, a required peer dependency as of v2.0.0.
 
-`npm install --save gatsby-plugin-sass`
+`npm install --save node-sass gatsby-plugin-sass`
 
 2.  Include the plugin in your `gatsby-config.js` file.
 


### PR DESCRIPTION
As per [gatsby-plugin-sass](/packages/gatsby-plugin-sass/), `node-sass` is moved to a peer dependency. Installing the package alongside `gatsby-plugin-sass` is now required. Updated the installation instructions accordingly.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Updated the installation instructions to include `node-sass` and mentioned that it is now a required peer dependency as of Gatsby v2.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

https://www.gatsbyjs.org/packages/gatsby-plugin-sass/#install
https://www.gatsbyjs.org/packages/gatsby-plugin-sass/#breaking-changes-history