### PR TITLE
fix(gatsby): check if navigator.connection is defined

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -88,7 +88,10 @@ const loadPageDataJson = loadObj => {
 }
 
 const doesConnectionSupportPrefetch = () => {
-  if (`connection` in navigator) {
+  if (
+    `connection` in navigator &&
+    typeof navigator.connection !== `undefined`
+  ) {
     if ((navigator.connection.effectiveType || ``).includes(`2g`)) {
       return false
     }


### PR DESCRIPTION
Some of our users report an error via Bugsnag that `navigator.connection`
is undefined. This issue seems to specifically occur in Chrome 69 in
Windows 7.

## Description

Adds a check for undefined on `navigator.connection` in `loader.js`, in addition to checking if the key exists.

![image](https://user-images.githubusercontent.com/394435/62924753-0c049a00-bdb1-11e9-8c9f-7999ccffe2b8.png)

![image](https://user-images.githubusercontent.com/394435/62924764-13c43e80-bdb1-11e9-8701-c1259ed70479.png)