### PR TITLE
fix(gatsby-plugin-sharp): Updates cpu core count path to correct location.

### DIFF
--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -20,7 +20,7 @@ try {
   // Handle Sharp's concurrency based on the Gatsby CPU count
   // See: http://sharp.pixelplumbing.com/en/stable/api-utility/#concurrency
   // See: https://www.gatsbyjs.org/docs/multi-core-builds/
-  const cpuCoreCount = require(`gatsby/dist/utils/cpu-core-count`)
+  const cpuCoreCount = require(`gatsby/dist/utils/worker/cpu-core-count`)
   sharp.concurrency(cpuCoreCount())
 } catch {
   // if above throws error this probably means that used Gatsby version


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This fixes the incorrect path to the cpu-core-count.js script that gatsby-plugin-sharp should be relying upon.

## Related Issues
Fixes #15748 
