### PR TITLE
Fix graphql import in template-feature-comparison.js

### DIFF
--- a/www/src/templates/template-feature-comparison.js
+++ b/www/src/templates/template-feature-comparison.js
@@ -14,6 +14,8 @@ import { itemListFeatures } from "../utils/sidebar/item-list"
 import { getFeaturesData } from "../utils/get-csv-features-data"
 import { space } from "../utils/presets"
 
+import { graphql } from "gatsby"
+
 class FeatureComparison extends Component {
   render() {
     const {


### PR DESCRIPTION
## Description

Building the Gatsby site throws the following warning:
```shell
warn Using the global `graphql` tag is deprecated, and will not be supported in v3.
Import it instead like:  import { graphql } from 'gatsby' in file:
/Users/juho/Documents/Koodei/gatsby/www/src/templates/template-feature-comparison.js
```

This PR fixes this error by importing graphql the way the error message suggests.

## Related Issues

No related issue.
