### PR TITLE
tests(gatsby-transformer-react-docgen): Fix bad merge

### DIFF
--- a/packages/gatsby-transformer-react-docgen/src/__tests__/__snapshots__/on-node-create.js.snap
+++ b/packages/gatsby-transformer-react-docgen/src/__tests__/__snapshots__/on-node-create.js.snap
@@ -66,6 +66,9 @@ Array [
     },
     "type": "object",
   },
+  Object {
+    "name": "ReactNode",
+  },
 ]
 `;
 

--- a/packages/gatsby-transformer-react-docgen/src/__tests__/on-node-create.js
+++ b/packages/gatsby-transformer-react-docgen/src/__tests__/on-node-create.js
@@ -199,25 +199,6 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
 
       expect(created).toMatchSnapshot(`flow types`)
     })
-  })
-
-  describe(`tsTypes`, () => {
-    beforeEach(() => {
-      node.__fixture = `typescript.tsx`
-    })
-
-    it(`should add TS type info`, async () => {
-      await run(node, {
-        parserOpts: {
-          plugins: [`jsx`, `typescript`, `classProperties`],
-        },
-      })
-
-      const created = createdNodes.map(f => f.tsType).filter(Boolean)
-
-      expect(created).toMatchSnapshot(`typescript types`)
-    })
-
     it(`literalsAndUnion property should be union type`, async () => {
       await run(node)
       const created = createdNodes.find(f => f.name === `literalsAndUnion`)
@@ -239,6 +220,24 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
           name: `ReactNode`,
         })
       )
+    })
+  })
+
+  describe(`tsTypes`, () => {
+    beforeEach(() => {
+      node.__fixture = `typescript.tsx`
+    })
+
+    it(`should add TS type info`, async () => {
+      await run(node, {
+        parserOpts: {
+          plugins: [`jsx`, `typescript`, `classProperties`],
+        },
+      })
+
+      const created = createdNodes.map(f => f.tsType).filter(Boolean)
+
+      expect(created).toMatchSnapshot(`typescript types`)
     })
   })
 })


### PR DESCRIPTION
Did a bad merge 😞 

## What   
Behaviour is all good. Tests were broken. This fixes them!

## Why  
Glad you asked

There are three states that you have to know of:

1. https://github.com/gatsbyjs/gatsby/blob/d5ba6cc0b066ab58cc82884420f98ad333092b58/packages/gatsby-transformer-react-docgen/src/__tests__/on-node-create.js

1. https://github.com/gatsbyjs/gatsby/blob/87a2759c788ce5585d4cab80bf4f1450c80b637f/packages/gatsby-transformer-react-docgen/src/__tests__/on-node-create.js

1. https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-transformer-react-docgen/src/__tests__/on-node-create.js

We first merged https://github.com/gatsbyjs/gatsby/pull/15202/files (1 -> 2) and then https://github.com/gatsbyjs/gatsby/pull/16094/files (2 -> 3)

In that the new Flow types added in the latter PR went in the wrong section (TypeScript instead of Flow) 😂 

I spent thirty minutes scratching my bad about what went wrong and then realised that the bottom section of the file changed (after addition of TypeScript support and the associated describe block)
