### PR TITLE
feat(gatsby-remark-copy-linked-files): change default destinationDir and allow override via config

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/README.md
+++ b/packages/gatsby-remark-copy-linked-files/README.md
@@ -1,35 +1,88 @@
 # gatsby-remark-copy-linked-files
 
-Copies local files linked to/from markdown to your `public` folder.
+Copies local files linked to/from Markdown (`.md|.markdown`) files to the root directory (i.e., `public` folder).
 
-## Install
+**A sample markdown file:**
+
+```md
+---
+title: My awesome blog post
+---
+
+Hey everyone, I just made a sweet PDF with lots of interesting stuff in it.
+
+[Download it now](my-awesome-pdf.pdf)
+```
+
+**When you build your site:**
+
+The `my-awesome-pdf.pdf` file will be copied to the root directory (i.e., `public/some-really-long-contenthash/my-awesome-pdf.pdf`) and the generated HTML page will be modified to point to it.
+
+> **Note**: The `my-awesome-pdf.pdf` file should be in the same directory as the markdown file.
+
+---
+
+## Install plugin
 
 `npm install --save gatsby-remark-copy-linked-files`
 
-## How to use
+## Add plugin to Gatsby Config
 
-#### Basic usage
+**Default settings:**
+
+Add `gatsby-remark-copy-linked-files` plugin as a plugin to [`gatsby-transformer-remark`](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/):
 
 ```javascript
 // In your gatsby-config.js
+
+// add plugin by name only
 plugins: [
   {
     resolve: `gatsby-transformer-remark`,
     options: {
-      plugins: ["gatsby-remark-copy-linked-files"],
+      plugins: [`gatsby-remark-copy-linked-files`],
     },
   },
 ]
 ```
 
-### How to change the directory the files are added to.
+**Custom settings:**
 
-By default, all files will be copied to the root of the `public` dir, but you
-can choose a different location using the `destinationDir` option. Provide a
-path, relative to the `public` directory. The path must be within the public
-directory, so `path/to/dir` is fine, but `../../dir` is not.
+```js
+// In your gatsby-config.js
 
+// add plugin by name and options
+plugins: [
+  {
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      plugins: [
+        {
+          resolve: `gatsby-remark-copy-linked-files`,
+          options: {
+            destinationDir: `path/to/dir`,
+            ignoreFileExtensions: [`png`, `jpg`, `jpeg`, `bmp`, `tiff`],
+          },
+        },
+      ],
+    },
+  },
+]
 ```
+
+---
+
+## Custom set where to copy the files using `destinationDir`
+
+By default, all files will be copied to the root directory (i.e., `public` folder) in the following format: `contentHash/fileName.ext`.
+
+> For example, `[Download it now](my-awesome-pdf.pdf)` will copy the file `my-awesome-pdf.pdf` to something like `public/2a0039f3a61f4510f41678438e4c863a/my-awesome-pdf.pdf`
+
+### Simple usage
+
+To change this, set `destinationDir` to a path of your own choosing (i.e., `path/to/dir`).
+
+```js
 // In your gatsby-config.js
 plugins: [
   {
@@ -37,18 +90,95 @@ plugins: [
     options: {
       plugins: [
         {
-          resolve: 'gatsby-remark-copy-linked-files',
+          resolve: "gatsby-remark-copy-linked-files",
           options: {
-            destinationDir: 'path/to/dir',
-          }
-        }
-      ]
-    }
-  }
+            destinationDir: "path/to/dir",
+          },
+        },
+      ],
+    },
+  },
 ]
 ```
 
-### How to override which file types are ignored
+> So now, `[Download it now](my-awesome-pdf.pdf)` will copy the file `my-awesome-pdf.pdf` to `public/path/to/dir/2a0039f3a61f4510f41678438e4c863a/my-awesome-pdf.pdf`
+
+### Advanced usage
+
+For more advanced control, set `destinationDir` to a function expression using properties `name` and/or `hash` to specify the path.
+
+**Examples:**
+
+```js
+# save `my-awesome-pdf.pdf` to `public/my-awesome-pdf.pdf`
+destinationDir: f => `${f.name}`
+
+# save `my-awesome-pdf.pdf` to `public/2a0039f3a61f4510f41678438e4c863a.pdf`
+destinationDir: f => `${f.hash}`
+
+# save `my-awesome-pdf.pdf` to `public/downloads/2a0039f3a61f4510f41678438e4c863a/my-awesome-pdf.pdf`
+destinationDir: f => `downloads/${f.hash}/${f.name}`
+
+# save `my-awesome-pdf.pdf` to `public/downloads/2a0039f3a61f4510f41678438e4c863a-my-awesome-pdf.pdf`
+destinationDir: f => `downloads/${f.hash}-${f.name}`
+
+# save `my-awesome-pdf.pdf` to `public/my-awesome-pdf/2a0039f3a61f4510f41678438e4c863a.pdf`
+destinationDir: f => `${f.name}/${f.hash}`
+
+# save `my-awesome-pdf.pdf` to `public/path/to/dir/hello-my-awesome-pdf+2a0039f3a61f4510f41678438e4c863a_world.pdf`
+destinationDir: f => `path/to/dir/hello-${f.name}+${f.hash}_world`
+```
+
+> **Note:** Make sure you use either `name` or `hash` property in your function expression!
+> If you don't include both `name` and `hash` properties in your function expression, `gatsby-remark-copy-linked-files` plugin will resolve the function expression to a string value and use default settings as a fallback mechanism to prevent your local files from getting copied with the same name (causing files to get overwritten).
+
+```js
+# Note: `my-awesome-pdf.pdf` is saved to `public/hello/2a0039f3a61f4510f41678438e4c863a/my-awesome-pdf.pdf`
+# because `name` and `hash` properties are not referenced in the function expression.
+# So these function expressions are treated the same way
+destinationDir: _ => `hello`
+destinationDir: `hello`
+```
+
+### Caveat: Error thrown if `destinationDir` points outside the root directory (i.e. `public` folder)
+
+> **Note:** An error will be thrown if the destination points outside the root directory (i.e. `public` folder).
+
+**Correct:**
+
+```js
+# saves to `public/path/to/dir/`
+destinationDir: `path/to/dir`
+
+# saves to `public/path/to/dir/`
+destinationDir: _ => `path/to/dir`
+
+# saves to `public/path/to/dir/fileName.ext`
+destinationDir: f => `path/to/dir/${f.name}`
+
+# saves to `public/contentHash.ext`
+destinationDir: f => `${f.hash}`
+```
+
+**Error thrown:**
+
+```js
+# cannot save outside root directory (i.e., outside `public` folder)
+destinationDir: `../path/to/dir`
+destinationDir: _ => `../path/to/dir`
+destinationDir: f => `../path/to/dir/${f.name}`
+destinationDir: f => `../${f.hash}`
+```
+
+---
+
+### Custom set which file types to ignore using `ignoreFileExtensions`
+
+By default, the file types that this plugin ignores are: `png`, `jpg`, `jpeg`, `bmp`, `tiff`.
+
+> For example, `[Download it now](image.png)` will be ignored and not copied to the root dir (i.e. `public` folder)
+
+To change this, set `ignoreFileExtensions` to an array of extensions to ignore (i.e., an empty array `[]` to ignore nothing).
 
 ```javascript
 // In your gatsby-config.js
@@ -77,28 +207,14 @@ plugins: [
 ]
 ```
 
-Then in your Markdown files, link to the file you desire to reference.
+> So now, `[Download it now](image.png)` will be copied to the root dir (i.e. `public` folder)
 
-E.g.
-
-```markdown
 ---
-title: My awesome blog post
----
-
-Hey everyone, I just made a sweet PDF with lots of interesting stuff in it.
-
-[Download it now](my-awesome-pdf.pdf)
-```
-
-`my-awesome-pdf.pdf` should be in the same directory as the markdown file. When
-you build your site, the file will be copied to the `public` folder and the
-markdown HTML will be modified to point to it.
 
 ### Supported Markdown tags
 
-- img
-- link
+- img - `![Image](my-img.png)`
+- link - `[Link](myFile.txt)`
 
 ### Supported HTML tags
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

change default destinationDir & make it customizable

<!-- Write a brief description of the changes introduced by this PR -->

1. change the default destination format from `filename-hash.ext` to `hash/filename.ext`
2. allow customization of the destination format:
    ```js
    destinationDir: f => `${f.hash}/${f.name}`  // f7fbd/myfile.txt
    destinationDir: f => `${f.name}-${f.hash}`  // myfile-f7fbd.txt
    destinationDir: f => `foo${f.hash}---${f.name}bar`  // foof7fbd---myfilebar.txt
    destinationDir: f => `foo${f.hash}/${f.name}bar`  // foof7fbd/myfilebar.txt
    ```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

https://github.com/gatsbyjs/gatsby/issues/10048