### PR TITLE
Updating links for client routes only on referenced items

### DIFF
--- a/docs/blog/2018-11-07-gatsby-for-apps/index.md
+++ b/docs/blog/2018-11-07-gatsby-for-apps/index.md
@@ -231,7 +231,7 @@ We can't wait to see what you build.
 [gatsby-graphql]: /docs/querying-with-graphql/
 [gatsby-without-graphql]: /docs/using-gatsby-without-graphql/
 [authentication-data]: /tutorial/authentication-tutorial/
-[client-only-routes]: /docs/building-apps-with-gatsby/#client-only-routes--user-authentication
+[client-only-routes]: /docs/client-only-routes-and-user-authentication
 [create-react-app]: https://facebook.github.io/create-react-app/
 [react-dom-render-to-string]: https://reactjs.org/docs/react-dom-server.html#rendertostring
 [cdm]: https://reactjs.org/docs/react-component.html#componentdidmount

--- a/docs/docs/routing.md
+++ b/docs/docs/routing.md
@@ -21,6 +21,6 @@ You can also use standard `<a>` links, but you won't get the benefit of prefetch
 
 ## Creating authentication-gated links
 
-If you don't want all of your content available on the public web, Gatsby lets you create ["client-only" routes](/docs/building-apps-with-gatsby/#client-only-routes--user-authentication) that live behind an authentication gate.
+If you don't want all of your content available on the public web, Gatsby lets you create ["client-only" routes](/docs/client-only-routes-and-user-authentication) that live behind an authentication gate.
 
 <GuideList slug={props.slug} />

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -138,4 +138,4 @@ You can also create a `_redirects` file in the `static` folder for the same effe
 You can validate the `_redirects` config through the
 [Netlify playground app](https://play.netlify.com/redirects).
 
-Redirect rules are automatically added for [client only paths](https://www.gatsbyjs.org/docs/building-apps-with-gatsby/#client-only-routes--user-authentication). If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.
+Redirect rules are automatically added for [client only paths](https://www.gatsbyjs.org/docs/client-only-routes-and-user-authentication). If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.


### PR DESCRIPTION
## Description

Follow up on my previews PR, updating the links where the old "Client-only routes" page/section were referenced and pointing those to the new page.

## Related Issues

Related to #16133 
