### PR TITLE
fix(gatsby-image): Make GatsbyImageProps's FixedObject and FluidObject props optional

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -1,34 +1,34 @@
 import * as React from "react"
 
 export interface FixedObject {
-  width: number
-  height: number
-  src: string
-  srcSet: string
-  base64?: string
-  tracedSVG?: string
-  srcWebp?: string
-  srcSetWebp?: string
-  media?: string
+  width?: number | null
+  height?: number | null
+  src?: string | null
+  srcSet?: string | null
+  base64?: string | null
+  tracedSVG?: string | null
+  srcWebp?: string | null
+  srcSetWebp?: string | null
+  media?: string | null
 }
 
 export interface FluidObject {
-  aspectRatio: number
-  src: string
-  srcSet: string
-  sizes: string
-  base64?: string
-  tracedSVG?: string
-  srcWebp?: string
-  srcSetWebp?: string
-  media?: string
+  aspectRatio?: number | null
+  src?: string | null
+  srcSet?: string | null
+  sizes?: string | null
+  base64?: string | null
+  tracedSVG?: string | null
+  srcWebp?: string | null
+  srcSetWebp?: string | null
+  media?: string | null
 }
 
 interface GatsbyImageProps {
   resolutions?: FixedObject
   sizes?: FluidObject
-  fixed?: FixedObject | FixedObject[]
-  fluid?: FluidObject | FluidObject[]
+  fixed?: FixedObject | FixedObject[] | null
+  fluid?: FluidObject | FluidObject[] | null
   fadeIn?: boolean
   title?: string
   alt?: string

--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react"
 
 export interface FixedObject {
-  width?: number | null
-  height?: number | null
-  src?: string | null
-  srcSet?: string | null
+  width: number
+  height: number
+  src: string
+  srcSet: string
   base64?: string | null
   tracedSVG?: string | null
   srcWebp?: string | null
@@ -13,10 +13,10 @@ export interface FixedObject {
 }
 
 export interface FluidObject {
-  aspectRatio?: number | null
-  src?: string | null
-  srcSet?: string | null
-  sizes?: string | null
+  aspectRatio: number
+  src: string
+  srcSet: string
+  sizes: string
   base64?: string | null
   tracedSVG?: string | null
   srcWebp?: string | null


### PR DESCRIPTION
When running codegen on GatbsyImage fields the returned types have null in it (which is the expected behaviour in GraphQL when a field is optional).

This should fix code generation issues (it does fix it for me at least), the only issue I see is
that maybe the optional fields I added should not be optional, in that case we should change the
GraphQL schema too, let me know if that's the case and I'll see if I can change that too :)

