### PR TITLE
chore(docs): Clean up "Adding a Path Prefix" doc

### DIFF
--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -4,16 +4,18 @@ title: Adding a Path Prefix
 
 Many applications are hosted at something other than the root (`/`) of their domain.
 
-For example, a Gatsby blog could live at `example.com/blog/` or a site could be hosted on GitHub Pages at `example.github.io/my-gatsby-site/`
+For example, a Gatsby blog could live at `example.com/blog/`, or a site could be hosted on GitHub Pages at `example.github.io/my-gatsby-site/`.
 
 Each of these sites need a prefix added to all paths on the site. So a link to
-`/my-sweet-blog-post/` should be rewritten to `/blog/my-sweet-blog-post`.
+`/my-sweet-blog-post/` should be rewritten as `/blog/my-sweet-blog-post`.
 
-In addition links to various resources (JavaScript, CSS, images, and other static content) need the same prefix, so that the site continues to function and display correctly, even if served from this path prefix.
+In addition, links to various resources (JavaScript, CSS, images, and other static content) need the same prefix, so that the site continues to function correctly when served with the path prefix in place.
 
-Let's get this functionality implemented. We'll add an option to our `gatsby-config.js`, and add a flag to our build command.
+Adding the path prefix is a two step process, as follows:
 
 ### Add to `gatsby-config.js`
+
+Firstly, add a `pathPrefix` value to your `gatsby-config.js`.
 
 ```js:title=gatsby-config.js
 module.exports = {
@@ -23,21 +25,21 @@ module.exports = {
 
 ### Build
 
-Once the `pathPrefix` is specified in `gatsby-config.js`, we are well on our way to a prefixed app. The final step is to build out your application with a flag `--prefix-paths`, like so:
+The final step is to build your application with the `--prefix-paths` flag, like so:
 
 ```shell
 gatsby build --prefix-paths
 ```
 
-If this flag is not passed, Gatsby will ignore your `pathPrefix` and build out your site as if it were hosted from the root domain.
+If this flag is not passed, Gatsby will ignore your `pathPrefix` and build the site as if hosted from the root domain.
 
 ### In-app linking
 
-As a developer using this feature, it should be seamless. We provide APIs and libraries to make using this functionality a breeze. Specifically, the [`Link`](/docs/gatsby-link/) component has built-in functionality to handle path prefixing.
+Gatsby provides APIs and libraries to make using this feature seamless. Specifically, the [`Link`](/docs/gatsby-link/) component has built-in functionality to handle path prefixing.
 
-For example, if we want to link to our `/page-2` link (but the actual link will be prefixed, e.g. `/blog/page-2`) we don't want to hard code this path prefix in all of our links. We have your back! By using the `Link` component, we will automatically prefix your paths for you. If you later migrate off of `pathPrefix` your links will _still_ work seamlessly.
+For example, if you want to link to the location `/page-2`, but the actual link will be prefixed (e.g. `/blog/page-2`); you don't need to hard code the prefix into your links. By using the Gatsby `Link` component, paths will automatically be prefixed with the `pathPrefix` value assigned in your `gatsby-config.js` file. If you later migrate away from using a path prefix, your links will _still_ work seamlessly.
 
-Let's look at a quick example.
+For example, when navigating to the `page-2` location in the `Link` component below; the location will be automatically prefixed with your assigned `pathPrefix` value.
 
 ```jsx:title=src/pages/index.js
 import React from "react"
@@ -54,9 +56,7 @@ function Index() {
 }
 ```
 
-Without doing _anything_ and merely using the `Link` component, this link will be prefixed with our specified `pathPrefix` in `gatsby-config.js`. Woo hoo!
-
-If we want to do programatic/dynamic navigation, totally possible too! We expose a `navigate` helper, and this too automatically handles path prefixing.
+If you want to do programmatic/dynamic navigation, this is also possible! Expose the Gatsby `navigate` helper, and this too automatically handles path prefixing.
 
 ```jsx:title=src/pages/index.js
 import React from "react"


### PR DESCRIPTION
Fix typo: programatic -> programmatic

Convert document to [using “you” as the pronoun:](https://www.gatsbyjs.org/contributing/gatsby-style-guide/#use-you-as-the-pronoun) we -> you

Plus general grammar and readability improvements :mag: