### PR TITLE
fix(PrismJS): Documentation highlighting

### DIFF
--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -315,7 +315,7 @@ const _options = {
       // PrismJS syntax highlighting token styles
       // https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/
       ".token": {
-        display: `inline-block`,
+        display: `inline`,
       },
       ".token.comment, .token.block-comment, .token.prolog, .token.doctype, .token.cdata": {
         color: colors.code.comment,


### PR DESCRIPTION
## Description

Browsing through your doc, I've noticed some highlighting was broken.
Using `display: inline` on the `.token` class instead of `inline-block` fixed it.

**Before:**
<img width="834" alt="Screenshot 2019-07-22 at 14 03 38" src="https://user-images.githubusercontent.com/6688748/61665403-bfceaa00-ac89-11e9-8465-db6487cad08a.png">

**After:**
<img width="824" alt="Screenshot 2019-07-22 at 14 03 48" src="https://user-images.githubusercontent.com/6688748/61665404-bfceaa00-ac89-11e9-8cfa-8190db4a0c27.png">

(Page of the screenshot : https://www.gatsbyjs.org/docs/node-apis/?origin_team=T026AN50K#createPages)
