### PR TITLE
(feat)gatsby-remark-copy-linked-files: create hashLength option to specify the digest hash length

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -418,6 +418,36 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
   })
 
+  describe(`options.hashLength`, () => {
+    const imagePath = `images/sample-image.gif`
+
+    it(`sets the contentDigest hash to the length supplied by hashLength`, async () => {
+      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const validHashLength = 3
+      const expectedNewPath = path.posix.join(
+        process.cwd(),
+        `public`,
+        `/undefined/undefined.gif`
+      )
+      expect.assertions(3)
+      await plugin(
+        {
+          files: getFiles(imagePath),
+          markdownAST,
+          markdownNode,
+          getNode,
+        },
+        {
+          hashLength: validHashLength,
+        }
+      ).then(v => {
+        expect(v).toBeDefined()
+        expect(fsExtra.copy).toHaveBeenCalledWith(imagePath, expectedNewPath)
+        expect(imageURL(markdownAST)).toEqual(`/undefined/undefined.gif`)
+      })
+    })
+  })
+
   describe(`options.ignoreFileExtensions`, () => {
     const pngImagePath = `images/sample-image.png`
     const jpgImagePath = `images/sample-image.jpg`


### PR DESCRIPTION
## Description

This PR adds a new option called `hashLength` that would allow users to specify the length of [contentDigest](https://www.gatsbyjs.org/docs/node-interface/#contentdigest)

```
{
  resolve: `gatsby-remark-copy-linked-files`,
  options: {
      hashLength: 9
  },
},
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
