### PR TITLE
chore(docs): Update environment variables to fix header hiearchy

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -35,7 +35,7 @@ or rebuild your site after changing them.
 
 ## Defining Environment Variables
 
-#### Client-side JavaScript
+### Client-side JavaScript
 
 For Project Env Vars that you want to access in client-side browser JavaScript, you can define
 an environment config file, `.env.development` and/or `.env.production`, in your root folder.
@@ -50,7 +50,7 @@ browser JavaScript.
 GATSBY_API_URL=https://dev.example.com/api
 ```
 
-#### Server-side Node.js
+### Server-side Node.js
 
 Gatsby runs several Node.js scripts at build time, notably `gatsby-config.js` and `gatsby-node.js`.
 OS Env Vars will already be available when Node is running, so you can add environment variables the


### PR DESCRIPTION
## Description

As examined by using the new Table of Contents component, there is a section that goes from h2's to h4's. I brought the 2 h4's up to h3's.

![Screenshot_2019-07-29 Environment Variables](https://user-images.githubusercontent.com/3685876/62096868-1cfec880-b253-11e9-9835-48f3f1751eeb.png)
