### PR TITLE
fix(gatsby-telemetry): Don't display analytics notification if opted out

### DIFF
--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -43,6 +43,10 @@ module.exports = class EventStorage {
     this.disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
   }
 
+  isTrackingDisabled() {
+    return this.disabled
+  }
+
   addEvent(event) {
     if (this.disabled) {
       return

--- a/packages/gatsby-telemetry/src/postinstall.js
+++ b/packages/gatsby-telemetry/src/postinstall.js
@@ -1,4 +1,5 @@
 const showAnalyticsNotification = require(`./showAnalyticsNotification`)
+const isTruthy = require("./is-truthy")
 
 let enabled = false
 try {
@@ -6,7 +7,8 @@ try {
   const Configstore = require(`configstore`)
   const config = new Configstore(`gatsby`, {}, { globalConfigPath: true })
   enabled = config.get(`telemetry.enabled`)
-  if (enabled === undefined && !ci.isCI) {
+  const disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
+  if (enabled === undefined && !disabled && !ci.isCI) {
     showAnalyticsNotification()
   }
 } catch (e) {

--- a/packages/gatsby-telemetry/src/postinstall.js
+++ b/packages/gatsby-telemetry/src/postinstall.js
@@ -1,5 +1,5 @@
 const showAnalyticsNotification = require(`./showAnalyticsNotification`)
-const isTruthy = require("./is-truthy")
+const isTruthy = require(`./is-truthy`)
 
 let enabled = false
 try {

--- a/packages/gatsby-telemetry/src/postinstall.js
+++ b/packages/gatsby-telemetry/src/postinstall.js
@@ -1,14 +1,12 @@
 const showAnalyticsNotification = require(`./showAnalyticsNotification`)
-const isTruthy = require(`./is-truthy`)
+const EventStorage = require(`./event-storage.js`)
 
-let enabled = false
 try {
   const ci = require(`ci-info`)
-  const Configstore = require(`configstore`)
-  const config = new Configstore(`gatsby`, {}, { globalConfigPath: true })
-  enabled = config.get(`telemetry.enabled`)
-  const disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
-  if (enabled === undefined && !disabled && !ci.isCI) {
+  const eventStorage = new EventStorage()
+  const disabled = eventStorage.disabled
+  const enabledInConfig = eventStorage.getConfig(`telemetry.enabled`)
+  if (enabledInConfig === undefined && !disabled && !ci.isCI) {
     showAnalyticsNotification()
   }
 } catch (e) {

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -21,10 +21,16 @@ module.exports = class AnalyticsTracker {
 
   constructor() {
     try {
-      this.componentVersion = require(`../package.json`).version
-      this.installedGatsbyVersion = this.getGatsbyVersion()
-      this.gatsbyCliVersion = this.getGatsbyCliVersion()
+      if (this.store.isTrackingDisabled()) {
+        this.trackingEnabled = false
+      }
+
       this.defaultTags = this.getTagsFromEnv()
+
+      // These may throw and should be last
+      this.componentVersion = require(`../package.json`).version
+      this.gatsbyCliVersion = this.getGatsbyCliVersion()
+      this.installedGatsbyVersion = this.getGatsbyVersion()
     } catch (e) {
       // ignore
     }


### PR DESCRIPTION
Fixes #16254 