### PR TITLE
fix(gatsby-cli): fallback to empty string when `appName` is empty

### DIFF
--- a/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
+++ b/packages/gatsby-cli/src/reporter/reporters/ink/components/develop.js
@@ -72,7 +72,7 @@ class Develop extends Component {
         <Box height={1} flexDirection="row">
           <Color>{this.state.pagesCount} pages</Color>
           <Box flexGrow={1} />
-          <Color>{this.props.stage.context.appName}</Color>
+          <Color>{this.props.stage.context.appName || ``}</Color>
         </Box>
       </Box>
     )


### PR DESCRIPTION
## Description

Since version `2.7.16`, `gatsby develop` throws a `RangeError: Maximum call stack size exceeded`.

After some investigation, at line 75, `appName` can be `undefined` and for some reason causes this issue but using an empty string as fallback fixed it.