### PR TITLE
feat(gatsby-plugin-sharp) Concurrency adjustment for sharp scheduler job queue.

### DIFF
--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -3,12 +3,13 @@ const { existsSync } = require(`fs`)
 const queue = require(`async/queue`)
 const { processFile } = require(`./process-file`)
 const { createProgress } = require(`./utils`)
+const cpuCoreCount = require(`gatsby/dist/utils/worker/cpu-core-count`)
 
 const toProcess = {}
 let totalJobs = 0
 const q = queue((task, callback) => {
   task(callback)
-}, 1)
+}, cpuCoreCount())
 
 let bar
 // when the queue is empty we stop the progressbar


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Currently, gatsby-plugin-sharp only processes one job at a time within the scheduler, causing the generation of a large amount of image thumbnails for a site to take a long time. Increasing this (or allowing adjustments) by using cpu-core-count as provided by the gatsby package significantly decreases the amount of time to process and create these thumbnail images.

Please let me know if I need to add any extra tests/benchmarks to this PR, thanks!
## Related Issues
#15845