### PR TITLE
fix(gatsby-transformer-sqip): Return null early for unsupported file types

### DIFF
--- a/packages/gatsby-transformer-sqip/src/__tests__/generate-sqip.js
+++ b/packages/gatsby-transformer-sqip/src/__tests__/generate-sqip.js
@@ -32,7 +32,7 @@ describe(`gatsby-transformer-sqip`, async () => {
   const absolutePath = resolve(
     __dirname,
     `images`,
-    `this-file-does-not-neet-to-exist-for-the-test.jpg`
+    `this-file-does-not-need-to-exist-for-the-test.jpg`
   )
   const cacheDir = __dirname
 
@@ -90,6 +90,32 @@ describe(`gatsby-transformer-sqip`, async () => {
       expect(exists).toHaveBeenCalledTimes(1)
       expect(writeFile).toHaveBeenCalledTimes(0)
       expect(readFile).toHaveBeenCalledTimes(1)
+    })
+    it(`returns null for unsupported files`, async () => {
+      exists.mockImplementationOnce(() => true)
+
+      const cache = {
+        get: jest.fn(),
+        set: jest.fn(),
+      }
+      const numberOfPrimitives = 5
+      const blur = 0
+      const mode = 3
+      const result = await generateSqip({
+        cache,
+        cacheDir,
+        absolutePath: absolutePath.replace(`.jpg`, `.svg`),
+        numberOfPrimitives,
+        blur,
+        mode,
+      })
+
+      expect(result).toBe(null)
+
+      expect(sqip).toHaveBeenCalledTimes(1)
+      expect(exists).toHaveBeenCalledTimes(1)
+      expect(writeFile).toHaveBeenCalledTimes(0)
+      expect(readFile).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/packages/gatsby-transformer-sqip/src/__tests__/generate-sqip.js
+++ b/packages/gatsby-transformer-sqip/src/__tests__/generate-sqip.js
@@ -112,8 +112,8 @@ describe(`gatsby-transformer-sqip`, async () => {
 
       expect(result).toBe(null)
 
-      expect(sqip).toHaveBeenCalledTimes(1)
-      expect(exists).toHaveBeenCalledTimes(1)
+      expect(sqip).toHaveBeenCalledTimes(0)
+      expect(exists).toHaveBeenCalledTimes(0)
       expect(writeFile).toHaveBeenCalledTimes(0)
       expect(readFile).toHaveBeenCalledTimes(0)
     })

--- a/packages/gatsby-transformer-sqip/src/generate-sqip.js
+++ b/packages/gatsby-transformer-sqip/src/generate-sqip.js
@@ -23,7 +23,12 @@ module.exports = async function generateSqip(options) {
 
   debug({ options })
 
-  const { name } = parse(absolutePath)
+  const { name, ext } = parse(absolutePath)
+
+  if (!ext.match(/(jpe?g|png|gif)$/)) {
+    debug(`Unsupported file type ${name} (${contentDigest})`)
+    return null
+  }
 
   const sqipOptions = {
     numberOfPrimitives,


### PR DESCRIPTION
## Description

If your list of nodes contains non-pixel images like SVGs, sqip will fail and break your side. Can be workaround via multiple queries and filtering, but, lets just fix the actual issue.

Return `null` when a file type is not supported.


Ps.: This issue has the potential to break a site only through content editing :scream: 