### PR TITLE
fix: Check for match-path when loading page-data json

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -144,7 +144,7 @@ export class BaseLoader {
   }
 
   loadPageDataJson(rawPath) {
-    const pagePath = cleanPath(rawPath)
+    const pagePath = cleanPath(findMatchPath(rawPath) || rawPath)
     if (this.pageDataDb.has(pagePath)) {
       return Promise.resolve(this.pageDataDb.get(pagePath))
     }


### PR DESCRIPTION
## Description

Per #16097 , requests made to `page-data.json` don't currently reflect client-only routes. This PR addresses that issue by checking for a corresponding `matchPath` before determining the path to the desired `page-data.json` on a given page.

### Current State

As described in [this comment](https://github.com/gatsbyjs/gatsby/tree/master/examples/client-only-paths), the underlying issue can be seen in the `client-only-paths` example. Because there's a link to several client-only paths on the page - (eg. `/page/1`), the `BaseLoader` tries to pre-fetch the corresponding `page-data.json` assets, which it presumes to be at `/page-data/page/1/page-data.json`. Because that's a client-only path, the corresponding _page_ doesn't even exist and as such, neither does the `page-data.json` at that path, resulting in the 404.

<img width="1400" alt="localhost_8080_page_4" src="https://user-images.githubusercontent.com/3766777/62264099-9d0c6600-b3ec-11e9-8279-586110e937e4.png">

### The Fix

With the fix, however, for each individual route (eg. `/page/1`), a `matchPath` of `/` is identified which corresponds to an entry in the `pagesDb` on the `BaseLoader` instance, thus preventing the additional requests from being issued, since `/page-data/index/page-data.json` has already been requested and cached.

<img width="1400" alt="localhost_8080_page_4" src="https://user-images.githubusercontent.com/3766777/62265445-24a8a380-b3f2-11e9-928c-61913b80fd50.png">

## Related Issues

#16097

## Additional questions

I'd love to add tests but I'm not sure where to begin in that regard - it's been a long while since I've contributed and the codebase has evolved tremendously to say the least. Any additional direction would be super helpful.