### PR TITLE
fix(gatsby): group and distinct optional fields

### DIFF
--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -29,7 +29,7 @@ const findManyPaginated = typeName => async (source, args, context, info) => {
   // `distinct` which might need to be resolved.
   const group = getProjectedField(info, `group`)
   const distinct = getProjectedField(info, `distinct`)
-  const extendedArgs = { ...args, group: group || [], distinct: distinct || [] }
+  const extendedArgs = { ...args, group, distinct }
 
   const result = await findMany(typeName)(source, extendedArgs, context, info)
   return paginate(result, { skip: args.skip, limit: args.limit })
@@ -234,10 +234,11 @@ const getProjectedField = (info, fieldName) => {
     info
   )
 
+  const fields = getNullableType(info.returnType).getFields()
+  if (!fields[fieldName]) return []
+
   const fieldEnum = getNullableType(
-    getNullableType(info.returnType)
-      .getFields()
-      [fieldName].args.find(arg => arg.name === `field`).type
+    fields[fieldName].args.find(arg => arg.name === `field`).type
   )
 
   return fieldNodes.reduce((acc, fieldNode) => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

`gatsby@2.13.22` seems to have introduced an error when running queries for some `nodes.children`. The specific stack trace was:

```
TypeError: Cannot read property 'args' of undefined",
        "    at getProjectedField (/Users/alexanderfenton/test-site/node_modules/gatsby/dist/schema/resolvers.js:237:92)",
        "    at /Users/alexanderfenton/test-site/node_modules/gatsby/dist/schema/resolvers.js:42:17",
        "    at resolveFieldValueOrError (/Users/alexanderfenton/test-site/node_modules/graphql/execution/execute.js:486:18)",
        "    at resolveField (/Users/alexanderfenton/test-site/node_modules/graphql/execution/execute.js:453:16)",
        "    at executeFields (/Users/alexanderfenton/test-site/node_modules/graphql/execution/execute.js:294:18)",
        "    at executeOperation (/Users/alexanderfenton/test-site/node_modules/graphql/execution/execute.js:238:122)",
        "    at executeImpl (/Users/alexanderfenton/test-site/node_modules/graphql/execution/execute.js:85:14)",
        "    at execute (/Users/alexanderfenton/test-site/node_modules/graphql/execution/execute.js:62:256)",
        "    at /Users/alexanderfenton/test-site/node_modules/express-graphql/dist/index.js:180:37",
        "    at processTicksAndRejections (internal/process/task_queues.js:85:5)
```

This was being caused because `group` and `distinct` where expected on all `*Connection` types. However, these fields are not always generated.

## Related Issues

N/A 
