### PR TITLE
docs(tutorial-part-four): missing plugins

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -224,8 +224,10 @@ module.exports = {
   },
   // highlight-end
   plugins: [
+    // highlight-start
     `gatsby-transformer-sharp`,
 		`gatsby-plugin-sharp`,
+    // highlight-end
     `gatsby-plugin-emotion`,
     {
       resolve: `gatsby-plugin-typography`,

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -224,6 +224,8 @@ module.exports = {
   },
   // highlight-end
   plugins: [
+    `gatsby-transformer-sharp`,
+		`gatsby-plugin-sharp`,
     `gatsby-plugin-emotion`,
     {
       resolve: `gatsby-plugin-typography`,


### PR DESCRIPTION
## Description

In "Your first GraphQL query" section in configuration of gatsby-config.js file, plugins: gatsby-transformer-sharp & gatsby-plugin-sharp are not included. Without them gatsby throws #85901 error.