### PR TITLE
fix(gatsby): revert redirects map to array

### DIFF
--- a/packages/gatsby/src/bootstrap/redirects-writer.js
+++ b/packages/gatsby/src/bootstrap/redirects-writer.js
@@ -12,9 +12,7 @@ const writeRedirects = async () => {
   let { program, redirects } = store.getState()
 
   // Filter for redirects that are meant for the browser.
-  const browserRedirects = Array.from(redirects.values()).filter(
-    r => r.redirectInBrowser
-  )
+  const browserRedirects = redirects.filter(r => r.redirectInBrowser)
 
   const newHash = crypto
     .createHash(`md5`)

--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -1,6 +1,11 @@
-const reducer = require(`../redirects`)
+let reducer
 
 describe(`redirects`, () => {
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      reducer = require(`../redirects`)
+    })
+  })
   it(`lets you redirect to an internal url`, () => {
     const action = {
       type: `CREATE_REDIRECT`,
@@ -12,17 +17,12 @@ describe(`redirects`, () => {
 
     let state = reducer(undefined, action)
 
-    expect(state).toEqual(
-      new Map([
-        [
-          `/page-internal`,
-          {
-            fromPath: `/page-internal`,
-            toPath: `/page-internal/`,
-          },
-        ],
-      ])
-    )
+    expect(state).toEqual([
+      {
+        fromPath: `/page-internal`,
+        toPath: `/page-internal/`,
+      },
+    ])
   })
 
   it(`lets you redirect to an external url`, () => {
@@ -36,17 +36,12 @@ describe(`redirects`, () => {
 
     let state = reducer(undefined, action)
 
-    expect(state).toEqual(
-      new Map([
-        [
-          `/page-external`,
-          {
-            fromPath: `/page-external`,
-            toPath: `https://example.com`,
-          },
-        ],
-      ])
-    )
+    expect(state).toEqual([
+      {
+        fromPath: `/page-external`,
+        toPath: `https://example.com`,
+      },
+    ])
   })
 
   const protocolArr = [
@@ -68,17 +63,12 @@ describe(`redirects`, () => {
         },
       }
 
-      expect(reducer(undefined, action)).toEqual(
-        new Map([
-          [
-            fromPath,
-            {
-              fromPath,
-              toPath,
-            },
-          ],
-        ])
-      )
+      expect(reducer(undefined, action)).toEqual([
+        {
+          fromPath,
+          toPath,
+        },
+      ])
     })
   })
 })

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,9 +1,15 @@
-module.exports = (state = new Map(), action) => {
+const fromPaths = new Set()
+
+module.exports = (state = [], action) => {
   switch (action.type) {
     case `CREATE_REDIRECT`: {
-      if (!state.has(action.payload.fromPath)) {
-        // Add redirect only if it wasn't yet added to prevent duplicates
-        state.set(action.payload.fromPath, action.payload)
+      const { fromPath } = action.payload
+
+      // Add redirect only if it wasn't yet added to prevent duplicates
+      if (!fromPaths.has(fromPath)) {
+        fromPaths.add(fromPath)
+
+        state.push(action.payload)
       }
 
       return state


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
This reverts my mistake of changing the redirects array in a Map as  I thought redirects was only used by redirects.json.

## Related Issues
Fixes #17151
Fixes #17167