### PR TITLE
feat(www): add ability to limit table of contents depth

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1,5 +1,6 @@
 ---
 title: Recipes
+tableOfContentsDepth: 2
 ---
 
 <!-- Basic template for a Gatsby recipe:

--- a/www/src/components/docs-table-of-contents.js
+++ b/www/src/components/docs-table-of-contents.js
@@ -9,7 +9,18 @@ import {
   transition,
 } from "../utils/presets"
 
-function createItems(items, location) {
+function isUnderDepthLimit(depth, maxDepth) {
+  if (maxDepth === null) {
+    // if no maxDepth is passed in, continue to render more items
+    return true
+  } else {
+    return depth < maxDepth
+  }
+}
+
+// depth and maxDepth are used to figure out how many bullets deep to render in the ToC sidebar, if no
+// max depth is set via the tableOfContentsDepth field in the frontmatter, all headings will be rendered
+function createItems(items, location, depth, maxDepth) {
   return (
     items &&
     items.map(item => (
@@ -49,13 +60,13 @@ function createItems(items, location) {
         >
           {item.title}
         </Link>
-        {item.items && (
+        {item.items && isUnderDepthLimit(depth, maxDepth) && (
           <ul
             css={{
               marginLeft: space[6],
             }}
           >
-            {createItems(item.items, location)}
+            {createItems(item.items, location, depth + 1, maxDepth)}
           </ul>
         )}
       </li>
@@ -85,7 +96,12 @@ function TableOfContents({ page, location }) {
           },
         }}
       >
-        {createItems(page.tableOfContents.items, location)}
+        {createItems(
+          page.tableOfContents.items,
+          location,
+          1,
+          page.frontmatter.tableOfContentsDepth
+        )}
       </ul>
     </nav>
   ) : null

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -170,6 +170,7 @@ export const pageQuery = graphql`
         overview
         issue
         disableTableOfContents
+        tableOfContentsDepth
       }
       ...MarkdownPageFooterMdx
     }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adds a `tableOfContentsDepth` field to the frontmatter of docs pages so that we can optionally limit the depth of headings shown in the table of contents.

This makes it easier to scan through really long pages with a lot of headers like the recipes page. Here's a before (left) and after (right) of what this looks like for the recipes page now (with depth set to 2):

![image](https://user-images.githubusercontent.com/21114044/63384000-33340c00-c35b-11e9-83cd-cdeead6a9889.png)

All other pages without setting a `tableOfContentsDepth` are unaffected and show all headings in the ToC.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #16341