### PR TITLE
fix(docs): Missing step in styled-components.md

### DIFF
--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -18,6 +18,7 @@ First, open a new terminal window and run the following to create a new site:
 
 ```shell
 gatsby new styled-components-tutorial https://github.com/gatsbyjs/gatsby-starter-hello-world
+cd styled-components-tutorial
 ```
 
 Second, install the necessary dependencies for `styled-components`, including the Gatsby plugin.


### PR DESCRIPTION
Added missing step for navigating to the project folder.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

All command examples for creating new project include the navigation to the project folder command. This one is missing it.

