### PR TITLE
fix(gatsby-theme-notes): Render correct breadcrumb path based on basePath

### DIFF
--- a/themes/gatsby-theme-notes/src/components/breadcrumbs.js
+++ b/themes/gatsby-theme-notes/src/components/breadcrumbs.js
@@ -8,6 +8,7 @@ import BreadcrumbHome from "./breadcrumb-home"
 
 export default ({ links }) => {
   const { basePath = `/`, homeText, breadcrumbSeparator } = useOptions()
+  const baseBreadcrumbText = basePath.replace(/^\//, ``)
 
   return (
     <nav
@@ -23,11 +24,13 @@ export default ({ links }) => {
       <BreadcrumbDivider text={breadcrumbSeparator} />
 
       <Styled.a as={Link} to={basePath}>
-        {basePath.replace(/^\//, ``)}
+        {baseBreadcrumbText}
       </Styled.a>
       {links.map(link => (
         <>
-          <BreadcrumbDivider text={breadcrumbSeparator} />
+          {baseBreadcrumbText.length ? (
+            <BreadcrumbDivider text={breadcrumbSeparator} />
+          ) : null}
           <Styled.a as={Link} to={link.url} key={link.url}>
             {link.name}
           </Styled.a>


### PR DESCRIPTION
## Description

In scenarios where the `basePath` option is not provided, it defaults to `"/"`. When this happens, the breadcrumbs render as such:

```
~ / / example-dir
```

This is due to a regex replacement that causes the base breadcrumb text to be an empty string:

```js
basePath.replace(/^\//, ``)
```

The initial breadcrumb divider should only render if there is a custom basePath (or more importantly, if the basePath has a text length). This results in proper breadcrumb text:

```
~ / example-dir
```

## Related Issues

Closes https://github.com/gatsbyjs/gatsby/issues/15493
