### PR TITLE
fix(gatsby): prevent unmount wrapPageElement while page-data loading in dev

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/dev-loader.js
+++ b/packages/gatsby/cache-dir/__tests__/dev-loader.js
@@ -7,7 +7,7 @@ jest.mock(`../emitter`)
 jest.mock(`../socketIo`, () => {
   return {
     default: jest.fn(),
-    getPageData: jest.fn(),
+    getPageData: jest.fn().mockResolvedValue(),
   }
 })
 

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -10,10 +10,11 @@ class DevLoader extends BaseLoader {
 
   loadPage(pagePath) {
     const realPath = cleanPath(pagePath)
-    return super.loadPage(realPath).then(result => {
-      require(`./socketIo`).getPageData(realPath)
-      return result
-    })
+    return super.loadPage(realPath).then(result =>
+      require(`./socketIo`)
+        .getPageData(realPath)
+        .then(() => result)
+    )
   }
 
   loadPageDataJson(rawPath) {

--- a/packages/gatsby/cache-dir/json-store.js
+++ b/packages/gatsby/cache-dir/json-store.js
@@ -72,12 +72,6 @@ class JSONStore extends React.Component {
     // - page data for path changed
     // - static query results changed
 
-    // Always return false if we're missing resources.
-    const data = nextState.pageQueryData[normalizePagePath(nextState.path)]
-    if (!data) {
-      return false
-    }
-
     return (
       this.props.location !== nextProps.location ||
       this.state.path !== nextState.path ||

--- a/packages/gatsby/cache-dir/json-store.js
+++ b/packages/gatsby/cache-dir/json-store.js
@@ -72,6 +72,12 @@ class JSONStore extends React.Component {
     // - page data for path changed
     // - static query results changed
 
+    // Always return false if we're missing resources.
+    const data = nextState.pageQueryData[normalizePagePath(nextState.path)]
+    if (!data) {
+      return false
+    }
+
     return (
       this.props.location !== nextProps.location ||
       this.state.path !== nextState.path ||

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -197,11 +197,7 @@ class WebsocketManager {
           try {
             const result = await getCachedPageData(path, this.programDir)
 
-            if (!result) {
-              return
-            }
-
-            this.pageResults.set(path, result)
+            this.pageResults.set(path, result || { id: path })
           } catch (err) {
             console.log(err.message)
 


### PR DESCRIPTION
In rare cases, when you go to a page, its data may not be loaded yet, which causes unmounting of `wrapPageComponent`.

Closes #16489