### PR TITLE
docs(gatsby-plugin-offline): Clarify how to pass in options

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -21,10 +21,10 @@ plugins: [`gatsby-plugin-offline`]
 
 ## Overriding options
 
-When adding this plugin to your `gatsby-config.js`, you can pass in options to
+When adding this plugin to your `gatsby-config.js`, you can pass in options (via the `options` key) to
 override the default [Workbox](https://developers.google.com/web/tools/workbox/modules/workbox-build) config.
 
-The default config is as follows. Warning: you can break the offline support by
+The default config is as follows. Warning: You can break the offline support by
 changing these options, so tread carefully.
 
 ```javascript
@@ -62,14 +62,6 @@ const options = {
   skipWaiting: true,
   clientsClaim: true,
 }
-
-// In your gatsby-config.js
-plugins: [
-  {
-    resolve: `gatsby-plugin-offline`,
-    options: options
-  }
-]
 ```
 
 ## Remove

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -62,6 +62,14 @@ const options = {
   skipWaiting: true,
   clientsClaim: true,
 }
+
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-offline`,
+    options: options
+  }
+]
 ```
 
 ## Remove


### PR DESCRIPTION
I wasn't initially clear on where to put the `options` object - this should clarify that.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
