### PR TITLE
fix(gatsby-cli): don't try to use local binaries

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -22,7 +22,7 @@ const spawn = (cmd: string, options: any) => {
   return spawnWithArgs(file, args, options)
 }
 const spawnWithArgs = (file: string, args: string[], options: any) =>
-  execa(file, args, { stdio: `inherit`, ...options })
+  execa(file, args, { stdio: `inherit`, preferLocal: false, ...options })
 
 // Checks the existence of yarn package and user preference if it exists
 // We use yarnpkg instead of yarn to avoid conflict with Hadoop yarn


### PR DESCRIPTION
## Description

Execa pre-2.0 had a weird default: `preferLocal` was causing execa to modify the PATH in order to prepend the directory containing the Node binary. This is annoying because if you happen to run a custom `yarn` binary while having a Yarn build installed next to the Node binary (which is fairly common), then execa will spawn the global one rather than the one that should have been selected according to the regular PATH traversal.

This behavior got [disabled by default in execa 2.0+](https://codeburst.io/execa-v2-20ffafeedfdf#18d9), and I think it would make sense to do it here as well (you seem to only be using execa on git, yarn, and npm).
