### PR TITLE
fix(scripts): Exit gracefully in publish starters if nothing to commit

### DIFF
--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -31,8 +31,11 @@ for folder in $GLOB; do
     yarn import # generate a new yarn.lock file based on package-lock.json
   fi
 
-  git diff-index --quiet HEAD || git commit -am "$COMMIT_MESSAGE"
-  git push origin master
+  if [ -n "$(git status --porcelain)" ]; then
+    git add .
+    git commit -m "$COMMIT_MESSAGE"
+    git push origin master
+  fi
 
   cd $BASE
 done

--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -31,8 +31,7 @@ for folder in $GLOB; do
     yarn import # generate a new yarn.lock file based on package-lock.json
   fi
 
-  git add .
-  git commit --message "$COMMIT_MESSAGE"
+  git diff-index --quiet HEAD || git commit -am "$COMMIT_MESSAGE"
   git push origin master
 
   cd $BASE


### PR DESCRIPTION
Currently every commit on master fails status checks because there is nothing to commit to starters for some commits and `set -e` passes through 1 as the exit code that `git commit` returns!

This fix checks if the diff has something before trying to commit so that nothing to commit isn't considered an error (which it is not)