### PR TITLE
fix(gatsby): Use publicLoader in production-app

### DIFF
--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -117,7 +117,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     })
   }
 
-  loader.loadPage(browserLoc.pathname).then(page => {
+  publicLoader.loadPage(browserLoc.pathname).then(page => {
     if (!page || page.status === `error`) {
       throw new Error(
         `page resources for ${


### PR DESCRIPTION
## Description

As part of https://github.com/gatsbyjs/gatsby/pull/16122, some work was made to make sure `publicLoader` was used across the board as `window.___loader`, instead of `ProdLoader`.

But there was an instance in `production-app.js` where the `ProdLoader` is still used instead of `publicLoader`.

By using the right public loader, plugins can override it when necessary.

https://github.com/wardpeet/gatsby-plugin-static-site/issues/6