### PR TITLE
Update `_experimentalThemes` instances to `plugins`

### DIFF
--- a/docs/blog/2018-11-11-introducing-gatsby-themes/index.md
+++ b/docs/blog/2018-11-11-introducing-gatsby-themes/index.md
@@ -80,7 +80,7 @@ the config.
 
 ```js
 module.exports = {
-  __experimentalThemes: [
+  plugins: [
     {
       resolve: "gatsby-theme-blog",
       options: {},
@@ -96,7 +96,7 @@ theme's gatsby-config as a function that returns an object.
 
 ```js
 module.exports = {
-  __experimentalThemes: [
+  plugins: [
     {
       resolve: "gatsby-theme-blog",
       options: {

--- a/docs/blog/2019-01-29-themes-update-child-theming-and-component-shadowing/index.md
+++ b/docs/blog/2019-01-29-themes-update-child-theming-and-component-shadowing/index.md
@@ -21,7 +21,7 @@ We've merged [a PR](https://github.com/gatsbyjs/gatsby/pull/10787) into Gatsby
 core to support Child theming. Child theming is an extension of the core theming
 algorithm to support a "parent/child" style relationship where child themes can
 rely on parent themes in the same way sites rely on themes. This means you can
-now use the `__experimentalThemes` gatsby-config key in a theme as well as your
+now add a child theme using the `plugins` gatsby-config key in a theme as well as your
 sites.
 
 This change is being made to make it easier for theme authors to produce themes
@@ -80,8 +80,7 @@ applied to the parent and focus on one possible child theme `gatsby-config.js`.
 
 ```js:title=gatsby-theme-blog/gatsby-config.js
 module.exports = {
-  __experimentalThemes: [`gatsby-theme-blog-core`],
-  plugins: [`gatsby-plugin-emotion`],
+  plugins: [`gatsby-theme-blog-core`, `gatsby-plugin-emotion`],
 }
 ```
 
@@ -91,7 +90,7 @@ by specifying only the child in their `gatsby-config.js`.
 
 ```js:title=my-site/gatsby-config.js
 module.exports = {
-  __experimentalThemes: [`gatsby-theme-blog`],
+  plugins: [`gatsby-theme-blog`],
 }
 ```
 

--- a/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
+++ b/docs/blog/2019-02-26-getting-started-with-gatsby-themes/index.md
@@ -134,7 +134,7 @@ Lastly, you're going to want to add a _gatsby-config.js_ file to your _site_ dir
 
 ```javascript:title=site/gatsby-config.js
 module.exports = {
-  __experimentalThemes: [`theme`],
+  plugins: [`theme`],
 }
 ```
 

--- a/docs/blog/2019-03-11-gatsby-themes-roadmap/index.md
+++ b/docs/blog/2019-03-11-gatsby-themes-roadmap/index.md
@@ -39,13 +39,12 @@ Themes](/blog/2018-11-11-introducing-gatsby-themes/).
 
 We introduced one major change to composition after the initial release to
 support child themes. A child theme is a theme that also uses the
-`__experimentalThemes` `gatsby-config` key. This change brought the full power
-of `gatsby-config` to theming as `__experimentalThemes` was until this change
-the only key not allowed in a theme.
+`plugins` `gatsby-config` key – a change that brought the full power
+of `gatsby-config` to theming.
 
 ```js:title="a child theme's gatsby-config.js"
 module.exports = {
-  __experimentalThemes: [`gatsby-theme-blog-core`],
+  plugins: [`gatsby-theme-blog-core`],
 }
 ```
 

--- a/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
+++ b/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
@@ -101,7 +101,7 @@ In the example site, create a `gatsby-config.js` file and add the theme.
 
 ```js:title=example/gatsby-config.js
 module.exports = {
-  __experimentalThemes: ["gatsby-theme-example-workspaces"],
+  plugins: ["gatsby-theme-example-workspaces"],
 }
 ```
 

--- a/docs/docs/how-shadowing-works.mdx
+++ b/docs/docs/how-shadowing-works.mdx
@@ -24,7 +24,7 @@ configures two sibling themes:
 
 ```js:title=gatsby-config.js
 module.exports = {
-  _experimentalThemes: [
+  plugins: [
     "gatsby-theme-tomato-blog",
     "gatsby-theme-tomato-portfolio",
   ],

--- a/themes/gatsby-starter-blog-theme-core/content/posts/hello-world.mdx
+++ b/themes/gatsby-starter-blog-theme-core/content/posts/hello-world.mdx
@@ -9,7 +9,7 @@ Delete me, and get writing!
 
 ```js:title=gatsby-config.js
 module.exports = {
-  __experimentalThemes: [
+  plugins: [
     "gatsby-theme-blog", // highlight-line
     "gatsby-theme-notes"
   ]

--- a/themes/gatsby-starter-blog-theme/content/posts/hello-world.mdx
+++ b/themes/gatsby-starter-blog-theme/content/posts/hello-world.mdx
@@ -9,7 +9,7 @@ Delete me, and get writing!
 
 ```js:title=gatsby-config.js
 module.exports = {
-  __experimentalThemes: [
+  plugins: [
     "gatsby-theme-blog", // highlight-line
     "gatsby-theme-notes"
   ]

--- a/themes/gatsby-starter-theme-workspace/gatsby-theme-minimal/README.md
+++ b/themes/gatsby-starter-theme-workspace/gatsby-theme-minimal/README.md
@@ -15,7 +15,7 @@ here for education purposes.
 
 ```javascript
 module.exports = {
-  __experimentalThemes: [
+  plugins: [
     {
       resolve: "gatsby-theme-minimal",
       options: {},

--- a/themes/gatsby-starter-theme/content/posts/hello-world.mdx
+++ b/themes/gatsby-starter-theme/content/posts/hello-world.mdx
@@ -7,7 +7,7 @@ Hello, world! This is a demo post for `gatsby-theme-blog`.
 
 ```js
 module.exports = {
-  __experimentalThemes: [
+  plugins: [
     "gatsby-theme-blog",
     "gatsby-theme-notes",
   ],


### PR DESCRIPTION
## Description
This PR updates the instances of `_experimentalThemes` in blog posts and documentation to `plugins`, as it will be deprecated in Gatsby v3.

I've separated changes to each file into their own commit, hopefully this makes reviewing easier!

### Todos
- [x] Find all instances of `_experimentalThemes`
- [x] Identify those which can clearly be swapped out 1:1 for `plugins`
- [x] Identify those which may need a slight rewording or note to explain that this information has changed and leave comments asking for clarification on the best course of action
