### PR TITLE
fix(gatsby): adjust regex to handle MODULE_NOT_FOUND errors thrown by Bazel

### DIFF
--- a/packages/gatsby/src/utils/__tests__/test-require-error.js
+++ b/packages/gatsby/src/utils/__tests__/test-require-error.js
@@ -37,4 +37,36 @@ describe(`test-require-error`, () => {
       )
     }
   })
+
+  describe(`handles error message thrown by Bazel`, () => {
+    it(`detects require errors`, () => {
+      const bazelModuleNotFoundError = new Error(`Error: //:build_bin cannot find module './fixtures/module-does-not-exist' required by '/private/var/tmp/_bazel_misiek/eba1803983a26276494495d851e478a5/execroot/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/build.runfiles/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/node_modules/gatsby/dist/bootstrap/get-config-file.js'
+      looked in:
+        built-in, relative, absolute, nested node_modules - Error: Cannot find module './fixtures/module-does-not-exist'
+        runfiles - Error: Cannot find module '/private/var/tmp/_bazel_misiek/eba1803983a26276494495d851e478a5/execroot/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/build.runfiles/fixtures/module-does-not-exist'
+        node_modules attribute (com_github_bweston92_debug_gatsby_bazel_rules_nodejs/node_modules) - Error: Cannot find module '/private/var/tmp/_bazel_misiek/eba1803983a26276494495d851e478a5/execroot/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/build.runfiles/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/node_modules/fixtures/module-does-not-exist'`)
+
+      expect(
+        testRequireError(
+          `./fixtures/module-does-not-exist`,
+          bazelModuleNotFoundError
+        )
+      ).toEqual(true)
+    })
+
+    it(`detects require errors`, () => {
+      const bazelModuleNotFoundError = new Error(`Error: //:build_bin cannot find module 'cheese' required by '/private/var/tmp/_bazel_misiek/eba1803983a26276494495d851e478a5/execroot/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/build.runfiles/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/node_modules/gatsby/dist/bootstrap/fixtures/bad-module-require.js'
+      looked in:
+        built-in, relative, absolute, nested node_modules - Error: Cannot find module 'cheese'
+        runfiles - Error: Cannot find module '/private/var/tmp/_bazel_misiek/eba1803983a26276494495d851e478a5/execroot/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/build.runfiles/cheese'
+        node_modules attribute (com_github_bweston92_debug_gatsby_bazel_rules_nodejs/node_modules) - Error: Cannot find module '/private/var/tmp/_bazel_misiek/eba1803983a26276494495d851e478a5/execroot/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/build.runfiles/com_github_bweston92_debug_gatsby_bazel_rules_nodejs/node_modules/cheese'`)
+
+      expect(
+        testRequireError(
+          `./fixtures/bad-module-require`,
+          bazelModuleNotFoundError
+        )
+      ).toEqual(false)
+    })
+  })
 })

--- a/packages/gatsby/src/utils/test-require-error.js
+++ b/packages/gatsby/src/utils/test-require-error.js
@@ -5,7 +5,8 @@ export default (moduleName, err) => {
   // dependency tree rules but the requested file doesn't exist
   if (
     err.code === `QUALIFIED_PATH_RESOLUTION_FAILED` ||
-    err.pnpCode === `QUALIFIED_PATH_RESOLUTION_FAILED`
+    err.pnpCode === `QUALIFIED_PATH_RESOLUTION_FAILED` ||
+    err.code === `MODULE_NOT_FOUND`
   ) {
     return true
   }

--- a/packages/gatsby/src/utils/test-require-error.js
+++ b/packages/gatsby/src/utils/test-require-error.js
@@ -5,14 +5,13 @@ export default (moduleName, err) => {
   // dependency tree rules but the requested file doesn't exist
   if (
     err.code === `QUALIFIED_PATH_RESOLUTION_FAILED` ||
-    err.pnpCode === `QUALIFIED_PATH_RESOLUTION_FAILED` ||
-    err.code === `MODULE_NOT_FOUND`
+    err.pnpCode === `QUALIFIED_PATH_RESOLUTION_FAILED`
   ) {
     return true
   }
 
   const regex = new RegExp(
-    `Error: Cannot find module\\s.${moduleName.replace(
+    `Error:\\s(\\S+\\s)?[Cc]annot find module\\s.${moduleName.replace(
       /[-/\\^$*+?.()|[\]{}]/g,
       `\\$&`
     )}`


### PR DESCRIPTION
## Description

I have been trying to build my Gatsby site with Bazel. However `rules_nodejs` patches the loader script. They return an error that is not caught by Gatsby correctly. Upon further investigation Bazel is throwing an error that is return with a code `MODULE_NOT_FOUND` which is actually the same as Node's own loader script.

--

The MODULE_NOT_FOUND error is provided by a loader script when the module is not found.

References to loaders:
- **Bazel rules_nodejs** - https://github.com/bazelbuild/rules_nodejs/blob/968b3a35cf6e4e3bf20fae70f7461514e28f24e6/internal/node/node_loader.js#L473
- **Nodes internal** - https://github.com/nodejs/node/blob/a49b20d3245dd2a4d890e28582f3c013c07c3136/lib/internal/modules/cjs/loader.js#L268
