### PR TITLE
fix(docs): add note for exception when using gatsby-source-contentful

### DIFF
--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -21,7 +21,7 @@ module.exports = {
 }
 ```
 
-Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise, no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). An exception to this is when using [`gatsby-source-contentful`](https://www.gatsbyjs.org/packages/gatsby-source-contentful/) as the source plugin and the assets are not [downloaded to the local filesystem](https://www.gatsbyjs.org/packages/gatsby-source-contentful/#download-assets-for-static-distribution).
+Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise, no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](/packages/gatsby-source-wordpress). 
 
 By default, the `gatsby-source-contentful` plugin creates a `ContentfulAsset` node for every image with links to Contentful’s CDN, therefore it is not necessary to use `gatsby-transformer-sharp` together with `gatsby-source-contentful`.
 

--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -23,7 +23,7 @@ module.exports = {
 
 Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise, no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](/packages/gatsby-source-wordpress). 
 
-By default, the `gatsby-source-contentful` plugin creates a `ContentfulAsset` node for every image with links to Contentful’s CDN, therefore it is not necessary to use `gatsby-transformer-sharp` together with `gatsby-source-contentful`.
+**Note**: An exception to this is when using [`gatsby-source-contentful`](/packages/gatsby-source-contentful/), as the source plugin and the assets are not [downloaded to the local filesystem](https://www.gatsbyjs.org/packages/gatsby-source-contentful/#download-assets-for-static-distribution). By default, the `gatsby-source-contentful` plugin creates a `ContentfulAsset` node for every image with links to Contentful’s CDN, therefore it is not necessary to use `gatsby-transformer-sharp` together with `gatsby-source-contentful`.
 
 ## Parsing algorithm
 

--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -21,7 +21,7 @@ module.exports = {
 }
 ```
 
-Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). An exception to this is when using [`gatsby-source-contentful`](https://www.gatsbyjs.org/packages/gatsby-source-contentful/) as the source plugin and the assets are not [downloaded to the local filesystem](https://www.gatsbyjs.org/packages/gatsby-source-contentful/#download-assets-for-static-distribution).
+Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise, no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). An exception to this is when using [`gatsby-source-contentful`](https://www.gatsbyjs.org/packages/gatsby-source-contentful/) as the source plugin and the assets are not [downloaded to the local filesystem](https://www.gatsbyjs.org/packages/gatsby-source-contentful/#download-assets-for-static-distribution).
 
 By default, the `gatsby-source-contentful` plugin creates a `ContentfulAsset` node for every image with links to Contentful’s CDN, therefore it is not necessary to use `gatsby-transformer-sharp` together with `gatsby-source-contentful`.
 

--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -21,7 +21,7 @@ module.exports = {
 }
 ```
 
-Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise, no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](/packages/gatsby-source-wordpress). 
+Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise, no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](/packages/gatsby-source-wordpress).
 
 **Note**: An exception to this is when using [`gatsby-source-contentful`](/packages/gatsby-source-contentful/), as the source plugin and the assets are not [downloaded to the local filesystem](https://www.gatsbyjs.org/packages/gatsby-source-contentful/#download-assets-for-static-distribution). By default, the `gatsby-source-contentful` plugin creates a `ContentfulAsset` node for every image with links to Contentful’s CDN, therefore it is not necessary to use `gatsby-transformer-sharp` together with `gatsby-source-contentful`.
 

--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -21,7 +21,9 @@ module.exports = {
 }
 ```
 
-Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress).
+Please note that you must have a source plugin (which brings in images) installed in your project. Otherwise no `ImageSharp` nodes can be created for your files. Examples would be [`gatsby-source-filesystem`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem) or source plugins for (headless) CMSs like [`gatsby-source-wordpress`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress). An exception to this is when using [`gatsby-source-contentful`](https://www.gatsbyjs.org/packages/gatsby-source-contentful/) as the source plugin and the assets are not [downloaded to the local filesystem](https://www.gatsbyjs.org/packages/gatsby-source-contentful/#download-assets-for-static-distribution).
+
+By default, the `gatsby-source-contentful` plugin creates a `ContentfulAsset` node for every image with links to Contentful’s CDN, therefore it is not necessary to use `gatsby-transformer-sharp` together with `gatsby-source-contentful`.
 
 ## Parsing algorithm
 


### PR DESCRIPTION
Using `gatsby-transformer-sharp` along with `gatsby-source-contentful`, while using the default behavior of the source plugin to link to Contentful's CDN instead of downloading the assets to the to the local filesystem, results in a warning during compiling.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Extended the existing note to mention that using `gatsby-transformer-sharp` together with `gatsby-source-contentful`, while using the default behavior of the source plugin to link to Contentful's CDN instead of downloading the assets to the local filesystem, results in a warning during compiling.

The `gatsby-source-contentful` plugin creates a `ContentfulAsset` node for every image with links to Contentful’s CDN while `gatsby-transformer-sharp` can not find any assets to generate nodes for.

The warning:

<img width="1678" alt="Screen Shot 2019-07-19 at 4 04 17 PM" src="https://user-images.githubusercontent.com/5240653/61577771-f9908c80-aaa0-11e9-8d88-5ea2b9f1a14f.png">

ImageSharp nodes generated:

<img width="1678" alt="Screen Shot 2019-07-19 at 4 12 17 PM" src="https://user-images.githubusercontent.com/5240653/61577779-0e6d2000-aaa1-11e9-9339-316ef60af93a.png">

<img width="1679" alt="Screen Shot 2019-07-19 at 4 13 11 PM" src="https://user-images.githubusercontent.com/5240653/61577780-15942e00-aaa1-11e9-89c3-2cde15bb0330.png">

ContentfulAsset nodes generated:

<img width="1680" alt="Screen Shot 2019-07-19 at 4 11 18 PM" src="https://user-images.githubusercontent.com/5240653/61577789-22b11d00-aaa1-11e9-8a39-2c4c6d7d4666.png">

<img width="1679" alt="Screen Shot 2019-07-19 at 4 11 46 PM" src="https://user-images.githubusercontent.com/5240653/61577793-2cd31b80-aaa1-11e9-865e-4862de5ef1d1.png">

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

https://www.gatsbyjs.org/packages/gatsby-source-contentful/#download-assets-for-static-distribution
