### PR TITLE
chore(ci): write specific cache name, restore fuzzily on prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,9 +223,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: www_public_dir_1_{{ epoch }}
+          key: www_public_dir_1_
       - restore_cache:
-          key: www_cache_dir_1_{{ epoch }}
+          key: www_cache_dir_1_
       - run:
           command: yarn
           working_directory: ~/project/www
@@ -248,7 +248,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: www_public_dir_1_{{ epoch }}
+          key: www_public_dir_1_
       - run:
           command: yarn add netlify-cli
           working_directory: ~/project/www


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Circle CI `restore_cache` works by matching the newest available cache that starts with the key name you provide. 

This change means that each build will write a new cache, and the following build will restore the newest written cache.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
