### PR TITLE
chore(docs): Clean up "Gatsby Lifecycle APIs" doc

### DIFF
--- a/docs/docs/gatsby-lifecycle-apis.md
+++ b/docs/docs/gatsby-lifecycle-apis.md
@@ -2,12 +2,12 @@
 title: Gatsby Lifecycle APIs
 ---
 
-Gatsby provides a rich set of lifecycle APIs to hook into Gatsby's bootstrap,
+Gatsby provides a rich set of lifecycle APIs to hook into its bootstrap,
 build, and client runtime operations.
 
 Gatsby's design principles include:
 
-- Conventions > code but use low-level primitives to build conventions with
+- Conventions > code, but use low-level primitives to build conventions with
   code.
 - Extracting logic and configuration into [plugins](/docs/plugins/) should be
   trivial and encouraged.
@@ -17,7 +17,7 @@ Gatsby's design principles include:
 
 ## Bootstrap sequence
 
-During "bootstrap" gatsby:
+During "bootstrap" Gatsby:
 
 - reads `gatsby-config.js` to load in your list of plugins
 - initializes its cache (stored in `/.cache`)
@@ -29,7 +29,7 @@ During "bootstrap" gatsby:
 - extracts, runs, and replaces graphql queries for pages and `StaticQuery`s
 - writes out the pages to cache
 
-In development this is a running process powered by [Webpack](https://github.com/gatsbyjs/gatsby/blob/dd91b8dceb3b8a20820b15acae36529799217ae4/packages/gatsby/package.json#L128) and [`react-hot-loader`](https://github.com/gatsbyjs/gatsby/blob/dd91b8dceb3b8a20820b15acae36529799217ae4/packages/gatsby/package.json#L104), so changes to any files get re-run through the sequence again, with [smart cache invalidation](https://github.com/gatsbyjs/gatsby/blob/ffd8b2d691c995c760fe380769852bcdb26a2278/packages/gatsby/src/bootstrap/index.js#L141). For example, `gatsby-source-filesystem` watches files for changes, and each change triggers re-running queries. Other plugins may also perform this service. Queries are also watched so if you modify a query your development app is hot reloaded.
+In development this is a running process powered by [Webpack](https://github.com/gatsbyjs/gatsby/blob/dd91b8dceb3b8a20820b15acae36529799217ae4/packages/gatsby/package.json#L128) and [`react-hot-loader`](https://github.com/gatsbyjs/gatsby/blob/dd91b8dceb3b8a20820b15acae36529799217ae4/packages/gatsby/package.json#L104), so changes to any files get re-run through the sequence again, with [smart cache invalidation](https://github.com/gatsbyjs/gatsby/blob/ffd8b2d691c995c760fe380769852bcdb26a2278/packages/gatsby/src/bootstrap/index.js#L141). For example, `gatsby-source-filesystem` watches files for changes, and each change triggers re-running queries. Other plugins may also perform this service. Queries are also watched, so if you modify a query, your development app is hot reloaded.
 
 The core of the bootstrap process is the "api-runner", which helps to execute APIs in sequence, with state managed in Redux. Gatsby exposes a number of lifecycle APIs which can either be implemented by you (or any of your configured plugins) in `gatsby-node.js`, `gatsby-browser.js` or `gatsby-ssr.js`.
 
@@ -39,7 +39,7 @@ The sequence of the **main** bootstrap Node API lifecycles are:
 - [sourceNodes](/docs/node-apis/#sourceNodes) e.g. implemented by [`gatsby-source-wikipedia`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wikipedia/src/gatsby-node.js)
   - within this `createNode` can be called multiple times, which then triggers [onCreateNode](/docs/node-apis/#onCreateNode).
 - (the first schema build happens here)
-- [resolvableExtensions](/docs/node-apis/#resolvableExtensions) for filetype/language extensions eg [`gatsby-plugin-typescript`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-typescript/src/gatsby-node.js)
+- [resolvableExtensions](/docs/node-apis/#resolvableExtensions) for filetype/language extensions e.g. [`gatsby-plugin-typescript`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-typescript/src/gatsby-node.js)
 - [createPages](/docs/node-apis/#createPages) e.g. implemented by [`page-hot-reloader`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/bootstrap/page-hot-reloader.js)
   - within this `createPage` can be called any number of times, which then triggers [onCreatePage](/docs/node-apis/#onCreatePage)
 - [onPreExtractQueries](/docs/node-apis/#onPreExtractQueries) e.g. implemented by [`gatsby-transformer-sharp`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-transformer-sharp/src/gatsby-node.js) and [`gatsby-source-contentful`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/src/gatsby-node.js)


### PR DESCRIPTION
Fix typos:
- gatsby -> Gatsby
- eg -> e.g.

Plus minor grammar tweaks :mag:
