### PR TITLE
fix(gatsby): Fix absent parents

### DIFF
--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -849,6 +849,17 @@ describe(`Define parent-child relationships with field extensions`, () => {
         `Check the type definition of \`NextGeneration\`.`
     )
   })
+
+  it(`handle non-existing parent type`, async () => {
+    dispatch(
+      createTypes(`
+        type Child implements Node @childOf(types: ["NonExistent"]) {
+          name: String
+        }
+      `)
+    )
+    await expect(buildSchema()).resolves.toEqual(expect.any(Object))
+  })
 })
 
 const buildSchema = async () => {

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -729,6 +729,7 @@ const addConvenienceChildrenFields = ({ schemaComposer }) => {
   })
 
   parentTypesToChildren.forEach((children, parent) => {
+    if (!schemaComposer.has(parent)) return
     const typeComposer = schemaComposer.getAnyTC(parent)
     if (
       typeComposer instanceof InterfaceTypeComposer &&
@@ -753,8 +754,7 @@ const addConvenienceChildrenFields = ({ schemaComposer }) => {
   mimeTypesToChildren.forEach((children, mimeType) => {
     const parentTypes = typesHandlingMimeTypes.get(mimeType)
     if (parentTypes) {
-      parentTypes.forEach(parent => {
-        const typeComposer = schemaComposer.getAnyTC(parent)
+      parentTypes.forEach(typeComposer => {
         if (
           typeComposer instanceof InterfaceTypeComposer &&
           !typeComposer.hasExtension(`nodeInterface`)


### PR DESCRIPTION
Check for nonexisting parent types when processing `childOf` extension. Also add test for it.