### PR TITLE
fix(www): large output of guess-js

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -13,7 +13,10 @@ const dynamicPlugins = []
 if (process.env.ANALYTICS_SERVICE_ACCOUNT) {
   // pick data from 3 months ago
   const startDate = new Date()
-  startDate.setMonth(startDate.getMonth() - 3)
+  // temporary lower guess to use 2 days of data to lower guess data
+  // real fix is to move gatsby-plugin-guess to aot mode
+  // startDate.setMonth(startDate.getMonth() - 3)
+  startDate.setDate(startDate.getDate() - 2)
   dynamicPlugins.push({
     resolve: `gatsby-plugin-guess-js`,
     options: {


### PR DESCRIPTION
## Description
Guess-js is making our webpack-runtime super big adds 2mb to it. We need to switch to guess AOT mode but for now this works.

Thanks for the quickfix @mgechev!
