### PR TITLE
chore: Fix Typos across repository

### DIFF
--- a/.github/actions/high-priority-prs/src/__tests__/fixtures/data.json
+++ b/.github/actions/high-priority-prs/src/__tests__/fixtures/data.json
@@ -3649,7 +3649,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-04-29T06:37:51Z",
-                  "message": "remove accidentally commited .patch file"
+                  "message": "remove accidentally committed .patch file"
                 }
               },
               {
@@ -4853,7 +4853,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-05-26T18:18:31Z",
-                  "message": "skip checking if createTypes is available - this is hard requirment now and wouldn't work without it"
+                  "message": "skip checking if createTypes is available - this is hard requirement now and wouldn't work without it"
                 }
               },
               {
@@ -6424,7 +6424,7 @@
         {
           "createdAt": "2019-05-17T13:04:21Z",
           "updatedAt": "2019-06-03T13:52:10Z",
-          "title": "fix(www): Normalize data from airtable on schema level, remove unnessecary hook.",
+          "title": "fix(www): Normalize data from airtable on schema level, remove unnecessary hook.",
           "url": "https://github.com/gatsbyjs/gatsby/pull/14114",
           "author": {
             "url": "https://github.com/freiksenet"
@@ -6465,7 +6465,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-05-17T13:03:04Z",
-                  "message": "Normalize data from airtable on schema level, remove unnessecary hook."
+                  "message": "Normalize data from airtable on schema level, remove unnecessary hook."
                 }
               },
               {

--- a/.github/actions/high-priority-prs/src/data.json
+++ b/.github/actions/high-priority-prs/src/data.json
@@ -3345,7 +3345,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-04-29T06:37:51Z",
-                  "message": "remove accidentally commited .patch file"
+                  "message": "remove accidentally committed .patch file"
                 }
               },
               {
@@ -3357,7 +3357,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-06-24T21:58:25Z",
-                  "message": "feat: add basic caching so an icon isn't generated multiple times durring a single build."
+                  "message": "feat: add basic caching so an icon isn't generated multiple times during a single build."
                 }
               },
               {
@@ -3775,13 +3775,13 @@
               {
                 "commit": {
                   "authoredDate": "2019-05-19T22:50:18Z",
-                  "message": "fix focusing on navigation from 404 to different 404, improve focus managment tests"
+                  "message": "fix focusing on navigation from 404 to different 404, improve focus management tests"
                 }
               },
               {
                 "commit": {
                   "authoredDate": "2019-05-19T22:55:39Z",
-                  "message": "fix most of focus navigation focus managment in development\n\nnavigating from and to 404 doesn't focus router wrapper correctly. This is because 404 in development is special case (see notes before skipped e2e-tests/development-runtime accessibility tests). This can be fixed but require a lot of changes which would be out of scope of this PR and would potentially make it harder to merge page manifest changes, so for now lets ship fixes that are already here."
+                  "message": "fix most of focus navigation focus management in development\n\nnavigating from and to 404 doesn't focus router wrapper correctly. This is because 404 in development is special case (see notes before skipped e2e-tests/development-runtime accessibility tests). This can be fixed but require a lot of changes which would be out of scope of this PR and would potentially make it harder to merge page manifest changes, so for now lets ship fixes that are already here."
                 }
               },
               {
@@ -4673,7 +4673,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-05-26T18:18:31Z",
-                  "message": "skip checking if createTypes is available - this is hard requirment now and wouldn't work without it"
+                  "message": "skip checking if createTypes is available - this is hard requirement now and wouldn't work without it"
                 }
               },
               {
@@ -4745,7 +4745,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-06-24T19:31:56Z",
-                  "message": "revert unnecesary change"
+                  "message": "revert unnecessary change"
                 }
               },
               {
@@ -6507,7 +6507,7 @@
               {
                 "commit": {
                   "authoredDate": "2019-06-27T15:15:53Z",
-                  "message": "Removed the difference between static and normal query from page.\n\nWill add this to seperate page on difference between Static and Normal query ."
+                  "message": "Removed the difference between static and normal query from page.\n\nWill add this to separate page on difference between Static and Normal query ."
                 }
               }
             ]

--- a/docs/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/index.md
+++ b/docs/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/index.md
@@ -16,7 +16,7 @@ Gatsby is **great** from a multititude of perspectives. Our community is **great
 As such--this post focuses on just a single element of what makes Gatsby great: performance. To prime the discussion, let's consider [this post on the `webdev` subreddit on Reddit](https://www.reddit.com/r/webdev/comments/9z5dsr/how_does_reactjs_have_such_a_fast_website/?st=jtqbllhm&sh=60148ea7).
 
 <Pullquote citation="reddit/r/webdev">
-Genuine question, every page is loaded immediatley [sic] on click. Seriously never seen such a quick website before. Any insight as to how they're able to achieve this?
+Genuine question, every page is loaded immediately [sic] on click. Seriously never seen such a quick website before. Any insight as to how they're able to achieve this?
 </Pullquote>
 
 Fun fact--that website in question is [reactjs.org](https://reactjs.org) which, as you may or may not know, is an application built with and powered by Gatsby 💪

--- a/docs/blog/2019-06-12-performance-improvements-for-large-sites/index.md
+++ b/docs/blog/2019-06-12-performance-improvements-for-large-sites/index.md
@@ -29,7 +29,7 @@ The central problem was that Gatsby generates a file for each build called `page
 
 When a user clicks a link to another page, Gatsby first looks up the manifest for the page's component and query result file. Gatsby then downloads them (if they haven't already been prefetched), and then passes the loaded query results to the page's component and renders it. Since `pages-manifest` contains the list of all pages on the site, Gatsby can also immediately show a 404 if necessary if the page is not able to be located.
 
-This works great for small sites, but as a Gatsby application grows, so too does the size of the page manfiest. The bigger the manifest gets the more data the browser has to download before any UI navigation can occur leading to slowdowns in important metrics like Time to Interactive (TTI).
+This works great for small sites, but as a Gatsby application grows, so too does the size of the page manifest. The bigger the manifest gets the more data the browser has to download before any UI navigation can occur leading to slowdowns in important metrics like Time to Interactive (TTI).
 
 Even after the manifest had been loaded, the manifest had to be searched for the matching path. This was necessary since pages can be declared with a [matchPath](https://www.gatsbyjs.org/docs/gatsby-internals-terminology/#matchpath) (a Regular Expression used to match client-only paths). Huge manifest files resulted in perceptable lag when clicking links too!
 

--- a/docs/creators/creators.yml
+++ b/docs/creators/creators.yml
@@ -117,7 +117,7 @@
   portfolio: true
 - name: Michael Uloth
   type: individual
-  description: Michael Uloth is a Toronto-based web developer who specializes in building fast-loading, accessibile websites with Gatsby.
+  description: Michael Uloth is a Toronto-based web developer who specializes in building fast-loading, accessible websites with Gatsby.
   location: Toronto
   website: "https://www.michaeluloth.com"
   github: "https://github.com/ooloth"

--- a/docs/docs/building-a-contact-form.md
+++ b/docs/docs/building-a-contact-form.md
@@ -47,7 +47,7 @@ Each method detailed below will start with the following contact form:
 
 If you're hosting your site with Netlify, you gain access to their excellent [form handling feature](https://www.netlify.com/docs/form-handling/).
 
-Setting this up only invloves adding a few form attributes:
+Setting this up only involves adding a few form attributes:
 
 ```diff:title=src/pages/contact.js
 - <form method="post" action="#">

--- a/docs/docs/gatsby-repl.md
+++ b/docs/docs/gatsby-repl.md
@@ -41,7 +41,7 @@ gatsby > babelrc
 
 ### `components`
 
-Returns a Map object with all of the components in your Gatsby environment (see [Mozilla Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) docs for more information on Map objects and how to use them). Propeties that get returned: `name`, `componentPath`, `query`, `pages`, and `isInBootstrap:`.
+Returns a Map object with all of the components in your Gatsby environment (see [Mozilla Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) docs for more information on Map objects and how to use them). Properties that get returned: `name`, `componentPath`, `query`, `pages`, and `isInBootstrap:`.
 
 Usage: `components`
 
@@ -200,7 +200,7 @@ gatsby > siteConfig.siteMetadata
 
 ### `staticQueries`
 
-Returns a Map object with all of the static queries in your Gatsby environment. Propeties that get returned: `name`, `componentPath`, `id`, `query`, and `hash`.
+Returns a Map object with all of the static queries in your Gatsby environment. Properties that get returned: `name`, `componentPath`, `id`, `query`, and `hash`.
 
 Usage: `staticQueries`
 

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1176,7 +1176,7 @@
   main_url: "https://mottox2.com"
   url: "https://mottox2.com"
   source_url: "https://github.com/mottox2/website"
-  description: Web developer / UI Desinger in Tokyo Japan.
+  description: Web developer / UI Designer in Tokyo Japan.
   featured: false
   categories:
     - Blog
@@ -2905,7 +2905,7 @@
   url: https://www.dekema.com/
   main_url: https://www.dekema.com/
   description: >
-    Worldclass crafting: Furnace, fervor, fullfilment. Delivering highest demand for future craftsmanship. Built using Gatsby v2 and Prismic.
+    Worldclass crafting: Furnace, fervor, fulfillment. Delivering highest demand for future craftsmanship. Built using Gatsby v2 and Prismic.
   categories:
     - Healthcare
     - Science
@@ -3634,7 +3634,7 @@
 - title: Gábor Fűzy pianist
   main_url: "https://pianobar.hu"
   url: "https://pianobar.hu"
-  description: Gábor Fűzy pianist's offical website built with Gatsby v2.
+  description: Gábor Fűzy pianist's official website built with Gatsby v2.
   categories:
     - Music
   built_by: Zoltán Bedi
@@ -4609,7 +4609,7 @@
   url: https://our-academy.org/
   source_url: "https://github.com/ouracademy/website"
   description: >
-    Ouracademy is an organization that promoves the education in software development throught blog posts & videos smiley.
+    Ouracademy is an organization that promoves the education in software development through blog posts & videos smiley.
   categories:
     - Open Source
     - Blog
@@ -5518,7 +5518,7 @@
   url: https://lendo.at
   main_url: https://lendo.at
   description: >
-    A Comparsion site for best private loan offer from banks in Austria.
+    A Comparison site for best private loan offer from banks in Austria.
   categories:
     - Business
     - Finance

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1259,7 +1259,7 @@
     - Minimal UI and Styling
 - url: https://gatsby-tutorial-starter.netlify.com/
   repo: https://github.com/justinformentin/gatsby-v2-tutorial-starter
-  description: Simple, modern desgined blog with post lists, tags, and easily customizable code.
+  description: Simple, modern designed blog with post lists, tags, and easily customizable code.
   tags:
     - Blog
     - Linting
@@ -1964,7 +1964,7 @@
     - Pagination logic
 - url: https://gatsby-blogger.netlify.com/
   repo: https://github.com/aslammultidots/blogger
-  description: A Simple, clean and modern desgined blog with firebase authentication feature and easily customizable code.
+  description: A Simple, clean and modern designed blog with firebase authentication feature and easily customizable code.
   tags:
     - Blog
     - Redux
@@ -2745,7 +2745,7 @@
     - SEO (including robots.txt, sitemap generation, automated yet customisable metadata, and social sharing data)
     - Google Analytics
     - PostCSS support
-    - Developer enviornment variables
+    - Developer environment variables
     - Accessibility support
     - Based on Gatsby Starter Default
 - url: https://material-ui-starter.netlify.com/
@@ -2962,7 +2962,7 @@
     - Web App Manifest
 - url: https://yellowcake.netlify.com/
   repo: https://github.com/thriveweb/yellowcake
-  description: A starter project for creating lightning-fast websites with Gatsby v2 and Netlify-CMS v2 + Uploadcare intergration.
+  description: A starter project for creating lightning-fast websites with Gatsby v2 and Netlify-CMS v2 + Uploadcare integration.
   tags:
     - CMS:Netlify
     - Netlify

--- a/e2e-tests/development-runtime/cypress/integration/functionality/accessibility.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/accessibility.js
@@ -1,4 +1,4 @@
-describe(`focus managment`, () => {
+describe(`focus management`, () => {
   it(`Focus router wrapper after navigation to regular page (from index)`, () => {
     cy.visit(`/`).waitForRouteChange()
 

--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -35,7 +35,7 @@ describe(`navigation`, () => {
     cy.location(`pathname`).should(`equal`, `/`)
   })
 
-  describe(`non-existant route`, () => {
+  describe(`non-existent route`, () => {
     beforeEach(() => {
       cy.getTestElement(`broken-link`)
         .click()

--- a/e2e-tests/development-runtime/src/pages/index.js
+++ b/e2e-tests/development-runtime/src/pages/index.js
@@ -23,7 +23,7 @@ const IndexPage = ({ data }) => (
     <Link to="/안녕" data-testid="page-with-unicode-path">
       Go to page with unicode path
     </Link>
-    <Link to="/__non_existant_page__/" data-testid="broken-link">
+    <Link to="/__non_existent_page__/" data-testid="broken-link">
       Go to a broken link
     </Link>
     <h2>Blog posts</h2>

--- a/e2e-tests/production-runtime/.env.production
+++ b/e2e-tests/production-runtime/.env.production
@@ -1,4 +1,4 @@
-# This file is commited to repo only to validate that env vars are available
+# This file is committed to repo only to validate that env vars are available
 # to use in frontend and don't leak if not used (secrets used in Node).
 # You should NOT commit `.env` files to your repository for production sites.
 EXISTING_VAR=foo bar

--- a/e2e-tests/production-runtime/cypress/integration/accessibility.js
+++ b/e2e-tests/production-runtime/cypress/integration/accessibility.js
@@ -1,4 +1,4 @@
-describe(`focus managment`, () => {
+describe(`focus management`, () => {
   it(`Focus router wrapper after navigation to regular page (from index)`, () => {
     cy.visit(`/`).waitForRouteChange()
 

--- a/examples/using-asciidoc/src/pages/test.adoc
+++ b/examples/using-asciidoc/src/pages/test.adoc
@@ -40,8 +40,8 @@ NOTE: Items marked with TODO are either not yet supported or a work in progress.
  
 .Inline markup
 * single quotes around a phrase place 'emphasis'
-* astericks around a phrase make the text *bold*
-* double astericks around one or more **l**etters in a word make those letters bold
+* asterisk around a phrase make the text *bold*
+* double asterisk around one or more **l**etters in a word make those letters bold
 * double underscore around a __sub__string in a word emphasize that substring
 * use carrots around characters to make them ^super^script
 * use tildes around characters to make them ~sub~script

--- a/junit.xml
+++ b/junit.xml
@@ -1066,7 +1066,7 @@
     </testcase>
     <testcase classname="watching copying files copies cache-dir files" name="watching copying files copies cache-dir files" time="0.001">
     </testcase>
-    <testcase classname="watching copying files filters non-existant files/directories" name="watching copying files filters non-existant files/directories" time="0.001">
+    <testcase classname="watching copying files filters non-existent files/directories" name="watching copying files filters non-existent files/directories" time="0.001">
     </testcase>
     <testcase classname="watching copying files filters duplicate directories" name="watching copying files filters duplicate directories" time="0.001">
     </testcase>
@@ -1208,7 +1208,7 @@
     </testcase>
     <testcase classname="Merge gatsby config Merging siteMetadata is recursive" name="Merge gatsby config Merging siteMetadata is recursive" time="0.002">
     </testcase>
-    <testcase classname="Merge gatsby config Merging proxy is overriden" name="Merge gatsby config Merging proxy is overriden" time="0">
+    <testcase classname="Merge gatsby config Merging proxy is overridden" name="Merge gatsby config Merging proxy is overridden" time="0">
     </testcase>
   </testsuite>
   <testsuite name="&lt;Img /&gt;" errors="0" failures="0" skipped="0" timestamp="2018-11-27T15:50:30" time="2.154" tests="5">

--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -129,7 +129,7 @@ describe(`watching`, () => {
       )
     })
 
-    it(`filters non-existant files/directories`, () => {
+    it(`filters non-existent files/directories`, () => {
       fs.existsSync.mockReset().mockImplementation(file => false)
 
       watch(...args)

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -21,7 +21,7 @@ const quit = () => {
 const MAX_COPY_RETRIES = 3
 
 /*
- * non-existant packages break on('ready')
+ * non-existent packages break on('ready')
  * See: https://github.com/paulmillr/chokidar/issues/449
  */
 async function watch(

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -48,7 +48,7 @@ exports[`gatsby-plugin-canonical-urls strips a trailing slash on the siteUrl and
 }
 `;
 
-exports[`gatsby-plugin-canonical-urls strips search paramaters if option stripQueryString is true 1`] = `
+exports[`gatsby-plugin-canonical-urls strips search parameters if option stripQueryString is true 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-browser.js
@@ -35,7 +35,7 @@ describe(`gatsby-plugin-canonical-urls`, () => {
       `"<link data-basehost=\\"someurl.com\\" data-baseprotocol=\\"http:\\" href=\\"http://someurl.com/hogwarts?house=gryffindor\\" rel=\\"canonical\\">"`
     )
   })
-  it(`should strip search paramaters if option stripQueryString is true`, () => {
+  it(`should strip search parameters if option stripQueryString is true`, () => {
     const pluginOptions = {
       stripQueryString: true,
     }

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-ssr.js
@@ -39,7 +39,7 @@ describe(`gatsby-plugin-canonical-urls`, () => {
     expect(setHeadComponents).toHaveBeenCalledTimes(1)
   })
 
-  it(`strips search paramaters if option stripQueryString is true`, async () => {
+  it(`strips search parameters if option stripQueryString is true`, async () => {
     const pluginOptions = {
       siteUrl: `http://someurl.com`,
       stripQueryString: true,

--- a/packages/gatsby-plugin-facebook-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-facebook-analytics/src/gatsby-ssr.js
@@ -17,7 +17,7 @@ export const onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
   if (process.env.NODE_ENV === `production` || includeInDevelopment || debug) {
     setPostBodyComponents([
       <script
-        key="plugin-facebook-analitycs"
+        key="plugin-facebook-analytics"
         dangerouslySetInnerHTML={{
           __html: stripIndent(`
             window.fbAsyncInit = function() {

--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -76,7 +76,7 @@ module.exports = {
 
 Each feed must include `output`, `query`, and `title`. Additionally, it is strongly recommended to pass a custom `serialize` function, otherwise an internal serialize function will be used which may not exactly match your particular use case.
 
-`match` is an optional configuration, indicating which pages will have feed reference included. The accepted types of `match` are `string` or `undefined`. By default, when `match` is not configured, all pages will have feed reference inserted. If `string` is provided, it will be used to build a RegExp and then to test whether `pathname` of current page satisifed this regular expression. Only pages that satisifed this rule will have feed reference included.
+`match` is an optional configuration, indicating which pages will have feed reference included. The accepted types of `match` are `string` or `undefined`. By default, when `match` is not configured, all pages will have feed reference inserted. If `string` is provided, it will be used to build a RegExp and then to test whether `pathname` of current page satisfied this regular expression. Only pages that satisfied this rule will have feed reference included.
 
 All additional options are passed through to the [`rss`][rss] utility. For more info on those additional options, [explore the `itemOptions` section of the `rss` package](https://www.npmjs.com/package/rss#itemoptions).
 

--- a/packages/gatsby-source-contentful/CHANGELOG.md
+++ b/packages/gatsby-source-contentful/CHANGELOG.md
@@ -303,7 +303,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **gatsby-source-contentful:** Fix check for fluid and fixed size fliters ([#11009](https://github.com/gatsbyjs/gatsby/issues/11009)) ([aeb2bbd](https://github.com/gatsbyjs/gatsby/commit/aeb2bbd))
+- **gatsby-source-contentful:** Fix check for fluid and fixed size filters ([#11009](https://github.com/gatsbyjs/gatsby/issues/11009)) ([aeb2bbd](https://github.com/gatsbyjs/gatsby/commit/aeb2bbd))
 
 <a name="2.0.23"></a>
 

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -29,7 +29,7 @@ module.exports = {
         url: "https://api.graphcms.com/simple/v1/swapi",
       },
     },
-    // Passing paramaters (passed to apollo-link)
+    // Passing parameters (passed to apollo-link)
     {
       resolve: "gatsby-source-graphql",
       options: {

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -453,7 +453,7 @@ exports.mapEntitiesToMedia = entities => {
       })
 
       // Deleting fields and replacing them with links to different nodes
-      // can cause build errors if object will have only linked properites:
+      // can cause build errors if object will have only linked properties:
       // https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-input-fields.js#L205
       // Hacky workaround:
       // Adding dummy field with concrete value (not link) fixes build

--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -102,7 +102,7 @@ Using the following GraphQL query you'll be able to get the table of contents
 
 ### Configuring the tableOfContents
 
-By default the tableOfContents is using the field `slug` to generate URLs. You can however provide another field using the pathToSlugField parameter. **Note** that providing a non existing field will cause the result to be null. To alter the default values for tableOfContents generation, include values for `heading` (string) and/or `maxDepth` (number 1 to 6) in graphQL query. If a value for `heading` is given, the first heading that matches will be ommitted and the toc is generated from the next heading of the same depth onwards. Value for `maxDepth` sets the maximum depth of the toc (i.e. if a maxDepth of 3 is set, only h1 to h3 headings will appear in the toc).
+By default the tableOfContents is using the field `slug` to generate URLs. You can however provide another field using the pathToSlugField parameter. **Note** that providing a non existing field will cause the result to be null. To alter the default values for tableOfContents generation, include values for `heading` (string) and/or `maxDepth` (number 1 to 6) in graphQL query. If a value for `heading` is given, the first heading that matches will be omitted and the toc is generated from the next heading of the same depth onwards. Value for `maxDepth` sets the maximum depth of the toc (i.e. if a maxDepth of 3 is set, only h1 to h3 headings will appear in the toc).
 
 ```graphql
 {
@@ -211,7 +211,7 @@ You can also get excerpts in Markdown format.
 
 ### Example: Excerpts
 
-If you don't want to use `pruneLength` for excerpts but a custom seperator, you can specify an `excerpt_separator`:
+If you don't want to use `pruneLength` for excerpts but a custom separator, you can specify an `excerpt_separator`:
 
 ```javascript
 {

--- a/packages/gatsby/CHANGELOG.md
+++ b/packages/gatsby/CHANGELOG.md
@@ -1406,7 +1406,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **gatsby:** avoid full page refresh when navigating to non-existant page ([#10684](https://github.com/gatsbyjs/gatsby/issues/10684)) ([88866c7](https://github.com/gatsbyjs/gatsby/commit/88866c7))
+- **gatsby:** avoid full page refresh when navigating to non-existent page ([#10684](https://github.com/gatsbyjs/gatsby/issues/10684)) ([88866c7](https://github.com/gatsbyjs/gatsby/commit/88866c7))
 
 <a name="2.0.77"></a>
 
@@ -2944,7 +2944,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - [www] Blog post meta styles #1561 @fk
 - Fix unsupported method in IE #1573 @variadicintegrity
-- Don't set a default title in html.js as not overriden by react-helmet #1578
+- Don't set a default title in html.js as not overridden by react-helmet #1578
   @KyleAMathews
 - Downgrade Glamor to v2 as v3 unstable #1580 @KyleAMathews
 - Remove the slash between the pathPrefix and pathname when navigating #1574
@@ -3153,7 +3153,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Added
 
 - Add using-remark example site #1230 @fk
-- Add friendly webpack ouput #1240 @craig-mulligan
+- Add friendly webpack output #1240 @craig-mulligan
 - Add documentation on how to use custom webpack-config #1242 @bananenmannfrau
 - Add graphql fields for creating responsive images using Contentful image API
   #1228 @kyleamathews

--- a/packages/gatsby/src/db/loki/index.js
+++ b/packages/gatsby/src/db/loki/index.js
@@ -127,7 +127,7 @@ function saveState() {
 
 /**
  * Returns a reference to the database. If undefined, the db has not been
- * initalized yet. Call `start()`
+ * initialized yet. Call `start()`
  *
  * @returns {Object} database, or undefined
  */

--- a/packages/gatsby/src/internal-plugins/prod-404/package.json
+++ b/packages/gatsby/src/internal-plugins/prod-404/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prod-404",
   "version": "1.0.0",
-  "description": "Internal plugin to detect various flavors of 404 pages and ensure there's a 404.html path created as well to ensure compatability with static hosts",
+  "description": "Internal plugin to detect various flavors of 404 pages and ensure there's a 404.html path created as well to ensure compatibility with static hosts",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -195,7 +195,7 @@ class Runner {
       // The way we currently export fragments requires duplicated ones
       // to be filtered out since there is a global Fragment namespace
       // We maintain a top level fragment Map to keep track of all definitions
-      // of thge fragment type and to filter them out if theythey've already been
+      // of the fragment type and to filter them out if theythey've already been
       // declared before
       doc.definitions = doc.definitions.filter(definition => {
         if (definition.kind === Kind.FRAGMENT_DEFINITION) {

--- a/packages/gatsby/src/schema/__tests__/fixtures/kitchen-sink.json
+++ b/packages/gatsby/src/schema/__tests__/fixtures/kitchen-sink.json
@@ -141,7 +141,7 @@
     "pluginFilepath": "<PROJECT_ROOT>/examples/gatsbygram/node_modules/gatsby/dist/internal-plugins/prod-404",
     "packageJson": {
       "name": "prod-404",
-      "description": "Internal plugin to detect various flavors of 404 pages and ensure there's a 404.html path created as well to ensure compatability with static hosts",
+      "description": "Internal plugin to detect various flavors of 404 pages and ensure there's a 404.html path created as well to ensure compatibility with static hosts",
       "version": "1.0.0",
       "main": "index.js",
       "author": "Kyle Mathews <mathews.kyle@gmail.com>",

--- a/packages/gatsby/src/schema/__tests__/pagination.js
+++ b/packages/gatsby/src/schema/__tests__/pagination.js
@@ -9,7 +9,7 @@ describe(`Paginate query results`, () => {
     expect(nodes).toEqual([results[0]])
   })
 
-  it(`returns next and previos nodes`, async () => {
+  it(`returns next and previous nodes`, async () => {
     const args = { limit: 3 }
     const next = paginate(results, args).edges.map(({ next }) => next)
     const prev = paginate(results, args).edges.map(({ previous }) => previous)

--- a/packages/gatsby/src/utils/__tests__/merge-gatsby-config.js
+++ b/packages/gatsby/src/utils/__tests__/merge-gatsby-config.js
@@ -88,7 +88,7 @@ describe(`Merge gatsby config`, () => {
     })
   })
 
-  it(`Merging proxy is overriden`, () => {
+  it(`Merging proxy is overridden`, () => {
     const a = {
       proxy: {
         prefix: `/something-not/api`,

--- a/peril/rules/validate-yaml.ts
+++ b/peril/rules/validate-yaml.ts
@@ -118,7 +118,7 @@ const getCreatorsSchema = async () => {
           .required(),
         description: Joi.string(),
         location: Joi.string(),
-        // need to explicitely allow `null` to not fail on github: null fields
+        // need to explicitly allow `null` to not fail on github: null fields
         github: Joi.string()
           .uri(uriOptions)
           .allow(null),

--- a/peril/tests/validate-yaml/validate-yaml-sites.test.ts
+++ b/peril/tests/validate-yaml/validate-yaml-sites.test.ts
@@ -85,7 +85,7 @@ describe("a new PR", () => {
     expect(dm.warn).not.toBeCalled()
   })
 
-  it(`Check for required fields and disallow unkown fields`, async () => {
+  it(`Check for required fields and disallow unknown fields`, async () => {
     setSitesYmlContent(`
       - test: loem
     `)

--- a/peril/tests/validate-yaml/validate-yaml-starters.test.ts
+++ b/peril/tests/validate-yaml/validate-yaml-starters.test.ts
@@ -68,7 +68,7 @@ describe("a new PR", () => {
     expect(mockedUtils.addErrorMsg).not.toBeCalled()
   })
 
-  it(`Check for required fields and disallow unkown fields`, async () => {
+  it(`Check for required fields and disallow unknown fields`, async () => {
     setStartersYmlContent(`
       - test: loem
     `)

--- a/starters/blog/content/blog/hi-folks/index.md
+++ b/starters/blog/content/blog/hi-folks/index.md
@@ -24,7 +24,7 @@ made herself on the way.
 When she reached the first hills of the **Italic Mountains**, she had a last
 view back on the skyline of her hometown _Bookmarksgrove_, the headline of
 [Alphabet Village](http://google.com) and the subline of her own road, the Line
-Lane. Pityful a rethoric question ran over her cheek, then she continued her
+Lane. Pityful a rhetoric question ran over her cheek, then she continued her
 way. On her way she met a copy.
 
 ### Overlaid the jeepers uselessly much excluding
@@ -59,7 +59,7 @@ made herself on the way.
 
 When she reached the first hills of the Italic Mountains, she had a last view
 back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet
-Village and the subline of her own road, the Line Lane. Pityful a rethoric
+Village and the subline of her own road, the Line Lane. Pityful a rhetoric
 question ran over her cheek, then she continued her way. On her way she met a
 copy.
 
@@ -94,7 +94,7 @@ She packed her seven versalia, put her initial into the belt and made herself on
 the way. When she reached the first hills of the Italic Mountains, she had a
 last view back on the skyline of her hometown Bookmarksgrove, the headline of
 Alphabet Village and the subline of her own road, the Line Lane. Pityful a
-rethoric question ran over her cheek, then she continued her way. On her way she
+rhetoric question ran over her cheek, then she continued her way. On her way she
 met a copy.
 
 ###### Slapped cozy a that lightheartedly and far

--- a/themes/gatsby-starter-theme/content/posts/new-beginnings.mdx
+++ b/themes/gatsby-starter-theme/content/posts/new-beginnings.mdx
@@ -23,7 +23,7 @@ made herself on the way.
 When she reached the first hills of the **Italic Mountains**, she had a last
 view back on the skyline of her hometown _Bookmarksgrove_, the headline of
 [Alphabet Village](http://google.com) and the subline of her own road, the Line
-Lane. Pityful a rethoric question ran over her cheek, then she continued her
+Lane. Pityful a rhetoric question ran over her cheek, then she continued her
 way. On her way she met a copy.
 
 ### Overlaid the jeepers uselessly much excluding
@@ -58,7 +58,7 @@ made herself on the way.
 
 When she reached the first hills of the Italic Mountains, she had a last view
 back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet
-Village and the subline of her own road, the Line Lane. Pityful a rethoric
+Village and the subline of her own road, the Line Lane. Pityful a rhetoric
 question ran over her cheek, then she continued her way. On her way she met a
 copy.
 
@@ -93,7 +93,7 @@ She packed her seven versalia, put her initial into the belt and made herself on
 the way. When she reached the first hills of the Italic Mountains, she had a
 last view back on the skyline of her hometown Bookmarksgrove, the headline of
 Alphabet Village and the subline of her own road, the Line Lane. Pityful a
-rethoric question ran over her cheek, then she continued her way. On her way she
+rhetoric question ran over her cheek, then she continued her way. On her way she
 met a copy.
 
 ###### Slapped cozy a that lightheartedly and far


### PR DESCRIPTION
## Description

**Fix Typos** across the Project

**Fixed Files**
```
gatsby/.github/actions/high-priority-prs/src/__tests__/fixtures/data.json:3652:50: "commited" is a misspelling of "committed"
gatsby/.github/actions/high-priority-prs/src/__tests__/fixtures/data.json:4856:87: "requirment" is a misspelling of "requirement"
gatsby/.github/actions/high-priority-prs/src/__tests__/fixtures/data.json:6427:83: "unnessecary" is a misspelling of "unnecessary"
gatsby/.github/actions/high-priority-prs/src/__tests__/fixtures/data.json:6468:83: "unnessecary" is a misspelling of "unnecessary"
gatsby/.github/actions/high-priority-prs/src/data.json:3348:50: "commited" is a misspelling of "committed"
gatsby/.github/actions/high-priority-prs/src/data.json:3360:96: "durring" is a misspelling of "during"
gatsby/.github/actions/high-priority-prs/src/data.json:3778:98: "managment" is a misspelling of "management"
gatsby/.github/actions/high-priority-prs/src/data.json:3784:65: "managment" is a misspelling of "management"
gatsby/.github/actions/high-priority-prs/src/data.json:4676:87: "requirment" is a misspelling of "requirement"
gatsby/.github/actions/high-priority-prs/src/data.json:4748:37: "unnecesary" is a misspelling of "unnecessary"
gatsby/.github/actions/high-priority-prs/src/data.json:6510:116: "seperate" is a misspelling of "separate"
gatsby/docs/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/index.md:19:39: "immediatley" is a misspelling of "immediately"
gatsby/docs/blog/2019-06-12-performance-improvements-for-large-sites/index.md:32:102: "manfiest" is a misspelling of "manifest"
gatsby/docs/creators/creators.yml:120:104: "accessibile" is a misspelling of "accessible"
gatsby/docs/docs/building-a-contact-form.md:50:21: "invloves" is a misspelling of "involves"
gatsby/docs/docs/gatsby-repl.md:44:243: "Propeties" is a misspelling of "Properties"
gatsby/docs/docs/gatsby-repl.md:203:80: "Propeties" is a misspelling of "Properties"
gatsby/docs/sites.yml:1179:34: "Desinger" is a misspelling of "Designer"
gatsby/docs/sites.yml:2908:42: "fullfilment" is a misspelling of "fulfillment"
gatsby/docs/sites.yml:3637:38: "offical" is a misspelling of "official"
gatsby/docs/sites.yml:4612:86: "throught" is a misspelling of "through"
gatsby/docs/sites.yml:5521:6: "Comparsion" is a misspelling of "Comparison"
gatsby/docs/starters.yml:1262:30: "desgined" is a misspelling of "designed"
gatsby/docs/starters.yml:1967:42: "desgined" is a misspelling of "designed"
gatsby/docs/starters.yml:2748:16: "enviornment" is a misspelling of "environment"
gatsby/docs/starters.yml:2965:117: "intergration" is a misspelling of "integration"
gatsby/e2e-tests/development-runtime/cypress/integration/functionality/accessibility.js:1:16: "managment" is a misspelling of "management"
gatsby/e2e-tests/development-runtime/cypress/integration/navigation/linking.js:38:16: "existant" is a misspelling of "existent"
gatsby/e2e-tests/development-runtime/src/pages/index.js:26:21: "existant" is a misspelling of "existent"
gatsby/e2e-tests/production-runtime/.env.production:1:15: "commited" is a misspelling of "committed"
gatsby/e2e-tests/production-runtime/cypress/integration/accessibility.js:1:16: "managment" is a misspelling of "management"
gatsby/examples/using-asciidoc/src/pages/test.adoc:43:2: "astericks" is a misspelling of "asterisk"
gatsby/examples/using-asciidoc/src/pages/test.adoc:44:9: "astericks" is a misspelling of "asterisk"
gatsby/junit.xml:1069:60: "existant" is a misspelling of "existent"
gatsby/junit.xml:1069:129: "existant" is a misspelling of "existent"
gatsby/junit.xml:1211:62: "overriden" is a misspelling of "overridden"
gatsby/junit.xml:1211:116: "overriden" is a misspelling of "overridden"
gatsby/packages/gatsby/CHANGELOG.md:1409:61: "existant" is a misspelling of "existent"
gatsby/packages/gatsby/CHANGELOG.md:2947:46: "overriden" is a misspelling of "overridden"
gatsby/packages/gatsby/CHANGELOG.md:3156:23: "ouput" is a misspelling of "output"
gatsby/packages/gatsby/src/db/loki/index.js:130:3: "initalized" is a misspelling of "initialized"
gatsby/packages/gatsby/src/internal-plugins/prod-404/package.json:4:134: "compatability" is a misspelling of "compatibility"
gatsby/packages/gatsby/src/query/query-compiler.js:198:12: "thge" is a misspelling of "the"
gatsby/packages/gatsby/src/schema/__tests__/fixtures/kitchen-sink.json:144:138: "compatability" is a misspelling of "compatibility"
gatsby/packages/gatsby/src/schema/__tests__/pagination.js:12:23: "previos" is a misspelling of "previous"
gatsby/packages/gatsby/src/utils/__tests__/merge-gatsby-config.js:91:23: "overriden" is a misspelling of "overridden"
gatsby/packages/gatsby-dev-cli/src/__tests__/watch.js:132:20: "existant" is a misspelling of "existent"
gatsby/packages/gatsby-dev-cli/src/watch.js:24:7: "existant" is a misspelling of "existent"
gatsby/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap:51:52: "paramaters" is a misspelling of "parameters"
gatsby/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-browser.js:38:26: "paramaters" is a misspelling of "parameters"
gatsby/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-ssr.js:42:20: "paramaters" is a misspelling of "parameters"
gatsby/packages/gatsby-plugin-facebook-analytics/src/gatsby-ssr.js:20:29: "analitycs" is a misspelling of "analytics"
gatsby/packages/gatsby-plugin-feed/README.md:79:355: "satisifed" is a misspelling of "satisfied"
gatsby/packages/gatsby-plugin-feed/README.md:79:406: "satisifed" is a misspelling of "satisfied"
gatsby/packages/gatsby-source-contentful/CHANGELOG.md:306:67: "fliters" is a misspelling of "filters"
gatsby/packages/gatsby-source-graphql/README.md:32:15: "paramaters" is a misspelling of "parameters"
gatsby/packages/gatsby-source-wordpress/src/normalize.js:456:64: "properites" is a misspelling of "properties"
gatsby/packages/gatsby-transformer-remark/README.md:105:453: "ommitted" is a misspelling of "omitted"
gatsby/packages/gatsby-transformer-remark/README.md:214:65: "seperator" is a misspelling of "separator"
gatsby/peril/rules/validate-yaml.ts:121:19: "explicitely" is a misspelling of "explicitly"
gatsby/peril/tests/validate-yaml/validate-yaml-sites.test.ts:88:45: "unkown" is a misspelling of "unknown"
gatsby/peril/tests/validate-yaml/validate-yaml-starters.test.ts:71:45: "unkown" is a misspelling of "unknown"
gatsby/starters/blog/content/blog/hi-folks/index.md:27:16: "rethoric" is a misspelling of "rhetoric"
gatsby/starters/blog/content/blog/hi-folks/index.md:62:66: "rethoric" is a misspelling of "rhetoric"
gatsby/starters/blog/content/blog/hi-folks/index.md:97:0: "rethoric" is a misspelling of "rhetoric"
gatsby/themes/gatsby-starter-theme/content/posts/new-beginnings.mdx:26:16: "rethoric" is a misspelling of "rhetoric"
gatsby/themes/gatsby-starter-theme/content/posts/new-beginnings.mdx:61:66: "rethoric" is a misspelling of "rhetoric"
gatsby/themes/gatsby-starter-theme/content/posts/new-beginnings.mdx:96:0: "rethoric" is a misspelling of "rhetoric"
```