### PR TITLE
fix(gatsby-transformer-remark): Add fallback when markdown doesn't include excerpt_separator

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -425,6 +425,90 @@ Object {
 }
 `;
 
+exports[`Excerpt is generated correctly from schema when plugins options has a excerpt_separator defined correctly prunes length to default value 1`] = `
+Object {
+  "excerpt": "Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla…",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor sit amet velit id facilisis. Nulla…",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
+      },
+    ],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+}
+`;
+
+exports[`Excerpt is generated correctly from schema when plugins options has a excerpt_separator defined correctly prunes length to provided parameter 1`] = `
+Object {
+  "excerpt": "Where oh where is my little pony? Lorem ipsum…",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony? Lorem ipsum…",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
+      },
+    ],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+}
+`;
+
+exports[`Excerpt is generated correctly from schema when plugins options has a excerpt_separator defined correctly prunes length to provided parameter with truncate 1`] = `
+Object {
+  "excerpt": "Where oh where is my little pony? Lorem ipsum dol…",
+  "excerptAst": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "Where oh where is my little pony? Lorem ipsum dol…",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "p",
+        "type": "element",
+      },
+    ],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+}
+`;
+
 exports[`Headings are generated correctly from schema returns value 1`] = `
 Object {
   "headings": Array [

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -332,6 +332,65 @@ In quis lectus sed eros efficitur luctus. Morbi tempor, nisl eget feugiat tincid
     }
   )
 
+  describe(`when plugins options has a excerpt_separator defined`, () => {
+    bootstrapTest(
+      `correctly prunes length to default value`,
+      content,
+      `excerpt
+        excerptAst
+        frontmatter {
+            title
+        }
+        `,
+      node => {
+        expect(node).toMatchSnapshot()
+        expect(node.excerpt.length).toBe(139)
+        expect(node.excerptAst.children.length).toBe(1)
+        expect(node.excerptAst.children[0].children.length).toBe(1)
+        expect(node.excerptAst.children[0].children[0].value.length).toBe(139)
+      },
+      { pluginOptions: { excerpt_separator: `<!-- end -->` } }
+    )
+
+    bootstrapTest(
+      `correctly prunes length to provided parameter`,
+      content,
+      `excerpt(pruneLength: 50)
+        excerptAst(pruneLength: 50)
+        frontmatter {
+            title
+        }
+        `,
+      node => {
+        expect(node).toMatchSnapshot()
+        expect(node.excerpt.length).toBe(46)
+        expect(node.excerptAst.children.length).toBe(1)
+        expect(node.excerptAst.children[0].children.length).toBe(1)
+        expect(node.excerptAst.children[0].children[0].value.length).toBe(46)
+      },
+      { pluginOptions: { excerpt_separator: `<!-- end -->` } }
+    )
+
+    bootstrapTest(
+      `correctly prunes length to provided parameter with truncate`,
+      content,
+      `excerpt(pruneLength: 50, truncate: true)
+        excerptAst(pruneLength: 50, truncate: true)
+        frontmatter {
+            title
+        }
+        `,
+      node => {
+        expect(node).toMatchSnapshot()
+        expect(node.excerpt.length).toBe(50)
+        expect(node.excerptAst.children.length).toBe(1)
+        expect(node.excerptAst.children[0].children.length).toBe(1)
+        expect(node.excerptAst.children[0].children[0].value.length).toBe(50)
+      },
+      { pluginOptions: { excerpt_separator: `<!-- end -->` } }
+    )
+  })
+
   bootstrapTest(
     `given an html format, it correctly maps nested markdown to html`,
     `---

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -351,7 +351,7 @@ module.exports = (
       { pruneLength, truncate, excerptSeparator }
     ) {
       const fullAST = await getHTMLAst(markdownNode)
-      if (excerptSeparator) {
+      if (excerptSeparator && markdownNode.excerpt !== ``) {
         return cloneTreeUntil(
           fullAST,
           ({ nextNode }) =>
@@ -457,7 +457,7 @@ module.exports = (
 
         const excerptText = excerptNodes.join(``).trim()
 
-        if (excerptSeparator) {
+        if (excerptSeparator && !isBeforeSeparator) {
           return excerptText
         }
         if (!truncate) {


### PR DESCRIPTION
## Description

When plugin option `excerpt_separator` is defined and the markdown content don't have the separator, add fallback to the default truncate method.

## Related Issues

Fixes #15286
