### PR TITLE
fix(gatsby-plugin-mdx): fix slashes for Windows

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -99,7 +99,8 @@ module.exports = async function(content) {
 
   let fileNode = getNodes().find(
     node =>
-      node.internal.type === `File` && node.absolutePath === this.resourcePath
+      node.internal.type === `File` &&
+      node.absolutePath === slash(this.resourcePath)
   )
   let isFakeFileNode = false
   if (!fileNode) {


### PR DESCRIPTION
## Description
```fileNode``` is ```undefined``` on windows.