### PR TITLE
fix(www): copy button now works on iOS

### DIFF
--- a/www/src/components/code-block/__tests__/index.js
+++ b/www/src/components/code-block/__tests__/index.js
@@ -3,7 +3,14 @@ import CodeBlock from ".."
 import { fireEvent, render } from "react-testing-library"
 
 beforeEach(() => {
+  document.createRange = jest.fn()
   document.execCommand = jest.fn()
+  window.getSelection = jest.fn().mockImplementation(() => {
+    return {
+      addRange: jest.fn(),
+      removeAllRanges: jest.fn(),
+    }
+  })
 })
 
 describe(`basic functionality`, () => {
@@ -16,7 +23,7 @@ describe(`basic functionality`, () => {
       expect(queryByText(`copy`)).toBeDefined()
     })
 
-    it(`copies text to clipboard`, () => {
+    it.only(`copies text to clipboard`, () => {
       const text = `alert('hello world')`
       const { queryByText } = render(
         <CodeBlock language="jsx">{text}</CodeBlock>

--- a/www/src/components/code-block/__tests__/index.js
+++ b/www/src/components/code-block/__tests__/index.js
@@ -23,7 +23,7 @@ describe(`basic functionality`, () => {
       expect(queryByText(`copy`)).toBeDefined()
     })
 
-    it.only(`copies text to clipboard`, () => {
+    it(`copies text to clipboard`, () => {
       const text = `alert('hello world')`
       const { queryByText } = render(
         <CodeBlock language="jsx">{text}</CodeBlock>

--- a/www/src/components/code-block/index.js
+++ b/www/src/components/code-block/index.js
@@ -101,7 +101,7 @@ const CodeBlock = ({
 CodeBlock.propTypes = {
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   className: PropTypes.string,
-  disableCopy: PropTypes.bool,
+  copy: PropTypes.bool,
 }
 
 CodeBlock.defaultProps = {

--- a/www/src/components/code-block/index.js
+++ b/www/src/components/code-block/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import PropTypes from "prop-types"
 import Highlight, { defaultProps } from "prism-react-renderer"
 
 import Copy from "../copy"
@@ -27,9 +28,10 @@ const getParams = (name = ``) => {
  * we un-wind it a bit to get the string content
  * but keep it extensible so it can be used with just children (string) and className
  */
-export default ({
+const CodeBlock = ({
   children,
   className = children.props ? children.props.className : ``,
+  disableCopy,
 }) => {
   const [language, { title = `` }] = getParams(className)
   const [content, highlights] = normalize(
@@ -55,16 +57,18 @@ export default ({
           )}
           <div className="gatsby-highlight">
             <pre className={`language-${language}`}>
-              <Copy
-                fileName={title}
-                css={{
-                  position: `absolute`,
-                  right: space[1],
-                  top: space[1],
-                  borderRadius: `${radii[2]}px ${radii[2]}px`,
-                }}
-                content={content}
-              />
+              {disableCopy !== false && (
+                <Copy
+                  fileName={title}
+                  css={{
+                    position: `absolute`,
+                    right: space[1],
+                    top: space[1],
+                    borderRadius: `${radii[2]}px ${radii[2]}px`,
+                  }}
+                  content={content}
+                />
+              )}
               <code className={`language-${language}`}>
                 {tokens.map((line, i) => {
                   const lineProps = getLineProps({ line, key: i })
@@ -93,3 +97,15 @@ export default ({
     </Highlight>
   )
 }
+
+CodeBlock.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  className: PropTypes.string,
+  disableCopy: PropTypes.bool,
+}
+
+CodeBlock.defaultProps = {
+  disableCopy: false,
+}
+
+export default CodeBlock

--- a/www/src/components/code-block/index.js
+++ b/www/src/components/code-block/index.js
@@ -31,7 +31,7 @@ const getParams = (name = ``) => {
 const CodeBlock = ({
   children,
   className = children.props ? children.props.className : ``,
-  disableCopy,
+  copy,
 }) => {
   const [language, { title = `` }] = getParams(className)
   const [content, highlights] = normalize(
@@ -57,7 +57,7 @@ const CodeBlock = ({
           )}
           <div className="gatsby-highlight">
             <pre className={`language-${language}`}>
-              {disableCopy !== false && (
+              {copy && (
                 <Copy
                   fileName={title}
                   css={{
@@ -105,7 +105,7 @@ CodeBlock.propTypes = {
 }
 
 CodeBlock.defaultProps = {
-  disableCopy: false,
+  copy: true,
 }
 
 export default CodeBlock

--- a/www/src/components/copy.js
+++ b/www/src/components/copy.js
@@ -16,6 +16,7 @@ const copyToClipboard = content => {
   const el = document.createElement(`textarea`)
   el.value = content
   el.setAttribute(`readonly`, ``)
+  el.setAttribute(`contenteditable`, true)
   el.style.position = `absolute`
   el.style.left = `-9999px`
   document.body.appendChild(el)

--- a/www/src/components/copy.js
+++ b/www/src/components/copy.js
@@ -13,16 +13,21 @@ import {
 } from "../utils/presets"
 
 const copyToClipboard = content => {
-  const el = document.createElement(`textarea`)
-  el.value = content
-  el.setAttribute(`readonly`, ``)
-  el.setAttribute(`contenteditable`, true)
-  el.style.position = `absolute`
-  el.style.left = `-9999px`
-  document.body.appendChild(el)
-  el.select()
+  const textarea = document.createElement(`textarea`)
+  textarea.value = content
+  textarea.setAttribute(`readonly`, true)
+  textarea.setAttribute(`contenteditable`, true)
+  textarea.style.position = `absolute`
+  textarea.style.left = `-9999px`
+  document.body.appendChild(textarea)
+  textarea.select()
+  const range = document.createRange()
+  const sel = window.getSelection()
+  sel.removeAllRanges()
+  sel.addRange(range)
+  textarea.setSelectionRange(0, textarea.value.length)
   document.execCommand(`copy`)
-  document.body.removeChild(el)
+  document.body.removeChild(textarea)
 }
 
 const delay = duration => new Promise(resolve => setTimeout(resolve, duration))


### PR DESCRIPTION
## Description

This fixes an issue with the copy button that `contenteditable` and `range` must be used to work on iOS Safari. _Fun_.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
