### PR TITLE
Update query structure in the queries example

### DIFF
--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -228,9 +228,12 @@ Here's a paragraph, followed by a paragraph with data!
 <p>{props.data.site.siteMetadata.description}</p>
 
 export const pageQuery = graphql`
-  site {
-    siteMetadata {
-      description
+  query {
+    site {
+      siteMetadata {
+        description
+        title
+      }
     }
   }
 `


### PR DESCRIPTION
## Description
This updates the query example on https://www.gatsbyjs.org/docs/mdx/writing-pages

Without at least the additional brackets, the query results in a Failure to Compile error. This includes the word `query`, to follow the structure from https://www.gatsbyjs.org/docs/querying-with-graphql


## Related Issues

Fixes an issue created outside of Gatsby https://github.com/ChristopherBiscardi/gatsby-mdx/issues/404 
