### PR TITLE
feat(gatsby): add better splitchunks config

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -468,13 +468,30 @@ module.exports = async (
   }
 
   if (stage === `build-javascript`) {
+    const componentsCount = store.getState().components.size
+
     config.optimization = {
       runtimeChunk: {
         name: `webpack-runtime`,
       },
       splitChunks: {
         name: false,
+        chunks: `all`,
         cacheGroups: {
+          default: false,
+          vendors: false,
+          commons: {
+            name: `commons`,
+            chunks: `all`,
+            // if a chunk is used more than half the components count,
+            // we can assume it's pretty global
+            minChunks: componentsCount > 2 ? componentsCount * 0.5 : 2,
+          },
+          react: {
+            name: `commons`,
+            chunks: `all`,
+            test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
+          },
           // Only create one CSS file to avoid
           // problems with code-split CSS loading in different orders
           // causing inconsistent/non-determanistic styling


### PR DESCRIPTION
## Description
Creates a basic splitChunks config that works better than our current one. It's not the final config we would like as that one needs more testing. This one works pretty well so far.

Credits go to Nextjs as I copied the code from their codebase.
https://github.com/zeit/next.js/blob/canary/packages/next/build/webpack-config.ts#L200-L216

We want to go to a granular way of splitting chunks like nextjs does https://github.com/zeit/next.js/blob/canary/packages/next/build/webpack-config.ts#L217-L275 but create one that works for Gatsby.

This PR saves around **400kb** on .org and lowers visual-complete and TTI (fist-cpu-idle) by 400ms which will lower even more when guess-js is fixed.

Comparison can be found here:
https://www.webpagetest.org/video/compare.php?tests=190826_2H_5a44521034c35d43ff27a3af95b7c53c%2C190826_D7_ed0d076acfadfd3575943dfcf6cf34b8&thumbSize=200&ival=100&end=visual

Test current:
https://www.webpagetest.org/result/190826_D7_ed0d076acfadfd3575943dfcf6cf34b8/

Test this pr:
https://www.webpagetest.org/result/190826_2H_5a44521034c35d43ff27a3af95b7c53c/

## Related Issues
Fixes #15302 