### PR TITLE
fix(gatsby): Add touchNode to populate typeOwners (#15918)

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -792,6 +792,11 @@ actions.touchNode = (options: any, plugin?: Plugin) => {
     nodeId = options
   }
 
+  const node = getNode(nodeId)
+  if (node && !typeOwners[node.internal.type]) {
+    typeOwners[node.internal.type] = node.internal.owner
+  }
+
   return {
     type: `TOUCH_NODE`,
     plugin,


### PR DESCRIPTION
## Description

Gatsby keeps track of different node types by different source plugins and allows source plugins to only manage nodes of types they own. Unfortunately typeOwners mapping is only populated when nodes are being created (by createNode API). If nodes of certain type have only been touched so far (with touchNode), no source plugin owns that node type. This prevents the real owner of that node type from deleting cached nodes until it has created at least a single node of that type.

This seems to be the minimal change to make touchNode populate typeOwners mapping, but I don't know if that's the correct one.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/15918
