### PR TITLE
docs(themes): Make naming convention required and not recommended

### DIFF
--- a/docs/docs/themes/conventions.md
+++ b/docs/docs/themes/conventions.md
@@ -6,8 +6,8 @@ As we begin to formalize and standardize the methodologies for building Gatsby T
 
 ## Naming
 
-It's recommended to prefix themes with `gatsby-theme-`. So if you'd like to name your theme "awesome" you
-can name it `gatsby-theme-awesome` and place that as the `name` key in your `package.json`.
+It's required to prefix themes with `gatsby-theme-`. So if you'd like to name your theme "awesome" you
+can name it `gatsby-theme-awesome` and place that as the `name` key in your `package.json`. Prefixing the themes with `gatsby-theme` allows the gatsby to identify the theme packages and compile the theme code.
 
 ## Initializing Required Directories
 

--- a/docs/docs/themes/conventions.md
+++ b/docs/docs/themes/conventions.md
@@ -7,7 +7,7 @@ As we begin to formalize and standardize the methodologies for building Gatsby T
 ## Naming
 
 It's required to prefix themes with `gatsby-theme-`. So if you'd like to name your theme "awesome" you
-can name it `gatsby-theme-awesome` and place that as the `name` key in your `package.json`. Prefixing the themes with `gatsby-theme` allows the gatsby to identify the theme packages and compile the theme code.
+can name it `gatsby-theme-awesome` and place that as the `name` key in your `package.json`. Prefixing themes with `gatsby-theme` enables gatsby in identifying theme packages for compilation.
 
 ## Initializing Required Directories
 


### PR DESCRIPTION
<!-- Write a brief description of the changes introduced by this PR -->
As discussed during the gatsby core meeting, prefixing the package name of gatsby themes with "gatsby-theme" is required, (and not only a recommendation)
