### PR TITLE
feat(gatsby): Allow specifying type on link extension

### DIFF
--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -110,10 +110,12 @@ const builtInFieldExtensions = {
         defaultValue: `id`,
       },
       from: `String`,
+      on: `String`,
     },
-    extend(args, fieldConfig) {
+    extend(args, fieldConfig, schemaComposer) {
+      const type = args.on && schemaComposer.typeMapper.getWrapped(args.on)
       return {
-        resolve: link(args, fieldConfig),
+        resolve: link({ ...args, type }, fieldConfig),
       }
     },
   },
@@ -225,7 +227,7 @@ const processFieldExtensions = ({
           const prevFieldConfig = typeComposer.getFieldConfig(fieldName)
           typeComposer.extendField(
             fieldName,
-            extend(extensions[name], prevFieldConfig)
+            extend(extensions[name], prevFieldConfig, schemaComposer)
           )
         }
       })

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -132,7 +132,7 @@ const link = (options = {}, fieldConfig) => async (
     return fieldValue
   }
 
-  const returnType = getNullableType(info.returnType)
+  const returnType = getNullableType(options.type || info.returnType)
   const type = getNamedType(returnType)
 
   if (options.by === `id`) {

--- a/packages/gatsby/src/utils/get-value-at.js
+++ b/packages/gatsby/src/utils/get-value-at.js
@@ -5,6 +5,7 @@ const getValueAt = (obj, selector) => {
 }
 
 const get = (obj, selectors) => {
+  if (Array.isArray(obj)) return getArray(obj, selectors)
   const [key, ...rest] = selectors
   const value = obj[key]
   if (!rest.length) return value


### PR DESCRIPTION
The `@link` extension by default uses a field's return type to determine the type of the linked node, which is totally sensible. However, when combining with other extensions on the same field, which can change a field's return type, it is good for composability to be able to specify the type explicitly.