### PR TITLE
Add README for gatsby/themes

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -1,0 +1,8 @@
+## Gatsby Themes and Starters
+
+Here are the first party themes maintained by Gatsby.
+
+The names tell you what they are: `gatsby-starter-*` vs `gatsby-theme-*`. For example:
+
+* `gatsby-starter-blog-theme` is a starter that uses the blog theme and comes with demo content, etc. [Starters](https://www.gatsbyjs.org/starters/?v=2) are a fairly common concept in the Gatsby ecosystem.
+* `gatsby-theme-blog` is a theme that is released as an npm package. You can see this since the `package.json` name is `gatsby-theme-blog` as well.

--- a/themes/README.md
+++ b/themes/README.md
@@ -4,5 +4,5 @@ Here are the first party themes maintained by Gatsby.
 
 The names tell you what they are: `gatsby-starter-*` vs `gatsby-theme-*`. For example:
 
-* `gatsby-starter-blog-theme` is a starter that uses the blog theme and comes with demo content, etc. [Starters](https://www.gatsbyjs.org/starters/?v=2) are a fairly common concept in the Gatsby ecosystem.
-* `gatsby-theme-blog` is a theme that is released as an npm package. You can see this since the `package.json` name is `gatsby-theme-blog` as well.
+- `gatsby-starter-blog-theme` is a starter that uses the blog theme and comes with demo content, etc. [Starters](https://www.gatsbyjs.org/starters/?v=2) are a fairly common concept in the Gatsby ecosystem.
+- `gatsby-theme-blog` is a theme that is released as an npm package. You can see this since the `package.json` name is `gatsby-theme-blog` as well.


### PR DESCRIPTION
## Description

Contributors to gatsby and creators of gatsby themes maybe confused when they first encounter `gatsby/themes`. This stubs out a README that gives a little guidance in-place and confirms that having starters here is intentional.

cc @ChristopherBiscardi just taking a quick stab at what i wanted to see happen, this what i meant by clarify things.

## Related Issues

addresses https://github.com/gatsbyjs/gatsby/issues/16145