### PR TITLE
fix: temporarily downgrade sharp to 0.22.1

### DIFF
--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.0.0",
     "gatsby-core-utils": "^1.0.5",
     "semver": "^5.7.1",
-    "sharp": "^0.23.0"
+    "sharp": "0.22.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -23,7 +23,7 @@
     "probe-image-size": "^4.1.1",
     "progress": "^2.0.3",
     "semver": "^5.7.1",
-    "sharp": "^0.23.0",
+    "sharp": "0.22.1",
     "svgo": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -21,7 +21,7 @@
     "is-relative-url": "^2.0.0",
     "lodash": "^4.17.15",
     "semver": "^5.7.1",
-    "sharp": "^0.23.0",
+    "sharp": "0.22.1",
     "unist-util-select": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -13,7 +13,7 @@
     "potrace": "^2.1.2",
     "probe-image-size": "^4.1.1",
     "semver": "^5.7.1",
-    "sharp": "^0.23.0"
+    "sharp": "0.22.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
## Description

The [recent upgrade of sharp](https://github.com/gatsbyjs/gatsby/commit/05e90da29ff965ec00ea9b8c226e081408903e9c#diff-197ada3f297f184cc283a8e4c3fcec1aR26) by @renovate-bot is causing very strange crashes on OSX: https://github.com/gatsbyjs/gatsby/issues/16957.  While I don't yet know the exact issue I think we should downgrade sharp temporarily so people don't spend time trying to understand what's wrong with their setup (there are 6 upvotes on the issue).

## Related Issues

Fixes #16957 
