### PR TITLE
docs: Replace Now with ZEIT Now

### DIFF
--- a/docs/docs/deploying-to-zeit-now.md
+++ b/docs/docs/deploying-to-zeit-now.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying to Now
+title: Deploying to ZEIT Now
 ---
 
 [ZEIT Now](https://zeit.co/now) is a cloud platform for websites and serverless APIs, that you can use to deploy your Gatsby projects to your personal domain (or a free `.now.sh` suffixed URL).

--- a/docs/docs/deploying-to-zeit-now.md
+++ b/docs/docs/deploying-to-zeit-now.md
@@ -22,7 +22,9 @@ You can deploy your application by running the following command in the root of 
 now
 ```
 
-That's all! Your application will now deploy, and you will receive a link similar to the following: https://my-gatsby-project-fhcc9hnqc.now.sh/
+That's all!
+
+Your site will now deploy, and you will receive a link similar to the following: https://gatsby-functions.now-examples.now.sh
 
 ## References:
 

--- a/docs/docs/preparing-for-deployment.md
+++ b/docs/docs/preparing-for-deployment.md
@@ -46,7 +46,7 @@ If you have a server from one of the following providers, you should read the in
 - [S3/Cloudfront](/docs/deploying-to-s3-cloudfront)
 - [Aerobatic](/docs/deploying-to-aerobatic)
 - [Heroku](/docs/deploying-to-heroku)
-- [Now](/docs/deploying-to-now)
+- [ZEIT Now](/docs/deploying-to-zeit-now)
 - [GitLab Pages](/docs/deploying-to-gitlab-pages)
 - [Netlify](/docs/hosting-on-netlify)
 - [Render](/docs/deploying-to-render)

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -102,6 +102,11 @@ exports.createPages = ({ graphql, actions, reporter }) => {
     isPermanent: true,
   })
   createRedirect({
+    fromPath: `/docs/deploying-to-now/`,
+    toPath: `/docs/deploying-to-zeit-now/`,
+    isPermanent: true,
+  })
+  createRedirect({
     fromPath: `/docs/pair-programming/`,
     toPath: `/contributing/pair-programming/`,
     isPermanent: true,

--- a/www/src/data/diagram/static-hosts.yml
+++ b/www/src/data/diagram/static-hosts.yml
@@ -8,5 +8,5 @@
   url: /docs/deploying-to-surge/
 - title: Aerobatic
   url: /docs/deploying-to-aerobatic/
-- title: Now.sh
-  url: /docs/deploying-to-now/
+- title: ZEIT Now
+  url: /docs/deploying-to-zeit-now/

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -44,9 +44,9 @@
             - title: Deploying to Heroku
               link: /docs/deploying-to-heroku/
               breadcrumbTitle: Heroku
-            - title: Deploying to Now
-              link: /docs/deploying-to-now/
-              breadcrumbTitle: Now
+            - title: Deploying to ZEIT Now
+              link: /docs/deploying-to-zeit-now/
+              breadcrumbTitle: ZEIT Now
             - title: Deploying to GitLab Pages
               link: /docs/deploying-to-gitlab-pages/
               breadcrumbTitle: GitLab Pages


### PR DESCRIPTION
## Description

This is a follow-up PR to https://github.com/gatsbyjs/gatsby/pull/16342 and replaces "Now" with "ZEIT Now", as that's the new brand name.

## Related PRs

https://github.com/gatsbyjs/gatsby/pull/16342
