### PR TITLE
docs(gatsby-plugin-sass): Update default precision

### DIFF
--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -85,7 +85,7 @@ plugins: [
 
 ### SASS Precision
 
-SASS defaults to [5 digits of precision](https://github.com/sass/sass/issues/1122). If this is too low for you (e.g. if you use Bootstrap), you may configure it as follows:
+SASS defaults to [10 digits of precision](https://github.com/sass/sass/issues/1122). If this is too low for you (e.g. if you use Bootstrap), you may configure it as follows:
 
 #### Bootstrap 4
 


### PR DESCRIPTION
SASS precision default is 10.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
