### PR TITLE
fix(gatsby): Prefer a user's shouldUpdateScroll over a plugin's

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -129,6 +129,8 @@ function shouldUpdateScroll(prevRouterProps, { location }) {
     getSavedScrollPosition: args => this._stateStorage.read(args),
   })
   if (results.length > 0) {
+    // Use the latest registered shouldUpdateScroll result, this allows users to override plugin's configuration
+    // @see https://github.com/gatsbyjs/gatsby/issues/12038
     return results[results.length - 1]
   }
 

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -129,7 +129,7 @@ function shouldUpdateScroll(prevRouterProps, { location }) {
     getSavedScrollPosition: args => this._stateStorage.read(args),
   })
   if (results.length > 0) {
-    return results[0]
+    return results[results.length - 1]
   }
 
   if (prevRouterProps) {


### PR DESCRIPTION
When a plugin's and a user's `gatsby-browser.js` both define a `shouldUpdateScroll`, we currently pick the result from the plugin. We should allow to overwrite the plugin-defined behavior by the user config.

Fixes #12038 