### PR TITLE
feat(docs): Document what breaking changes are for themes

### DIFF
--- a/docs/docs/themes/conventions.md
+++ b/docs/docs/themes/conventions.md
@@ -190,7 +190,7 @@ means that public facing APIs are unaffected.
 #### Example patch versions
 
 - **Fixing a bug** in a component, such as fixing a warning or adding a fallback value.
-- **Upgrading upstream dependencies** to their latest minor and patch versions.
+- **Upgrading dependencies** to their latest minor and patch versions.
 
 ### Minor _(0.X.0)_
 

--- a/docs/docs/themes/conventions.md
+++ b/docs/docs/themes/conventions.md
@@ -171,3 +171,59 @@ export default () => {
   )
 }
 ```
+
+## Breaking Changes
+
+Since themes will typically be installed by an end user from npm, it's
+important to follow [semantic versioning](https://semver.org/), commonly
+referred to as semver.
+
+This will allow your users to quickly discern how a dependency update might
+affect them. Patches and minor versions are not considered breaking changes,
+major versions are.
+
+### Patch _(0.0.X)_
+
+Patches are defined as bug fixes that are done in a backwards-compatible way. This
+means that public facing APIs are unaffected.
+
+#### Example patch versions
+
+- **Fixing a bug** in a component, such as fixing a warning or adding a fallback value.
+- **Upgrading upstream dependencies** to their latest minor and patch versions.
+
+### Minor _(0.X.0)_
+
+Minor versions are defined as new features or functionality that are added in a
+backwards-compatible way. This means that _existing_ public facing APIs are unaffected.
+
+#### Example minor versions
+
+- **Adding new pages or queries** to your theme. For example, adding tag pages to a blog.
+- **Adding new configuration options** to further customize a theme.
+- **Displaying additional data** such as displaying excerpts to a post list.
+- **Adding additional props to a component** for new functionality.
+- **Adding a new MDX shortcode** that users can opt into.
+
+### Major _(X.0.0)_
+
+Major versions are any bugfixes or new features that have been added without full
+backwards-compatibility. These are often called "breaking changes".
+
+These changes should be accompanied with a migration guide that users can follow along
+for performing a theme upgrade.
+
+#### Example major versions
+
+- **Changing a filename in `src`** will always be a breaking change due to shadowing.
+  - Moving where a query occurs
+  - Renaming a component
+  - Renaming a directory
+- **Removing or changing the props a component accepts** since it will affect component extending.
+- **Changing queries** since a user could be using the original data in shadowed components.
+- **Removing or changing the behaviour** of your theme's configuration.
+- **Removing attributes in schema definitions** because it can break end user queries.
+- **Removing default data** this could change your generated schema and break a user's site if they
+  depend on some part of that generated schema.
+- **Changing plugins or plugin configuration** such as removing a remark plugin as it will change
+  the behavior of MD/MDX rendering.


### PR DESCRIPTION
## Description

It's important to document what breaking changes are for themes, especially since shadowing makes the definition of breaking changes different than most npm libraries.

In order to set the stage I also added in minor/patch definitions with a couple examples. Not sure if this is necessary or not.

Any thoughts, feedback, or additional examples welcome!

## Related Issues

Closes #16031