### PR TITLE
fix(gatsby-source-mongodb): work with _id types that are not ObjectIds

### DIFF
--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -66,6 +66,10 @@ exports.sourceNodes = (
     })
 }
 
+function idToString(id) {
+  return id.hasOwnProperty(`toHexString`) ? id.toHexString() : String(id)
+}
+
 function createNodes(
   db,
   pluginOptions,
@@ -87,7 +91,7 @@ function createNodes(
       }
 
       documents.forEach(({ _id, ...item }) => {
-        const id = _id.toHexString()
+        const id = idToString(_id)
 
         // only call recursive function to preserve relations represented by objectids if pluginoption set.
         if (preserveObjectIds) {


### PR DESCRIPTION
## Description

Using mongodb, it is possible to use arbritary values (e.g. strings) as _id.
In that case the current implementation will throw
"TypeError: _id.toHexString is not a function"
This fix will prevent this, at least for string _ids.
