### PR TITLE
chore(docs): Update gatsby-plugin-mdx README.md to correct docs example 

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -430,7 +430,7 @@ from a GraphQL page query or `StaticQuery`.
 just like a normal React component.
 
 ```js
-<MDXRenderer title="My Stuff!">{mdx.code.body}</MDXRenderer>
+<MDXRenderer title="My Stuff!">{mdx.body}</MDXRenderer>
 ```
 
 Using a page query:
@@ -440,7 +440,7 @@ import { MDXRenderer } from "gatsby-plugin-mdx"
 
 export default class MyPageLayout {
   render() {
-    ;<MDXRenderer>{this.props.data.mdx.code.body}</MDXRenderer>
+    ;<MDXRenderer>{this.props.data.mdx.body}</MDXRenderer>
   }
 }
 
@@ -448,9 +448,7 @@ export const pageQuery = graphql`
   query MDXQuery($id: String!) {
     mdx(id: { eq: $id }) {
       id
-      code {
-        body
-      }
+      body
     }
   }
 `


### PR DESCRIPTION
`mdx.code.body` doesn't existed when using `gatsby-plugin-mdx`, now is direct `mdx.body`

my plugins version:
gatsby v2.13.25
gatsby-plugin-mdx v1.0.13

![image](https://user-images.githubusercontent.com/24786522/61379288-d2d42980-a8d9-11e9-8232-e9ae0682c56c.png)
