### PR TITLE
fix(gatsby-plugin-mdx): fix filter by heading depth

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -59,7 +59,7 @@ module.exports = (
   const { createTypes } = actions;
 
   const options = defaultOptions(pluginOptions);
-
+  const headingsMdx = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
   createTypes(`
     type MdxFrontmatter {
       title: String!
@@ -71,12 +71,7 @@ module.exports = (
     }
 
     enum HeadingsMdx {
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6
+      ${headingsMdx}
     }
 
     type MdxWordCount {
@@ -172,8 +167,8 @@ module.exports = (
               depth: heading.depth
             });
           });
-          if (typeof depth === `number`) {
-            headings = headings.filter(heading => heading.depth === depth);
+          if (headingsMdx.includes(depth)) {
+            headings = headings.filter(heading => `h${heading.depth}` === depth);
           }
           return headings;
         }


### PR DESCRIPTION
This branch fixes an issue where heading fields on an MDX node can't be filtered by depth. Here's the query that I was using:

```graphql
{
  allMdx {
    nodes {
      headings(depth: h2) {
        depth
      }
    }
  }
}
```

In this case, all headings would be returned, regardless of their depth. This was happening because in the `headings` resolver, the `depth` arg was defined as a `HeadingMdx` [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-mdx/gatsby/source-nodes.js#L162), but filtering would only happen [if `depth` is a number](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-mdx/gatsby/source-nodes.js#L175).

I changed the logic to only perform filtering when `depth` is one of the values that `HeadingMdx` allows, and adjusted the filtering to make this strategy work properly.