### PR TITLE
chore(gatsby-theme-blog-core): Remove duplicate body from post-query.js

### DIFF
--- a/themes/gatsby-theme-blog-core/src/templates/post-query.js
+++ b/themes/gatsby-theme-blog-core/src/templates/post-query.js
@@ -20,7 +20,6 @@ export const query = graphql`
       body
       slug
       title
-      body
       tags
       keywords
       date(formatString: "MMMM DD, YYYY")


### PR DESCRIPTION
## Description

The post-query.js file in gatsby-theme-blog-core had an unnecessary 2nd "body" field.


