### PR TITLE
docs(gatsby-plugin-mdx): Fix incorrect configuration key

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -164,7 +164,7 @@ offers the option to set default layouts in the `gatsby-config.js` plugin
 config. Set the key to the `name` set in the `gatsby-source-filesystem` config.
 If no matching default layout is found, the `default` default layout is used.
 
-You can also set `options.defaultLayout.default` if you only want to
+You can also set `options.defaultLayouts.default` if you only want to
 use one layout for all MDX pages that don't already have a layout defined.
 
 ```js


### PR DESCRIPTION
Variable name was options.defaultLayout.default, should [I think?] be defaultLayout**s**.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Variable name was options.defaultLayout.default, changed to defaultLayout**s**.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
