### PR TITLE
fix(gatsby-source-filesystem): Use forward slashes on relativeDirectory

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node.js
@@ -18,9 +18,8 @@ exports.createFileNode = async (
     ...parsedSlashed,
     absolutePath: slashed,
     // Useful for limiting graphql query with certain parent directory
-    relativeDirectory: path.relative(
-      pluginOptions.path || process.cwd(),
-      parsedSlashed.dir
+    relativeDirectory: slash(
+      path.relative(pluginOptions.path || process.cwd(), parsedSlashed.dir)
     ),
   }
 


### PR DESCRIPTION
When creating `File` nodes, `gatsby-source-filesystem` ensures file paths in forward-slash format for the `dir`, `relativePath` and `absolutePath` fields, but not for `relativeDirectory`.
This PR fixes that, but I'm not sure if anybody on Windows might rely on the previous behavior?

Related: #16987