### PR TITLE
fix(gatsby-plugin-offline): prevent caching invalid relative paths

### DIFF
--- a/packages/gatsby-plugin-offline/src/get-resources-from-html.js
+++ b/packages/gatsby-plugin-offline/src/get-resources-from-html.js
@@ -43,7 +43,7 @@ module.exports = (htmlPath, pathPrefix) => {
 
     // check resource URLs from header tags start with the correct prefix
     // (these are not page URLs)
-    if (!blackListRegex.test(url) && url.startsWith(pathPrefix)) {
+    if (!blackListRegex.test(url) && url.startsWith(`${pathPrefix}/`)) {
       criticalFilePaths.push(url.replace(/^\//, ``))
     }
   })


### PR DESCRIPTION
## Description

Check for leading slash in `getResourcesForHTML` to prevent adding relative URLs to the precache list which cannot be resolved relative to the root directory (e.g. 3rd party resources such as `cms.js` in Netlify CMS admin)