### PR TITLE
feat(gatsby-theme-blog): use dirname as fallback as slug

### DIFF
--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -169,7 +169,10 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
 
   const toPostPath = node => {
     const { dir } = path.parse(node.relativePath)
-    return urlResolve(basePath, dir, node.name)
+    const isIndex = node.name === `index`
+    return isIndex
+      ? urlResolve(basePath, dir)
+      : urlResolve(basePath, dir, node.name)
   }
 
   // Make sure it's an MDX node

--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -3,7 +3,7 @@ const path = require(`path`)
 const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { urlResolve } = require(`gatsby-core-utils`)
+const { createFilePath } = require(`gatsby-source-filesystem`)
 
 const debug = Debug(`gatsby-theme-blog`)
 
@@ -167,14 +167,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
   const { createNode, createParentChildLink } = actions
 
-  const toPostPath = node => {
-    const { dir } = path.parse(node.relativePath)
-    const isIndex = node.name === `index`
-    return isIndex
-      ? urlResolve(basePath, dir)
-      : urlResolve(basePath, dir, node.name)
-  }
-
   // Make sure it's an MDX node
   if (node.internal.type !== `Mdx`) {
     return
@@ -185,7 +177,11 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
   const source = fileNode.sourceInstanceName
 
   if (node.internal.type === `Mdx` && source === contentPath) {
-    const slug = toPostPath(fileNode)
+    const slug = createFilePath({
+      node: fileNode,
+      getNode,
+      basePath: contentPath,
+    })
 
     const fieldData = {
       title: node.frontmatter.title,

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -24,7 +24,6 @@
     "@theme-ui/prism": "^0.2.14",
     "@theme-ui/typography": "^0.2.5",
     "deepmerge": "^4.0.0",
-    "gatsby-core-utils": "^1.0.3",
     "gatsby-image": "^2.2.6",
     "gatsby-plugin-emotion": "^4.1.2",
     "gatsby-plugin-feed": "^2.3.4",


### PR DESCRIPTION
Some people (me included) use a folder for each blog post with an `index.mdx`.

Currently, if I have `content/posts/my-first-post/index.mdx` it creates the page at `/my-first-post/index`. I changed so it creates the page at `/my-first-post`.

For files other than `index` it uses the full path (same as before): `content/posts/my-first-post/foo.mdx` -> `/my-first-post/foo`