### PR TITLE
feat(docs): add egghead embed component

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -10,9 +10,10 @@ The component is a wrapper around [@reach/router's Link component](https://reach
 
 ## How to use Gatsby Link
 
-<iframe title="Screencast on egghead of how to use a Gatsby Link" class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/egghead-why-and-how-to-use-gatsby-s-link-component/embed" />
-
-Video hosted on [egghead.io][egghead].
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-why-and-how-to-use-gatsby-s-link-component"
+  lessonTitle="Why and How to Use Gatsby’s Link Component"
+/>
 
 ### Replace `a` tags with the `Link` tag for local links
 
@@ -39,9 +40,10 @@ const Page = () => (
 
 ### Add custom styles for the currently active link
 
-<iframe title="Screencast on egghead of how to style the currently active link in Gatsby." class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/egghead-add-custom-styles-for-the-active-link-using-gatsby-s-link-component/embed" />
-
-Video hosted on [egghead.io][egghead].
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-add-custom-styles-for-the-active-link-using-gatsby-s-link-component"
+  lessonTitle="Add Custom Styles for the Active Link Using Gatsby’s Link Component"
+/>
 
 It’s often a good idea to show which page is currently being viewed by visually changing the link matching the current page.
 
@@ -107,9 +109,10 @@ _**Note:** Available from Gatsby V2.1.31, if you are experiencing issues please 
 
 ### Pass state as props to the linked page
 
-<iframe title="Screencast on egghead of how to pass state as props using Gatsby’s Link component." class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/egghead-include-information-about-state-in-navigation-with-gatsby-s-link-component/embed" />
-
-Video hosted on [egghead.io][egghead].
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-include-information-about-state-in-navigation-with-gatsby-s-link-component"
+  lessonTitle="Include Information About State in Navigation With Gatsby’s Link Component"
+/>
 
 Sometimes you'll want to pass data from the source page to the linked page. You can do this by passing a `state` prop to the `Link` component or on a call to the `navigate` function. The linked page will have a `location` prop containing a nested `state` object structure containing the passed data.
 
@@ -140,9 +143,10 @@ const Photo = ({ location, photoId }) => {
 
 ### Replace history to change “back” button behavior
 
-<iframe title="Screencast on egghead of how to replace history on navigation." class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/egghead-replace-navigation-history-items-with-gatsby-s-link-component/embed" />
-
-Video hosted on [egghead.io][egghead].
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-replace-navigation-history-items-with-gatsby-s-link-component"
+  lessonTitle="Replace Navigation History Items with Gatsby’s Link Component"
+/>
 
 There are a few cases where it might make sense to modify the “back” button’s behavior. For example, if you build a page where you choose something, then see an “are you sure?” page to make sure it’s what you really wanted, and finally see a confirmation page, it may be desirable to skip the “are you sure?” page if the “back” button is clicked.
 
@@ -165,9 +169,10 @@ const AreYouSureLink = () => (
 
 ## How to use the `navigate` helper function
 
-<iframe title="Screencast on egghead of how to navigate programmatically in Gatsby." class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/egghead-navigate-to-a-new-page-programmatically-in-gatsby/embed" />
-
-Video hosted on [egghead.io][egghead].
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-navigate-to-a-new-page-programmatically-in-gatsby"
+  lessonTitle="Navigate to a New Page Programmatically in Gatsby"
+/>
 
 Sometimes you need to navigate to pages programmatically, such as during form submissions. In these cases, `Link` won’t work.
 
@@ -354,8 +359,6 @@ You can similarly check for file downloads:
     )
   }
 ```
-
-[egghead]: https://egghead.io/playlists/use-gatsby-s-link-component-to-improve-site-performance-and-simplify-site-development-7ed3ddfe
 
 ## Recommendations for programmatic, in-app navigation
 

--- a/docs/docs/introducing-graphiql.md
+++ b/docs/docs/introducing-graphiql.md
@@ -34,11 +34,10 @@ Make sure to check out the GraphiQL docs in the upper right-hand corner of the I
 
 The GraphiQL Explorer enables you to interactively construct full queries by clicking through available fields and inputs without the repetitive process of typing these queries out by hand.
 
-<iframe class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer/embed" title="Video: Build a GraphQL Query using Gatsby’s GraphiQL Explorer" />
-
-Video hosted on [egghead.io][egghead].
-
-[egghead]: https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer"
+  lessonTitle="Build a GraphQL Query using Gatsby’s GraphiQL Explorer"
+/>
 
 ## Other resources
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -6,11 +6,10 @@ This quick start is intended for intermediate to advanced developers. For a gent
 
 ## Use the Gatsby CLI
 
-<iframe title="Screencast on egghead of getting started with Gatsby." class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/gatsby-quick-start-with-gatsby-create-develop-and-build-gatsby-sites-from-the-command-line/embed" />
-
-Video hosted on [egghead.io][egghead].
-
-[egghead]: https://egghead.io/lessons/gatsby-quick-start-with-gatsby-create-develop-and-build-gatsby-sites-from-the-command-line
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-quick-start-with-gatsby-create-develop-and-build-gatsby-sites-from-the-command-line"
+  lessonTitle="Quick Start with Gatsby: Create, Develop, and Build Gatsby Sites From the Command Line"
+/>
 
 ### Install the Gatsby CLI.
 

--- a/docs/docs/static-query.md
+++ b/docs/docs/static-query.md
@@ -8,11 +8,10 @@ In this guide, we'll walk through an example using `StaticQuery`, and discuss [t
 
 ## How to use `StaticQuery` in components
 
-<iframe class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/gatsby-load-data-using-graphql-queries-directly-in-a-gatsby-v2-component-with-staticquery/embed" />
-
-Video hosted on [egghead.io][egghead].
-
-[egghead]: https://egghead.io/lessons/gatsby-load-data-using-graphql-queries-directly-in-a-gatsby-v2-component-with-staticquery
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-load-data-using-graphql-queries-directly-in-a-gatsby-v2-component-with-staticquery"
+  lessonTitle="Load Data using GraphQL Queries Directly in a Gatsby v2 Component with StaticQuery"
+/>
 
 ### Basic example
 

--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -10,9 +10,10 @@ One of the most important problems they solve is selector name collisions. With 
 
 With CSS-in-JS, you avoid all that as CSS selectors are scoped automatically to their component. Styles are tightly coupled with their components. This makes it much easier to know how to edit a component's CSS as there's never any confusion about how and where CSS is being used.
 
-<iframe class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/gatsby-style-gatsby-sites-with-styled-components/embed" />
-
-Video hosted on [egghead.io](https://egghead.io/lessons/gatsby-style-gatsby-sites-with-styled-components).
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-style-gatsby-sites-with-styled-components"
+  lessonTitle="Style Gatsby sites with styled-components"
+/>
 
 First, open a new terminal window and run the following to create a new site:
 

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -4,6 +4,11 @@ title: Building Themes
 
 The quickest way to get up and running with a workspace for building themes is to use the official [`gatsby-starter-theme-workspace`](https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-starter-theme-workspace) starter.
 
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-use-the-gatsby-theme-workspace-starter-to-begin-building-a-new-theme"
+  lessonTitle="Use the Gatsby Theme Workspace Starter to Begin Building a New Theme"
+/>
+
 To get started, run:
 
 ```shell

--- a/docs/docs/why-gatsby-uses-graphql.md
+++ b/docs/docs/why-gatsby-uses-graphql.md
@@ -8,14 +8,10 @@ Without providing some context, it can seem like GraphQL is overkill for somethi
 
 ## Create a page without any data
 
-<iframe
-  title="Screencast on egghead of creating pages in Gatsby from hard-coded React components."
-  src="https://egghead.io/lessons/gatsby-create-a-gatsby-page-without-any-data/embed"
-  class="egghead-video"
-  width={600} height={348}
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-create-a-gatsby-page-without-any-data"
+  lessonTitle="Create a Gatsby Page Without Any Data"
 />
-
-Video hosted on [egghead.io][egghead].
 
 For any kind of pages that aren’t directly created in `src/pages/`, you’ll need Gatsby’s [`createPages` Node API](/docs/node-apis/#createPages) to create pages programmatically.
 
@@ -57,14 +53,10 @@ In the simplest cases, this is all that’s required for building pages with Gat
 
 ## Create a page with hard-coded data
 
-<iframe
-  title="Screencast on egghead of creating pages from hard-coded context data in Gatsby."
-  src="https://egghead.io/lessons/gatsby-create-a-gatsby-page-with-hard-coded-data/embed"
-  class="egghead-video"
-  width={600} height={348}
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-create-a-gatsby-page-with-hard-coded-data"
+  lessonTitle="Create a Gatsby Page With Hard-Coded Data"
 />
-
-Video hosted on [egghead.io][egghead].
 
 To pass data to the created pages, you’ll need to pass `context` to the `createPage` call.
 
@@ -110,14 +102,10 @@ In some cases, this approach may be enough. However, it’s often necessary to c
 
 ## Create pages from JSON with images
 
-<iframe
-  title="Screencast on egghead of creating pages from JSON data in Gatsby."
-  src="https://egghead.io/lessons/gatsby-create-pages-from-json-with-images/embed"
-  class="egghead-video"
-  width={600} height={348}
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-create-pages-from-json-with-images"
+  lessonTitle="Create Pages from JSON With Images"
 />
-
-Video hosted on [egghead.io][egghead].
 
 In many cases, the data for pages can't feasibly be hard-coded into `gatsby-node.js`. More likely it will come from an external source, such as a third-party API, local Markdown, or JSON files.
 
@@ -220,14 +208,10 @@ Using `data/products.json` as an example, by using GraphQL we’re able to solve
 
 ### Add the necessary plugins to load data into GraphQL
 
-<iframe
-  title="Screencast on egghead of adding data to GraphQL in Gatsby."
-  src="https://egghead.io/lessons/gatsby-make-data-queryable-in-graphql-with-gatsby/embed"
-  class="egghead-video"
-  width={600} height={348}
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-make-data-queryable-in-graphql-with-gatsby"
+  lessonTitle="Make Data Queryable in GraphQL With Gatsby"
 />
-
-Video hosted on [egghead.io][egghead].
 
 In order to load the product and image data into GraphQL, we need to add a few [Gatsby plugins](/plugins/). Namely, we need plugins to:
 
@@ -298,14 +282,10 @@ The results will appear in the panel between the query and the docs, and they’
 
 ### Generate pages with GraphQL
 
-<iframe
-  title="Screencast on egghead of generating pages using GraphQL in Gatsby."
-  src="https://egghead.io/lessons/gatsby-create-pages-in-gatsby-using-graphql/embed"
-  class="egghead-video"
-  width={600} height={348}
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-create-pages-in-gatsby-using-graphql"
+  lessonTitle="Create Pages in Gatsby Using GraphQL"
 />
-
-Video hosted on [egghead.io][egghead].
 
 In `gatsby-node.js`, we can use the GraphQL query we just wrote to generate pages.
 
@@ -405,5 +385,3 @@ The image is now optimized and lazy loaded.
 After the initial setup, loading data with GraphQL is fairly similar to directly loading JSON, but it provides extra benefits like automatically optimizing images and keeping the data loading in the same place where it’s used.
 
 GraphQL is certainly not required, but the benefits of adopting GraphQL are significant. GraphQL will simplify the process of building and optimizing your pages, so it’s considered a best practice for structuring and writing Gatsby applications.
-
-[egghead]: https://egghead.io/playlists/why-gatsby-uses-graphql-1c319a1c

--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -28,11 +28,10 @@ Poke around the built-in `Site` "type" and see what fields are available on it -
 
 The GraphiQL Explorer enables you to interactively construct full queries by clicking through available fields and inputs without the repetitive process of typing these queries out by hand.
 
-<iframe class="egghead-video" width={600} height={348} src="https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer/embed" title="Video: Build a GraphQL Query using Gatsby’s GraphiQL Explorer" />
-
-Video hosted on [egghead.io][egghead].
-
-[egghead]: https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer"
+  lessonTitle="Build a GraphQL Query using Gatsby’s GraphiQL Explorer"
+/>
 
 ## Source plugins
 

--- a/www/src/components/shared/egghead-embed.js
+++ b/www/src/components/shared/egghead-embed.js
@@ -1,0 +1,28 @@
+import React, { Fragment } from "react"
+import PropTypes from "prop-types"
+
+const EggheadEmbed = ({ lessonLink, lessonTitle }) => (
+  <Fragment>
+    <iframe
+      className="egghead-video"
+      width={600}
+      height={348}
+      src={`${lessonLink}/embed`}
+      title={`Video: ${lessonTitle}`}
+    />
+
+    <p>
+      <em>
+        Video hosted on <a href={lessonLink}>egghead.io</a>
+      </em>
+      .
+    </p>
+  </Fragment>
+)
+
+EggheadEmbed.propTypes = {
+  lessonLink: PropTypes.string.isRequired,
+  lessonTitle: PropTypes.string.isRequired,
+}
+
+export default EggheadEmbed

--- a/www/wrap-root-element.js
+++ b/www/wrap-root-element.js
@@ -3,6 +3,7 @@ import { MDXProvider } from "@mdx-js/react"
 import GuideList from "./src/components/guide-list.js"
 import HubspotForm from "./src/components/hubspot-form"
 import Pullquote from "./src/components/shared/pullquote"
+import EggheadEmbed from "./src/components/shared/egghead-embed"
 import DateChart from "./src/components/chart"
 import CodeBlock from "./src/components/code-block"
 
@@ -11,6 +12,7 @@ const components = {
   HubspotForm,
   DateChart,
   Pullquote,
+  EggheadEmbed,
   pre: CodeBlock,
 }
 


### PR DESCRIPTION
## Description

- Add an MDX component for embedding egghead lessons in the docs
- Add new lesson on using the theme workspace starter.
