### PR TITLE
fix(gatsby-theme-blog): keywords

### DIFF
--- a/themes/gatsby-theme-blog/gatsby-node.js
+++ b/themes/gatsby-theme-blog/gatsby-node.js
@@ -188,6 +188,7 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
       tags: node.frontmatter.tags || [],
       slug,
       date: node.frontmatter.date,
+      keywords: node.frontmatter.keywords || [],
     }
     createNode({
       ...fieldData,


### PR DESCRIPTION
In graphiQL, querying for keywords in the frontmatter results in 
`"Cannot return null for non-nullable field BlogPost.keywords."`

Added the frontmatter field to the nodes that get created.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
