### PR TITLE
fix(gatsby): Don't delete 404 page-data so we don't crash build

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -144,6 +144,7 @@ module.exports = async (args: BootstrapArgs) => {
     await del([
       `public/*.{html,css}`,
       `public/**/*.{html,css}`,
+      `!public/page-data/404.html`,
       `!public/static`,
       `!public/static/**/*.{html,css}`,
     ])


### PR DESCRIPTION
We currently crash on `build` with a warm cache when there is a query in the 404 page, because we delete `public/page-data/404.html` during bootstrap but expect it is still there later.

Fixes #15273