### PR TITLE
fix(gatsby): Fix special case id:eq queries for abstract types

### DIFF
--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -118,12 +118,14 @@ describe(`run-sift`, () => {
         gqlType,
         queryArgs,
         firstOnly: true,
+        nodeTypeNames: [gqlType.name],
       })
 
       const resultMany = await runSift({
         gqlType,
         queryArgs,
         firstOnly: false,
+        nodeTypeNames: [gqlType.name],
       })
 
       expect(resultSingular).toEqual([nodes[1]])
@@ -141,12 +143,14 @@ describe(`run-sift`, () => {
         gqlType,
         queryArgs,
         firstOnly: true,
+        nodeTypeNames: [gqlType.name],
       })
 
       const resultMany = await runSift({
         gqlType,
         queryArgs,
         firstOnly: false,
+        nodeTypeNames: [gqlType.name],
       })
 
       // `id-1` node is not of queried type, so results should be empty
@@ -165,12 +169,14 @@ describe(`run-sift`, () => {
         gqlType,
         queryArgs,
         firstOnly: true,
+        nodeTypeNames: [gqlType.name],
       })
 
       const resultMany = await runSift({
         gqlType,
         queryArgs,
         firstOnly: false,
+        nodeTypeNames: [gqlType.name],
       })
 
       expect(resultSingular).toEqual([nodes[2]])
@@ -199,6 +205,7 @@ describe(`run-sift`, () => {
       gqlType,
       queryArgs,
       firstOnly: true,
+      nodeTypeNames: [gqlType.name],
     })
 
     expect(results[0].id).toBe(`id_4`)

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -107,7 +107,7 @@ function handleMany(siftArgs, nodes, sort) {
 module.exports = (args: Object) => {
   const { getNode, getNodesByType } = require(`../db/nodes`)
 
-  const { queryArgs, gqlType, firstOnly = false } = args
+  const { queryArgs, gqlType, firstOnly = false, nodeTypeNames } = args
 
   // If nodes weren't provided, then load them from the DB
   const nodes = args.nodes || getNodesByType(gqlType.name)
@@ -121,7 +121,10 @@ module.exports = (args: Object) => {
   if (isEqId(firstOnly, fieldsToSift, siftFilter)) {
     const node = getNode(siftFilter[0].id[`$eq`])
 
-    if (!node || (node.internal && node.internal.type !== gqlType.name)) {
+    if (
+      !node ||
+      (node.internal && !nodeTypeNames.includes(node.internal.type))
+    ) {
       return []
     }
 

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -339,6 +339,29 @@ describe(`Queryable Node interfaces`, () => {
         `\`id\` of type \`ID!\`. Check the type definition of \`WrongInterface\`.`
     )
   })
+
+  it(`works with special case id: { eq: $id } queries`, async () => {
+    const query = `
+      {
+        testInterface(id: { eq: "test1" }) {
+          id
+        }
+        test(id: { eq: "test1" }) {
+          id
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      testInterface: {
+        id: `test1`,
+      },
+      test: {
+        id: `test1`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
 })
 
 const buildSchema = async () => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -171,12 +171,15 @@ class LocalNodeModel {
     // We provide nodes in case of abstract types, because `run-sift` should
     // only need to know about node types in the store.
     let nodes
+    let nodeTypeNames
     if (isAbstractType(gqlType)) {
-      const nodeTypeNames = toNodeTypeNames(this.schema, gqlType)
+      nodeTypeNames = toNodeTypeNames(this.schema, gqlType)
       nodes = nodeTypeNames.reduce(
         (acc, typeName) => acc.concat(this.nodeStore.getNodesByType(typeName)),
         []
       )
+    } else {
+      nodeTypeNames = [gqlType.name]
     }
 
     const queryResult = await this.nodeStore.runQuery({
@@ -184,6 +187,7 @@ class LocalNodeModel {
       firstOnly,
       gqlType,
       nodes,
+      nodeTypeNames,
     })
 
     let result = queryResult


### PR DESCRIPTION
We treat queries with a filter that only consists of `id: { eq: "someID" }` as a special case. This special casing does not yet handle abstract types (interfaces). This PR fixes that.

Fixes  #16021