### PR TITLE
docs(gatsby-plugin-preact): Use preact@next as dependency

### DIFF
--- a/packages/gatsby-plugin-preact/README.md
+++ b/packages/gatsby-plugin-preact/README.md
@@ -10,7 +10,7 @@ React.
 
 ## Install
 
-`npm install --save gatsby-plugin-preact preact@beta`
+`npm install --save gatsby-plugin-preact preact@next`
 
 ## How to use
 


### PR DESCRIPTION
## Description

Preact currently doesn't have a `@beta` release (anymore). `npm install` would fail.

```bash
dist-tags:
latest: 8.5.2      next: 10.0.0-rc.1
```
