### PR TITLE
Adds info to @link args

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -386,8 +386,8 @@ You simply provide a `@link` directive on a field and Gatsby will internally
 add a resolver that is quite similar to the one we wrote manually above. If no
 argument is provided, Gatsby will use the `id` field as the foreign-key,
 otherwise the foreign-key has to be provided with the `by` argument. The
-optional `from` argument allows getting the foreign-keys from the specified
-field, which is especially helpful when adding a field for back-linking.
+optional `from` argument allows getting the field on the current type which acts as the foreign-key to the field specified in `by`.
+In other words, you `link` __on__ `from` __to__ `by`. This makes `from` especially helpful when adding a field for back-linking.
 
 > Note that when using `createTypes` to fix type inference for a foreign-key field
 > created by a plugin, the underlying data will probably live on a field with

--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -387,7 +387,7 @@ add a resolver that is quite similar to the one we wrote manually above. If no
 argument is provided, Gatsby will use the `id` field as the foreign-key,
 otherwise the foreign-key has to be provided with the `by` argument. The
 optional `from` argument allows getting the field on the current type which acts as the foreign-key to the field specified in `by`.
-In other words, you `link` __on__ `from` __to__ `by`. This makes `from` especially helpful when adding a field for back-linking.
+In other words, you `link` **on** `from` **to** `by`. This makes `from` especially helpful when adding a field for back-linking.
 
 > Note that when using `createTypes` to fix type inference for a foreign-key field
 > created by a plugin, the underlying data will probably live on a field with

--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -346,7 +346,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
             //   type: "AuthorJson",
             // })
             // But since we are using the author email as foreign key,
-            // we can use `runQuery`, or simply get all author nodes
+            // we can use `runQuery`, or get all author nodes
             // with `getAllNodes` and manually find the linked author
             // node:
             return context.nodeModel
@@ -382,7 +382,7 @@ type AuthorJson implements Node {
 }
 ```
 
-You simply provide a `@link` directive on a field and Gatsby will internally
+You provide a `@link` directive on a field and Gatsby will internally
 add a resolver that is quite similar to the one we wrote manually above. If no
 argument is provided, Gatsby will use the `id` field as the foreign-key,
 otherwise the foreign-key has to be provided with the `by` argument. The


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
The language around the `@link` directive is very high level. It took me a while to actually grok how to use the `@link` extension  appropriately. In its current form, the distinction between `by` and `from` is not super clear. This is my attempt to more clearly explain that difference. 

It actually took me reading [the blog announcing the feature](https://www.gatsbyjs.org/blog/2019-05-17-improvements-to-schema-customization/) and then playing with them some to actually understand them enough to get them to work.

I'm not sure this is perfect, but it feels a little less jargony to me. Would love to workshop this a bit. 
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Not directly related to an issue, but as I mentioned above, I just couldn't understand how to use `@link`, and struggled with this for like 2 weeks before I finally figured it out. 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
