### PR TITLE
chore(gatsby-remark-copy-linked-files): Remove fs

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -1,6 +1,6 @@
 const visit = require(`unist-util-visit`)
 const isRelativeUrl = require(`is-relative-url`)
-const fse = require(`fs-extra`)
+const fsExtra = require(`fs-extra`)
 const path = require(`path`)
 const _ = require(`lodash`)
 const cheerio = require(`cheerio`)
@@ -149,7 +149,7 @@ module.exports = (
 
     if (!image.attr(`width`) || !image.attr(`height`)) {
       dimensions = imageSize.sync(
-        toArray(fse.readFileSync(imageNode.absolutePath))
+        toArray(fsExtra.readFileSync(imageNode.absolutePath))
       )
     }
 
@@ -298,10 +298,10 @@ module.exports = (
   return Promise.all(
     Array.from(filesToCopy, async ([linkPath, newFilePath]) => {
       // Don't copy anything if the file already exists at the location.
-      if (!fse.existsSync(newFilePath)) {
+      if (!fsExtra.existsSync(newFilePath)) {
         try {
-          await fse.ensureDir(path.dirname(newFilePath))
-          await fse.copy(linkPath, newFilePath)
+          await fsExtra.ensureDir(path.dirname(newFilePath))
+          await fsExtra.copy(linkPath, newFilePath)
         } catch (err) {
           console.error(`error copying file`, err)
         }

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -1,7 +1,6 @@
 const visit = require(`unist-util-visit`)
 const isRelativeUrl = require(`is-relative-url`)
-const fs = require(`fs`)
-const fsExtra = require(`fs-extra`)
+const fse = require(`fs-extra`)
 const path = require(`path`)
 const _ = require(`lodash`)
 const cheerio = require(`cheerio`)
@@ -150,7 +149,7 @@ module.exports = (
 
     if (!image.attr(`width`) || !image.attr(`height`)) {
       dimensions = imageSize.sync(
-        toArray(fs.readFileSync(imageNode.absolutePath))
+        toArray(fse.readFileSync(imageNode.absolutePath))
       )
     }
 
@@ -299,10 +298,10 @@ module.exports = (
   return Promise.all(
     Array.from(filesToCopy, async ([linkPath, newFilePath]) => {
       // Don't copy anything if the file already exists at the location.
-      if (!fsExtra.existsSync(newFilePath)) {
+      if (!fse.existsSync(newFilePath)) {
         try {
-          await fsExtra.ensureDir(path.dirname(newFilePath))
-          await fsExtra.copy(linkPath, newFilePath)
+          await fse.ensureDir(path.dirname(newFilePath))
+          await fse.copy(linkPath, newFilePath)
         } catch (err) {
           console.error(`error copying file`, err)
         }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
remove redundant `const fs = require('fs')` module from [gatsby-remark-copy-linked-files](https://www.gatsbyjs.org/packages/gatsby-remark-copy-linked-files/) plugin since it already has `fs-extra` module

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
