### PR TITLE
chore: Add Renovate for packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":disablePeerDependencies"],
-  "includePaths": ["starters/**", "themes/**"],
+  "includePaths": ["starters/**", "themes/**", "packages/**"],
   "major": {
     "enabled": false
   },


### PR DESCRIPTION
Now that we have more confidence in our test suite, looks like we should be able to add auto updating of deps for all our packages 🎉 

Might be noisy to start with, will configure if it is too much!

Fixes https://github.com/gatsbyjs/gatsby/issues/16316 and https://github.com/gatsbyjs/gatsby/issues/16323