### PR TITLE
fix(gatsby): Handle missing match-paths.json in serve

### DIFF
--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -31,7 +31,22 @@ onExit(() => {
 
 const readMatchPaths = async program => {
   const filePath = path.join(program.directory, `.cache`, `match-paths.json`)
-  const rawJSON = await fs.readFile(filePath)
+  let rawJSON = `[]`
+  try {
+    rawJSON = await fs.readFile(filePath)
+  } catch (error) {
+    console.log(`${chalk.yellow(`warn`)} ${error}`)
+    console.log(
+      `${chalk.yellow(
+        `warn`
+      )} Could not read "match-paths.json" from the .cache directory`
+    )
+    console.log(
+      `${chalk.yellow(
+        `warn`
+      )} Client-side routing will not work correctly. Maybe you need to re-run "gatsby build"?`
+    )
+  }
   return JSON.parse(rawJSON)
 }
 

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -8,6 +8,7 @@ const chalk = require(`chalk`)
 const { match: reachMatch } = require(`@reach/router/lib/utils`)
 const rl = require(`readline`)
 const onExit = require(`signal-exit`)
+const report = require(`gatsby-cli/lib/reporter`)
 
 const telemetry = require(`gatsby-telemetry`)
 
@@ -35,16 +36,16 @@ const readMatchPaths = async program => {
   try {
     rawJSON = await fs.readFile(filePath)
   } catch (error) {
-    console.log(`${chalk.yellow(`warn`)} ${error}`)
-    console.log(
-      `${chalk.yellow(
-        `warn`
-      )} Could not read "match-paths.json" from the .cache directory`
+    report.warn(error)
+    report.warn(
+      `Could not read ${chalk.bold(
+        `match-paths.json`
+      )} from the .cache directory`
     )
-    console.log(
-      `${chalk.yellow(
-        `warn`
-      )} Client-side routing will not work correctly. Maybe you need to re-run "gatsby build"?`
+    report.warn(
+      `Client-side routing will not work correctly. Maybe you need to re-run ${chalk.bold(
+        `gatsby build`
+      )}?`
     )
   }
   return JSON.parse(rawJSON)
@@ -116,19 +117,11 @@ module.exports = async program => {
   const startListening = () => {
     app.listen(port, host, () => {
       let openUrlString = `http://${host}:${port}${pathPrefix}`
-      console.log(
-        `${chalk.blue(`info`)} gatsby serve running at: ${chalk.bold(
-          openUrlString
-        )}`
-      )
+      report.info(`gatsby serve running at: ${chalk.bold(openUrlString)}`)
       if (open) {
-        console.log(`${chalk.blue(`info`)} Opening browser...`)
+        report.info(`Opening browser...`)
         Promise.resolve(openurl(openUrlString)).catch(err =>
-          console.log(
-            `${chalk.yellow(
-              `warn`
-            )} Browser not opened because no browser was found`
-          )
+          report.warn(`Browser not opened because no browser was found`)
         )
       }
     })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

`gatsby serve` uses the `match-paths.json` file from Gatsby's `.cache` directory to configure client side routing. It assumes that file always exists. If that file _doesn't_ exist, the error bubbles up to [the cli's generic fail handling code](https://github.com/gatsbyjs/gatsby/blob/742b818ab176c3953e21d6e5d05a66cb6bd55254/packages/gatsby-cli/src/create-cli.js#L437-L448). 

This results in a confusing error as seen in #16092.

This PR adds a warning if `match-paths.json` doesn't exist:

<img width="765" alt="Screenshot of updated warning message" src="https://user-images.githubusercontent.com/381801/62206782-7a496580-b38a-11e9-95c8-8e97c62eb952.png">

## Related Issues

Fixes #16092