### PR TITLE
fix(www): fix variable name [type] to [featureType]

### DIFF
--- a/www/src/utils/generate-comparison-page-set.js
+++ b/www/src/utils/generate-comparison-page-set.js
@@ -38,7 +38,7 @@ const generateComparisonPageSet = type => {
       )
       pages.push({
         options,
-        type,
+        featureType: type,
         path: `/features/${type}/gatsby-vs-${set.join(`-vs-`)}`,
       })
     }


### PR DESCRIPTION
## Description
gatsby-node.js refer `featureType` 
https://github.com/gatsbyjs/gatsby/blob/a2855b38cc8b1b871c352ccc859771a22c96389d/www/gatsby-node.js#L772

but `featureType` is not defined in generate-comparison-page-set.js. ( It define `type`. )
https://github.com/gatsbyjs/gatsby/blob/a2855b38cc8b1b871c352ccc859771a22c96389d/www/src/utils/generate-comparison-page-set.js#L39-L43

So in template-feature-comparison.js, `featureType` is always undefined and `https://www.gatsbyjs.org/features/cms/gatsby-vs-wordpress/` page display wrong information.
https://github.com/gatsbyjs/gatsby/blob/a2855b38cc8b1b871c352ccc859771a22c96389d/www/src/templates/template-feature-comparison.js#L27-L30

## Solution
`type` remame to `featureType`

## ScreenShot
### before
![Screenshot from 2019-08-04 21-51-20](https://user-images.githubusercontent.com/10436320/62423953-f92ffc80-b702-11e9-9032-ce3c9487db6a.png)

### after
![Screenshot from 2019-08-04 21-51-07](https://user-images.githubusercontent.com/10436320/62423957-fdf4b080-b702-11e9-8964-282309612439.png)

## Related Issues

none (maybe)
