### PR TITLE
gatsby-plugin-preact: remove 'preact/debug'

### DIFF
--- a/packages/gatsby-plugin-preact/README.md
+++ b/packages/gatsby-plugin-preact/README.md
@@ -18,3 +18,9 @@ React.
 // In your gatsby-config.js
 plugins: [`gatsby-plugin-preact`]
 ```
+
+## Usage in a development environment
+
+Gastby development server currently has a hardcoded dependency on React-dom, therefore this plugin does not enable Preact in development.
+
+While Preact is designed to be a drop-in replacement, you should check that your production build works as expected before putting it live.

--- a/packages/gatsby-plugin-preact/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-browser.js
@@ -1,5 +1,0 @@
-exports.onClientEntry = () => {
-  if (process.env.NODE_ENV !== `production`) {
-    require(`preact/debug`)
-  }
-}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Preact is not actually used by the plugin in development: https://github.com/gatsbyjs/gatsby/blob/193f4cd3728cc6af3e55640fb712747e1b369c7e/packages/gatsby-plugin-preact/src/gatsby-node.js#L2-L4 

This PR updates the docs to make that clear.

The current version of `preact/debug` is also not compatible with latest react devtools: https://github.com/preactjs/preact/issues/1885, throwing errors in the console. 

Since Preact is not being used anyway, this PR also removes import of `preact/debug`.
