### PR TITLE
chore(www): Update cache name to match name used in build_www job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: www_public_dir_1
+          key: v1_www_public_dir
       - run:
           command: yarn add netlify-cli
           working_directory: ~/project/www


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

The cache names in the build_www and deploy_www jobs were mismatched. This resulted the deploy job pulling an old cache and deploying that version of the site. Instead of the freshly built site.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
