### PR TITLE
fix(www): replace \n into newlines for guess

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -20,7 +20,11 @@ if (process.env.ANALYTICS_SERVICE_ACCOUNT) {
       GAViewID: GA.viewId,
       jwt: {
         client_email: process.env.ANALYTICS_SERVICE_ACCOUNT,
-        private_key: process.env.ANALYTICS_SERVICE_ACCOUNT_KEY,
+        // replace \n characters in real new lines for circleci deploys
+        private_key: process.env.ANALYTICS_SERVICE_ACCOUNT_KEY.replace(
+          /\\n/g,
+          `\n`
+        ),
       },
       period: {
         startDate,


### PR DESCRIPTION
## Description
This should fix our circleci builds when guess-js is enabled. dotenv replaces \n into real newlines. Circleci doesn't so we have to do it ourselves.

https://github.com/wardpeet/circleci-test
https://circleci.com/gh/wardpeet/circleci-test/7