### PR TITLE
chore(blog): Fix broken link and typo in card sort result blog

### DIFF
--- a/docs/blog/2018-06-26-card-sort-results/index.md
+++ b/docs/blog/2018-06-26-card-sort-results/index.md
@@ -11,7 +11,7 @@ Recently, 36 Gatsby users completed an open card sort to help make our docs here
 
 ### Raw & beautified data
 
-I ran this card sort through [OptimalSort](https://www.optimalworkshop.com/), a software that moderates the card sort and presents the data in usable forms. If you’re curious to see the full results, you can [view the data](https://www.optimalworkshop.com/optimalsort/x87kpp82/5x34psa3-0/shared-results/fa8b66knb66qyhwh5l8j38bd273vkkm7), including raw data as well as things like a similarity matrix and a [dendogram](https://support.optimalworkshop.com/hc/en-us/articles/201997650-Interpreting-the-OptimalSort-dendrograms).
+I ran this card sort through [OptimalSort](https://www.optimalworkshop.com/), a software that moderates the card sort and presents the data in usable forms. If you’re curious to see the full results, you can [view the data](https://www.optimalworkshop.com/optimalsort/x87kpp82/5x34psa3-0/shared-results/fa8b66knb66qyhwh5l8j38bd273vkkm7), including raw data as well as things like a similarity matrix and a [dendrogram](https://support.optimalworkshop.com/en/articles/2626862-interpret-the-optimalsort-dendrograms-for-open-and-hybrid-card-sorts).
 
 ## How did participants categorize the docs?
 
@@ -74,11 +74,11 @@ List of other lonely docs that didn’t find a solid home through the card sort:
 - There was little agreement on where the “Html.js” doc goes. There was a 47% association with Babel and a 47% association with using layouts to build reusable site sections.
 - “React components” highest association was a 47% association with “basic structure of a Gatsby site” and all its associated pages. This slightly low association score probably results from the fact that the .org site doesn’t teach that much React at all, and there aren’t many docs on React specifically.
 
-## Dendogram adventures
+## Dendrogram adventures
 
-These screenshots that show a portion of the dendogram show that the clearest category was "Contributing", clear because the category name and the contents of the category are consistent:
+These screenshots that show a portion of the dendrogram show that the clearest category was "Contributing", clear because the category name and the contents of the category are consistent:
 
-![Contributing dendogram](contributing-dendogram.png)
+![Contributing dendrogram](contributing-dendogram.png)
 
 Gatsby users are in agreement on what that category ought to be called and what docs it should contain :)
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

* This fixes a possible typo and a broken link in the doc:
`dendogram` -> `dendrogram`
The old link contains the word `dendrograms` referring to the type of graphical representation

* Fixed link:
Old Link: <https://support.optimalworkshop.com/hc/en-us/articles/201997650-Interpreting-the-OptimalSort-dendrograms>
Updated Link: <https://support.optimalworkshop.com/en/articles/2626862-interpret-the-optimalsort-dendrograms-for-open-and-hybrid-card-sorts>

I presume the link broke when the post title was updated 
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

There are no issues related to this PR.
If these changes are inaccurate, please let me know and I'l make the necessary changes (^_^)

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
