### PR TITLE
chore: add package.json to renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":disablePeerDependencies"],
-  "includePaths": ["starters/**", "themes/**", "packages/**", "www"],
+  "includePaths": ["package.json", "starters/**", "themes/**", "packages/**", "www"],
   "major": {
     "enabled": false
   },


### PR DESCRIPTION
This solves the missing lock file updates reported in https://github.com/renovatebot/config-help/issues/333
If `package.json` is not included, it also ends up excluding its `yarn.lock`. Adding `package.json` to `includePaths` fixes the problem.