### PR TITLE
fix(gatsby-remark-autolink-headers): Fix invalid AST

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`gatsby-remark-autolink-headers adds id to a markdown header 1`] = `
 Object {
   "children": Array [
     Object {
+      "children": Array [],
       "data": Object {
         "hChildren": Array [
           Object {
@@ -69,6 +70,7 @@ exports[`gatsby-remark-autolink-headers adds id to a markdown header with custom
 Object {
   "children": Array [
     Object {
+      "children": Array [],
       "data": Object {
         "hChildren": Array [
           Object {
@@ -134,6 +136,7 @@ exports[`gatsby-remark-autolink-headers adds id to a markdown header with custom
 Object {
   "children": Array [
     Object {
+      "children": Array [],
       "data": Object {
         "hChildren": Array [
           Object {
@@ -247,6 +250,7 @@ exports[`gatsby-remark-autolink-headers maintain case of markdown header for id 
 Object {
   "children": Array [
     Object {
+      "children": Array [],
       "data": Object {
         "hChildren": Array [
           Object {
@@ -312,6 +316,7 @@ exports[`gatsby-remark-autolink-headers maintain case of markdown header for id 
 Object {
   "children": Array [
     Object {
+      "children": Array [],
       "data": Object {
         "hChildren": Array [
           Object {
@@ -377,6 +382,7 @@ exports[`gatsby-remark-autolink-headers maintain case of markdown header for id 
 Object {
   "children": Array [
     Object {
+      "children": Array [],
       "data": Object {
         "hChildren": Array [
           Object {

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -60,6 +60,7 @@ module.exports = (
         type: `link`,
         url: `#${id}`,
         title: null,
+        children: [],
         data: {
           hProperties: {
             "aria-label": `${label} permalink`,


### PR DESCRIPTION
Fixes invalid AST produced by `gatsby-remark-autolink-headers` -- `link` nodes are required to have children. See https://github.com/remarkjs/strip-markdown/issues/18