### PR TITLE
feat(gatsby-source-shopify): add metafields to product nodes

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -62,6 +62,9 @@ plugins: [
 ]
 ```
 
+NOTE: By default, all metafields are private. In order to pull metafields,
+you must first [expose the metafield to the Storefront API](https://help.shopify.com/en/api/guides/metafields/storefront-api-metafields#expose-metafields-to-the-storefront-api).
+
 ## How to query
 
 You can query nodes created from Shopify using GraphQL like the following:
@@ -224,9 +227,6 @@ Products in the collection are provided on the `products` field.
 
 Product variants and options are provided on the `variants` and `options`
 fields.
-
-_Note:_ By default, all metafields are private. In order to pull metafields,
-you must first [expose the metafield to the Storefront API](https://help.shopify.com/en/api/guides/metafields/storefront-api-metafields#expose-metafields-to-the-storefront-api).
 
 ```graphql
 {

--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -225,6 +225,9 @@ Products in the collection are provided on the `products` field.
 Product variants and options are provided on the `variants` and `options`
 fields.
 
+_Note:_ By default, all metafields are private. In order to pull metafields,
+you must first [expose the metafield to the Storefront API](https://help.shopify.com/en/api/guides/metafields/storefront-api-metafields#expose-metafields-to-the-storefront-api).
+
 ```graphql
 {
   allShopifyProduct {

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -10,6 +10,7 @@ import {
   ProductNode,
   ProductOptionNode,
   ProductVariantNode,
+  ProductMetafieldNode,
   ShopPolicyNode,
   ProductTypeNode,
   PageNode,
@@ -77,6 +78,11 @@ export const sourceNodes = async (
         if (x.variants)
           await forEach(x.variants.edges, async edge =>
             createNode(await ProductVariantNode(imageArgs)(edge.node))
+          )
+
+        if (x.metafields)
+          await forEach(x.metafields.edges, async edge =>
+            createNode(await ProductMetafieldNode(imageArgs)(edge.node))
           )
 
         if (x.options)

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -14,6 +14,7 @@ const COMMENT = `Comment`
 const PRODUCT = `Product`
 const PRODUCT_OPTION = `ProductOption`
 const PRODUCT_VARIANT = `ProductVariant`
+const PRODUCT_METAFIELD = `ProductMetafield`
 const SHOP_POLICY = `ShopPolicy`
 const PRODUCT_TYPE = `ProductType`
 const PAGE = `Page`
@@ -109,6 +110,14 @@ export const ProductNode = imageArgs =>
       )
     }
 
+    if (node.metafields) {
+      const metafields = node.metafields.edges.map(edge => edge.node)
+
+      node.metafields___NODE = metafields.map(metafield =>
+        generateNodeId(PRODUCT_METAFIELD, metafield.id)
+      )
+    }
+
     if (node.options)
       node.options___NODE = node.options.map(option =>
         generateNodeId(PRODUCT_OPTION, option.id)
@@ -128,6 +137,9 @@ export const ProductNode = imageArgs =>
 
     return node
   })
+
+export const ProductMetafieldNode = _imageArgs =>
+  createNodeFactory(PRODUCT_METAFIELD)
 
 export const ProductOptionNode = _imageArgs => createNodeFactory(PRODUCT_OPTION)
 

--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -132,6 +132,18 @@ export const PRODUCTS_QUERY = `
                 }
               }
             }
+            metafields(first: 250) {
+              edges {
+                node {
+                  description
+                  id
+                  key
+                  namespace
+                  value
+                  valueType
+                }
+              }
+            }
             onlineStoreUrl
             options {
               id


### PR DESCRIPTION
## Description

Shopify introduced access to metafields via the Storefront API back in May. This adds the metafield endpoint to products via gatsby-source-shopify.

## Related Issues

N/A
