### PR TITLE
feat(gatsby-transformer-asciidoc): add custom template converter

### DIFF
--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -153,3 +153,39 @@ Each attribute with the prefix page- will be automatically added under `pageAttr
   }
 }
 ```
+
+## Define a custom converter
+
+You can define a custom converter by adding the `converterFactory` option.
+
+```javascript
+// In your gatsby-config.js, make sure to import or declare TemplateConverter
+plugins: [
+  {
+    resolve: `gatsby-transformer-asciidoc`,
+    options: {
+      converterFactory: TemplateConverter,
+    },
+  },
+]
+```
+
+`TemplateConverter` needs to be declared by you, information on what templates you can provide and further information can be found in the [asciidoctor docs](https://asciidoctor-docs.netlify.com/asciidoctor.js/extend/converter/custom-converter/)
+
+```javascript
+const asciidoc = require(`asciidoctor.js`)();
+
+class TemplateConverter {
+  constructor() {
+    this.baseConverter = asciidoc.Html5Converter.$new();
+  }
+
+  convert(node, transform) {
+    if (node.getNodeName() === 'paragraph') {
+      return `<p>${node.getContent()}</p>`
+    }
+
+    return this.baseConverter.convert(node, transform);
+  }
+}
+```

--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -170,7 +170,9 @@ plugins: [
 ]
 ```
 
-`TemplateConverter` needs to be declared by you, information on what templates you can provide and further information can be found in the [asciidoctor docs](https://asciidoctor-docs.netlify.com/asciidoctor.js/extend/converter/custom-converter/)
+`TemplateConverter` is a custom javascript class you'll need to write. Information on how to write a custom `TemplateConverter` can be found at the [asciidoctor docs](https://asciidoctor-docs.netlify.com/asciidoctor.js/extend/converter/custom-converter/).
+
+In the example below, we will use a custom converter to convert paragraphs but the other nodes will be converted using the built-in HTML5 converter:
 
 ```javascript
 const asciidoc = require(`asciidoctor.js`)()

--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -170,7 +170,7 @@ plugins: [
 ]
 ```
 
-`TemplateConverter` is a custom javascript class you'll need to write. Information on how to write a custom `TemplateConverter` can be found at the [asciidoctor docs](https://asciidoctor-docs.netlify.com/asciidoctor.js/extend/converter/custom-converter/).
+`TemplateConverter` is a custom javascript class you'll need to create. Information on how to write a custom `TemplateConverter` can be found at the [asciidoctor docs](https://asciidoctor-docs.netlify.com/asciidoctor.js/extend/converter/custom-converter/).
 
 In the example below, we will use a custom converter to convert paragraphs but the other nodes will be converted using the built-in HTML5 converter:
 

--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -173,19 +173,19 @@ plugins: [
 `TemplateConverter` needs to be declared by you, information on what templates you can provide and further information can be found in the [asciidoctor docs](https://asciidoctor-docs.netlify.com/asciidoctor.js/extend/converter/custom-converter/)
 
 ```javascript
-const asciidoc = require(`asciidoctor.js`)();
+const asciidoc = require(`asciidoctor.js`)()
 
 class TemplateConverter {
   constructor() {
-    this.baseConverter = asciidoc.Html5Converter.$new();
+    this.baseConverter = asciidoc.Html5Converter.$new()
   }
 
   convert(node, transform) {
-    if (node.getNodeName() === 'paragraph') {
+    if (node.getNodeName() === "paragraph") {
       return `<p>${node.getContent()}</p>`
     }
 
-    return this.baseConverter.convert(node, transform);
+    return this.baseConverter.convert(node, transform)
   }
 }
 ```

--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -42,7 +42,7 @@ async function onCreateNode(
   // Load Asciidoc file for extracting
   // https://asciidoctor-docs.netlify.com/asciidoctor.js/processor/extract-api/
   // We use a `let` here as a warning: some operations, like .convert() mutate the document
-  const doc = await asciidoc.load(content, asciidocOptions)
+  let doc = await asciidoc.load(content, asciidocOptions)
 
   try {
     const html = doc.convert()
@@ -71,7 +71,7 @@ async function onCreateNode(
       }
     }
 
-    const pageAttributes = extractPageAttributes(doc.getAttributes())
+    let pageAttributes = extractPageAttributes(doc.getAttributes())
 
     const asciiNode = {
       id: createNodeId(`${node.id} >>> ASCIIDOC`),

--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -25,6 +25,11 @@ async function onCreateNode(
     return
   }
 
+  // register custom converter if given
+  if (pluginOptions.converterFactory) {
+    asciidoc.ConverterFactory.register(new pluginOptions.converterFactory(asciidoc), ['html5']);
+  }
+
   // changes the incoming imagesdir option to take the
   const asciidocOptions = processPluginOptions(pluginOptions, pathPrefix)
 

--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -27,7 +27,10 @@ async function onCreateNode(
 
   // register custom converter if given
   if (pluginOptions.converterFactory) {
-    asciidoc.ConverterFactory.register(new pluginOptions.converterFactory(asciidoc), ['html5']);
+    asciidoc.ConverterFactory.register(
+      new pluginOptions.converterFactory(asciidoc),
+      [`html5`]
+    )
   }
 
   // changes the incoming imagesdir option to take the
@@ -39,7 +42,7 @@ async function onCreateNode(
   // Load Asciidoc file for extracting
   // https://asciidoctor-docs.netlify.com/asciidoctor.js/processor/extract-api/
   // We use a `let` here as a warning: some operations, like .convert() mutate the document
-  let doc = await asciidoc.load(content, asciidocOptions)
+  const doc = await asciidoc.load(content, asciidocOptions)
 
   try {
     const html = doc.convert()
@@ -68,7 +71,7 @@ async function onCreateNode(
       }
     }
 
-    let pageAttributes = extractPageAttributes(doc.getAttributes())
+    const pageAttributes = extractPageAttributes(doc.getAttributes())
 
     const asciiNode = {
       id: createNodeId(`${node.id} >>> ASCIIDOC`),


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This PR adds a `converterFactory` flag to the options of `gatsby-transformer-asciidoc`, allowing users to declare custom converters and updates the Readme with a small guide - further informations are found at https://asciidoctor-docs.netlify.com/asciidoctor.js/extend/converter/custom-converter/
