### PR TITLE
fix(gatsby): run onPrefetchPathname when prefetch is disabled

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/dev-loader.js
+++ b/packages/gatsby/cache-dir/__tests__/dev-loader.js
@@ -537,9 +537,13 @@ describe(`Dev loader`, () => {
       const devLoader = new DevLoader(null, [])
       devLoader.shouldPrefetch = jest.fn(() => false)
       devLoader.doPrefetch = jest.fn()
+      devLoader.apiRunner = jest.fn()
 
       expect(devLoader.prefetch(`/mypath/`)).toBe(false)
       expect(devLoader.shouldPrefetch).toHaveBeenCalledWith(`/mypath/`)
+      expect(devLoader.apiRunner).toHaveBeenCalledWith(`onPrefetchPathname`, {
+        pathname: `/mypath/`,
+      })
       expect(devLoader.doPrefetch).not.toHaveBeenCalled()
     })
 

--- a/packages/gatsby/cache-dir/__tests__/dev-loader.js
+++ b/packages/gatsby/cache-dir/__tests__/dev-loader.js
@@ -541,6 +541,19 @@ describe(`Dev loader`, () => {
 
       expect(devLoader.prefetch(`/mypath/`)).toBe(false)
       expect(devLoader.shouldPrefetch).toHaveBeenCalledWith(`/mypath/`)
+      expect(devLoader.apiRunner).not.toHaveBeenCalled()
+      expect(devLoader.doPrefetch).not.toHaveBeenCalled()
+    })
+
+    it(`should trigger custom prefetch logic when core is disabled`, () => {
+      const devLoader = new DevLoader(null, [])
+      devLoader.shouldPrefetch = jest.fn(() => true)
+      devLoader.doPrefetch = jest.fn()
+      devLoader.apiRunner = jest.fn()
+      devLoader.prefetchDisabled = true
+
+      expect(devLoader.prefetch(`/mypath/`)).toBe(false)
+      expect(devLoader.shouldPrefetch).toHaveBeenCalledWith(`/mypath/`)
       expect(devLoader.apiRunner).toHaveBeenCalledWith(`onPrefetchPathname`, {
         pathname: `/mypath/`,
       })

--- a/packages/gatsby/cache-dir/__tests__/loader.js
+++ b/packages/gatsby/cache-dir/__tests__/loader.js
@@ -556,6 +556,19 @@ describe(`Production loader`, () => {
 
       expect(prodLoader.prefetch(`/mypath/`)).toBe(false)
       expect(prodLoader.shouldPrefetch).toHaveBeenCalledWith(`/mypath/`)
+      expect(prodLoader.apiRunner).not.toHaveBeenCalled()
+      expect(prodLoader.doPrefetch).not.toHaveBeenCalled()
+    })
+
+    it(`should trigger custom prefetch logic when core is disabled`, () => {
+      const prodLoader = new ProdLoader(null, [])
+      prodLoader.shouldPrefetch = jest.fn(() => true)
+      prodLoader.doPrefetch = jest.fn()
+      prodLoader.apiRunner = jest.fn()
+      prodLoader.prefetchDisabled = true
+
+      expect(prodLoader.prefetch(`/mypath/`)).toBe(false)
+      expect(prodLoader.shouldPrefetch).toHaveBeenCalledWith(`/mypath/`)
       expect(prodLoader.apiRunner).toHaveBeenCalledWith(`onPrefetchPathname`, {
         pathname: `/mypath/`,
       })

--- a/packages/gatsby/cache-dir/__tests__/loader.js
+++ b/packages/gatsby/cache-dir/__tests__/loader.js
@@ -552,9 +552,13 @@ describe(`Production loader`, () => {
       const prodLoader = new ProdLoader(null, [])
       prodLoader.shouldPrefetch = jest.fn(() => false)
       prodLoader.doPrefetch = jest.fn()
+      prodLoader.apiRunner = jest.fn()
 
       expect(prodLoader.prefetch(`/mypath/`)).toBe(false)
       expect(prodLoader.shouldPrefetch).toHaveBeenCalledWith(`/mypath/`)
+      expect(prodLoader.apiRunner).toHaveBeenCalledWith(`onPrefetchPathname`, {
+        pathname: `/mypath/`,
+      })
       expect(prodLoader.doPrefetch).not.toHaveBeenCalled()
     })
 

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -239,11 +239,6 @@ export class BaseLoader {
   }
 
   shouldPrefetch(pagePath) {
-    // If a plugin has disabled core prefetching, stop now.
-    if (this.prefetchDisabled) {
-      return false
-    }
-
     // Skip prefetching if we know user is on slow or constrained connection
     if (!doesConnectionSupportPrefetch()) {
       return false
@@ -258,6 +253,10 @@ export class BaseLoader {
   }
 
   prefetch(pagePath) {
+    if (!this.shouldPrefetch(pagePath)) {
+      return false
+    }
+
     // Tell plugins with custom prefetching logic that they should start
     // prefetching this path.
     if (!this.prefetchTriggered.has(pagePath)) {
@@ -265,7 +264,8 @@ export class BaseLoader {
       this.prefetchTriggered.add(pagePath)
     }
 
-    if (!this.shouldPrefetch(pagePath)) {
+    // If a plugin has disabled core prefetching, stop now.
+    if (this.prefetchDisabled) {
       return false
     }
 

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -258,15 +258,15 @@ export class BaseLoader {
   }
 
   prefetch(pagePath) {
-    if (!this.shouldPrefetch(pagePath)) {
-      return false
-    }
-
     // Tell plugins with custom prefetching logic that they should start
     // prefetching this path.
     if (!this.prefetchTriggered.has(pagePath)) {
       this.apiRunner(`onPrefetchPathname`, { pathname: pagePath })
       this.prefetchTriggered.add(pagePath)
+    }
+
+    if (!this.shouldPrefetch(pagePath)) {
+      return false
     }
 
     const realPath = cleanPath(pagePath)


### PR DESCRIPTION
## Description
When changing the page-manifest logic of gatsby we also broke the `onPrefetchPathname` api. It was not being called when prefetching was being disabled by plugins like guess-js.

Before page manifest:
https://github.com/gatsbyjs/gatsby/blob/8291044020254b04eb47b021101e79743794243a/packages/gatsby/cache-dir/loader.js#L237-L247

## Related Issues
No bugs yet but guess-js doesn't work anymore, it doesn't crash so that's good 👍 