### PR TITLE
docs: fix json snippet in end-to-end-testing docs

### DIFF
--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -84,7 +84,7 @@ Cypress right now will look for tests inside the `cypress/integration` folder. I
 
 ```json:title=cypress.json
 {
-  "baseUrl": "http://localhost:8000/"
+  "baseUrl": "http://localhost:8000/",
   "integrationFolder": "cypress/e2e" // highlight-line
 }
 ```


### PR DESCRIPTION
Missing comma in e2e cypress,json file example

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
