### PR TITLE
feat(gatsby): Allow plugins to make functionality available on field resolver context

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
@@ -8,6 +8,7 @@ const createStore = (schema = {}) => {
     getState: () => {
       return {
         schema,
+        schemaCustomization: {},
       }
     },
   }

--- a/packages/gatsby/src/bootstrap/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/graphql-runner.js
@@ -4,13 +4,13 @@ const withResolverContext = require(`../schema/context`)
 const errorParser = require(`../query/error-parser`).default
 
 const createGraphqlRunner = (store, reporter) => (query, context = {}) => {
-  const schema = store.getState().schema
+  const { schema, schemaCustomization } = store.getState()
 
   return graphql(
     schema,
     query,
     context,
-    withResolverContext(context, schema),
+    withResolverContext(context, schema, schemaCustomization.context),
     context
   ).then(result => {
     if (result.errors) {

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -155,11 +155,11 @@ async function startServer(program) {
   app.use(
     graphqlEndpoint,
     graphqlHTTP(() => {
-      const schema = store.getState().schema
+      const { schema, schemaCustomization } = store.getState()
       return {
         schema,
         graphiql: false,
-        context: withResolverContext({}, schema),
+        context: withResolverContext({}, schema, schemaCustomization.context),
         formatError(err) {
           return {
             ...formatError(err),

--- a/packages/gatsby/src/query/query-runner.js
+++ b/packages/gatsby/src/query/query-runner.js
@@ -24,14 +24,19 @@ type QueryJob = {
 
 // Run query
 module.exports = async (queryJob: QueryJob) => {
-  const { schema, program, webpackCompilationHash } = store.getState()
+  const {
+    schema,
+    schemaCustomization,
+    program,
+    webpackCompilationHash,
+  } = store.getState()
 
   const graphql = (query, context) =>
     graphqlFunction(
       schema,
       query,
       context,
-      withResolverContext(context, schema),
+      withResolverContext(context, schema, schemaCustomization.context),
       context
     )
 

--- a/packages/gatsby/src/redux/prepare-nodes.js
+++ b/packages/gatsby/src/redux/prepare-nodes.js
@@ -22,12 +22,17 @@ const enhancedNodeCacheId = ({ node, args }) =>
 function awaitSiftField(fields, node, k) {
   const field = fields[k]
   if (field.resolve) {
-    const { schema } = store.getState()
-    return field.resolve(node, {}, withResolverContext({}, schema), {
-      fieldName: k,
-      schema,
-      returnType: field.type,
-    })
+    const { schema, schemaCustomization } = store.getState()
+    return field.resolve(
+      node,
+      {},
+      withResolverContext({}, schema, schemaCustomization.context),
+      {
+        fieldName: k,
+        schema,
+        returnType: field.type,
+      }
+    )
   } else if (node[k] !== undefined) {
     return node[k]
   }

--- a/packages/gatsby/src/redux/reducers/schema-customization.js
+++ b/packages/gatsby/src/redux/reducers/schema-customization.js
@@ -1,6 +1,7 @@
 module.exports = (
   state = {
     composer: null,
+    context: {},
     fieldExtensions: {},
     thirdPartySchemas: [],
     types: [],
@@ -48,9 +49,17 @@ module.exports = (
         fieldExtensions: { ...state.fieldExtensions, [name]: extension },
       }
     }
+    case `CREATE_RESOLVER_CONTEXT`: {
+      const context = action.payload
+      return {
+        ...state,
+        context: { ...state.context, ...context },
+      }
+    }
     case `DELETE_CACHE`:
       return {
         composer: null,
+        context: {},
         fieldExtensions: {},
         thirdPartySchemas: [],
         types: [],

--- a/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
+++ b/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
@@ -30,10 +30,15 @@ async function queryResult(nodes, query) {
   nodes.forEach(node => store.dispatch({ type: `CREATE_NODE`, payload: node }))
 
   await build({})
-  const { schema } = store.getState()
+  const { schema, schemaCustomization } = store.getState()
 
   const context = { path: `foo` }
-  return graphql(schema, query, undefined, withResolverContext(context))
+  return graphql(
+    schema,
+    query,
+    undefined,
+    withResolverContext(context, schema, schemaCustomization.context)
+  )
 }
 
 describe(`filtering on linked nodes`, () => {

--- a/packages/gatsby/src/schema/__tests__/context.js
+++ b/packages/gatsby/src/schema/__tests__/context.js
@@ -1,0 +1,217 @@
+const { graphql } = require(`graphql`)
+const { build } = require(`..`)
+const withResolverContext = require(`../context`)
+const { buildObjectType } = require(`../types/type-builders`)
+const { store } = require(`../../redux`)
+const { dispatch } = store
+const { actions } = require(`../../redux/actions/restricted`)
+const { createTypes, createFieldExtension, createResolverContext } = actions
+require(`../../db/__tests__/fixtures/ensure-loki`)()
+
+jest.mock(`gatsby-cli/lib/reporter`)
+const report = require(`gatsby-cli/lib/reporter`)
+afterEach(() => {
+  report.error.mockClear()
+})
+
+describe(`Resolver context`, () => {
+  beforeEach(() => {
+    dispatch({ type: `DELETE_CACHE` })
+    const nodes = [
+      {
+        id: `test1`,
+        internal: {
+          type: `Test`,
+          contentDigest: `test1`,
+        },
+      },
+    ]
+    nodes.forEach(node => {
+      dispatch({ type: `CREATE_NODE`, payload: { ...node } })
+    })
+  })
+
+  describe(`createResolverContext action`, () => {
+    it(`allows extending resolver context`, async () => {
+      dispatch(
+        createResolverContext({
+          hello(planet) {
+            return `Hello ${planet}!`
+          },
+        })
+      )
+      dispatch(
+        createTypes(
+          buildObjectType({
+            name: `Test`,
+            interfaces: [`Node`],
+            fields: {
+              hello: {
+                type: `String!`,
+                args: {
+                  planet: {
+                    type: `String!`,
+                    defaultValue: `World`,
+                  },
+                },
+                resolve(source, args, context, info) {
+                  return context.hello(args.planet)
+                },
+              },
+            },
+          })
+        )
+      )
+      const query = `
+        {
+          test {
+            world: hello
+            mars: hello(planet: "Mars")
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        test: {
+          world: `Hello World!`,
+          mars: `Hello Mars!`,
+        },
+      }
+      expect(results).toEqual(expected)
+    })
+
+    it(`custom resolver context is avalable in custom field extension`, async () => {
+      dispatch(
+        createResolverContext({
+          hello(planet) {
+            return `Hello ${planet}!`
+          },
+        })
+      )
+      dispatch(
+        createFieldExtension({
+          name: `hello`,
+          extend() {
+            return {
+              args: {
+                planet: {
+                  type: `String!`,
+                  defaultValue: `World`,
+                },
+              },
+              resolve(source, args, context, info) {
+                return context.hello(args.planet)
+              },
+            }
+          },
+        })
+      )
+      dispatch(
+        createTypes(`
+          type Test implements Node {
+            hello: String @hello
+          }
+        `)
+      )
+      const query = `
+        {
+          test {
+            world: hello
+            mars: hello(planet: "Mars")
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        test: {
+          world: `Hello World!`,
+          mars: `Hello Mars!`,
+        },
+      }
+      expect(results).toEqual(expected)
+    })
+
+    it(`correctly namespaces context value by plugin name`, async () => {
+      const plugin = { name: `gatsby-transformer-hello` }
+      dispatch(
+        createResolverContext(
+          {
+            hello(planet) {
+              return `Hello ${planet}!`
+            },
+          },
+          plugin
+        )
+      )
+      dispatch(
+        createTypes(
+          buildObjectType({
+            name: `Test`,
+            interfaces: [`Node`],
+            fields: {
+              hello: {
+                type: `String!`,
+                args: {
+                  planet: {
+                    type: `String!`,
+                    defaultValue: `World`,
+                  },
+                },
+                resolve(source, args, context, info) {
+                  // Custom context value under namespace
+                  return context.transformerHello.hello(args.planet)
+                },
+              },
+            },
+          }),
+          plugin
+        )
+      )
+      const query = `
+        {
+          test {
+            world: hello
+            mars: hello(planet: "Mars")
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        test: {
+          world: `Hello World!`,
+          mars: `Hello Mars!`,
+        },
+      }
+      expect(results).toEqual(expected)
+    })
+
+    it(`shows error when no context value passed`, () => {
+      dispatch(createResolverContext())
+      expect(report.error).toBeCalledWith(
+        `Expected context value passed to \`createResolverContext\` to be an ` +
+          `object. Received "undefined".`
+      )
+    })
+
+    it(`shows error when context value is not an object`, () => {
+      dispatch(createResolverContext(() => {}))
+      expect(report.error).toBeCalledWith(
+        `Expected context value passed to \`createResolverContext\` to be an ` +
+          `object. Received "() => {}".`
+      )
+    })
+  })
+})
+
+const runQuery = async query => {
+  await build({})
+  const { schema, schemaCustomization } = store.getState()
+  const results = await graphql(
+    schema,
+    query,
+    undefined,
+    withResolverContext({}, schema, schemaCustomization.context)
+  )
+  expect(results.errors).toBeUndefined()
+  return results.data
+}

--- a/packages/gatsby/src/schema/context.js
+++ b/packages/gatsby/src/schema/context.js
@@ -1,11 +1,12 @@
 const { LocalNodeModel } = require(`./node-model`)
 
-const withResolverContext = (context, schema) => {
+const withResolverContext = (context, schema, customContext) => {
   const nodeStore = require(`../db/nodes`)
   const createPageDependency = require(`../redux/actions/add-page-dependency`)
 
   return {
     ...context,
+    ...customContext,
     nodeModel: new LocalNodeModel({
       nodeStore,
       schema,

--- a/packages/gatsby/src/schema/extensions/__tests__/field-extensions.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/field-extensions.js
@@ -1237,7 +1237,7 @@ const runQuery = async query => {
     schema,
     query,
     undefined,
-    withResolverContext({})
+    withResolverContext({}, schema)
   )
   expect(results.errors).toBeUndefined()
   return results.data


### PR DESCRIPTION
Allow plugins to put methods on `context`, which would allow using plugin functionality to compose new custom types (e.g. more than one markdown type with different frontmatter fields).