### PR TITLE
chore(gatsby): Remove fallback for v8 serialize

### DIFF
--- a/packages/gatsby/src/redux/persist.js
+++ b/packages/gatsby/src/redux/persist.js
@@ -1,47 +1,10 @@
 const v8 = require(`v8`)
 const fs = require(`fs-extra`)
-const stringify = require(`json-stringify-safe`)
 
-const objectToMap = obj => {
-  const map = new Map()
-  Object.keys(obj).forEach(key => {
-    map.set(key, obj[key])
-  })
-  return map
-}
+const file = `${process.cwd()}/.cache/redux.state`
 
-const mapToObject = map => {
-  const obj = {}
-  for (let [key, value] of map) {
-    obj[key] = value
-  }
-  return obj
-}
+const readFromCache = () => v8.deserialize(fs.readFileSync(file))
 
-const jsonStringify = contents => {
-  contents.staticQueryComponents = mapToObject(contents.staticQueryComponents)
-  contents.components = mapToObject(contents.components)
-  contents.nodes = contents.nodes ? mapToObject(contents.nodes) : {}
-  return stringify(contents, null, 2)
-}
-
-const jsonParse = buffer => {
-  const parsed = JSON.parse(buffer.toString(`utf8`))
-  parsed.staticQueryComponents = objectToMap(parsed.staticQueryComponents)
-  parsed.components = objectToMap(parsed.components)
-  parsed.nodes = objectToMap(parsed.nodes || {})
-  return parsed
-}
-
-const useV8 = Boolean(v8.serialize)
-const [serialize, deserialize, file] = useV8
-  ? [v8.serialize, v8.deserialize, `${process.cwd()}/.cache/redux.state`]
-  : [jsonStringify, jsonParse, `${process.cwd()}/.cache/redux-state.json`]
-
-const readFromCache = () => deserialize(fs.readFileSync(file))
-
-const writeToCache = contents => {
-  fs.writeFileSync(file, serialize(contents))
-}
+const writeToCache = contents => fs.writeFileSync(file, v8.serialize(contents))
 
 module.exports = { readFromCache, writeToCache }


### PR DESCRIPTION
Since we now depend on Node 8+, we can assume `v8.serialize` to be present and can remove the fallback.