### PR TITLE
feat(gatsby-plugin-sitemap): add siteUrl validation

### DIFF
--- a/docs/docs/creating-a-sitemap.md
+++ b/docs/docs/creating-a-sitemap.md
@@ -25,6 +25,7 @@ module.exports = {
   plugins: [`gatsby-plugin-sitemap`],
 }
 ```
+**Note:** The siteUrl property must be defined and not left empty.
 
 Next run a build (`npm run build`) since the sitemap generation will only happen for production builds. This is all that's required to get a working sitemap with Gatsby! By default, the generated sitemap path is /sitemap.xml and will include all of your site’s pages, but of course the plugin exposes options to configure this default functionality.
 

--- a/docs/docs/creating-a-sitemap.md
+++ b/docs/docs/creating-a-sitemap.md
@@ -25,6 +25,7 @@ module.exports = {
   plugins: [`gatsby-plugin-sitemap`],
 }
 ```
+
 **Note:** The siteUrl property must be defined and not left empty.
 
 Next run a build (`npm run build`) since the sitemap generation will only happen for production builds. This is all that's required to get a working sitemap with Gatsby! By default, the generated sitemap path is /sitemap.xml and will include all of your site’s pages, but of course the plugin exposes options to configure this default functionality.

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -29,18 +29,13 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
     })
 
     // siteUrl Validation
-    if (!r.data.site.siteMetadata.siteUrl) {
-      throw new Error(
-        `SiteMetaData 'siteUrl' property is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
-      )
-    }
-
     if (
+      !r.data.site.siteMetadata.siteUrl ||
       r.data.site.siteMetadata.siteUrl == null ||
       r.data.site.siteMetadata.siteUrl.trim().length == 0
     ) {
       throw new Error(
-        `SiteMetaData 'siteUrl' property can't be left empty, site's url is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
+        `SiteMetaData 'siteUrl' property is required and cannot be left empty. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
       )
     }
 

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -34,8 +34,11 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
         `SiteMetaData 'siteUrl' property is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
       )
     }
-    
-    if(r.data.site.siteMetadata.siteUrl!=null || r.data.site.siteMetadata.siteUrl.trim()!="") {
+
+    if (
+      r.data.site.siteMetadata.siteUrl == null ||
+      r.data.site.siteMetadata.siteUrl.trim() == ""
+    ) {
       throw new Error(
         `SiteMetaData 'siteUrl' property can't be left empty, site's url is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
       )

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -37,7 +37,7 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
 
     if (
       r.data.site.siteMetadata.siteUrl == null ||
-      r.data.site.siteMetadata.siteUrl.trim() == ""
+      r.data.site.siteMetadata.siteUrl.trim().length == 0
     ) {
       throw new Error(
         `SiteMetaData 'siteUrl' property can't be left empty, site's url is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -28,9 +28,16 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
       return page
     })
 
+    // siteUrl Validation
     if (!r.data.site.siteMetadata.siteUrl) {
       throw new Error(
         `SiteMetaData 'siteUrl' property is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
+      )
+    }
+    
+    if(r.data.site.siteMetadata.siteUrl!=null || r.data.site.siteMetadata.siteUrl.trim()!="") {
+      throw new Error(
+        `SiteMetaData 'siteUrl' property can't be left empty, site's url is required. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
       )
     }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This PR is a fix for #15754 

1. Validating siteUrl and throwing an error if it's an empty string
2. Adding a note to docs to prompt that siteUrl can't be left blank or undefined

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes #15754 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
