### PR TITLE
test(gatsby): assert shadow support of org scoped packages

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
@@ -4,12 +4,14 @@ import ShadowingPlugin from "../"
 describe(`Component Shadowing`, () => {
   it(`gets matching themes`, () => {
     const plugin = new ShadowingPlugin({
-      themes: [`a-theme`, `theme-b`, `gatsby-theme-c`].map(name => {
-        return {
-          themeName: name,
-          themeDir: path.join(path.sep, `some`, `place`, name),
+      themes: [`a-theme`, `theme-b`, `gatsby-theme-c`, `@orgname/theme-d`].map(
+        name => {
+          return {
+            themeName: name,
+            themeDir: path.join(path.sep, `some`, `place`, name),
+          }
         }
-      }),
+      ),
     })
     expect(
       // simple request path to a theme's component
@@ -135,6 +137,33 @@ describe(`Component Shadowing`, () => {
           `some`,
           `node_modules`,
           `theme-b`,
+          `src`,
+          `components`,
+          `a-component`
+        ),
+        userSiteDir: path.join(path.sep, `some`),
+      })
+    ).toEqual(true)
+
+    expect(
+      plugin.requestPathIsIssuerShadowPath({
+        // issuer is in the user's site
+        issuerPath: path.join(
+          path.sep,
+          `some`,
+          `src`,
+          `@orgname`,
+          `theme-d`,
+          `components`,
+          `a-component`
+        ),
+        // require'ing a file it is a "shadow child" of
+        requestPath: path.join(
+          path.sep,
+          `some`,
+          `node_modules`,
+          `@orgname`,
+          `theme-d`,
           `src`,
           `components`,
           `a-component`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Added test to ensure support of [NPM org scoped packages](https://docs.npmjs.com/about-org-scopes-and-packages) with Gatsby Themes component shadowing logic.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
