### PR TITLE
feat(gatsby): Switch over to watchpack

### DIFF
--- a/e2e-tests/themes/development-runtime/cypress/integration/hot-reloading.js
+++ b/e2e-tests/themes/development-runtime/cypress/integration/hot-reloading.js
@@ -3,7 +3,7 @@ describe(`Hot Reloading`, () => {
     cy.visit(`/hot-reloading`).waitForRouteChange()
   })
 
-  it.skip(`works for changes in queries in themes`, () => {
+  it(`works for changes in queries in themes`, () => {
     cy.exec(
       `npm run update -- --file ../gatsby-theme-about/src/pages/hot-reloading.js --new-file scripts/new-file.js`
     )

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -144,6 +144,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "rimraf": "^2.6.1",
+    "watchpack": "^1.6.0",
     "xhr-mock": "^2.4.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21041,7 +21041,7 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.5.0:
+watchpack@^1.5.0, watchpack@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   dependencies:


### PR DESCRIPTION
## Elevator Pitch

Everyone who uses Gatsby uses `gatsby develop` and this change will make it faster and perform with fewer system resources on lower end machines by making file watching more efficient. 

## Why?

We've seen several issues with `chokidar` where changes aren't triggered in CI, on Docker, on Vagrant etc and it can be very expensive to have multiple file watchers across `webpack` and Gatsby's own query watchers. This PR replaces `chokidar` in `query-watcher.js` with `watchpack` (what webpack uses) 

Advantages include:
- Gets changes from directories and not individual files so faster and scales better with _large_ projects with lots of files
- Shares a single instance across Gatsby (so shares it with webpack) resulting in reduced resource usage
- Always gets triggered consistently (check out the test in this PR that we had to 
skip until this change because it refused to trigger change when writing to disk on a CircleCI job worker)
- Includes a `aggregated` options which lets us batch changes together meaning we can wait till successive changes till say 1 second rather invoking query compilation on every single individual change (this is what happens now)

<details>
<summary>Goodbye, Chokidar</summary>

https://www.youtube.com/watch?v=DQAKY1ntM9o


Know it sounds funny
But I just can't stand the pain
Girl I'm leaving you tomorrow
Seems to me girl
You know I've done all I can
You see I begged, stole
And I borrowed

Ooh, that's why I'm easy
I'm easy like Sunday morning
That's why I'm easy
I'm easy like Sunday morning

Why in the world
Would anybody put chains on me?
I've paid my dues to make it
Everybody wants me to be
What they want me to be
I'm not happy when I try to fake it!
No!

Ooh, that's why I'm easy
I'm easy like Sunday morning
That's why I'm easy
I'm easy like Sunday morning

I wanna be high, so high
I wanna be free to know
The things I do are right
I wanna be free
Just me, babe!

That's why I'm easy
I'm easy like Sunday morning
That's why I'm easy
I'm easy like Sunday morning
Because I'm easy
Easy like Sunday morning
Because I'm easy
Easy like Sunday morning

</details>


## Disclaimer

`chokidar` is awesome and `watchpack` is a wrapper on top of it (at least at v1) so this doesn't imply by any means that `chokidar` isn't valuable, just that `watchpack` seems like a more appropriate level of abstraction 

## Related

https://github.com/gatsbyjs/gatsby/pull/6207