### PR TITLE
chore(gatsby-source-graphql): Use gatsby's graphql package

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -10,7 +10,6 @@
     "@babel/runtime": "^7.5.5",
     "apollo-link": "1.2.12",
     "apollo-link-http": "^1.5.15",
-    "graphql": "^14.5.3",
     "graphql-tools": "^3.1.1",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",

--- a/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
@@ -6,8 +6,8 @@ jest.mock(`graphql-tools`, () => {
     RenameTypes: jest.fn(),
   }
 })
-jest.mock(`graphql`, () => {
-  const graphql = jest.requireActual(`graphql`)
+jest.mock(`gatsby/graphql`, () => {
+  const graphql = jest.requireActual(`gatsby/graphql`)
   return {
     ...graphql,
     buildSchema: jest.fn(),

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -1,5 +1,5 @@
 const uuidv4 = require(`uuid/v4`)
-const { buildSchema, printSchema } = require(`graphql`)
+const { buildSchema, printSchema } = require(`gatsby/graphql`)
 const {
   makeRemoteExecutableSchema,
   transformSchema,


### PR DESCRIPTION
Use the `graphql` package from `gatsby` to avoid duplicate `graphql` instances in a project.

Fixes #17051