### PR TITLE
docs: fix minor grammar in remark plugin tutorial

### DIFF
--- a/docs/docs/remark-plugin-tutorial.md
+++ b/docs/docs/remark-plugin-tutorial.md
@@ -272,7 +272,7 @@ At this point, our plugin is now ready to be used. To see the resulting function
 
 ## Publishing the plugin
 
-To be shared with others, you can extract the plugin to its own directory outside of this site and then publish it to NPM so it can be accessed both on NPM and [Submitted to the Plugin Library](/contributing/submit-to-plugin-library).
+To share this plugin with others, you can extract the plugin to its own directory outside of this site and then publish it to NPM so it can be accessed both on NPM and [Submitted to the Plugin Library](/contributing/submit-to-plugin-library).
 
 ## Summary
 


### PR DESCRIPTION
While reading through Gatsby docs, I noticed a minor grammatical error in [Remark Plugin Tutorial](https://www.gatsbyjs.org/docs/remark-plugin-tutorial/).

I figured I'd make a PR to help with it.

Also, props to @lannonbr for writing a super helpful guide about AST and Remark plugins! I learned a lot from it.