### PR TITLE
Release stdio streams when exiting `gatsby develop`

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -60,8 +60,10 @@ const rlInterface = rl.createInterface({
 
 // Quit immediately on hearing ctrl-c
 rlInterface.on(`SIGINT`, () => {
-  rlInterface.close()
-  process.exit()
+  // fixes issue with bash shell not receiving control of
+  // stdio when exiting
+  rlInterface.close() // Release stdio streams
+  process.exit(0)
 })
 
 onExit(() => {

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -60,6 +60,7 @@ const rlInterface = rl.createInterface({
 
 // Quit immediately on hearing ctrl-c
 rlInterface.on(`SIGINT`, () => {
+  rlInterface.close()
   process.exit()
 })
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

When using the `bash` shell, stdio streams are not returned to the shell when `gatsby develop` exits after receiving a `SIGINT` signal.

I believe this is due to this node behavior:
> <https://nodejs.org/api/process.html#process_signal_events>:
> `SIGTERM` and `SIGINT` have default handlers on non-Windows platforms that reset the terminal mode before exiting with code 128 + signal number. If one of these signals has a listener installed, its default behavior will be removed (Node.js will no longer exit).

Fairly simple fix: Exit the process gracefully by releasing stdio streams from `readline` interface prior to calling `process.exit(0)` (I added the exit code, since exit was initiated by the user).

One alternative would be to pass the signal on to the node process:
```js
process.kill(process.pid, `SIGINT`);
```
However, I was concerned about Windows compatibility, since Windows does not support signals, as such.  I believe that would require additional logic to account for a Windows environment, which would wind up being a simple `process.exit(0)` anyway....

Node documentation isn't clear about what "reset the terminal mode" means in its entirety.  It's possible that if you have custom controls configured in the terminal, they might be overwritten by Node, and exiting like this will not reset them.  In that case, relaying the signal to node will (I believe) cause node to execute its default behavior.

## Related Issues

Fixes #16621