### PR TITLE
chore(gatsby-image): Clarify IntersectionObserver support in README.md

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -435,4 +435,4 @@ While you could achieve a similar effect with plain CSS media queries, `gatsby-i
   to use a gif with `gatsby-image`, it won't work. For now, the best workaround is
   to [import the gif directly](/docs/adding-images-fonts-files).
 - Lazy loading behavior is dependent on `IntersectionObserver` which is not available
-  in some fairly common browsers including Safari (pre-12.1), Mobile Safari (pre-12.2), and IE. A polyfill is recommended.
+  in IE. A polyfill is recommended.

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -435,4 +435,4 @@ While you could achieve a similar effect with plain CSS media queries, `gatsby-i
   to use a gif with `gatsby-image`, it won't work. For now, the best workaround is
   to [import the gif directly](/docs/adding-images-fonts-files).
 - Lazy loading behavior is dependent on `IntersectionObserver` which is not available
-  in some fairly common browsers including Safari and IE. A polyfill is recommended.
+  in some fairly common browsers including Safari (pre-12.1), Mobile Safari (pre-12.2), and IE. A polyfill is recommended.


### PR DESCRIPTION
The latest Safari releases for Desktop and iOS now include support for IntersectionObserver:
https://caniuse.com/#feat=intersectionobserver

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Documentation edits gatsby-image

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
