### PR TITLE
fix(www): fix styling of email input on .org newsletter form

### DIFF
--- a/www/src/components/email-capture-form.js
+++ b/www/src/components/email-capture-form.js
@@ -79,6 +79,7 @@ const SingleLineInput = styled(`input`)`
   ${formInput};
   border-color: ${colors.purple[20]};
   width: 100%;
+  -webkit-appearance: none;
 
   :focus {
     ${formInputFocus}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

At the footer of the Gatsby homepage:

![C8980227-FFD1-4B17-8E35-4D1777618411](https://user-images.githubusercontent.com/5074763/61763041-913ff480-ad99-11e9-9772-6443f4c23519.jpeg)

This PR removes the input inset shadow on iOS Safari.

## Related Issues

Not aware of any