### PR TITLE
docs(recipes): typo fix

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -270,7 +270,7 @@ There are so many ways to add styles to your website; Gatsby supports almost eve
 #### Prerequisites
 
 - A [Gatsby site](/docs/quick-start/) with an index page component
-- [gatsby-plugin-styled-components, styled-components, and babel-plugin-styled-components](/packages/gatsby-plugin-styled-components/) installed in `package.json`
+- [gatsby-plugin-styled-components, styled-components and babel-plugin-styled-components](/packages/gatsby-plugin-styled-components/) installed in `package.json`
 
 #### Directions
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
`,` is not required when `and` is used
<!-- Write a brief description of the changes introduced by this PR -->
