### PR TITLE
chore(showcase): Removing Devol's Dance from showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1870,18 +1870,6 @@
     - Blog
   built_by: Linton Ye
   built_by_url: "https://twitter.com/lintonye"
-- title: Devol’s Dance
-  main_url: "https://www.devolsdance.com/"
-  url: "https://www.devolsdance.com/"
-  description: >
-    Devol’s Dance is an invite-only, one-day event celebrating industrial
-    robotics, AI, and automation.
-  categories:
-    - Marketing
-    - Technology
-  built_by: Corey Ward
-  built_by_url: "http://www.coreyward.me/"
-  featured: false
 - title: Mega House Creative
   main_url: "https://www.megahousecreative.com/"
   url: "https://www.megahousecreative.com/"


### PR DESCRIPTION
## Description

@coreyward just for notice. Devol's Dance is now using YUI for their splash page so we are going to remove it from the showcase. We are always welcome to adding sites back if they switch back to Gatsby.