### PR TITLE
feat(gatsby-transformer-remark): subscribe to mimeTypes in type definitions

### DIFF
--- a/packages/gatsby-transformer-remark/src/create-schema-customization.js
+++ b/packages/gatsby-transformer-remark/src/create-schema-customization.js
@@ -24,6 +24,10 @@ const typeDefs = `
     sentences: Int
     words: Int
   }
+
+  type MarkdownRemark implements Node @infer @childOf(mimeTypes: ["text/markdown", "text/x-markdown"]) {
+    id: ID!
+  }
 `
 
 module.exports = (nodeApiArgs, pluginOptions = {}) => {


### PR DESCRIPTION
Built on top of features added in https://github.com/gatsbyjs/gatsby/pull/15715

This should be no-op on older versions of Gatsby that don't support `@childOf` directive and not cause any unknown API situation.

/cc @stefanprobst Let me know if this is correct - it does seem to work and create `childMarkdownRemark` fields (when parent node types have `@mimeTypes` directive/extension)