### PR TITLE
feat(gatsby-remark-primsjs): Support overriding prompt user/host.

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -370,13 +370,20 @@ plugins: [
 ### Shell prompt
 
 To show fancy prompts next to shell commands (only triggers on `bash`), either set `prompt.global` to `true` in `gatsby-config.js`,
-or pass `{outputLines: <range>}` to a snippet
+or pass at least one of `{outputLines: <range>}`, `{promptUser: <user>}`, or `{promptHost: <host>}` to a snippet
 
 By default, every line gets a prompt appended to the start, this behaviour can be changed by specififying `{outputLines: <range>}`
 to the language.
 
 ````
 ```bash{outputLines: 2-10,12}
+````
+
+The user and host used in the appended prompt is pulled from the `prompt.user` and `prompt.host` values,
+unless explicitly overridden by the `promptUser` and `promptHost` options in the snippet, e.g.:
+
+````
+```bash{promptUser: alice}{promptHost: dev.localhost}
 ````
 
 ### Line hiding

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -632,3 +632,122 @@ color<span class=\\"token punctuation\\">:</span> red<span class=\\"token punctu
 }
 `;
 
+exports[`remark prism plugin promptUser/promptHost adds prompts if promptHost set 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "bash{promptHost:server}",
+      "position": Position {
+        "end": Object {
+          "column": 15,
+          "line": 2,
+          "offset": 41,
+        },
+        "indent": Array [
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=root data-host=server></span></span><span class=\\"token keyword\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 15,
+      "line": 2,
+      "offset": 41,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`remark prism plugin promptUser/promptHost adds prompts if promptUser and promptHost set 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "bash{promptUser:alice}{promptHost:server}",
+      "position": Position {
+        "end": Object {
+          "column": 15,
+          "line": 2,
+          "offset": 59,
+        },
+        "indent": Array [
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=alice data-host=server></span></span><span class=\\"token keyword\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 15,
+      "line": 2,
+      "offset": 59,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`remark prism plugin promptUser/promptHost adds prompts if promptUser set 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": "bash{promptUser:alice}",
+      "position": Position {
+        "end": Object {
+          "column": 15,
+          "line": 2,
+          "offset": 40,
+        },
+        "indent": Array [
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "html",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=alice data-host=localhost></span></span><span class=\\"token keyword\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 15,
+      "line": 2,
+      "offset": 40,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -84,6 +84,29 @@ describe(`remark prism plugin`, () => {
     expect(markdownAST).toMatchSnapshot()
   })
 
+  describe(`promptUser/promptHost`, () => {
+    it(`adds prompts if promptUser set`, () => {
+      const code = `\`\`\`bash{promptUser:alice}\necho 'test'\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST })
+      expect(markdownAST).toMatchSnapshot()
+    })
+
+    it(`adds prompts if promptHost set`, () => {
+      const code = `\`\`\`bash{promptHost:server}\necho 'test'\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST })
+      expect(markdownAST).toMatchSnapshot()
+    })
+
+    it(`adds prompts if promptUser and promptHost set`, () => {
+      const code = `\`\`\`bash{promptUser:alice}{promptHost:server}\necho 'test'\`\`\``
+      const markdownAST = remark.parse(code)
+      plugin({ markdownAST })
+      expect(markdownAST).toMatchSnapshot()
+    })
+  })
+
   describe(`numberLines`, () => {
     it(`adds line-number markup when necessary`, () => {
       const code = `\`\`\`js{numberLines:5}\n//.foo { \ncolor: red;\n }\``

--- a/packages/gatsby-remark-prismjs/src/__tests__/parse-options.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/parse-options.js
@@ -58,6 +58,27 @@ describe(`parses numeric ranges from the languages markdown code directive`, () 
     })
   })
 
+  describe(`parses both prompt user and host options`, () => {
+    it(`parses only promptUser option supplied`, () => {
+      expect(parseOptions(`bash{promptUser: pi}`).promptUserLocal).toEqual(`pi`)
+    })
+
+    it(`parses only promptHost option supplied`, () => {
+      expect(
+        parseOptions(`bash{promptHost: dev.localhost}`).promptHostLocal
+      ).toEqual(`dev.localhost`)
+    })
+
+    it(`parses promptHost and promptUser options supplied together`, () => {
+      expect(
+        parseOptions(`bash{promptUser: pi}{promptHost: dev.localhost}`)
+      ).toMatchObject({
+        promptHostLocal: `dev.localhost`,
+        promptUserLocal: `pi`,
+      })
+    })
+  })
+
   describe(`parses both line numbering and line highlighting options`, () => {
     it(`one line highlighted`, () => {
       expect(parseOptions(`jsx{1}{numberLines: 3}`)).toEqual({

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -38,8 +38,12 @@ module.exports = (
       showLineNumbersLocal,
       numberLinesStartAt,
       outputLines,
+      promptUserLocal,
+      promptHostLocal,
     } = parseOptions(language)
     const showLineNumbers = showLineNumbersLocal || showLineNumbersGlobal
+    const promptUser = promptUserLocal || prompt.user
+    const promptHost = promptHostLocal || prompt.host
     language = splitLanguage
 
     // PrismJS's theme styles are targeting pre[class*="language-"]
@@ -79,14 +83,17 @@ module.exports = (
 
     const useCommandLine =
       [`bash`].includes(languageName) &&
-      (prompt.global || (outputLines && outputLines.length > 0))
+      (prompt.global ||
+        (outputLines && outputLines.length > 0) ||
+        promptUserLocal ||
+        promptHostLocal)
 
     // prettier-ignore
     node.value = ``
     + `<div class="${highlightClassName}" data-language="${languageName}">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`
     +     `<code class="${className}">`
-    +       `${useCommandLine ? commandLine(node.value, outputLines, prompt.user, prompt.host) : ``}`
+    +       `${useCommandLine ? commandLine(node.value, outputLines, promptUser, promptHost) : ``}`
     +       `${highlightCode(languageName, node.value, highlightLines, noInlineHighlight)}`
     +     `</code>`
     +     `${numLinesNumber}`

--- a/packages/gatsby-remark-prismjs/src/parse-options.js
+++ b/packages/gatsby-remark-prismjs/src/parse-options.js
@@ -9,7 +9,9 @@ module.exports = language => {
     let highlightLines = [],
       outputLines = [],
       showLineNumbersLocal = false,
-      numberLinesStartAt
+      numberLinesStartAt,
+      promptUserLocal,
+      promptHostLocal
     // Options can be given in any order and are optional
 
     options.forEach(option => {
@@ -36,6 +38,12 @@ module.exports = language => {
             ? 1
             : parseInt(splitOption[1].trim(), 10)
       }
+      if (splitOption.length === 2 && splitOption[0] === `promptHost`) {
+        promptHostLocal = splitOption[1]
+      }
+      if (splitOption.length === 2 && splitOption[0] === `promptUser`) {
+        promptUserLocal = splitOption[1]
+      }
       if (splitOption.length === 2 && splitOption[0] === `outputLines`) {
         outputLines = rangeParser
           .parse(splitOption[1].trim())
@@ -49,6 +57,8 @@ module.exports = language => {
       showLineNumbersLocal,
       numberLinesStartAt,
       outputLines,
+      promptUserLocal,
+      promptHostLocal,
     }
   }
 


### PR DESCRIPTION
* Add `promptUser` and `promptHost` options to snippet language
  to override global settings, and turn on prompt appending mode.


## Description

I recently switched to trying GatsbyJS for my blog, and while writing a post that included a requirement to have the snippet "prompt" be different per snippet, I found that the current `gatsby-remark-prismjs` package only allows configuring the prompt host and user globally.

This PR adds support for providing `promptUser`, and `promptHost` options to a language tag. Doing so allows for the global defaults and overriding those values per-snippet.

In doing so, I also made providing either of those values add the "prompt behaviour" even if not turned on globally, similar to how adding `outputLines` triggers this behaviour even if `prompt.global` is false.

First PR to Gatsby, I've tried to update both tests + docs, let me know if there's anything else I'm missing.

Thanks!
