### PR TITLE
Show highlight-* comments in code samples in docs

### DIFF
--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -273,7 +273,7 @@ You may also choose to include line highlighting in your code snippets, using th
 ```javascript:title=gatsby-config.js
 module.exports = {
 	siteMetadata: {
-		title: `GatsbyJS`, // highlight-line
+		title: `GatsbyJS`, // highlight‒line
 		siteUrl: `https://www.gatsbyjs.org`,
 	},
 }
@@ -296,7 +296,7 @@ module.exports = {
 module.exports = {
 	siteMetadata: {
 		title: `GatsbyJS`,
-		// highlight-next-line
+		// highlight‒next‒line
 		siteUrl: `https://www.gatsbyjs.org`,
 	},
 }
@@ -318,12 +318,12 @@ module.exports = {
 ````
 ```javascript:title=gatsby-config.js
 module.exports = {
-	// highlight-start
+	// highlight‒start
 	siteMetadata: {
 		title: `GatsbyJS`,
 		siteUrl: `https://www.gatsbyjs.org`,
 	},
-	// highlight-end
+	// highlight‒end
 }
 ```
 ````


### PR DESCRIPTION
## Description

### Problem

In the [Line highlighting section](https://www.gatsbyjs.org/contributing/gatsby-style-guide/#code-formatting-line-highlighting) of the Gatsby Style Guide, the code samples don't actually display the comments (e.g. `// highlight-line`). As a result, reading that section of the docs is quite confusing because the comments being referenced don't actually appear in the code sample.

Based on the assumption that the comment is being processed by `gatsby-remark-prismjs`, I tried various ways to make the comment show up (escaping the slashes, putting the comment inside a <span> element, etc.), but the only approach that  worked was replacing the hyphen in the keywords like "highlight-line" with another dash character (in this case, the figure dash (U+2012)).

The downside of this approach is that if someone were to copy and paste the code sample, it wouldn't work for them since "highlight‒line" (with a figure dash) wouldn't trigger `gatsby-remark-prismjs`, but I think that this is a better solution than not having the comments show up at all in the code snippet.

Open to other suggestions if there's a better way around this!

### Before

<img width="715" alt="Screen Shot 2019-08-29 at 9 41 00 PM" src="https://user-images.githubusercontent.com/535248/63989400-d399d700-caa5-11e9-85e0-7baa60a6fa34.png">

### After

<img width="711" alt="Screen Shot 2019-08-29 at 9 41 18 PM" src="https://user-images.githubusercontent.com/535248/63989408-da284e80-caa5-11e9-9848-5cd4af1233a3.png">


