### PR TITLE
chore: Update link to Gatsby unit testing docs for VSCode

### DIFF
--- a/docs/blog/2019-04-30-how-to-build-a-blog-with-wordpress-and-gatsby-part-2/index.md
+++ b/docs/blog/2019-04-30-how-to-build-a-blog-with-wordpress-and-gatsby-part-2/index.md
@@ -98,7 +98,7 @@ These files will be present in all Gatsby starters you use, so it's worth your t
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/docs/blog/2019-04-30-how-to-build-a-blog-with-wordpress-and-gatsby-part-2/index.md
+++ b/docs/blog/2019-04-30-how-to-build-a-blog-with-wordpress-and-gatsby-part-2/index.md
@@ -98,7 +98,7 @@ These files will be present in all Gatsby starters you use, so it's worth your t
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/examples/recipe-static-image/package.json
+++ b/examples/recipe-static-image/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "dependencies": {
     "gatsby": "^2.13.25",

--- a/examples/recipe-static-image/package.json
+++ b/examples/recipe-static-image/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "dependencies": {
     "gatsby": "^2.13.25",

--- a/examples/recipe-webpack-image/package.json
+++ b/examples/recipe-webpack-image/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "dependencies": {
     "gatsby": "^2.13.25",

--- a/examples/recipe-webpack-image/package.json
+++ b/examples/recipe-webpack-image/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "dependencies": {
     "gatsby": "^2.13.25",

--- a/examples/recipes-gatsby-image/package.json
+++ b/examples/recipes-gatsby-image/package.json
@@ -34,7 +34,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/examples/recipes-gatsby-image/package.json
+++ b/examples/recipes-gatsby-image/package.json
@@ -34,7 +34,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/examples/using-jest/README.md
+++ b/examples/using-jest/README.md
@@ -11,7 +11,7 @@ Kick off your next Gatsby app with some great testing practices enabled via [Jes
 
 Check out the [unit testing doc][unit-testing-doc] for further info!
 
-[jest]: https://jestjs.io/
+[jest]: https://jestjs.io
 [react-testing-library]: https://github.com/testing-library/react-testing-library
 [gatsby]: https://gatsbyjs.org
 [unit-testing-doc]: https://www.gatsbyjs.org/docs/unit-testing

--- a/examples/using-jest/README.md
+++ b/examples/using-jest/README.md
@@ -14,4 +14,4 @@ Check out the [unit testing doc][unit-testing-doc] for further info!
 [jest]: https://jestjs.io/
 [react-testing-library]: https://github.com/testing-library/react-testing-library
 [gatsby]: https://gatsbyjs.org
-[unit-testing-doc]: https://www.gatsbyjs.org/docs/unit-testing/
+[unit-testing-doc]: https://www.gatsbyjs.org/docs/unit-testing

--- a/examples/using-js-search/package.json
+++ b/examples/using-js-search/package.json
@@ -14,7 +14,7 @@
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/examples/using-js-search/package.json
+++ b/examples/using-js-search/package.json
@@ -4,7 +4,9 @@
   "description": "Gatsby example site to demonstrate client side search",
   "version": "0.1.0",
   "keywords": [
-    "Gatsby", "client side search", "js-search"
+    "Gatsby",
+    "client side search",
+    "js-search"
   ],
   "license": "MIT",
   "scripts": {
@@ -12,7 +14,7 @@
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/examples/using-markdown-pages/package.json
+++ b/examples/using-markdown-pages/package.json
@@ -32,6 +32,6 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   }
 }

--- a/examples/using-markdown-pages/package.json
+++ b/examples/using-markdown-pages/package.json
@@ -32,6 +32,6 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   }
 }

--- a/examples/using-shopify/package.json
+++ b/examples/using-shopify/package.json
@@ -29,7 +29,7 @@
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/examples/using-shopify/package.json
+++ b/examples/using-shopify/package.json
@@ -29,7 +29,7 @@
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/starters/blog/package.json
+++ b/starters/blog/package.json
@@ -54,6 +54,6 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   }
 }

--- a/starters/blog/package.json
+++ b/starters/blog/package.json
@@ -54,6 +54,6 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   }
 }

--- a/starters/default/package.json
+++ b/starters/default/package.json
@@ -31,7 +31,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/starters/default/package.json
+++ b/starters/default/package.json
@@ -31,7 +31,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "repository": {
     "type": "git",

--- a/starters/hello-world/package.json
+++ b/starters/hello-world/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
   },
   "dependencies": {
     "gatsby": "^2.13.67",

--- a/starters/hello-world/package.json
+++ b/starters/hello-world/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "dependencies": {
     "gatsby": "^2.13.67",


### PR DESCRIPTION
## Description

When pawing through the `package.json` of starters and examples, clicking the link (in VSCode) to the unit testing documentation in the `test` script leads to a 404 because a `\` is misinterpreted as being part of the URL. The URL itself (without the superfluous backslash) seems to be an old URL with a redirect to the unit testing documentation at https://www.gatsbyjs.org/docs/unit-testing.

I changed the URL to https://www.gatsbyjs.org/docs/unit-testing and added a space between the URL and the backslash, which achieves the following:

**Opening the link in VSCode takes you to the docs instead of a 404**

![gatsby-open-link-vscode](https://user-images.githubusercontent.com/5732000/63226793-b06d4e80-c1ac-11e9-8360-b85b83633162.gif)

**...and when the link is echoed into the shell by the placeholder `test` script, it still works :**

![gatsby-run-test-link](https://user-images.githubusercontent.com/5732000/63226825-312c4a80-c1ad-11e9-99c1-0a98d507cf56.gif)

