### PR TITLE
fix(gatsby-cli): fix cloning repository with commithash

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -156,7 +156,7 @@ const clone = async (hostInfo: any, rootPath: string) => {
     url = hostInfo.https({ noCommittish: true, noGitPlus: true })
   }
 
-  const branch = hostInfo.committish ? [`-b`, `hostInfo.committish`] : [``]
+  const branch = hostInfo.committish ? [`-b`, hostInfo.committish] : []
 
   report.info(`Creating new site from git: ${url}`)
 


### PR DESCRIPTION
fixes cloning starters when using "commithash"/ref (i.e. `gatsby new gatsby-v1 gatsbyjs/gatsby-starter-default#v1` - `v1` is branch name) 

```
➜ gatsby new gatsby-v1 gatsbyjs/gatsby-starter-default#v1
info Creating new site from git: https://github.com/gatsbyjs/gatsby-starter-default.git

Cloning into 'gatsby-v1'...
warning: Could not find remote branch hostInfo.committish to clone.

 ERROR

Command failed: git clone -b hostInfo.committish https://github.com/gatsbyjs/gatsby-starter-default.git gatsby-v1 --single-branch



  Error: Command failed: git clone -b hostInfo.committish https://github.com/gatsbyjs/gatsby-starter-default.git gatsby-v1 --single-branch

  - index.js:236 Promise.all.then.arr
    [lib]/[gatsby-cli]/[execa]/index.js:236:11

  - next_tick.js:68 process._tickCallback
    internal/process/next_tick.js:68:7
```