### PR TITLE
fix(gatsby-transformer-remark): Don't produce invalid AST in TOC

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -593,7 +593,14 @@ Object {
   "frontmatter": Object {
     "title": "my little pony",
   },
-  "tableOfContents": null,
+  "tableOfContents": "<ul>
+<li>
+<p></p>
+<ul>
+<li></li>
+</ul>
+</li>
+</ul>",
 }
 `;
 

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -882,7 +882,6 @@ some other text
     node => {
       expect(node).toMatchSnapshot()
       expect(console.warn).toBeCalled()
-      expect(node.tableOfContents).toBe(null)
     }
   )
 

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -105,6 +105,10 @@ const bootstrapTest = (
         additionalParameters,
         pluginOptions,
       }).then(result => {
+        if (result.errors) {
+          done.fail(result.errors)
+        }
+
         try {
           test(result.data.listNode[0])
           done()

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -294,7 +294,9 @@ module.exports = (
                 .replace(/\/\//g, `/`)
             }
             if (node.children) {
-              node.children = node.children.map(node => addSlugToUrl(node))
+              node.children = node.children
+                .map(node => addSlugToUrl(node))
+                .filter(Boolean)
             }
 
             return node


### PR DESCRIPTION
The table of contents generation in `gatsby-transformer-remark` can produce an invalid AST (when no `pathToSlug` field is provided, `node.children` will be a sparse `[null]` array.

Unrelated: what's the reason `pathToSlug` is required in the first place?