### PR TITLE
Adding Forestry.io to CMS tags

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -14,6 +14,7 @@ starter:
   - CMS:Netlify
   - CMS:Wordpress
   - CMS:sanity.io
+  - CMS:Forestry.io
   - CMS:Other
   - Disqus
   - Documentation


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Adding the option to specify Forestry.io as a CMS tag for the gatsby starters. 