### PR TITLE
docs: Document switching off type inference for SitePage.context

### DIFF
--- a/docs/docs/scaling-issues.md
+++ b/docs/docs/scaling-issues.md
@@ -73,3 +73,18 @@ Loki allows us to opt-in to possibly more performant internal operations and it 
   }
 }
 ```
+
+### Switch off type inference for `SitePage.context`
+
+When using the `createPages` API to pass large amounts of data to pages via `context` (which is generally not recommended), Gatsby's type inference can become slow. In most cases, it is not actually necessary to include the `SitePage.context` field in the GraphQL schema, so switching off type inference for the `SitePage` type should be safe:
+
+```js
+// gatsby-node.js
+exports.createSchemaCustomization = ({ actions }) => {
+  actions.createTypes(`
+    type SitePage implements Node @dontInfer {
+      path: String!
+    }
+  `)
+}
+```


### PR DESCRIPTION
Not sure if "Scaling issues" is the best place to put this -- documents switching off type inference for `SitePage.context` which can take a long time when `context` data is huge.