### PR TITLE
fix(gatsby): keep all page-data files in public

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -145,9 +145,8 @@ module.exports = async (args: BootstrapArgs) => {
     )
     activity.start()
     await del([
-      `public/*.{html,css}`,
       `public/**/*.{html,css}`,
-      `!public/page-data/404.html`,
+      `!public/page-data/**/*`,
       `!public/static`,
       `!public/static/**/*.{html,css}`,
     ])


### PR DESCRIPTION
## Description
We remove all {.html,.css} files from public which also includes page-data files that end with .html. For example page-data/page-3.html/page-data.json also gets removed. This pr fixes it.

## Related Issues
Related to #16354
Fixes #16645
