### PR TITLE
feat(www): add aria attributes to pagination

### DIFF
--- a/www/src/components/pagination/index.js
+++ b/www/src/components/pagination/index.js
@@ -94,7 +94,7 @@ class Pagination extends React.Component {
                 value={`${i === 0 ? `` : i + 1}`}
                 key={`pagination-number${i + 1}`}
                 aria-label={`Goto Page ${i + 1}`}
-                aria-current={currentPage === i + 1 && `page`}
+                aria-current={currentPage === i + 1}
               >
                 {i + 1}
               </option>

--- a/www/src/components/pagination/index.js
+++ b/www/src/components/pagination/index.js
@@ -78,6 +78,7 @@ class Pagination extends React.Component {
         >
           <span>Showing page &nbsp;</span>
           <select
+            aria-label="Pagination Dropdown"
             value={currentPage === 1 ? `` : currentPage.toString()}
             onChange={this.changePage}
             css={{
@@ -92,6 +93,8 @@ class Pagination extends React.Component {
               <option
                 value={`${i === 0 ? `` : i + 1}`}
                 key={`pagination-number${i + 1}`}
+                aria-label={`Goto Page ${i + 1}`}
+                aria-current={currentPage === i + 1 && `page`}
               >
                 {i + 1}
               </option>


### PR DESCRIPTION
Added aria attributes to pagination.

Adding aria attributes can do more harm than good if not done correctly, does this move the needle in the right direction?
Used these resources:
https://a11y-style-guide.com/style-guide/section-navigation.html
https://tink.uk/using-the-aria-current-attribute/
https://www.a11ymatters.com/pattern/pagination/