### PR TITLE
fix(gatsby-link) Clean up IntersectionObservers to fix a memory leak

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -79,6 +79,9 @@ class GatsbyLink extends React.Component {
   }
 
   componentWillUnmount() {
+    if (!this.io) {
+      return
+    }
     const { instance, el } = this.io
 
     instance.unobserve(el)

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -30,7 +30,7 @@ const NavLinkPropTypes = {
 }
 
 // Set up IntersectionObserver
-const handleIntersection = (el, cb) => {
+const createIntersectionObserver = (el, cb) => {
   const io = new window.IntersectionObserver(entries => {
     entries.forEach(entry => {
       if (el === entry.target) {
@@ -46,6 +46,7 @@ const handleIntersection = (el, cb) => {
   })
   // Add element to the observer
   io.observe(el)
+  return { instance: io, el }
 }
 
 class GatsbyLink extends React.Component {
@@ -77,6 +78,13 @@ class GatsbyLink extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    const { instance, el } = this.io
+
+    instance.unobserve(el)
+    instance.disconnect()
+  }
+
   handleRef(ref) {
     if (this.props.innerRef && this.props.innerRef.hasOwnProperty(`current`)) {
       this.props.innerRef.current = ref
@@ -86,7 +94,7 @@ class GatsbyLink extends React.Component {
 
     if (this.state.IOSupported && ref) {
       // If IO supported and element reference found, setup Observer functionality
-      handleIntersection(ref, () => {
+      this.io = createIntersectionObserver(ref, () => {
         ___loader.enqueue(parsePath(this.props.to).pathname)
       })
     }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR fixes a memory leak caused by `IntersectionObserver`s not being cleaned up in case the intersection is never reached.

Many thanks to @atomiks who did a thorough investigation on the matter and came up with this solution 👏

I tested it on https://reactjs.org with the following procedure:

- Head to https://reactjs.org/docs/getting-started.html
- Take a Heap Snapshot
- Switch back and forth to https://reactjs.org/docs/add-react-to-a-website.html multiple times
- Take another Heap snapshot
- The presence of the memory leak can be detected by filtering with `Intersection` in the memory heap snapshot and seeing `Detached…` entries.

Here’s a comparison of before and after the fix (tested locally):

| 🙁Before | 🙂After |
|---|---|
| ![Memory Leak before PR](https://user-images.githubusercontent.com/2587348/63643047-7549ae80-c6c9-11e9-8a89-18cd567286e9.png) | ![No memory leak after PR](https://user-images.githubusercontent.com/2587348/63643053-8eeaf600-c6c9-11e9-9b79-f1f1687d2aa8.png) |

## Related Issues

Fixes #12198.
