### PR TITLE
chore(gatsby-plugin-guess-js): bump guess-webpack~0.3.10

### DIFF
--- a/packages/gatsby-plugin-guess-js/package.json
+++ b/packages/gatsby-plugin-guess-js/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "guess-webpack": "~0.1.3"
+    "guess-webpack": "~0.3.10"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
## Description
We disabled guess-js in gatsbyjs.org (https://github.com/gatsbyjs/gatsby/commit/00a4f7f386ed69267538efb0a9a257bd7dbdb7e6#diff-b09d495b0fe3dd9622c95a87fa08aa61) as it broke our builds. @mgechev fixed the issue in wepback-guess so let's bump the dependency.

## Related Issues
https://github.com/gatsbyjs/gatsby/commit/00a4f7f386ed69267538efb0a9a257bd7dbdb7e6#diff-b09d495b0fe3dd9622c95a87fa08aa61
