### PR TITLE
chore: Update react-testing-library to @testing-library/react

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -272,7 +272,7 @@ though remember you may need to install the Babel 7 versions. See
 For more information on Jest testing, visit
 [the Jest site](https://jestjs.io/docs/en/getting-started).
 
-For an example encapsulating all of these techniques--and a full unit test suite with [react-testing-library][react-testing-library], check out the [using-jest][using-jest] example.
+For an example encapsulating all of these techniques--and a full unit test suite with [@testing-library/react][react-testing-library], check out the [using-jest][using-jest] example.
 
 [using-jest]: https://github.com/gatsbyjs/gatsby/tree/master/examples/using-jest
-[react-testing-library]: https://github.com/kentcdodds/react-testing-library
+[react-testing-library]: https://github.com/testing-library/react-testing-library

--- a/examples/using-jest/README.md
+++ b/examples/using-jest/README.md
@@ -7,11 +7,11 @@
   using Jest
 </h1>
 
-Kick off your next Gatsby app with some great testing practices enabled via [Jest][jest], [react-testing-library][react-testing-library], and of course, [Gatsby][gatsby] 💪
+Kick off your next Gatsby app with some great testing practices enabled via [Jest][jest], [@testing-library/react][react-testing-library], and of course, [Gatsby][gatsby] 💪
 
 Check out the [unit testing doc][unit-testing-doc] for further info!
 
 [jest]: https://jestjs.io/
-[react-testing-library]: https://github.com/kentcdodds/react-testing-library
+[react-testing-library]: https://github.com/testing-library/react-testing-library
 [gatsby]: https://gatsbyjs.org
 [unit-testing-doc]: https://www.gatsbyjs.org/docs/unit-testing/

--- a/examples/using-jest/jest.setup.js
+++ b/examples/using-jest/jest.setup.js
@@ -1,2 +1,2 @@
 require(`jest-dom/extend-expect`)
-require(`react-testing-library/cleanup-after-each`)
+require(`@testing-library/react/cleanup-after-each`)

--- a/examples/using-jest/package.json
+++ b/examples/using-jest/package.json
@@ -30,12 +30,12 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.5",
     "babel-jest": "^24.0.0",
     "babel-preset-gatsby": "^0.1.6",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.0.0",
-    "jest-dom": "^3.0.0",
-    "react-testing-library": "^5.4.4"
+    "jest-dom": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/examples/using-jest/src/components/__tests__/header.test.js
+++ b/examples/using-jest/src/components/__tests__/header.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render } from '@testing-library/react'
 
 import Header from '../header'
 

--- a/examples/using-jest/src/components/__tests__/image.test.js
+++ b/examples/using-jest/src/components/__tests__/image.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render } from '@testing-library/react'
 import { StaticQuery } from 'gatsby' // mocked
 
 import Image from '../image'

--- a/examples/using-jest/src/components/__tests__/layout.test.js
+++ b/examples/using-jest/src/components/__tests__/layout.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render } from '@testing-library/react'
 import { StaticQuery } from 'gatsby' // mocked
 
 import Layout from '../layout'

--- a/examples/using-jest/src/pages/__tests__/404.test.js
+++ b/examples/using-jest/src/pages/__tests__/404.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render } from '@testing-library/react'
 import { StaticQuery } from 'gatsby' // mocked
 
 import FourOhFour from '../404'

--- a/examples/using-jest/src/pages/__tests__/index.test.js
+++ b/examples/using-jest/src/pages/__tests__/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render } from '@testing-library/react'
 import { StaticQuery } from 'gatsby' // mocked
 
 import Index from '../index'

--- a/examples/using-jest/src/pages/__tests__/page-2.test.js
+++ b/examples/using-jest/src/pages/__tests__/page-2.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render } from '@testing-library/react'
 import { StaticQuery } from 'gatsby' // mocked
 
 import PageTwo from '../page-2'


### PR DESCRIPTION
## Description

This is an attempt to change the react-testing-library to its updated, namespaced replacement @testing-library/react. It may prevent future deprecation notices.

Though it starts as a localized attempt to bring the doc/example repo up-to-date, many other points on the Gatsby monorepo also refer to this library. I keep the PR open to more feedback on this issue and if it would be a good move to update all at once or make smaller PRs on each.

## Related Issues

None so far
