### PR TITLE
fix(gatsby): Allow overriding options for default instance of gatsby-plugin-page-creator

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -512,7 +512,7 @@ Array [
       "ignore": Array [
         "___Test___.(js|ts)?(x)",
       ],
-      "path": "___TEST___/src/pages",
+      "path": "<PROJECT_ROOT>/packages/gatsby/src/bootstrap/load-plugins/__tests__/src/pages",
       "plugins": Array [],
     },
     "resolve": "",
@@ -651,10 +651,8 @@ Array [
       "createPagesStatefully",
     ],
     "pluginOptions": Object {
-      "ignore": Array [
-        "___Test___.(js|ts)?(x)",
-      ],
-      "path": "___TEST___/src/pages",
+      "path": "/src/pages",
+      "pathCheck": false,
       "plugins": Array [],
     },
     "resolve": "",

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -512,7 +512,7 @@ Array [
       "ignore": Array [
         "___Test___.(js|ts)?(x)",
       ],
-      "path": "___TEST___",
+      "path": "___TEST___/src/pages",
       "plugins": Array [],
     },
     "resolve": "",
@@ -654,7 +654,7 @@ Array [
       "ignore": Array [
         "___Test___.(js|ts)?(x)",
       ],
-      "path": "___TEST___",
+      "path": "___TEST___/src/pages",
       "plugins": Array [],
     },
     "resolve": "",

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -427,3 +427,239 @@ Array [
   },
 ]
 `;
+
+exports[`Load plugins Overrides the options for gatsby-plugin-page-creator 1`] = `
+Array [
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "dev-404-page",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "load-babel-config",
+    "nodeAPIs": Array [
+      "onPreBootstrap",
+    ],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "internal-data-bridge",
+    "nodeAPIs": Array [
+      "sourceNodes",
+      "onCreatePage",
+    ],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "prod-404",
+    "nodeAPIs": Array [
+      "onCreatePage",
+    ],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "webpack-theme-component-shadowing",
+    "nodeAPIs": Array [
+      "onCreateWebpackConfig",
+    ],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "ignore": Array [
+        "___Test___.(js|ts)?(x)",
+      ],
+      "path": "___TEST___",
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "default-site-plugin",
+    "nodeAPIs": Array [],
+    "pluginOptions": Object {
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/dev-404-page/src/pages",
+      "pathCheck": false,
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/load-babel-config/src/pages",
+      "pathCheck": false,
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/internal-data-bridge/src/pages",
+      "pathCheck": false,
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/prod-404/src/pages",
+      "pathCheck": false,
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/src/pages",
+      "pathCheck": false,
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "path": "<PROJECT_ROOT>/packages/gatsby-plugin-page-creator/src/pages",
+      "pathCheck": false,
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "path": "<PROJECT_ROOT>/src/pages",
+      "pathCheck": false,
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+  Object {
+    "browserAPIs": Array [],
+    "id": "",
+    "name": "gatsby-plugin-page-creator",
+    "nodeAPIs": Array [
+      "createPagesStatefully",
+    ],
+    "pluginOptions": Object {
+      "ignore": Array [
+        "___Test___.(js|ts)?(x)",
+      ],
+      "path": "___TEST___",
+      "plugins": Array [],
+    },
+    "resolve": "",
+    "ssrAPIs": Array [],
+    "version": "1.0.0",
+  },
+]
+`;

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
@@ -51,4 +51,24 @@ describe(`Load plugins`, () => {
 
     expect(plugins).toMatchSnapshot()
   })
+
+  it(`Overrides the options for gatsby-plugin-page-creator`, async () => {
+    const config = {
+      plugins: [
+        {
+          resolve: `gatsby-plugin-page-creator`,
+          options: {
+            path: `___TEST___`,
+            ignore: [`___Test___.(js|ts)?(x)`],
+          },
+        },
+      ],
+    }
+
+    let plugins = await loadPlugins(config)
+
+    plugins = replaceFieldsThatCanVary(plugins)
+
+    expect(plugins).toMatchSnapshot()
+  })
 })

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
@@ -58,7 +58,7 @@ describe(`Load plugins`, () => {
         {
           resolve: `gatsby-plugin-page-creator`,
           options: {
-            path: `___TEST___`,
+            path: `___TEST___/src/pages`,
             ignore: [`___Test___.(js|ts)?(x)`],
           },
         },

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.js
@@ -58,7 +58,7 @@ describe(`Load plugins`, () => {
         {
           resolve: `gatsby-plugin-page-creator`,
           options: {
-            path: `___TEST___/src/pages`,
+            path: `${__dirname}/src/pages`,
             ignore: [`___Test___.(js|ts)?(x)`],
           },
         },

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -211,13 +211,27 @@ module.exports = (config = {}, rootDir = null) => {
     )
   })
   const program = store.getState().program
+
+  // default options for gatsby-plugin-page-creator
+  let pageCreatorOptions = {
+    path: slash(path.join(program.directory, `src/pages`)),
+    pathCheck: false,
+  }
+
+  if (config.plugins) {
+    const pageCreatorPlugin = config.plugins.find(
+      plugin => plugin.resolve === `gatsby-plugin-page-creator`
+    )
+    if (pageCreatorPlugin) {
+      // override the options if there are any user specified options
+      pageCreatorOptions = pageCreatorPlugin.options
+    }
+  }
+
   plugins.push(
     processPlugin({
       resolve: require.resolve(`gatsby-plugin-page-creator`),
-      options: {
-        path: slash(path.join(program.directory, `src/pages`)),
-        pathCheck: false,
-      },
+      options: pageCreatorOptions,
     })
   )
 

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -222,7 +222,7 @@ module.exports = (config = {}, rootDir = null) => {
     const pageCreatorPlugin = config.plugins.find(
       plugin =>
         plugin.resolve === `gatsby-plugin-page-creator` &&
-        plugin.options.path.match(/src\/pages$/)
+        plugin.options.path === slash(path.join(program.directory, `src/pages`))
     )
     if (pageCreatorPlugin) {
       // override the options if there are any user specified options

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -220,7 +220,9 @@ module.exports = (config = {}, rootDir = null) => {
 
   if (config.plugins) {
     const pageCreatorPlugin = config.plugins.find(
-      plugin => plugin.resolve === `gatsby-plugin-page-creator`
+      plugin =>
+        plugin.resolve === `gatsby-plugin-page-creator` &&
+        plugin.options.path.match(/src\/pages$/)
     )
     if (pageCreatorPlugin) {
       // override the options if there are any user specified options


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Override the default options for gatsby-plugin-page-creator with options specified in gatsby-config.js

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #17379
