### PR TITLE
feat(gatsby): Allow all dateformat options as directive args

### DIFF
--- a/packages/gatsby/src/schema/extensions/__tests__/field-extensions.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/field-extensions.js
@@ -628,7 +628,7 @@ describe(`GraphQL field extensions`, () => {
     )
     const directive = schema.getDirective(`dateformat`)
     expect(directive).toBeDefined()
-    expect(directive.args).toHaveLength(2)
+    expect(directive.args).toHaveLength(4)
   })
 
   it(`shows error message when extension is already defined`, async () => {

--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -92,6 +92,8 @@ const builtInFieldExtensions = {
     args: {
       formatString: `String`,
       locale: `String`,
+      fromNow: `Boolean`,
+      difference: `String`,
     },
     extend(args, fieldConfig) {
       return getDateResolver(args, fieldConfig)

--- a/packages/gatsby/src/schema/types/date.js
+++ b/packages/gatsby/src/schema/types/date.js
@@ -1,11 +1,5 @@
 const moment = require(`moment`)
-const {
-  GraphQLString,
-  GraphQLBoolean,
-  GraphQLScalarType,
-  Kind,
-  defaultFieldResolver,
-} = require(`graphql`)
+const { GraphQLScalarType, Kind, defaultFieldResolver } = require(`graphql`)
 const { oneLine } = require(`common-tags`)
 
 const ISO_8601_FORMAT = [
@@ -218,12 +212,12 @@ const formatDate = ({
 
 const getDateResolver = (defaults, prevFieldConfig) => {
   const resolver = prevFieldConfig.resolve || defaultFieldResolver
-  const { locale, formatString } = defaults
+  const { locale, formatString, fromNow, difference } = defaults
   return {
     args: {
       ...prevFieldConfig.args,
       formatString: {
-        type: GraphQLString,
+        type: `String`,
         description: oneLine`
         Format the date using Moment.js' date tokens, e.g.
         \`date(formatString: "YYYY MMMM DD")\`.
@@ -232,20 +226,22 @@ const getDateResolver = (defaults, prevFieldConfig) => {
         defaultValue: formatString,
       },
       fromNow: {
-        type: GraphQLBoolean,
+        type: `Boolean`,
         description: oneLine`
         Returns a string generated with Moment.js' \`fromNow\` function`,
+        defaultValue: fromNow,
       },
       difference: {
-        type: GraphQLString,
+        type: `String`,
         description: oneLine`
         Returns the difference between this date and the current time.
         Defaults to "milliseconds" but you can also pass in as the
         measurement "years", "months", "weeks", "days", "hours", "minutes",
         and "seconds".`,
+        defaultValue: difference,
       },
       locale: {
-        type: GraphQLString,
+        type: `String`,
         description: oneLine`
         Configures the locale Moment.js will use to format the date.`,
         defaultValue: locale,


### PR DESCRIPTION
We currently only have `locale` and `formatString` as config arguments for the `@dateformat` extension. This PR adds `fromNow` and `difference`.