### PR TITLE
fix(www): title is required in gatsby-plugin-feed

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -226,6 +226,7 @@ module.exports = {
       options: {
         feeds: [
           {
+            title: `GatsbyJS`,
             query: `
               {
                 allMdx(


### PR DESCRIPTION
## Description
We weren't using `title` as an option in `gatsby-plugin-feed`. Latest patch version enforces title to be set as it was specified in the README.md all this time.