### PR TITLE
fix(gatsby): Make intermediate schema available to createResolvers API

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -670,7 +670,7 @@ export interface SourceNodesArgs extends ParentSpanPluginArgs {
 }
 
 export interface CreateResolversArgs extends ParentSpanPluginArgs {
-  schema: object
+  intermediateSchema: object
   createResolvers: Function
   traceId: `initial-createResolvers`
 }

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -621,7 +621,7 @@ const addCustomResolveFunctions = async ({ schemaComposer, parentSpan }) => {
     })
   }
   await apiRunner(`createResolvers`, {
-    schema: intermediateSchema,
+    intermediateSchema,
     createResolvers,
     traceId: `initial-createResolvers`,
     parentSpan,

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -259,7 +259,7 @@ exports.createSchemaCustomization = true
  * * When extending a field with an existing field resolver, the original
  *   resolver function is available from `info.originalResolver`.
  * * The `createResolvers` API is called as the last step in schema generation.
- *   Thus, an intermediate schema is made available on the `schema` property.
+ *   Thus, an intermediate schema is made available on the `intermediateSchema` property.
  *   In resolver functions themselves, it is recommended to access the final
  *   built schema from `info.schema`.
  * * Gatsby's data layer, including all internal query capabilities, is
@@ -279,7 +279,7 @@ exports.createSchemaCustomization = true
  * For fuller examples, see [`using-type-definitions`](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-type-definitions).
  *
  * @param {object} $0
- * @param {GraphQLSchema} $0.schema Current GraphQL schema
+ * @param {GraphQLSchema} $0.intermediateSchema Current GraphQL schema
  * @param {function} $0.createResolvers Add custom resolvers to GraphQL field configs
  * @param {object} $1
  * @param {object} $1.resolvers Resolvers from plugin options in `gatsby-config.js`.


### PR DESCRIPTION
According to the docs we make an intermediate schema available to `createResolvers` on the `schema` arg. This is not actually true, because we already put the type builders on `schema`. This PR renames to `intermediateSchema`.