### PR TITLE
feat(docs): Include explicit mention of GraphQL arguments coming from context

### DIFF
--- a/docs/docs/programmatically-create-pages-from-data.md
+++ b/docs/docs/programmatically-create-pages-from-data.md
@@ -51,11 +51,21 @@ exports.createPages = async function({ actions, graphql }) {
 
 For each page we want to create we must specify the `path` for visiting that
 page, the `component` template used to render that page, and any `context`
-we need in the component for rendering. The `context` parameter is
-_optional_ though often times it will include a unique identifier that can
-be used to query for associated data that will be rendered to the page. All
-`context` values are made available to a template's GraphQL queries as
-arguments prefaced with `$` (ex. `slug` -> `$slug`).
+we need in the component for rendering.
+
+The `context` parameter is _optional_, though often times it will include a
+unique identifier that can be used to query for associated data that will be
+rendered to the page. All `context` values are made available to a template's
+GraphQL queries as arguments prefaced with `$`, so from our example above the
+`slug` property will become the `$slug` argument in our page query:
+
+```js
+export const query = graphql`
+  query($slug: String!) {
+    ...
+  }
+`
+```
 
 ### Specifying A Template
 
@@ -92,11 +102,11 @@ export const query = graphql`
 `
 ```
 
-Notice that the `slug` value we specified in the `createPage` context is
-used in the template's GraphQL query. As a result we can provide the `title`
-and `html` from the matching `markdownRemark` record to our component. The
-context is also available as the `pageContext` prop in the template
-component itself.
+Notice that we're able to query with the `$slug` value from our `context` as
+an argument, which ensures that we're returning only the data that matches
+that specific page. As a result we can provide the `title` and `html` from
+the matching `markdownRemark` record to our component. The `context` values
+are also available as the `pageContext` prop in the template component itself.
 
 ### Not Just Markdown
 

--- a/docs/docs/programmatically-create-pages-from-data.md
+++ b/docs/docs/programmatically-create-pages-from-data.md
@@ -53,7 +53,9 @@ For each page we want to create we must specify the `path` for visiting that
 page, the `component` template used to render that page, and any `context`
 we need in the component for rendering. The `context` parameter is
 _optional_ though often times it will include a unique identifier that can
-be used to query for associated data that will be rendered to the page.
+be used to query for associated data that will be rendered to the page. All
+`context` values are made available to a template's GraphQL queries as 
+arguments prefaced with `$` (ex. `slug` -> `$slug`).
 
 ### Specifying A Template
 

--- a/docs/docs/programmatically-create-pages-from-data.md
+++ b/docs/docs/programmatically-create-pages-from-data.md
@@ -54,7 +54,7 @@ page, the `component` template used to render that page, and any `context`
 we need in the component for rendering. The `context` parameter is
 _optional_ though often times it will include a unique identifier that can
 be used to query for associated data that will be rendered to the page. All
-`context` values are made available to a template's GraphQL queries as 
+`context` values are made available to a template's GraphQL queries as
 arguments prefaced with `$` (ex. `slug` -> `$slug`).
 
 ### Specifying A Template


### PR DESCRIPTION
## Description

I got confused as to why certain fields weren't being sent into my GraphQL queries and spent an embarrassing amount of time trying to debug it in all the wrong ways.

This PR adds a sentence the "Programmatically Create Pages From Data" section of the docs explicitly clarifying that all values passed to `context` are made available to GraphQL queries as arguments.

:bulb: It might be worth also explaining the related inverse, where any argument you expect to use in GraphQL queries must be specified on the `context`. **Opinions appreciated!**

## Related Issues

My own lack of understanding 😁

I also want to thank whoever sees this for doing incredibly impressive work on Gatsby thus far. I've had a blast working on a few `theme` projects for my company and I hope I can contribute more in the coming weeks!

Also big thanks to @lannonbr for pointing out the fix in the [`#need-help` Discord channel](https://discordapp.com/channels/484383807575687178/537691356487876624)!