### PR TITLE
chore(ci): Fix lerna concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *persist_cache
-      - run: yarn bootstrap
+      - run: yarn bootstrap -- concurrency=2
       - persist_to_workspace:
           root: packages
           paths:

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     }
   },
   "scripts": {
-    "bootstrap": "npm-run-all -s check-versions lerna-prepare",
+    "bootstrap": "npm-run-all -s check-versions \"lerna-prepare -- --{@}\" --",
     "check-versions": "babel-node scripts/check-versions.js",
     "check-repo-fields": "babel-node scripts/check-repo-fields.js",
     "format": "npm run format:code && npm run format:other && npm run format:svg",


### PR DESCRIPTION
The new dependency updates seem to cause https://github.com/lerna/lerna/issues/1798 and `bootstrap` fails as a result on CircleCI. 

This is happening because CircleCI incorrectly reports the number of CPUs and lerna tries to run too many at once and runs out of memory. 

The fix here is to set concurrency to 2 for `lerna prepare` (only when running in CI)