### PR TITLE
fix(gatsby-plugin-mdx): Raise error if MDXRenderer receives undefined or null

### DIFF
--- a/packages/gatsby-plugin-mdx/mdx-renderer.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.js
@@ -8,8 +8,8 @@ module.exports = function MDXRenderer({
   children,
   ...props
 }) {
-  if (typeof children === 'undefined') {
-    throw new Error('MDXRenderer expected to receive an MDX string. Instead it received "undefined"')
+  if (!children) {
+    throw new Error(`MDXRenderer expected to receive an MDX String in children. Instead, it received: ${children}`)
   }
 
   const mdxComponents = useMDXComponents(components);

--- a/packages/gatsby-plugin-mdx/mdx-renderer.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.js
@@ -8,6 +8,10 @@ module.exports = function MDXRenderer({
   children,
   ...props
 }) {
+  if (typeof children === 'undefined') {
+    throw new Error('MDXRenderer expected to receive an MDX string. Instead it received "undefined"')
+  }
+
   const mdxComponents = useMDXComponents(components);
   const mdxScope = useMDXScope(scope);
 

--- a/packages/gatsby-plugin-mdx/mdx-renderer.test.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.test.js
@@ -14,4 +14,14 @@ describe("mdx-renderer", () => {
 
     expect(result.toJSON()).toEqual({ type: "div", props: {}, children: null });
   });
+
+  test("provides a useful error message when no mdx is passed", () => {
+    const expectedErrorMessage = 'MDXRenderer expected to receive an MDX string. Instead it received "undefined"';
+
+    const renderUndefined = () => {
+      TestRenderer.create(<MDXRenderer scope={{ React: React }} />);
+    }
+
+    expect(renderUndefined).toThrowError(expectedErrorMessage);
+  });
 });

--- a/packages/gatsby-plugin-mdx/mdx-renderer.test.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.test.js
@@ -16,7 +16,7 @@ describe("mdx-renderer", () => {
   });
 
   test("provides a useful error message when no mdx is passed", () => {
-    const expectedErrorMessage = 'MDXRenderer expected to receive an MDX string. Instead it received "undefined"';
+    const expectedErrorMessage = 'MDXRenderer expected to receive an MDX String in children. Instead, it received: undefined';
 
     const renderUndefined = () => {
       TestRenderer.create(<MDXRenderer scope={{ React: React }} />);


### PR DESCRIPTION
We should validate that MDXRenderer receives a transpiled MDX
string. If we don't, we should error out with a useful error
message.

This is related to #16481, but doesn't completely solve all causes.
An additional PR will follow later.