### PR TITLE
chore(gatsby): Remove skipped date format tests

### DIFF
--- a/packages/gatsby/src/schema/types/__tests__/date.js
+++ b/packages/gatsby/src/schema/types/__tests__/date.js
@@ -80,20 +80,6 @@ describe(`isDate`, () => {
     }
   )
 
-  it.skip.each([
-    `2018-08-31T23:25:16.019345123+02:00`,
-    `2018-08-31T23:25:16.019345123Z`,
-  ])(`should return true for nanosecond precision: %s`, dateString => {
-    expect(isDate(dateString)).toBeTruthy()
-  })
-
-  it.skip.each([`2018-08-31T23:25:16.012345678901+02:00`])(
-    `should return false for precision beyond 9 digits: %s`,
-    dateString => {
-      expect(isDate(dateString)).toBeFalsy()
-    }
-  )
-
   it.each([
     `2010-00-00`,
     `2010-01-00`,
@@ -123,32 +109,6 @@ describe(`isDate`, () => {
     `2012-04-01T00:basketball`,
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeFalsy()
-  })
-
-  it.skip.each([
-    1371065286,
-    1379066897.0,
-    1379066897.7,
-    1379066897.0,
-    1379066897.07,
-    1379066897.17,
-    1379066897.0,
-    1379066897.007,
-    1379066897.017,
-    1379066897.157,
-    `1371065286`,
-    `1379066897.`,
-    `1379066897.0`,
-    `1379066897.7`,
-    `1379066897.00`,
-    `1379066897.07`,
-    `1379066897.17`,
-    `1379066897.000`,
-    `1379066897.007`,
-    `1379066897.017`,
-    `1379066897.157`,
-  ])(`should return true for unix timestamps: %s`, dateString => {
-    expect(isDate(dateString)).toBeTruthy()
   })
 })
 
@@ -217,27 +177,6 @@ describe(`looksLikeADate`, () => {
     `should return true for ISO 8601 ordinal dates: %s`,
     dateString => {
       expect(looksLikeADate(dateString)).toBeTruthy()
-    }
-  )
-
-  it.skip.each([
-    `2018-08-31T23:25:16.019345+02:00`,
-    `2018-08-31T23:25:16.019345Z`,
-  ])(`should return true for microsecond precision: %s`, dateString => {
-    expect(looksLikeADate(dateString)).toBeTruthy()
-  })
-
-  it.skip.each([
-    `2018-08-31T23:25:16.019345123+02:00`,
-    `2018-08-31T23:25:16.019345123Z`,
-  ])(`should return true for nanosecond precision: %s`, dateString => {
-    expect(looksLikeADate(dateString)).toBeTruthy()
-  })
-
-  it.skip.each([`2018-08-31T23:25:16.012345678901+02:00`])(
-    `should return false for precision beyond 9 digits: %s`,
-    dateString => {
-      expect(looksLikeADate(dateString)).toBeFalsy()
     }
   )
 


### PR DESCRIPTION
Removed a couple of skipped tests - i don't think there's a reason to keep them around?