### PR TITLE
chore(gatsby-theme-blog): Capitalization in social link names

### DIFF
--- a/themes/gatsby-theme-blog/README.md
+++ b/themes/gatsby-theme-blog/README.md
@@ -70,11 +70,11 @@ module.exports = {
     // Used for social links in the root footer
     social: [
       {
-        name: `twitter`,
+        name: `Twitter`,
         url: `https://twitter.com/gatsbyjs`,
       },
       {
-        name: `github`,
+        name: `GitHub`,
         url: `https://github.com/gatsbyjs`,
       },
     ],

--- a/themes/gatsby-theme-blog/gatsby-config.js
+++ b/themes/gatsby-theme-blog/gatsby-config.js
@@ -8,11 +8,11 @@ module.exports = options => {
       description: `Description placeholder`,
       social: [
         {
-          name: `twitter`,
+          name: `Twitter`,
           url: `https://twitter.com/gatsbyjs`,
         },
         {
-          name: `github`,
+          name: `GitHub`,
           url: `https://github.com/gatsbyjs`,
         },
       ],


### PR DESCRIPTION
Following up on #15738, changing ![image](https://user-images.githubusercontent.com/1120926/61699161-a9345b80-ad3a-11e9-9f50-914a8f19dcc3.png) to say `Twitter` and `GitHub`.

I don't know how to test changes to themes yet, but I believe this shouldn't break anything?