### PR TITLE
docs(gatsby-plugin-sass): Update suggested precision

### DIFF
--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -85,7 +85,11 @@ plugins: [
 
 ### SASS Precision
 
-SASS defaults to [5 digits of precision](https://github.com/sass/sass/issues/1122). If this is too low for you (e.g. [if you use Bootstrap](https://github.com/twbs/bootstrap-sass/blob/master/README.md#sass-number-precision)), you may configure it as follows:
+SASS defaults to [5 digits of precision](https://github.com/sass/sass/issues/1122). If this is too low for you (e.g. if you use Bootstrap), you may configure it as follows:
+
+#### Bootstrap 4
+
+See [Bootstrap's documentation on theming](https://github.com/twbs/bootstrap/blob/master/site/content/docs/4.3/getting-started/theming.md#sass) for reference.
 
 ```javascript
 // in gatsby-config.js
@@ -94,7 +98,24 @@ plugins: [
     resolve: `gatsby-plugin-sass`,
     options: {
       postCssPlugins: [somePostCssPlugin()],
-      precision: 8, // Set to 6 for Bootstrap 4: https://github.com/twbs/bootstrap/blob/master/site/content/docs/4.3/getting-started/theming.md#sass
+      precision: 6,
+    },
+  },
+]
+```
+
+### Bootstrap 3 (with `bootstrap-sass`)
+
+See [`bootstrap-sass`](https://github.com/twbs/bootstrap-sass/blob/master/README.md#sass-number-precision) for reference.
+
+```javascript
+// in gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-sass`,
+    options: {
+      postCssPlugins: [somePostCssPlugin()],
+      precision: 8,
     },
   },
 ]

--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -94,7 +94,7 @@ plugins: [
     resolve: `gatsby-plugin-sass`,
     options: {
       postCssPlugins: [somePostCssPlugin()],
-      precision: 8,
+      precision: 8, // Set to 6 for Bootstrap 4: https://github.com/twbs/bootstrap/blob/master/site/content/docs/4.3/getting-started/theming.md#sass
     },
   },
 ]


### PR DESCRIPTION
## Description

The old https://github.com/twbs/bootstrap-sass/ repo, for Bootstrap 3, needs a precision of 8 digits.  
The new https://github.com/twbs/bootstrap repo, for Bootstrap 4, needs a precision of 6 digits.

See: https://github.com/twbs/bootstrap/blob/master/site/content/docs/4.3/getting-started/theming.md#sass