### PR TITLE
localhost:8000/__graphql instead of localhost:8000

### DIFF
--- a/docs/docs/sourcing-from-wordpress.md
+++ b/docs/docs/sourcing-from-wordpress.md
@@ -120,7 +120,7 @@ A [Gatsby page is defined](/docs/api-specification/#concepts) as "a site page wi
 
 When you restart your server with the `gatsby develop` command, you'll be able to navigate to the new pages created for each of your posts at their respective paths.
 
-In the GraphiQL IDE at [localhost:8000/__graphql](http://localhost:8000/__graphql) you should now see queryable fields for `allWordpressPosts` in the docs or explorer sidebar.
+In the GraphiQL IDE at [localhost:8000/\_\_graphql](http://localhost:8000/__graphql) you should now see queryable fields for `allWordpressPosts` in the docs or explorer sidebar.
 
 ## Wrapping Up
 

--- a/docs/docs/sourcing-from-wordpress.md
+++ b/docs/docs/sourcing-from-wordpress.md
@@ -120,7 +120,7 @@ A [Gatsby page is defined](/docs/api-specification/#concepts) as "a site page wi
 
 When you restart your server with the `gatsby develop` command, you'll be able to navigate to the new pages created for each of your posts at their respective paths.
 
-In the GraphiQL IDE at [localhost:8000](http://localhost:8000) you should now see queryable fields for `allWordpressPosts` in the docs or explorer sidebar.
+In the GraphiQL IDE at [localhost:8000/__graphql](http://localhost:8000/__graphql) you should now see queryable fields for `allWordpressPosts` in the docs or explorer sidebar.
 
 ## Wrapping Up
 


### PR DESCRIPTION
## Description

Make it more clear that the actual URL for the GraphQL IDE is localhost:8000/__graphql

URL in docs: https://www.gatsbyjs.org/docs/sourcing-from-wordpress/