### PR TITLE
fix(examples): remove using-fragments submodule

### DIFF
--- a/examples/using-fragments/LICENSE
+++ b/examples/using-fragments/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 gatsbyjs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/using-fragments/README.md
+++ b/examples/using-fragments/README.md
@@ -1,0 +1,3 @@
+# Using Fragments Example
+
+This repo contains a simplified example of using GraphQL fragments in a Gatsby site

--- a/examples/using-fragments/gatsby-config.js
+++ b/examples/using-fragments/gatsby-config.js
@@ -1,0 +1,19 @@
+/**
+ * Configure your Gatsby site with this file.
+ *
+ * See: https://www.gatsbyjs.org/docs/gatsby-config/
+ */
+
+module.exports = {
+  siteMetadata: {
+    title: `GatsbyJS`,
+    details: {
+      url: `https://www.gatsbyjs.org`,
+      description: `Blazing fast modern site generator for React`,
+    },
+    social: {
+      twitter: `@gatsbyjs`,
+    },
+  },
+  /* Your site config here */
+}

--- a/examples/using-fragments/package.json
+++ b/examples/using-fragments/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "using-fragments",
+  "private": true,
+  "description": "A simplified example of using GraphQL fragments",
+  "version": "0.1.0",
+  "license": "MIT",
+  "scripts": {
+    "build": "gatsby build",
+    "develop": "gatsby develop",
+    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "start": "npm run develop",
+    "serve": "gatsby serve",
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+  },
+  "dependencies": {
+    "gatsby": "^2.13.63",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
+  },
+  "devDependencies": {
+    "prettier": "^1.18.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby-starter-hello-world"
+  },
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  }
+}

--- a/examples/using-fragments/src/components/details.js
+++ b/examples/using-fragments/src/components/details.js
@@ -1,0 +1,22 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+const Details = ({ data }) => (
+  <div>
+    {data.site.siteMetadata.details.url} -{` `}
+    {data.site.siteMetadata.details.description}
+  </div>
+)
+
+export default Details
+
+export const detailsFragment = graphql`
+  fragment DetailsFragment on Site {
+    siteMetadata {
+      details {
+        url
+        description
+      }
+    }
+  }
+`

--- a/examples/using-fragments/src/components/social.js
+++ b/examples/using-fragments/src/components/social.js
@@ -1,0 +1,16 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+const Social = ({ data }) => <div>{data.site.siteMetadata.social.twitter}</div>
+
+export default Social
+
+export const socialFragment = graphql`
+  fragment SocialFragment on Site {
+    siteMetadata {
+      social {
+        twitter
+      }
+    }
+  }
+`

--- a/examples/using-fragments/src/pages/index.js
+++ b/examples/using-fragments/src/pages/index.js
@@ -1,0 +1,45 @@
+import React from "react"
+import { graphql } from "gatsby"
+import Details from "../components/details"
+import Social from "../components/social"
+
+export default ({ data }) => (
+  <div>
+    Hello world! This is {data.site.siteMetadata.title}
+    <Details data={data} />
+    <Social data={data} />
+  </div>
+)
+
+export const pageQuery = graphql`
+  query SiteQuery {
+    site {
+      siteMetadata {
+        title
+      }
+      ...DetailsFragment
+      ...SocialFragment
+    }
+  }
+`
+
+/*
+  instead of...
+
+export const pageQuery = graphql`
+  query SiteQuery {
+    site {
+      siteMetadata {
+        title
+        details {
+          url
+          description
+        }
+        social {
+          twitter
+        }
+      }
+    }
+  }
+`
+*/


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The example for `using-fragments` got committed as a submodule by accident. This just removes the submodule and replaces it with a folder of the files that are supposed to be used for the example. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

https://github.com/gatsbyjs/gatsby/commit/fdf50b6f70a99154bc7963c528d2a7b8458d8d16#commitcomment-34762552 😬 
