### PR TITLE
fix(gatsby-theme-blog): Add margin and improved props handling for code blocks

### DIFF
--- a/themes/gatsby-starter-theme/content/posts/hello-world.mdx
+++ b/themes/gatsby-starter-theme/content/posts/hello-world.mdx
@@ -27,3 +27,7 @@ export default props => (
   <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
 )
 ```
+
+Here's a `pre` tag:
+
+<pre>hello!</pre>

--- a/themes/gatsby-theme-blog/package.json
+++ b/themes/gatsby-theme-blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-blog",
-  "version": "0.0.11",
+  "version": "1.0.2",
   "description": "A Gatsby theme for miscellaneous blogging with a dark/light mode",
   "main": "index.js",
   "keywords": [
@@ -39,6 +39,7 @@
     "gatsby-remark-smartypants": "^2.1.2",
     "gatsby-source-filesystem": "^2.1.8",
     "gatsby-transformer-sharp": "^2.2.5",
+    "mdx-utils": "^0.2.0",
     "react-helmet": "^5.2.1",
     "react-switch": "^5.0.1",
     "remark-slug": "^5.1.2",

--- a/themes/gatsby-theme-blog/src/gatsby-plugin-theme-ui/components.js
+++ b/themes/gatsby-theme-blog/src/gatsby-plugin-theme-ui/components.js
@@ -1,10 +1,27 @@
-import React from "react"
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import { preToCodeBlock } from "mdx-utils"
 import PrismCodeBlock from "@theme-ui/prism"
 
 import headings from "../components/headings"
 
+const CodeBlock = preProps => {
+  const props = preToCodeBlock(preProps)
+
+  if (props) {
+    const { codeString, ...restProps } = props
+
+    return (
+      <div sx={{ mb: 2 }}>
+        <PrismCodeBlock {...restProps}>{codeString}</PrismCodeBlock>
+      </div>
+    )
+  } else {
+    return <pre {...preProps} />
+  }
+}
+
 export default {
-  pre: ({ children }) => <>{children}</>,
-  code: PrismCodeBlock,
+  pre: CodeBlock,
   ...headings,
 }

--- a/themes/gatsby-theme-blog/src/gatsby-plugin-theme-ui/styles.js
+++ b/themes/gatsby-theme-blog/src/gatsby-plugin-theme-ui/styles.js
@@ -7,7 +7,7 @@ export default {
     fontFamily: `monospace`,
     tabSize: 4,
     hyphens: `none`,
-    marginBottom: 0,
+    marginBottom: 2,
     color: `white`,
     bg: `prism.background`,
     overflow: `auto`,


### PR DESCRIPTION
This adds margin bottom to the prism code blocks and also improves
code handling to ensure that pre tags are properly wrapped.

![image](https://user-images.githubusercontent.com/1424573/62500015-fdf7bd80-b7a1-11e9-8fdf-919adb1dcfbd.png)

## Related

- Closes #15476

## References

- https://www.christopherbiscardi.com/post/codeblocks-mdx-and-mdx-utils