### PR TITLE
fix(telemetry): don't show telemetry notification when telemetry collection is disabled via env flag

### DIFF
--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -43,6 +43,10 @@ module.exports = class EventStorage {
     this.disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
   }
 
+  isTrackingDisabled() {
+    return this.disabled
+  }
+
   addEvent(event) {
     if (this.disabled) {
       return

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -21,10 +21,16 @@ module.exports = class AnalyticsTracker {
 
   constructor() {
     try {
-      this.componentVersion = require(`../package.json`).version
-      this.installedGatsbyVersion = this.getGatsbyVersion()
-      this.gatsbyCliVersion = this.getGatsbyCliVersion()
+      if (this.store.isTrackingDisabled()) {
+        this.trackingEnabled = false
+      }
+
       this.defaultTags = this.getTagsFromEnv()
+
+      // These may throw and should be last
+      this.componentVersion = require(`../package.json`).version
+      this.gatsbyCliVersion = this.getGatsbyCliVersion()
+      this.installedGatsbyVersion = this.getGatsbyVersion()
     } catch (e) {
       // ignore
     }


### PR DESCRIPTION
The env check was also implemented deeper just before sending events, and
hence the flag did work even though we showed the notification. 

fixes #16258 

