### PR TITLE
feat: add Code of Conduct link to footer

### DIFF
--- a/www/src/components/shared/footer-links.js
+++ b/www/src/components/shared/footer-links.js
@@ -45,6 +45,9 @@ const FooterLinks = props => (
       <Link to="/accessibility-statement">Accessibility Statement</Link>
     </li>
     <li>
+      <Link to="/contributing/code-of-conduct/">Code of Conduct</Link>
+    </li>
+    <li>
       <a href="/guidelines/logo/">Logo &amp; Assets</a>
     </li>
     <li>


### PR DESCRIPTION
## Description

This PR adds a link to Gatsby's Code of Conduct in the footer on gatsbyjs.org. This makes it easier to find from all pages, so users don't have to go looking for it in the contributing section. I have one outstanding question about the contact email on the CoC page itself (and a process to go along with that should issues arise), but we can tackle that separately.

While our community is supportive and we've very rarely had issues come up, it's important that Gatsby users know what to do if they encounter something or someone harmful. A Code of Conduct is just the start of that–the real work is in enforcing it. A clearly defined and easy-to-find process for mediating issues is an important step in fostering a safe and inclusive community.

## Related Issues

N/A
