### PR TITLE
docs(gatsby-image): Add Table of Contents to Readme

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -16,6 +16,25 @@ of a container. Some ways you can use `<img />` won't work with gatsby-image._
 
 **[Demo](https://using-gatsby-image.gatsbyjs.org)**
 
+## Table of Contents
+- [Problem](#problem)
+- [Solution](#solution)
+- [Install](#install)
+- [How to use](#how-to-use)
+- [Polyfilling object-fit/object-position for IE](#polyfilling-object-fitobject-position-for-ie)
+- [Types of Responsive Images](#two-types-of-responsive-images)
+- [Fragments](#fragments)
+  - [gatsby-transformer-sharp](#gatsby-transformer-sharp)
+  - [gatsby-source-contentful](#gatsby-source-contentful)
+  - [gatsby-source-datocms](#gatsby-source-datocms)
+  - [gatsby-source-sanity](#gatsby-source-sanity)
+- [Fixed Queries](#fixed-queries)
+- [Fluid Queries](#fluid-queries)
+- [Art directing multiple images](#art-directing-multiple-images)
+- [Gatsby Image Props](#gatsby-image-props)
+- [Image Processing Arguments](#image-processing-arguments)
+- [Other Stuff](#some-other-stuff-to-be-aware-of)
+
 ## Problem
 
 Large, unoptimized images dramatically slow down your site.

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -17,6 +17,7 @@ of a container. Some ways you can use `<img />` won't work with gatsby-image._
 **[Demo](https://using-gatsby-image.gatsbyjs.org)**
 
 ## Table of Contents
+
 - [Problem](#problem)
 - [Solution](#solution)
 - [Install](#install)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Added Table of Contents to the README file for easier navigation to different sections of the README. 


