### PR TITLE
docs: Add Recipe on Deploying to ZEIT Now

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1709,7 +1709,7 @@ gatsby build && gatsby serve
 
 ### Deploying to Netlify
 
-Use [`netlify-cli`](https://www.netlify.com/docs/cli/) to deploy your Gatsby application without leaving the command line interface.
+Use [`netlify-cli`](https://www.netlify.com/docs/cli/) to deploy your Gatsby application without leaving the command-line interface.
 
 #### Prerequisites
 
@@ -1737,3 +1737,25 @@ Use [`netlify-cli`](https://www.netlify.com/docs/cli/) to deploy your Gatsby app
 
 - [Hosting on Netlify](/docs/hosting-on-netlify)
 - [gatsby-plugin-netlify](/packages/gatsby-plugin-netlify)
+
+### Deploying to ZEIT Now
+
+Use [Now CLI](https://zeit.co/download) to deploy your Gatsby application without leaving the command-line interface.
+
+#### Prerequisites
+
+- A [Gatsby site](/docs/quick-start) with a single component `index.js`
+- [Now CLI](https://zeit.co/download) package installed
+- [Gatsby CLI](/docs/gatsby-cli) installed
+
+#### Directions
+
+1. Login into Now CLI using `now login`
+
+2. Move into the directory of your Gatsby.js application
+
+3. Run `now` to deploy it
+
+#### Additional resources
+
+- [Deploying to ZEIT Now](/docs/deploying-to-zeit-now/)

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1752,7 +1752,7 @@ Use [Now CLI](https://zeit.co/download) to deploy your Gatsby application withou
 
 1. Login into Now CLI using `now login`
 
-2. Move into the directory of your Gatsby.js application
+2. Change to the directory of your Gatsby.js application in the Terminal if you aren't already there
 
 3. Run `now` to deploy it
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1744,6 +1744,7 @@ Use [Now CLI](https://zeit.co/download) to deploy your Gatsby application withou
 
 #### Prerequisites
 
+- A [ZEIT Now](https://zeit.co/signup) account
 - A [Gatsby site](/docs/quick-start) with a single component `index.js`
 - [Now CLI](https://zeit.co/download) package installed
 - [Gatsby CLI](/docs/gatsby-cli) installed


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/gatsbyjs/gatsby/pull/16398 and adds [ZEIT Now](https://zeit.co) (the easiest way to deploy Gatsby) to the list of recipes.

## Related Issues

No related issues.
