### PR TITLE
feat(gatsby-plugin-react-helmet): add support for base tag

### DIFF
--- a/packages/gatsby-plugin-react-helmet/src/__mocks__/react-helmet.js
+++ b/packages/gatsby-plugin-react-helmet/src/__mocks__/react-helmet.js
@@ -7,6 +7,7 @@ const helmet = {
   noscript: { toComponent: () => `noscript-component` },
   script: { toComponent: () => `script-component` },
   style: { toComponent: () => `style-component` },
+  base: { toComponent: () => `base-component` },
 }
 
 module.exports = {

--- a/packages/gatsby-plugin-react-helmet/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/__tests__/gatsby-ssr.js
@@ -24,6 +24,7 @@ describe(`gatsby-plugin-react-helmet`, () => {
         `noscript-component`,
         `script-component`,
         `style-component`,
+        `base-component`,
       ])
     })
 

--- a/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
@@ -20,5 +20,6 @@ export const onRenderBody = ({
     helmet.noscript.toComponent(),
     helmet.script.toComponent(),
     helmet.style.toComponent(),
+    helmet.base.toComponent(),
   ])
 }


### PR DESCRIPTION
## Description

This supports the `base` tag as a child of `Helmet`

## Examples
```
<Helmet>
  <base href="{{BASE_HREF}}" />
</Helmet>
```