### PR TITLE
feat(gatsby-plugin-sass): Enable url() resolution for modules

### DIFF
--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -27,12 +27,6 @@ exports.onCreateWebpackConfig = (
           sassLoader,
         ],
   }
-  if (useResolveUrlLoader && !isSSR) {
-    sassRule.use.splice(-1, 0, {
-      loader: `resolve-url-loader`,
-      options: useResolveUrlLoader.options ? useResolveUrlLoader.options : {},
-    })
-  }
   const sassRuleModules = {
     test: /\.module\.s(a|c)ss$/,
     use: [
@@ -41,6 +35,16 @@ exports.onCreateWebpackConfig = (
       loaders.postcss({ plugins: postCssPlugins }),
       sassLoader,
     ].filter(Boolean),
+  }
+  if (useResolveUrlLoader && !isSSR) {
+    sassRule.use.splice(-1, 0, {
+      loader: `resolve-url-loader`,
+      options: useResolveUrlLoader.options ? useResolveUrlLoader.options : {},
+    })
+    sassRuleModules.use.splice(-1, 0, {
+      loader: `resolve-url-loader`,
+      options: useResolveUrlLoader.options ? useResolveUrlLoader.options : {},
+    })
   }
 
   let configRules = []


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Duplicates the logic for including `resolve-url-loader` in `sassRule` into `sassRuleModule`.  The lack of `resolve-url-loader` in sass modules was causing issues when `@import`ing from, for example, a global reference `*.scss` file into a `*.module.scss` file.  `url()`'s were not being resolved relative to the declaration.

## Related Issues

Addresses issue #16361
