### PR TITLE
chore(docs): add note for app shell and its meaning in server logs

### DIFF
--- a/docs/docs/progressive-web-app.md
+++ b/docs/docs/progressive-web-app.md
@@ -46,7 +46,7 @@ A [web app manifest](https://www.w3.org/TR/appmanifest/) is a JSON file that pro
 
 It includes information like the web app's `name`, `icons`, `start_url`, `background-color` and [more](https://developers.google.com/web/fundamentals/web-app-manifest/).
 
-Gatsby provides a plugin interface to add support for shipping a manifest with your site -- [**gatsby-plugin-manifest**](https://www.npmjs.com/package/gatsby-plugin-manifest).
+Gatsby provides a plugin interface to add support for shipping a manifest with your site -- [**gatsby-plugin-manifest**](/packages/gatsby-plugin-manifest).
 
 ### It must implement a service worker.
 
@@ -54,6 +54,6 @@ A [service worker](https://developers.google.com/web/fundamentals/primers/servic
 
 It's a script that runs separately in the background, supporting features like push notifications and background sync.
 
-Gatsby also provides a plugin interface to create and load a service worker into your site -- [**gatsby-plugin-offline**](https://www.npmjs.com/package/gatsby-plugin-offline).
+Gatsby also provides a plugin interface to create and load a service worker into your site -- [**gatsby-plugin-offline**](/packages/gatsby-plugin-offline).
 
-We recommend using this plugin together with the [manifest plugin](https://www.npmjs.com/package/gatsby-plugin-manifest). (Don't forget to list the `offline` plugin after the `manifest` plugin so that the manifest file can be included in the service worker).
+We recommend using this plugin together with the [manifest plugin](/packages/gatsby-plugin-manifest). (Don't forget to list the `offline` plugin after the `manifest` plugin so that the manifest file can be included in the service worker).

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -100,3 +100,7 @@ curl https://www.yourdomain.tld
 ```
 
 Alternatively you can have a look at the `/public/index.html` file in your project folder.
+
+### App shell and server logs
+
+Server logs (like from [Netlify analytics](https://www.netlify.com/products/analytics/)) may show a large number of pageviews to a route like `/offline-plugin-app-shell-fallback/index.html`, this is a result of `gatsby-plugin-offline` adding an [app shell](https://developers.google.com/web/fundamentals/architecture/app-shell) to the page. The app shell is a minimal amount of user interface that can be cached offline for reliable performance loading on repeat visits. The shell can be loaded from the cache, and the content of the site loaded into the shell by the service worker.


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Based on a tweet from Kent C Dodds and @DSchau's subsequent response, this note adds a little more context about what `gatsby-plugin-offline` does, as well as gives information on why server logs would be filled with info from the app shell fallback route. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

This tweet: https://twitter.com/kentcdodds/status/1158843226788261888, which led to this tweet: https://twitter.com/SchauDustin/status/1158911949821771780
