### PR TITLE
fix(gatsby): move default-site-plugin lower than plugin page-creation

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -76,18 +76,6 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "default-site-plugin",
-    "nodeAPIs": Array [],
-    "pluginOptions": Object {
-      "plugins": Array [],
-    },
-    "resolve": "",
-    "ssrAPIs": Array [],
-    "version": "1.0.0",
-  },
-  Object {
-    "browserAPIs": Array [],
-    "id": "",
     "name": "gatsby-plugin-page-creator",
     "nodeAPIs": Array [
       "createPagesStatefully",
@@ -168,13 +156,9 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "gatsby-plugin-page-creator",
-    "nodeAPIs": Array [
-      "createPagesStatefully",
-    ],
+    "name": "default-site-plugin",
+    "nodeAPIs": Array [],
     "pluginOptions": Object {
-      "path": "<PROJECT_ROOT>/src/pages",
-      "pathCheck": false,
       "plugins": Array [],
     },
     "resolve": "",
@@ -288,18 +272,6 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "default-site-plugin",
-    "nodeAPIs": Array [],
-    "pluginOptions": Object {
-      "plugins": Array [],
-    },
-    "resolve": "",
-    "ssrAPIs": Array [],
-    "version": "1.0.0",
-  },
-  Object {
-    "browserAPIs": Array [],
-    "id": "",
     "name": "gatsby-plugin-page-creator",
     "nodeAPIs": Array [
       "createPagesStatefully",
@@ -396,13 +368,9 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "gatsby-plugin-page-creator",
-    "nodeAPIs": Array [
-      "createPagesStatefully",
-    ],
+    "name": "default-site-plugin",
+    "nodeAPIs": Array [],
     "pluginOptions": Object {
-      "path": "<PROJECT_ROOT>/src/pages",
-      "pathCheck": false,
       "plugins": Array [],
     },
     "resolve": "",

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -183,6 +183,23 @@ module.exports = (config = {}, rootDir = null) => {
     })
   }
 
+  // the order of all of these page-creators matters. The "last plugin wins",
+  // so the user's site comes last, and each page-creator instance has to
+  // match the plugin definition order before that. This works fine for themes
+  // because themes have already been added in the proper order to the plugins
+  // array
+  plugins.forEach(plugin => {
+    plugins.push(
+      processPlugin({
+        resolve: require.resolve(`gatsby-plugin-page-creator`),
+        options: {
+          path: slash(path.join(plugin.resolve, `src/pages`)),
+          pathCheck: false,
+        },
+      })
+    )
+  })
+
   // Add the site's default "plugin" i.e. gatsby-x files in root of site.
   plugins.push({
     resolve: slash(process.cwd()),
@@ -194,23 +211,6 @@ module.exports = (config = {}, rootDir = null) => {
     },
   })
 
-  // the order of all of these page-creators matters. The "last plugin wins",
-  // so the user's site comes last, and each page-creator instance has to
-  // match the plugin definition order before that. This works fine for themes
-  // because themes have already been added in the proper order to the plugins
-  // array
-  // also, skip the default "plugin"
-  plugins.slice(0, -1).forEach(plugin => {
-    plugins.push(
-      processPlugin({
-        resolve: require.resolve(`gatsby-plugin-page-creator`),
-        options: {
-          path: slash(path.join(plugin.resolve, `src/pages`)),
-          pathCheck: false,
-        },
-      })
-    )
-  })
   const program = store.getState().program
   plugins.push(
     processPlugin({

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -199,7 +199,8 @@ module.exports = (config = {}, rootDir = null) => {
   // match the plugin definition order before that. This works fine for themes
   // because themes have already been added in the proper order to the plugins
   // array
-  plugins.forEach(plugin => {
+  // also, skip the default "plugin"
+  plugins.slice(0, -1).forEach(plugin => {
     plugins.push(
       processPlugin({
         resolve: require.resolve(`gatsby-plugin-page-creator`),


### PR DESCRIPTION
## Description

Skip the default site "plugin".

## Related issues

#17373