### PR TITLE
fix(www/guidelines): Fix `transition` token doc

### DIFF
--- a/www/src/pages/guidelines/design-tokens.js
+++ b/www/src/pages/guidelines/design-tokens.js
@@ -630,15 +630,15 @@ const DesignTokens = ({ location }) => (
                 </tr>
               </thead>
               <tbody>
-                {Object.keys(theme.transition).map((color, i) => {
-                  if (typeof theme.transition[color] === `object`) {
-                    return Object.keys(theme.transition[color]).map(
-                      (range, i) => (
+                {Object.keys(theme.transition).map(token => {
+                  if (typeof theme.transition[token] === `object`) {
+                    return Object.keys(theme.transition[token]).map(
+                      (value, i) => (
                         <tr key={`tokens-transition-${i}`}>
                           <td>
-                            <code>{`colors.${color}.${range}`}</code>
+                            <code>{`transition.${token}.${value}`}</code>
                           </td>
-                          <td>{theme.transition[color][range]}</td>
+                          <td>{theme.transition[token][value]}</td>
                         </tr>
                       )
                     )


### PR DESCRIPTION
Thanks to @greglobinski for spotting this: The `transition` tokens on https://www.gatsbyjs.org/guidelines/design-tokens/ were mislabeled as `color`, e.g. the token `transition.curve.default` was mistakenly labeled `colors.curve.default`:

![image](https://user-images.githubusercontent.com/21834/61372932-b2d04600-a898-11e9-8c53-343c74bd15f9.png)

👇 

![image](https://user-images.githubusercontent.com/21834/61372958-c085cb80-a898-11e9-9287-4b98ca58ab62.png)
