### PR TITLE
chore(docs): fix typo in 'Hosting on Netlify' documentation

### DIFF
--- a/docs/docs/hosting-on-netlify.md
+++ b/docs/docs/hosting-on-netlify.md
@@ -51,7 +51,7 @@ Now, login to Netlify and we will see a `New site from git` button at the top ri
 - Branch to deploy: We can specify the branch, when we push to that particular branch, then only Netlify will build and deploy our site. The default is `master`.
 - Build Command: We can specify the command we want Netlify to run when we push to above branch. The default is `npm run build`.
 - Publish directory: We can specify which folder should Netlify use to host our website. eg. public, dist, build. The default is `public`.
-- Advanced build settings: If our site needs environment variables to build, we can spectify them by clicking on `Show advanced` and then the `New Variable` button.
+- Advanced build settings: If our site needs environment variables to build, we can specify them by clicking on `Show advanced` and then the `New Variable` button.
 
 Click on `Deploy site` button and Netlify will start to build and deploy process we specified. In a few moments, it will give us our site URL like `random-name.netlify.com`. We can go to the `Deploys` tab and see what is actually happening.
 


### PR DESCRIPTION
Changed spectify to specify :mag: