### PR TITLE
chore(showcase): add Grüne Dresden site

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -6898,3 +6898,14 @@
   built_by: Joeri Smits
   built_by_url: https://joeri.dev
   featured: false
+- title: Grüne Dresden
+  main_url: https://ltw19dresden.de
+  url: https://ltw19dresden.de
+  description: >
+    This site was built for the Green Party in Germany (Bündnis 90/Die Grünen) for their local election in Dresden, Saxony. The site was built with Gatsby v2 and Styled-Components.
+  categories:
+    - Government
+    - Nonprofit
+  built_by: Jacob Herper
+  built_by_url: https://herper.io
+  featured: false


### PR DESCRIPTION
## Description

This site was built for the Green Party in Germany (Bündnis 90/Die Grünen) for their local election in Dresden, Saxony. The site was built with Gatsby v2 and Styled-Components.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
