### PR TITLE
fix(docs): change relative url to absolute url for gatsby-link readme

### DIFF
--- a/packages/gatsby-link/README.md
+++ b/packages/gatsby-link/README.md
@@ -2,4 +2,4 @@
 
 All components and utility functions from this package are now exported from [`gatsby`](/packages/gatsby) package. You should not import anything from this package directly.
 
-The [API reference](/docs/gatsby-link/) has more documentation.
+The [API reference](https://www.gatsbyjs.org/docs/gatsby-link/) has more documentation.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fix gatsby-link, because this page is not visible on the website so it will connect to the website link

## Related Issues

Fixes #15760