### PR TITLE
fix(gatsby-plugin-mdx): pass maxDepth correctly to mdast-util-toc

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -217,7 +217,7 @@ ${e}`
         },
         async resolve(mdxNode, { maxDepth }) {
           const { mdast } = await processMDX({ node: mdxNode });
-          const toc = generateTOC(mdast, maxDepth);
+          const toc = generateTOC(mdast, {maxDepth});
 
           return getTableOfContents(toc.map, {});
         }


### PR DESCRIPTION
According to this line of plugin `mdast-util-toc`.
https://github.com/syntax-tree/mdast-util-toc/blob/beca120e03db0a715b8517248968bf34290ebd1a/lib/search.js#L18
`maxDepth` should be `{maxDepth}`  , or param may not be resolved correctly.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
