### PR TITLE
chore(gatsby-transformer-javascript-static-exports): Fix typo in README

### DIFF
--- a/packages/gatsby-transformer-javascript-static-exports/README.md
+++ b/packages/gatsby-transformer-javascript-static-exports/README.md
@@ -15,7 +15,7 @@ plugins: [`gatsby-transformer-javascript-static-exports`]
 
 ## Parsing algorithm
 
-The algorithm for uses babylon and traverse (from the babel family of code) to
+The algorithm uses babylon and traverse (from the babel family of code) to
 statically read the data exports.
 
 In a .js file, export a data object to set your metadata variables, like so:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
remove extraneous `for`

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
