### PR TITLE
fix(gatsby-source-wordpress): WordPress does not properly encode its media urls #15593

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -503,9 +503,12 @@ exports.downloadMediaFiles = async ({
 
         // If we don't have cached data, download the file
         if (!fileNodeID) {
+          // wordpress does not properly encode it's media urls
+          const encodedSourceUrl = encodeURI(e.source_url)
+
           try {
             const fileNode = await createRemoteFileNode({
-              url: e.source_url,
+              url: encodedSourceUrl,
               store,
               cache,
               createNode,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

If WordPress media URLs contain non-ASCII characters, then they will not get properly encoded by WordPress. This makes them invalid URLs, and they get ignored by `gatsby-source-filesystem`. This causes the media files to not exist locally.

## Related Issues
Fixes #15593 