### PR TITLE
[docs] Add missing command to quick start guide

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -20,7 +20,7 @@ npm install -g gatsby-cli
 ### Create a new site.
 
 ```shell
-gatsby new gatsby-site
+npx gatsby new gatsby-site
 ```
 
 ### Change directories into site folder.


### PR DESCRIPTION
## Description

Adding a missing command to the quick start guide.

Reasons for this update:
1) For a beginner following this quick start guide exactly, it won't actually work without this addition
2) To match the first instruction in the linked video tutorial in the quick start guide (https://egghead.io/lessons/gatsby-quick-start-with-gatsby-create-develop-and-build-gatsby-sites-from-the-command-line)

## Related Issues

#13708 [good first issue]
