### PR TITLE
docs(gatsby-transformer-remark): Add section for excerpts in MD with HTML

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -262,10 +262,10 @@ Edit your Markdown files to include that HTML tag after the text you'd like to a
 title: "my little pony"
 date: "2017-09-18T23:19:51.246Z"
 ---
+
 <p>Where oh where is that pony?</p>
 <!-- endexcerpt -->
 <p>Is he in the stable or down by the stream?</p>
-
 ```
 
 Then specify `MARKDOWN` as the format in your graphql query:

--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -211,7 +211,7 @@ You can also get excerpts in Markdown format.
 
 ### Example: Excerpts
 
-If you don't want to use `pruneLength` for excerpts but a custom separator, you can specify an `excerpt_separator`:
+If you don't want to use `pruneLength` for excerpts but a custom separator, you can specify an `excerpt_separator` in the `gatsby-config.js` file:
 
 ```javascript
 {
@@ -236,6 +236,44 @@ If that is the case, you can set `truncate` option on `excerpt` field, like:
 {
   markdownRemark {
     excerpt(truncate: true)
+  }
+}
+```
+
+### Excerpts for HTML embedded in Markdown files
+
+If your Markdown file contains HTML `except` will not return a value.
+
+In that case, you can set an `excerpt_separator` in the `gatsby-config.js` file:
+
+```javascript
+{
+  "resolve": `gatsby-transformer-remark`,
+  "options": {
+    "excerpt_separator": `<!-- endexcerpt -->`
+  }
+}
+```
+
+Edit your Markdown files to include that HTML tag after the text you'd like to appear in the excerpt:
+
+```markdown
+---
+title: "my little pony"
+date: "2017-09-18T23:19:51.246Z"
+---
+<p>Where oh where is that pony?</p>
+<!-- endexcerpt -->
+<p>Is he in the stable or down by the stream?</p>
+
+```
+
+Then specify `MARKDOWN` as the format in your graphql query:
+
+```graphql
+{
+  markdownRemark {
+    excerpt(format: MARKDOWN)
   }
 }
 ```


### PR DESCRIPTION
## Description

I found `excerpt` would return an empty string when my markdown files began with HTML (which I think is still valid Markdown?) So I thought I should document how I got it to work.

## Related Issues