### PR TITLE
fix(gatsby-transformer-yaml): stop crashing and use meaningful type name when sourced node is not a file

### DIFF
--- a/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Process YAML nodes correctly correctly creates a node from JSON which is a single object 1`] = `
+exports[`Processing YAML nodes with internal type 'File' from a YAML array of dictionaries, when no target type name is specified, all nodes have a type name based on the file name 1`] = `
 Array [
   Array [
     Object {
@@ -10,59 +10,7 @@ Array [
       "id": "uuid-from-gatsby",
       "internal": Object {
         "contentDigest": "contentDigest",
-        "type": "BarYaml",
-      },
-      "parent": "whatever",
-    },
-  ],
-]
-`;
-
-exports[`Process YAML nodes correctly correctly creates a node from JSON which is a single object 2`] = `
-Array [
-  Array [
-    Object {
-      "child": Object {
-        "blue": true,
-        "children": Array [],
-        "funny": "yup",
-        "id": "uuid-from-gatsby",
-        "internal": Object {
-          "contentDigest": "contentDigest",
-          "type": "BarYaml",
-        },
-        "parent": "whatever",
-      },
-      "parent": Object {
-        "children": Array [],
-        "content": "blue: true
-funny: yup
-",
-        "dir": "<TEMP_DIR>/bar/",
-        "id": "whatever",
-        "internal": Object {
-          "contentDigest": "whatever",
-          "mediaType": "text/yaml",
-        },
-        "name": "test",
-        "parent": null,
-      },
-    },
-  ],
-]
-`;
-
-exports[`Process YAML nodes correctly correctly creates nodes from JSON which is an array of objects 1`] = `
-Array [
-  Array [
-    Object {
-      "blue": true,
-      "children": Array [],
-      "funny": "yup",
-      "id": "uuid-from-gatsby",
-      "internal": Object {
-        "contentDigest": "contentDigest",
-        "type": "TestYaml",
+        "type": "MyFileYaml",
       },
       "parent": "whatever",
     },
@@ -75,7 +23,7 @@ Array [
       "id": "uuid-from-gatsby",
       "internal": Object {
         "contentDigest": "contentDigest",
-        "type": "TestYaml",
+        "type": "MyFileYaml",
       },
       "parent": "whatever",
     },
@@ -83,7 +31,7 @@ Array [
 ]
 `;
 
-exports[`Process YAML nodes correctly correctly creates nodes from JSON which is an array of objects 2`] = `
+exports[`Processing YAML nodes with internal type 'File' from a YAML array of dictionaries, when no target type name is specified, all nodes have a type name based on the file name 2`] = `
 Array [
   Array [
     Object {
@@ -94,23 +42,26 @@ Array [
         "id": "uuid-from-gatsby",
         "internal": Object {
           "contentDigest": "contentDigest",
-          "type": "TestYaml",
+          "type": "MyFileYaml",
         },
         "parent": "whatever",
       },
       "parent": Object {
         "children": Array [],
-        "content": "- blue: true
-  funny: yup
-- blue: false
-  funny: nope
-",
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
         "id": "whatever",
         "internal": Object {
           "contentDigest": "whatever",
           "mediaType": "text/yaml",
+          "type": "File",
         },
-        "name": "test",
+        "name": "My File",
         "parent": null,
       },
     },
@@ -124,23 +75,395 @@ Array [
         "id": "uuid-from-gatsby",
         "internal": Object {
           "contentDigest": "contentDigest",
-          "type": "TestYaml",
+          "type": "MyFileYaml",
         },
         "parent": "whatever",
       },
       "parent": Object {
         "children": Array [],
-        "content": "- blue: true
-  funny: yup
-- blue: false
-  funny: nope
-",
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
         "id": "whatever",
         "internal": Object {
           "contentDigest": "whatever",
           "mediaType": "text/yaml",
+          "type": "File",
         },
-        "name": "test",
+        "name": "My File",
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a YAML array of dictionaries, with the specified target type name 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "fixed",
+      },
+      "parent": "whatever",
+    },
+  ],
+  Array [
+    Object {
+      "blue": false,
+      "children": Array [],
+      "funny": "nope",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "fixed",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a YAML array of dictionaries, with the specified target type name 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "fixed",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "File",
+        },
+        "name": "My File",
+        "parent": null,
+      },
+    },
+  ],
+  Array [
+    Object {
+      "child": Object {
+        "blue": false,
+        "children": Array [],
+        "funny": "nope",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "fixed",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "File",
+        },
+        "name": "My File",
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a YAML array of dictionaries, with the target type name explicitely retrieved from the YAML content 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "yup",
+      },
+      "parent": "whatever",
+    },
+  ],
+  Array [
+    Object {
+      "blue": false,
+      "children": Array [],
+      "funny": "nope",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "nope",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a YAML array of dictionaries, with the target type name explicitely retrieved from the YAML content 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "yup",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "File",
+        },
+        "name": "My File",
+        "parent": null,
+      },
+    },
+  ],
+  Array [
+    Object {
+      "child": Object {
+        "blue": false,
+        "children": Array [],
+        "funny": "nope",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "nope",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "File",
+        },
+        "name": "My File",
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a single YAML dictionary, when no target type name is specified, the type name is based on the directory name 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "some",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "FooBarYaml",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a single YAML dictionary, when no target type name is specified, the type name is based on the directory name 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "some",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "FooBarYaml",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            id: some
+            blue: true
+            funny: yup
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "File",
+        },
+        "name": "My File",
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a single YAML dictionary, with the specified target type name 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "some",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "fixed",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a single YAML dictionary, with the specified target type name 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "some",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "fixed",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            id: some
+            blue: true
+            funny: yup
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "File",
+        },
+        "name": "My File",
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a single YAML dictionary, with the target type name explicitely retrieved from the YAML content 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "some",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "yup",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type 'File' from a single YAML dictionary, with the target type name explicitely retrieved from the YAML content 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "some",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "yup",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            id: some
+            blue: true
+            funny: yup
+      ",
+        "dir": "<TEMP_DIR>/top/foo bar/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "File",
+        },
+        "name": "My File",
         "parent": null,
       },
     },

--- a/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -470,3 +470,456 @@ Array [
   ],
 ]
 `;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a YAML array of dictionaries, when no target type name is specified, all nodes have a type name based on the original node's internal type 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "OtherYaml",
+      },
+      "parent": "whatever",
+    },
+  ],
+  Array [
+    Object {
+      "blue": false,
+      "children": Array [],
+      "funny": "nope",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "OtherYaml",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a YAML array of dictionaries, when no target type name is specified, all nodes have a type name based on the original node's internal type 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "OtherYaml",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+  Array [
+    Object {
+      "child": Object {
+        "blue": false,
+        "children": Array [],
+        "funny": "nope",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "OtherYaml",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a YAML array of dictionaries, with the specified target type name 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "fixed",
+      },
+      "parent": "whatever",
+    },
+  ],
+  Array [
+    Object {
+      "blue": false,
+      "children": Array [],
+      "funny": "nope",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "fixed",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a YAML array of dictionaries, with the specified target type name 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "fixed",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+  Array [
+    Object {
+      "child": Object {
+        "blue": false,
+        "children": Array [],
+        "funny": "nope",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "fixed",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a YAML array of dictionaries, with the target type name explicitely retrieved from the YAML content 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "yup",
+      },
+      "parent": "whatever",
+    },
+  ],
+  Array [
+    Object {
+      "blue": false,
+      "children": Array [],
+      "funny": "nope",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "nope",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a YAML array of dictionaries, with the target type name explicitely retrieved from the YAML content 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "yup",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+  Array [
+    Object {
+      "child": Object {
+        "blue": false,
+        "children": Array [],
+        "funny": "nope",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "nope",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a single YAML dictionary, when no target type name is specified, the type name is based on the original node's internal type 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "some",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "OtherYaml",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a single YAML dictionary, when no target type name is specified, the type name is based on the original node's internal type 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "some",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "OtherYaml",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            id: some
+            blue: true
+            funny: yup
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a single YAML dictionary, with the specified target type name 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "some",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "fixed",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a single YAML dictionary, with the specified target type name 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "some",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "fixed",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            id: some
+            blue: true
+            funny: yup
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a single YAML dictionary, with the target type name explicitely retrieved from the YAML content 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "some",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "yup",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Processing YAML nodes with internal type other than 'File' from a single YAML dictionary, with the target type name explicitely retrieved from the YAML content 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "some",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "yup",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "
+            id: some
+            blue: true
+            funny: yup
+      ",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "text/yaml",
+          "type": "Other",
+        },
+        "parent": null,
+      },
+    },
+  ],
+]
+`;

--- a/packages/gatsby-transformer-yaml/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml/src/__tests__/gatsby-node.js
@@ -1,11 +1,24 @@
 const Promise = require(`bluebird`)
 const os = require(`os`)
-const yaml = require(`js-yaml`)
-
 const { onCreateNode } = require(`../gatsby-node`)
 
-describe(`Process YAML nodes correctly`, () => {
-  const node = {
+const createNodeId = jest.fn().mockReturnValue(`uuid-from-gatsby`)
+const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
+
+const loadNodeContent = node => Promise.resolve(node.content)
+
+let createNode
+let createParentChildLink
+let actions
+let node
+let createNodeSpec
+
+beforeEach(() => {
+  createNode = jest.fn()
+  createParentChildLink = jest.fn()
+  actions = { createNode, createParentChildLink }
+
+  node = {
     id: `whatever`,
     parent: null,
     children: [],
@@ -13,170 +26,114 @@ describe(`Process YAML nodes correctly`, () => {
       contentDigest: `whatever`,
       mediaType: `text/yaml`,
     },
-    name: `test`,
   }
 
-  // Make some fake functions its expecting.
-  const loadNodeContent = node => Promise.resolve(node.content)
+  createNodeSpec = {
+    node,
+    loadNodeContent,
+    actions,
+    createNodeId,
+    createContentDigest,
+  }
+})
 
-  it(`correctly creates nodes from JSON which is an array of objects`, async () => {
-    const data = [{ blue: true, funny: `yup` }, { blue: false, funny: `nope` }]
-    node.content = yaml.safeDump(data)
+const expectCreatedNodesMatchingSnapshot = count => {
+  expect(createNode.mock.calls).toMatchSnapshot()
+  expect(createParentChildLink.mock.calls).toMatchSnapshot()
+  expect(createNode).toHaveBeenCalledTimes(count)
+  expect(createParentChildLink).toHaveBeenCalledTimes(count)
+}
 
-    const createNode = jest.fn()
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-    const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-      createContentDigest,
-    }).then(() => {
-      expect(createNode.mock.calls).toMatchSnapshot()
-      expect(createParentChildLink.mock.calls).toMatchSnapshot()
-      expect(createNode).toHaveBeenCalledTimes(2)
-      expect(createParentChildLink).toHaveBeenCalledTimes(2)
+const expectCreatedNodeTypeName = nodeTypeName => {
+  expect(createNode).toBeCalledWith(
+    expect.objectContaining({
+      internal: expect.objectContaining({
+        type: nodeTypeName,
+      }),
     })
+  )
+}
+
+describe(`Processing YAML nodes with internal type 'File'`, () => {
+  beforeEach(() => {
+    node.internal.type = `File`
+    node.dir = `${os.tmpdir()}/top/foo bar/`
+    node.name = `My File`
   })
 
-  it(`correctly creates a node from JSON which is a single object`, async () => {
-    const data = { blue: true, funny: `yup` }
-    node.content = yaml.safeDump(data)
-    node.dir = `${os.tmpdir()}/bar/`
-
-    const createNode = jest.fn()
-    const createParentChildLink = jest.fn()
-    const actions = { createNode, createParentChildLink }
-    const createNodeId = jest.fn()
-    createNodeId.mockReturnValue(`uuid-from-gatsby`)
-    const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
-
-    await onCreateNode({
-      node,
-      loadNodeContent,
-      actions,
-      createNodeId,
-      createContentDigest,
-    }).then(() => {
-      expect(createNode.mock.calls).toMatchSnapshot()
-      expect(createParentChildLink.mock.calls).toMatchSnapshot()
-      expect(createNode).toHaveBeenCalledTimes(1)
-      expect(createParentChildLink).toHaveBeenCalledTimes(1)
+  describe(`from a single YAML dictionary,`, () => {
+    beforeEach(() => {
+      node.content = `
+            id: some
+            blue: true
+            funny: yup
+      `
     })
-  })
 
-  it(`correctly sets node type for array of objects`, () =>
-    Promise.all(
-      [
-        {
-          typeName: null,
-          expectedNodeTypes: [`TestYaml`, `TestYaml`],
-        },
-        {
-          typeName: `fixed`,
-          expectedNodeTypes: [`fixed`, `fixed`],
-        },
-        {
-          typeName: ({ node, object }) => object.funny,
-          expectedNodeTypes: [`yup`, `nope`],
-        },
-      ].map(
-        async ({ typeName, expectedNodeTypes: [expectedOne, expectedTwo] }) => {
-          const data = [
-            { id: `foo`, blue: true, funny: `yup` },
-            { blue: false, funny: `nope` },
-          ]
+    it(`when no target type name is specified, the type name is based on the directory name`, async () => {
+      await onCreateNode(createNodeSpec)
 
-          node.content = yaml.safeDump(data)
-          node.dir = `${os.tmpdir()}/bar/`
+      expectCreatedNodesMatchingSnapshot(1)
+      expectCreatedNodeTypeName(`FooBarYaml`)
+    })
 
-          const createNode = jest.fn()
-          const createParentChildLink = jest.fn()
-          const actions = { createNode, createParentChildLink }
-          const createNodeId = jest.fn()
-          createNodeId.mockReturnValue(`uuid-from-gatsby`)
-          const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
-
-          return onCreateNode(
-            {
-              node,
-              loadNodeContent,
-              actions,
-              createNodeId,
-              createContentDigest,
-            },
-            { typeName }
-          ).then(() => {
-            expect(createNode).toBeCalledWith(
-              expect.objectContaining({
-                internal: expect.objectContaining({
-                  type: expectedOne,
-                }),
-              })
-            )
-            expect(createNode).toBeCalledWith(
-              expect.objectContaining({
-                internal: expect.objectContaining({
-                  type: expectedTwo,
-                }),
-              })
-            )
-          })
-        }
-      )
-    ))
-
-  it(`correctly sets node type for single object`, () =>
-    Promise.all(
-      [
-        {
-          typeName: null,
-          expectedNodeType: `TestdirYaml`,
-        },
-        {
-          typeName: `fixed`,
-          expectedNodeType: `fixed`,
-        },
-        {
-          typeName: ({ node, object }) => object.funny,
-          expectedNodeType: `yup`,
-        },
-      ].map(async ({ typeName, expectedNodeType }) => {
-        const data = { id: `foo`, blue: true, funny: `yup` }
-
-        node.content = yaml.safeDump(data)
-        node.dir = `${os.tmpdir()}/testdir/`
-
-        const createNode = jest.fn()
-        const createParentChildLink = jest.fn()
-        const actions = { createNode, createParentChildLink }
-        const createNodeId = jest.fn()
-        createNodeId.mockReturnValue(`uuid-from-gatsby`)
-        const createContentDigest = jest.fn().mockReturnValue(`contentDigest`)
-
-        return onCreateNode(
-          {
-            node,
-            loadNodeContent,
-            actions,
-            createNodeId,
-            createContentDigest,
-          },
-          { typeName }
-        ).then(() => {
-          expect(createNode).toBeCalledWith(
-            expect.objectContaining({
-              internal: expect.objectContaining({
-                type: expectedNodeType,
-              }),
-            })
-          )
-        })
+    it(`with the specified target type name`, async () => {
+      await onCreateNode(createNodeSpec, {
+        typeName: `fixed`,
       })
-    ))
+
+      expectCreatedNodesMatchingSnapshot(1)
+      expectCreatedNodeTypeName(`fixed`)
+    })
+
+    it(`with the target type name explicitely retrieved from the YAML content`, async () => {
+      // noinspection JSUnusedLocalSymbols (unused fields left as documentation)
+      await onCreateNode(createNodeSpec, {
+        typeName: ({ node, object, isArray }) => object.funny,
+      })
+
+      expectCreatedNodesMatchingSnapshot(1)
+      expectCreatedNodeTypeName(`yup`)
+    })
+  })
+
+  describe(`from a YAML array of dictionaries,`, () => {
+    beforeEach(() => {
+      node.content = `
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      `
+    })
+
+    it(`when no target type name is specified, all nodes have a type name based on the file name`, async () => {
+      await onCreateNode(createNodeSpec)
+
+      expectCreatedNodesMatchingSnapshot(2)
+      expectCreatedNodeTypeName(`MyFileYaml`)
+      expectCreatedNodeTypeName(`MyFileYaml`)
+    })
+
+    it(`with the specified target type name`, async () => {
+      await onCreateNode(createNodeSpec, {
+        typeName: `fixed`,
+      })
+
+      expectCreatedNodesMatchingSnapshot(2)
+      expectCreatedNodeTypeName(`fixed`)
+      expectCreatedNodeTypeName(`fixed`)
+    })
+
+    it(`with the target type name explicitely retrieved from the YAML content`, async () => {
+      // noinspection JSUnusedLocalSymbols (unused fields left as documentation)
+      await onCreateNode(createNodeSpec, {
+        typeName: ({ node, object, isArray }) => object.funny,
+      })
+
+      expectCreatedNodesMatchingSnapshot(2)
+      expectCreatedNodeTypeName(`yup`)
+      expectCreatedNodeTypeName(`nope`)
+    })
+  })
 })

--- a/packages/gatsby-transformer-yaml/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml/src/__tests__/gatsby-node.js
@@ -137,3 +137,85 @@ describe(`Processing YAML nodes with internal type 'File'`, () => {
     })
   })
 })
+
+describe(`Processing YAML nodes with internal type other than 'File'`, () => {
+  beforeEach(() => {
+    node.internal.type = `Other`
+  })
+
+  describe(`from a single YAML dictionary,`, () => {
+    beforeEach(() => {
+      node.content = `
+            id: some
+            blue: true
+            funny: yup
+      `
+    })
+
+    it(`when no target type name is specified, the type name is based on the original node's internal type`, async () => {
+      await onCreateNode(createNodeSpec)
+
+      expectCreatedNodesMatchingSnapshot(1)
+      expectCreatedNodeTypeName(`OtherYaml`)
+    })
+
+    it(`with the specified target type name`, async () => {
+      await onCreateNode(createNodeSpec, {
+        typeName: `fixed`,
+      })
+
+      expectCreatedNodesMatchingSnapshot(1)
+      expectCreatedNodeTypeName(`fixed`)
+    })
+
+    it(`with the target type name explicitely retrieved from the YAML content`, async () => {
+      // noinspection JSUnusedLocalSymbols (unused fields left as documentation)
+      await onCreateNode(createNodeSpec, {
+        typeName: ({ node, object, isArray }) => object.funny,
+      })
+
+      expectCreatedNodesMatchingSnapshot(1)
+      expectCreatedNodeTypeName(`yup`)
+    })
+  })
+
+  describe(`from a YAML array of dictionaries,`, () => {
+    beforeEach(() => {
+      node.content = `
+            - blue: true
+              funny: yup
+            - blue: false
+              funny: nope
+      `
+    })
+
+    it(`when no target type name is specified, all nodes have a type name based on the original node's internal type`, async () => {
+      await onCreateNode(createNodeSpec)
+
+      expectCreatedNodesMatchingSnapshot(2)
+      expectCreatedNodeTypeName(`OtherYaml`)
+      expectCreatedNodeTypeName(`OtherYaml`)
+    })
+
+    it(`with the specified target type name`, async () => {
+      await onCreateNode(createNodeSpec, {
+        typeName: `fixed`,
+      })
+
+      expectCreatedNodesMatchingSnapshot(2)
+      expectCreatedNodeTypeName(`fixed`)
+      expectCreatedNodeTypeName(`fixed`)
+    })
+
+    it(`with the target type name explicitely retrieved from the YAML content`, async () => {
+      // noinspection JSUnusedLocalSymbols (unused fields left as documentation)
+      await onCreateNode(createNodeSpec, {
+        typeName: ({ node, object, isArray }) => object.funny,
+      })
+
+      expectCreatedNodesMatchingSnapshot(2)
+      expectCreatedNodeTypeName(`yup`)
+      expectCreatedNodeTypeName(`nope`)
+    })
+  })
+})

--- a/packages/gatsby-transformer-yaml/src/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml/src/gatsby-node.js
@@ -11,6 +11,8 @@ async function onCreateNode(
       return pluginOptions.typeName({ node, object, isArray })
     } else if (pluginOptions && _.isString(pluginOptions.typeName)) {
       return pluginOptions.typeName
+    } else if (node.internal.type !== `File`) {
+      return _.upperFirst(_.camelCase(`${node.internal.type} Yaml`))
     } else if (isArray) {
       return _.upperFirst(_.camelCase(`${node.name} Yaml`))
     } else {


### PR DESCRIPTION
## Description 

The plugin selects a default type name, unless it is explicitly specified in the plugin options. The type name is inferred from `node.dir`. For various source plugins, the YAML nodes do not have a `dir` property. 

In this case, the node's internal type is a good fit for the type name. This PR changes the code to set the node type appropriately.

Currently, the error message is somehow cryptic and doesn't hint at the actual issue:
```
Error: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined

  - validators.js:107 validateString
    internal/validators.js:107:11

  - gatsby-node.js:32 getType
    [gatsby-lab]/[gatsby-transformer-yaml]/gatsby-node.js:32:47

  - gatsby-node.js:74 Object.onCreateNode
    [gatsby-lab]/[gatsby-transformer-yaml]/gatsby-node.js:74:111

  - task_queues.js:85 processTicksAndRejections
    internal/process/task_queues.js:85:5
```

## Related Issues
Reported in issue https://github.com/gatsbyjs/gatsby/pull/15825

The same issue has already been fixed for the JSON transformer plugin in PR https://github.com/gatsbyjs/gatsby/pull/8544/
