### PR TITLE
fix: Missing comma on 'Installing Typography themes' section

### DIFF
--- a/docs/docs/typography-js.md
+++ b/docs/docs/typography-js.md
@@ -84,7 +84,7 @@ const typography = new Typography(
 -     baseLineHeight: 1.666,
 -     headerFontFamily: ['Avenir Next', 'Helvetica Neue', 'Segoe UI', 'Helvetica', 'Arial', 'sans-serif'],
 -     bodyFontFamily: ['Georgia', 'serif'],
-- }
+- },
 + funstonTheme
 );
 


### PR DESCRIPTION
Added missing comma right after the '}' curly bracket and before 'funstonTheme'.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
