### PR TITLE
chore(ci): revert "ci: add an (optional) approval step to build out www"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,17 +318,6 @@ workflows:
             branches:
               only:
                 - master
-      - manual_www_approval:
-          type: approval
-      - build_www:
-          context: build_www
-          requires:
-            - manual_www_approval
-      - deploy_www:
-          requires:
-            - build_www
-          context: build_www
-
   www_deploy:
     triggers:
       - schedule:


### PR DESCRIPTION
Reverts gatsbyjs/gatsby#16319

It can be triggered by users and isn't being used by _us_ currently. We can add this back later if needed.