### PR TITLE
fix(gatsby): Use concrete type resolvers when filtering on node interface fields

### DIFF
--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -107,7 +107,7 @@ function handleMany(siftArgs, nodes, sort) {
 module.exports = (args: Object) => {
   const { getNode, getNodesByType } = require(`../db/nodes`)
 
-  const { queryArgs, gqlType, firstOnly = false, nodeTypeNames } = args
+  const { queryArgs, gqlType, firstOnly = false, nodeTypeNames, schema } = args
 
   // If nodes weren't provided, then load them from the DB
   const nodes = args.nodes || getNodesByType(gqlType.name)
@@ -128,9 +128,13 @@ module.exports = (args: Object) => {
       return []
     }
 
-    return resolveRecursive(node, fieldsToSift, gqlType.getFields()).then(
-      node => (node ? [node] : [])
-    )
+    return resolveRecursive(
+      node,
+      fieldsToSift,
+      gqlType.getFields(),
+      gqlType,
+      schema
+    ).then(node => (node ? [node] : []))
   }
 
   return resolveNodes(
@@ -138,7 +142,9 @@ module.exports = (args: Object) => {
     gqlType.name,
     firstOnly,
     fieldsToSift,
-    gqlType.getFields()
+    gqlType.getFields(),
+    gqlType,
+    schema
   ).then(resolvedNodes => {
     if (firstOnly) {
       return handleFirst(siftFilter, resolvedNodes)

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -8,7 +8,7 @@ const {
 const { store } = require(`../../../redux`)
 const { dispatch } = store
 const { actions } = require(`../../../redux/actions/restricted`)
-const { createTypes } = actions
+const { createTypes, createFieldExtension } = actions
 require(`../../../db/__tests__/fixtures/ensure-loki`)()
 
 const report = require(`gatsby-cli/lib/reporter`)
@@ -358,6 +358,126 @@ describe(`Queryable Node interfaces`, () => {
       },
       test: {
         id: `test1`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`uses concrete type resolvers when filtering on interface fields`, async () => {
+    const nodes = [
+      {
+        id: `author1`,
+        internal: { type: `AuthorYaml` },
+        name: `Author 1`,
+        birthday: new Date(Date.UTC(1978, 8, 26)),
+      },
+      {
+        id: `author2`,
+        internal: { type: `AuthorJson` },
+        name: `Author 2`,
+        birthday: new Date(Date.UTC(1978, 8, 26)),
+      },
+      {
+        id: `post1`,
+        internal: { type: `ThisPost` },
+        author: `author1`,
+      },
+      {
+        id: `post2`,
+        internal: { type: `ThatPost` },
+        author: `author2`,
+      },
+    ]
+    nodes.forEach(node =>
+      dispatch({ type: `CREATE_NODE`, payload: { ...node } })
+    )
+    dispatch(
+      createFieldExtension({
+        name: `echo`,
+        args: {
+          value: `String!`,
+        },
+        extend(options) {
+          return {
+            resolve() {
+              return options.value
+            },
+          }
+        },
+      })
+    )
+    dispatch(
+      createTypes(`
+        interface Post @nodeInterface {
+          id: ID!
+          author: Author @link
+        }
+        type ThisPost implements Node & Post {
+          author: Author @link
+        }
+        type ThatPost implements Node & Post {
+          author: Author @link
+        }
+        interface Author @nodeInterface {
+          id: ID!
+          name: String
+          echo: String @echo(value: "Interface")
+          birthday: Date @dateformat(formatString: "YYYY")
+        }
+        type AuthorJson implements Node & Author {
+          name: String
+          echo: String @echo(value: "Concrete Type")
+          birthday: Date @dateformat(formatString: "DD-MM-YYYY")
+        }
+        type AuthorYaml implements Node & Author {
+          name: String
+          echo: String @echo(value: "Another Concrete Type")
+          birthday: Date @dateformat(formatString: "MM/DD/YYYY")
+        }
+      `)
+    )
+    const query = `
+      {
+        allNodeInterface(
+          filter: {
+            author: {
+              echo: {
+                in: ["Concrete Type", "Another Concrete Type"]
+              }
+              birthday: {
+                in: ["26-09-1978", "09/26/1978"]
+              }
+            }
+          }
+        ) {
+          nodes {
+            author {
+              name
+              echo
+              birthday
+            }
+          }
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allNodeInterface: {
+        nodes: [
+          {
+            author: {
+              name: `Author 1`,
+              echo: `Another Concrete Type`,
+              birthday:
+            },
+          },
+          {
+            author: {
+              name: `Author 2`,
+              echo: `Concrete Type`,
+            },
+          },
+        ],
       },
     }
     expect(results).toEqual(expected)

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -422,30 +422,24 @@ describe(`Queryable Node interfaces`, () => {
           id: ID!
           name: String
           echo: String @echo(value: "Interface")
-          birthday: Date @dateformat(formatString: "YYYY")
         }
         type AuthorJson implements Node & Author {
           name: String
           echo: String @echo(value: "Concrete Type")
-          birthday: Date @dateformat(formatString: "DD-MM-YYYY")
         }
         type AuthorYaml implements Node & Author {
           name: String
           echo: String @echo(value: "Another Concrete Type")
-          birthday: Date @dateformat(formatString: "MM/DD/YYYY")
         }
       `)
     )
     const query = `
       {
-        allNodeInterface(
+        allPost(
           filter: {
             author: {
               echo: {
                 in: ["Concrete Type", "Another Concrete Type"]
-              }
-              birthday: {
-                in: ["26-09-1978", "09/26/1978"]
               }
             }
           }
@@ -454,7 +448,6 @@ describe(`Queryable Node interfaces`, () => {
             author {
               name
               echo
-              birthday
             }
           }
         }
@@ -462,13 +455,12 @@ describe(`Queryable Node interfaces`, () => {
     `
     const results = await runQuery(query)
     const expected = {
-      allNodeInterface: {
+      allPost: {
         nodes: [
           {
             author: {
               name: `Author 1`,
               echo: `Another Concrete Type`,
-              birthday:
             },
           },
           {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -188,6 +188,7 @@ class LocalNodeModel {
       gqlType,
       nodes,
       nodeTypeNames,
+      schema: this.schema,
     })
 
     let result = queryResult


### PR DESCRIPTION
When filtering on `@nodeInterface` fields, we currently use the resolver on the interface type. This PR changes this to use the resolver on the type returned from the interface's `resolveType`, which is in line with what graphql does when resolving the fields in the selection set.

Related: https://github.com/gatsbyjs/gatsby/issues/12272#issuecomment-520039307
Fixes:  #16890

Note: I tried to change as little as possible in `prepare-nodes` which will be replaced by @freiksenet's work in the `materialization` branch anyway.