### PR TITLE
chore(themes): Manually bump dependencies in theme starters

### DIFF
--- a/themes/gatsby-starter-blog-theme/package-lock.json
+++ b/themes/gatsby-starter-blog-theme/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-      "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.5",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -44,13 +44,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
       "requires": {
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -102,96 +102,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-replace-supers": "^7.5.5",
         "@babel/helper-split-export-declaration": "^7.4.4"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-          "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-          "requires": {
-            "@babel/types": "^7.5.5",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-          "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
-          "requires": {
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-          "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.5.5",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/traverse": "^7.5.5",
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-          "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
-        },
-        "@babel/traverse": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-          "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.5.5",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.5.5",
-            "@babel/types": "^7.5.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-          "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-      "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -230,11 +150,11 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -246,16 +166,16 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-      "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+      "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "@babel/template": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -272,11 +192,11 @@
       "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-regex": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-      "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -292,14 +212,14 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-      "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-simple-access": {
@@ -331,19 +251,19 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
       "requires": {
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -351,9 +271,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
@@ -374,6 +294,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -384,9 +313,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
-      "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+      "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -484,9 +413,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
-      "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -502,25 +431,25 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
-      "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
+      "integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
-      "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.4",
+        "@babel/helper-define-map": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.4",
+        "@babel/helper-replace-supers": "^7.5.5",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "globals": "^11.1.0"
       }
@@ -534,9 +463,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
-      "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+      "integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -552,9 +481,9 @@
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-      "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -611,31 +540,64 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-      "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+      "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
-      "integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
+      "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
       "requires": {
         "@babel/helper-module-transforms": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
-      "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -664,12 +626,12 @@
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-      "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+      "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-replace-supers": "^7.5.5"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -718,9 +680,9 @@
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
-      "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -815,42 +777,44 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
-      "integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
+      "integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.4.4",
+        "@babel/plugin-transform-async-to-generator": "^7.5.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.4.4",
-        "@babel/plugin-transform-classes": "^7.4.4",
+        "@babel/plugin-transform-block-scoping": "^7.5.5",
+        "@babel/plugin-transform-classes": "^7.5.5",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.4.4",
+        "@babel/plugin-transform-destructuring": "^7.5.0",
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
-        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
         "@babel/plugin-transform-for-of": "^7.4.4",
         "@babel/plugin-transform-function-name": "^7.4.4",
         "@babel/plugin-transform-literals": "^7.2.0",
         "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
-        "@babel/plugin-transform-modules-systemjs": "^7.4.4",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.5.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
         "@babel/plugin-transform-new-target": "^7.4.4",
-        "@babel/plugin-transform-object-super": "^7.2.0",
+        "@babel/plugin-transform-object-super": "^7.5.5",
         "@babel/plugin-transform-parameters": "^7.4.4",
         "@babel/plugin-transform-property-literals": "^7.2.0",
         "@babel/plugin-transform-regenerator": "^7.4.5",
@@ -861,7 +825,7 @@
         "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
         "@babel/plugin-transform-unicode-regex": "^7.4.4",
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "browserslist": "^4.6.0",
         "core-js-compat": "^3.1.1",
         "invariant": "^2.2.2",
@@ -870,13 +834,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.6.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-          "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+          "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000975",
-            "electron-to-chromium": "^1.3.164",
-            "node-releases": "^1.1.23"
+            "caniuse-lite": "^1.0.30000984",
+            "electron-to-chromium": "^1.3.191",
+            "node-releases": "^1.1.25"
           }
         }
       }
@@ -894,9 +858,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -912,19 +876,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -938,12 +902,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1113,9 +1077,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
-          "integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw=="
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
+          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
         }
       }
     },
@@ -1415,31 +1379,31 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.0.21.tgz",
-      "integrity": "sha512-B+n3PvrtdUcaCgDmWFaBf4n/zsls5hoyNPkWe2CzUx3ggR0SoD4UqCQR7iIZZ//fUjAwFODGf+2H0aJ3tIlB7w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.1.4.tgz",
+      "integrity": "sha512-CL01jH8AOiaIGVYXGFEwVbnKmtUF7fh9Cr/nYTBsH/MeOkNesJD+OMmdskfraTo/QI0l4Bt70AeD165WPMXaGw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-        "change-case": "^3.0.2",
-        "detab": "^2.0.0",
-        "hast-util-raw": "^5.0.0",
-        "lodash.uniq": "^4.5.0",
-        "mdast-util-to-hast": "^4.0.0",
-        "remark-mdx": "^1.0.21",
-        "remark-parse": "^6.0.0",
-        "remark-squeeze-paragraphs": "^3.0.1",
-        "to-style": "^1.3.3",
-        "unified": "^7.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-visit": "^1.3.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "camelcase-css": "2.0.1",
+        "detab": "2.0.2",
+        "hast-util-raw": "5.0.1",
+        "lodash.uniq": "4.5.0",
+        "mdast-util-to-hast": "6.0.1",
+        "remark-mdx": "^1.1.4",
+        "remark-parse": "7.0.0",
+        "remark-squeeze-paragraphs": "3.0.4",
+        "style-to-object": "0.2.3",
+        "unified": "8.3.2",
+        "unist-builder": "1.0.4",
+        "unist-util-visit": "1.4.1"
       }
     },
     "@mdx-js/react": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.0.21.tgz",
-      "integrity": "sha512-+7H1UfIytxKN/nSdojCRzUM/ZeQ6/EUg8F9bnY2NnPGuF+67cug6vZBAx9famtAey0Ms0dr2QAuCOd8k3SkhJg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.1.4.tgz",
+      "integrity": "sha512-qh6M6Uv1CxL8SszBbeTEbB2Ko27j6HLSqlDzPvbsxXZ9Nt87S/B65tvN1HjE8ZH8I0DO8V4L/ebalCy+pkEfIw=="
     },
     "@mikaelkristiansson/domready": {
       "version": "1.0.9",
@@ -1489,22 +1453,22 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
     "@styled-system/css": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.11.tgz",
-      "integrity": "sha512-rq/KO2SEpUbk9dWIRdWEkNL3w6Eds55KGdAcD+9DttqrC+FwPXfk27ebmTMfwyIAiDES9uW7z57Bo6v34VUNqw=="
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.17.tgz",
+      "integrity": "sha512-MSKnFq3zK53fJ/Au2oAnioNiKZJ2GATi4/tGYlh+/qSbDa09YX0siOzO8kIMKYt4L2fNCZnCuKPXJS7NFcWbmA=="
     },
     "@theme-ui/prism": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/prism/-/prism-0.2.5.tgz",
-      "integrity": "sha512-43aAMFYpgvi16ZUmXaKlG3BChhgibuHXO9dZ9fr7Hqx33Pf1Wfp6kW/STat8qabsR36FuSC36H0VdoSY3Ny/5g==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@theme-ui/prism/-/prism-0.2.25.tgz",
+      "integrity": "sha512-uS41Vh3sbaZuJFysUevy3oOmhmTZ5+8wdU/SYXzAF0B7axPoHvAraC3bhVos3RWT6Zzsigis1w2RkGHQizwzlw==",
       "requires": {
         "prism-react-renderer": "^0.1.7"
       }
     },
     "@theme-ui/typography": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/typography/-/typography-0.2.5.tgz",
-      "integrity": "sha512-Vde++rLNQUsQxFMaSvMgNxPTGfSx83HqYP36TO5iJ2cPNrEjzZLCJ0yogmg4wdL20C69o4sYrdNw/Qfqkhcqqw==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@theme-ui/typography/-/typography-0.2.25.tgz",
+      "integrity": "sha512-djLsN+QFQ9fb1z4EluHWu2FW7lppMugmRSCUAGRZaSzolPyNtDRkkvE3nwk7PYg/YaEzr+qwOX6iXGyzJeXSww==",
       "requires": {
         "compass-vertical-rhythm": "^1.4.5",
         "modularscale": "^2.0.1",
@@ -1557,9 +1521,9 @@
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.6.tgz",
-      "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA=="
+      "version": "7.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.7.tgz",
+      "integrity": "sha512-4I7+hXKyq7e1deuzX9udu0hPIYqSSkdKXtjow6fMnQ3OR9qkxIErGHbGY08YrfZJrCS1ajK8lOuzd0k3n2WM4A=="
     },
     "@types/prop-types": {
       "version": "15.7.1",
@@ -1581,9 +1545,9 @@
       }
     },
     "@types/react": {
-      "version": "16.8.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
-      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "version": "16.8.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
+      "integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1827,9 +1791,9 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2193,24 +2157,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
@@ -3223,6 +3169,21 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
           "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         }
       }
     },
@@ -3271,6 +3232,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+    },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
@@ -3306,34 +3272,14 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30000987",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-              "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-            }
-          }
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000979",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000979.tgz",
-      "integrity": "sha512-gcu45yfq3B7Y+WB05fOMfr0EiSlq+1u+m6rPHyJli/Wy3PVQNGaU7VA4bZE5qw+AU2UVOBR/N5g1bzADUqdvFw=="
+      "version": "1.0.30000988",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
+      "integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3476,9 +3422,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -3997,19 +3943,19 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.6.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-          "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+          "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000975",
-            "electron-to-chromium": "^1.3.164",
-            "node-releases": "^1.1.23"
+            "caniuse-lite": "^1.0.30000984",
+            "electron-to-chromium": "^1.3.191",
+            "node-releases": "^1.1.25"
           }
         },
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -4302,11 +4248,11 @@
       }
     },
     "css-tree": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
       "requires": {
-        "mdn-data": "~1.1.0",
+        "mdn-data": "2.0.4",
         "source-map": "^0.5.3"
       }
     },
@@ -4314,11 +4260,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
-    },
-    "css-url-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-      "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
     },
     "css-what": {
       "version": "2.1.3",
@@ -4417,13 +4358,18 @@
             "mdn-data": "~1.1.0",
             "source-map": "^0.5.3"
           }
+        },
+        "mdn-data": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
         }
       }
     },
     "csstype": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4625,9 +4571,9 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+      "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -5090,9 +5036,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.184.tgz",
-      "integrity": "sha512-jctpw2OkTBfpKg6PI3ndZZ+LlH6y0Pc+o9wvOkm9iqqgQ/FcOxpiADeB4kGddAEtZ+PBR4+TStEcoj1ApS3lUA=="
+      "version": "1.3.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.210.tgz",
+      "integrity": "sha512-m1i/F+gw9jkauxDx0mOr7Sj6vp6se1mfkQNYqZb1yL5VGTp0AC1NZH5CGI6YMSO7WaScILmkKDZFG9/hlR9axQ=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -5646,9 +5592,9 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -5656,9 +5602,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eval": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.3.tgz",
-      "integrity": "sha512-lDBa3hl9YynB+3J7aNPaajAapr+7ZiAylqFeUmx/r9s7I0tkkUJFLw2CQ2oMRYGg/rL7g4IYkZenbKaQGKPnGQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.4.tgz",
+      "integrity": "sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==",
       "requires": {
         "require-like": ">= 0.1.1"
       }
@@ -6856,9 +6802,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.13.45",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.13.45.tgz",
-      "integrity": "sha512-LvbEjb5gpYjTwpjGv6u70TC1ryyjzLuU+YY//bcIdI4UxioX2GKD2caQYQ8de5clMS7Vhqd7I4D0jq8hwmDxfQ==",
+      "version": "2.13.48",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.13.48.tgz",
+      "integrity": "sha512-GaDUQLPrkUFYYnLSBBZS5tedn/O3RdnrHJjPrxxFdk6dEQculDU4RaDsDymXxPzz7Lszke73dTYSRd8SiZ2rTw==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -6916,13 +6862,13 @@
         "flat": "^4.0.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^5.0.0",
-        "gatsby-cli": "^2.7.21",
+        "gatsby-cli": "^2.7.24",
         "gatsby-core-utils": "^1.0.3",
         "gatsby-graphiql-explorer": "^0.2.3",
         "gatsby-link": "^2.2.4",
         "gatsby-plugin-page-creator": "^2.1.5",
         "gatsby-react-router-scroll": "^2.1.3",
-        "gatsby-telemetry": "^1.1.7",
+        "gatsby-telemetry": "^1.1.9",
         "glob": "^7.1.1",
         "got": "8.0.0",
         "graphql": "^14.1.1",
@@ -7059,9 +7005,9 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.7.21",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.7.21.tgz",
-          "integrity": "sha512-M80MfpIm/S6IMGDthPu5kEUT4i6SXYjmfpg/0/BJxPpvj5xA+CMECzmLk1olSw+5//nVXpf2r3nuiZl1AR78jA==",
+          "version": "2.7.24",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.7.24.tgz",
+          "integrity": "sha512-rKK6Tv09pywtCzn3TlXR0FgFw1OdDWl9wmCOuMHZpGq9RQVf2VYNevptaiEDKAI7ECM0vTVf7MNz34ePNOTkFQ==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/runtime": "^7.0.0",
@@ -7079,7 +7025,7 @@
             "execa": "^0.8.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^4.0.1",
-            "gatsby-telemetry": "^1.1.7",
+            "gatsby-telemetry": "^1.1.9",
             "hosted-git-info": "^2.6.0",
             "ink": "^2.3.0",
             "ink-spinner": "^3.0.1",
@@ -7295,9 +7241,9 @@
       }
     },
     "gatsby-image": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.4.tgz",
-      "integrity": "sha512-wlbqGsfIX2+ILz/fk/94fDShc5zfhTlj7vYGyTFZfKombvwPXFAJD6pey4zTBZUUBrxMt2tROMXNnmFi3wGyww==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.8.tgz",
+      "integrity": "sha512-R0hc37xf03Bqi51TlRHuu6KB5sFiXzHx0tQotml8TeFXu1k5yvV13D8fHhlHCZQq5zJe4KHx0rGfAprzb4s1fA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "object-fit-images": "^3.2.4",
@@ -7330,37 +7276,26 @@
       }
     },
     "gatsby-plugin-emotion": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.0.tgz",
-      "integrity": "sha512-6Wrw47MK7j2OLgdjUmJVgdMtykFT9PNan2UTAjIWqquNMJgWWa96iM5kS4DnExhlwfyb50vji/SaWjW8JrUI8w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.2.tgz",
+      "integrity": "sha512-CDOzfhiP0V6p5Z+wDSpVhpa4MpK0JFaIOlC1Ope8wg6+/5upMXvQ2zrWqYhE7O1UeaHByjAWUA/af4M3OM3ICw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@emotion/babel-preset-css-prop": "^10.0.5"
       }
     },
     "gatsby-plugin-feed": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.2.tgz",
-      "integrity": "sha512-n+RkfLEtgtt9CbVnmIzVD5WjqEFi4heE5a78aT3tCTRpx04rkHpvGowe0NF4RzsiSuM2+Obmbzy/il0HkmCzIA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.6.tgz",
+      "integrity": "sha512-iBywR85MF6zJ13wH45L5wKwkruwTQNG5CXoSeL8gMRZJvYRhTsoMTihK9YDVEemct1vRtZmzDWabSBGsKuNlZQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@hapi/joi": "^15.0.0",
         "fs-extra": "^7.0.1",
-        "lodash.merge": "^4.6.0",
+        "lodash.merge": "^4.6.2",
         "rss": "^1.2.2"
       },
       "dependencies": {
-        "@hapi/joi": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-          "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
-          "requires": {
-            "@hapi/address": "2.x.x",
-            "@hapi/hoek": "6.x.x",
-            "@hapi/marker": "1.x.x",
-            "@hapi/topo": "3.x.x"
-          }
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -7374,22 +7309,29 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.7.tgz",
-      "integrity": "sha512-sXubUJhKO8nC4vEe7ME1htlQ4LPtRC7hhZF3fHl26gy5zNuHiCVtHZROoVIaiEY7UECGZzX8CjEblGVNgSmD2A==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.22.tgz",
+      "integrity": "sha512-+ZBuy7I0a4T+udlPnoUgII6PIm3YKHv26hNBXhZYTPk//R4LiCD3vlhZeeHqHAQaOamNquHt7DPxXZezNIATkw==",
       "requires": {
         "@babel/core": "^7.4.3",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
         "@babel/preset-env": "^7.4.3",
         "@babel/preset-react": "^7.0.0",
+        "@babel/types": "^7.5.5",
+        "camelcase-css": "^2.0.1",
+        "change-case": "^3.1.0",
         "core-js": "2",
         "dataloader": "^1.4.0",
         "debug": "^4.0.1",
         "escape-string-regexp": "^1.0.5",
+        "eval": "^0.1.4",
         "fs-extra": "^7.0.0",
         "gray-matter": "^4.0.1",
+        "json5": "^2.1.0",
         "loader-utils": "^1.2.3",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "mdast-util-to-string": "^1.0.4",
         "mdast-util-toc": "^3.0.0",
         "mime": "^2.3.1",
@@ -7400,7 +7342,9 @@
         "retext-english": "^3.0.2",
         "slash": "^2.0.0",
         "static-site-generator-webpack-plugin": "^3.4.2",
+        "style-to-object": "^0.2.3",
         "underscore.string": "^3.3.4",
+        "unified": "^8.3.2",
         "unist-util-map": "^1.0.4",
         "unist-util-remove": "^1.0.1",
         "unist-util-visit": "^1.4.0"
@@ -7446,27 +7390,29 @@
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.0.tgz",
-      "integrity": "sha512-QJefYCTvu+WRgnckNipnfvNVUR8+1TsXN+/AZPWJ9OyFUWmgYJO/PyDpIzEEYekDnDMb7gKFFj+UuJ8bSGvj2g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.2.tgz",
+      "integrity": "sha512-9rqa0D7qV+d7lMcnoV2Y4PTSNJcolTVZDygINYAboeef8fflcvGmOYUl16SbC0HjRjdGSiS9bmcsUNHeYPC/7g==",
       "requires": {
         "@babel/runtime": "^7.0.0"
       }
     },
     "gatsby-plugin-sharp": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.2.tgz",
-      "integrity": "sha512-e7+4EWLhcucRHFjtDTJFe04IjvLyh0U6Q+CqqcYmL/veIDTVf7XvGefiKlcFxG8ys6l2d3gd3L4+nR8WzV6lCA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.9.tgz",
+      "integrity": "sha512-yFaBuV4G6NRl3ExkWOJFtQlUO5rA3guvuR+30GwwdiHTSYuIFBvoCDgKQ+4k2fpAM5tbG6BHaUr7r/ccxWUWYg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "async": "^2.1.2",
         "bluebird": "^3.5.0",
         "fs-extra": "^7.0.0",
+        "gatsby-core-utils": "^1.0.0",
+        "got": "^8.3.2",
         "imagemin": "^6.0.0",
         "imagemin-mozjpeg": "^8.0.0",
         "imagemin-pngquant": "^6.0.0",
         "imagemin-webp": "^5.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "mini-svg-data-uri": "^1.0.0",
         "potrace": "^2.1.1",
         "probe-image-size": "^4.0.0",
@@ -7477,11 +7423,11 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         },
         "fs-extra": {
@@ -7493,18 +7439,73 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "got": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+        },
+        "p-timeout": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+          "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
         }
       }
     },
     "gatsby-plugin-theme-ui": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.5.tgz",
-      "integrity": "sha512-TlcQ/FCIu+2ns+ADOEjIj6sThBfShLjqU2zCDTvcfHIBoV2wCt/G9wNlaytt5pPTUtVd9lZkvkNdXY8zPDOUtg=="
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.25.tgz",
+      "integrity": "sha512-yEmxgHdF3o/txiEXLJBcHByukF8ECq6hVYQNcx8AR9OWefw1WI5as136qc7L4Ue9BBgtP95igr/DpPcQp+1Gog=="
     },
     "gatsby-plugin-twitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-twitter/-/gatsby-plugin-twitter-2.1.0.tgz",
-      "integrity": "sha512-OTYzB4lRWBdQmDHehoViuTtIIEKPQ4PtK4vWFNYGEHUNdg4MGB8VmAhoFsPbkVKiV2rocVmEdvMtYkYXb9v/Pg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-twitter/-/gatsby-plugin-twitter-2.1.2.tgz",
+      "integrity": "sha512-/9zuJcITmhALNtSOAw0QtZmx45qCd8AfqM+S+nlRX6PO2boUcE4AJwa9OK/hHOFrmrE5lFHchRC5exzt3gWTQw==",
       "requires": {
         "@babel/runtime": "^7.0.0"
       }
@@ -7558,15 +7559,15 @@
       }
     },
     "gatsby-remark-copy-linked-files": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.0.tgz",
-      "integrity": "sha512-MJVkLwH/IhWjNdCNEgRfmwyQPOGan5pvGscbVYC3Ho1sIBMkH3ruTyjgpCJzITuQe3gUIhsCSqsr3FlLSkHzsA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.4.tgz",
+      "integrity": "sha512-CEJYF4mj3Z4+s9yoUOyaQA/L0deydC/gu6Kay/PFwTyIDcgkWG1RFsFocEcEb6kbgimZxTElsbDk0MOulr1NIg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "cheerio": "^1.0.0-rc.2",
         "fs-extra": "^4.0.1",
         "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "path-is-inside": "^1.0.2",
         "probe-image-size": "^4.0.0",
         "unist-util-visit": "^1.3.0"
@@ -7606,14 +7607,14 @@
       }
     },
     "gatsby-remark-images": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.1.2.tgz",
-      "integrity": "sha512-RZUtqT7cqfFfQ3UFoL0ahy5duQo3/BSJdodyw3gp+PhWlWB3hz9fEZ5mvuCXJql+n/kLv+ifZAL5udPl1TNEqA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.1.7.tgz",
+      "integrity": "sha512-lTfHUUwCLEMpM4OlaLzjipcuuOIgj1PoxXhFwETgR3qaeLRovMtvCF26NqYShBkGn8R42WnegJw5Wh4yTQJDow==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "cheerio": "^1.0.0-rc.2",
         "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "mdast-util-definitions": "^1.2.0",
         "potrace": "^2.1.1",
         "query-string": "^6.1.0",
@@ -7644,9 +7645,9 @@
           }
         },
         "query-string": {
-          "version": "6.8.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.1.tgz",
-          "integrity": "sha512-g6y0Lbq10a5pPQpjlFuojfMfV1Pd2Jw9h75ypiYPPia3Gcq2rgkKiIwbkS6JxH7c5f5u/B/sB+d13PU+g1eu4Q==",
+          "version": "6.8.2",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",
@@ -7669,9 +7670,9 @@
       }
     },
     "gatsby-remark-smartypants": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-smartypants/-/gatsby-remark-smartypants-2.1.0.tgz",
-      "integrity": "sha512-lh4uIewueTtJ2D1CysbDxWMbv4R+k3/KQgs1/yHhOXrnCUQ+2YiUvQYFmyHTMS6k+ShBpDE4x0gqptkzvCgIhg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-smartypants/-/gatsby-remark-smartypants-2.1.2.tgz",
+      "integrity": "sha512-F3fyvuCA42nGRA2/cMeRxO48C4y8cEhorQCFHOBnNahVxoyunc4YWFhuc1WE2wEaj8DxVI0cFwjXNeNxD6g1YA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "retext": "^5.0.0",
@@ -7680,9 +7681,9 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.2.tgz",
-      "integrity": "sha512-mrlQ00Es+qjb2MCIEHAkv/F3yfR5IgI8z2q54tqpxu4amlUy3SQH5ThJDGD7Ya574ub9aKdHOr8virTssmTDgA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.8.tgz",
+      "integrity": "sha512-/EhMIlp6LA09+zzNkkhSW/zmJON9Ma9HQ5NpGTop7RVf9RIWiqhLA3klqVAnOwcYo2ALvAenGdGX2pgfH4PiMw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "better-queue": "^3.8.7",
@@ -7690,6 +7691,7 @@
         "chokidar": "2.1.2",
         "file-type": "^10.2.0",
         "fs-extra": "^5.0.0",
+        "gatsby-core-utils": "^1.0.0",
         "got": "^7.1.0",
         "md5-file": "^3.1.1",
         "mime": "^2.2.0",
@@ -7734,9 +7736,9 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.7.tgz",
-      "integrity": "sha512-mVJwkg4kdHGBt1OKlpcDO1gKoRd5oiJHKYR1jGrShXbB8FE4c52Z2Geg0xMKNXCeUbMUEZB78IPGlJ94nnPAag==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.9.tgz",
+      "integrity": "sha512-k6JtA52UjQddKCo88EnlIlQOEszjfUv6B24N0bMbEStS8XDxCkMS6+minBtjyXCa8XEGogU6IKLwqB9KDSGc+Q==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/runtime": "^7.0.0",
@@ -7801,44 +7803,45 @@
       }
     },
     "gatsby-theme-blog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-1.0.0.tgz",
-      "integrity": "sha512-4kyFPRM5JOk1D+YpXaMhQhU4ZRivR5eAYfk4lnMBsf9M53RnpfBduMTEmSX1I/9hRRncfffgFQEh+haUG1igDQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-1.0.2.tgz",
+      "integrity": "sha512-1p0+ne9SUytiHlMT4qV1S9FChfScQgMF01qz8tlYvf6eB8ly0zt3TXHudov2hQLJpyv4kfB84knKCGpfbc3/zA==",
       "requires": {
         "@emotion/core": "^10.0.14",
-        "@mdx-js/mdx": "^1.0.21",
-        "@mdx-js/react": "^1.0.21",
-        "@theme-ui/prism": "^0.2.5",
+        "@mdx-js/mdx": "^1.1.0",
+        "@mdx-js/react": "^1.0.27",
+        "@theme-ui/prism": "^0.2.14",
         "@theme-ui/typography": "^0.2.5",
-        "gatsby-image": "^2.2.4",
-        "gatsby-plugin-emotion": "^4.1.0",
-        "gatsby-plugin-feed": "^2.3.2",
-        "gatsby-plugin-mdx": "^1.0.7",
-        "gatsby-plugin-react-helmet": "^3.1.0",
-        "gatsby-plugin-sharp": "^2.2.2",
-        "gatsby-plugin-theme-ui": "^0.2.5",
-        "gatsby-plugin-twitter": "^2.1.0",
+        "deepmerge": "^4.0.0",
+        "gatsby-core-utils": "^1.0.3",
+        "gatsby-image": "^2.2.6",
+        "gatsby-plugin-emotion": "^4.1.2",
+        "gatsby-plugin-feed": "^2.3.4",
+        "gatsby-plugin-mdx": "^1.0.14",
+        "gatsby-plugin-react-helmet": "^3.1.2",
+        "gatsby-plugin-sharp": "^2.2.8",
+        "gatsby-plugin-theme-ui": "^0.2.6",
+        "gatsby-plugin-twitter": "^2.1.2",
         "gatsby-remark-code-titles": "^1.1.0",
-        "gatsby-remark-copy-linked-files": "^2.1.0",
-        "gatsby-remark-images": "^3.1.2",
+        "gatsby-remark-copy-linked-files": "^2.1.3",
+        "gatsby-remark-images": "^3.1.6",
         "gatsby-remark-numbered-footnotes": "^1.0.0",
-        "gatsby-remark-smartypants": "^2.1.0",
-        "gatsby-source-filesystem": "^2.1.2",
-        "gatsby-transformer-sharp": "^2.2.1",
-        "lodash.merge": "^4.6.1",
+        "gatsby-remark-smartypants": "^2.1.2",
+        "gatsby-source-filesystem": "^2.1.5",
+        "gatsby-transformer-sharp": "^2.2.4",
         "react-helmet": "^5.2.1",
-        "react-switch": "^5.0.0",
+        "react-switch": "^5.0.1",
         "remark-slug": "^5.1.2",
-        "theme-ui": "^0.2.5",
+        "theme-ui": "^0.2.14",
         "typeface-merriweather": "0.0.72",
-        "typeface-montserrat": "0.0.54",
+        "typeface-montserrat": "0.0.75",
         "typography-theme-wordpress-2016": "^0.16.19"
       }
     },
     "gatsby-transformer-sharp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.1.tgz",
-      "integrity": "sha512-KmUqtvt3ry8bL6RMfHwMgRH4AJcDOJgGMTyLeULUScDoKTSriColPhbXMmJzM4Gsq3NUNqJkRo9qvNxBqnSWtQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.5.tgz",
+      "integrity": "sha512-Onyic4Nfx4874bY6iBIal11zMct2VFU613KRSfiJJPkNCEAEfWje9XiQbI9De3ivIM0Cj8en/eg2vn5QtUeoRg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "bluebird": "^3.5.0",
@@ -9882,9 +9885,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -10248,9 +10251,9 @@
       }
     },
     "mdast-util-to-hast": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
-      "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-6.0.1.tgz",
+      "integrity": "sha512-KRh9wIYzUQk877JcV+8q4FqBUEouLpCKMObqeWg4dnL1/rh9vtSIq5mqQFwIK9YzSULl91F8FP5+EJ/xqRHaBw==",
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
@@ -10300,9 +10303,9 @@
       }
     },
     "mdn-data": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -10435,9 +10438,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+      "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A=="
     },
     "methods": {
       "version": "1.1.2",
@@ -10771,9 +10774,9 @@
       }
     },
     "node-abi": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz",
-      "integrity": "sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.10.0.tgz",
+      "integrity": "sha512-OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -10848,9 +10851,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.24.tgz",
-      "integrity": "sha512-wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
+      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -10917,21 +10920,9 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "prepend-http": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-        }
-      }
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
     "npm-conf": {
       "version": "1.1.3",
@@ -11134,9 +11125,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "omggif": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
-      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -11519,13 +11510,6 @@
         "normalize-url": "^3.3.0",
         "parse-path": "^4.0.0",
         "protocols": "^1.4.0"
-      },
-      "dependencies": {
-        "normalize-url": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
-        }
       }
     },
     "parse5": {
@@ -11877,24 +11861,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -12053,24 +12019,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-selector-parser": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -12138,24 +12086,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         },
         "postcss-value-parser": {
@@ -12406,24 +12336,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -12442,11 +12354,6 @@
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
-        "normalize-url": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -12506,24 +12413,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
@@ -12659,9 +12548,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "pretty-bytes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
-      "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -12683,12 +12572,12 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "probe-image-size": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz",
-      "integrity": "sha512-nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.1.1.tgz",
+      "integrity": "sha512-42LqKZqTLxH/UvAZ2/cKhAsR4G/Y6B7i7fI2qtQu9hRBK4YjS6gqO+QRtwTjvojUx4+/+JuOMzLoFyRecT9qRw==",
       "requires": {
         "any-promise": "^1.3.0",
-        "deepmerge": "^2.0.1",
+        "deepmerge": "^4.0.0",
         "inherits": "^2.0.3",
         "next-tick": "^1.0.0",
         "request": "^2.83.0",
@@ -12743,9 +12632,9 @@
       }
     },
     "property-information": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.1.0.tgz",
-      "integrity": "sha512-tODH6R3+SwTkAQckSp2S9xyYX8dEKYkeXw+4TmJzTxnNzd6mQPu1OD4f9zPrvw/Rm4wpPgI+Zp63mNSGNzUgHg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.2.2.tgz",
+      "integrity": "sha512-N2moasZmjn2mjVGIWpaqz5qnz6QyeQSGgGvMtl81gA9cPTWa6wpesRSe/quNnOjUHpvSH1oZx0pdz0EEckLFnA==",
       "requires": {
         "xtend": "^4.0.1"
       }
@@ -12780,9 +12669,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -13184,9 +13073,9 @@
       }
     },
     "react-switch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.0.tgz",
-      "integrity": "sha512-+zxY9xj9dMc8Y4gv/kkqQrirfEiIQ+SlQfJDW1Wi81L3xoh1fcbBYyJyh0TnhM/U/b6HxuBmkmU4Ooxgtuoavw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
+      "integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
       "requires": {
         "prop-types": "^15.6.2"
       }
@@ -13313,14 +13202,14 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
-      "integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
       "requires": {
         "private": "^0.1.6"
       }
@@ -13335,9 +13224,9 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
-      "integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ=="
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
+      "integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg=="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -13411,34 +13300,102 @@
         "remark-parse": "^6.0.0",
         "remark-stringify": "^6.0.0",
         "unified": "^7.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "remark-parse": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+          "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unified": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+          "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "@types/vfile": "^3.0.0",
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^3.0.0",
+            "x-is-string": "^0.1.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+        },
+        "vfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+          "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+          "requires": {
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
+        }
       }
     },
     "remark-mdx": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.0.21.tgz",
-      "integrity": "sha512-paYs43yHPkxEuhyWXvRGJdupdurua1ttmGeu5GLqU/qc17BaZklCdNSEjCNXRa2LM0pOFRv0KVJigfA2vfaDEQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.1.4.tgz",
+      "integrity": "sha512-pMmLvEyhNYcGd9qe8KNR9StAH35HUTgLobfRFpU4V8vyrWT+mNsd7+pTPKQbxGat5+PZ9IgmTjf760k3abdE6A==",
       "requires": {
-        "@babel/core": "^7.2.2",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "is-alphabetical": "^1.0.2",
-        "remark-parse": "^6.0.0",
-        "unified": "^7.0.0"
+        "@babel/core": "7.5.5",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.5.5",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "is-alphabetical": "1.0.3",
+        "remark-parse": "7.0.0",
+        "unified": "8.3.2"
       }
     },
     "remark-numbered-footnotes": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-1.0.11.tgz",
-      "integrity": "sha512-CBjXeRLgYyJ3dTSlH2k7qPfeammoaagxh8JMQPNQvheRRwawzGv/lyWwuJOh7tdtLIirB++a/mhiZmpKuPXJUQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-1.0.12.tgz",
+      "integrity": "sha512-PTC6ID97uup+jTow+gQ3gJivMYpbg8UMVDDcxi0BhpAOdRAZrtDH05daX/4I6jX8CQB60Gx1kfxcpT1VtAZidg==",
       "requires": {
         "unist-util-visit": "^1.3.1"
       }
     },
     "remark-parse": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.0.tgz",
+      "integrity": "sha512-UlfoqASKUnwSrzOcLSa7fwYdkpbeWwAs49YYdQmoYXK1TUJ2CvDBb3v8Lkt2GQzdPW9dWbjhteOsJJ27p1rNFg==",
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
@@ -13599,9 +13556,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -13678,6 +13635,11 @@
             "x-is-string": "^0.1.0"
           }
         },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+        },
         "vfile": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
@@ -13687,6 +13649,14 @@
             "replace-ext": "1.0.0",
             "unist-util-stringify-position": "^1.0.0",
             "vfile-message": "^1.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
           }
         }
       }
@@ -14140,9 +14110,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -14560,9 +14530,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -14609,9 +14579,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "spdy": {
       "version": "4.0.1",
@@ -14953,13 +14923,13 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -15070,24 +15040,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-selector-parser": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -15109,16 +15061,15 @@
       }
     },
     "svgo": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
-      "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "^1.1.0",
+        "css-tree": "1.0.0-alpha.33",
         "csso": "^3.5.1",
         "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
@@ -15166,9 +15117,9 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
-      "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+      "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -15176,17 +15127,6 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -15357,12 +15297,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theme-ui": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.5.tgz",
-      "integrity": "sha512-hFTOi0nDNB8ZejSg7zKQr2AKAcYv+nbbxE1oU9T/Is56tFvBgFDxc5DXrO82CayOAdAx3LN6iCsFzh/20f5HcQ==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.25.tgz",
+      "integrity": "sha512-ENvlYEXkODtc9/ohFWxFdazUxH26ObC74MVBZQ5UtIRhnrMjij3kbIIzWijK33ZqmnWEzofbk6f0TtQCdHqTNA==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.1",
-        "@styled-system/css": "^5.0.5",
+        "@styled-system/css": "^5.0.16",
         "deepmerge": "^3.2.0",
         "react": "^16.8.0"
       },
@@ -15495,11 +15435,6 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
-    },
-    "to-style": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/to-style/-/to-style-1.3.3.tgz",
-      "integrity": "sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -15634,9 +15569,9 @@
       "integrity": "sha512-gO0+fcZ1fTyKUsYY1ltYOOTI6FmBGeEdyIfeQg9NL8aInndk0feiJJVJsKHm/DiyYrnQEezraAQhz/KQoqMGtw=="
     },
     "typeface-montserrat": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-0.0.54.tgz",
-      "integrity": "sha512-Typhap0PWT299+Va0G/8ZtycHMXrH4gBWKfiW977KEBx5rXUUCa70gvqLx1fdA0WAo6bhSAQmo8uc+QFAmjPww=="
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-0.0.75.tgz",
+      "integrity": "sha512-8ski20t3hdwu2T85pVfjK4jsDbwW8yWzd+LAKxYEmu+JVLVlB7G2yfmdKZz06pUwYCLVFvHvup+NYYulHDpE+w=="
     },
     "typography-breakpoint-constants": {
       "version": "0.16.19",
@@ -15725,18 +15660,22 @@
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "unified": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.3.2.tgz",
+      "integrity": "sha512-NDtUAXcd4c+mKppCbsZHzmhkKEQuhveZNBrFYmNgMIMk2K9bc8hmG3mLEGVtRmSNodobwyMePAnvIGVWZfPdzQ==",
       "requires": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
+        }
       }
     },
     "union-value": {
@@ -15865,9 +15804,12 @@
       }
     },
     "unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+      "integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
     },
     "unist-util-visit": {
       "version": "1.4.1",
@@ -16193,14 +16135,15 @@
       }
     },
     "vfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
+      "integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
       "requires": {
+        "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
       },
       "dependencies": {
         "is-buffer": {
@@ -16216,11 +16159,12 @@
       "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ=="
     },
     "vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz",
+      "integrity": "sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==",
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "@types/unist": "^2.0.2",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vm-browserify": {
@@ -16702,9 +16646,9 @@
       }
     },
     "webpack-sources": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.1.tgz",
+      "integrity": "sha512-XSz38193PTo/1csJabKaV4b53uRVotlMgqJXm3s3eje0Bu6gQTxYDqpD38CmQfDBA+gN+QqaGjasuC8I/7eW3Q==",
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
@@ -16935,9 +16879,9 @@
       "integrity": "sha512-mqgtH6BXOgjOHVDxZPyW/h6QUC5kfEggh5IN8uOitjzrdCScE/a/cwcRvgcH8CGAXYReDNvasOKD0aFBWAZ1fg=="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/themes/gatsby-starter-blog-theme/package.json
+++ b/themes/gatsby-starter-blog-theme/package.json
@@ -8,8 +8,8 @@
     "build": "gatsby build"
   },
   "dependencies": {
-    "gatsby": "^2.13.45",
-    "gatsby-theme-blog": "^1.0.0",
+    "gatsby": "^2.13.48",
+    "gatsby-theme-blog": "^1.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/themes/gatsby-starter-notes-theme/package-lock.json
+++ b/themes/gatsby-starter-notes-theme/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-      "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.5",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -44,13 +44,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
       "requires": {
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -102,96 +102,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-replace-supers": "^7.5.5",
         "@babel/helper-split-export-declaration": "^7.4.4"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-          "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-          "requires": {
-            "@babel/types": "^7.5.5",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-          "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
-          "requires": {
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-          "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.5.5",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/traverse": "^7.5.5",
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-          "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
-        },
-        "@babel/traverse": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-          "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.5.5",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.5.5",
-            "@babel/types": "^7.5.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-          "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-      "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -230,11 +150,11 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -246,16 +166,16 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-      "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+      "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "@babel/template": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -272,11 +192,11 @@
       "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-regex": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-      "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -292,14 +212,14 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-      "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-simple-access": {
@@ -331,19 +251,19 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
       "requires": {
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -351,9 +271,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
@@ -374,6 +294,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -384,9 +313,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
-      "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+      "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -484,9 +413,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
-      "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -502,25 +431,25 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
-      "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
+      "integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
-      "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.4",
+        "@babel/helper-define-map": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.4",
+        "@babel/helper-replace-supers": "^7.5.5",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "globals": "^11.1.0"
       }
@@ -534,9 +463,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
-      "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+      "integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -552,9 +481,9 @@
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-      "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -611,31 +540,64 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-      "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+      "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
-      "integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
+      "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
       "requires": {
         "@babel/helper-module-transforms": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
-      "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -664,12 +626,12 @@
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-      "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+      "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-replace-supers": "^7.5.5"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -718,9 +680,9 @@
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
-      "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -815,42 +777,44 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
-      "integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
+      "integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.4.4",
+        "@babel/plugin-transform-async-to-generator": "^7.5.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.4.4",
-        "@babel/plugin-transform-classes": "^7.4.4",
+        "@babel/plugin-transform-block-scoping": "^7.5.5",
+        "@babel/plugin-transform-classes": "^7.5.5",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.4.4",
+        "@babel/plugin-transform-destructuring": "^7.5.0",
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
-        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
         "@babel/plugin-transform-for-of": "^7.4.4",
         "@babel/plugin-transform-function-name": "^7.4.4",
         "@babel/plugin-transform-literals": "^7.2.0",
         "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
-        "@babel/plugin-transform-modules-systemjs": "^7.4.4",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.5.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
         "@babel/plugin-transform-new-target": "^7.4.4",
-        "@babel/plugin-transform-object-super": "^7.2.0",
+        "@babel/plugin-transform-object-super": "^7.5.5",
         "@babel/plugin-transform-parameters": "^7.4.4",
         "@babel/plugin-transform-property-literals": "^7.2.0",
         "@babel/plugin-transform-regenerator": "^7.4.5",
@@ -861,7 +825,7 @@
         "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
         "@babel/plugin-transform-unicode-regex": "^7.4.4",
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "browserslist": "^4.6.0",
         "core-js-compat": "^3.1.1",
         "invariant": "^2.2.2",
@@ -870,13 +834,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.6.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-          "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+          "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000975",
-            "electron-to-chromium": "^1.3.164",
-            "node-releases": "^1.1.23"
+            "caniuse-lite": "^1.0.30000984",
+            "electron-to-chromium": "^1.3.191",
+            "node-releases": "^1.1.25"
           }
         }
       }
@@ -894,9 +858,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -912,19 +876,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -938,12 +902,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1410,31 +1374,31 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.0.21.tgz",
-      "integrity": "sha512-B+n3PvrtdUcaCgDmWFaBf4n/zsls5hoyNPkWe2CzUx3ggR0SoD4UqCQR7iIZZ//fUjAwFODGf+2H0aJ3tIlB7w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.1.4.tgz",
+      "integrity": "sha512-CL01jH8AOiaIGVYXGFEwVbnKmtUF7fh9Cr/nYTBsH/MeOkNesJD+OMmdskfraTo/QI0l4Bt70AeD165WPMXaGw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-        "change-case": "^3.0.2",
-        "detab": "^2.0.0",
-        "hast-util-raw": "^5.0.0",
-        "lodash.uniq": "^4.5.0",
-        "mdast-util-to-hast": "^4.0.0",
-        "remark-mdx": "^1.0.21",
-        "remark-parse": "^6.0.0",
-        "remark-squeeze-paragraphs": "^3.0.1",
-        "to-style": "^1.3.3",
-        "unified": "^7.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-visit": "^1.3.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "camelcase-css": "2.0.1",
+        "detab": "2.0.2",
+        "hast-util-raw": "5.0.1",
+        "lodash.uniq": "4.5.0",
+        "mdast-util-to-hast": "6.0.1",
+        "remark-mdx": "^1.1.4",
+        "remark-parse": "7.0.0",
+        "remark-squeeze-paragraphs": "3.0.4",
+        "style-to-object": "0.2.3",
+        "unified": "8.3.2",
+        "unist-builder": "1.0.4",
+        "unist-util-visit": "1.4.1"
       }
     },
     "@mdx-js/react": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.0.21.tgz",
-      "integrity": "sha512-+7H1UfIytxKN/nSdojCRzUM/ZeQ6/EUg8F9bnY2NnPGuF+67cug6vZBAx9famtAey0Ms0dr2QAuCOd8k3SkhJg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.1.4.tgz",
+      "integrity": "sha512-qh6M6Uv1CxL8SszBbeTEbB2Ko27j6HLSqlDzPvbsxXZ9Nt87S/B65tvN1HjE8ZH8I0DO8V4L/ebalCy+pkEfIw=="
     },
     "@mikaelkristiansson/domready": {
       "version": "1.0.9",
@@ -1488,9 +1452,9 @@
       }
     },
     "@styled-system/css": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.11.tgz",
-      "integrity": "sha512-rq/KO2SEpUbk9dWIRdWEkNL3w6Eds55KGdAcD+9DttqrC+FwPXfk27ebmTMfwyIAiDES9uW7z57Bo6v34VUNqw=="
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.17.tgz",
+      "integrity": "sha512-MSKnFq3zK53fJ/Au2oAnioNiKZJ2GATi4/tGYlh+/qSbDa09YX0siOzO8kIMKYt4L2fNCZnCuKPXJS7NFcWbmA=="
     },
     "@types/configstore": {
       "version": "2.1.1",
@@ -1538,9 +1502,9 @@
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.6.tgz",
-      "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA=="
+      "version": "7.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.7.tgz",
+      "integrity": "sha512-4I7+hXKyq7e1deuzX9udu0hPIYqSSkdKXtjow6fMnQ3OR9qkxIErGHbGY08YrfZJrCS1ajK8lOuzd0k3n2WM4A=="
     },
     "@types/prop-types": {
       "version": "15.7.1",
@@ -1562,9 +1526,9 @@
       }
     },
     "@types/react": {
-      "version": "16.8.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
-      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "version": "16.8.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
+      "integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -2128,24 +2092,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
@@ -2977,6 +2923,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -2996,34 +2947,14 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30000987",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-              "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-            }
-          }
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000979",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000979.tgz",
-      "integrity": "sha512-gcu45yfq3B7Y+WB05fOMfr0EiSlq+1u+m6rPHyJli/Wy3PVQNGaU7VA4bZE5qw+AU2UVOBR/N5g1bzADUqdvFw=="
+      "version": "1.0.30000988",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
+      "integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3620,19 +3551,19 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.6.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-          "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+          "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000975",
-            "electron-to-chromium": "^1.3.164",
-            "node-releases": "^1.1.23"
+            "caniuse-lite": "^1.0.30000984",
+            "electron-to-chromium": "^1.3.191",
+            "node-releases": "^1.1.25"
           }
         },
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -4039,9 +3970,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4471,9 +4402,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.184.tgz",
-      "integrity": "sha512-jctpw2OkTBfpKg6PI3ndZZ+LlH6y0Pc+o9wvOkm9iqqgQ/FcOxpiADeB4kGddAEtZ+PBR4+TStEcoj1ApS3lUA=="
+      "version": "1.3.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.210.tgz",
+      "integrity": "sha512-m1i/F+gw9jkauxDx0mOr7Sj6vp6se1mfkQNYqZb1yL5VGTp0AC1NZH5CGI6YMSO7WaScILmkKDZFG9/hlR9axQ=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -5027,9 +4958,9 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -5037,9 +4968,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eval": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.3.tgz",
-      "integrity": "sha512-lDBa3hl9YynB+3J7aNPaajAapr+7ZiAylqFeUmx/r9s7I0tkkUJFLw2CQ2oMRYGg/rL7g4IYkZenbKaQGKPnGQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.4.tgz",
+      "integrity": "sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==",
       "requires": {
         "require-like": ">= 0.1.1"
       }
@@ -6106,9 +6037,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.13.45",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.13.45.tgz",
-      "integrity": "sha512-LvbEjb5gpYjTwpjGv6u70TC1ryyjzLuU+YY//bcIdI4UxioX2GKD2caQYQ8de5clMS7Vhqd7I4D0jq8hwmDxfQ==",
+      "version": "2.13.48",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.13.48.tgz",
+      "integrity": "sha512-GaDUQLPrkUFYYnLSBBZS5tedn/O3RdnrHJjPrxxFdk6dEQculDU4RaDsDymXxPzz7Lszke73dTYSRd8SiZ2rTw==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -6166,13 +6097,13 @@
         "flat": "^4.0.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^5.0.0",
-        "gatsby-cli": "^2.7.21",
+        "gatsby-cli": "^2.7.24",
         "gatsby-core-utils": "^1.0.3",
         "gatsby-graphiql-explorer": "^0.2.3",
         "gatsby-link": "^2.2.4",
         "gatsby-plugin-page-creator": "^2.1.5",
         "gatsby-react-router-scroll": "^2.1.3",
-        "gatsby-telemetry": "^1.1.7",
+        "gatsby-telemetry": "^1.1.9",
         "glob": "^7.1.1",
         "got": "8.0.0",
         "graphql": "^14.1.1",
@@ -6309,9 +6240,9 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.7.21",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.7.21.tgz",
-          "integrity": "sha512-M80MfpIm/S6IMGDthPu5kEUT4i6SXYjmfpg/0/BJxPpvj5xA+CMECzmLk1olSw+5//nVXpf2r3nuiZl1AR78jA==",
+          "version": "2.7.24",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.7.24.tgz",
+          "integrity": "sha512-rKK6Tv09pywtCzn3TlXR0FgFw1OdDWl9wmCOuMHZpGq9RQVf2VYNevptaiEDKAI7ECM0vTVf7MNz34ePNOTkFQ==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/runtime": "^7.0.0",
@@ -6329,7 +6260,7 @@
             "execa": "^0.8.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^4.0.1",
-            "gatsby-telemetry": "^1.1.7",
+            "gatsby-telemetry": "^1.1.9",
             "hosted-git-info": "^2.6.0",
             "ink": "^2.3.0",
             "ink-spinner": "^3.0.1",
@@ -6570,40 +6501,47 @@
       }
     },
     "gatsby-plugin-compile-es6-packages": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-compile-es6-packages/-/gatsby-plugin-compile-es6-packages-1.1.0.tgz",
-      "integrity": "sha512-YjB9LDyUBcWfVVF8mN+t4OziYghys08nb2vpYgW+sqXO4giHRLWpANFmVUXW+H2c1g8fAwPlKYcwDXyqNunibw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-compile-es6-packages/-/gatsby-plugin-compile-es6-packages-1.2.0.tgz",
+      "integrity": "sha512-imFA3VFJHSs+Jfu4HKhF9b89nZE24bSR0Xn9g9OK2vTI945kszstWoxKSWJYXQB7K6rsJ2Ml5iONjvwqfX8y6w==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "regex-escape": "^3.4.8"
       }
     },
     "gatsby-plugin-emotion": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.0.tgz",
-      "integrity": "sha512-6Wrw47MK7j2OLgdjUmJVgdMtykFT9PNan2UTAjIWqquNMJgWWa96iM5kS4DnExhlwfyb50vji/SaWjW8JrUI8w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.2.tgz",
+      "integrity": "sha512-CDOzfhiP0V6p5Z+wDSpVhpa4MpK0JFaIOlC1Ope8wg6+/5upMXvQ2zrWqYhE7O1UeaHByjAWUA/af4M3OM3ICw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@emotion/babel-preset-css-prop": "^10.0.5"
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.7.tgz",
-      "integrity": "sha512-sXubUJhKO8nC4vEe7ME1htlQ4LPtRC7hhZF3fHl26gy5zNuHiCVtHZROoVIaiEY7UECGZzX8CjEblGVNgSmD2A==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.22.tgz",
+      "integrity": "sha512-+ZBuy7I0a4T+udlPnoUgII6PIm3YKHv26hNBXhZYTPk//R4LiCD3vlhZeeHqHAQaOamNquHt7DPxXZezNIATkw==",
       "requires": {
         "@babel/core": "^7.4.3",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
         "@babel/preset-env": "^7.4.3",
         "@babel/preset-react": "^7.0.0",
+        "@babel/types": "^7.5.5",
+        "camelcase-css": "^2.0.1",
+        "change-case": "^3.1.0",
         "core-js": "2",
         "dataloader": "^1.4.0",
         "debug": "^4.0.1",
         "escape-string-regexp": "^1.0.5",
+        "eval": "^0.1.4",
         "fs-extra": "^7.0.0",
         "gray-matter": "^4.0.1",
+        "json5": "^2.1.0",
         "loader-utils": "^1.2.3",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "mdast-util-to-string": "^1.0.4",
         "mdast-util-toc": "^3.0.0",
         "mime": "^2.3.1",
@@ -6614,7 +6552,9 @@
         "retext-english": "^3.0.2",
         "slash": "^2.0.0",
         "static-site-generator-webpack-plugin": "^3.4.2",
+        "style-to-object": "^0.2.3",
         "underscore.string": "^3.3.4",
+        "unified": "^8.3.2",
         "unist-util-map": "^1.0.4",
         "unist-util-remove": "^1.0.1",
         "unist-util-visit": "^1.4.0"
@@ -6699,9 +6639,9 @@
       }
     },
     "gatsby-plugin-theme-ui": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.5.tgz",
-      "integrity": "sha512-TlcQ/FCIu+2ns+ADOEjIj6sThBfShLjqU2zCDTvcfHIBoV2wCt/G9wNlaytt5pPTUtVd9lZkvkNdXY8zPDOUtg=="
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.25.tgz",
+      "integrity": "sha512-yEmxgHdF3o/txiEXLJBcHByukF8ECq6hVYQNcx8AR9OWefw1WI5as136qc7L4Ue9BBgtP95igr/DpPcQp+1Gog=="
     },
     "gatsby-react-router-scroll": {
       "version": "2.1.3",
@@ -6714,9 +6654,9 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.2.tgz",
-      "integrity": "sha512-mrlQ00Es+qjb2MCIEHAkv/F3yfR5IgI8z2q54tqpxu4amlUy3SQH5ThJDGD7Ya574ub9aKdHOr8virTssmTDgA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.8.tgz",
+      "integrity": "sha512-/EhMIlp6LA09+zzNkkhSW/zmJON9Ma9HQ5NpGTop7RVf9RIWiqhLA3klqVAnOwcYo2ALvAenGdGX2pgfH4PiMw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "better-queue": "^3.8.7",
@@ -6724,6 +6664,7 @@
         "chokidar": "2.1.2",
         "file-type": "^10.2.0",
         "fs-extra": "^5.0.0",
+        "gatsby-core-utils": "^1.0.0",
         "got": "^7.1.0",
         "md5-file": "^3.1.1",
         "mime": "^2.2.0",
@@ -6773,9 +6714,9 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.7.tgz",
-      "integrity": "sha512-mVJwkg4kdHGBt1OKlpcDO1gKoRd5oiJHKYR1jGrShXbB8FE4c52Z2Geg0xMKNXCeUbMUEZB78IPGlJ94nnPAag==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.9.tgz",
+      "integrity": "sha512-k6JtA52UjQddKCo88EnlIlQOEszjfUv6B24N0bMbEStS8XDxCkMS6+minBtjyXCa8XEGogU6IKLwqB9KDSGc+Q==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/runtime": "^7.0.0",
@@ -6840,24 +6781,25 @@
       }
     },
     "gatsby-theme-notes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-1.0.0.tgz",
-      "integrity": "sha512-LYO9gEGbTQc3FMB/dUeerksFmyn6mFaTw7+pATslFfs8o4Hx9Qh3fG6K/mWw7/pGetnzyGyevt9QPZOh7/uH7Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-1.0.3.tgz",
+      "integrity": "sha512-i8Ndd2nXjGfhyEVK/d9g7OBjzX5TLwCpbbUl1aAUS+B7KKe/kBoJ3/UPLd/93accriuRLE3pAXm8ylA+TewGTQ==",
       "requires": {
         "@emotion/core": "^10.0.14",
-        "@mdx-js/mdx": "^1.0.21",
-        "@mdx-js/react": "^1.0.21",
-        "gatsby-plugin-compile-es6-packages": "^1.1.0",
-        "gatsby-plugin-emotion": "^4.1.0",
-        "gatsby-plugin-mdx": "^1.0.7",
+        "@mdx-js/mdx": "^1.1.0",
+        "@mdx-js/react": "^1.0.27",
+        "gatsby-core-utils": "^1.0.3",
+        "gatsby-plugin-compile-es6-packages": "^1.2.0",
+        "gatsby-plugin-emotion": "^4.1.2",
+        "gatsby-plugin-mdx": "^1.0.16",
         "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-plugin-og-image": "0.0.1",
         "gatsby-plugin-redirects": "^1.0.0",
-        "gatsby-plugin-theme-ui": "^0.2.5",
-        "gatsby-source-filesystem": "^2.1.2",
+        "gatsby-plugin-theme-ui": "^0.2.18",
+        "gatsby-source-filesystem": "^2.1.6",
         "is-present": "^1.0.0",
         "react-feather": "^1.1.6",
-        "theme-ui": "^0.2.5"
+        "theme-ui": "^0.2.18"
       }
     },
     "get-caller-file": {
@@ -8578,9 +8520,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -8903,9 +8845,9 @@
       }
     },
     "mdast-util-to-hast": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
-      "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-6.0.1.tgz",
+      "integrity": "sha512-KRh9wIYzUQk877JcV+8q4FqBUEouLpCKMObqeWg4dnL1/rh9vtSIq5mqQFwIK9YzSULl91F8FP5+EJ/xqRHaBw==",
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
@@ -9005,9 +8947,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+      "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A=="
     },
     "methods": {
       "version": "1.1.2",
@@ -9354,9 +9296,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.24.tgz",
-      "integrity": "sha512-wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
+      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -9586,9 +9528,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "omggif": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
-      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -10229,24 +10171,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -10405,24 +10329,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-selector-parser": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -10490,24 +10396,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         },
         "postcss-value-parser": {
@@ -10758,24 +10646,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -10853,24 +10723,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
@@ -10954,9 +10806,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "pretty-bytes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
-      "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -11020,9 +10872,9 @@
       }
     },
     "property-information": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.1.0.tgz",
-      "integrity": "sha512-tODH6R3+SwTkAQckSp2S9xyYX8dEKYkeXw+4TmJzTxnNzd6mQPu1OD4f9zPrvw/Rm4wpPgI+Zp63mNSGNzUgHg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.2.2.tgz",
+      "integrity": "sha512-N2moasZmjn2mjVGIWpaqz5qnz6QyeQSGgGvMtl81gA9cPTWa6wpesRSe/quNnOjUHpvSH1oZx0pdz0EEckLFnA==",
       "requires": {
         "xtend": "^4.0.1"
       }
@@ -11543,14 +11395,14 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
-      "integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
       "requires": {
         "private": "^0.1.6"
       }
@@ -11570,9 +11422,9 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
-      "integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ=="
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
+      "integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg=="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -11646,26 +11498,94 @@
         "remark-parse": "^6.0.0",
         "remark-stringify": "^6.0.0",
         "unified": "^7.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "remark-parse": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+          "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unified": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+          "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "@types/vfile": "^3.0.0",
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^3.0.0",
+            "x-is-string": "^0.1.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+        },
+        "vfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+          "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+          "requires": {
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
+        }
       }
     },
     "remark-mdx": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.0.21.tgz",
-      "integrity": "sha512-paYs43yHPkxEuhyWXvRGJdupdurua1ttmGeu5GLqU/qc17BaZklCdNSEjCNXRa2LM0pOFRv0KVJigfA2vfaDEQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.1.4.tgz",
+      "integrity": "sha512-pMmLvEyhNYcGd9qe8KNR9StAH35HUTgLobfRFpU4V8vyrWT+mNsd7+pTPKQbxGat5+PZ9IgmTjf760k3abdE6A==",
       "requires": {
-        "@babel/core": "^7.2.2",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "is-alphabetical": "^1.0.2",
-        "remark-parse": "^6.0.0",
-        "unified": "^7.0.0"
+        "@babel/core": "7.5.5",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.5.5",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "is-alphabetical": "1.0.3",
+        "remark-parse": "7.0.0",
+        "unified": "8.3.2"
       }
     },
     "remark-parse": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.0.tgz",
+      "integrity": "sha512-UlfoqASKUnwSrzOcLSa7fwYdkpbeWwAs49YYdQmoYXK1TUJ2CvDBb3v8Lkt2GQzdPW9dWbjhteOsJJ27p1rNFg==",
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
@@ -11774,9 +11694,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -12566,9 +12486,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -12881,13 +12801,13 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -12974,24 +12894,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-selector-parser": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -13069,9 +12971,9 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
-      "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+      "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -13178,12 +13080,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theme-ui": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.5.tgz",
-      "integrity": "sha512-hFTOi0nDNB8ZejSg7zKQr2AKAcYv+nbbxE1oU9T/Is56tFvBgFDxc5DXrO82CayOAdAx3LN6iCsFzh/20f5HcQ==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.25.tgz",
+      "integrity": "sha512-ENvlYEXkODtc9/ohFWxFdazUxH26ObC74MVBZQ5UtIRhnrMjij3kbIIzWijK33ZqmnWEzofbk6f0TtQCdHqTNA==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.1",
-        "@styled-system/css": "^5.0.5",
+        "@styled-system/css": "^5.0.16",
         "deepmerge": "^3.2.0",
         "react": "^16.8.0"
       }
@@ -13304,11 +13206,6 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
-    },
-    "to-style": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/to-style/-/to-style-1.3.3.tgz",
-      "integrity": "sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -13448,18 +13345,22 @@
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "unified": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.3.2.tgz",
+      "integrity": "sha512-NDtUAXcd4c+mKppCbsZHzmhkKEQuhveZNBrFYmNgMIMk2K9bc8hmG3mLEGVtRmSNodobwyMePAnvIGVWZfPdzQ==",
       "requires": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
+        }
       }
     },
     "union-value": {
@@ -13563,9 +13464,12 @@
       }
     },
     "unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+      "integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
     },
     "unist-util-visit": {
       "version": "1.4.1",
@@ -13881,14 +13785,15 @@
       "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw=="
     },
     "vfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
+      "integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
       "requires": {
+        "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
       },
       "dependencies": {
         "is-buffer": {
@@ -13904,11 +13809,12 @@
       "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ=="
     },
     "vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz",
+      "integrity": "sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==",
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "@types/unist": "^2.0.2",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vm-browserify": {
@@ -14390,9 +14296,9 @@
       }
     },
     "webpack-sources": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.1.tgz",
+      "integrity": "sha512-XSz38193PTo/1csJabKaV4b53uRVotlMgqJXm3s3eje0Bu6gQTxYDqpD38CmQfDBA+gN+QqaGjasuC8I/7eW3Q==",
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
@@ -14605,9 +14511,9 @@
       "integrity": "sha512-mqgtH6BXOgjOHVDxZPyW/h6QUC5kfEggh5IN8uOitjzrdCScE/a/cwcRvgcH8CGAXYReDNvasOKD0aFBWAZ1fg=="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/themes/gatsby-starter-notes-theme/package.json
+++ b/themes/gatsby-starter-notes-theme/package.json
@@ -8,8 +8,8 @@
     "build": "gatsby build"
   },
   "dependencies": {
-    "gatsby": "^2.13.45",
-    "gatsby-theme-notes": "^1.0.0",
+    "gatsby": "^2.13.48",
+    "gatsby-theme-notes": "^1.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/themes/gatsby-starter-theme/package-lock.json
+++ b/themes/gatsby-starter-theme/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-      "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.5",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -44,13 +44,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
       "requires": {
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -102,96 +102,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-replace-supers": "^7.5.5",
         "@babel/helper-split-export-declaration": "^7.4.4"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-          "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-          "requires": {
-            "@babel/types": "^7.5.5",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-          "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
-          "requires": {
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-          "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.5.5",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/traverse": "^7.5.5",
-            "@babel/types": "^7.5.5"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-          "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
-        },
-        "@babel/traverse": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-          "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.5.5",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.5.5",
-            "@babel/types": "^7.5.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-          "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-      "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -230,11 +150,11 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -246,16 +166,16 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-      "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+      "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "@babel/template": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -272,11 +192,11 @@
       "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-regex": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-      "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -292,14 +212,14 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-      "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-simple-access": {
@@ -331,19 +251,19 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
       "requires": {
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -351,9 +271,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
@@ -374,6 +294,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -384,9 +313,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
-      "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+      "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -484,9 +413,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
-      "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -502,25 +431,25 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
-      "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
+      "integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
-      "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.4",
+        "@babel/helper-define-map": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.4",
+        "@babel/helper-replace-supers": "^7.5.5",
         "@babel/helper-split-export-declaration": "^7.4.4",
         "globals": "^11.1.0"
       }
@@ -534,9 +463,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
-      "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+      "integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -552,9 +481,9 @@
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-      "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -611,31 +540,64 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-      "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+      "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
-      "integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
+      "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
       "requires": {
         "@babel/helper-module-transforms": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
-      "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+          "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -664,12 +626,12 @@
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-      "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+      "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-replace-supers": "^7.5.5"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -718,9 +680,9 @@
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
-      "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -815,42 +777,44 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
-      "integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
+      "integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.4.4",
+        "@babel/plugin-transform-async-to-generator": "^7.5.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.4.4",
-        "@babel/plugin-transform-classes": "^7.4.4",
+        "@babel/plugin-transform-block-scoping": "^7.5.5",
+        "@babel/plugin-transform-classes": "^7.5.5",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.4.4",
+        "@babel/plugin-transform-destructuring": "^7.5.0",
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
-        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
         "@babel/plugin-transform-for-of": "^7.4.4",
         "@babel/plugin-transform-function-name": "^7.4.4",
         "@babel/plugin-transform-literals": "^7.2.0",
         "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.4",
-        "@babel/plugin-transform-modules-systemjs": "^7.4.4",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.5.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
         "@babel/plugin-transform-new-target": "^7.4.4",
-        "@babel/plugin-transform-object-super": "^7.2.0",
+        "@babel/plugin-transform-object-super": "^7.5.5",
         "@babel/plugin-transform-parameters": "^7.4.4",
         "@babel/plugin-transform-property-literals": "^7.2.0",
         "@babel/plugin-transform-regenerator": "^7.4.5",
@@ -861,7 +825,7 @@
         "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
         "@babel/plugin-transform-unicode-regex": "^7.4.4",
-        "@babel/types": "^7.4.4",
+        "@babel/types": "^7.5.5",
         "browserslist": "^4.6.0",
         "core-js-compat": "^3.1.1",
         "invariant": "^2.2.2",
@@ -870,13 +834,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.6.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-          "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+          "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000975",
-            "electron-to-chromium": "^1.3.164",
-            "node-releases": "^1.1.23"
+            "caniuse-lite": "^1.0.30000984",
+            "electron-to-chromium": "^1.3.191",
+            "node-releases": "^1.1.25"
           }
         }
       }
@@ -894,9 +858,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -912,19 +876,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/types": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -938,12 +902,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1113,9 +1077,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
-          "integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw=="
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
+          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
         }
       }
     },
@@ -1415,31 +1379,31 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.0.21.tgz",
-      "integrity": "sha512-B+n3PvrtdUcaCgDmWFaBf4n/zsls5hoyNPkWe2CzUx3ggR0SoD4UqCQR7iIZZ//fUjAwFODGf+2H0aJ3tIlB7w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.1.4.tgz",
+      "integrity": "sha512-CL01jH8AOiaIGVYXGFEwVbnKmtUF7fh9Cr/nYTBsH/MeOkNesJD+OMmdskfraTo/QI0l4Bt70AeD165WPMXaGw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-        "change-case": "^3.0.2",
-        "detab": "^2.0.0",
-        "hast-util-raw": "^5.0.0",
-        "lodash.uniq": "^4.5.0",
-        "mdast-util-to-hast": "^4.0.0",
-        "remark-mdx": "^1.0.21",
-        "remark-parse": "^6.0.0",
-        "remark-squeeze-paragraphs": "^3.0.1",
-        "to-style": "^1.3.3",
-        "unified": "^7.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-visit": "^1.3.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "camelcase-css": "2.0.1",
+        "detab": "2.0.2",
+        "hast-util-raw": "5.0.1",
+        "lodash.uniq": "4.5.0",
+        "mdast-util-to-hast": "6.0.1",
+        "remark-mdx": "^1.1.4",
+        "remark-parse": "7.0.0",
+        "remark-squeeze-paragraphs": "3.0.4",
+        "style-to-object": "0.2.3",
+        "unified": "8.3.2",
+        "unist-builder": "1.0.4",
+        "unist-util-visit": "1.4.1"
       }
     },
     "@mdx-js/react": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.0.21.tgz",
-      "integrity": "sha512-+7H1UfIytxKN/nSdojCRzUM/ZeQ6/EUg8F9bnY2NnPGuF+67cug6vZBAx9famtAey0Ms0dr2QAuCOd8k3SkhJg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.1.4.tgz",
+      "integrity": "sha512-qh6M6Uv1CxL8SszBbeTEbB2Ko27j6HLSqlDzPvbsxXZ9Nt87S/B65tvN1HjE8ZH8I0DO8V4L/ebalCy+pkEfIw=="
     },
     "@mikaelkristiansson/domready": {
       "version": "1.0.9",
@@ -1498,22 +1462,22 @@
       }
     },
     "@styled-system/css": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.11.tgz",
-      "integrity": "sha512-rq/KO2SEpUbk9dWIRdWEkNL3w6Eds55KGdAcD+9DttqrC+FwPXfk27ebmTMfwyIAiDES9uW7z57Bo6v34VUNqw=="
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.17.tgz",
+      "integrity": "sha512-MSKnFq3zK53fJ/Au2oAnioNiKZJ2GATi4/tGYlh+/qSbDa09YX0siOzO8kIMKYt4L2fNCZnCuKPXJS7NFcWbmA=="
     },
     "@theme-ui/prism": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/prism/-/prism-0.2.5.tgz",
-      "integrity": "sha512-43aAMFYpgvi16ZUmXaKlG3BChhgibuHXO9dZ9fr7Hqx33Pf1Wfp6kW/STat8qabsR36FuSC36H0VdoSY3Ny/5g==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@theme-ui/prism/-/prism-0.2.25.tgz",
+      "integrity": "sha512-uS41Vh3sbaZuJFysUevy3oOmhmTZ5+8wdU/SYXzAF0B7axPoHvAraC3bhVos3RWT6Zzsigis1w2RkGHQizwzlw==",
       "requires": {
         "prism-react-renderer": "^0.1.7"
       }
     },
     "@theme-ui/typography": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@theme-ui/typography/-/typography-0.2.5.tgz",
-      "integrity": "sha512-Vde++rLNQUsQxFMaSvMgNxPTGfSx83HqYP36TO5iJ2cPNrEjzZLCJ0yogmg4wdL20C69o4sYrdNw/Qfqkhcqqw==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@theme-ui/typography/-/typography-0.2.25.tgz",
+      "integrity": "sha512-djLsN+QFQ9fb1z4EluHWu2FW7lppMugmRSCUAGRZaSzolPyNtDRkkvE3nwk7PYg/YaEzr+qwOX6iXGyzJeXSww==",
       "requires": {
         "compass-vertical-rhythm": "^1.4.5",
         "modularscale": "^2.0.1",
@@ -1566,9 +1530,9 @@
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.6.tgz",
-      "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA=="
+      "version": "7.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.7.tgz",
+      "integrity": "sha512-4I7+hXKyq7e1deuzX9udu0hPIYqSSkdKXtjow6fMnQ3OR9qkxIErGHbGY08YrfZJrCS1ajK8lOuzd0k3n2WM4A=="
     },
     "@types/prop-types": {
       "version": "15.7.1",
@@ -1590,9 +1554,9 @@
       }
     },
     "@types/react": {
-      "version": "16.8.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
-      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "version": "16.8.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
+      "integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1836,9 +1800,9 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2202,24 +2166,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
@@ -3232,6 +3178,21 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
           "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         }
       }
     },
@@ -3280,6 +3241,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+    },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
@@ -3315,34 +3281,14 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30000987",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-              "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-            }
-          }
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000979",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000979.tgz",
-      "integrity": "sha512-gcu45yfq3B7Y+WB05fOMfr0EiSlq+1u+m6rPHyJli/Wy3PVQNGaU7VA4bZE5qw+AU2UVOBR/N5g1bzADUqdvFw=="
+      "version": "1.0.30000988",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
+      "integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3485,9 +3431,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -4006,19 +3952,19 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.6.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-          "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+          "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000975",
-            "electron-to-chromium": "^1.3.164",
-            "node-releases": "^1.1.23"
+            "caniuse-lite": "^1.0.30000984",
+            "electron-to-chromium": "^1.3.191",
+            "node-releases": "^1.1.25"
           }
         },
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -4311,11 +4257,11 @@
       }
     },
     "css-tree": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
       "requires": {
-        "mdn-data": "~1.1.0",
+        "mdn-data": "2.0.4",
         "source-map": "^0.5.3"
       }
     },
@@ -4323,11 +4269,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
-    },
-    "css-url-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-      "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
     },
     "css-what": {
       "version": "2.1.3",
@@ -4426,13 +4367,18 @@
             "mdn-data": "~1.1.0",
             "source-map": "^0.5.3"
           }
+        },
+        "mdn-data": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
         }
       }
     },
     "csstype": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4634,9 +4580,9 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+      "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -5099,9 +5045,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.184.tgz",
-      "integrity": "sha512-jctpw2OkTBfpKg6PI3ndZZ+LlH6y0Pc+o9wvOkm9iqqgQ/FcOxpiADeB4kGddAEtZ+PBR4+TStEcoj1ApS3lUA=="
+      "version": "1.3.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.210.tgz",
+      "integrity": "sha512-m1i/F+gw9jkauxDx0mOr7Sj6vp6se1mfkQNYqZb1yL5VGTp0AC1NZH5CGI6YMSO7WaScILmkKDZFG9/hlR9axQ=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -5655,9 +5601,9 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -5665,9 +5611,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eval": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.3.tgz",
-      "integrity": "sha512-lDBa3hl9YynB+3J7aNPaajAapr+7ZiAylqFeUmx/r9s7I0tkkUJFLw2CQ2oMRYGg/rL7g4IYkZenbKaQGKPnGQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.4.tgz",
+      "integrity": "sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==",
       "requires": {
         "require-like": ">= 0.1.1"
       }
@@ -6865,9 +6811,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.13.45",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.13.45.tgz",
-      "integrity": "sha512-LvbEjb5gpYjTwpjGv6u70TC1ryyjzLuU+YY//bcIdI4UxioX2GKD2caQYQ8de5clMS7Vhqd7I4D0jq8hwmDxfQ==",
+      "version": "2.13.48",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.13.48.tgz",
+      "integrity": "sha512-GaDUQLPrkUFYYnLSBBZS5tedn/O3RdnrHJjPrxxFdk6dEQculDU4RaDsDymXxPzz7Lszke73dTYSRd8SiZ2rTw==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -6925,13 +6871,13 @@
         "flat": "^4.0.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^5.0.0",
-        "gatsby-cli": "^2.7.21",
+        "gatsby-cli": "^2.7.24",
         "gatsby-core-utils": "^1.0.3",
         "gatsby-graphiql-explorer": "^0.2.3",
         "gatsby-link": "^2.2.4",
         "gatsby-plugin-page-creator": "^2.1.5",
         "gatsby-react-router-scroll": "^2.1.3",
-        "gatsby-telemetry": "^1.1.7",
+        "gatsby-telemetry": "^1.1.9",
         "glob": "^7.1.1",
         "got": "8.0.0",
         "graphql": "^14.1.1",
@@ -7068,9 +7014,9 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.7.21",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.7.21.tgz",
-          "integrity": "sha512-M80MfpIm/S6IMGDthPu5kEUT4i6SXYjmfpg/0/BJxPpvj5xA+CMECzmLk1olSw+5//nVXpf2r3nuiZl1AR78jA==",
+          "version": "2.7.24",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.7.24.tgz",
+          "integrity": "sha512-rKK6Tv09pywtCzn3TlXR0FgFw1OdDWl9wmCOuMHZpGq9RQVf2VYNevptaiEDKAI7ECM0vTVf7MNz34ePNOTkFQ==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/runtime": "^7.0.0",
@@ -7088,7 +7034,7 @@
             "execa": "^0.8.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^4.0.1",
-            "gatsby-telemetry": "^1.1.7",
+            "gatsby-telemetry": "^1.1.9",
             "hosted-git-info": "^2.6.0",
             "ink": "^2.3.0",
             "ink-spinner": "^3.0.1",
@@ -7304,9 +7250,9 @@
       }
     },
     "gatsby-image": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.4.tgz",
-      "integrity": "sha512-wlbqGsfIX2+ILz/fk/94fDShc5zfhTlj7vYGyTFZfKombvwPXFAJD6pey4zTBZUUBrxMt2tROMXNnmFi3wGyww==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.8.tgz",
+      "integrity": "sha512-R0hc37xf03Bqi51TlRHuu6KB5sFiXzHx0tQotml8TeFXu1k5yvV13D8fHhlHCZQq5zJe4KHx0rGfAprzb4s1fA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "object-fit-images": "^3.2.4",
@@ -7339,46 +7285,35 @@
       }
     },
     "gatsby-plugin-compile-es6-packages": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-compile-es6-packages/-/gatsby-plugin-compile-es6-packages-1.1.0.tgz",
-      "integrity": "sha512-YjB9LDyUBcWfVVF8mN+t4OziYghys08nb2vpYgW+sqXO4giHRLWpANFmVUXW+H2c1g8fAwPlKYcwDXyqNunibw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-compile-es6-packages/-/gatsby-plugin-compile-es6-packages-1.2.0.tgz",
+      "integrity": "sha512-imFA3VFJHSs+Jfu4HKhF9b89nZE24bSR0Xn9g9OK2vTI945kszstWoxKSWJYXQB7K6rsJ2Ml5iONjvwqfX8y6w==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "regex-escape": "^3.4.8"
       }
     },
     "gatsby-plugin-emotion": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.0.tgz",
-      "integrity": "sha512-6Wrw47MK7j2OLgdjUmJVgdMtykFT9PNan2UTAjIWqquNMJgWWa96iM5kS4DnExhlwfyb50vji/SaWjW8JrUI8w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.1.2.tgz",
+      "integrity": "sha512-CDOzfhiP0V6p5Z+wDSpVhpa4MpK0JFaIOlC1Ope8wg6+/5upMXvQ2zrWqYhE7O1UeaHByjAWUA/af4M3OM3ICw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@emotion/babel-preset-css-prop": "^10.0.5"
       }
     },
     "gatsby-plugin-feed": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.2.tgz",
-      "integrity": "sha512-n+RkfLEtgtt9CbVnmIzVD5WjqEFi4heE5a78aT3tCTRpx04rkHpvGowe0NF4RzsiSuM2+Obmbzy/il0HkmCzIA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.6.tgz",
+      "integrity": "sha512-iBywR85MF6zJ13wH45L5wKwkruwTQNG5CXoSeL8gMRZJvYRhTsoMTihK9YDVEemct1vRtZmzDWabSBGsKuNlZQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@hapi/joi": "^15.0.0",
         "fs-extra": "^7.0.1",
-        "lodash.merge": "^4.6.0",
+        "lodash.merge": "^4.6.2",
         "rss": "^1.2.2"
       },
       "dependencies": {
-        "@hapi/joi": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-          "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
-          "requires": {
-            "@hapi/address": "2.x.x",
-            "@hapi/hoek": "6.x.x",
-            "@hapi/marker": "1.x.x",
-            "@hapi/topo": "3.x.x"
-          }
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -7392,22 +7327,29 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.7.tgz",
-      "integrity": "sha512-sXubUJhKO8nC4vEe7ME1htlQ4LPtRC7hhZF3fHl26gy5zNuHiCVtHZROoVIaiEY7UECGZzX8CjEblGVNgSmD2A==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.22.tgz",
+      "integrity": "sha512-+ZBuy7I0a4T+udlPnoUgII6PIm3YKHv26hNBXhZYTPk//R4LiCD3vlhZeeHqHAQaOamNquHt7DPxXZezNIATkw==",
       "requires": {
         "@babel/core": "^7.4.3",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
         "@babel/preset-env": "^7.4.3",
         "@babel/preset-react": "^7.0.0",
+        "@babel/types": "^7.5.5",
+        "camelcase-css": "^2.0.1",
+        "change-case": "^3.1.0",
         "core-js": "2",
         "dataloader": "^1.4.0",
         "debug": "^4.0.1",
         "escape-string-regexp": "^1.0.5",
+        "eval": "^0.1.4",
         "fs-extra": "^7.0.0",
         "gray-matter": "^4.0.1",
+        "json5": "^2.1.0",
         "loader-utils": "^1.2.3",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "mdast-util-to-string": "^1.0.4",
         "mdast-util-toc": "^3.0.0",
         "mime": "^2.3.1",
@@ -7418,7 +7360,9 @@
         "retext-english": "^3.0.2",
         "slash": "^2.0.0",
         "static-site-generator-webpack-plugin": "^3.4.2",
+        "style-to-object": "^0.2.3",
         "underscore.string": "^3.3.4",
+        "unified": "^8.3.2",
         "unist-util-map": "^1.0.4",
         "unist-util-remove": "^1.0.1",
         "unist-util-visit": "^1.4.0"
@@ -7495,9 +7439,9 @@
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.0.tgz",
-      "integrity": "sha512-QJefYCTvu+WRgnckNipnfvNVUR8+1TsXN+/AZPWJ9OyFUWmgYJO/PyDpIzEEYekDnDMb7gKFFj+UuJ8bSGvj2g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.2.tgz",
+      "integrity": "sha512-9rqa0D7qV+d7lMcnoV2Y4PTSNJcolTVZDygINYAboeef8fflcvGmOYUl16SbC0HjRjdGSiS9bmcsUNHeYPC/7g==",
       "requires": {
         "@babel/runtime": "^7.0.0"
       }
@@ -7511,19 +7455,21 @@
       }
     },
     "gatsby-plugin-sharp": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.2.tgz",
-      "integrity": "sha512-e7+4EWLhcucRHFjtDTJFe04IjvLyh0U6Q+CqqcYmL/veIDTVf7XvGefiKlcFxG8ys6l2d3gd3L4+nR8WzV6lCA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.9.tgz",
+      "integrity": "sha512-yFaBuV4G6NRl3ExkWOJFtQlUO5rA3guvuR+30GwwdiHTSYuIFBvoCDgKQ+4k2fpAM5tbG6BHaUr7r/ccxWUWYg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "async": "^2.1.2",
         "bluebird": "^3.5.0",
         "fs-extra": "^7.0.0",
+        "gatsby-core-utils": "^1.0.0",
+        "got": "^8.3.2",
         "imagemin": "^6.0.0",
         "imagemin-mozjpeg": "^8.0.0",
         "imagemin-pngquant": "^6.0.0",
         "imagemin-webp": "^5.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "mini-svg-data-uri": "^1.0.0",
         "potrace": "^2.1.1",
         "probe-image-size": "^4.0.0",
@@ -7534,11 +7480,11 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         },
         "fs-extra": {
@@ -7550,18 +7496,73 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "got": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+        },
+        "p-timeout": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+          "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
         }
       }
     },
     "gatsby-plugin-theme-ui": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.5.tgz",
-      "integrity": "sha512-TlcQ/FCIu+2ns+ADOEjIj6sThBfShLjqU2zCDTvcfHIBoV2wCt/G9wNlaytt5pPTUtVd9lZkvkNdXY8zPDOUtg=="
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.25.tgz",
+      "integrity": "sha512-yEmxgHdF3o/txiEXLJBcHByukF8ECq6hVYQNcx8AR9OWefw1WI5as136qc7L4Ue9BBgtP95igr/DpPcQp+1Gog=="
     },
     "gatsby-plugin-twitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-twitter/-/gatsby-plugin-twitter-2.1.0.tgz",
-      "integrity": "sha512-OTYzB4lRWBdQmDHehoViuTtIIEKPQ4PtK4vWFNYGEHUNdg4MGB8VmAhoFsPbkVKiV2rocVmEdvMtYkYXb9v/Pg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-twitter/-/gatsby-plugin-twitter-2.1.2.tgz",
+      "integrity": "sha512-/9zuJcITmhALNtSOAw0QtZmx45qCd8AfqM+S+nlRX6PO2boUcE4AJwa9OK/hHOFrmrE5lFHchRC5exzt3gWTQw==",
       "requires": {
         "@babel/runtime": "^7.0.0"
       }
@@ -7615,15 +7616,15 @@
       }
     },
     "gatsby-remark-copy-linked-files": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.0.tgz",
-      "integrity": "sha512-MJVkLwH/IhWjNdCNEgRfmwyQPOGan5pvGscbVYC3Ho1sIBMkH3ruTyjgpCJzITuQe3gUIhsCSqsr3FlLSkHzsA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.4.tgz",
+      "integrity": "sha512-CEJYF4mj3Z4+s9yoUOyaQA/L0deydC/gu6Kay/PFwTyIDcgkWG1RFsFocEcEb6kbgimZxTElsbDk0MOulr1NIg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "cheerio": "^1.0.0-rc.2",
         "fs-extra": "^4.0.1",
         "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "path-is-inside": "^1.0.2",
         "probe-image-size": "^4.0.0",
         "unist-util-visit": "^1.3.0"
@@ -7663,14 +7664,14 @@
       }
     },
     "gatsby-remark-images": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.1.2.tgz",
-      "integrity": "sha512-RZUtqT7cqfFfQ3UFoL0ahy5duQo3/BSJdodyw3gp+PhWlWB3hz9fEZ5mvuCXJql+n/kLv+ifZAL5udPl1TNEqA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.1.7.tgz",
+      "integrity": "sha512-lTfHUUwCLEMpM4OlaLzjipcuuOIgj1PoxXhFwETgR3qaeLRovMtvCF26NqYShBkGn8R42WnegJw5Wh4yTQJDow==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "cheerio": "^1.0.0-rc.2",
         "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "mdast-util-definitions": "^1.2.0",
         "potrace": "^2.1.1",
         "query-string": "^6.1.0",
@@ -7701,9 +7702,9 @@
           }
         },
         "query-string": {
-          "version": "6.8.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.1.tgz",
-          "integrity": "sha512-g6y0Lbq10a5pPQpjlFuojfMfV1Pd2Jw9h75ypiYPPia3Gcq2rgkKiIwbkS6JxH7c5f5u/B/sB+d13PU+g1eu4Q==",
+          "version": "6.8.2",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",
@@ -7726,9 +7727,9 @@
       }
     },
     "gatsby-remark-smartypants": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-smartypants/-/gatsby-remark-smartypants-2.1.0.tgz",
-      "integrity": "sha512-lh4uIewueTtJ2D1CysbDxWMbv4R+k3/KQgs1/yHhOXrnCUQ+2YiUvQYFmyHTMS6k+ShBpDE4x0gqptkzvCgIhg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-smartypants/-/gatsby-remark-smartypants-2.1.2.tgz",
+      "integrity": "sha512-F3fyvuCA42nGRA2/cMeRxO48C4y8cEhorQCFHOBnNahVxoyunc4YWFhuc1WE2wEaj8DxVI0cFwjXNeNxD6g1YA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "retext": "^5.0.0",
@@ -7737,9 +7738,9 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.2.tgz",
-      "integrity": "sha512-mrlQ00Es+qjb2MCIEHAkv/F3yfR5IgI8z2q54tqpxu4amlUy3SQH5ThJDGD7Ya574ub9aKdHOr8virTssmTDgA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.8.tgz",
+      "integrity": "sha512-/EhMIlp6LA09+zzNkkhSW/zmJON9Ma9HQ5NpGTop7RVf9RIWiqhLA3klqVAnOwcYo2ALvAenGdGX2pgfH4PiMw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "better-queue": "^3.8.7",
@@ -7747,6 +7748,7 @@
         "chokidar": "2.1.2",
         "file-type": "^10.2.0",
         "fs-extra": "^5.0.0",
+        "gatsby-core-utils": "^1.0.0",
         "got": "^7.1.0",
         "md5-file": "^3.1.1",
         "mime": "^2.2.0",
@@ -7791,9 +7793,9 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.7.tgz",
-      "integrity": "sha512-mVJwkg4kdHGBt1OKlpcDO1gKoRd5oiJHKYR1jGrShXbB8FE4c52Z2Geg0xMKNXCeUbMUEZB78IPGlJ94nnPAag==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.9.tgz",
+      "integrity": "sha512-k6JtA52UjQddKCo88EnlIlQOEszjfUv6B24N0bMbEStS8XDxCkMS6+minBtjyXCa8XEGogU6IKLwqB9KDSGc+Q==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/runtime": "^7.0.0",
@@ -7858,65 +7860,67 @@
       }
     },
     "gatsby-theme-blog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-1.0.0.tgz",
-      "integrity": "sha512-4kyFPRM5JOk1D+YpXaMhQhU4ZRivR5eAYfk4lnMBsf9M53RnpfBduMTEmSX1I/9hRRncfffgFQEh+haUG1igDQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-blog/-/gatsby-theme-blog-1.0.2.tgz",
+      "integrity": "sha512-1p0+ne9SUytiHlMT4qV1S9FChfScQgMF01qz8tlYvf6eB8ly0zt3TXHudov2hQLJpyv4kfB84knKCGpfbc3/zA==",
       "requires": {
         "@emotion/core": "^10.0.14",
-        "@mdx-js/mdx": "^1.0.21",
-        "@mdx-js/react": "^1.0.21",
-        "@theme-ui/prism": "^0.2.5",
+        "@mdx-js/mdx": "^1.1.0",
+        "@mdx-js/react": "^1.0.27",
+        "@theme-ui/prism": "^0.2.14",
         "@theme-ui/typography": "^0.2.5",
-        "gatsby-image": "^2.2.4",
-        "gatsby-plugin-emotion": "^4.1.0",
-        "gatsby-plugin-feed": "^2.3.2",
-        "gatsby-plugin-mdx": "^1.0.7",
-        "gatsby-plugin-react-helmet": "^3.1.0",
-        "gatsby-plugin-sharp": "^2.2.2",
-        "gatsby-plugin-theme-ui": "^0.2.5",
-        "gatsby-plugin-twitter": "^2.1.0",
+        "deepmerge": "^4.0.0",
+        "gatsby-core-utils": "^1.0.3",
+        "gatsby-image": "^2.2.6",
+        "gatsby-plugin-emotion": "^4.1.2",
+        "gatsby-plugin-feed": "^2.3.4",
+        "gatsby-plugin-mdx": "^1.0.14",
+        "gatsby-plugin-react-helmet": "^3.1.2",
+        "gatsby-plugin-sharp": "^2.2.8",
+        "gatsby-plugin-theme-ui": "^0.2.6",
+        "gatsby-plugin-twitter": "^2.1.2",
         "gatsby-remark-code-titles": "^1.1.0",
-        "gatsby-remark-copy-linked-files": "^2.1.0",
-        "gatsby-remark-images": "^3.1.2",
+        "gatsby-remark-copy-linked-files": "^2.1.3",
+        "gatsby-remark-images": "^3.1.6",
         "gatsby-remark-numbered-footnotes": "^1.0.0",
-        "gatsby-remark-smartypants": "^2.1.0",
-        "gatsby-source-filesystem": "^2.1.2",
-        "gatsby-transformer-sharp": "^2.2.1",
-        "lodash.merge": "^4.6.1",
+        "gatsby-remark-smartypants": "^2.1.2",
+        "gatsby-source-filesystem": "^2.1.5",
+        "gatsby-transformer-sharp": "^2.2.4",
         "react-helmet": "^5.2.1",
-        "react-switch": "^5.0.0",
+        "react-switch": "^5.0.1",
         "remark-slug": "^5.1.2",
-        "theme-ui": "^0.2.5",
+        "theme-ui": "^0.2.14",
         "typeface-merriweather": "0.0.72",
-        "typeface-montserrat": "0.0.54",
+        "typeface-montserrat": "0.0.75",
         "typography-theme-wordpress-2016": "^0.16.19"
       }
     },
     "gatsby-theme-notes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-1.0.0.tgz",
-      "integrity": "sha512-LYO9gEGbTQc3FMB/dUeerksFmyn6mFaTw7+pATslFfs8o4Hx9Qh3fG6K/mWw7/pGetnzyGyevt9QPZOh7/uH7Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-notes/-/gatsby-theme-notes-1.0.3.tgz",
+      "integrity": "sha512-i8Ndd2nXjGfhyEVK/d9g7OBjzX5TLwCpbbUl1aAUS+B7KKe/kBoJ3/UPLd/93accriuRLE3pAXm8ylA+TewGTQ==",
       "requires": {
         "@emotion/core": "^10.0.14",
-        "@mdx-js/mdx": "^1.0.21",
-        "@mdx-js/react": "^1.0.21",
-        "gatsby-plugin-compile-es6-packages": "^1.1.0",
-        "gatsby-plugin-emotion": "^4.1.0",
-        "gatsby-plugin-mdx": "^1.0.7",
+        "@mdx-js/mdx": "^1.1.0",
+        "@mdx-js/react": "^1.0.27",
+        "gatsby-core-utils": "^1.0.3",
+        "gatsby-plugin-compile-es6-packages": "^1.2.0",
+        "gatsby-plugin-emotion": "^4.1.2",
+        "gatsby-plugin-mdx": "^1.0.16",
         "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-plugin-og-image": "0.0.1",
         "gatsby-plugin-redirects": "^1.0.0",
-        "gatsby-plugin-theme-ui": "^0.2.5",
-        "gatsby-source-filesystem": "^2.1.2",
+        "gatsby-plugin-theme-ui": "^0.2.18",
+        "gatsby-source-filesystem": "^2.1.6",
         "is-present": "^1.0.0",
         "react-feather": "^1.1.6",
-        "theme-ui": "^0.2.5"
+        "theme-ui": "^0.2.18"
       }
     },
     "gatsby-transformer-sharp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.1.tgz",
-      "integrity": "sha512-KmUqtvt3ry8bL6RMfHwMgRH4AJcDOJgGMTyLeULUScDoKTSriColPhbXMmJzM4Gsq3NUNqJkRo9qvNxBqnSWtQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.2.5.tgz",
+      "integrity": "sha512-Onyic4Nfx4874bY6iBIal11zMct2VFU613KRSfiJJPkNCEAEfWje9XiQbI9De3ivIM0Cj8en/eg2vn5QtUeoRg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "bluebird": "^3.5.0",
@@ -9987,9 +9991,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -10358,9 +10362,9 @@
       }
     },
     "mdast-util-to-hast": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
-      "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-6.0.1.tgz",
+      "integrity": "sha512-KRh9wIYzUQk877JcV+8q4FqBUEouLpCKMObqeWg4dnL1/rh9vtSIq5mqQFwIK9YzSULl91F8FP5+EJ/xqRHaBw==",
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
@@ -10410,9 +10414,9 @@
       }
     },
     "mdn-data": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -10545,9 +10549,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+      "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A=="
     },
     "methods": {
       "version": "1.1.2",
@@ -10881,9 +10885,9 @@
       }
     },
     "node-abi": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz",
-      "integrity": "sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.10.0.tgz",
+      "integrity": "sha512-OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -10958,9 +10962,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.24.tgz",
-      "integrity": "sha512-wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
+      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -11027,21 +11031,9 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "prepend-http": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-        }
-      }
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
     "npm-conf": {
       "version": "1.1.3",
@@ -11244,9 +11236,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "omggif": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
-      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -11629,13 +11621,6 @@
         "normalize-url": "^3.3.0",
         "parse-path": "^4.0.0",
         "protocols": "^1.4.0"
-      },
-      "dependencies": {
-        "normalize-url": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
-        }
       }
     },
     "parse5": {
@@ -11987,24 +11972,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -12163,24 +12130,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-selector-parser": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -12248,24 +12197,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         },
         "postcss-value-parser": {
@@ -12516,24 +12447,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -12552,11 +12465,6 @@
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
-        "normalize-url": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
-        },
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
@@ -12616,24 +12524,6 @@
             "caniuse-lite": "^1.0.30000984",
             "electron-to-chromium": "^1.3.191",
             "node-releases": "^1.1.25"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
           }
         }
       }
@@ -12769,9 +12659,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "pretty-bytes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
-      "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -12793,12 +12683,12 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "probe-image-size": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz",
-      "integrity": "sha512-nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.1.1.tgz",
+      "integrity": "sha512-42LqKZqTLxH/UvAZ2/cKhAsR4G/Y6B7i7fI2qtQu9hRBK4YjS6gqO+QRtwTjvojUx4+/+JuOMzLoFyRecT9qRw==",
       "requires": {
         "any-promise": "^1.3.0",
-        "deepmerge": "^2.0.1",
+        "deepmerge": "^4.0.0",
         "inherits": "^2.0.3",
         "next-tick": "^1.0.0",
         "request": "^2.83.0",
@@ -12853,9 +12743,9 @@
       }
     },
     "property-information": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.1.0.tgz",
-      "integrity": "sha512-tODH6R3+SwTkAQckSp2S9xyYX8dEKYkeXw+4TmJzTxnNzd6mQPu1OD4f9zPrvw/Rm4wpPgI+Zp63mNSGNzUgHg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.2.2.tgz",
+      "integrity": "sha512-N2moasZmjn2mjVGIWpaqz5qnz6QyeQSGgGvMtl81gA9cPTWa6wpesRSe/quNnOjUHpvSH1oZx0pdz0EEckLFnA==",
       "requires": {
         "xtend": "^4.0.1"
       }
@@ -12890,9 +12780,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -13299,9 +13189,9 @@
       }
     },
     "react-switch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.0.tgz",
-      "integrity": "sha512-+zxY9xj9dMc8Y4gv/kkqQrirfEiIQ+SlQfJDW1Wi81L3xoh1fcbBYyJyh0TnhM/U/b6HxuBmkmU4Ooxgtuoavw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
+      "integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
       "requires": {
         "prop-types": "^15.6.2"
       }
@@ -13428,14 +13318,14 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
-      "integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
       "requires": {
         "private": "^0.1.6"
       }
@@ -13455,9 +13345,9 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
-      "integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ=="
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
+      "integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg=="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -13531,34 +13421,102 @@
         "remark-parse": "^6.0.0",
         "remark-stringify": "^6.0.0",
         "unified": "^7.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "remark-parse": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+          "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unified": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+          "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "@types/vfile": "^3.0.0",
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^3.0.0",
+            "x-is-string": "^0.1.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+        },
+        "vfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+          "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+          "requires": {
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
+        }
       }
     },
     "remark-mdx": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.0.21.tgz",
-      "integrity": "sha512-paYs43yHPkxEuhyWXvRGJdupdurua1ttmGeu5GLqU/qc17BaZklCdNSEjCNXRa2LM0pOFRv0KVJigfA2vfaDEQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.1.4.tgz",
+      "integrity": "sha512-pMmLvEyhNYcGd9qe8KNR9StAH35HUTgLobfRFpU4V8vyrWT+mNsd7+pTPKQbxGat5+PZ9IgmTjf760k3abdE6A==",
       "requires": {
-        "@babel/core": "^7.2.2",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
-        "@babel/plugin-syntax-jsx": "^7.2.0",
-        "is-alphabetical": "^1.0.2",
-        "remark-parse": "^6.0.0",
-        "unified": "^7.0.0"
+        "@babel/core": "7.5.5",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.5.5",
+        "@babel/plugin-syntax-jsx": "7.2.0",
+        "is-alphabetical": "1.0.3",
+        "remark-parse": "7.0.0",
+        "unified": "8.3.2"
       }
     },
     "remark-numbered-footnotes": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-1.0.11.tgz",
-      "integrity": "sha512-CBjXeRLgYyJ3dTSlH2k7qPfeammoaagxh8JMQPNQvheRRwawzGv/lyWwuJOh7tdtLIirB++a/mhiZmpKuPXJUQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-1.0.12.tgz",
+      "integrity": "sha512-PTC6ID97uup+jTow+gQ3gJivMYpbg8UMVDDcxi0BhpAOdRAZrtDH05daX/4I6jX8CQB60Gx1kfxcpT1VtAZidg==",
       "requires": {
         "unist-util-visit": "^1.3.1"
       }
     },
     "remark-parse": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.0.tgz",
+      "integrity": "sha512-UlfoqASKUnwSrzOcLSa7fwYdkpbeWwAs49YYdQmoYXK1TUJ2CvDBb3v8Lkt2GQzdPW9dWbjhteOsJJ27p1rNFg==",
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
@@ -13719,9 +13677,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -13798,6 +13756,11 @@
             "x-is-string": "^0.1.0"
           }
         },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+        },
         "vfile": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
@@ -13807,6 +13770,14 @@
             "replace-ext": "1.0.0",
             "unist-util-stringify-position": "^1.0.0",
             "vfile-message": "^1.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
           }
         }
       }
@@ -14265,9 +14236,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -14685,9 +14656,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -14734,9 +14705,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "spdy": {
       "version": "4.0.1",
@@ -15078,13 +15049,13 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -15195,24 +15166,6 @@
             "node-releases": "^1.1.25"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000987",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000987.tgz",
-          "integrity": "sha512-O3VrjtRMTxoU5Cn5/QSmXeIR1gkVps4j9jqfIm4FLaQ5JzqBlVjMUG1xWnoYFv8N+H3Lp++aa05TekyIbjHL7g=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.206",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.206.tgz",
-          "integrity": "sha512-djq9Ehxs2rwPh7pyY1GMf8vkOWPoK8eoMp913E4t0UaEXvbnOsiSowBBHI8YoN4aKVQJjvxQp5I0LdZkT3Uzmw=="
-        },
-        "node-releases": {
-          "version": "1.1.26",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-          "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
         "postcss-selector-parser": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
@@ -15234,16 +15187,15 @@
       }
     },
     "svgo": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
-      "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "^1.1.0",
+        "css-tree": "1.0.0-alpha.33",
         "csso": "^3.5.1",
         "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
@@ -15291,9 +15243,9 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
-      "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+      "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -15301,17 +15253,6 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -15482,12 +15423,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theme-ui": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.5.tgz",
-      "integrity": "sha512-hFTOi0nDNB8ZejSg7zKQr2AKAcYv+nbbxE1oU9T/Is56tFvBgFDxc5DXrO82CayOAdAx3LN6iCsFzh/20f5HcQ==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.25.tgz",
+      "integrity": "sha512-ENvlYEXkODtc9/ohFWxFdazUxH26ObC74MVBZQ5UtIRhnrMjij3kbIIzWijK33ZqmnWEzofbk6f0TtQCdHqTNA==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.1",
-        "@styled-system/css": "^5.0.5",
+        "@styled-system/css": "^5.0.16",
         "deepmerge": "^3.2.0",
         "react": "^16.8.0"
       },
@@ -15620,11 +15561,6 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
-    },
-    "to-style": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/to-style/-/to-style-1.3.3.tgz",
-      "integrity": "sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -15759,9 +15695,9 @@
       "integrity": "sha512-gO0+fcZ1fTyKUsYY1ltYOOTI6FmBGeEdyIfeQg9NL8aInndk0feiJJVJsKHm/DiyYrnQEezraAQhz/KQoqMGtw=="
     },
     "typeface-montserrat": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-0.0.54.tgz",
-      "integrity": "sha512-Typhap0PWT299+Va0G/8ZtycHMXrH4gBWKfiW977KEBx5rXUUCa70gvqLx1fdA0WAo6bhSAQmo8uc+QFAmjPww=="
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-0.0.75.tgz",
+      "integrity": "sha512-8ski20t3hdwu2T85pVfjK4jsDbwW8yWzd+LAKxYEmu+JVLVlB7G2yfmdKZz06pUwYCLVFvHvup+NYYulHDpE+w=="
     },
     "typography-breakpoint-constants": {
       "version": "0.16.19",
@@ -15850,18 +15786,22 @@
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "unified": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.3.2.tgz",
+      "integrity": "sha512-NDtUAXcd4c+mKppCbsZHzmhkKEQuhveZNBrFYmNgMIMk2K9bc8hmG3mLEGVtRmSNodobwyMePAnvIGVWZfPdzQ==",
       "requires": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
+        }
       }
     },
     "union-value": {
@@ -15990,9 +15930,12 @@
       }
     },
     "unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+      "integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
     },
     "unist-util-visit": {
       "version": "1.4.1",
@@ -16318,14 +16261,15 @@
       }
     },
     "vfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
+      "integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
       "requires": {
+        "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
       },
       "dependencies": {
         "is-buffer": {
@@ -16341,11 +16285,12 @@
       "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ=="
     },
     "vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz",
+      "integrity": "sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==",
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "@types/unist": "^2.0.2",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vm-browserify": {
@@ -16827,9 +16772,9 @@
       }
     },
     "webpack-sources": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.1.tgz",
+      "integrity": "sha512-XSz38193PTo/1csJabKaV4b53uRVotlMgqJXm3s3eje0Bu6gQTxYDqpD38CmQfDBA+gN+QqaGjasuC8I/7eW3Q==",
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
@@ -17060,9 +17005,9 @@
       "integrity": "sha512-mqgtH6BXOgjOHVDxZPyW/h6QUC5kfEggh5IN8uOitjzrdCScE/a/cwcRvgcH8CGAXYReDNvasOKD0aFBWAZ1fg=="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/themes/gatsby-starter-theme/package.json
+++ b/themes/gatsby-starter-theme/package.json
@@ -8,9 +8,9 @@
     "build": "gatsby build"
   },
   "dependencies": {
-    "gatsby": "^2.13.45",
-    "gatsby-theme-blog": "^1.0.0",
-    "gatsby-theme-notes": "^1.0.0",
+    "gatsby": "^2.13.48",
+    "gatsby-theme-blog": "^1.0.2",
+    "gatsby-theme-notes": "^1.0.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }


### PR DESCRIPTION
Right now, until #16178 starters aren't managed by lerna
so their dependencies haven't been updated. There have been
a handful of bugfixes that aren't being installed by default
until the user upgrades their dependencies.
