### PR TITLE
chore(gatsby-source-filesystem): Remove debug message

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -43,7 +43,6 @@ exports.sourceNodes = (
   { actions, getNode, createNodeId, reporter, emitter },
   pluginOptions
 ) => {
-  reporter.info(`Creating GraphQL type definition for File`)
   const { createNode, createTypes, deleteNode } = actions
 
   const typeDefs = `


### PR DESCRIPTION
No need to inform about creating types.