### PR TITLE
fix(gatsby-source-filesystem): Queue all operations which happen before chokidar's ready state

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/gatsby-node.js
@@ -100,8 +100,7 @@ describe(`tests`, () => {
       expect(api.actions.createNode).toBeCalled()
     })
 
-    // change event doesn't queue currently - this need to be fixed
-    it.skip(`queues node creation from changed files`, async () => {
+    it(`queues node creation from changed files`, async () => {
       const api = createApi()
       const sourceNodesPromise = gatsbyNode.sourceNodes(api, { path: `` })
       // allow microtasks execution
@@ -138,8 +137,7 @@ describe(`tests`, () => {
       expect(api.actions.createNode).toBeCalled()
     })
 
-    // unlink event doesn't queue currently - this need to be fixed
-    it.skip(`queues node deletion from deleted files`, async () => {
+    it(`queues node deletion from deleted files`, async () => {
       const api = createApi()
       const sourceNodesPromise = gatsbyNode.sourceNodes(api, { path: `` })
       // allow microtasks execution
@@ -157,8 +155,7 @@ describe(`tests`, () => {
       expect(api.actions.deleteNode).toBeCalled()
     })
 
-    // unlinkDir event doesn't queue currently - this need to be fixed
-    it.skip(`queues node deletion from deleted directories`, async () => {
+    it(`queues node deletion from deleted directories`, async () => {
       const api = createApi()
       const sourceNodesPromise = gatsbyNode.sourceNodes(api, { path: `` })
       // allow microtasks execution


### PR DESCRIPTION
Followup to https://github.com/gatsbyjs/gatsby/pull/17192#discussion_r320191389

**Before**
<img src="https://user-images.githubusercontent.com/9800850/64169594-66dc5f00-ce4e-11e9-9fc6-5ccaf612bb59.png"/>
**After**
<img width="704" alt="Screenshot 2019-09-05 at 07 20 31" src="https://user-images.githubusercontent.com/9800850/64313988-ae2d3180-cfad-11e9-822f-53dd804f3c6e.png">
