### PR TITLE
fix(gatsby-plugin-feed): Fixes URL in warning message

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -12,7 +12,7 @@ const warnMessage = (error, behavior) => `
   gatsby-plugin-feed was initialized in gatsby-config.js without a ${error}.
   This means that the plugin will use ${behavior}, which may not match your use case.
   This behavior will be removed in the next major release of gatsby-plugin-feed.
-  For more info, check out: https://www.gatsbyjs.org/docs/adding-an-rss-feed/
+  For more info, check out: https://gatsby.dev/adding-rss-feed
 `
 
 // TODO: remove in the next major release

--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -12,7 +12,7 @@ const warnMessage = (error, behavior) => `
   gatsby-plugin-feed was initialized in gatsby-config.js without a ${error}.
   This means that the plugin will use ${behavior}, which may not match your use case.
   This behavior will be removed in the next major release of gatsby-plugin-feed.
-  For more info, check out: https://gatsby.app/adding-rss-feed
+  For more info, check out: https://www.gatsbyjs.org/docs/adding-an-rss-feed/
 `
 
 // TODO: remove in the next major release


### PR DESCRIPTION
## Description

The warning message points to `https://gatsby.app/adding-rss-feed` which is a dead link. This PR replaces it with `https://www.gatsbyjs.org/docs/adding-an-rss-feed/`.
