### PR TITLE
docs: update browser-support.md

### DIFF
--- a/docs/docs/browser-support.md
+++ b/docs/docs/browser-support.md
@@ -21,8 +21,6 @@ supported by some of your targeted browsers, you won't have to worry about it
 breaking the older browsers as Babel will automatically add the needed polyfill
 `core-js/modules/es7.array.includes`.
 
-> Gatsby only automatically adds polyfills for your code (and not for your project's dependencies in `node_modules`) at the moment. You can track work on this in [this issue](https://github.com/gatsbyjs/gatsby/issues/7064).
-
 ## Specify what browsers your project supports using "Browserslist"
 
 You may customize your list of supported browser versions by declaring a


### PR DESCRIPTION
## Description

remove warning about polyfilling node_modules as the issue has been resolved and updated in gatsby version 2.11.0

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/7064
