### PR TITLE
fix(gatsby): Check if callSite exists in stack-trace-utils

### DIFF
--- a/packages/gatsby/src/utils/stack-trace-utils.js
+++ b/packages/gatsby/src/utils/stack-trace-utils.js
@@ -9,7 +9,12 @@ const gatsbyLocation = path.dirname(require.resolve(`gatsby/package.json`))
 const getNonGatsbyCallSite = () =>
   stackTrace
     .get()
-    .find(callSite => !callSite.getFileName().includes(gatsbyLocation))
+    .find(
+      callSite =>
+        callSite &&
+        callSite.getFileName() &&
+        !callSite.getFileName().includes(gatsbyLocation)
+    )
 
 const getNonGatsbyCodeFrame = ({ highlightCode = true } = {}) => {
   const callSite = getNonGatsbyCallSite()


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

includes() was being called on a potentially undefined variable. Added conditionals to check for it prior to method call. This was causing a fatal build error in project. 

## Related Issues

Fixes #16210
