### PR TITLE
test(gatsby): Fix typo in test name

### DIFF
--- a/packages/gatsby/src/schema/extensions/__tests__/field-extensions.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/field-extensions.js
@@ -59,7 +59,7 @@ describe(`GraphQL field extensions`, () => {
     })
   })
 
-  it(`allows creating a cutom field extension`, async () => {
+  it(`allows creating a custom field extension`, async () => {
     dispatch(
       createFieldExtension({
         name: `birthday`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Fixes a typo in a test name (missing the letter 's' in 'custom').

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
