### PR TITLE
fix(tests): Remove unreliable code in Cypress tests

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/static-query.js
+++ b/e2e-tests/production-runtime/cypress/integration/static-query.js
@@ -1,8 +1,8 @@
-beforeEach(() => {
-  cy.visit(`/static-query/`).waitForRouteChange()
-})
-
 describe(`StaticQuery behavior`, () => {
+  beforeEach(() => {
+    cy.visit(`/static-query/`).waitForRouteChange()
+  })
+
   it(`works with inline query`, () => {
     cy.getTestElement(`inline`)
       .invoke(`text`)

--- a/e2e-tests/production-runtime/cypress/plugins/compilation-hash.js
+++ b/e2e-tests/production-runtime/cypress/plugins/compilation-hash.js
@@ -20,8 +20,11 @@ const overwriteWebpackCompilationHash = newHash => {
     .sync(path.join(__dirname, `../../public/page-data/**/page-data.json`))
     .forEach(filename => replacePageDataCompilationHash(filename, newHash))
   glob
-    .sync(path.join(__dirname, `../../public/**/index.html`))
-    .forEach(filename => replaceHtmlCompilationHash(filename, newHash))
+    .sync(path.join(__dirname, `../../public/**/*.html`))
+    .forEach(filename => {
+      if (!filename.match(/\/page-data\/[^/.]+\.html/))
+        replaceHtmlCompilationHash(filename, newHash)
+    })
 
   // cypress requires that null be returned instead of undefined
   return null

--- a/e2e-tests/production-runtime/cypress/plugins/compilation-hash.js
+++ b/e2e-tests/production-runtime/cypress/plugins/compilation-hash.js
@@ -22,6 +22,8 @@ const overwriteWebpackCompilationHash = newHash => {
   glob
     .sync(path.join(__dirname, `../../public/**/*.html`))
     .forEach(filename => {
+      // `page-data/404.html` matches the glob above but is a directory
+      // (containing `page-data.json`), so ignore this and similar dirs
       if (!filename.match(/\/page-data\/[^/.]+\.html/))
         replaceHtmlCompilationHash(filename, newHash)
     })

--- a/e2e-tests/production-runtime/cypress/plugins/index.js
+++ b/e2e-tests/production-runtime/cypress/plugins/index.js
@@ -6,15 +6,11 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
 
   on(`before:browser:launch`, (browser = {}, args) => {
-    if (browser.name === `chrome`) {
-      if (process.env.CYPRESS_CONNECTION_TYPE === `slow`) {
-        args.push(`--force-effective-connection-type=2G`)
-      }
-
-      const index = args.indexOf(`--disable-gpu`)
-      if (index !== -1) {
-        args.splice(index, 1)
-      }
+    if (
+      browser.name === `chrome` &&
+      process.env.CYPRESS_CONNECTION_TYPE === `slow`
+    ) {
+      args.push(`--force-effective-connection-type=2G`)
     }
 
     return args

--- a/e2e-tests/production-runtime/cypress/plugins/index.js
+++ b/e2e-tests/production-runtime/cypress/plugins/index.js
@@ -5,18 +5,20 @@ module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 
-  if (process.env.CYPRESS_CONNECTION_TYPE) {
-    on(`before:browser:launch`, (browser = {}, args) => {
-      if (
-        browser.name === `chrome` &&
-        process.env.CYPRESS_CONNECTION_TYPE === `slow`
-      ) {
+  on(`before:browser:launch`, (browser = {}, args) => {
+    if (browser.name === `chrome`) {
+      if (process.env.CYPRESS_CONNECTION_TYPE === `slow`) {
         args.push(`--force-effective-connection-type=2G`)
       }
 
-      return args
-    })
-  }
+      const index = args.indexOf(`--disable-gpu`)
+      if (index !== -1) {
+        args.splice(index, 1)
+      }
+    }
+
+    return args
+  })
 
   on(`task`, Object.assign({}, compilationHash, blockResources))
 }


### PR DESCRIPTION
Partially address issues in #16432:

- move `beforeEach` hook inside `describe` block to prevent it running for each test
- remove redundant `if` statement
- replace compilation hash for `404.html` and other HTML files which aren't `index.html`