### PR TITLE
docs: Configuring a CA for private package registries

### DIFF
--- a/docs/docs/configuring-ca-certificates.md
+++ b/docs/docs/configuring-ca-certificates.md
@@ -2,11 +2,11 @@
 title: Configuring CA Certificates
 ---
 
-For developers using a private (or corporate) package registry that requires a certificate from a certificate authority (CA), you may need to set your certificate in your npm, yarn, or node config.
+If you're using a private (typically a corporate) package registry that requires a certificate from a CA (certificate authority), you may need to setup the certificate in your `npm`, `yarn`, and `node` config.
 
 ## Common errors from misconfigured certificates
 
-This might be a problem if you are seeing errors like `unable to get local issuer certificate` in the console output while trying to install Gatsby plugins, particularly with plugins or themes that need to be built as native Node.js modules (eg. `gatsby-plugin-sharp`). It may happen after running `npm install` or `yarn install` in a fresh clone of a repository when trying to pull packages from a place besides a public registry and the certifcate has not been set in your config.
+If you're seeing errors like `unable to get local issuer certificate` in the console output while trying to install a Gatsby plugin, a misconfigured certificate might be the problem. This occurs particularly with plugins or themes that need to be built as native Node.js modules (eg. `gatsby-plugin-sharp`). It may happen when installing packages from a private registry (via `npm install` or `yarn install`) without an appropriately setup certificate in config.
 
 ## cafile config option
 
@@ -30,7 +30,7 @@ npm config ls -l
 yarn config set cafile "path-to-my-cert.pem"
 ```
 
-You can then check what the values in the yarn config with the following command:
+You can now check values in your yarn config with the following command:
 
 ```shell
 yarn config list
@@ -38,7 +38,7 @@ yarn config list
 
 ### Using Node.js
 
-Alternately, if you aren't using npm or yarn, you can configure the option for your installation of Node.js on your machine. Export the path to your certificate with the `NODE_EXTRA_CA_CERTS` variable:
+Alternatively, you can also configure this for Node.js on your machine. Export the path to your certificate with the `NODE_EXTRA_CA_CERTS` variable:
 
 ```shell
 export NODE_EXTRA_CA_CERTS=["path-to-my-cert.pem"]

--- a/docs/docs/configuring-ca-certificates.md
+++ b/docs/docs/configuring-ca-certificates.md
@@ -1,0 +1,45 @@
+---
+title: Configuring CA Certificates
+---
+
+For developers using a private (or corporate) package registry that requires a certificate from a certificate authority (CA), you may need to set your certificate in your npm, yarn, or node config.
+
+## Common errors from misconfigured certificates
+
+This might be a problem if you are seeing errors like `unable to get local issuer certificate` in the console output while trying to install Gatsby plugins, particularly with plugins or themes that need to be built as native Node.js modules (eg. `gatsby-plugin-sharp`). It may happen after running `npm install` or `yarn install` in a fresh clone of a repository when trying to pull packages from a place besides a public registry and the certifcate has not been set in your config.
+
+## cafile config option
+
+Both [npm](https://docs.npmjs.com/misc/config#cafile) and [yarn](https://yarnpkg.com/lang/en/docs/cli/config/), support a `cafile` config option. You'll have to add `cafile` as the key, and set the path to your certificate as the value.
+
+### Using npm to set cafile
+
+```shell
+npm config set cafile "path-to-my-cert.pem"
+```
+
+To check the value of the certificate path at the `cafile` key, use the following command to list all keys in your npm config:
+
+```shell
+npm config ls -l
+```
+
+### Using yarn to set cafile
+
+```shell
+yarn config set cafile "path-to-my-cert.pem"
+```
+
+You can then check what the values in the yarn config with the following command:
+
+```shell
+yarn config list
+```
+
+### Using Node.js
+
+Alternately, if you aren't using npm or yarn, you can configure the option for your installation of Node.js on your machine. Export the path to your certificate with the `NODE_EXTRA_CA_CERTS` variable:
+
+```shell
+export NODE_EXTRA_CA_CERTS=["path-to-my-cert.pem"]
+```

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -26,6 +26,8 @@
               link: /docs/gatsby-on-windows/
             - title: Gatsby on Linux
               link: /docs/gatsby-on-linux/
+            - title: Configuring CA Certificates
+              link: /docs/configuring-ca-certificates/
         - title: Deploying & Hosting
           link: /docs/deploying-and-hosting/
           items:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This adds some docs to the setting up your local environment section that mentions how to set a configuration for a corporate issued certificate to your `npm`, `yarn`, or Node.js config to fix installation of plugins or themes.

## Screenshot

<details>
<summary>Details</summary>

![localhost_8000_docs_configuring-ca-certificates_ (1)](https://user-images.githubusercontent.com/21114044/63303142-2ac8cc00-c29c-11e9-82dd-ad571af22414.png)

</details>

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Addresses #15807