### PR TITLE
docs(gatsby-plugin-mdx): Add gatsby-remark-images to list of plugins for gatsby-plugin-mdx

### DIFF
--- a/docs/docs/working-with-images-in-markdown.md
+++ b/docs/docs/working-with-images-in-markdown.md
@@ -138,7 +138,7 @@ npm install --save gatsby-remark-images gatsby-plugin-sharp
 
 Also be make sure that `gatsby-source-filesystem` is installed and points at the directory where your images are located.
 
-Configure the plugins in your `gatsby-config` file. As with the previous example, either `Remark` or `MDX` can be used; `gatsby-plugin-mdx` will be used in this case. Put the `gatsby-remark-images` plugin within the `gatsbyRemarkPlugins` option field of `gatsby-plugin-mdx`.
+Configure the plugins in your `gatsby-config` file. As with the previous example, either `Remark` or `MDX` can be used; `gatsby-plugin-mdx` will be used in this case. Put the `gatsby-remark-images` plugin within the `gatsbyRemarkPlugins` option field of `gatsby-plugin-mdx`.  Also, list `gatsby-remark-images` in the plugins array for `gatsby-plugin-mdx`.
 
 ```js:title=gatsby-config.js
 module.exports = {
@@ -155,6 +155,7 @@ module.exports = {
             },
           },
         ],
+        plugins: [`gatsby-remark-images`],
       },
     },
     {

--- a/docs/docs/working-with-images-in-markdown.md
+++ b/docs/docs/working-with-images-in-markdown.md
@@ -138,7 +138,7 @@ npm install --save gatsby-remark-images gatsby-plugin-sharp
 
 Also be make sure that `gatsby-source-filesystem` is installed and points at the directory where your images are located.
 
-Configure the plugins in your `gatsby-config` file. As with the previous example, either `Remark` or `MDX` can be used; `gatsby-plugin-mdx` will be used in this case. Put the `gatsby-remark-images` plugin within the `gatsbyRemarkPlugins` option field of `gatsby-plugin-mdx`.  Also, list `gatsby-remark-images` in the plugins array for `gatsby-plugin-mdx`.
+Configure the plugins in your `gatsby-config` file. As with the previous example, either `Remark` or `MDX` can be used; `gatsby-plugin-mdx` will be used in this case. Put the `gatsby-remark-images` plugin within the `gatsbyRemarkPlugins` option field of `gatsby-plugin-mdx`. Also, list `gatsby-remark-images` in the plugins array for `gatsby-plugin-mdx`.
 
 ```js:title=gatsby-config.js
 module.exports = {


### PR DESCRIPTION
## Description

When `gatsby-remark-images` is not listed as a plugin for `gatsby-plugin-mdx` or added as a plugin for `gatsby-transformer-remark` then images do not display properly when added to .mdx files.

Adding this to the documentation to hopefully prevent issues.

## Related Issues

Related to [gatsby-remark-images gatsby-resp-image-background-image #15486](https://github.com/gatsbyjs/gatsby/issues/15486)
Possibly also related to [Remove specialness of sub-plugins #16242](https://github.com/gatsbyjs/gatsby/issues/16242)
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
