### PR TITLE
chore(blog): Add a description field on first blog entry

### DIFF
--- a/starters/blog/content/blog/hello-world/index.md
+++ b/starters/blog/content/blog/hello-world/index.md
@@ -1,6 +1,7 @@
 ---
 title: Hello World
 date: "2015-05-01T22:12:03.284Z"
+description: "Hello World"
 ---
 
 This is my first post on my new fake blog! How exciting!


### PR DESCRIPTION
 I recently discovered React and Gatsby.  Great framework!  I am pivoting my career from embedded firmware to Web/Mobile so I am pretty new to React.

More on this change:
I think a common use of starter is to clone it and remove all but first blog entry. Unfortunately this will cause error with graphql query since there are no description fields in any blog posts.

Also a QUESTION: I tried to issue a  PR to https://github.com/gatsbyjs/gatsby-starter-blog and a bot response directed me here (https://github.com/gatsbyjs/gatsby).  Is https://github.com/gatsbyjs/gatsby/tree/master/starters/blog re-published to https://github.com/gatsbyjs/gatsby-starter-blog?  I ask, because the README file still references the old Github site.

Thanks again for the great framework. -Al


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
