### PR TITLE
Fix capitalization of 'Xcode'

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -22,10 +22,10 @@ How to install or verify Homebrew on your computer:
 1. If not, download and install [Homebrew with the instructions](https://docs.brew.sh/Installation) for your operating system (Mac, Linux or Windows).
 1. Once you've installed Homebrew, repeat step 2 to verify.
 
-### Mac Users: install XCode Command Line Tools
+### Mac Users: install Xcode Command Line Tools
 
 1. Open your Terminal.
-1. On a Mac, install XCode Command line tools by running `xcode-select --install`.
+1. On a Mac, install Xcode Command line tools by running `xcode-select --install`.
    1. If that fails, download it [directly from the Apple site](https://developer.apple.com/download/more/), after signing-in with Apple developer account
 1. After being prompted to start the installation, you'll be prompted again to accept a software license for the tools to download.
 


### PR DESCRIPTION
## Description

"Xcode" is properly capitalized with a lowercase `c`, not an uppercase `C`.