### PR TITLE
fix(gatsby-source-filesystem): Move GraphQL definition for File into sourceNodes

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.12.0"
+    "gatsby": "^2.2.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -40,10 +40,19 @@ const createFSMachine = () =>
   })
 
 exports.sourceNodes = (
-  { actions, getNode, createNodeId, hasNodeChanged, reporter, emitter },
+  { actions, getNode, createNodeId, reporter, emitter },
   pluginOptions
 ) => {
-  const { createNode, deleteNode } = actions
+  reporter.info(`Creating GraphQL type definition for File`)
+  const { createNode, createTypes, deleteNode } = actions
+
+  const typeDefs = `
+    type File implements Node @infer {
+      birthtime: Date @deprecated(reason: "Use \`birthTime\` instead")
+      birthtimeMs: Float @deprecated(reason: "Use \`birthTime\` instead")
+    }
+  `
+  createTypes(typeDefs)
 
   // Validate that the path exists.
   if (!fs.existsSync(pluginOptions.path)) {
@@ -183,14 +192,3 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
 }
 
 exports.setFieldsOnGraphQLNodeType = require(`./extend-file-node`)
-
-exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions
-  const typeDefs = `
-  type File implements Node @infer {
-    birthtime: Date @deprecated(reason: "Use \`birthTime\` instead")
-    birthtimeMs: Float @deprecated(reason: "Use \`birthTime\` instead")
-  }
-  `
-  createTypes(typeDefs)
-}


### PR DESCRIPTION
Since #15409 `gatsby-source-filesystem` uses the `createSchemaCustomization` API, which is only available in Gatsby ^2.12, so we should bump the peer deps.

Fixes #15680