### PR TITLE
 fix(gatsby-plugin-mdx): Don't throw an error from MDXRenderer

### DIFF
--- a/packages/gatsby-plugin-mdx/mdx-renderer.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.js
@@ -8,12 +8,6 @@ module.exports = function MDXRenderer({
   children,
   ...props
 }) {
-  if (!children) {
-    throw new Error(
-      `MDXRenderer expected to receive an MDX String in children. Instead, it received: ${children}`
-    )
-  }
-
   const mdxComponents = useMDXComponents(components)
   const mdxScope = useMDXScope(scope)
 

--- a/packages/gatsby-plugin-mdx/mdx-renderer.test.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.test.js
@@ -13,14 +13,4 @@ describe(`mdx-renderer`, () => {
 
     expect(result.toJSON()).toEqual({ type: `div`, props: {}, children: null })
   })
-
-  test(`provides a useful error message when no mdx is passed`, () => {
-    const expectedErrorMessage = `MDXRenderer expected to receive an MDX String in children. Instead, it received: undefined`
-
-    const renderUndefined = () => {
-      TestRenderer.create(<MDXRenderer scope={{ React: React }} />)
-    }
-
-    expect(renderUndefined).toThrowError(expectedErrorMessage)
-  })
 })


### PR DESCRIPTION
This deviates from React conventions and there are valid usecases
where content passed to MDXRenderer might be stateful meaning that
it might be undefined at some point.

Related/reverts #16555