### PR TITLE
fix(gatsby-transformer-sharp): mark highlight/shadow duotone args as required

### DIFF
--- a/packages/gatsby-transformer-sharp/src/types.js
+++ b/packages/gatsby-transformer-sharp/src/types.js
@@ -5,6 +5,7 @@ const {
   GraphQLInt,
   GraphQLFloat,
   GraphQLEnumType,
+  GraphQLNonNull,
 } = require(`gatsby/graphql`)
 const sharp = require(`./safe-sharp`)
 const { Potrace } = require(`potrace`)
@@ -49,8 +50,8 @@ const DuotoneGradientType = new GraphQLInputObjectType({
   name: `DuotoneGradient`,
   fields: () => {
     return {
-      highlight: { type: GraphQLString },
-      shadow: { type: GraphQLString },
+      highlight: { type: new GraphQLNonNull(GraphQLString) },
+      shadow: { type: new GraphQLNonNull(GraphQLString) },
       opacity: { type: GraphQLInt },
     }
   },


### PR DESCRIPTION
Fixes #15823