### PR TITLE
fix(ci): pass ci flag to require creating snapshot files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,8 @@ aliases:
       - <<: *install_node_modules
       - <<: *persist_cache
       - <<: *attach_to_bootstrap
-      - run: yarn jest -w 1
-      - run: GATSBY_DB_NODES=loki yarn jest -w 1
+      - run: yarn jest -w 1 --ci
+      - run: GATSBY_DB_NODES=loki yarn jest -w 1 --ci
 
   e2e-test-workflow: &e2e-test-workflow
     filters:


### PR DESCRIPTION
## Description

This passes the `—-ci` flag to Jest so that it will behave a little more expectedly with snapshots in CI.

Specifically, this change means that when a snapshot _needs to be created_ in CI, it will fail rather than automatically create the snapshot.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
