### PR TITLE
Add success message after installing  gastsby-cli.

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -75,7 +75,8 @@
   "scripts": {
     "build": "babel src --out-dir lib --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\""
+    "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\"",
+    "postinstall": "node scripts/postinstall.js"
   },
   "yargs": {
     "boolean-negation": false

--- a/packages/gatsby-cli/scripts/postinstall.js
+++ b/packages/gatsby-cli/scripts/postinstall.js
@@ -1,0 +1,6 @@
+const createCli = require('../lib/create-cli');
+
+console.log('\033[1;32mSuccess!\n\033[0m');
+console.log('\033[1;36mWelcome to the Gatsby CLI! Please visit \033[7;36mhttps://www.gatsbyjs.org/docs/gatsby-cli/\033[m \033[1;36mfor more information.\033[0m\n');
+
+createCli('--help');


### PR DESCRIPTION
## Description

Show custom message when a user does `npm install gatsby-cli` to install `gatsby-cli`.

Adds a nice looking success message and point users to the Gatsby documentation website.
Also, shows the commands available to the cli users (default help prompt).

![Screenshot from 2019-08-30 15-55-48](https://user-images.githubusercontent.com/11889942/64014000-b107cc80-cb3e-11e9-958e-4bd68c678291.png)



## Related Issues

Fixes #13511 