### PR TITLE
chore: enable renovate master issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,9 @@
   "extends": ["config:base", ":disablePeerDependencies"],
   "includePaths": ["starters/**", "themes/**", "packages/**", "www"],
   "major": {
-    "enabled": false
+    "masterIssueApproval": true
   },
+  "masterIssue": true,
   "rebaseStalePrs": false,
   "rangeStrategy": "bump",
   "bumpVersion": null,


### PR DESCRIPTION
This config changes enables Renovate's master issue (ref: https://renovatebot.com/blog/master-issue). Instead of simply disabling major updates, they will be blocked awaiting approval in the master issue. This gives visibility of them while not raising them as PRs until requested.