### PR TITLE
Add grayMatter option to gatsby-plugin-mdx

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -49,6 +49,7 @@ module.exports = async (
     id: createNodeId(`${node.id} >>> Mdx`),
     node,
     content,
+    options,
   })
 
   createNode(mdxNode)

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -119,6 +119,7 @@ module.exports = async function(content) {
       id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
       node: fileNode,
       content,
+      options,
     })
   } catch (e) {
     return callback(e)

--- a/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
+++ b/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
@@ -3,10 +3,10 @@ const { createContentDigest } = require(`gatsby-core-utils`)
 const mdx = require(`../utils/mdx`)
 const extractExports = require(`../utils/extract-exports`)
 
-module.exports = async ({ id, node, content }) => {
+module.exports = async ({ id, node, content, options }) => {
   let code
   try {
-    code = await mdx(content)
+    code = await mdx(content, options)
   } catch (e) {
     // add the path of the file to simplify debugging error messages
     e.message += `${node.absolutePath}: ${e.message}`

--- a/packages/gatsby-plugin-mdx/utils/default-options.js
+++ b/packages/gatsby-plugin-mdx/utils/default-options.js
@@ -19,6 +19,7 @@ module.exports = ({ mdPlugins, hastPlugins, ...pluginOptions }) => {
       gatsbyRemarkPlugins: [],
       globalScope: `export default {}`,
       shouldBlockNodeFromTransformation: () => false,
+      grayMatter: {},
     },
     pluginOptions
   )

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -1,5 +1,5 @@
 const babel = require(`@babel/core`)
-const grayMatter = require(`gray-matter`)
+const grayMatterWrapper = require(`./gray-matter-wrapper`)
 const mdx = require(`@mdx-js/mdx`)
 const objRestSpread = require(`@babel/plugin-proposal-object-rest-spread`)
 
@@ -76,7 +76,10 @@ module.exports = async function genMDX(
 
   // pull classic style frontmatter off the raw MDX body
   debug(`processing classic frontmatter`)
-  const { data, content: frontMatterCodeResult } = grayMatter(node.rawBody)
+  const { data, content: frontMatterCodeResult } = grayMatterWrapper(
+    node.rawBody,
+    options
+  )
   const content = `${frontMatterCodeResult}
 
 export const _frontmatter = ${JSON.stringify(data)}`

--- a/packages/gatsby-plugin-mdx/utils/gray-matter-wrapper/__snapshots__/index.test.js.snap
+++ b/packages/gatsby-plugin-mdx/utils/gray-matter-wrapper/__snapshots__/index.test.js.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gray-matter excerpt snapshot with body 1`] = `
+Object {
+  "content": "
+This is an excerpt.
+This is also an excerpt.
+
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {},
+}
+`;
+
+exports[`gray-matter excerpt snapshot with excerpt 1`] = `
+Object {
+  "content": "
+This is an excerpt.
+This is also an excerpt.
+
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {
+    "excerpt": "
+This is an excerpt.
+This is also an excerpt.
+
+This could be an excerpt.
+",
+  },
+}
+`;
+
+exports[`gray-matter excerpt snapshot with excerpt_separator 1`] = `
+Object {
+  "content": "
+This is an excerpt.
+This is also an excerpt.
+<!--more-->
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {
+    "excerpt": "
+This is an excerpt.
+This is also an excerpt.
+",
+  },
+}
+`;
+
+exports[`gray-matter excerpt snapshot with excerpt-excerpt_separator 1`] = `
+Object {
+  "content": "
+This is an excerpt.
+This is also an excerpt.
+<!--more-->
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {
+    "excerpt": "
+This is an excerpt.
+This is also an excerpt.
+",
+  },
+}
+`;
+
+exports[`gray-matter excerpt snapshot with frontmatter 1`] = `
+Object {
+  "content": "This is an excerpt.
+This is also an excerpt.
+
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {
+    "excerpt": "This is excerpt from frontmatter.",
+    "one": "two",
+  },
+}
+`;
+
+exports[`gray-matter excerpt snapshot with frontmatter-excerpt 1`] = `
+Object {
+  "content": "This is an excerpt.
+This is also an excerpt.
+
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {
+    "excerpt": "This is excerpt from frontmatter.",
+    "one": "two",
+  },
+}
+`;
+
+exports[`gray-matter excerpt snapshot with frontmatter-excerpt_separator 1`] = `
+Object {
+  "content": "This is an excerpt.
+This is also an excerpt.
+<!--more-->
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {
+    "excerpt": "This is excerpt from frontmatter.",
+    "one": "two",
+  },
+}
+`;
+
+exports[`gray-matter excerpt snapshot with frontmatter-excerpt-excerpt_separator 1`] = `
+Object {
+  "content": "This is an excerpt.
+This is also an excerpt.
+<!--more-->
+This could be an excerpt.
+---
+This is content.",
+  "data": Object {
+    "excerpt": "This is excerpt from frontmatter.",
+    "one": "two",
+  },
+}
+`;

--- a/packages/gatsby-plugin-mdx/utils/gray-matter-wrapper/index.js
+++ b/packages/gatsby-plugin-mdx/utils/gray-matter-wrapper/index.js
@@ -1,0 +1,8 @@
+const grayMatter = require(`gray-matter`)
+
+module.exports = (input, options) => {
+  const matter = grayMatter(input, options.grayMatter || {})
+  const { data: origData, excerpt, content } = matter
+  const data = excerpt === `` ? origData : { excerpt, ...origData }
+  return { data, content }
+}

--- a/packages/gatsby-plugin-mdx/utils/gray-matter-wrapper/index.test.js
+++ b/packages/gatsby-plugin-mdx/utils/gray-matter-wrapper/index.test.js
@@ -1,0 +1,60 @@
+const grayMatterWrapper = require(`.`)
+const c = require(`js-combinatorics`)
+
+const generateExcerptFixture = params => {
+  const { frontmatter, excerpt, excerpt_separator } = params
+  const code = {
+    frontmatter: `---
+one: two
+excerpt: This is excerpt from frontmatter.
+---`,
+    excerpt: `This is an excerpt.
+This is also an excerpt.`,
+    excerptSeparator: `<!--more-->`,
+    body: `This could be an excerpt.
+---
+This is content.`,
+  }
+  return {
+    name:
+      Object.entries(params)
+        .filter(([_, v]) => !!v)
+        .map(([k, _]) => k)
+        .join(`-`) || `body`,
+    input: [
+      frontmatter ? code.frontmatter : ``,
+      code.excerpt,
+      excerpt_separator ? code.excerptSeparator : ``,
+      code.body,
+    ].join(`\n`),
+    options: {
+      grayMatter: {
+        excerpt: excerpt,
+        excerpt_separator: excerpt_separator
+          ? code.excerptSeparator
+          : undefined,
+      },
+    },
+  }
+}
+
+const excerptFixtures = c
+  .baseN([true, false], 3)
+  .toArray()
+  .map(([frontmatter, excerpt, excerpt_separator]) => {
+    const { name, input, options } = generateExcerptFixture({
+      frontmatter,
+      excerpt,
+      excerpt_separator,
+    })
+    return [name, input, options]
+  })
+
+describe(`gray-matter`, () => {
+  describe(`excerpt`, () => {
+    test.each(excerptFixtures)(`snapshot with %s`, (name, input, options) => {
+      const matter = grayMatterWrapper(input, options)
+      expect(matter).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/gatsby-plugin-mdx/utils/mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/mdx.js
@@ -1,5 +1,5 @@
 const mdx = require(`@mdx-js/mdx`)
-const grayMatter = require(`gray-matter`)
+const grayMatterWrapper = require(`./gray-matter-wrapper`)
 /**
  * Converts MDX to JSX, including converting classic frontmatter to an
  * exported variable.
@@ -9,7 +9,7 @@ const grayMatter = require(`gray-matter`)
  * @return {String}         JSX source
  */
 module.exports = async function mdxToJsx(source, options) {
-  const { data, content } = grayMatter(source)
+  const { data, content } = grayMatterWrapper(source, options || {})
 
   let code = await mdx(content, options || {})
 


### PR DESCRIPTION
## Description
This commit is adding a new option for `gray-matter` used inside `gatsby-plugin-mdx`. The main motivation of this PR is for adding `excerpt_separator` which is commonly used in blogs.

When you specify:
```
module.exports = {
  plugins: [
    {
      resolve: `gatsby-plugin-mdx`,
      options: {
        grayMatter: {
          excerpt_separator: "<<<my-separator>>>"
        }
      }
    }
  ]
};
```

`gray-matter` automatically pick content before the `excerpt_separator`. ~~However, it contains mdx resources, so we need to translate it. In the `excerpt` resolver, it runs `processMDX()` for the extracted excerpt string just like it does for without `excerpt_separator`, then concat them.~~ Any MDX syntax won't be transformed since `gray-matter` doesn't know anything about MDX.

## Related Issues
Fixes #16865 

Note: Previously I tried to implement `excerpt_separator` inside the resolver but it seemed too complex. #16820