### PR TITLE
docs: sourcing data and creating pages recipes

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -130,204 +130,6 @@ export default () => (
 
 > **Note**: Gatsby's `<Link />` component is a wrapper around [`@reach/router`'s Link component](https://reach.tech/router/api/Link). For more information about Gatsby's `<Link />` component, consult the [API reference for `<Link />`](/docs/gatsby-link/).
 
-### Creating pages with `createPage`
-
-Using Gatsby's [`createPages` API](/docs/actions/#createPage), you can create pages dynamically from a variety of data sources, including Markdown or Wordpress content.
-
-This recipe shows how to create pages from Markdown files on your local filesystem using Gatsby's GraphQL data layer.
-
-#### Prerequisites
-
-- A [Gatsby site](/docs/quick-start) with a `gatsby-config.js` file
-- The [Gatsby CLI](/docs/gatsby-cli) installed
-- The [gatsby-source-filesystem plugin](/packages/gatsby-source-filesystem) installed
-- The [gatsby-transformer-remark plugin](/packages/gatsby-transformer-remark) installed
-- A `gatsby-node.js` file
-
-#### Directions
-
-1. In `gatsby-config.js`, configure `gatsby-transformer-remark` along with `gatsby-source-filesystem` to pull in Markdown files from a source folder. This would be in addition to any previous `gatsby-source-filesystem` entries, such as for images:
-
-```js:title=gatsby-config.js
-module.exports = {
-  plugins: [
-    `gatsby-transformer-remark`,
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `content`,
-        path: `${__dirname}/src/content`,
-      },
-    },
-  ]
-```
-
-2. Add a Markdown post to `src/content`, including frontmatter for the title, date, and path, with some initial content for the body of the post:
-
-```markdown:title=src/content/my-first-post.md
----
-title: My First Post
-date: 2019-07-10
-path: /my-first-post
----
-
-This is my first Gatsby post written in Markdown!
-```
-
-3. Add the JavaScript code to generate pages from Markdown posts at build time with a GraphQL query in `gatsby-node.js`:
-
-```js:title=gatsby-node.js
-const path = require(`path`)
-
-exports.createPages = async ({ actions, graphql }) => {
-  const { createPage } = actions
-
-  const blogPostTemplate = path.resolve(`src/templates/post.js`)
-
-  const result = await graphql(`
-    {
-      allMarkdownRemark(
-        sort: { order: DESC, fields: [frontmatter___date] }
-        limit: 1000
-      ) {
-        edges {
-          node {
-            frontmatter {
-              path
-            }
-          }
-        }
-      }
-    }
-  `)
-  if (result.errors) {
-    console.log(result.errors)
-    throw new Error("Things broke, see console output above")
-  }
-
-  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-    createPage({
-      path: node.frontmatter.path,
-      component: blogPostTemplate,
-      context: {}, // additional data can be passed via context
-    })
-  })
-}
-```
-
-4. Add a post template in `src/templates`, including a GraphQL query for generating pages dynamically from Markdown content at build time:
-
-```jsx:title=src/templates/post.js
-import React from "react"
-import { graphql } from "gatsby"
-
-export default function Template({ data }) {
-  const { markdownRemark } = data // data.markdownRemark holds your post data
-  const { frontmatter, html } = markdownRemark
-  return (
-    <div className="blog-post">
-      <h1>{frontmatter.title}</h1>
-      <h2>{frontmatter.date}</h2>
-      <div
-        className="blog-post-content"
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
-    </div>
-  )
-}
-
-export const pageQuery = graphql`
-  query($path: String!) {
-    markdownRemark(frontmatter: { path: { eq: $path } }) {
-      html
-      frontmatter {
-        date(formatString: "MMMM DD, YYYY")
-        path
-        title
-      }
-    }
-  }
-`
-```
-
-5. Run `gatsby develop` to start the development server. View your post in the browser: `http://localhost:8000/my-first-post`
-
-#### Additional resources
-
-- [Inspect Gatsby's data layer in GraphiQL](/docs/introducing-graphiql/)
-- [Tutorial: Programmatically create pages from data](/tutorial/part-seven/)
-- [Creating and modifying pages](/docs/creating-and-modifying-pages/)
-- [Adding Markdown pages](/docs/adding-markdown-pages/)
-- [Adding a list of Markdown blog posts](/docs/adding-a-list-of-markdown-blog-posts/)
-- [Guide to creating pages from data programmatically](/docs/programmatically-create-pages-from-data/)
-
-### Creating pages from data without GraphQL
-
-You can use the node `createPages` API to pull unstructured data directly into Gatsby sites rather than through GraphQL and source plugins. In this recipe, you'll create dynamic pages from data fetched from the [PokéAPI’s REST endpoints](https://www.pokeapi.co/). The [full example](https://github.com/jlengstorf/gatsby-with-unstructured-data/) can be found on GitHub.
-
-#### Prerequisites
-
-- A Gatsby Site with a `gatsby-node.js` file
-- The [Gatsby CLI](/docs/gatsby-cli) installed
-- The [axios](https://www.npmjs.com/package/axios) package installed through npm
-
-#### Directions
-
-1. In `gatsby-node.js`, add the JavaScript code to fetch data from the PokéAPI and programmatically create an index page:
-
-```js:title=gatsby-node.js
-const axios = require("axios")
-
-const get = endpoint => axios.get(`https://pokeapi.co/api/v2${endpoint}`)
-
-const getPokemonData = names =>
-  Promise.all(
-    names.map(async name => {
-      const { data: pokemon } = await get(`/pokemon/${name}`)
-      return { ...pokemon }
-    })
-  )
-exports.createPages = async ({ actions: { createPage } }) => {
-  const allPokemon = await getPokemonData(["pikachu", "charizard", "squirtle"])
-
-  // Create a page that lists Pokémon.
-  createPage({
-    path: `/`,
-    component: require.resolve("./src/templates/all-pokemon.js"),
-    context: { allPokemon },
-  })
-}
-```
-
-2. Create a template to display Pokémon on the homepage:
-
-```js:title=src/templates/all-pokemon.js
-import React from "react"
-
-export default ({ pageContext: { allPokemon } }) => (
-  <div>
-    <h1>Behold, the Pokémon!</h1>
-    <ul>
-      {allPokemon.map(pokemon => (
-        <li key={pokemon.id}>
-          <img src={pokemon.sprites.front_default} alt={pokemon.name} />
-          <p>{pokemon.name}</p>
-        </li>
-      ))}
-    </ul>
-  </div>
-)
-```
-
-3. Run `gatsby develop` to fetch the data, build pages, and start the development server.
-4. View your homepage in a browser: `http://localhost:8000`
-
-#### Additional resources
-
-- [Full Pokemon data repo](https://github.com/jlengstorf/gatsby-with-unstructured-data/)
-- More on using unstructured data in [Using Gatsby without GraphQL](/docs/using-gatsby-without-graphql/)
-- When and how to [Query data with GraphQL](/docs/querying-with-graphql/) for more complex Gatsby sites
-
 ### Creating a layout component
 
 It's common to wrap pages with a React layout component, which makes it possible to share markup, styles, and functionality across multiple pages.
@@ -368,6 +170,28 @@ export default () => (
 
 - Create a layout component in [tutorial part three](/tutorial/part-three/#your-first-layout-component)
 - Styling with [Layout Components](/docs/layout-components/)
+
+### Creating pages programmatically with createPage
+
+You can create pages programmatically in the `gatsby-node.js` file with helper methods Gatsby provides.
+
+#### Prerequisites
+
+- A [Gatsby site](/docs/quick-start)
+
+#### Directions
+
+1. Create a React component to serve as a template for your page
+
+2. In `gatsby-node.js`, add an export for `createPages`
+
+3. Destructure the `createPage` action from the available actions so it can be called by itself
+
+4. Loop through data and provide the path and template to `createPage` for each invocation
+
+5. Run `gatsby develop` and navigate to the path of one of the pages you created to see the data you passed it displayed
+
+#### Additional resources
 
 ## 2. Styling with CSS
 
@@ -517,7 +341,7 @@ body {
 }
 ```
 
-#### Additional Resources
+#### Additional resources
 
 - [Typography.js](/docs/typography-js/) - Another option for using Google fonts on a Gatsby site
 - [The Typefaces Project Docs](https://github.com/KyleAMathews/typefaces/blob/master/README.md)
@@ -628,7 +452,11 @@ yarn workspace example develop
 
 Data sourcing in Gatsby is plugin-driven; Source plugins fetch data from their source (e.g. the `gatsby-source-filesystem` plugin fetches data from the file system, the `gatsby-source-wordpress` plugin fetches data from the WordPress API, etc). You can also source the data yourself.
 
-### Creating source nodes
+### Adding data to GraphQL
+
+Gatsby's [GraphQL data layer](/docs/querying-with-graphql/) uses nodes to model chunks of data. Gatsby source plugins add source nodes that you can query for, but you can also create source nodes yourself. To add custom data to the GraphQL data layer yourself, Gatsby provides methods you can leverage.
+
+This recipe shows you how to add custom data using `createNode()`.
 
 #### Directions
 
@@ -680,6 +508,206 @@ query MyPokemonQuery {
 - Search available source plugins in the [Gatsby library](/plugins/?=source)
 - Understand source plugins by building one in the [Pixabay source plugin tutorial](/docs/pixabay-source-plugin-tutorial/)
 - The createNode function [documentation](/docs/actions/#createNode)
+
+### Sourcing Markdown data and creating pages with GraphQL
+
+You can source Markdown data and use Gatsby's [`createPages` API](/docs/actions/#createPage) to create pages dynamically.
+
+This recipe shows how to create pages from Markdown files on your local filesystem using Gatsby's GraphQL data layer.
+
+#### Prerequisites
+
+- A [Gatsby site](/docs/quick-start) with a `gatsby-config.js` file
+- The [Gatsby CLI](/docs/gatsby-cli) installed
+- The [gatsby-source-filesystem plugin](/packages/gatsby-source-filesystem) installed
+- The [gatsby-transformer-remark plugin](/packages/gatsby-transformer-remark) installed
+- A `gatsby-node.js` file
+
+#### Directions
+
+1. In `gatsby-config.js`, configure `gatsby-transformer-remark` along with `gatsby-source-filesystem` to pull in Markdown files from a source folder. This would be in addition to any previous `gatsby-source-filesystem` entries, such as for images:
+
+```js:title=gatsby-config.js
+module.exports = {
+  plugins: [
+    `gatsby-transformer-remark`,
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `content`,
+        path: `${__dirname}/src/content`,
+      },
+    },
+  ]
+```
+
+2. Add a Markdown post to `src/content`, including frontmatter for the title, date, and path, with some initial content for the body of the post:
+
+```markdown:title=src/content/my-first-post.md
+---
+title: My First Post
+date: 2019-07-10
+path: /my-first-post
+---
+
+This is my first Gatsby post written in Markdown!
+```
+
+3. Add the JavaScript code to generate pages from Markdown posts at build time with a GraphQL query in `gatsby-node.js`:
+
+```js:title=gatsby-node.js
+const path = require(`path`)
+
+exports.createPages = async ({ actions, graphql }) => {
+  const { createPage } = actions
+
+  const blogPostTemplate = path.resolve(`src/templates/post.js`)
+
+  const result = await graphql(`
+    {
+      allMarkdownRemark(
+        sort: { order: DESC, fields: [frontmatter___date] }
+        limit: 1000
+      ) {
+        edges {
+          node {
+            frontmatter {
+              path
+            }
+          }
+        }
+      }
+    }
+  `)
+  if (result.errors) {
+    console.log(result.errors)
+    throw new Error("Things broke, see console output above")
+  }
+
+  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+    createPage({
+      path: node.frontmatter.path,
+      component: blogPostTemplate,
+      context: {}, // additional data can be passed via context
+    })
+  })
+}
+```
+
+4. Add a post template in `src/templates`, including a GraphQL query for generating pages dynamically from Markdown content at build time:
+
+```jsx:title=src/templates/post.js
+import React from "react"
+import { graphql } from "gatsby"
+
+export default function Template({ data }) {
+  const { markdownRemark } = data // data.markdownRemark holds your post data
+  const { frontmatter, html } = markdownRemark
+  return (
+    <div className="blog-post">
+      <h1>{frontmatter.title}</h1>
+      <h2>{frontmatter.date}</h2>
+      <div
+        className="blog-post-content"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  )
+}
+
+export const pageQuery = graphql`
+  query($path: String!) {
+    markdownRemark(frontmatter: { path: { eq: $path } }) {
+      html
+      frontmatter {
+        date(formatString: "MMMM DD, YYYY")
+        path
+        title
+      }
+    }
+  }
+`
+```
+
+5. Run `gatsby develop` to start the development server. View your post in the browser: `http://localhost:8000/my-first-post`
+
+#### Additional resources
+
+- [Inspect Gatsby's data layer in GraphiQL](/docs/introducing-graphiql/)
+- [Tutorial: Programmatically create pages from data](/tutorial/part-seven/)
+- [Creating and modifying pages](/docs/creating-and-modifying-pages/)
+- [Adding Markdown pages](/docs/adding-markdown-pages/)
+- [Adding a list of Markdown blog posts](/docs/adding-a-list-of-markdown-blog-posts/)
+- [Guide to creating pages from data programmatically](/docs/programmatically-create-pages-from-data/)
+
+### Pulling data from an external source and creating pages without GraphQL
+
+You don't have to use the GraphQL data layer to include data in pages, [though there are reasons why you should conisder GraphQL](/docs/why-gatsby-uses-graphql/). You can use the node `createPages` API to pull unstructured data directly into Gatsby sites rather than through GraphQL and source plugins.
+
+In this recipe, you'll create dynamic pages from data fetched from the [PokéAPI’s REST endpoints](https://www.pokeapi.co/). The [full example](https://github.com/jlengstorf/gatsby-with-unstructured-data/) can be found on GitHub.
+
+#### Prerequisites
+
+- A Gatsby Site with a `gatsby-node.js` file
+- The [Gatsby CLI](/docs/gatsby-cli) installed
+- The [axios](https://www.npmjs.com/package/axios) package installed through npm
+
+#### Directions
+
+1. In `gatsby-node.js`, add the JavaScript code to fetch data from the PokéAPI and programmatically create an index page:
+
+```js:title=gatsby-node.js
+const axios = require("axios")
+
+const get = endpoint => axios.get(`https://pokeapi.co/api/v2${endpoint}`)
+
+const getPokemonData = names =>
+  Promise.all(
+    names.map(async name => {
+      const { data: pokemon } = await get(`/pokemon/${name}`)
+      return { ...pokemon }
+    })
+  )
+exports.createPages = async ({ actions: { createPage } }) => {
+  const allPokemon = await getPokemonData(["pikachu", "charizard", "squirtle"])
+
+  // Create a page that lists Pokémon.
+  createPage({
+    path: `/`,
+    component: require.resolve("./src/templates/all-pokemon.js"),
+    context: { allPokemon },
+  })
+}
+```
+
+2. Create a template to display Pokémon on the homepage:
+
+```js:title=src/templates/all-pokemon.js
+import React from "react"
+
+export default ({ pageContext: { allPokemon } }) => (
+  <div>
+    <h1>Behold, the Pokémon!</h1>
+    <ul>
+      {allPokemon.map(pokemon => (
+        <li key={pokemon.id}>
+          <img src={pokemon.sprites.front_default} alt={pokemon.name} />
+          <p>{pokemon.name}</p>
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+```
+
+3. Run `gatsby develop` to fetch the data, build pages, and start the development server.
+4. View your homepage in a browser: `http://localhost:8000`
+
+#### Additional resources
+
+- [Full Pokemon data repo](https://github.com/jlengstorf/gatsby-with-unstructured-data/)
+- More on using unstructured data in [Using Gatsby without GraphQL](/docs/using-gatsby-without-graphql/)
+- When and how to [query data with GraphQL](/docs/querying-with-graphql/) for more complex Gatsby sites
 
 ## 6. Querying data
 
@@ -1103,7 +1131,7 @@ export const pageQuery = graphql`
 
 Fragments can be nested inside other fragments, and multiple fragments can be used in the same query.
 
-#### Additional Resources
+#### Additional resources
 
 - [Simple example repo using fragments](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-fragments)
 - [Gatsby GraphQL reference for fragments](/docs/graphql-reference/#fragments)
@@ -1387,7 +1415,7 @@ return (
 
 5. Run `gatsby develop`, to generate images from files in the filesystem (if not done already) and cache them
 
-#### Additional Resources
+#### Additional resources
 
 - [Example repository illustrating these examples](https://github.com/gatsbyjs/gatsby/tree/master/examples/recipes-gatsby-image)
 - [Gatsby Image API](/docs/gatsby-image/)
@@ -1483,7 +1511,7 @@ export const pageQuery = graphql`
 
 4. Run `gatsby develop`, which will generate images for files sourced in the filesystem
 
-#### Additional Resources
+#### Additional resources
 
 - [Example repository using this recipe](https://github.com/gatsbyjs/gatsby/tree/master/examples/recipes-gatsby-image)
 - [Featured images with frontmatter](/docs/working-with-images-in-markdown/#featured-images-with-frontmatter-metadata)
@@ -1589,7 +1617,7 @@ gatsby build --prefix-paths
 gatsby build && gatsby serve
 ```
 
-#### Additional Resources
+#### Additional resources
 
 - Walk through building and deploying an example site in [tutorial part one](/tutorial/part-one/#deploying-a-gatsby-site)
 - Learn about [performance optimization](/docs/performance/)

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -259,7 +259,7 @@ export default ({ pageContext: { dog } }) => (
 
 - Tutorial section on [programmatically creating pages from data](/tutorial/part-seven/)
 - Reference guide on [using Gatsby without GraphQL](/docs/using-gatsby-without-graphql/)
-- [Example repo for this recipe](https://github.com/gatsbyjs/gatsby/tree/master/examples/recipe-createPage)
+- [Example repo](https://github.com/gatsbyjs/gatsby/tree/master/examples/recipe-createPage) for this recipe
 
 ## 2. Styling with CSS
 
@@ -637,6 +637,13 @@ This is my first Gatsby post written in Markdown!
 }
 ```
 
+<iframe
+  title="Query for all markdown"
+  src="https://q4xpb.sse.codesandbox.io/___graphql?explorerIsOpen=false&query=%7B%0A%20%20allMarkdownRemark%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D"
+  width="600"
+  height="300"
+/>
+
 4. Add the JavaScript code to generate pages from Markdown posts at build time by copying the GraphQL query into `gatsby-node.js` and looping through the results:
 
 ```js:title=gatsby-node.js
@@ -710,11 +717,11 @@ export const pageQuery = graphql`
 
 #### Additional resources
 
-- [Inspect Gatsby's data layer in GraphiQL](/docs/introducing-graphiql/)
 - [Tutorial: Programmatically create pages from data](/tutorial/part-seven/)
 - [Creating and modifying pages](/docs/creating-and-modifying-pages/)
 - [Adding Markdown pages](/docs/adding-markdown-pages/)
 - [Guide to creating pages from data programmatically](/docs/programmatically-create-pages-from-data/)
+- [Example repo](https://github.com/gatsbyjs/gatsby/tree/master/examples/recipe-sourcing-markdown) for this recipe
 
 ### Pulling data from an external source and creating pages without GraphQL
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -243,7 +243,7 @@ exports.createPages = ({ actions }) => {
 
 4. Create a React component to serve as the template for your page that was used in `createPage`
 
-```javascript:title=src/templates/dog-template.js
+```jsx:title=src/templates/dog-template.js
 import React from "react"
 
 export default ({ pageContext: { dog } }) => (

--- a/examples/recipe-createPage/README.md
+++ b/examples/recipe-createPage/README.md
@@ -1,0 +1,3 @@
+# createPage Recipe
+
+This repo gives a simple example of creating pages programmatically from basic data

--- a/examples/recipe-createPage/gatsby-config.js
+++ b/examples/recipe-createPage/gatsby-config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  siteMetadata: {
+    title: `createPage Recipe`,
+    description: `Example using the createPage API`,
+    author: `@gatsbyjs`,
+  },
+  plugins: [
+    `gatsby-transformer-remark`,
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `content`,
+        path: `${__dirname}/src/content`,
+      },
+    },
+  ],
+}

--- a/examples/recipe-createPage/gatsby-config.js
+++ b/examples/recipe-createPage/gatsby-config.js
@@ -4,14 +4,4 @@ module.exports = {
     description: `Example using the createPage API`,
     author: `@gatsbyjs`,
   },
-  plugins: [
-    `gatsby-transformer-remark`,
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `content`,
-        path: `${__dirname}/src/content`,
-      },
-    },
-  ],
 }

--- a/examples/recipe-createPage/gatsby-node.js
+++ b/examples/recipe-createPage/gatsby-node.js
@@ -1,0 +1,21 @@
+exports.createPages = ({ actions }) => {
+  const { createPage } = actions
+
+  const dogData = [
+    {
+      name: `Fido`,
+      breed: `Sheltie`,
+    },
+    {
+      name: `Sparky`,
+      breed: `Corgi`,
+    },
+  ]
+  dogData.forEach(dog => {
+    createPage({
+      path: `/${dog.name}`,
+      component: require.resolve(`./src/templates/dog-template.js`),
+      context: { dog },
+    })
+  })
+}

--- a/examples/recipe-createPage/package.json
+++ b/examples/recipe-createPage/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "gatsby-starter-default",
+  "private": true,
+  "description": "A simple starter to get up and developing quickly with Gatsby",
+  "version": "0.1.0",
+  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "dependencies": {
+    "gatsby": "^2.13.73",
+    "gatsby-source-filesystem": "^2.1.16",
+    "gatsby-transformer-remark": "^2.6.19",
+    "prop-types": "^15.7.2",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
+    "react-helmet": "^5.2.1"
+  },
+  "devDependencies": {
+    "prettier": "^1.18.2"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "gatsby build",
+    "develop": "gatsby develop",
+    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "start": "npm run develop",
+    "serve": "gatsby serve",
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby-starter-default"
+  },
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  }
+}

--- a/examples/recipe-createPage/src/content/my-first-post.md
+++ b/examples/recipe-createPage/src/content/my-first-post.md
@@ -1,7 +1,0 @@
----
-title: My First Post
-date: 2019-07-10
-path: /my-first-post
----
-
-This is my first Gatsby post written in Markdown!

--- a/examples/recipe-createPage/src/content/my-first-post.md
+++ b/examples/recipe-createPage/src/content/my-first-post.md
@@ -1,0 +1,7 @@
+---
+title: My First Post
+date: 2019-07-10
+path: /my-first-post
+---
+
+This is my first Gatsby post written in Markdown!

--- a/examples/recipe-createPage/src/pages/index.js
+++ b/examples/recipe-createPage/src/pages/index.js
@@ -1,0 +1,11 @@
+import React from "react"
+import { Link } from "gatsby"
+
+const IndexPage = () => (
+  <main>
+    createPage Recipe (see pages at <Link to="Fido">Fido</Link> and{` `}
+    <Link to="Sparky">Sparky</Link>)
+  </main>
+)
+
+export default IndexPage

--- a/examples/recipe-createPage/src/templates/dog-template.js
+++ b/examples/recipe-createPage/src/templates/dog-template.js
@@ -1,0 +1,7 @@
+import React from "react"
+
+export default ({ pageContext: { dog } }) => (
+  <section>
+    {dog.name} - {dog.breed}
+  </section>
+)

--- a/examples/recipe-sourcing-markdown/gatsby-config.js
+++ b/examples/recipe-sourcing-markdown/gatsby-config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  siteMetadata: {
+    title: `sourcing markdown recipe`,
+    description: `Example sourcing markdown`,
+    author: `@gatsbyjs`,
+  },
+  plugins: [
+    `gatsby-transformer-remark`,
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `content`,
+        path: `${__dirname}/src/content`,
+      },
+    },
+  ],
+}

--- a/examples/recipe-sourcing-markdown/gatsby-node.js
+++ b/examples/recipe-sourcing-markdown/gatsby-node.js
@@ -1,0 +1,29 @@
+const path = require(`path`)
+
+exports.createPages = async ({ actions, graphql }) => {
+  const { createPage } = actions
+
+  const result = await graphql(`
+    {
+      allMarkdownRemark {
+        edges {
+          node {
+            frontmatter {
+              path
+            }
+          }
+        }
+      }
+    }
+  `)
+  if (result.errors) {
+    console.error(result.errors)
+  }
+
+  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+    createPage({
+      path: node.frontmatter.path,
+      component: path.resolve(`src/templates/post.js`),
+    })
+  })
+}

--- a/examples/recipe-sourcing-markdown/package.json
+++ b/examples/recipe-sourcing-markdown/package.json
@@ -1,11 +1,13 @@
 {
-  "name": "recipe-create-page",
+  "name": "recipe-sourcing-markdown",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.0",
   "author": "@gatsbyjs",
   "dependencies": {
     "gatsby": "^2.13.73",
+    "gatsby-source-filesystem": "^2.1.16",
+    "gatsby-transformer-remark": "^2.6.19",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/examples/recipe-sourcing-markdown/src/content/my-first-post.md
+++ b/examples/recipe-sourcing-markdown/src/content/my-first-post.md
@@ -1,0 +1,7 @@
+---
+title: My First Post
+date: 2019-07-10
+path: /my-first-post
+---
+
+This is my first Gatsby post written in Markdown!

--- a/examples/recipe-sourcing-markdown/src/pages/index.js
+++ b/examples/recipe-sourcing-markdown/src/pages/index.js
@@ -1,0 +1,11 @@
+import React from "react"
+import { Link } from "gatsby"
+
+const IndexPage = () => (
+  <main>
+    Sourcing markdown recipe (see page at{` `}
+    <Link to="my-first-post">/my-first-post</Link>)
+  </main>
+)
+
+export default IndexPage

--- a/examples/recipe-sourcing-markdown/src/templates/post.js
+++ b/examples/recipe-sourcing-markdown/src/templates/post.js
@@ -1,0 +1,30 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+export default function Template({ data }) {
+  const { markdownRemark } = data // data.markdownRemark holds your post data
+  const { frontmatter, html } = markdownRemark
+  return (
+    <div className="blog-post">
+      <h1>{frontmatter.title}</h1>
+      <h2>{frontmatter.date}</h2>
+      <div
+        className="blog-post-content"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  )
+}
+
+export const pageQuery = graphql`
+  query($path: String!) {
+    markdownRemark(frontmatter: { path: { eq: $path } }) {
+      html
+      frontmatter {
+        date(formatString: "MMMM DD, YYYY")
+        path
+        title
+      }
+    }
+  }
+`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

These changes are hard to read in the diff so here's what changed:

- moved the old recipes for creating pages in section 1 to the sourcing data section
- updated the recipes to include example repos and a GraphiQL embed for getting markdown data
- added a new recipe for creating pages in section 1 that doesn't rely on sourcing data, just using a hardcoded object with the `createPage` api 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #14947
