### PR TITLE
fix(gatsby-cli): don't crash when creating project from local starter

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -271,7 +271,7 @@ module.exports = async (starter: string, options: InitOptions = {}) => {
   const hostedInfo = hostedGitInfo.fromUrl(starterPath)
 
   trackCli(`NEW_PROJECT`, {
-    starterName: hostedInfo.shortcut(),
+    starterName: hostedInfo ? hostedInfo.shortcut() : `local:starter`,
   })
   if (hostedInfo) await clone(hostedInfo, rootPath)
   else await copy(starterPath, rootPath)


### PR DESCRIPTION
## Description

Fix issue when attempting to create a new project using a local starter.

## Related Issues

Fixes #16065