### PR TITLE
ci: add an (optional) approval step to build out www

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,6 +318,17 @@ workflows:
             branches:
               only:
                 - master
+      - manual_www_approval:
+          type: approval
+      - build_www:
+          context: build_www
+          requires:
+            - manual_www_approval
+      - deploy_www:
+          requires:
+            - build_www
+          context: build_www
+
   www_deploy:
     triggers:
       - schedule:


### PR DESCRIPTION
## Description

We can re-run a job that (possibly) failed for an automatic deploy, but that has the problem of being a snapshot at that commit hash. If we'd like to grab _new changes_ this should do the trick.

This should be used sparingly, only when something needs to go live at a certain time when the automated schedule won't suffice.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
