### PR TITLE
fix(gatsby-plugin-postcss): Always ensure postcss.config.js is loaded

### DIFF
--- a/packages/gatsby-plugin-postcss/src/__tests__/__snapshots__/gatsby-node.test.js.snap
+++ b/packages/gatsby-plugin-postcss/src/__tests__/__snapshots__/gatsby-node.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gatsby-plugin-postcss Stage: build-html / No options 1`] = `
+exports[`gatsby-plugin-postcss Stage: build-html / Css options 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -12,46 +12,7 @@ exports[`gatsby-plugin-postcss Stage: build-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      },
-    ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -63,32 +24,13 @@ exports[`gatsby-plugin-postcss Stage: build-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "sourceMap": false,
-                      },
-                    },
+                    "null-loader",
                   ],
                 },
-              ],
-            },
-          ],
-        },
-      },
-    ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -103,12 +45,95 @@ exports[`gatsby-plugin-postcss Stage: build-html / No options 1`] = `
                     "null-loader",
                   ],
                 },
+                Object {
+                  "test": /\\\\\\.module\\\\\\.css\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    Object {
+                      "loader": "/resolved/path/postcss-loader",
+                      "options": Object {
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.css\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    Object {
+                      "loader": "/resolved/path/postcss-loader",
+                      "options": Object {
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.module\\\\\\.css\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    Object {
+                      "loader": "/resolved/path/postcss-loader",
+                      "options": Object {
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.css\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    Object {
+                      "loader": "/resolved/path/postcss-loader",
+                      "options": Object {
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "loaders": Array [
+                    "css-loader",
+                  ],
+                  "test": /\\\\\\.css\\$/,
+                },
+                Object {
+                  "loaders": Array [
+                    "css-loader",
+                  ],
+                  "test": /\\\\\\.module\\\\\\.css\\$/,
+                },
+              ],
+            },
+            Object {
+              "test": /\\\\\\.js/,
+              "use": Array [
+                "babel-loader",
               ],
             },
           ],
         },
       },
     ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-postcss Stage: build-html / No options 1`] = `
+[MockFunction] {
+  "calls": Array [
     Array [
       Object {
         "module": Object {
@@ -141,18 +166,6 @@ exports[`gatsby-plugin-postcss Stage: build-html / No options 1`] = `
     ],
   ],
   "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
     Object {
       "type": "return",
       "value": undefined,
@@ -300,6 +313,19 @@ exports[`gatsby-plugin-postcss Stage: build-html / PostCss options 1`] = `
         },
       },
     ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-postcss Stage: build-javascript / Css options 1`] = `
+[MockFunction] {
+  "calls": Array [
     Array [
       Object {
         "module": Object {
@@ -309,56 +335,11 @@ exports[`gatsby-plugin-postcss Stage: build-html / PostCss options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
                         "sourceMap": false,
                       },
                     },
@@ -368,13 +349,10 @@ exports[`gatsby-plugin-postcss Stage: build-html / PostCss options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
                         "sourceMap": false,
                       },
                     },
@@ -384,14 +362,11 @@ exports[`gatsby-plugin-postcss Stage: build-html / PostCss options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
+                        "sourceMap": true,
                       },
                     },
                   ],
@@ -400,286 +375,11 @@ exports[`gatsby-plugin-postcss Stage: build-html / PostCss options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.css\\$/,
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                },
-              ],
-            },
-            Object {
-              "test": /\\\\\\.js/,
-              "use": Array [
-                "babel-loader",
-              ],
-            },
-          ],
-        },
-      },
-    ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.css\\$/,
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                },
-              ],
-            },
-            Object {
-              "test": /\\\\\\.js/,
-              "use": Array [
-                "babel-loader",
-              ],
-            },
-          ],
-        },
-      },
-    ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
+                        "sourceMap": true,
                       },
                     },
                   ],
@@ -710,18 +410,6 @@ exports[`gatsby-plugin-postcss Stage: build-html / PostCss options 1`] = `
     ],
   ],
   "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
     Object {
       "type": "return",
       "value": undefined,
@@ -747,44 +435,6 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      },
-    ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
                         "sourceMap": false,
                       },
                     },
@@ -811,10 +461,6 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / No options 1`] = `
     ],
   ],
   "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
     Object {
       "type": "return",
       "value": undefined,
@@ -920,6 +566,19 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / PostCss options 1`] = `
         },
       },
     ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-postcss Stage: develop / Css options 1`] = `
+[MockFunction] {
+  "calls": Array [
     Array [
       Object {
         "module": Object {
@@ -930,14 +589,11 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / PostCss options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
+                        "sourceMap": true,
                       },
                     },
                   ],
@@ -946,46 +602,11 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / PostCss options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
+                        "sourceMap": true,
                       },
                     },
                   ],
@@ -1016,10 +637,6 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / PostCss options 1`] = `
     ],
   ],
   "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
     Object {
       "type": "return",
       "value": undefined,
@@ -1154,7 +771,7 @@ exports[`gatsby-plugin-postcss Stage: develop / PostCss options 1`] = `
 }
 `;
 
-exports[`gatsby-plugin-postcss Stage: develop-html / No options 1`] = `
+exports[`gatsby-plugin-postcss Stage: develop-html / Css options 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -1166,8 +783,7 @@ exports[`gatsby-plugin-postcss Stage: develop-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -1179,33 +795,14 @@ exports[`gatsby-plugin-postcss Stage: develop-html / No options 1`] = `
                 Object {
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "sourceMap": true,
-                      },
-                    },
+                    "null-loader",
                   ],
                 },
-              ],
-            },
-          ],
-        },
-      },
-    ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -1218,7 +815,7 @@ exports[`gatsby-plugin-postcss Stage: develop-html / No options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -1227,12 +824,69 @@ exports[`gatsby-plugin-postcss Stage: develop-html / No options 1`] = `
                     },
                   ],
                 },
+                Object {
+                  "test": /\\\\\\.module\\\\\\.css\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    Object {
+                      "loader": "/resolved/path/postcss-loader",
+                      "options": Object {
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.css\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    Object {
+                      "loader": "/resolved/path/postcss-loader",
+                      "options": Object {
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "loaders": Array [
+                    "css-loader",
+                  ],
+                  "test": /\\\\\\.css\\$/,
+                },
+                Object {
+                  "loaders": Array [
+                    "css-loader",
+                  ],
+                  "test": /\\\\\\.module\\\\\\.css\\$/,
+                },
+              ],
+            },
+            Object {
+              "test": /\\\\\\.js/,
+              "use": Array [
+                "babel-loader",
               ],
             },
           ],
         },
       },
     ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-postcss Stage: develop-html / No options 1`] = `
+[MockFunction] {
+  "calls": Array [
     Array [
       Object {
         "module": Object {
@@ -1265,14 +919,6 @@ exports[`gatsby-plugin-postcss Stage: develop-html / No options 1`] = `
     ],
   ],
   "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
     Object {
       "type": "return",
       "value": undefined,
@@ -1399,246 +1045,8 @@ exports[`gatsby-plugin-postcss Stage: develop-html / PostCss options 1`] = `
         },
       },
     ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.css\\$/,
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                },
-              ],
-            },
-            Object {
-              "test": /\\\\\\.js/,
-              "use": Array [
-                "babel-loader",
-              ],
-            },
-          ],
-        },
-      },
-    ],
-    Array [
-      Object {
-        "module": Object {
-          "rules": Array [
-            Object {
-              "oneOf": Array [
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "null-loader",
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1,\\"modules\\":true})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "test": /\\\\\\.css\\$/,
-                  "use": Array [
-                    "miniCssExtract",
-                    "css-loader({\\"importLoaders\\":1})",
-                    Object {
-                      "loader": "/resolved/path/postcss-loader",
-                      "options": Object {
-                        "plugins": Array [
-                          "autoprefixer",
-                        ],
-                        "sourceMap": false,
-                      },
-                    },
-                  ],
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.css\\$/,
-                },
-                Object {
-                  "loaders": Array [
-                    "css-loader",
-                  ],
-                  "test": /\\\\\\.module\\\\\\.css\\$/,
-                },
-              ],
-            },
-            Object {
-              "test": /\\\\\\.js/,
-              "use": Array [
-                "babel-loader",
-              ],
-            },
-          ],
-        },
-      },
-    ],
   ],
   "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
     Object {
       "type": "return",
       "value": undefined,

--- a/packages/gatsby-plugin-postcss/src/__tests__/__snapshots__/gatsby-node.test.js.snap
+++ b/packages/gatsby-plugin-postcss/src/__tests__/__snapshots__/gatsby-node.test.js.snap
@@ -12,7 +12,7 @@ exports[`gatsby-plugin-postcss Stage: build-html / Css options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -30,7 +30,7 @@ exports[`gatsby-plugin-postcss Stage: build-html / Css options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -49,7 +49,7 @@ exports[`gatsby-plugin-postcss Stage: build-html / Css options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -62,7 +62,7 @@ exports[`gatsby-plugin-postcss Stage: build-html / Css options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -75,7 +75,7 @@ exports[`gatsby-plugin-postcss Stage: build-html / Css options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -88,7 +88,7 @@ exports[`gatsby-plugin-postcss Stage: build-html / Css options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -336,7 +336,7 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / Css options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -349,7 +349,7 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / Css options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -362,7 +362,7 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / Css options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -375,7 +375,7 @@ exports[`gatsby-plugin-postcss Stage: build-javascript / Css options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -589,7 +589,7 @@ exports[`gatsby-plugin-postcss Stage: develop / Css options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -602,7 +602,7 @@ exports[`gatsby-plugin-postcss Stage: develop / Css options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -783,7 +783,7 @@ exports[`gatsby-plugin-postcss Stage: develop-html / Css options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -802,7 +802,7 @@ exports[`gatsby-plugin-postcss Stage: develop-html / Css options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -815,7 +815,7 @@ exports[`gatsby-plugin-postcss Stage: develop-html / Css options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -828,7 +828,7 @@ exports[`gatsby-plugin-postcss Stage: develop-html / Css options 1`] = `
                   "test": /\\\\\\.module\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1,\\"modules\\":true})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1,\\"modules\\":true})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {
@@ -841,7 +841,7 @@ exports[`gatsby-plugin-postcss Stage: develop-html / Css options 1`] = `
                   "test": /\\\\\\.css\\$/,
                   "use": Array [
                     "miniCssExtract",
-                    "css-loader({\\"camelCase\\":\\"true\\",\\"importLoaders\\":1})",
+                    "css-loader({\\"camelCase\\":true,\\"importLoaders\\":1})",
                     Object {
                       "loader": "/resolved/path/postcss-loader",
                       "options": Object {

--- a/packages/gatsby-plugin-postcss/src/__tests__/gatsby-node.test.js
+++ b/packages/gatsby-plugin-postcss/src/__tests__/gatsby-node.test.js
@@ -19,7 +19,7 @@ describe(`gatsby-plugin-postcss`, () => {
     options: {
       "No options": {},
       "PostCss options": { postCssPlugins: [`autoprefixer`], sourceMap: false },
-      "Css options": { cssLoaderOptions: { camelCase: `true` } },
+      "Css options": { cssLoaderOptions: { camelCase: true } },
     },
     configs: {
       "No options": jest.fn().mockReturnValue({

--- a/packages/gatsby-plugin-postcss/src/__tests__/gatsby-node.test.js
+++ b/packages/gatsby-plugin-postcss/src/__tests__/gatsby-node.test.js
@@ -19,6 +19,7 @@ describe(`gatsby-plugin-postcss`, () => {
     options: {
       "No options": {},
       "PostCss options": { postCssPlugins: [`autoprefixer`], sourceMap: false },
+      "Css options": { cssLoaderOptions: { camelCase: `true` } },
     },
     configs: {
       "No options": jest.fn().mockReturnValue({
@@ -53,12 +54,40 @@ describe(`gatsby-plugin-postcss`, () => {
           ],
         },
       }),
+      "Css options": jest.fn().mockReturnValue({
+        module: {
+          rules: [
+            {
+              oneOf: [
+                {
+                  test: /\.css$/,
+                  loaders: [`css-loader`],
+                },
+                {
+                  test: /\.module\.css$/,
+                  loaders: [`css-loader`],
+                },
+              ],
+            },
+            {
+              test: /\.js/,
+              use: [`babel-loader`],
+            },
+          ],
+        },
+      }),
     },
     actions: {
       "No options": actions.setWebpackConfig,
       "PostCss options": actions.replaceWebpackConfig,
+      "Css options": actions.replaceWebpackConfig,
     },
   }
+
+  beforeEach(() => {
+    actions.setWebpackConfig.mockClear()
+    actions.replaceWebpackConfig.mockClear()
+  })
 
   tests.stages.forEach(stage => {
     for (const label in tests.options) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

If you specify `cssLoaderOptions` then `postcss-loader` wound not picked up `postcss.config.js` config.

The `postcssOptions` options would contain `cssLoaderOptions` property (`{cssLoaderOptions: {...}}`) and `postcss-loader` gets it as is and does not use some built-in defaults.

This PR aims to fix that and also add some code-style adjustments to align with existing codebase.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

https://github.com/gatsbyjs/gatsby/pull/10861