### PR TITLE
feat(gatsby-plugin-netlify-cms): Add includeRobots

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -182,7 +182,8 @@ bar).
 
 (_optional_, type: `boolean`, default: `true`)
 
-Use a `meta` tag to ask robots to not index the CMS page.
+Use a `meta` tag to ask robots to not index the CMS page. When using this, it's advisable
+[_not_ to have your CMS page in a `robots.txt` file](https://support.google.com/webmasters/answer/93710?hl=en).
 
 ## Example
 

--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -178,12 +178,11 @@ bar).
 Customize the value of the `favicon` tag in your CMS HTML (shows in the browser
 bar).
 
-### `excludeRobots`
+### `includeRobots`
 
-(_optional_, type: `boolean`, default: `true`)
+(_optional_, type: `boolean`, default: `false`)
 
-Use a `meta` tag to ask robots to not index the CMS page. When using this, it's advisable
-[_not_ to have your CMS page in a `robots.txt` file](https://support.google.com/webmasters/answer/93710?hl=en).
+By default, the CMS page is not indexed by crawlers. Use this to add a `meta` tag to invite robots to index the CMS page.
 
 ## Example
 
@@ -200,7 +199,7 @@ plugins: [
       publicPath: `admin`,
       htmlTitle: `Content Manager`,
       htmlFavicon: `path/to/favicon`,
-      excludeRobots: false,
+      includeRobots: false,
     },
   },
 ]

--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -178,6 +178,12 @@ bar).
 Customize the value of the `favicon` tag in your CMS HTML (shows in the browser
 bar).
 
+### `excludeRobots`
+
+(_optional_, type: `boolean`, default: `true`)
+
+Use a `meta` tag to ask robots to not index the CMS page.
+
 ## Example
 
 Here is the plugin with example values for all options (note that no option is
@@ -193,6 +199,7 @@ plugins: [
       publicPath: `admin`,
       htmlTitle: `Content Manager`,
       htmlFavicon: `path/to/favicon`,
+      excludeRobots: false,
     },
   },
 ]

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -98,7 +98,7 @@ exports.onCreateWebpackConfig = (
     htmlTitle = `Content Manager`,
     htmlFavicon = ``,
     manualInit = false,
-    excludeRobots = true,
+    includeRobots = false,
   }
 ) => {
   if (![`develop`, `build-javascript`].includes(stage)) {
@@ -163,7 +163,7 @@ exports.onCreateWebpackConfig = (
         chunks: [`cms`],
         excludeAssets: [/cms.css/],
         meta: {
-          robots: excludeRobots ? `noindex` : ``, // Ensure search engines don't index this page.
+          robots: includeRobots ? `all` : `none`, // Control whether search engines index this page
         },
       }),
 

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -98,6 +98,7 @@ exports.onCreateWebpackConfig = (
     htmlTitle = `Content Manager`,
     htmlFavicon = ``,
     manualInit = false,
+    excludeRobots = true,
   }
 ) => {
   if (![`develop`, `build-javascript`].includes(stage)) {
@@ -161,6 +162,9 @@ exports.onCreateWebpackConfig = (
         favicon: htmlFavicon,
         chunks: [`cms`],
         excludeAssets: [/cms.css/],
+        meta: {
+          robots: excludeRobots ? `noindex` : ``, // Ensure search engines don't index this page.
+        },
       }),
 
       // Exclude CSS from index.html, as any imported styles are assumed to be


### PR DESCRIPTION
## Description

In `gatsby-plugin-netlify-cms` Adds a meta tag to the `<head>` of the Netlify CMS to request robots (like Googlebot) to not index the page. That way the admin can be hidden from search engines since it's not something that many (most?) site owners want publicly accessible.

It's on by default but I added an option to the config so it can be turned off if the site owner desires.

## Related Issues

None (can make one if you want)