### PR TITLE
chore(gatsby): Pass program to developMiddleware

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -215,7 +215,7 @@ async function startServer(program) {
   const { developMiddleware } = store.getState().config
 
   if (developMiddleware) {
-    developMiddleware(app)
+    developMiddleware(app, program)
   }
 
   // Set up API proxy.


### PR DESCRIPTION
passing program along with app to develop middleware, so it can actually be useful

## Description
I wanted to write a middleware that would allow me to send a reload signal through the websocket connection, when files that are not controlled by gatsby are changed, now maybe an option to add to the watched directorys would work also, but i really liked this solution because it adds a lot of possibilities to middleware by giving it the extra context. 


Thoughts? 