### PR TITLE
docs(tutorial): add missing query keyword in gatsby-node.js snippet

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -180,7 +180,7 @@ exports.createPages = async ({ graphql, actions }) => {
   // **Note:** The graphql function call returns a Promise
   // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise for more info
   const result = await graphql(`
-    {
+    query {
       allMarkdownRemark {
         edges {
           node {
@@ -254,7 +254,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions // highlight-line
   const result = await graphql(`
-    {
+    query {
       allMarkdownRemark {
         edges {
           node {


### PR DESCRIPTION
## Description

In tutorial part 7, add missing query keywords in the GraphQL query of the gatsby-node.js snippet. 

## Related Issues

none.
