### PR TITLE
feat(gatsby-cli): Added support and docs for NO_COLOR env variable

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -153,3 +153,7 @@ You can type in a command, such as one of these:
 When combined with the [GraphQL explorer](/docs/introducing-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
 
 See the Gatsby REPL documentation [here](/docs/gatsby-repl/).
+
+### Disabling colored output
+
+In addition to the explicit `--no-color` option, the CLI respects the presence of the `NO_COLOR` environment variable (see [no-color.org](https://no-color.org/)).

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -83,8 +83,7 @@ function buildLocalCommands(cli, isLocalSite) {
     return argv => {
       report.setVerbose(!!argv.verbose)
 
-      const noColor = argv.noColor || process.env.NO_COLOR
-      report.setNoColor(noColor)
+      report.setNoColor(argv.noColor || process.env.NO_COLOR)
 
       process.env.gatsby_log_level = argv.verbose ? `verbose` : `normal`
       report.verbose(`set gatsby_log_level: "${process.env.gatsby_log_level}"`)

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -82,7 +82,7 @@ function buildLocalCommands(cli, isLocalSite) {
   function getCommandHandler(command, handler) {
     return argv => {
       report.setVerbose(!!argv.verbose)
-      if (argv.noColor) {
+      if (argv.noColor || process.env.NO_COLOR) {
         // disables colors in popular terminal output coloring packages
         //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
         //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -82,14 +82,13 @@ function buildLocalCommands(cli, isLocalSite) {
   function getCommandHandler(command, handler) {
     return argv => {
       report.setVerbose(!!argv.verbose)
-      if (argv.noColor || process.env.NO_COLOR) {
-        // disables colors in popular terminal output coloring packages
-        //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
-        //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
-        process.env.FORCE_COLOR = `0`
-      }
 
-      report.setNoColor(!!argv.noColor)
+      const noColor = argv.noColor || process.env.NO_COLOR
+      // disables colors in popular terminal output coloring packages
+      //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
+      //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
+      process.env.FORCE_COLOR = noColor ? `0` : undefined
+      report.setNoColor(noColor)
 
       process.env.gatsby_log_level = argv.verbose ? `verbose` : `normal`
       report.verbose(`set gatsby_log_level: "${process.env.gatsby_log_level}"`)

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -84,10 +84,6 @@ function buildLocalCommands(cli, isLocalSite) {
       report.setVerbose(!!argv.verbose)
 
       const noColor = argv.noColor || process.env.NO_COLOR
-      // disables colors in popular terminal output coloring packages
-      //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
-      //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
-      process.env.FORCE_COLOR = noColor ? `0` : undefined
       report.setNoColor(noColor)
 
       process.env.gatsby_log_level = argv.verbose ? `verbose` : `normal`

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -42,7 +42,9 @@ const reporter: Reporter = {
     // disables colors in popular terminal output coloring packages
     //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
     //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
-    process.env.FORCE_COLOR = isNoColor ? `0` : undefined
+    if (isNoColor) {
+      process.env.FORCE_COLOR = `0`
+    }
   },
   /**
    * Log arguments and exit process with status 1.

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -38,6 +38,11 @@ const reporter: Reporter = {
     if (isNoColor) {
       errorFormatter.withoutColors()
     }
+
+    // disables colors in popular terminal output coloring packages
+    //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
+    //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
+    process.env.FORCE_COLOR = isNoColor ? `0` : undefined
   },
   /**
    * Log arguments and exit process with status 1.


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Adds support for the `NO_COLOR` environment variable as described on https://no-color.org/.
As described in the spec, the simple presence of the env variable is checked, not its value (e.g. `NO_COLOR=false` also produces un-colored output).

Usage Example:

`export NO_COLOR=somevalue && gatsby build`

or set the env variable globally.

## Related Issues

Closes #16324.
