### PR TITLE
fix(gatsby-theme-notes): Use basePath as home breadcrumb link

### DIFF
--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -74,7 +74,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        mdPlugins: [capitalize, emoji],
+        remarkPlugins: [capitalize, emoji],
       },
     },
   ],

--- a/themes/gatsby-theme-notes/src/components/breadcrumb-home.js
+++ b/themes/gatsby-theme-notes/src/components/breadcrumb-home.js
@@ -2,8 +2,14 @@ import React from "react"
 import { Link } from "gatsby"
 import { Styled } from "theme-ui"
 
-export default ({ text }) => (
-  <Styled.a as={Link} to="/">
-    {text}
-  </Styled.a>
-)
+import useOptions from "../use-options"
+
+export default ({ text }) => {
+  const { basePath } = useOptions()
+
+  return (
+    <Styled.a as={Link} to={basePath}>
+      {text}
+    </Styled.a>
+  )
+}

--- a/themes/gatsby-theme-notes/src/components/breadcrumbs.js
+++ b/themes/gatsby-theme-notes/src/components/breadcrumbs.js
@@ -7,8 +7,7 @@ import BreadcrumbDivider from "./breadcrumb-divider"
 import BreadcrumbHome from "./breadcrumb-home"
 
 export default ({ links }) => {
-  const { basePath = `/`, homeText, breadcrumbSeparator } = useOptions()
-  const baseBreadcrumbText = basePath.replace(/^\//, ``)
+  const { homeText, breadcrumbSeparator } = useOptions()
 
   return (
     <nav
@@ -21,16 +20,9 @@ export default ({ links }) => {
       })}
     >
       <BreadcrumbHome text={homeText} />
-      <BreadcrumbDivider text={breadcrumbSeparator} />
-
-      <Styled.a as={Link} to={basePath}>
-        {baseBreadcrumbText}
-      </Styled.a>
       {links.map(link => (
         <>
-          {baseBreadcrumbText.length ? (
-            <BreadcrumbDivider text={breadcrumbSeparator} />
-          ) : null}
+          <BreadcrumbDivider text={breadcrumbSeparator} />
           <Styled.a as={Link} to={link.url} key={link.url}>
             {link.name}
           </Styled.a>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Use the `basePath` option in `gatsby-theme-notes` to construct the link of the home breadcrumb icon.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/15494
