### PR TITLE
docs: GraphQL Fragments recipe

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -879,7 +879,12 @@ To limit data, you'll need a Gatsby site with some nodes in the GraphQL data lay
 - [Gatsby GraphQL reference for limiting](/docs/graphql-reference/#limit)
 - Live example:
 
-<iframe title="Limiting returned data" src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePage(limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false" width="600" height="300"></iframe>
+<iframe
+  title="Limiting returned data"
+  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePage(limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
+  width="600"
+  height="300"
+/>
 
 ### Sorting with GraphQL
 
@@ -935,7 +940,12 @@ For this recipe, you'll need a Gatsby site with a collection of nodes to sort in
 - Learn about [nodes in Gatsby's GraphQL data API](/docs/node-interface/)
 - Live example:
 
-<iframe title="Sorting data" src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePage(sort%3A%20%7Bfields%3A%20path%2C%20order%3A%20ASC%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false" width="600" height="300"></iframe>
+<iframe
+  title="Sorting data"
+  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePage(sort%3A%20%7Bfields%3A%20path%2C%20order%3A%20ASC%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
+  width="600"
+  height="300"
+/>
 
 ### Filtering with GraphQL
 
@@ -995,17 +1005,18 @@ For this recipe, you'll need a Gatsby site with a collection of nodes to filter 
 - Learn about [nodes in Gatsby's GraphQL data API](/docs/node-interface/)
 - Live example:
 
-<iframe title="Filtering data" src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Bcategories%3A%20%7Beq%3A%20%22magical%20creatures%22%7D%7D%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20categories%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false" width="600" height="300"></iframe>
+<iframe
+  title="Filtering data"
+  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Bcategories%3A%20%7Beq%3A%20%22magical%20creatures%22%7D%7D%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20categories%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
+  width="600"
+  height="300"
+/>
 
-### Query Aliases
+### GraphQL Query Aliases
 
 You can rename any field in a GraphQL query with an alias.
 
 If you would like to run two queries on the same datasource, you can use an alias to avoid a naming collision with two queries of the same name.
-
-#### Prerequisites
-
-- A [Gatsby site](/docs/quick-start)
 
 #### Directions
 
@@ -1048,7 +1059,40 @@ If you would like to run two queries on the same datasource, you can use an alia
 - [Gatsby GraphQL reference for aliasing](/docs/graphql-reference/#aliasing)
 - Live example:
 
-<iframe title="Using aliases" src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20fileCount%3A%20allFile%20%7B%20%0A%20%20%20%20totalCount%0A%20%20%7D%0A%20%20filePageInfo%3A%20allFile%20%7B%0A%20%20%20%20pageInfo%20%7B%0A%20%20%20%20%20%20currentPage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false" width="600" height="300"></iframe>
+<iframe
+  title="Using aliases"
+  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20fileCount%3A%20allFile%20%7B%20%0A%20%20%20%20totalCount%0A%20%20%7D%0A%20%20filePageInfo%3A%20allFile%20%7B%0A%20%20%20%20pageInfo%20%7B%0A%20%20%20%20%20%20currentPage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
+  width="600"
+  height="300"
+/>
+
+### GraphQL Query Fragments
+
+GraphQL fragments are shareable chunks of a query that can be reused.
+
+You might want to use them to share multiple fields between queries or to co-locate the data with the component it's used in.
+
+#### Directions
+
+1. Declare a `graphql` template string with a Fragment in it:
+
+```jsx
+export const query = graphql`
+  fragment SiteInformation on Site {
+    site {
+      title
+      description
+    }
+  }
+`
+```
+
+#### Additional Resources
+
+- [Simple example repo using fragments]()
+- [Example repo with co-located data]()
+- [Gatsby GraphQL reference for fragments](/docs/graphql-reference/#fragments)
+- [Gatsby image fragments](/docs/gatsby-image/#image-query-fragments)
 
 ## 7. Working with images
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1070,7 +1070,7 @@ If you would like to run two queries on the same datasource, you can use an alia
 
 GraphQL fragments are shareable chunks of a query that can be reused.
 
-You might want to use them to share multiple fields between queries or to co-locate the data with the component it's used in.
+You might want to use them to share multiple fields between queries or to colocate a component with the data it uses. 
 
 #### Directions
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1070,7 +1070,7 @@ If you would like to run two queries on the same datasource, you can use an alia
 
 GraphQL fragments are shareable chunks of a query that can be reused.
 
-You might want to use them to share multiple fields between queries or to colocate a component with the data it uses. 
+You might want to use them to share multiple fields between queries or to colocate a component with the data it uses.
 
 #### Directions
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1074,25 +1074,43 @@ You might want to use them to share multiple fields between queries or to co-loc
 
 #### Directions
 
-1. Declare a `graphql` template string with a Fragment in it:
+1. Declare a `graphql` template string with a Fragment in it. The fragment should be made up of the keyword fragment, a name, and the GraphQL type it is associated with (in this case of type `Site`, demonstrated by `on Site`), and the fields that make up the fragment inside:
 
 ```jsx
 export const query = graphql`
+  // highlight-start
   fragment SiteInformation on Site {
+    title
+    description
+  }
+  // highlight-end
+`
+```
+
+2. Then you can include the fragment in a query for a field of the type specified by the fragment, to include those fields without you having to type them all out:
+
+```diff
+export const pageQuery = graphql`
+  query SiteQuery {
     site {
-      title
-      description
+-     title
+-     description
++   ...SiteInformation
     }
   }
 `
 ```
 
+**Note**: if the fragment is used in a different file it doesn't need to be imported. Exporting the query from the original file will make it available for queries across your project.
+
+Fragments can be nested inside other fragments, and multiple fragments can be used in the same query.
+
 #### Additional Resources
 
-- [Simple example repo using fragments]()
-- [Example repo with co-located data]()
+- [Simple example repo using fragments](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-fragments)
 - [Gatsby GraphQL reference for fragments](/docs/graphql-reference/#fragments)
 - [Gatsby image fragments](/docs/gatsby-image/#image-query-fragments)
+- [Example repo with co-located data](https://github.com/gatsbyjs/gatsby/tree/master/examples/gatsbygram)
 
 ## 7. Working with images
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1074,7 +1074,7 @@ You might want to use them to share multiple fields between queries or to co-loc
 
 #### Directions
 
-1. Declare a `graphql` template string with a Fragment in it. The fragment should be made up of the keyword fragment, a name, and the GraphQL type it is associated with (in this case of type `Site`, demonstrated by `on Site`), and the fields that make up the fragment inside:
+1. Declare a `graphql` template string with a Fragment in it. The fragment should be made up of the keyword `fragment`, a name, the GraphQL type it is associated with (in this case of type `Site`, as demonstrated by `on Site`), and the fields that make up the fragment:
 
 ```jsx
 export const query = graphql`
@@ -1087,7 +1087,7 @@ export const query = graphql`
 `
 ```
 
-2. Then you can include the fragment in a query for a field of the type specified by the fragment, to include those fields without you having to type them all out:
+2. Now, include the fragment in a query for a field of the type specified by the fragment. This includes those fields without having to declare them all independently:
 
 ```diff
 export const pageQuery = graphql`
@@ -1101,7 +1101,7 @@ export const pageQuery = graphql`
 `
 ```
 
-**Note**: if the fragment is used in a different file it doesn't need to be imported. Exporting the query from the original file will make it available for queries across your project.
+**Note**: Fragments don't need to be imported in Gatsby. Exporting a query with a Fragment makes that Fragment available in _all_ queries in your project.
 
 Fragments can be nested inside other fragments, and multiple fragments can be used in the same query.
 

--- a/docs/docs/using-fragments.md
+++ b/docs/docs/using-fragments.md
@@ -4,7 +4,7 @@ title: Using fragments
 
 Fragments allow you to reuse parts of GraphQL queries. It also allows you to split up complex queries into smaller, easier to understand components.
 
-### The building blocks of a fragment
+## The building blocks of a fragment
 
 Here is an example fragment:
 
@@ -21,7 +21,7 @@ A fragment consists of three components:
 2. `TypeName`: the [GraphQL type](https://graphql.org/graphql-js/object-types/) of the object the fragment will be used on. This is important because you can only query for fields that actually exist on a given object.
 3. The body of the query. You can define any fields with any level of nesting in here, the same that you would elsewhere in a GraphQL query
 
-### Creating and using a fragment
+## Creating and using a fragment
 
 A fragment can be created inside any GraphQL query, but it's good practice to create the query separately. More organization advice in the [Conceptual Guide](/docs/querying-with-graphql/#fragments).
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adds a recipe for GraphQL fragments with an example repository containing a really simplified example.

I omitted prerequisites because it didn't really seem like there was a really compelling one, maybe "An existing GraphQL query"?

## Screenshot

<details>
<summary>Details</summary>

<img width="1102" alt="Screen Shot 2019-08-15 at 10 44 30 AM" src="https://user-images.githubusercontent.com/21114044/63111080-28880a00-bf4a-11e9-938c-bea52af83016.png">

</details>

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #14984
