### PR TITLE
Added support to override style on revealed image

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -381,6 +381,7 @@ class Image extends React.Component {
       itemProp,
       loading,
       draggable,
+      revealedStyle = {},
     } = convertProps(this.props)
 
     const shouldReveal = this.state.fadeIn === false || this.state.imgLoaded
@@ -390,6 +391,7 @@ class Image extends React.Component {
       opacity: shouldReveal ? 1 : 0,
       transition: shouldFadeIn ? `opacity ${durationFadeIn}ms` : `none`,
       ...imgStyle,
+      ...(shouldReveal ? revealedStyle : {})
     }
 
     const bgColor =


### PR DESCRIPTION
## Description

Currently revealed opacity is configured as 1 and unrevealed as 0 and there's no way to override this. I would like to use 0.8 and a backgroundColor of #000 to darken the image a bit.

Added support to override style when the image is revealed. 

```
<Img revealedStyle={{opacity: 0.8}} /> // Having revealedStyle default to {opacity:1}
```


## Related Issues

Addresses #16581
