### PR TITLE
docs(themes): Wrong file name in building theme docs

### DIFF
--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -49,7 +49,7 @@ For Gatsby theme development, that means you can keep multiple themes and exampl
 
 The `package.json` in the root of the new project is primarily responsible for setting up the yarn workspaces. In this case, there are two workspaces, `gatsby-theme-minimal` and `example`.
 
-```json:title=my-theme/gatsby-config.js
+```json:title=my-theme/package.json
 {
   "name": "gatsby-starter-theme-workspace",
   "private": true,


### PR DESCRIPTION
Updated the file name. The parent folder is also wrong according to the repo, but probably intentional when you want people to use this as a template for making themes.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
