### PR TITLE
chore(gatsby): Improve typings for reporter

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -937,15 +937,16 @@ export interface Store {
 }
 
 type logMessageType = (format: string, ...args: any[]) => void
+type logErrorType = (message: string, error?: Error) => void
 
 export interface Reporter {
   stripIndent: Function
   format: object
   setVerbose(isVerbose: boolean): void
   setNoColor(isNoColor: boolean): void
-  panic(...args: any[]): void
-  panicOnBuild(...args: any[]): void
-  error(message: string, error: Error): void
+  panic: logErrorType
+  panicOnBuild: logErrorType
+  error: logErrorType
   uptime(prefix: string): void
   success: logMessageType
   verbose: logMessageType


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

`panic`, `painicOnBuild`, and `error` should now match what is described on https://www.gatsbyjs.org/docs/node-api-helpers/#reporter
