### PR TITLE
docs(gatsby-theme-blog): make default values in README consistent with code

### DIFF
--- a/themes/gatsby-theme-blog/README.md
+++ b/themes/gatsby-theme-blog/README.md
@@ -32,8 +32,8 @@ npm install --save gatsby-theme-blog
 | Key           | Default value     | Description                                                                                               |
 | ------------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
 | `basePath`    | `/`               | Root url for all blog posts                                                                               |
-| `contentPath` | `/content/posts`  | Location of blog posts                                                                                    |
-| `assetPath`   | `/content/assets` | Location of assets                                                                                        |
+| `contentPath` | `content/posts`  | Location of blog posts                                                                                    |
+| `assetPath`   | `content/assets` | Location of assets                                                                                        |
 | `mdx`         | `true`            | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
 
 #### Example usage

--- a/themes/gatsby-theme-blog/README.md
+++ b/themes/gatsby-theme-blog/README.md
@@ -29,12 +29,12 @@ npm install --save gatsby-theme-blog
 
 ### Theme options
 
-| Key           | Default value     | Description                                                                                               |
-| ------------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
-| `basePath`    | `/`               | Root url for all blog posts                                                                               |
-| `contentPath` | `content/posts`   | Location of blog posts                                                                                    |
-| `assetPath`   | `content/assets`  | Location of assets                                                                                        |
-| `mdx`         | `true`            | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| Key           | Default value    | Description                                                                                               |
+| ------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
+| `basePath`    | `/`              | Root url for all blog posts                                                                               |
+| `contentPath` | `content/posts`  | Location of blog posts                                                                                    |
+| `assetPath`   | `content/assets` | Location of assets                                                                                        |
+| `mdx`         | `true`           | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
 
 #### Example usage
 

--- a/themes/gatsby-theme-blog/README.md
+++ b/themes/gatsby-theme-blog/README.md
@@ -32,8 +32,8 @@ npm install --save gatsby-theme-blog
 | Key           | Default value     | Description                                                                                               |
 | ------------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
 | `basePath`    | `/`               | Root url for all blog posts                                                                               |
-| `contentPath` | `content/posts`  | Location of blog posts                                                                                    |
-| `assetPath`   | `content/assets` | Location of assets                                                                                        |
+| `contentPath` | `content/posts`   | Location of blog posts                                                                                    |
+| `assetPath`   | `content/assets`  | Location of assets                                                                                        |
 | `mdx`         | `true`            | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
 
 #### Example usage


### PR DESCRIPTION
Removed slashes in docs for default values in theme options section

Following this code: https://github.com/gatsbyjs/gatsby/blob/0c39a4506493fa0409bca30c54c86daa9715a1e9/themes/gatsby-theme-blog/gatsby-config.js#L44-L45

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
