### PR TITLE
Add `export default`

### DIFF
--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -245,7 +245,7 @@ import React from "react"
 import { graphql } from "gatsby"
 import MDXRenderer from "gatsby-plugin-mdx/mdx-renderer"
 
-function PageTemplate({ data: { mdx } }) {
+export default function PageTemplate({ data: { mdx } }) {
   return (
     <div>
       <h1>{mdx.frontmatter.title}</h1>
@@ -283,7 +283,7 @@ import React from "react"
 import { graphql } from "gatsby"
 import MDXRenderer from "gatsby-plugin-mdx/mdx-renderer"
 
-function PageTemplate({ data: { mdx } }) {
+export default function PageTemplate({ data: { mdx } }) {
   return (
     <div>
       <h1>{mdx.frontmatter.title}</h1>


### PR DESCRIPTION
Fix next error by adding `export default` to the template component
```console
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
```

Please merge. I got stuck with this for a while :(