### PR TITLE
fix(gatsby): fix an infinite loop in node child collection

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -27,7 +27,7 @@ const findChildren = initialChildren => {
   const traversedNodes = new Set()
 
   while (queue.length > 0) {
-    const currentChild = getNode(queue.shift())
+    const currentChild = getNode(queue.pop())
     if (traversedNodes.has(currentChild.id)) {
       continue
     }
@@ -35,7 +35,7 @@ const findChildren = initialChildren => {
     const newChildren = currentChild.children
     if (_.isArray(newChildren) && newChildren.length > 0) {
       children.push(...newChildren)
-      queue.unshift(...newChildren)
+      queue.push(...newChildren)
     }
   }
   return children

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -21,18 +21,23 @@ const { trackCli } = require(`gatsby-telemetry`)
 
 const actions = {}
 
-const findChildrenRecursively = (children = []) => {
-  children = children.concat(
-    ...children.map(child => {
-      const newChildren = getNode(child).children
-      if (_.isArray(newChildren) && newChildren.length > 0) {
-        return findChildrenRecursively(newChildren)
-      } else {
-        return []
-      }
-    })
-  )
+const findChildren = initialChildren => {
+  const children = [...initialChildren]
+  const queue = [...initialChildren]
+  const traversedNodes = new Set()
 
+  while (queue.length > 0) {
+    const currentChild = getNode(queue.shift())
+    if (traversedNodes.has(currentChild.id)) {
+      continue
+    }
+    traversedNodes.add(currentChild.id)
+    const newChildren = currentChild.children
+    if (_.isArray(newChildren) && newChildren.length > 0) {
+      children.push(...newChildren)
+      queue.unshift(...newChildren)
+    }
+  }
   return children
 }
 
@@ -482,7 +487,7 @@ actions.deleteNode = (options: any, plugin: Plugin, args: any) => {
   // write and then immediately delete temporary files to the file system.
   const deleteDescendantsActions =
     node &&
-    findChildrenRecursively(node.children)
+    findChildren(node.children)
       .map(getNode)
       .map(createDeleteAction)
 
@@ -510,7 +515,7 @@ actions.deleteNodes = (nodes: any[], plugin: Plugin) => {
 
   // Also delete any nodes transformed from these.
   const descendantNodes = _.flatten(
-    nodes.map(n => findChildrenRecursively(getNode(n).children))
+    nodes.map(n => findChildren(getNode(n).children))
   )
 
   const deleteNodesAction = {
@@ -745,7 +750,7 @@ const createNode = (
           payload: node,
         }
       }
-      deleteActions = findChildrenRecursively(oldNode.children)
+      deleteActions = findChildren(oldNode.children)
         .map(getNode)
         .map(createDeleteAction)
     }

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -28,7 +28,7 @@ const findChildren = initialChildren => {
 
   while (queue.length > 0) {
     const currentChild = getNode(queue.pop())
-    if (traversedNodes.has(currentChild.id)) {
+    if (!currentChild || traversedNodes.has(currentChild.id)) {
       continue
     }
     traversedNodes.add(currentChild.id)


### PR DESCRIPTION
## Description

Currently there are cases where a cyclic node graph can cause findChildrenRecursively to hit the limit of the stack. Also, recursive functions are notoriously slow in JS.

I've replaced this with a non-recursive implementation of a pre-order depth first search tree traversal, and also made it keep track of traversed nodes. This will prevent duplicate nodes being found, and also prevent infinite loops with cyclic node trees.

~Performance wise this should theoretically be the same or possibly slightly better - I have not done a performance benchmark.~ Edit: Just made a change and benchmarked it, this is 3x faster than before.

Correct me if I'm wrong - but renaming this method is fine as it is not exported, and all local usages have been fixed.