### PR TITLE
fix(gatsby-plugin-mdx): prevent crash when Markdown syntax error

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -112,11 +112,15 @@ module.exports = async function(content) {
 
   const source = fileNode && fileNode.sourceInstanceName
 
-  const mdxNode = await createMDXNode({
-    id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
-    node: fileNode,
-    content,
-  })
+  try {
+    const mdxNode = await createMDXNode({
+      id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
+      node: fileNode,
+      content,
+    })
+  } catch (e) {
+    return callback(e)
+  }  
 
   // get the default layout for the file source group, or if it doesn't
   // exist, the overall default layout

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -112,15 +112,16 @@ module.exports = async function(content) {
 
   const source = fileNode && fileNode.sourceInstanceName
 
+  let mdxNode;
   try {
-    const mdxNode = await createMDXNode({
+    mdxNode = await createMDXNode({
       id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
       node: fileNode,
       content,
     })
   } catch (e) {
     return callback(e)
-  }  
+  }
 
   // get the default layout for the file source group, or if it doesn't
   // exist, the overall default layout

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -112,7 +112,7 @@ module.exports = async function(content) {
 
   const source = fileNode && fileNode.sourceInstanceName
 
-  let mdxNode;
+  let mdxNode
   try {
     mdxNode = await createMDXNode({
       id: `fakeNodeIdMDXFileABugIfYouSeeThis`,


### PR DESCRIPTION
## Description
This PR will catch the error from MDX compile. Avoid the develop server crash and show the error message in the browser.

## Related Issues
Fixes https://github.com/gatsbyjs/gatsby/issues/16107
Fixes https://github.com/gatsbyjs/gatsby/issues/16502

### Before
![before](https://user-images.githubusercontent.com/289419/63829364-e9bb7080-c99b-11e9-82bc-aaf5e2f5f825.gif)

### After
![after](https://user-images.githubusercontent.com/289419/63829370-f049e800-c99b-11e9-8cdc-8d845572a7cd.gif)




