### PR TITLE
fix(gatsby-transformer-remark): Restore pathPrefix option in remark plugins

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -91,7 +91,6 @@ module.exports = (
   {
     type,
     basePath,
-    pathPrefix,
     getNode,
     getNodesByType,
     cache,


### PR DESCRIPTION
## Description

This branch resolves an issue where `gatsby-transformer-remark` is no longer supplying the configured `pathPrefix` to Gatsby Remark plugins. This is happening because in [this commit](https://github.com/gatsbyjs/gatsby/commit/44f7550147cf589d5a2941cb29e5f70e8f573b2e#diff-488d99b036db541ee4a25a6991027b5dL262), the `pathPrefix` variable was replaced with `basePath`, but `pathPrefix` was left in the destructured function argument.

Since the destructured `pathPrefix` variable isn't being used within the function, I removed it. This causes the property to remain in the `...rest` object, which in turn gets spread into the options provided to Gatsby remark plugins [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-transformer-remark/src/extend-node-type.js#L233).

## Related Issues

Fixes #15787 