### PR TITLE
feat(gatsby-image): Add lazyOffset prop

### DIFF
--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -370,6 +370,8 @@ After you've made a query, you can pass additional options to the gatsby-image c
 | `objectPosition`       | `string`            | Passed to the `object-fit-images` polyfill when importing from `gatsby-image/withIEPolyfill`. Defaults to `50% 50%`.          |
 | `loading`              | `string`            | Set the browser's native lazy loading attribute. One of `lazy`, `eager` or `auto`. Defaults to `lazy`.                        |
 | `critical`             | `bool`              | Opt-out of lazy-loading behavior. Defaults to `false`. Deprecated, use `loading` instead.                                     |
+| `draggable`            | `string`            | Passed to the rendered HTML `img` element                                                                                     |
+| `lazyOffset`           | `string`            | An offset for lazy-loading. The same as `IntersectionObserver.rootMargin`, Defaults to `200px`.                               |
 
 Here are some usage examples:
 

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -85,6 +85,7 @@ const setup = (
       itemProp={`item-prop-for-the-image`}
       placeholderStyle={{ color: `red` }}
       placeholderClassName={`placeholder`}
+      lazyOffset={`200px`}
       {...props}
     />
   )


### PR DESCRIPTION
## Description

`lazyOffset` prop was added to `gatsby-image` component which passes to IntersectionObserver as a `rootMargin` property. The default value remains `200px`. It makes possible to control how early or lately an image will be loaded.

## Related Issues

Implementation of #14662
