### PR TITLE
chore: add createTypes call to docs example

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -890,6 +890,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       receivedSwag: Boolean
     }
   `
+  createTypes(typeDefs)
 }
 
 exports.createResolvers = ({ createResolvers }) => {


### PR DESCRIPTION
The custom union/interface example was missing a call to `createTypes`, which caused confusion. This adds it in to complete the example.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
