### PR TITLE
fix(gatsby-theme-blog): don't use a p element to surround children

### DIFF
--- a/themes/gatsby-theme-blog/src/components/bio.js
+++ b/themes/gatsby-theme-blog/src/components/bio.js
@@ -44,9 +44,9 @@ const Bio = () => {
           role="presentation"
         />
       )}
-      <Styled.p>
+      <Styled.div>
         <BioContent />
-      </Styled.p>
+      </Styled.div>
     </Flex>
   )
 }


### PR DESCRIPTION
It can't surround other p elements. Div is more general.
