### PR TITLE
fix(scripts): Skip lock file generation for workspaces

### DIFF
--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -14,6 +14,7 @@ for folder in $GLOB; do
   cd $BASE
 
   NAME=$(cat $folder/package.json | jq -r '.name')
+  IS_WORKSPACE=$(cat $folder/package.json | jq -r '.workspaces')
   CLONE_DIR="__${NAME}__clone__"
   
   # sync to read-only clones
@@ -25,8 +26,10 @@ for folder in $GLOB; do
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   cp -r $BASE/$folder/. .
 
-  rm -rf yarn.lock
-  yarn import # generate a new yarn.lock file based on package-lock.json
+  if [ "$IS_WORKSPACE" = null ]; then
+    rm -rf yarn.lock
+    yarn import # generate a new yarn.lock file based on package-lock.json
+  fi
 
   git add .
   git commit --message "$COMMIT_MESSAGE"

--- a/themes/gatsby-starter-theme-workspace/package-lock.json
+++ b/themes/gatsby-starter-theme-workspace/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "gatsby-starter-theme-workspace",
-  "version": "0.0.1",
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Publishing starters currently fails for `../themes/gatsby-starter-theme-workspace` because `yarn import` fails when trying to run it inside a work space. 

This changes skips the lock file generation when running in a workspace starter like this one! 