### PR TITLE
fix(gatsby): Panic when root config is a function

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.js
+++ b/packages/gatsby-cli/src/structured-errors/error-map.js
@@ -83,11 +83,13 @@ const errorMap = {
   },
   "10126": {
     text: context =>
-      `A ${
+      `${context.path}/${context.configName} cannot export a function.` +
+      `\n\nA ${
         context.configName
-      } that exports a function can only be used as a theme and not run directly.` +
+      } exported as a Function can only be used as a theme and not run directly.` +
       `\nIf you are trying to run a theme directly, use the theme in an example site or starter instead and run that site to test.` +
-      `\nIf you are in the root gatsby-config.js for your site, change the export to be an object and not a function as functions are not supported in the root gatsby-config.`,
+      `\nIf you are in the root gatsby-config.js for your site, change the export to be an object and not a function as functions` +
+      `\nare not supported in the root gatsby-config.`,
     type: `CONFIG`,
     level: `ERROR`,
   },

--- a/packages/gatsby-cli/src/structured-errors/error-map.js
+++ b/packages/gatsby-cli/src/structured-errors/error-map.js
@@ -81,6 +81,17 @@ const errorMap = {
     type: `CONFIG`,
     level: `ERROR`,
   },
+  "10126": {
+    text: context =>
+      `A ${
+        context.configName
+      } that exports a function can only be used as a theme and not run directly.` +
+      `\nIf you are trying to run a theme directly, use the theme in an example site or starter instead and run that site to test.` +
+      `\nIf you are in the root gatsby-config.js for your site, change the export to be an object and not a function as functions are not supported in the root gatsby-config.`,
+    type: `CONFIG`,
+    level: `ERROR`,
+  },
+  // Plugin errors
   "11321": {
     text: context =>
       `"${context.pluginName}" threw an error while running the ${

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -75,12 +75,14 @@ module.exports = async (args: BootstrapArgs) => {
     getConfigFile(program.directory, `gatsby-config`)
   )
 
+  // The root config cannot be exported as a function, only theme configs
   if (typeof config === `function`) {
-    report.panic(
-      `A gatsby-config that exports a function can only be used as a theme and not run directly.
-      If you are trying to run a theme directly, use the theme in an example site or starter instead and run that site to test.
-      If you are in the root gatsby-config.js for your site, change the export to be an object and not a function as functions are not supported in the root gatsby-config.`
-    )
+    report.panic({
+      id: `10126`,
+      context: {
+        configName: `gatsby-config`,
+      },
+    })
   }
 
   // theme gatsby configs can be functions or objects

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -75,6 +75,12 @@ module.exports = async (args: BootstrapArgs) => {
     getConfigFile(program.directory, `gatsby-config`)
   )
 
+  if (typeof config === `function`) {
+    report.panic(
+      `Custom gatsby-config as a Function is not supported in site root.`
+    )
+  }
+
   // theme gatsby configs can be functions or objects
   if (config && config.__experimentalThemes) {
     // TODO: deprecation message for old __experimentalThemes

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -77,7 +77,9 @@ module.exports = async (args: BootstrapArgs) => {
 
   if (typeof config === `function`) {
     report.panic(
-      `Custom gatsby-config as a Function is not supported in site root.`
+      `A gatsby-config that exports a function can only be used as a theme and not run directly.
+      If you are trying to run a theme directly, use the theme in an example site or starter instead and run that site to test.
+      If you are in the root gatsby-config.js for your site, change the export to be an object and not a function as functions are not supported in the root gatsby-config.`
     )
   }
 

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -81,6 +81,7 @@ module.exports = async (args: BootstrapArgs) => {
       id: `10126`,
       context: {
         configName: `gatsby-config`,
+        path: program.directory,
       },
     })
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

Not 100% sure if or where tests for this should be written, I could not find any other tests for bootstrap's index. I did use gatsby-dev to test that this change works however and it appears to do so.

Additionally, not sure if we want this panic to occur on configs that are still using experimental configs _AND_ non experimental configs so it does it before loading either config.

## Description

<!-- Write a brief description of the changes introduced by this PR -->

When bootstrap loads the root config, throw a panic if the config is of type `Function`.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #16265
