### PR TITLE
docs(gatsby-cli): Add info about noColor build option

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -70,6 +70,7 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                       |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                   |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
+|         `--noColor`          | Sets the `process.env.FORCE_COLOR` variable to disable colored terminal output)                           |
 
 ### `serve`
 

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -70,7 +70,7 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                       |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                   |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
-|         `--noColor`          | Sets the `process.env.FORCE_COLOR` variable to disable colored terminal output)                           |
+| `--no-color`, `--no-colors`  | Sets the `process.env.FORCE_COLOR` variable to disable colored terminal output)                           |
 
 ### `serve`
 

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -70,7 +70,7 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                       |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                   |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
-| `--no-color`, `--no-colors`  | Sets the `process.env.FORCE_COLOR` variable to disable colored terminal output)                           |
+| `--no-color`, `--no-colors`  | Disables colored terminal output                                                                          |
 
 ### `serve`
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -64,6 +64,7 @@ At the root of a Gatsby app run `gatsby build` to do a production build of a sit
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        | `false` |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    | `false` |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |         |
+| `--no-color`, `--no-colors`  | Sets the `process.env.FORCE_COLOR` variable to disable colored terminal output)                            | `false` |
 
 ### `serve`
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -64,7 +64,7 @@ At the root of a Gatsby app run `gatsby build` to do a production build of a sit
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        | `false` |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    | `false` |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |         |
-| `--no-color`, `--no-colors`  | Sets the `process.env.FORCE_COLOR` variable to disable colored terminal output)                            | `false` |
+| `--no-color`, `--no-colors`  | Disables colored terminal output                                                                           | `false` |
 
 ### `serve`
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

I was informed about the existence of the `--noColor` option in #16324, which is currently not documented. Therefore I added it to the respective section in the docs.

## Related Issues

Related to #16324

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
