### PR TITLE
chore: update testing dependencies to @testing-library/*

### DIFF
--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -4,7 +4,7 @@ title: End-to-End Testing
 
 [Cypress](https://www.cypress.io/) is one of the options when it comes to end-to-end (E2E) testing. Cypress is an all-in-one testing framework focused on E2E testing, meaning that you don't have to install 10 different things to get your test suite set up. You can write your first passing test in minutes without any configuration with the help of Cypress' API, which is easy to read and understand. It runs tests as fast as your browser can render content, which also makes test-driven development possible. You'll also profit from the time travel feature or the extensive debugging capabilities with Chrome DevTools. Of course you can also use it with Gatsby, and this guide will explain how.
 
-In order to run Gatsby's development server and Cypress at the same time you'll use the little helper [start-server-and-test](https://github.com/bahmutov/start-server-and-test). If you're already using [react-testing-library](/docs/testing-react-components) for [unit testing](/docs/unit-testing) you might want to install [cypress-testing-library](https://github.com/kentcdodds/cypress-testing-library), too. This way you can use the exact same methods you used with `react-testing-library` in your Cypress tests. Install the following packages to your `devDependencies`:
+In order to run Gatsby's development server and Cypress at the same time you'll use the little helper [start-server-and-test](https://github.com/bahmutov/start-server-and-test). If you're already using [@testing-library/react](https://github.com/testing-library/react-testing-library) for [unit testing](/docs/unit-testing) you might want to install [@testing-library/react](https://github.com/testing-library/cypress-testing-library), too. This way you can use the exact same methods you used with `@testing-library/react` in your Cypress tests. Install the following packages to your `devDependencies`:
 
 ```shell
 npm install --save-dev cypress start-server-and-test
@@ -64,13 +64,13 @@ Please read the [Cypress' official documentation](https://docs.cypress.io/guides
 
 A good use case for writing automated end-to-end tests is asserting **accessibility** with [cypress-axe](https://github.com/avanslaars/cypress-axe), a Cypress plugin that incorporates the [axe](https://deque.com/axe) accessibility testing API. While some [manual testing](https://www.smashingmagazine.com/2018/09/importance-manual-accessibility-testing/) is still required to ensure good web accessibility, automation can ease the burden on human testers.
 
-To use cypress-axe you have to install `cypress-axe` and [axe-core](https://github.com/dequelabs/axe-core). You'll also use some commands from [cypress-testing-library](https://testing-library.com/docs/cypress-testing-library/intro) to target elements easier:
+To use cypress-axe you have to install `cypress-axe` and [axe-core](https://github.com/dequelabs/axe-core). You'll also use some commands from [@testing-library/cypress](https://testing-library.com/docs/cypress-testing-library/intro) to target elements easier:
 
 ```bash
 npm install --save-dev cypress-axe axe-core @testing-library/cypress
 ```
 
-Then you add the `cypress-axe` and `cypress-testing-library` commands in `cypress/support/commands.js`:
+Then you add the `cypress-axe` and `@testing-library/cypress` commands in `cypress/support/commands.js`:
 
 ```js:title=cypress/support/commands.js
 import "./commands"

--- a/docs/docs/testing-css-in-js.md
+++ b/docs/docs/testing-css-in-js.md
@@ -50,7 +50,7 @@ Lastly you need to tell Jest where to find this file. Open your `package.json` a
 
 ## Usage
 
-In this example you'll use `react-test-renderer` but you can also use [react-testing-library](/docs/testing-react-components) or any other appropriate library. Because you created the `setup-test-env.js` file you can write your unit tests like you used to do. But now you'll also get the styling information!
+In this example you'll use `react-test-renderer` but you can also use [@testing-library/react](/docs/testing-react-components) or any other appropriate library. Because you created the `setup-test-env.js` file you can write your unit tests like you used to do. But now you'll also get the styling information!
 
 ```js:title=src/components/Button.test.js
 import React from "react"

--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -4,7 +4,7 @@ title: "Testing React components"
 
 _The recommended testing framework is [Jest](https://jestjs.io/). This guide assumes that you followed the [Unit testing](/docs/unit-testing) guide to setup Jest._
 
-Kent C. Dodds' [react-testing-library](https://github.com/kentcdodds/react-testing-library) has risen in popularity since its release and is a great replacement for [enzyme](https://github.com/airbnb/enzyme). You can write unit and integration tests and it encourages you to query the DOM in the same way the user would. Hence the guiding principle:
+The [@testing-library/react](https://github.com/testing-library/react-testing-library) by Kent C. Dodds has risen in popularity since its release and is a great replacement for [enzyme](https://github.com/airbnb/enzyme). You can write unit and integration tests and it encourages you to query the DOM in the same way the user would. Hence the guiding principle:
 
 > The more your tests resemble the way your software is used, the more confidence they can give you.
 

--- a/e2e-tests/development-runtime/cypress/support/commands.js
+++ b/e2e-tests/development-runtime/cypress/support/commands.js
@@ -1,4 +1,4 @@
-import "cypress-testing-library/add-commands"
+import "@testing-library/cypress/add-commands"
 
 Cypress.Commands.add(`lifecycleCallCount`, action =>
   cy

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -42,9 +42,9 @@
     "cy:run": "cypress run --browser chrome --record"
   },
   "devDependencies": {
+    "@testing-library/cypress": "^4.0.4",
     "cross-env": "^5.2.0",
     "cypress": "^3.1.3",
-    "cypress-testing-library": "^3.0.1",
     "fs-extra": "^7.0.1",
     "gatsby-cypress": "^0.1.7",
     "prettier": "^1.15.2",

--- a/packages/gatsby-image/package.json
+++ b/packages/gatsby-image/package.json
@@ -14,9 +14,9 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@testing-library/react": "^8.0.6",
     "babel-preset-gatsby-package": "^0.2.2",
-    "cross-env": "^5.1.4",
-    "react-testing-library": "^5.0.0"
+    "cross-env": "^5.1.4"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image#readme",
   "keywords": [

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -1,6 +1,6 @@
 import "@babel/polyfill"
 import React from "react"
-import { render, cleanup, fireEvent } from "react-testing-library"
+import { render, cleanup, fireEvent } from "@testing-library/react"
 import Image from "../"
 
 afterAll(cleanup)

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -14,9 +14,9 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@testing-library/react": "^8.0.6",
     "babel-preset-gatsby-package": "^0.2.2",
-    "cross-env": "^5.1.4",
-    "react-testing-library": "^5.0.0"
+    "cross-env": "^5.1.4"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-link#readme",
   "keywords": [

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -1,6 +1,6 @@
 import "@babel/polyfill"
 import React from "react"
-import { render, cleanup } from "react-testing-library"
+import { render, cleanup } from "@testing-library/react"
 import {
   createMemorySource,
   createHistory,

--- a/www/jest.config.js
+++ b/www/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   testURL: `http://localhost`,
   setupFiles: [`<rootDir>/loadershim.js`],
   setupFilesAfterEnv: [
-    `react-testing-library/cleanup-after-each`,
+    `@testing-library/react/cleanup-after-each`,
     `jest-dom/extend-expect`,
   ],
 }

--- a/www/package.json
+++ b/www/package.json
@@ -120,6 +120,7 @@
     "postinstall": "cd plugins/gatsby-transformer-gatsby-api-calls && npm install"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.6",
     "babel-jest": "^24.3.1",
     "babel-preset-gatsby": "^0.1.8",
     "cross-env": "^5.2.0",
@@ -128,7 +129,6 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.3.1",
     "jest-dom": "^3.1.3",
-    "react-testing-library": "^6.0.0",
     "stylelint": "^9.6.0",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-config-styled-components": "^0.1.1",

--- a/www/src/components/__tests__/banner.js
+++ b/www/src/components/__tests__/banner.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "react-testing-library"
+import { render } from "@testing-library/react"
 
 import Banner from "../banner"
 

--- a/www/src/components/__tests__/button.js
+++ b/www/src/components/__tests__/button.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render } from "react-testing-library"
+import { fireEvent, render } from "@testing-library/react"
 
 import Button from "../button"
 

--- a/www/src/components/__tests__/copy.js
+++ b/www/src/components/__tests__/copy.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "react-testing-library"
+import { render } from "@testing-library/react"
 
 import Copy from "../copy"
 

--- a/www/src/components/code-block/__tests__/index.js
+++ b/www/src/components/code-block/__tests__/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "react-testing-library"
+import { render } from "@testing-library/react"
 
 import CodeBlock from ".."
 

--- a/www/src/components/events/__tests__/events.js
+++ b/www/src/components/events/__tests__/events.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "react-testing-library"
+import { render } from "@testing-library/react"
 
 import Events from "../events"
 
@@ -37,7 +37,6 @@ describe(`<Events />`, () => {
     )
     const upcoming = getByText(`Upcoming Events`)
     const past = getByText(`Past Events`)
-
     ;[upcoming, past].forEach(el => {
       expect(el.nextSibling.querySelectorAll(`li`).length).toBeGreaterThan(0)
     })

--- a/www/src/pages/contributing/__tests__/stub-list.js
+++ b/www/src/pages/contributing/__tests__/stub-list.js
@@ -31,7 +31,7 @@ jest.mock(`react-modal`, () => {
 })
 import React from "react"
 import { useStaticQuery } from "gatsby"
-import { render } from "react-testing-library"
+import { render } from "@testing-library/react"
 
 import StubList from "../stub-list"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,6 +1941,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0.tgz#c2bc9870405959c89a9c814376a2ecb247838c80"
@@ -2914,12 +2921,31 @@
     pretty-format "^24.8.0"
     wait-for-expect "^1.2.0"
 
+"@testing-library/dom@^5.5.4":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.6.0.tgz#18a7c162a6a79964e731ad7b810022a28218047c"
+  integrity sha512-nAsRvQLr/b6TGNjuHMEbWXCNPLrQYnzqa/KKQZL7wBOtfptUxsa4Ah9aqkHW0ZmCSFmUDj4nFUxWPVTeMu0iCw==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
 "@testing-library/react@^8.0.1":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.1.tgz#91c254adf855b13de50020613cb5d3915f9f7875"
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@testing-library/dom" "^5.0.0"
+
+"@testing-library/react@^8.0.6":
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.6.tgz#614340646f32027426377dc6e5895a566eeb61b5"
+  integrity sha512-/4oeS0eatnHvAf9yuxIg1/8pjl1OrtWN7SLpDFEdxFjllIAEL09xXhA88C93vvlN+8enZa+xlXJ8ecohECT6Yg==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@testing-library/dom" "^5.5.4"
 
 "@types/configstore@^2.1.1":
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7831,14 +7831,6 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-testing-library@^3.9.0:
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.11.2.tgz#11ecb840641f89fbbdcf8cc625009c24e7779615"
-  dependencies:
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^23.6.0"
-    wait-for-expect "^1.0.0"
-
 dom-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/dom-urls/-/dom-urls-1.1.0.tgz#001ddf81628cd1e706125c7176f53ccec55d918e"
@@ -17160,12 +17152,6 @@ react-test-renderer@^16.8.0:
     react-is "^16.8.6"
     scheduler "^0.13.6"
 
-react-testing-library@^5.0.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.2.1.tgz#31f163e900457e5c0dcff7669ae06b502f8a9a7a"
-  dependencies:
-    dom-testing-library "^3.9.0"
-
 react-typography@^0.16.18:
   version "0.16.18"
   resolved "https://registry.yarnpkg.com/react-typography/-/react-typography-0.16.18.tgz#89341b63d615f1dfcf5e471797df5acce5bde1f3"
@@ -21053,10 +21039,6 @@ w3c-xmlserializer@^1.0.1:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.0.0.tgz#edf2d5790c36dc67c4e21ac6ccedd7d4b79dc6ac"
 
 wait-for-expect@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description

This PR updates the testing dependencies from [react|cypress]-testing-library to @testing-library/[react|cypress]. It may avoid future deprecation notices.

The references to these libraries were also updated on related docs.

## Related Issues

Related to #16006 
