### PR TITLE
fix(docs): dead links to sharp documentation, need to point to new host

### DIFF
--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -85,7 +85,7 @@ class Index extends React.Component {
           {` `}
           exposes Sharp
           {`'`}s{` `}
-          <a href="http://sharp.dimens.io/en/stable/api-operation/#rotate">
+          <a href="http://sharp.pixelplumbing.com/en/stable/api-operation/#rotate">
             <code>rotate</code>
           </a>
           {` `}.
@@ -114,7 +114,7 @@ class Index extends React.Component {
         >
           We also expose all of Sharp
           {`'`}s{` `}
-          <a href="http://sharp.dimens.io/en/stable/api-resize/#crop">
+          <a href="http://sharp.pixelplumbing.com/en/stable/api-resize/#crop">
             <code>crop</code>
           </a>
           {` `}
@@ -327,7 +327,7 @@ class Index extends React.Component {
           {` `}
           uses Sharp
           {`'`}s{` `}
-          <a href="http://sharp.dimens.io/en/stable/api-colour/#greyscale">
+          <a href="http://sharp.pixelplumbing.com/en/stable/api-colour/#greyscale">
             <code>greyscale</code>
           </a>
           {` `}

--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -215,7 +215,7 @@ will be [flattened][15] before creating the composite.
 
 This works by adding an alpha channel to the duotone'd image - then we let Sharp
 do its magic via
-[`overlayWith`](http://sharp.dimens.io/en/stable/api-composite/#overlaywith);
+[`overlayWith`](http://sharp.pixelplumbing.com/en/stable/api-composite/#overlaywith);
 quoting the Sharp documentation:
 
 > If the overlay image contains an alpha channel then composition with
@@ -335,16 +335,16 @@ If updating these doesn't fix the issue, your project probably uses other plugin
 [3]: https://ines.io/blog/dynamic-duotone-svg-jade
 [4]: https://en.wikipedia.org/wiki/Relative_luminance
 [5]: https://github.com/nagelflorian/react-duotone
-[6]: http://sharp.dimens.io/en/stable/api-resize/#crop
-[7]: http://sharp.dimens.io/en/stable/api-operation/#rotate
-[8]: http://sharp.dimens.io/en/stable/api-colour/#greyscale
+[6]: http://sharp.pixelplumbing.com/en/stable/api-resize/#crop
+[7]: http://sharp.pixelplumbing.com/en/stable/api-operation/#rotate
+[8]: http://sharp.pixelplumbing.com/en/stable/api-colour/#greyscale
 [9]: https://github.com/gatsbyjs/gatsby/issues/2435
 [10]: https://codepen.io/tigt/post/optimizing-svgs-in-data-uris
 [11]: https://github.com/tooolbox/node-potrace
 [12]: https://github.com/svg/svgo
 [13]: https://github.com/tooolbox/node-potrace#parameters
 [14]: https://github.com/oliver-moran/jimp
-[15]: http://sharp.dimens.io/en/stable/api-operation/#flatten
+[15]: http://sharp.pixelplumbing.com/en/stable/api-operation/#flatten
 [16]: https://github.com/mozilla/mozjpeg
 [17]: https://www.sno.phy.queensu.ca/~phil/exiftool/
 [18]: https://www.npmjs.com/package/color


### PR DESCRIPTION
## Description

Fix dead links to Sharp documentation, need to point to new docs host `sharp.pixelplumbing.com`. This is the official docs page for [Sharp](https://github.com/lovell/sharp) now.

Re: `gatsby-plugin-sharp` plugin
