### PR TITLE
docs: Link mapping to @link

### DIFF
--- a/docs/docs/gatsby-config.md
+++ b/docs/docs/gatsby-config.md
@@ -87,6 +87,8 @@ See more about [Browser Support](/docs/browser-support/#polyfills) in Gatsby.
 
 Gatsby includes an advanced feature that lets you create "mappings" between node types.
 
+> Note: Gatsby v2.2 introduced a new way to create foreign-key relations between node types with [the `@link` GraphQL field extension](/docs/schema-customization/#foreign-key-fields).
+
 For instance, imagine you have a multi-author markdown blog where you want to "link" from each blog post to the author information stored in a yaml file named `author.yaml`:
 
 ```markdown

--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -319,6 +319,10 @@ Gatsby's automatic type inference has one trick up its sleeve: for every field
 that ends in `___NODE` it will interpret the field value as an `id` and create a
 foreign-key relation.
 
+> Note: Before the introduction of the Schema Customization APIs in Gatsby v2.2,
+> there were two mechanisms to create links between node types: with the `___NODE`
+> fieldname convention (for plugins), or by defining [mappings](/docs/gatsby-config/#mapping-node-types) between fields in a user's `gatsby-config.js`.
+
 Creating foreign-key relations with the `createTypes` action,
 i.e. without relying on type inference and the `___NODE` field naming
 convention, requires a bit of manual setup.

--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -320,8 +320,8 @@ that ends in `___NODE` it will interpret the field value as an `id` and create a
 foreign-key relation.
 
 > Note: Before the introduction of the Schema Customization APIs in Gatsby v2.2,
-> there were two mechanisms to create links between node types: with the `___NODE`
-> fieldname convention (for plugins), or by defining [mappings](/docs/gatsby-config/#mapping-node-types) between fields in a user's `gatsby-config.js`.
+> there were two mechanisms to create links between node types: a plugin author would use the `___NODE`
+> fieldname convention (for plugins), and a user would define [mappings](/docs/gatsby-config/#mapping-node-types) between fields in their `gatsby-config.js`. Both users and plugin authors can now use the `@link` extension described below.
 
 Creating foreign-key relations with the `createTypes` action,
 i.e. without relying on type inference and the `___NODE` field naming


### PR DESCRIPTION
Link to creating foreign-key relations with the `@link` directive from mappings, and vice versa.

Fixes:  #15816
Related: #16118, #15920