### PR TITLE
don't use experimental syntax that documentation plugin can't handle

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -265,7 +265,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       try {
         // most systems
         trueComponentPath = slash(trueCasePathSync(page.component))
-      } catch {
+      } catch (e) {
         // systems where user doesn't have access to /
         const commonDir = getCommonDir(
           store.getState().program.directory,


### PR DESCRIPTION
this fixes missing public actions in docs ( https://www.gatsbyjs.org/docs/actions/ ),

next step would be to make `gatsby-plugin-documentation` not fail silently (at least warning would be needed I think)