### PR TITLE
docs: fix link in part 7 of tutorial

### DIFF
--- a/docs/docs/working-with-images-in-markdown.md
+++ b/docs/docs/working-with-images-in-markdown.md
@@ -8,7 +8,7 @@ When building Gatsby sites composed primarily of Markdown pages or posts, insert
 
 In sites like a blog, you may want to include a featured image that appears at the top of a page. One way to do this is to grab the image filename from a frontmatter field and then transforming it with `gatsby-plugin-sharp` in a GraphQL query.
 
-This solution assumes you already have programmatically generated pages from Markdown with renderers like `gatsby-transformer-remark` or `gatsby-plugin-mdx`. If not, take a read through up to [Part 7 of the Gatsby Tutorial](tutorial/part-seven/). This will build upon the tutorial and as such, `gatsby-transformer-remark` will be used for this example.
+This solution assumes you already have programmatically generated pages from Markdown with renderers like `gatsby-transformer-remark` or `gatsby-plugin-mdx`. If not, take a read through up to [Part 7 of the Gatsby Tutorial](/tutorial/part-seven/). This will build upon the tutorial and as such, `gatsby-transformer-remark` will be used for this example.
 
 > Note: This can be done similarly using [MDX](/docs/mdx/) as well. Instead of the `markdownRemark` nodes in GraphQL, `Mdx` can be swapped in and should work.
 


### PR DESCRIPTION

## Description

the link `Part 7 of the Gatsby Tutorial.`in `working-with-images-in-markdown.md` is broken for relative address, it should be absolute address.

## Related Issues

no