### PR TITLE
fix(gatsby): update check for default exports

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -359,6 +359,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       !fileContent.includes(`export default`) &&
       !fileContent.includes(`module.exports`) &&
       !fileContent.includes(`exports.default`) &&
+      !fileContent.includes(`exports["default"]`) &&
       // this check only applies to js and ts, not mdx
       /\.(jsx?|tsx?)/.test(path.extname(fileName))
     ) {


### PR DESCRIPTION
```
    return _react["default"].createElement(_react["default"].Fragment, null);
  };

  return AppShell;
}(_react["default"].Component);

var _default = AppShell;
exports["default"] = _default;
```

The code above throws with 

```
error #11328 

A page component must export a React component for it to be valid. Please make sure this file exports a React component:

/root/project/e2e-tests/production-runtime/node_modules/gatsby-plugin-offline/app-shell.js
```

This happens because our check doesn't handle `exports["default"]`

(babel prior to https://github.com/gatsbyjs/gatsby/pull/16929 output `exports.default = _default;` but now outputs `exports["default"] = _default;`)

This PR adds that 