### PR TITLE
chore(themes): Switch pathContext to pageContext

### DIFF
--- a/themes/gatsby-theme-blog/src/templates/post.js
+++ b/themes/gatsby-theme-blog/src/templates/post.js
@@ -3,7 +3,7 @@ import { graphql } from "gatsby"
 
 import Post from "../components/post"
 
-export default ({ pathContext: { previous, next }, location, data }) => (
+export default ({ pageContext: { previous, next }, location, data }) => (
   <Post data={data} location={location} previous={previous} next={next} />
 )
 

--- a/themes/gatsby-theme-blog/src/templates/posts.js
+++ b/themes/gatsby-theme-blog/src/templates/posts.js
@@ -3,7 +3,7 @@ import React from "react"
 import Posts from "../components/posts"
 
 export default ({
-  pathContext: { posts, siteTitle, socialLinks },
+  pageContext: { posts, siteTitle, socialLinks },
   location,
 }) => (
   <Posts

--- a/themes/gatsby-theme-notes/src/templates/notes.js
+++ b/themes/gatsby-theme-notes/src/templates/notes.js
@@ -3,7 +3,7 @@ import React from "react"
 import Notes from "../components/notes"
 
 export default ({
-  pathContext: { groupedNotes, urls, breadcrumbs, siteTitle },
+  pageContext: { groupedNotes, urls, breadcrumbs, siteTitle },
   ...props
 }) => (
   <Notes


### PR DESCRIPTION
## Description

The two themes used the deprecated (in v2) `pathContext` instead of `pageContext.`
