### PR TITLE
Fix docz version in docs tutorial

### DIFF
--- a/docs/tutorial/writing-documentation-with-docz.md
+++ b/docs/tutorial/writing-documentation-with-docz.md
@@ -24,10 +24,10 @@ To set up Docz you need to install the Docz Gatsby theme and add some custom con
 cd my-gatsby-site-with-docz
 ```
 
-And install the following packages:
+And install the `gatsby-theme-docz` package:
 
 ```shell
-npm install --save gatsby-theme-docz
+npm install --save gatsby-theme-docz@next
 ```
 
 Add `gatsby-theme-docz` under `plugins` in `gatsby-config.js`:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

`gatsby-theme-docz` version 2 is currently in prerelease so @next needs to be specified when installing to get latest hottness!! so i updated docs to reflect that.  

## Related Issues

#16286 
