### PR TITLE
chore: update eslint-utils to 1.4.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8637,8 +8637,11 @@ eslint-scope@^4.0.3:
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

From [npm's security advisory](https://www.npmjs.com/advisories/1118):

> Versions of `eslint-utils` >=1.2.0 or <1.4.1 are vulnerable to Arbitrary Code Execution. The `getStaticValue` does not properly sanitize user input allowing attackers to supply malicious input that executes arbitrary code during the linting process. The `getStringIfConstant` and `getPropertyName` functions are not affected.

More info:

- https://github.com/mysticatea/eslint-utils/security/advisories/GHSA-3gx7-xhv7-5mx3
- https://eslint.org/blog/2019/08/eslint-v6.2.1-released