### PR TITLE
chore: update dependencies for styleguide example

### DIFF
--- a/examples/styleguide/package.json
+++ b/examples/styleguide/package.json
@@ -13,7 +13,7 @@
     "html-to-react": "^1.3.1",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
-    "react-live": "^1.7.1"
+    "react-live": "^2.2.0"
   },
   "keywords": [
     "gatsby"

--- a/examples/styleguide/package.json
+++ b/examples/styleguide/package.json
@@ -7,7 +7,7 @@
     "app-root-dir": "^1.0.2",
     "gatsby": "^2.0.0",
     "gatsby-source-filesystem": "^2.0.1",
-    "gatsby-transformer-react-docgen": "^2.1.1",
+    "gatsby-transformer-react-docgen": "^5.0.8",
     "gatsby-transformer-remark": "^2.1.1",
     "glamor": "^2.20.40",
     "html-to-react": "^1.3.1",

--- a/examples/styleguide/src/templates/ComponentPage/components/ComponentPreview/ComponentPreview.js
+++ b/examples/styleguide/src/templates/ComponentPage/components/ComponentPreview/ComponentPreview.js
@@ -5,11 +5,11 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live"
 import * as components from "../../../../../.cache/components"
 
 import "./prism-theme.css"
+import "./editor.css"
 
 const editorStyles = {
   backgroundColor: `#f2f2f2`,
   boxSizing: `border-box`,
-  padding: `16px`,
 }
 
 class ComponentPreview extends React.Component {

--- a/examples/styleguide/src/templates/ComponentPage/components/ComponentPreview/editor.css
+++ b/examples/styleguide/src/templates/ComponentPage/components/ComponentPreview/editor.css
@@ -1,0 +1,7 @@
+div > textarea + pre {
+  top: 0%;
+  left: 0%;
+
+  height: 100%;
+  width: 100%;
+}


### PR DESCRIPTION
## Description
Update dependencies of examples/styleguide to the latest versions. :)
Updating `gatsby-transformer-react-docgen` was completely seamless, but apparently `react-live` have blocked the option to use prism css files, so the editor theme is now their default. 
I can make an effort to convert the `prism-theme.css` file to a theme object, if that necessary. 
## Related Issues
Fixes #13399 
