### PR TITLE
chore(gatsby-plugin-sharp): pass md5 hash of input file to Cloud

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -18,7 +18,6 @@
     "imagemin-pngquant": "^6.0.0",
     "imagemin-webp": "^5.0.0",
     "lodash": "^4.17.14",
-    "md5-file": "^4.0.0",
     "mini-svg-data-uri": "^1.0.0",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -18,6 +18,7 @@
     "imagemin-pngquant": "^6.0.0",
     "imagemin-webp": "^5.0.0",
     "lodash": "^4.17.14",
+    "md5-file": "^4.0.0",
     "mini-svg-data-uri": "^1.0.0",
     "potrace": "^2.1.1",
     "probe-image-size": "^4.0.0",

--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/process-file.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/process-file.js.snap
@@ -5,37 +5,3 @@ Array [
   Promise {},
 ]
 `;
-
-exports[`processFile should offload sharp transforms to the cloud 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "https://example.com/image-service",
-      Object {
-        "body": Object {
-          "file": "mypath/file.jpg",
-          "options": Object {
-            "stripMetadata": true,
-          },
-          "transforms": Array [
-            Object {
-              "args": Object {
-                "height": 100,
-                "width": 100,
-              },
-              "outputPath": "myoutputpath/1234/file.jpg",
-            },
-          ],
-        },
-        "json": true,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": Promise {},
-    },
-  ],
-}
-`;

--- a/packages/gatsby-plugin-sharp/src/__tests__/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/process-file.js
@@ -1,5 +1,4 @@
 jest.mock(`got`)
-jest.mock(`md5-file/promise`)
 jest.mock(`../safe-sharp`, () => {
   return {
     simd: jest.fn(),
@@ -8,7 +7,6 @@ jest.mock(`../safe-sharp`, () => {
 })
 const { createArgsDigest, processFile, sortKeys } = require(`../process-file`)
 const got = require(`got`)
-const md5File = require(`md5-file/promise`)
 
 describe(`createArgsDigest`, () => {
   const defaultArgsBaseline = {
@@ -147,9 +145,7 @@ describe(`processFile`, () => {
       },
     }
 
-    md5File.mockResolvedValueOnce(hash)
-
-    const res = await processFile(`mypath/file.jpg`, [transforms], {
+    const res = await processFile(`mypath/file.jpg`, hash, [transforms], {
       stripMetadata: true,
     })
 

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -101,6 +101,7 @@ function queueImageResizing({ file, args = {}, reporter }) {
   const job = {
     args: options,
     inputPath: file.absolutePath,
+    contentDigest: file.internal.contentDigest,
     outputPath: filePath,
   }
 

--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -119,6 +119,7 @@ function runJobs(
   try {
     const promises = processFile(
       job.inputPath,
+      job.contentDigest,
       jobs.map(job => job.job),
       pluginOptions
     ).map(promise =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14115,6 +14115,7 @@ md5-file@^3.1.1:
 md5-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-4.0.0.tgz#f3f7ba1e2dd1144d5bf1de698d0e5f44a4409584"
+  integrity sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==
 
 md5.js@^1.3.4:
   version "1.3.4"


### PR DESCRIPTION
## Description

This simple PR adds a content hash mechanism to send to Gatsby Cloud so that subsequent Cloud image requests can be cached based on the content and transforms arguments, rather than the file argument (which could change to a cache directory on subsequent builds).

Why?

Cloud can't compute a unique hash based on input file file alone (which changes between runs), we need a content hash and transforms to compute a cache key, which we can then cache as long as those are unique/non-changing.

## Questions

Both of the below were fixed by threading the digest down to the scheduler 🎉 

1. ~Could be fairly expensive to compute md5-file for each file; we have this in the file node; is there a better way we can use to avoid computing it each time?~
1. ~We should compute md5-file based on _original input file_ instead of the cached file (which could theoretically change?)~
	- In other words: first invocation `src/images/gatsby-icon.png`
	- Second invocation: `.cache/caches/gatsby-source-filesystem/gatsby-icon-1234.png`

cc @rase- @wardpeet (since you worked on this previously!)
