### PR TITLE
fix(babel-preset-gatsby): Adds a missing `resolve` call

### DIFF
--- a/packages/babel-preset-gatsby/src/__tests__/__snapshots__/dependencies.js.snap
+++ b/packages/babel-preset-gatsby/src/__tests__/__snapshots__/dependencies.js.snap
@@ -17,7 +17,7 @@ Object {
   ],
   "presets": Array [
     Array [
-      "@babel/preset-env",
+      "<PROJECT_ROOT>/node_modules/@babel/preset-env/lib/index.js",
       Object {
         "corejs": 2,
         "exclude": Array [

--- a/packages/babel-preset-gatsby/src/dependencies.js
+++ b/packages/babel-preset-gatsby/src/dependencies.js
@@ -18,7 +18,7 @@ module.exports = function(api, options = {}) {
     presets: [
       [
         // Latest stable ECMAScript features
-        `@babel/preset-env`,
+        resolve(`@babel/preset-env`),
         {
           // Allow importing core-js in entrypoint and use browserlist to select polyfills
           useBuiltIns: `usage`,


### PR DESCRIPTION
## Description

Seems to be a typo. The resolve being missing caused `preset-env` to be resolved starting from the root of the project rather than `babel-preset-gatsby` as it should have been 🙂
