### PR TITLE
fix(gatsby): Reserve graphqljs internal directive names

### DIFF
--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -3,6 +3,7 @@ const {
   GraphQLDirective,
   DirectiveLocation,
   defaultFieldResolver,
+  specifiedDirectives,
 } = require(`graphql`)
 
 const { link, fileByPath } = require(`../resolvers`)
@@ -157,6 +158,7 @@ const internalExtensionNames = [
   `directives`,
   `infer`,
   `plugin`,
+  ...specifiedDirectives.map(directive => directive.name),
 ]
 const reservedExtensionNames = [
   ...internalExtensionNames,


### PR DESCRIPTION
Include the `graphql-js` directives (`deprecated`, `include`, `skip`) in our reserved directive names.