### PR TITLE
feat(gatsby-transformer-sharp): define ImageSharp as child of File type

### DIFF
--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -24,7 +24,7 @@ exports.sourceNodes = ({ actions }) => {
 
   if (createTypes) {
     createTypes(`
-      type ImageSharp implements Node @infer {
+      type ImageSharp implements Node @infer @childOf(types: ["File"]) {
         id: ID!
       }
     `)


### PR DESCRIPTION
Querying on `File.childImageSharp` in a site/theme where no image files are present currently fails because children fields are not being created. This PR uses the new `@childOf` extension to explicitly define `ImageSharp` nodes as children of `File`nodes.

Fixes  #16099