### PR TITLE
chore(gatsby-design-tokens): Fix z-inidices naming d'ohs, bump README

### DIFF
--- a/packages/gatsby-design-tokens/README.md
+++ b/packages/gatsby-design-tokens/README.md
@@ -9,7 +9,13 @@ Design tokens originated at Salesforce—quoting the [Lightning Desing System De
 Gatsby's design tokens are following the [System UI Theme Specification](https://system-ui.com/theme/).  
 They are not fully complying to the design token abstraction and are (initially) primarily focused on CSS/JS development – i.e. a potential _output_ from design tokens.
 
-They also are a work-in-progress: If you are looking to use them in your own projects, please be ready for breaking changes. We will not be following the [Semantic Versioning](https://semver.org/) specification yet.
+They also are a work-in-progress but we _do_ follow the [Semantic Versioning](https://semver.org/) specification. As such:
+
+- Minor fixes to tokens will be released as patch versions
+- Major design changes will be released as minor versions
+- _Breaking_ public API changes will be released in a major versions only
+
+So to prevent your site from breaking due to a breaking change or looking dramatically different due to a minor version bump, we recommend the [~](https://docs.npmjs.com/misc/semver#tilde-ranges-123-12-1) comparator when using this package
 
 ## Installation
 

--- a/packages/gatsby-design-tokens/README.md
+++ b/packages/gatsby-design-tokens/README.md
@@ -1,3 +1,50 @@
 # gatsby-design-tokens
 
-Design tokens for Gatsby products including our brand colours, fonts and other guidelines.
+Design tokens for Gatsby's design system.
+
+Design tokens originated at Salesforce—quoting the [Lightning Desing System Design Tokens documentation](https://www.lightningdesignsystem.com/design-tokens/):
+
+> Design tokens are the visual design atoms of the design system — specifically, they are named entities that store visual design attributes. We use them in place of hard-coded values (such as hex values for color or pixel values for spacing) in order to maintain a scalable and consistent visual system for UI development.
+
+Gatsby's design tokens are following the [System UI Theme Specification](https://system-ui.com/theme/).  
+They are not fully complying to the design token abstraction and are (initially) primarily focused on CSS/JS development – i.e. a potential _output_ from design tokens.
+
+They also are a work-in-progress: If you are looking to use them in your own projects, please be ready for breaking changes. We will not be following the [Semantic Versioning](https://semver.org/) specification yet.
+
+## Installation
+
+Using [npm](https://www.npmjs.com/):
+
+```console
+npm install gatsby-design-tokens --save
+```
+
+Using [Yarn](https://yarnpkg.com/):
+
+```console
+yarn add gatsby-design-tokens
+```
+
+## Usage
+
+Find a work-in-progress list of design tokens in the design tokens documentation at [gatsbyjs.org/guidelines/design-tokens](https://www.gatsbyjs.org/guidelines/design-tokens/).
+
+```js
+import {
+  borders,
+  breakpoints,
+  colors,
+  fonts,
+  fontSizes,
+  fontWeights,
+  letterSpacings,
+  lineHeights,
+  mediaQueries,
+  radii,
+  shadows,
+  sizes,
+  space,
+  transition,
+  zIndices,
+} from "gatsby-design-tokens"
+```

--- a/packages/gatsby-design-tokens/src/z-indices.js
+++ b/packages/gatsby-design-tokens/src/z-indices.js
@@ -1,9 +1,9 @@
 export default {
-  feedbackWidget: 2,
+  widget: 2,
   navigation: 5,
   banner: 10,
   modal: 10,
   sidebar: 10,
-  sidebarToggleButton: 20,
+  floatingActionButton: 20,
   skipLink: 100,
 }


### PR DESCRIPTION
- rename two z-indices tokens, as originally announced in https://github.com/gatsbyjs/gatsby/pull/15779#discussion_r303919547 and https://github.com/gatsbyjs/gatsby/pull/15779#discussion_r303919146, both of which never happened because I'm a dork (https://github.com/gatsbyjs/gatsby/pull/15779#discussion_r304009806)
- expand README a little, link to https://www.gatsbyjs.org/guidelines/design-tokens/

BREAKING CHANGE: renamed `zIndices.feedbackWidget` to `zIndices.widget`
BREAKING CHANGE: renamed `zIndices.sidebarToggleButton` to `zIndices.floatingActionButton`