### PR TITLE
feat(telemetry): Refactor and test CI detection and add support for heroku and now

### DIFF
--- a/packages/gatsby-telemetry/src/__mocks__/ci-info.js
+++ b/packages/gatsby-telemetry/src/__mocks__/ci-info.js
@@ -1,0 +1,15 @@
+const ciInfo = jest.genMockFromModule(`ci-info`)
+
+ciInfo.isCI = false
+ciInfo.name = `bad default`
+
+function setIsCI(value) {
+  ciInfo.isCI = value
+}
+
+function setName(name) {
+  ciInfo.name = name
+}
+ciInfo.setIsCI = setIsCI
+ciInfo.setName = setName
+module.exports = ciInfo

--- a/packages/gatsby-telemetry/src/__tests__/ci.js
+++ b/packages/gatsby-telemetry/src/__tests__/ci.js
@@ -1,0 +1,71 @@
+jest.mock(`ci-info`)
+describe(`CI detection`, () => {
+  const origEnv = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...origEnv }
+    // We need to remove the env our CI adds to ensure accurate tests
+    ;[
+      `CI`,
+      `CIRCLECI`,
+      `CIRCLE_PULL_REQUEST`,
+      `SYSTEM_TEAMFOUNDATIONCOLLECTIONURI`,
+      `SYSTEM_PULLREQUEST_PULLREQUESTID`,
+    ].forEach(e => delete process.env[e])
+  })
+
+  afterEach(() => {
+    process.env = origEnv
+  })
+
+  it(`Detects CI when ci-info detects one`, () => {
+    const ciInfo = require(`ci-info`)
+    ciInfo.setIsCI(true)
+    ciInfo.setName(`testname`)
+
+    const { isCI, getCIName } = require(`../ci`)
+    expect(isCI()).toBeTruthy()
+    expect(getCIName()).toEqual(`testname`)
+  })
+
+  it(`Detects Now v2`, () => {
+    process.env.NOW_BUILDER_ANNOTATE = 1
+    const { isCI, getCIName } = require(`../ci`)
+
+    expect(isCI()).toBeTruthy()
+    expect(getCIName()).toEqual(`ZEIT Now`)
+  })
+
+  it(`Detects Now v1`, () => {
+    process.env.NOW_REGION = `none`
+    const { isCI, getCIName } = require(`../ci`)
+
+    expect(isCI()).toBeTruthy()
+    expect(getCIName()).toEqual(`ZEIT Now v1`)
+  })
+
+  it(`Detects Heroku`, () => {
+    process.env.NODE = `/tmp/build_8a43526a8849e690a3b67906d404e434/.heroku/node/bin/node`
+    const { isCI, getCIName } = require(`../ci`)
+
+    expect(isCI()).toBeTruthy()
+    expect(getCIName()).toEqual(`Heroku`)
+  })
+  it(`Detects CI and CI_NAME`, () => {
+    process.env.CI = true
+    process.env.CI_NAME = `test CI`
+    const { isCI, getCIName } = require(`../ci`)
+
+    expect(isCI()).toBeTruthy()
+    expect(getCIName()).toEqual(`test CI`)
+  })
+  it(`Detects CI and no CI_NAME`, () => {
+    process.env.CI = true
+    delete process.env.CI_NAME
+    const { isCI, getCIName } = require(`../ci`)
+
+    expect(isCI()).toBeTruthy()
+    expect(getCIName()).toEqual(`CI detected without name`)
+  })
+})

--- a/packages/gatsby-telemetry/src/ci.js
+++ b/packages/gatsby-telemetry/src/ci.js
@@ -1,0 +1,70 @@
+const ci = require(`ci-info`)
+
+const CI_DEFINITIONS = [
+  envFromCIandCIName,
+  getEnvDetect({ key: `NOW_BUILDER_ANNOTATE`, name: `ZEIT Now` }),
+  getEnvDetect({ key: `NOW_REGION`, name: `ZEIT Now v1` }),
+  herokuDetect,
+  getEnvFromCIInfo,
+  envFromCIWithNoName,
+]
+
+function lookupCI() {
+  for (const fn of CI_DEFINITIONS) {
+    try {
+      const res = fn()
+      if (res) {
+        return res
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
+  return null
+}
+const CIName = lookupCI()
+
+function isCI() {
+  return !!CIName
+}
+
+function getCIName() {
+  if (!isCI()) {
+    return null
+  }
+  return CIName
+}
+
+module.exports = { isCI, getCIName }
+
+function getEnvFromCIInfo() {
+  if (ci.isCI) return ci.name || `ci-info detected w/o name`
+  return null
+}
+
+function getEnvDetect({ key, name }) {
+  return function() {
+    if (process.env[key]) {
+      return name
+    }
+    return null
+  }
+}
+
+function herokuDetect() {
+  return /\.heroku\/node\/bin\/node/.test(process.env.NODE) && `Heroku`
+}
+
+function envFromCIandCIName() {
+  if (process.env.CI_NAME && process.env.CI) {
+    return process.env.CI_NAME
+  }
+  return null
+}
+
+function envFromCIWithNoName() {
+  if (process.env.CI) {
+    return `CI detected without name`
+  }
+  return null
+}

--- a/packages/gatsby-telemetry/src/telemetry.js
+++ b/packages/gatsby-telemetry/src/telemetry.js
@@ -1,7 +1,7 @@
 const uuidv4 = require(`uuid/v4`)
 const EventStorage = require(`./event-storage`)
 const { cleanPaths } = require(`./error-helpers`)
-const ci = require(`ci-info`)
+const ci = require(`./ci`)
 const os = require(`os`)
 const { join, sep } = require(`path`)
 const isDocker = require(`is-docker`)
@@ -207,7 +207,7 @@ module.exports = class AnalyticsTracker {
     }
     let enabled = this.store.getConfig(`telemetry.enabled`)
     if (enabled === undefined || enabled === null) {
-      if (!ci.isCI) {
+      if (!ci.isCI()) {
         showAnalyticsNotification()
       }
       enabled = true
@@ -228,8 +228,8 @@ module.exports = class AnalyticsTracker {
       release: os.release(),
       cpus: (cpus && cpus.length > 0 && cpus[0].model) || undefined,
       arch: os.arch(),
-      ci: ci.isCI,
-      ciName: (ci.isCI && ci.name) || process.env.CI_NAME || undefined,
+      ci: ci.isCI(),
+      ciName: ci.getCIName(),
       docker: isDocker(),
     }
     this.osInfo = osInfo


### PR DESCRIPTION
This PR refactors and adds tests for CI detection. 

While `ci-info` detects many CIs we've already had additional logic in place for detecting a few more CIs. This cleans it up and adds more accurate detection for heroku and Now v1 and v2 platforms.

This is to be appended while we identify new CI.