### PR TITLE
docs(gatsby-plugin-sass): Improve example configuration 

### DIFF
--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -139,7 +139,7 @@ plugins: [
       // Override the file regex for SASS
       sassRuleTest: /\.global\.s(a|c)ss$/,
       // Override the file regex for CSS modules
-      sassRuleModulesTest: /\.global\.s(a|c)ss$/,
+      sassRuleModulesTest: /\.mod\.s(a|c)ss$/,
     },
   },
 ]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
- `sassRuleModulesTest` selects files that will be loaded via css modules. Having `global` in the filename is misleading as global is usually used for global style sheets.
- The configuration in the example have the same test for both rules. Which one will webpack use for loading `*.global.scss` files ?

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/15879
https://github.com/gatsbyjs/gatsby/pull/16494
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->