### PR TITLE
fix(gatsby): Add findMatchPath to the default loader

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -387,6 +387,7 @@ export const publicLoader = {
   prefetch: rawPath => instance.prefetch(rawPath),
   isPageNotFound: rawPath => instance.isPageNotFound(rawPath),
   hovering: rawPath => instance.hovering(rawPath),
+  findMatchPath: rawPath => instance.findMatchPath(rawPath),
 }
 
 export default publicLoader


### PR DESCRIPTION
## Description

`findMatchPath` is missing from the defaultLoader, and it fails in certain scenarios

