### PR TITLE
gastby-remark-images: fix onRouteUpdate signature

### DIFF
--- a/packages/gatsby-remark-images/src/__tests__/gastby-browser.js
+++ b/packages/gatsby-remark-images/src/__tests__/gastby-browser.js
@@ -1,0 +1,37 @@
+const {
+  imageClass,
+  imageWrapperClass,
+  imageBackgroundClass,
+} = require(`../constants`)
+const { onRouteUpdate } = require(`../gatsby-browser`)
+
+const createImageElement = () => {
+  global.document.body.innerHTML = `
+    <span class="${imageWrapperClass}">
+      <span class="${imageBackgroundClass}"></span>
+      <img class="${imageClass}">
+    </span>
+  `
+
+  return global.document.querySelector(`.${imageClass}`)
+}
+
+test(`it sets correct box-shadow on img element`, () => {
+  const pluginOptions = {}
+  const imageElement = createImageElement()
+
+  onRouteUpdate({}, pluginOptions)
+  imageElement.dispatchEvent(new Event(`load`))
+
+  expect(imageElement.style[`box-shadow`]).toBe(`inset 0px 0px 0px 400px white`)
+})
+
+test(`it sets correct box-shadow on img element with custom backgroundColor`, () => {
+  const pluginOptions = { backgroundColor: `blue` }
+  const imageElement = createImageElement()
+
+  onRouteUpdate({}, pluginOptions)
+  imageElement.dispatchEvent(new Event(`load`))
+
+  expect(imageElement.style[`box-shadow`]).toBe(`inset 0px 0px 0px 400px blue`)
+})

--- a/packages/gatsby-remark-images/src/gatsby-browser.js
+++ b/packages/gatsby-remark-images/src/gatsby-browser.js
@@ -5,7 +5,7 @@ const {
   imageWrapperClass,
 } = require(`./constants`)
 
-exports.onRouteUpdate = ({ pluginOptions }) => {
+exports.onRouteUpdate = (apiCallbackContext, pluginOptions) => {
   const options = Object.assign({}, DEFAULT_OPTIONS, pluginOptions)
 
   const imageWrappers = document.querySelectorAll(`.${imageWrapperClass}`)


### PR DESCRIPTION
## Description

According [to the `onRouteUpdate` docs](https://www.gatsbyjs.org/docs/browser-apis/#onRouteUpdate), the correct signature is `(apiCallbackContext, pluginOptions)`. Change

```js
exports.onRouteUpdate = ({ pluginOptions }) => {
```

to

```js
exports.onRouteUpdate = (apiCallbackContext, pluginOptions) => {
```

With the old signature, `({ pluginOptions })`, `pluginOptions` will always be undefined, causing the default options to be used. This causes the `box-shadow` later in the file to always be `white`, the default `options.backgroundColor`.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/15676. See that issue for bug repro instructions.

cc @birjolaxew
