### PR TITLE
fix(gatsby): enable babel.config.js once again

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
@@ -33,7 +33,7 @@ Object {
       "loader": "<PROJECT_ROOT>/packages/gatsby/src/utils/babel-loader.js",
       "options": Object {
         "compact": true,
-        "configFile": false,
+        "configFile": true,
         "stage": "develop",
       },
     },

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -326,7 +326,6 @@ module.exports = async ({
         use: [
           loaders.js({
             ...options,
-            // TODO(v3): set configFile to false
             configFile: true,
             compact: true,
           }),

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -326,7 +326,8 @@ module.exports = async ({
         use: [
           loaders.js({
             ...options,
-            configFile: false,
+            // TODO(v3): set configFile to false
+            configFile: true,
             compact: true,
           }),
         ],


### PR DESCRIPTION
## Description
Bring back support for babel.config.js which we should disable in V3 as it's a breaking change for v2. It's not encouraged to use it the way people are using it for gatsby.

## Related Issues
Fixes #16134
