### PR TITLE
chore(docs): Deploying to ZEIT Now has become even easier

### DIFF
--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -16,7 +16,7 @@ npm i -g now
 
 ## Step 2: Deploying
 
-You can deploy your application by running the following in the root of the project directory:
+You can deploy your application by running the following command in the root of the project directory:
 
 ```shell
 now

--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -2,58 +2,21 @@
 title: Deploying to Now
 ---
 
-[ZEIT Now](https://zeit.co/now) is a [cloud platform for serverless deployment](https://zeit.co/docs/v2/getting-started/introduction-to-now/) that you can use to deploy your Gatsby projects and [alias them](https://zeit.co/docs/v2/domains-and-aliases/aliasing-a-deployment/) to your personal domain or a free `.now.sh` suffixed URL.
+[ZEIT Now](https://zeit.co/now) is a cloud platform for websites and serverless APIs, that you can use to deploy your Gatsby projects to your personal domain (or a free `.now.sh` suffixed URL).
 
 This guide will show you how to get started in a few quick steps:
 
-## Step 1: Getting Now
+## Step 1: Installing Now CLI
 
-You can use Now by installing [Now Desktop](https://zeit.co/docs/v2/getting-started/installation/#now-desktop), which also installs Now CLI and keeps it up-to-date automatically.
-
-To install Now CLI quickly with npm, use the following:
+To install their command-line interface with [npm](https://www.npmjs.com/), run the following command:
 
 ```shell
-npm install -g now
+npm i -g now
 ```
 
-## Step 2: Preparing to Deploy
+## Step 2: Deploying
 
-With Now CLI installed, we can go on to deploy our previously setup Gatsby project by first creating a `now.json` file with the following contents:
-
-```json:title=now.json
-{
-  "version": 2,
-  "name": "my-gatsby-project",
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@now/static-build",
-      "config": { "distDir": "public" }
-    }
-  ]
-}
-```
-
-This `now.json` file will allow us to do several things, specifically:
-
-- Use the [latest Now 2.0 version](https://zeit.co/blog/now-2) of [the platform](https://zeit.co/docs/v2/platform/overview/)
-- Set the project name to `my-gatsby-project`
-- Use the [@now/static-build builder](https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/) to take the `package.json` file as an entrypoint and use the `public` directory as our content directory
-
-The final step is to add a script to the `package.json` which will build our application:
-
-```json:title=package.json
-{
-  "scripts": {
-    ...
-    "now-build": "npm run build"
-  }
-}
-```
-
-## Step 3: Deploying
-
-You can deploy your application by running the following in the root of the project directory, where the `now.json` is:
+You can deploy your application by running the following in the root of the project directory:
 
 ```shell
 now
@@ -63,4 +26,4 @@ That's all! Your application will now deploy, and you will receive a link simila
 
 ## References:
 
-- [Deploying Gatsby with Now](https://zeit.co/examples/gatsby/)
+- [Example Project](https://github.com/zeit/now-examples/tree/master/gatsby)

--- a/docs/docs/deploying-to-now.md
+++ b/docs/docs/deploying-to-now.md
@@ -11,7 +11,7 @@ This guide will show you how to get started in a few quick steps:
 To install their command-line interface with [npm](https://www.npmjs.com/), run the following command:
 
 ```shell
-npm i -g now
+npm install -g now
 ```
 
 ## Step 2: Deploying


### PR DESCRIPTION
## Description 

Now that deploying a Gatsby site to [ZEIT Now](http://zeit.co) is as easy as...

```
gatsby new gatsby-site
now gatsby-site
```

...I've adjusted the documentation to reflect that.

## Related Issues

No related issues.