### PR TITLE
chore: speed up and lower memory usage of jobs

### DIFF
--- a/packages/gatsby/src/redux/reducers/jobs.js
+++ b/packages/gatsby/src/redux/reducers/jobs.js
@@ -18,20 +18,14 @@ module.exports = (state = { active: [], done: [] }, action) => {
         })
 
         state.active[index] = mergedJob
-        return {
-          done: state.done,
-          active: state.active,
-        }
+        return state
       } else {
         state.active.push({
           ...action.payload,
           createdAt: Date.now(),
           plugin: action.plugin,
         })
-        return {
-          done: state.done,
-          active: state.active,
-        }
+        return state
       }
     }
     case `END_JOB`: {
@@ -53,10 +47,7 @@ module.exports = (state = { active: [], done: [] }, action) => {
         runTime: moment(completedAt).diff(moment(job.createdAt)),
       })
 
-      return {
-        done: state.done,
-        active: state.active,
-      }
+      return state
     }
   }
 

--- a/packages/gatsby/src/redux/reducers/jobs.js
+++ b/packages/gatsby/src/redux/reducers/jobs.js
@@ -10,31 +10,27 @@ module.exports = (state = { active: [], done: [] }, action) => {
         throw new Error(`An ID must be provided when creating or setting job`)
       }
       const index = _.findIndex(state.active, j => j.id === action.payload.id)
-      const mergedJob = _.merge(state.active[index], {
-        ...action.payload,
-        createdAt: Date.now(),
-        plugin: action.plugin,
-      })
       if (index !== -1) {
+        const mergedJob = _.merge(state.active[index], {
+          ...action.payload,
+          createdAt: Date.now(),
+          plugin: action.plugin,
+        })
+
+        state.active[index] = mergedJob
         return {
           done: state.done,
-          active: [
-            ...state.active
-              .slice(0, index)
-              .concat([mergedJob])
-              .concat(state.active.slice(index + 1)),
-          ],
+          active: state.active,
         }
       } else {
+        state.active.push({
+          ...action.payload,
+          createdAt: Date.now(),
+          plugin: action.plugin,
+        })
         return {
           done: state.done,
-          active: state.active.concat([
-            {
-              ...action.payload,
-              createdAt: Date.now(),
-              plugin: action.plugin,
-            },
-          ]),
+          active: state.active,
         }
       }
     }
@@ -43,23 +39,23 @@ module.exports = (state = { active: [], done: [] }, action) => {
         throw new Error(`An ID must be provided when ending a job`)
       }
       const completedAt = Date.now()
-      const job = state.active.find(j => j.id === action.payload.id)
-      if (!job) {
+      const index = _.findIndex(state.active, j => j.id === action.payload.id)
+      if (index === -1) {
         throw new Error(oneLine`
           The plugin "${_.get(action, `plugin.name`, `anonymous`)}"
           tried to end a job with the id "${action.payload.id}"
           that either hasn't yet been created or has already been ended`)
       }
+      const job = state.active.splice(index, 1)[0]
+      state.done.push({
+        ...job,
+        completedAt,
+        runTime: moment(completedAt).diff(moment(job.createdAt)),
+      })
 
       return {
-        done: state.done.concat([
-          {
-            ...job,
-            completedAt,
-            runTime: moment(completedAt).diff(moment(job.createdAt)),
-          },
-        ]),
-        active: state.active.filter(j => j.id !== action.payload.id),
+        done: state.done,
+        active: state.active,
       }
     }
   }


### PR DESCRIPTION
## Description

In the case of Gatsby, immutable operations inside the reducers can be rather slow due to the potential size of the state data. Normally mutable operations here are frowned upon, but as Gatsby is using Redux in this way, it's perfectly fine to keep them mutable for performance reasons.

This change appears to have trimmed 60 seconds off a build time of 400 seconds. It is however a very image-heavy build.