### PR TITLE
fix(gatsby): remove finally to enable ie11 + firefox support

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -1,4 +1,3 @@
-import "core-js/modules/es7.promise.finally"
 import prefetchHelper from "./prefetch"
 import emitter from "./emitter"
 import { setMatchPaths, findMatchPath, cleanPath } from "./find-path"
@@ -223,8 +222,14 @@ export class BaseLoader {
           return pageResources
         })
       })
-      .finally(() => {
+      // prefer duplication with then + catch over .finally to prevent problems in ie11 + firefox
+      .then(response => {
         this.inFlightDb.delete(pagePath)
+        return response
+      })
+      .catch(err => {
+        this.inFlightDb.delete(pagePath)
+        throw err
       })
 
     this.inFlightDb.set(pagePath, inFlight)


### PR DESCRIPTION
## Description

since Gatsby 12.2.1 firefox + ie11 have been broken due to the use of `.finally`.

I've opted not to use `async/await` as that would  change the behaviour of the function, instead i've dupe'd the `finally` code in a `then` and `catch`.  This mean there is no change in code behaviour.

## Related Issues

fixed https://github.com/gatsbyjs/gatsby/issues/16287
