### PR TITLE
fix(gatsby-plugin-google-analytics): Fix broken script

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -127,7 +127,7 @@ export const onRenderBody = (
         }
         return gaSetCommands
       }, ``)}
-      `,
+      }`,
       }}
     />,
   ])


### PR DESCRIPTION
Fixing a syntax error in gatsby-plugin-google-analytics
where an if-statement was not closed in transpiled code.

## Description
#15280 introduced a post-transpilation syntax error. 😢 

There was an if-statement which ends up not being closed.
This PR fixes that.

## Related Issues
- Caused by #15280 
- Fixes #16226 

PS: I would love some advice on possible indentation improvements using our linter or tests. 😄 I gave some things a shot but nothing looked quite right.
