### PR TITLE
Docs: fix auto-config command. mention `gatsby clean`

### DIFF
--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -47,9 +47,12 @@ If you use VS Code and its integrated terminal, you can configure it to automati
 1.  Press `Ctrl + ,` or `⌘ + ,` to open your preferences. Type `node debug` into the search bar. Make sure the `Auto Attach` option is set to `on`.
     ![Search for on debug and set attach to enable](./images/set-node-attach-to-on.png)
 
-2.  Using VS Code's integrated terminal run `node --inspect node_modules/.bin/gatsby develop` instead of `gatsby develop`
+2.  Using VS Code's integrated terminal run `node --nolazy --inspect-brk node_modules/.bin/gatsby develop` instead of `gatsby develop`
 
 3.  Set breakpoints and debug!
+
+> **Note:** If the breakpoint is not being hit on `const value = createFilePath({ node, getNode })`
+> try running `gatsby clean` to delete the `.cache` and `public` folder and try again.
 
 ## VS Code Debugger (Manual Config)
 
@@ -90,6 +93,9 @@ We won't go in depth here about how to debug in VS Code - for that you can check
 After putting a breakpoint in `gatsby-node.js` and using the `Start debugging` command from VS Code you can see the final result:
 
 ![VSCode breakpoint hit](./images/vscode-debug.png)
+
+> **Note:** If the breakpoint is not being hit on `const value = createFilePath({ node, getNode })`
+> try running `gatsby clean` to delete the `.cache` and `public` folder and try again.
 
 ## Chrome DevTools for Node
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

I spent a long time trying to figure out why VS Code Debugger (Auto-Config) wasn't working. I spent even more time trying to figure out why breakpoint on the line `const value = createFilePath({ node, getNode })` wasn't getting hit. I hope this helps someone else following this documentation and facing same issues as me.

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I made 2 minor (but significant imho) changes:
1. fix command to debug in vscode using auto-config
2. inform users to run `gatsby clean` and try again if the breakpoint on the line `const value = createFilePath({ node, getNode })` doesn't get hit.

## Reasoning

I found 2 issues while attempting to follow the documentation on [Debugging the build process](https://www.gatsbyjs.org/docs/debugging-the-build-process/):

1. In [VS Code Debugger (Auto-Config)](https://www.gatsbyjs.org/docs/debugging-the-build-process/#vs-code-debugger-auto-config) section, the command `node --inspect node_modules/.bin/gatsby develop` does not work. Changing the command to `node --nolazy --inspect-brk node_modules/.bin/gatsby develop` fixes the problem. The `--nolazy` option is required for breakpoints to work in source code areas that haven't been parsed by Node.js. The `--inspect-brk` option is required to break before the user code starts.

2. If a user attempts to put a breakpoint on the line `const value = createFilePath({ node, getNode })` and try to debug, that breakpoint might not get hit if the user already debugged that line due to GatsbyJS caching. In order for that breakpoint to hit, the user will need to run `gatsby clean` to delete `.cache` and `public` folder. This will ensure that the next time the user debugs that line, the breakpoint will get hit.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
