### PR TITLE
feat(gatsby-plugin-google-analytics): Add more checks of Do Not Track preference

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -78,7 +78,7 @@ export const onRenderBody = (
   if(${
     typeof pluginOptions.respectDNT !== `undefined` &&
     pluginOptions.respectDNT == true
-      ? `!(navigator.doNotTrack == "1" || window.doNotTrack == "1")`
+      ? `!(parseInt(navigator.doNotTrack) === 1 || parseInt(window.doNotTrack) === 1 || parseInt(navigator.msDoNotTrack) === 1 || navigator.doNotTrack === "yes")`
       : `true`
   }) {
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
## Description

This PR adds more specific condition to check whether user wants to send Do Not Track preference.

- adds older browsers compatibility (IE9, IE10, Gecko-based pre 32 version), see https://caniuse.com/#feat=do-not-track
- updates condition for possible DNT value extensions, see https://www.w3.org/TR/tracking-dnt/#dnt-extensions

