### PR TITLE
feat: Allow themes to modify GraphQL types

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -299,11 +299,15 @@ const mergeTypes = ({
   parentSpan,
 }) => {
   // Only allow user or plugin owning the type to extend already existing type.
+  // Themes are also allowed to modify plugin-owned types, but not types already
+  // modified by another plugin.
   const typeOwner = typeComposer.getExtension(`plugin`)
   if (
     !plugin ||
+    plugin.name === typeOwner ||
     plugin.name === `default-site-plugin` ||
-    plugin.name === typeOwner
+    (plugin.name.startsWith(`gatsby-theme-`) &&
+      !typeOwner.startsWith(`gatsby-theme-`))
   ) {
     typeComposer.merge(type)
     if (isNamedTypeComposer(type)) {


### PR DESCRIPTION
Currently, a GraphQL type can only be modified by the plugin which created that type, or by a user's `gatsby-node`. This excludes a theme's `gatsby-node`.

This PR allows a theme's `gatsby-node` to modify types. A top-level `gatsby-node` always takes precedence. If a type has already been modified by another theme, modification is not allowed.

Fixes #16529, #15544