### PR TITLE
chore(ci): Filter manual approval job to apply only to master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,10 @@ workflows:
                 - master
       - manual_www_approval:
           type: approval
+          filters:
+            branches:
+              only:
+                - master
       - build_www:
           context: build_www
           requires:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

We don't need this job on most branches. If you don't know what it is, it's a bit mysterious why it doesn't run automatically.

## Related Issues

Refs https://github.com/gatsbyjs/gatsby/pull/16414