### PR TITLE
fix(gatsby-theme-notes): Don't use gatsby-plugin-mdx in notes usage

### DIFF
--- a/themes/gatsby-starter-theme/gatsby-config.js
+++ b/themes/gatsby-starter-theme/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       resolve: `gatsby-theme-notes`,
       options: {
-        mdx: true,
+        mdx: false,
         basePath: `/notes`,
       },
     },


### PR DESCRIPTION
For the time being we need to ensure that gatsby-plugin-mdx is
only used once. This ensures gatsby-theme-notes doesn't also
configure the plugin.
