### PR TITLE
docs: fix wrong link to create-content-digest.js

### DIFF
--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -31,7 +31,7 @@ Reserved for plugins who wish to extend other nodes.
 
 Digest "Hash" (for example `md5sum`) of the content of this node.
 
-The digest should be unique to the content of this node since it's used for caching. If the content changes, this digest should also change. There's a helper function called [createContentDigest](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/create-content-digest.js) to create an `md5` digest.
+The digest should be unique to the content of this node since it's used for caching. If the content changes, this digest should also change. There's a helper function called [createContentDigest](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-core-utils/src/create-content-digest.js) to create an `md5` digest.
 
 ### `mediaType`
 


### PR DESCRIPTION
## Description
Fixed a link into the gatsby source of file `create-content-digest.js` as I was reading this article just now.

## Discussion/Idea
Maybe it would be better to use permalinks in the docs. Those would include the commit hash (key y on github)? Everyone clicking would always get a working link regardless of the file being moved or deleted. That way I would get at least the idea of the file when it was linked. If I'm truly interested in finding the actual implementation, I think I would be able to find it by using git blame. What do you think ? When changing the file I can still update the permalink to always point to the current version but missing it is not yielding a 404 instantly like now.

The actual permalink (at the time of writing this) would be: https://github.com/gatsbyjs/gatsby/blob/42317c16ea1f86b1b3fe04b91cc25e16b79f757b/packages/gatsby-core-utils/src/create-content-digest.js

I'm not sure how this would look like in the bigger image, if internal source links are pointing to different states of the implementation. That's why I kept the master based link in this PR for now.