### PR TITLE
docs(testing-react-components): Remove unnecessary import

### DIFF
--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -22,9 +22,6 @@ Create the file `setup-test-env.js` at the root of your project. Insert this cod
 
 ```js:title=setup-test-env.js
 import "@testing-library/jest-dom/extend-expect"
-
-// this is basically: afterEach(cleanup)
-import "@testing-library/react/cleanup-after-each"
 ```
 
 This file gets run automatically by Jest before every test and therefore you don't need to add the imports to every single test file.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
cleanup-after-each is no longer needed
https://github.com/testing-library/react-testing-library/blob/master/cleanup-after-each.js
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
