### PR TITLE
Fix Typos in why-gatsby-uses-graphql.md

### DIFF
--- a/docs/docs/why-gatsby-uses-graphql.md
+++ b/docs/docs/why-gatsby-uses-graphql.md
@@ -189,7 +189,7 @@ This gets the job done, but it has a few shortcomings that are going to get more
 1. The images and the product data are in different places in the source code.
 2. The image paths are absolute from the _built_ site, not the source code, which makes it confusing to know how to find them from the JSON.
 3. The images are unoptimized, and any optimization you do would have to be manual.
-4. To create a preview listing of all products, we’d need to pass _all_ of the product info in `context`, which will get unweildy as the number of products increases.
+4. To create a preview listing of all products, we’d need to pass _all_ of the product info in `context`, which will get unwieldy as the number of products increases.
 5. It’s not very obvious where data is coming from in the templates that render the pages, so updating the data might be confusing later.
 
 To overcome these limitations, Gatsby introduces GraphQL as a data management layer.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description
Spelling mistakes in why-gatsby-uses-graphql.md is cleared .It's wrong in both English .
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
