### PR TITLE
docs:UserWrapper is not defined

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -314,10 +314,10 @@ const Username = styled.h2`
 `
 
 const User = props => (
-  <UserWrapper>
+  <>
     <Avatar src={props.avatar} alt={props.username} />
     <Username>{props.username}</Username>
-  </UserWrapper>
+  </>
 )
 
 export default () => (


### PR DESCRIPTION
In the quickstart recipe on styled-components (https://www.gatsbyjs.org/docs/recipes/#using-styled-components), the component UserWrapper is not defined. My suggested change is to just use a Fragment since UserWrapper did not have any true functionality (as far as I could tell).

The alternative would be something like the following, but I do not see that being any more helpful.

```jsx
const UserWrapper = ({ children }) => {
  return <div>{children}</div>
}
```

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
