### PR TITLE
docs(categories): Add categories for Gallery and Infinite Scroll

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -22,6 +22,7 @@ starter:
   - Google Sheets
   - HTML5UP
   - i18n
+  - Infinite Scroll
   - Landing Page
   - Language:Other
   - Language:TypeScript
@@ -32,6 +33,7 @@ starter:
   - Official
   - Onepage
   - Pagination
+  - Photos
   - Portfolio
   - Presentation
   - PWA

--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -19,6 +19,7 @@ starter:
   - Documentation
   - eCommerce
   - Firebase
+  - Gallery
   - Google Sheets
   - HTML5UP
   - i18n
@@ -33,7 +34,6 @@ starter:
   - Official
   - Onepage
   - Pagination
-  - Photos
   - Portfolio
   - Presentation
   - PWA


### PR DESCRIPTION
I recently created a starter and noticed that none of the current tags are suitable for it. But tags are required and it's not possible to add a starter without marking tags to it (even if it was possible, people wouldn't find it without tags). This is why I would like to add new tags "Infinite Scroll" and "Gallery". I think both of these tags are fairly generic and applicable to many other projects besides my starter.

The starter is here: https://github.com/baobabKoodaa/gatsby-starter-photo-book