### PR TITLE
fix(gatsby-transformer-json): Coerce id field to always be a String

### DIFF
--- a/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Process JSON nodes correctly coerces an id field to always be a String 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "12345",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "FooJson",
+      },
+      "parent": "whatever",
+    },
+  ],
+]
+`;
+
+exports[`Process JSON nodes correctly coerces an id field to always be a String 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "12345",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "FooJson",
+        },
+        "parent": "whatever",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "{\\"id\\":12345,\\"blue\\":true,\\"funny\\":\\"yup\\"}",
+        "dir": "<TEMP_DIR>/foo/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "application/json",
+          "type": "File",
+        },
+        "name": "nodeName",
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
 exports[`Process JSON nodes correctly correctly creates a node from JSON which is a single object 1`] = `
 Array [
   Array [

--- a/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
@@ -93,6 +93,21 @@ describe(`Process JSON nodes correctly`, () => {
     })
   })
 
+  it(`coerces an id field to always be a String`, async () => {
+    const data = { id: 12345, blue: true, funny: `yup` }
+    const node = {
+      ...baseFileNode,
+      content: JSON.stringify(data),
+    }
+
+    return bootstrapTest(node).then(({ createNode, createParentChildLink }) => {
+      expect(createNode.mock.calls).toMatchSnapshot()
+      expect(createParentChildLink.mock.calls).toMatchSnapshot()
+      expect(createNode).toHaveBeenCalledTimes(1)
+      expect(createParentChildLink).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it(`correctly sets node type for array of objects`, async () => {
     ;[
       {

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -48,14 +48,16 @@ async function onCreateNode(
     parsedContent.forEach((obj, i) => {
       transformObject(
         obj,
-        obj.id ? obj.id : createNodeId(`${node.id} [${i}] >>> JSON`),
+        obj.id ? String(obj.id) : createNodeId(`${node.id} [${i}] >>> JSON`),
         getType({ node, object: obj, isArray: true })
       )
     })
   } else if (_.isPlainObject(parsedContent)) {
     transformObject(
       parsedContent,
-      parsedContent.id ? parsedContent.id : createNodeId(`${node.id} >>> JSON`),
+      parsedContent.id
+        ? String(parsedContent.id)
+        : createNodeId(`${node.id} >>> JSON`),
       getType({ node, object: parsedContent, isArray: false })
     )
   }


### PR DESCRIPTION
We expect any field called `id` on a Node to be a String and break if it is not. So it makes sense for transformer-json to coerce any values in id to a String so that a user isn't required to manipulate input JSON data when using `gatsby-transformer-json`