### PR TITLE
chore: CI www schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ jobs:
           working_directory: ~/project/www
       - run:
           command: node_modules/.bin/netlify deploy --prod --dir=public --auth="$NETLIFY_ACCESS_TOKEN" --site="$NETLIFY_SITE_ID" --message "Deployed from Circle CI workflow https://circleci.com/workflow-run/$CIRCLE_WORKFLOW_ID"
+          no_output_timeout: 2h
           working_directory: ~/project/www
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ workflows:
   www_deploy:
     triggers:
       - schedule:
-          cron: "0 */6 * * *"
+          cron: "0 */4 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,10 +302,10 @@ workflows:
             branches:
               only:
                 - master
-  nightly:
+  www_deploy:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0 */6 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Increase no output timeout, and run every four hours.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
