### PR TITLE
docs(visual-testing-with-storybook): Update static file directory

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -164,8 +164,8 @@ However, if you use `StaticQuery` or `useStaticQuery` in your project Storybook 
 ```json:title=package.json
 {
   "scripts": {
-    "storybook": "NODE_ENV=production start-storybook -s static",
-    "build-storybook": "NODE_ENV=production build-storybook -s static"
+    "storybook": "NODE_ENV=production start-storybook -s public",
+    "build-storybook": "NODE_ENV=production build-storybook -s public"
   }
 }
 ```


### PR DESCRIPTION
## Description

Change the static file directory in the storybook docs to "public". I don't know if this is a mistake, or the doc is outdated, but the static files from Gatsby, AFAIK go in a directory called public, in which there is a directory called static. This can lead to confusion (definitely confused me, maybe because I am new to Gatsby)

## Related Issues

None
