### PR TITLE
fix(gatsby): Respect infer extension in schema update

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -66,14 +66,20 @@ const rebuildSchemaWithSitePage = async ({
   typeConflictReporter,
   parentSpan,
 }) => {
-  const typeComposer = addInferredType({
-    schemaComposer,
-    typeComposer: schemaComposer.getOTC(`SitePage`),
-    nodeStore,
-    typeConflictReporter,
-    typeMapping,
-    parentSpan,
-  })
+  const typeComposer = schemaComposer.getOTC(`SitePage`)
+  const shouldInfer =
+    !typeComposer.hasExtension(`infer`) ||
+    typeComposer.getExtension(`infer`) !== false
+  if (shouldInfer) {
+    addInferredType({
+      schemaComposer,
+      typeComposer,
+      nodeStore,
+      typeConflictReporter,
+      typeMapping,
+      parentSpan,
+    })
+  }
   await processTypeComposer({
     schemaComposer,
     typeComposer,


### PR DESCRIPTION
Currently we don't actually respect the type inference config set with `@infer`/`@dontInfer` in the "schema update" step. This is quite important as it means not being able to switch off infering for `SitePage.context`