### PR TITLE
chore(showcase): Removing Onramp from showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -6442,18 +6442,6 @@
     - Consulting
     - Education
     - Landing Page
-- title: Onramp
-  url: https://www.onramp.io/
-  main_url: https://www.onramp.io/
-  description: >
-    Onramp is a technical workforce solutions company. We help corporate clients build new pipelines of talent to meet their technical and HR goals. We specialize in discovering new pools of talent and provide customized training so candidates are qualified and better prepared employees.
-  categories:
-    - Business
-    - Education
-    - Landing Page
-  built_by: Nicola B.
-  built_by_url: https://www.linkedin.com/in/nicola-b/
-  featured: false
 - title: Write/Speak/Code
   url: https://www.writespeakcode.com/
   main_url: https://www.writespeakcode.com/


### PR DESCRIPTION
## Description

@deweydell just for notice. The site showcase validator picked up that Onramp no longer uses Gatsby. I took a look and it seems to be using a webcomponents framework now. If this is an error, please let us know, but otherwise we are going to remove it from the showcase.
