### PR TITLE
chore(docs): Add note about react-loadable

### DIFF
--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -72,4 +72,4 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
 }
 ```
 
-Another solution is to use a package like [react-loadable] (https://github.com/jamiebuilds/react-loadable). The module that tries to use `window` will be dynamically loaded only on the client side (and not during SSR).
+Another solution is to use a package like [react-loadable](https://github.com/jamiebuilds/react-loadable). The module that tries to use `window` will be dynamically loaded only on the client side (and not during SSR).

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -72,4 +72,4 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
 }
 ```
 
-Another solution is to use a package named [reactloadble] (https://github.com/jamiebuilds/react-loadable). The module that wants to use the window object will be imported in a way that doesn't trigger a build error.
+Another solution is to use a package named [reactloadble](https://github.com/jamiebuilds/react-loadable). The module that wants to use the window object will be imported in a way that doesn't trigger a build error.

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -72,4 +72,4 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
 }
 ```
 
-Another solution is to use a package named [reactloadble] (https://github.com/jamiebuilds/react-loadable). The module will be imported in a way that doesn't trigger a build error.
+Another solution is to use a package named [reactloadble] (https://github.com/jamiebuilds/react-loadable). The module that wants to use the window object will be imported in a way that doesn't trigger a build error.

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -71,3 +71,5 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
   }
 }
 ```
+
+Another solution is to use a package named [reactloadble] (https://github.com/jamiebuilds/react-loadable). The module will be imported in a way that doesn't trigger a build error.

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -72,4 +72,4 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
 }
 ```
 
-Another solution is to use a package named [reactloadble](https://github.com/jamiebuilds/react-loadable). The module that wants to use the window object will be imported in a way that doesn't trigger a build error.
+Another solution is to use a package like [react-loadable] (https://github.com/jamiebuilds/react-loadable). The module that tries to use `window` will be dynamically loaded only on the client side (and not during SSR).


### PR DESCRIPTION
using 'react loadable' module fixed the error that blocks SSR. (no window object problem)
The webpack hack provided in the article on the other hand didn't work.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The solution provided in the article (changing the gatsby-node.js) didn't work. Using 'react loadable' is a very decent alternative solution that should be mentioned.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
