### PR TITLE
Updating to use proper grammar

### DIFF
--- a/docs/docs/sourcing-from-wordpress.md
+++ b/docs/docs/sourcing-from-wordpress.md
@@ -6,7 +6,7 @@ This guide will walk you through the process of using [Gatsby](/) with [WordPres
 
 WordPress is a free and open-source content management system (CMS). Let's say you have a site built with WordPress and you want to pull the existing data into your static Gatsby site. You can do that with [gatsby-source-wordpress](/packages/gatsby-source-wordpress/?=wordpress). Let's begin!
 
-_Note: this guide uses the `gatsby-starter-default` to provide you with a knowledge necessary to start working with WordPress but if you get stuck at some point of the guide feel free to use
+_Note: this guide uses the `gatsby-starter-default` to provide you with the knowledge necessary to start working with WordPress but if you get stuck at some point of the guide feel free to use
 [this example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-wordpress) to gain extra insights._
 
 ## Setup


### PR DESCRIPTION
## Description

Updating the grammar to use the proper word "the" instead of "a" when referring to the knowledge necessary to start working.

## Related Issues

N/A
