### PR TITLE
gatsby-theme-blog path generation fixes

### DIFF
--- a/themes/gatsby-theme-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-blog-core/gatsby-node.js
@@ -113,7 +113,7 @@ exports.onCreateNode = async (
     let slug
     if (node.frontmatter.slug) {
       if (path.isAbsolute(node.frontmatter.slug)) {
-        // absolute paths take precedance
+        // absolute paths take precedence
         slug = node.frontmatter.slug
       } else {
         // otherwise a relative slug gets turned into a sub path

--- a/themes/gatsby-theme-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-blog-core/gatsby-node.js
@@ -4,6 +4,7 @@ const mkdirp = require(`mkdirp`)
 const crypto = require(`crypto`)
 const Debug = require(`debug`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
+const { urlResolve } = require(`gatsby-core-utils`)
 
 const debug = Debug(`gatsby-theme-blog-core`)
 const withDefaults = require(`./utils/default-options`)
@@ -97,7 +98,7 @@ exports.onCreateNode = async (
   themeOptions
 ) => {
   const { createNode, createParentChildLink } = actions
-  const { contentPath } = withDefaults(themeOptions)
+  const { contentPath, basePath } = withDefaults(themeOptions)
 
   // Make sure it's an MDX node
   if (node.internal.type !== `Mdx`) {
@@ -118,7 +119,7 @@ exports.onCreateNode = async (
     const fieldData = {
       title: node.frontmatter.title,
       tags: node.frontmatter.tags || [],
-      slug,
+      slug: node.frontmatter.slug || urlResolve(basePath, slug),
       date: node.frontmatter.date,
       keywords: node.frontmatter.keywords || [],
     }

--- a/themes/gatsby-theme-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-blog-core/gatsby-node.js
@@ -129,7 +129,6 @@ exports.onCreateNode = async (
 
       slug = urlResolve(basePath, filePath)
     }
-    console.log("slug", slug)
     const fieldData = {
       title: node.frontmatter.title,
       tags: node.frontmatter.tags || [],

--- a/themes/gatsby-theme-blog-core/gatsby-node.js
+++ b/themes/gatsby-theme-blog-core/gatsby-node.js
@@ -110,16 +110,30 @@ exports.onCreateNode = async (
   const source = fileNode.sourceInstanceName
 
   if (node.internal.type === `Mdx` && source === contentPath) {
-    const slug = createFilePath({
-      node: fileNode,
-      getNode,
-      basePath: contentPath,
-    })
+    let slug
+    if (node.frontmatter.slug) {
+      if (path.isAbsolute(node.frontmatter.slug)) {
+        // absolute paths take precedance
+        slug = node.frontmatter.slug
+      } else {
+        // otherwise a relative slug gets turned into a sub path
+        slug = urlResolve(basePath, node.frontmatter.slug)
+      }
+    } else {
+      // otherwise use the filepath function from gatsby-source-filesystem
+      const filePath = createFilePath({
+        node: fileNode,
+        getNode,
+        basePath: contentPath,
+      })
 
+      slug = urlResolve(basePath, filePath)
+    }
+    console.log("slug", slug)
     const fieldData = {
       title: node.frontmatter.title,
       tags: node.frontmatter.tags || [],
-      slug: node.frontmatter.slug || urlResolve(basePath, slug),
+      slug,
       date: node.frontmatter.date,
       keywords: node.frontmatter.keywords || [],
     }


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/15988 caused a regression in the url generation for `gatsby-theme-blog` that resulted in the `basePath` theme option never being applied to the url. This PR adds that back in and also makes sure that you can override the slug from the frontmatter. If the slug is relative, we prepend `basePath`, if the slug is absolute, we use that URL directly. If there is no slug, we fall back to `createFilePath` which included the `index.js` behavior originally added in #15988

This fix happens in `gatsby-theme-blog-core` now because that's where the logic is.