### PR TITLE
docs(recipes): fix netlify init command in "Deploying your site" section

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1723,7 +1723,7 @@ Use [`netlify-cli`](https://www.netlify.com/docs/cli/) to deploy your Gatsby app
 
 2. Login into Netlify using `netlify login`
 
-3. Run the command `netlify build`. Select the "Create & configure a new site" option.
+3. Run the command `netlify init`. Select the "Create & configure a new site" option.
 
 4. Choose a custom website name if you want or press enter to receive a random one.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

In "Deploying your site" section, "Deploying to Netlify" the right command to deploy is `netlify init`. `netlify build` does not exist.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

none
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
