### PR TITLE
docs(gatsby-plugin-mdx): Change "mdPlugins" to "remarkPlugins"

### DIFF
--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -74,7 +74,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        mdPlugins: [capitalize, emoji],
+        remarkPlugins: [capitalize, emoji],
       },
     },
   ],


### PR DESCRIPTION
The underlying mdx/remark code appears to have stopped honoring `mdPlugins` as an option name. This updates it to `remarkPlugins`, the current name of the option.

## Description

Despite still being marked as "deprecated", the `mdOptions` plugin option seems to no longer work. Replacing with `remarkPlugins` appears to have solved my problem. Updating the docs to reflect this.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
