### PR TITLE
chore(e2e-tests): Only record cypress runs on CI

### DIFF
--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -39,7 +39,7 @@
     "update:preview": "curl -X POST http://localhost:8000/__refresh",
     "start-server-and-test": "start-server-and-test develop http://localhost:8000 cy:run",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --browser chrome --record"
+    "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
     "@testing-library/cypress": "^4.0.4",
@@ -47,6 +47,7 @@
     "cypress": "^3.1.3",
     "fs-extra": "^7.0.1",
     "gatsby-cypress": "^0.1.7",
+    "is-ci": "^2.0.0",
     "prettier": "^1.15.2",
     "start-server-and-test": "^1.7.11",
     "yargs": "^12.0.5"

--- a/e2e-tests/gatsby-image/package.json
+++ b/e2e-tests/gatsby-image/package.json
@@ -29,10 +29,11 @@
     "start-server-and-test": "start-server-and-test serve http://localhost:9000 cy:run",
     "serve": "gatsby serve",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --browser chrome --record"
+    "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
     "gatsby-cypress": "^0.1.7",
+    "is-ci": "^2.0.0",
     "prettier": "^1.14.3",
     "start-server-and-test": "^1.7.1"
   },

--- a/e2e-tests/path-prefix/package.json
+++ b/e2e-tests/path-prefix/package.json
@@ -30,10 +30,11 @@
     "serve": "gatsby serve --prefix-paths & npm run serve:assets",
     "serve:assets": "node scripts/serve.js",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --browser chrome --record"
+    "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
     "gatsby-cypress": "^0.1.7",
+    "is-ci": "^2.0.0",
     "prettier": "^1.14.3",
     "serve-handler": "^6.0.0",
     "start-server-and-test": "^1.7.1"

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -35,11 +35,12 @@
     "cy:open:offline": "npm run cy:open -- --env TEST_PLUGIN_OFFLINE=y",
     "cy:run": "npm run cy:run:normal && npm run cy:run:slow",
     "cy:run:offline": "npm run cy:run:normal -- --env TEST_PLUGIN_OFFLINE=y && npm run cy:run:slow -- --env TEST_PLUGIN_OFFLINE=y",
-    "cy:run:normal": "cypress run --browser chrome --record",
+    "cy:run:normal": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome",
     "cy:run:slow": "CYPRESS_CONNECTION_TYPE=slow cypress run --browser chrome --config testFiles=prefetching.js"
   },
   "devDependencies": {
     "fs-extra": "^7.0.1",
+    "is-ci": "^2.0.0",
     "prettier": "^1.14.3",
     "start-server-and-test": "^1.7.1"
   },

--- a/e2e-tests/themes/development-runtime/package.json
+++ b/e2e-tests/themes/development-runtime/package.json
@@ -5,9 +5,9 @@
   "author": "Sidhartha Chatterjee <sid@gatsbyjs.com>",
   "dependencies": {
     "gatsby": "^2.13.14",
+    "gatsby-theme-about": "*",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "gatsby-theme-about": "*"
+    "react-dom": "^16.8.0"
   },
   "license": "MIT",
   "scripts": {
@@ -22,12 +22,13 @@
     "update": "node scripts/update.js",
     "start-server-and-test": "start-server-and-test develop http://localhost:8000 cy:run",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --browser chrome --record"
+    "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",
     "cypress": "^3.1.3",
     "gatsby-cypress": "^0.2.2",
+    "is-ci": "^2.0.0",
     "prettier": "^1.15.2",
     "start-server-and-test": "^1.7.11"
   },

--- a/e2e-tests/themes/production-runtime/package.json
+++ b/e2e-tests/themes/production-runtime/package.json
@@ -5,9 +5,9 @@
   "author": "Sidhartha Chatterjee <sid@gatsbyjs.com>",
   "dependencies": {
     "gatsby": "^2.13.14",
+    "gatsby-theme-about": "*",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "gatsby-theme-about": "*"
+    "react-dom": "^16.8.0"
   },
   "license": "MIT",
   "scripts": {
@@ -19,12 +19,13 @@
     "test": "cross-env CYPRESS_SUPPORT=y npm run build && npm run start-server-and-test",
     "start-server-and-test": "start-server-and-test serve http://localhost:9000 cy:run",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --browser chrome --record"
+    "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",
     "cypress": "^3.1.3",
     "gatsby-cypress": "^0.1.7",
+    "is-ci": "^2.0.0",
     "prettier": "^1.15.2",
     "start-server-and-test": "^1.7.11"
   },


### PR DESCRIPTION
Currently end to end tests don't work locally when run via `yarn test` because cypress complains of being called with `--record` but without a secret and project ID 

Since cypress dashboard secrets and project IDs are in Circle CI config and we shouldn't record local cypress runs IMO anyway, this PR checks you're on CI and only then passes in `--record` when running cypress