### PR TITLE
fix(gatsby-theme-blog): Trigger link icon beside Heading on hover

### DIFF
--- a/themes/gatsby-theme-blog/src/components/headings.js
+++ b/themes/gatsby-theme-blog/src/components/headings.js
@@ -28,6 +28,7 @@ const heading = Tag => props => (
       ":hover a": {
         visibility: `visible`,
       },
+      pointerEvents: `painted`,
     }}
   >
     <a


### PR DESCRIPTION
## Description & motivation

Hovering over where the link icon would be now triggers showing it.
This brings the behaviour more in line with `gatsby-remark-autolink-headers`.

Mouse users often don't hover over the text of a header first to click the link.
I know this is a very minor change, but it relieves a minor inconvenience of the icon not showing up when you expect it to.

If not set `pointer-events` defaults to `auto`, which is the same as `visiblePainted`.
This sets `pointer-events` to `painted` instead, allowing pointer events even when the `visibility` is set to `hidden`

#### Before
You had to hover over the text first, then move the mouse to the left to click the icon.
![qUkhkMRBfy](https://user-images.githubusercontent.com/30179461/63106190-9cde9f80-bf82-11e9-8ff4-46cd0b941564.gif)

#### After
Hovering to the left of the heading also shows the link icon.
![0PlRy9nNig](https://user-images.githubusercontent.com/30179461/63106276-c5ff3000-bf82-11e9-9d8d-64986d7cb3db.gif)

