### PR TITLE
fix(docs): adds back some missing guides to sidebar

### DIFF
--- a/docs/docs/introducing-graphiql.md
+++ b/docs/docs/introducing-graphiql.md
@@ -18,7 +18,7 @@ When you have <http://localhost:8000/___graphql> open, it will look something li
 on it—including the `siteMetadata` object.
 
 <video controls="controls" autoplay="true" loop="true">
-  <source type="video/mp4" src="/graphiql-explore.mp4"></source>
+  <source type="video/mp4" src="/graphiql-explore.mp4" />
   <p>Your browser does not support the video element.</p>
 </video>
 
@@ -43,3 +43,4 @@ The GraphiQL Explorer enables you to interactively construct full queries by cli
 
 - See [Tutorial Part 5: Source Plugins](/tutorial/part-five/) for a more complete example of using GraphiQL
 - See the [README for GraphiQL](https://github.com/graphql/graphiql)
+- See [Using GraphQL Playground](/docs/using-graphql-playground/) for another example of a GraphQL IDE

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -401,7 +401,7 @@
                   link: /docs/rendering-sidebar-navigation-dynamically/
                 - title: Client-only Routes & User Authentication
                   link: /docs/client-only-routes-and-user-authentication/
-                  breadcrumbTitle: Client routes & User auth
+                  breadcrumbTitle: Client Routes & User Auth
             - title: Client Data Fetching
               link: /docs/client-data-fetching/
             - title: Using Client-Side Only Packages

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -66,6 +66,8 @@
               breadcrumbTitle: GitHub Pages
             - title: Multi-Core Builds
               link: /docs/multi-core-builds/
+            - title: Asset Prefix
+              link: /docs/asset-prefix/
         - title: Custom Configuration
           link: /docs/customization/
           items:
@@ -184,6 +186,8 @@
               link: /docs/adding-markdown-pages/
             - title: Adding a List of Markdown Blog Posts
               link: /docs/adding-a-list-of-markdown-blog-posts/
+            - title: Using GraphQL Playground
+              link: /docs/using-graphql-playground/
         - title: Plugins
           link: /docs/plugins/
           items:
@@ -395,10 +399,13 @@
                   link: /docs/centralizing-your-sites-navigation/
                 - title: Rendering Sidebar Navigation Dynamically*
                   link: /docs/rendering-sidebar-navigation-dynamically/
+                - title: Client-only Routes & User Authentication
+                  link: /docs/client-only-routes-and-user-authentication/
+                  breadcrumbTitle: Client routes & User auth
             - title: Client Data Fetching
               link: /docs/client-data-fetching/
             - title: Using Client-Side Only Packages
-              link: /docs/using-client-side-only-packages
+              link: /docs/using-client-side-only-packages/
         - title: Improving Performance
           link: /docs/performance/
           items:
@@ -424,6 +431,8 @@
             - title: Optimizing Site Performance with Guess.js
               link: /docs/optimizing-site-performance-with-guessjs/
               breadcrumbTitle: Guess.js
+            - title: Scaling Issues
+              link: /docs/scaling-issues/
         - title: Localization and Internationalization with Gatsby
           link: /docs/localization-i18n/
           breadcrumbTitle: Localization


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I merged a guide #16391 without remembering we needed to add it back into the sidebar. 

I figured this would also be a good time to add back some guides that had been missing from the sidebar that could be useful into sections I thought they made sense. Happy to hear opinions about where they'd belong better but this makes them much more discoverable as guides.

