### PR TITLE
feat(gatsby-graphiql-explorer): Implement CodeExporter

### DIFF
--- a/packages/gatsby-graphiql-explorer/package.json
+++ b/packages/gatsby-graphiql-explorer/package.json
@@ -42,6 +42,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "graphiql": "^0.14.2",
+    "graphiql-code-exporter": "^2.0.5",
     "graphiql-explorer": "^0.4.3",
     "html-webpack-plugin": "^3.2.0",
     "npm-run-all": "4.1.5",

--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -4,11 +4,14 @@ import ReactDOM from "react-dom"
 import GraphiQL from "graphiql"
 import GraphiQLExplorer from "graphiql-explorer"
 import { getIntrospectionQuery, buildClientSchema, parse } from "graphql"
+import CodeExporter from "graphiql-code-exporter"
+import snippets from "./snippets"
 
 import "whatwg-fetch"
 
 import "graphiql/graphiql.css"
 import "./app.css"
+import "graphiql-code-exporter/CodeExporter.css"
 
 const parameters = {}
 window.location.search
@@ -142,11 +145,22 @@ const storedExplorerPaneState =
     ? window.localStorage.getItem(`graphiql:graphiqlExplorerOpen`) !== `false`
     : true
 
+const storedCodeExporterPaneState =
+  typeof parameters.codeExporterIsOpen !== `undefined`
+    ? parameters.codeExporterIsOpen === `false`
+      ? false
+      : true
+    : window.localStorage
+    ? window.localStorage.getItem(`graphiql:graphiqlCodeExporterIsOpen`) !==
+      `false`
+    : true
+
 class App extends React.Component {
   state = {
     schema: null,
     query: DEFAULT_QUERY,
     explorerIsOpen: storedExplorerPaneState,
+    codeExporterIsOpen: storedCodeExporterPaneState,
   }
 
   componentDidMount() {
@@ -269,8 +283,29 @@ class App extends React.Component {
     this.setState({ explorerIsOpen: newExplorerIsOpen })
   }
 
+  _handleToggleExporter = () => {
+    const newCodeExporterIsOpen = !this.state.codeExporterIsOpen
+    if (window.localStorage) {
+      window.localStorage.setItem(
+        `graphiql:graphiqlCodeExporterOpen`,
+        newCodeExporterIsOpen
+      )
+    }
+    parameters.codeExporterIsOpen = newCodeExporterIsOpen
+    updateURL()
+    this.setState({ codeExporterIsOpen: newCodeExporterIsOpen })
+  }
+
   render() {
-    const { query, schema } = this.state
+    const { query, schema, codeExporterIsOpen } = this.state
+    const codeExporter = codeExporterIsOpen ? (
+      <CodeExporter
+        hideCodeExporter={this._handleToggleExporter}
+        snippets={snippets}
+        query={query}
+        codeMirrorTheme="default"
+      />
+    ) : null
 
     return (
       <React.Fragment>
@@ -309,8 +344,14 @@ class App extends React.Component {
               label="Explorer"
               title="Toggle Explorer"
             />
+            <GraphiQL.Button
+              onClick={this._handleToggleExporter}
+              label="Code Exporter"
+              title="Toggle Code Exporter"
+            />
           </GraphiQL.Toolbar>
         </GraphiQL>
+        {codeExporter}
       </React.Fragment>
     )
   }

--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -151,8 +151,8 @@ const storedCodeExporterPaneState =
       ? false
       : true
     : window.localStorage
-    ? window.localStorage.getItem(`graphiql:graphiqlCodeExporterOpen`) !==
-      `false`
+    ? window.localStorage.getItem(`graphiql:graphiqlCodeExporterOpen`) ===
+      `true`
     : false
 
 class App extends React.Component {

--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -153,7 +153,7 @@ const storedCodeExporterPaneState =
     : window.localStorage
     ? window.localStorage.getItem(`graphiql:graphiqlCodeExporterIsOpen`) !==
       `false`
-    : true
+    : false
 
 class App extends React.Component {
   state = {

--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -151,7 +151,7 @@ const storedCodeExporterPaneState =
       ? false
       : true
     : window.localStorage
-    ? window.localStorage.getItem(`graphiql:graphiqlCodeExporterIsOpen`) !==
+    ? window.localStorage.getItem(`graphiql:graphiqlCodeExporterOpen`) !==
       `false`
     : false
 

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -114,8 +114,8 @@ const getFieldQuery = (root, enableComments) => {
     if (enableComments) {
       return `  // could not find field 'nodes' on ${rootName}\n  // this should probably be queried directly from a page by using the '${pageQuery.name}'`
     }
-    return null
   }
+  return null
 }
 
 const createPagesQuery = {

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -1,7 +1,11 @@
-const getQuery = arg => {
+const getQuery = (arg, spaceCount) => {
   const { operationDataList } = arg
   const { query } = operationDataList[0]
-  return query
+  const anonymousQuery = query.replace(/query\s.+{/gim, `{`)
+  return (
+    ` `.repeat(spaceCount) +
+    anonymousQuery.replace(/\n/g, `\n` + ` `.repeat(spaceCount))
+  )
 }
 
 const pageQuery = {
@@ -15,8 +19,9 @@ import { graphql } from "gatsby"
 export default ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>
 
 export const query = graphql\`
-${getQuery(arg)}
+${getQuery(arg, 2)}
 \`
+
 `,
 }
 
@@ -29,11 +34,12 @@ const staticHook = {
 import { useStaticQuery, graphql } from "gatsby"
 
 export default () => {
-const data = useStaticQuery(graphql\`
-  ${getQuery(arg)}
-\`)
-return <pre>{JSON.stringify(data, null, 4)}</pre>
+  const data = useStaticQuery(graphql\`
+${getQuery(arg, 4)}
+  \`)
+  return <pre>{JSON.stringify(data, null, 4)}</pre>
 }
+
 `,
 }
 
@@ -48,11 +54,12 @@ import { StaticQuery, graphql } from "gatsby"
 export default () => (
   <StaticQuery
     query={graphql\`
-      ${getQuery(arg)}
+${getQuery(arg, 6)}
     \`}
     render={data => <pre>{JSON.stringify(data, null, 4)}</pre>}
   ></StaticQuery>
 )
+
 `,
 }
 

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -16,11 +16,13 @@ const pageQuery = {
   generate: arg => `import React from "react"
 import { graphql } from "gatsby"
 
-export default ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>
+const ComponentName = ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>
 
 export const query = graphql\`
 ${getQuery(arg, 2)}
 \`
+
+export default ComponentName
 
 `,
 }
@@ -33,12 +35,14 @@ const staticHook = {
   generate: arg => `import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 
-export default () => {
+const ComponentName = () => {
   const data = useStaticQuery(graphql\`
 ${getQuery(arg, 4)}
   \`)
   return <pre>{JSON.stringify(data, null, 4)}</pre>
 }
+
+export default ComponentName
 
 `,
 }
@@ -51,7 +55,7 @@ const staticQuery = {
   generate: arg => `import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 
-export default () => (
+const ComponentName = () => (
   <StaticQuery
     query={graphql\`
 ${getQuery(arg, 6)}
@@ -60,99 +64,9 @@ ${getQuery(arg, 6)}
   ></StaticQuery>
 )
 
-`,
-}
-
-const getDataNodeName = name =>
-  name.startsWith(`all`) && name.length > 3
-    ? name.substring(3, 4).toLowerCase() + name.substring(4, name.length)
-    : name
-
-const getFieldQuery = (root, enableComments) => {
-  const rootName = root.name.value
-  const dataNodeName = getDataNodeName(rootName)
-  let nodes
-
-  const comment = message => (enableComments ? `\n      // ${message}` : ``)
-
-  if (root.selectionSet) {
-    nodes = root.selectionSet.selections.find(
-      selection => selection.name.value === `nodes`
-    )
-
-    if (nodes && nodes.selectionSet) {
-      let hasId = false
-      let hasSlug = false
-      nodes.selectionSet.selections.forEach(field => {
-        if (field.name.value === `id`) {
-          hasId = true
-        }
-        if (field.name.value === `slug`) {
-          hasSlug = true
-        }
-      })
-
-      return `  result.data.${rootName}.${
-        nodes.name.value
-      }.forEach(${dataNodeName} => {
-    createPage({${comment(`set URL of the page`)}
-      path: ${
-        hasSlug
-          ? `\`/${dataNodeName}/\${${dataNodeName}.slug}/\``
-          : `\`/${dataNodeName}/\${${dataNodeName}.uniquePathField}/\``
-      },${comment(`set react template used to render page`)}
-      component: path.resolve(\`./src/templates/${dataNodeName}.js\`),${comment(
-        `provide variables that can be used in page query`
-      )}
-      context: {
-        ${hasId ? `id: ${dataNodeName}.id,` : ``}
-      },
-    })
-  })`
-    }
-
-    if (enableComments) {
-      return `  // could not find field 'nodes' on ${rootName}\n  // this should probably be queried directly from a page by using the '${pageQuery.name}'`
-    }
-  }
-  return null
-}
-
-const createPagesQuery = {
-  name: `createPages`,
-  language: `JavaScript`,
-  codeMirrorMode: `jsx`,
-  options: [
-    {
-      id: `comments`,
-      label: `Comments`,
-      initial: false,
-    },
-  ],
-  generate: arg => `const path = require(\`path\`)
-  
-exports.createPages = async ({ graphql, actions, reporter }) => {
-  const { createPage } = actions
-  const result = await graphql(\`
-${getQuery(arg, 4)}
-  \`)
-
-  if (result.errors) {
-    reporter.panicOnBuild(
-      \`There was error while executing query in gatsby-node.js:\\n\\n\${result.errors
-        .map(e => e.toString())
-        .join(\`\\n\\n\`)}\`
-    )
-    return
-  }
-
-${arg.operationDataList[0].operationDefinition.selectionSet.selections
-  .map(selection => getFieldQuery(selection, arg.options.comments))
-  .filter(fieldQuery => fieldQuery !== null)
-  .join(`\n\n`)}
-}
+export default ComponentName
 
 `,
 }
 
-export default [pageQuery, staticHook, staticQuery, createPagesQuery]
+export default [pageQuery, staticHook, staticQuery]

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -63,4 +63,19 @@ ${getQuery(arg, 6)}
 `,
 }
 
-export default [pageQuery, staticHook, staticQuery]
+const createPagesQuery = {
+  name: `createPages`,
+  language: `JavaScript`,
+  codeMirrorMode: `jsx`,
+  options: [],
+  generate: arg => `exports.createPages = async ({ graphql, actions }) => {
+  const { createPage } = actions
+  const result = await graphql(\`
+${getQuery(arg, 4)}
+  \`)
+}
+
+`,
+}
+
+export default [pageQuery, staticHook, staticQuery, createPagesQuery]

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -68,11 +68,37 @@ const createPagesQuery = {
   language: `JavaScript`,
   codeMirrorMode: `jsx`,
   options: [],
-  generate: arg => `exports.createPages = async ({ graphql, actions }) => {
+  generate: arg => `const path = require(\`path\`)
+  
+exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
   const result = await graphql(\`
 ${getQuery(arg, 4)}
   \`)
+
+  if (result.errors) {
+    reporter.panicOnBuild(
+      \`There was error while executing query in gatsby-node.js:\\n\\n\${result.errors
+        .map(e => e.toString())
+        .join(\`\\n\\n\`)}\`
+    )
+    return
+  }
+
+  // Use result.data to create pages, snippet below is sample that need to be adjusted for shape of your query
+  result.data.allData.nodes.forEach(dataNode => {
+    createPage({
+      // set URL of the page
+      path: \`/my/url/\${dataNode.slug}\`,
+      // set react template used to render page
+      component: path.resolve(\`./src/templates/my-template.js\`),
+      // provide variables that can be used in page query to
+      // select node - id is great choice as it is unique
+      context: {
+        id: dataNode.id,
+      },
+    })
+  })
 }
 
 `,

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -63,11 +63,10 @@ ${getQuery(arg, 6)}
 `,
 }
 
-const getDataNodeName = name => {
-  return name.startsWith("all") && name.length > 3
+const getDataNodeName = name =>
+  name.startsWith(`all`) && name.length > 3
     ? name.substring(3, 4).toLowerCase() + name.substring(4, name.length)
     : null
-}
 
 const getFieldQuery = (root, enableComments) => {
   const rootName = root.name.value
@@ -78,17 +77,17 @@ const getFieldQuery = (root, enableComments) => {
 
   if (root.selectionSet) {
     nodes = root.selectionSet.selections.find(
-      selection => selection.name.value === "nodes"
+      selection => selection.name.value === `nodes`
     )
 
     if (nodes && nodes.selectionSet) {
       let hasId = false
       let hasSlug = false
       nodes.selectionSet.selections.forEach(field => {
-        if (field.name.value === "id") {
+        if (field.name.value === `id`) {
           hasId = true
         }
-        if (field.name.value === "slug") {
+        if (field.name.value === `slug`) {
           hasSlug = true
         }
       })
@@ -125,8 +124,8 @@ const createPagesQuery = {
   codeMirrorMode: `jsx`,
   options: [
     {
-      id: "comments",
-      label: "Comments",
+      id: `comments`,
+      label: `Comments`,
       initial: false,
     },
   ],
@@ -150,7 +149,7 @@ ${getQuery(arg, 4)}
 ${arg.operationDataList[0].operationDefinition.selectionSet.selections
   .map(selection => getFieldQuery(selection, arg.options.comments))
   .filter(fieldQuery => fieldQuery !== null)
-  .join("\n\n")}
+  .join(`\n\n`)}
 }
 
 `,

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -1,0 +1,59 @@
+const getQuery = arg => {
+  const { operationDataList } = arg
+  const { query } = operationDataList[0]
+  return query
+}
+
+const pageQuery = {
+  name: `Page query`,
+  language: `JavaScript`,
+  codeMirrorMode: `jsx`,
+  options: [],
+  generate: arg => `import React from "react"
+import { graphql } from "gatsby"
+
+export default ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>
+
+export const query = graphql\`
+${getQuery(arg)}
+\`
+`,
+}
+
+const staticHook = {
+  name: `StaticQuery hook`,
+  language: `JavaScript`,
+  codeMirrorMode: `jsx`,
+  options: [],
+  generate: arg => `import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export default () => {
+const data = useStaticQuery(graphql\`
+  ${getQuery(arg)}
+\`)
+return <pre>{JSON.stringify(data, null, 4)}</pre>
+}
+`,
+}
+
+const staticQuery = {
+  name: `StaticQuery`,
+  language: `JavaScript`,
+  codeMirrorMode: `jsx`,
+  options: [],
+  generate: arg => `import React from "react"
+import { StaticQuery, graphql } from "gatsby"
+
+export default () => (
+  <StaticQuery
+    query={graphql\`
+      ${getQuery(arg)}
+    \`}
+    render={data => <pre>{JSON.stringify(data, null, 4)}</pre>}
+  ></StaticQuery>
+)
+`,
+}
+
+export default [pageQuery, staticHook, staticQuery]

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -66,7 +66,7 @@ ${getQuery(arg, 6)}
 const getDataNodeName = name =>
   name.startsWith(`all`) && name.length > 3
     ? name.substring(3, 4).toLowerCase() + name.substring(4, name.length)
-    : null
+    : name
 
 const getFieldQuery = (root, enableComments) => {
   const rootName = root.name.value

--- a/yarn.lock
+++ b/yarn.lock
@@ -3651,18 +3651,6 @@ babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-eslint@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.2.tgz#182d5ac204579ff0881684b040560fdcc1558456"
-  integrity sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@babel/types" "^7.0.0"
-    eslint-scope "3.7.1"
-    eslint-visitor-keys "^1.0.0"
-
 babel-eslint@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
@@ -5615,7 +5603,7 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-copy-to-clipboard@^3.2.0:
+copy-to-clipboard@^3.0.8, copy-to-clipboard@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz#d2724a3ccbfed89706fac8a894872c979ac74467"
   integrity sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==
@@ -7328,13 +7316,6 @@ eslint-plugin-react@^7.14.3:
     object.values "^1.1.0"
     prop-types "^15.7.2"
     resolve "^1.10.1"
-
-eslint-scope@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -9070,6 +9051,13 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.1
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+graphiql-code-exporter@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/graphiql-code-exporter/-/graphiql-code-exporter-2.0.5.tgz#763ffc70ef2518fb4ea4277d89bd5f322599ea4d"
+  integrity sha512-Sh0gU7zjQPTRjQa8XjZwsn0lDIJQ9bpbJGP9nlSKXzx+XgPQxMbm1UEK9tAejhB824PvkUnq+z7Wdx6nDtGCSg==
+  dependencies:
+    copy-to-clipboard "^3.0.8"
 
 graphiql-explorer@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
## Description

Add's `graphiql-code-exporter` into `gatsby-graphiql-explorer` allowing the user to choose between 3 graphql snippets which can be copied/pasted.

## Examples

Page query template
![image](https://user-images.githubusercontent.com/11328618/63873924-6c522900-c9b8-11e9-808a-89588ae04d3d.png)

useStaticQuery Hook
![image](https://user-images.githubusercontent.com/11328618/63873954-7b38db80-c9b8-11e9-862b-0b16547952a0.png)

StaticQuery Component
![image](https://user-images.githubusercontent.com/11328618/63873979-855ada00-c9b8-11e9-85a2-a20de65c8196.png)


## Related Issues

Fixes #14476 
