### PR TITLE
chore(gatsby): speed up redirect creation

### DIFF
--- a/packages/gatsby/src/bootstrap/redirects-writer.js
+++ b/packages/gatsby/src/bootstrap/redirects-writer.js
@@ -12,7 +12,9 @@ const writeRedirects = async () => {
   let { program, redirects } = store.getState()
 
   // Filter for redirects that are meant for the browser.
-  const browserRedirects = redirects.filter(r => r.redirectInBrowser)
+  const browserRedirects = Array.from(redirects.values()).filter(
+    r => r.redirectInBrowser
+  )
 
   const newHash = crypto
     .createHash(`md5`)
@@ -20,12 +22,12 @@ const writeRedirects = async () => {
     .digest(`hex`)
 
   if (newHash === lastHash) {
-    return Promise.resolve()
+    return
   }
 
   lastHash = newHash
 
-  return await fs.writeFile(
+  await fs.writeFile(
     joinPath(program.directory, `.cache/redirects.json`),
     JSON.stringify(browserRedirects, null, 2)
   )
@@ -34,15 +36,10 @@ const writeRedirects = async () => {
 exports.writeRedirects = writeRedirects
 
 let bootstrapFinished = false
-let oldRedirects
 const debouncedWriteRedirects = _.debounce(() => {
   // Don't write redirects again until bootstrap has finished.
-  if (
-    bootstrapFinished &&
-    !_.isEqual(oldRedirects, store.getState().redirects)
-  ) {
+  if (bootstrapFinished) {
     writeRedirects()
-    oldRedirects = store.getState().Redirects
   }
 }, 250)
 

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -12,12 +12,17 @@ describe(`redirects`, () => {
 
     let state = reducer(undefined, action)
 
-    expect(state).toEqual([
-      {
-        fromPath: `/page-internal`,
-        toPath: `/page-internal/`,
-      },
-    ])
+    expect(state).toEqual(
+      new Map([
+        [
+          `/page-internal`,
+          {
+            fromPath: `/page-internal`,
+            toPath: `/page-internal/`,
+          },
+        ],
+      ])
+    )
   })
 
   it(`lets you redirect to an external url`, () => {
@@ -31,12 +36,17 @@ describe(`redirects`, () => {
 
     let state = reducer(undefined, action)
 
-    expect(state).toEqual([
-      {
-        fromPath: `/page-external`,
-        toPath: `https://example.com`,
-      },
-    ])
+    expect(state).toEqual(
+      new Map([
+        [
+          `/page-external`,
+          {
+            fromPath: `/page-external`,
+            toPath: `https://example.com`,
+          },
+        ],
+      ])
+    )
   })
 
   const protocolArr = [
@@ -58,12 +68,17 @@ describe(`redirects`, () => {
         },
       }
 
-      expect(reducer(undefined, action)).toEqual([
-        {
-          fromPath,
-          toPath,
-        },
-      ])
+      expect(reducer(undefined, action)).toEqual(
+        new Map([
+          [
+            fromPath,
+            {
+              fromPath,
+              toPath,
+            },
+          ],
+        ])
+      )
     })
   })
 })

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -5,8 +5,8 @@ describe(`redirects`, () => {
     const action = {
       type: `CREATE_REDIRECT`,
       payload: {
-        fromPath: `/page1`,
-        toPath: `/page1/`,
+        fromPath: `/page-internal`,
+        toPath: `/page-internal/`,
       },
     }
 
@@ -14,8 +14,8 @@ describe(`redirects`, () => {
 
     expect(state).toEqual([
       {
-        fromPath: `/page1`,
-        toPath: `/page1/`,
+        fromPath: `/page-internal`,
+        toPath: `/page-internal/`,
       },
     ])
   })
@@ -24,7 +24,7 @@ describe(`redirects`, () => {
     const action = {
       type: `CREATE_REDIRECT`,
       payload: {
-        fromPath: `/page1`,
+        fromPath: `/page-external`,
         toPath: `https://example.com`,
       },
     }
@@ -33,7 +33,7 @@ describe(`redirects`, () => {
 
     expect(state).toEqual([
       {
-        fromPath: `/page1`,
+        fromPath: `/page-external`,
         toPath: `https://example.com`,
       },
     ])
@@ -49,7 +49,7 @@ describe(`redirects`, () => {
 
   protocolArr.forEach(([protocol, toPath], index) => {
     it(`lets you redirect using ${protocol}`, () => {
-      const fromPath = `/page${index}`
+      const fromPath = `/page-protocol-${index}`
       const action = {
         type: `CREATE_REDIRECT`,
         payload: {

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,5 +1,3 @@
-const fromPaths = new Set()
-
 module.exports = (state = new Map(), action) => {
   switch (action.type) {
     case `CREATE_REDIRECT`: {

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,14 +1,13 @@
 const fromPaths = new Set()
 
-module.exports = (state = [], action) => {
+module.exports = (state = new Map(), action) => {
   switch (action.type) {
     case `CREATE_REDIRECT`: {
-      if (!fromPaths.has(action.payload.fromPath)) {
+      if (!state.has(action.payload.fromPath)) {
         // Add redirect only if it wasn't yet added to prevent duplicates
-        fromPaths.add(action.payload.fromPath)
-        state.push(action.payload)
-        return state
+        state.set(action.payload.fromPath, action.payload)
       }
+
       return state
     }
 

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,11 +1,13 @@
-const _ = require(`lodash`)
+const fromPaths = new Set()
 
 module.exports = (state = [], action) => {
   switch (action.type) {
     case `CREATE_REDIRECT`: {
-      if (!state.some(redirect => _.isEqual(redirect, action.payload))) {
+      if (!fromPaths.has(action.payload.fromPath)) {
         // Add redirect only if it wasn't yet added to prevent duplicates
-        return [...state, action.payload]
+        fromPaths.add(action.payload.fromPath)
+        state.push(action.payload)
+        return state
       }
       return state
     }


### PR DESCRIPTION
## Description

This PR prevents redirects massively slowing down the build. The tests needed to be changed so that they don't conflict on the fromPath, and that was a better change than exporting fromPaths.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/17126
